### PR TITLE
Issues with Path and Port

### DIFF
--- a/src/main/java/net/kencochrane/sentry/RavenConfig.java
+++ b/src/main/java/net/kencochrane/sentry/RavenConfig.java
@@ -17,7 +17,7 @@ public class RavenConfig {
     /**
      * Takes in a sentryDSN and builds up the configuration
      *
-     * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
+     * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}/{PROJECT_ID}'
      */
     public RavenConfig(String sentryDSN) {
         this(sentryDSN, null);
@@ -26,7 +26,7 @@ public class RavenConfig {
     /**
      * Takes in a sentryDSN and builds up the configuration
      *
-     * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}'
+     * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}/{PROJECT_ID}'
      * @param proxy     proxy to use for the HTTP connections; blank or null when no proxy is to be used
      */
     public RavenConfig(String sentryDSN, String proxy) {
@@ -36,9 +36,11 @@ public class RavenConfig {
             this.host = url.getHost();
             this.protocol = url.getProtocol();
             String urlPath = url.getPath();
-            String[] urlParts = urlPath.split("/");
-            this.path = urlPath;
-            this.projectId = urlParts[1];
+
+            int lastSlash = urlPath.lastIndexOf("/");
+            this.path = urlPath.substring(0, lastSlash);
+            // ProjectId is the integer after the last slash in the path
+            this.projectId = urlPath.substring(lastSlash+1);
 
             String userInfo = url.getUserInfo();
             String[] userParts = userInfo.split(":");
@@ -72,9 +74,10 @@ public class RavenConfig {
         serverUrl.append(getProtocol());
         serverUrl.append("://");
         serverUrl.append(getHost());
-        if ((getPort() != 0) && (getPort() != 80)) {
+        if ((getPort() != 0) && (getPort() != 80) && getPort() != -1) {
             serverUrl.append(":").append(getPort());
         }
+        serverUrl.append(getPath());
         serverUrl.append("/api/store/");
         return serverUrl.toString();
     }

--- a/src/test/java/net/kencochrane/sentry/RavenConfigTest.java
+++ b/src/test/java/net/kencochrane/sentry/RavenConfigTest.java
@@ -1,0 +1,26 @@
+package net.kencochrane.sentry;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RavenConfigTest
+{
+    @Test
+    public void testDSNComponents() {
+
+        // Without Port
+        RavenClient client = new RavenClient("http://public:secret@example.com/path/sentry/1");
+        assertEquals("http://public:secret@example.com/path/sentry/1", client.getSentryDSN());
+        assertEquals("example.com", client.getConfig().getHost());
+        assertEquals("/path/sentry", client.getConfig().getPath());
+        assertEquals(-1, client.getConfig().getPort());
+        assertEquals("1", client.getConfig().getProjectId());
+        assertEquals("http://example.com/path/sentry/api/store/", client.getConfig().getSentryURL());
+
+        // With Port
+        client = new RavenClient("http://public:secret@example.com:9000/path/sentry/1");
+        assertEquals(9000, client.getConfig().getPort());
+        assertEquals("http://example.com:9000/path/sentry/api/store/", client.getConfig().getSentryURL());
+    }
+}


### PR DESCRIPTION
There were issues with the code when you have Sentry configured in a subdirectory rather than the root of the webserver (projectId comes after the last slash).  Also, URL.getPort() returns -1 if there is no port.

I added a Config test to validate that RavenConfig pulls the DSN apart correctly.
