### PR TITLE
Fixing SSL issue with log4j SentryAppender

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,16 @@ If you want to make sure log events always reach sentry, you can turn blocking o
 
 WARNING: By setting blocking true, you will effectively lock up the thread doing the logging! Use with care.
 
+Naive SSL
+^^^^^^^^^
+If you're using Java 6 or earlier, you might encounter errors when connecting to a Sentry instance using a TLS (https)
+connection since Server Name Indication (SNI) support has only been available in Java since Java 7. You can either add
+the corresponding certificate to your keystore (recommended!) or enable ``naiveSsl`` on the Sentry appender. This will
+make the Raven client use a custom hostname verifier that *will* allow the JVM to connect with the host - in fact it
+will let the Raven client connect to any host even if the certificate is invalid. Use at your own risk::
+
+    log4j.appender.sentry.naiveSsl=true
+
 
 SENTRY_DSN Environment Variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/net/kencochrane/sentry/RavenConfig.java
+++ b/src/main/java/net/kencochrane/sentry/RavenConfig.java
@@ -13,6 +13,7 @@ public class RavenConfig {
     private int port;
     private String proxyType, proxyHost;
     private int proxyPort;
+    private boolean naiveSsl;
 
     /**
      * Takes in a sentryDSN and builds up the configuration
@@ -20,7 +21,7 @@ public class RavenConfig {
      * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}/{PROJECT_ID}'
      */
     public RavenConfig(String sentryDSN) {
-        this(sentryDSN, null);
+        this(sentryDSN, null, false);
     }
 
     /**
@@ -28,9 +29,10 @@ public class RavenConfig {
      *
      * @param sentryDSN '{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}/{PROJECT_ID}'
      * @param proxy     proxy to use for the HTTP connections; blank or null when no proxy is to be used
+     * @param naiveSsl use a hostname verifier for SSL connections that allows all connections
      */
-    public RavenConfig(String sentryDSN, String proxy) {
-
+    public RavenConfig(String sentryDSN, String proxy, boolean naiveSsl) {
+        this.naiveSsl = naiveSsl;
         try {
             URL url = new URL(sentryDSN);
             this.host = url.getHost();
@@ -181,6 +183,14 @@ public class RavenConfig {
         this.port = port;
     }
 
+    public boolean isNaiveSsl() {
+        return naiveSsl;
+    }
+
+    public void setNaiveSsl(boolean naiveSsl) {
+        this.naiveSsl = naiveSsl;
+    }
+
     @Override
     public String toString() {
         return "RavenConfig{" +
@@ -190,6 +200,7 @@ public class RavenConfig {
                 ", secretKey='" + secretKey + '\'' +
                 ", path='" + path + '\'' +
                 ", projectId='" + projectId + '\'' +
+                ", naiveSsl='" + naiveSsl + '\'' +
                 ", SentryUrl='" + getSentryURL() + '\'' +
                 '}';
     }

--- a/src/main/java/net/kencochrane/sentry/SentryAppender.java
+++ b/src/main/java/net/kencochrane/sentry/SentryAppender.java
@@ -15,6 +15,7 @@ public class SentryAppender extends AppenderSkeleton {
     private String proxy;
     private int queue_size;
     private boolean blocking;
+    private boolean naiveSsl;
 
     public SentryAppender()
     {
@@ -54,6 +55,14 @@ public class SentryAppender extends AppenderSkeleton {
         this.blocking = blocking;
     }
 
+    public boolean isNaiveSsl() {
+        return naiveSsl;
+    }
+
+    public void setNaiveSsl(boolean naiveSsl) {
+        this.naiveSsl = naiveSsl;
+    }
+
     /**
     * Look for the ENV variable first, and if it isn't there, then look in the log4j properties
     *
@@ -79,7 +88,7 @@ public class SentryAppender extends AppenderSkeleton {
         {
             if(!SentryQueue.getInstance().isSetup())
             {
-                SentryQueue.getInstance().setup(sentryDSN, getProxy(), queue_size, blocking);
+                SentryQueue.getInstance().setup(sentryDSN, getProxy(), queue_size, blocking, naiveSsl);
             }
         }
 

--- a/src/main/java/net/kencochrane/sentry/SentryQueue.java
+++ b/src/main/java/net/kencochrane/sentry/SentryQueue.java
@@ -41,12 +41,12 @@ public class SentryQueue
         return (queue != null);
     }
 
-    public synchronized void setup(String sentryDSN, String proxy, int queueSize, boolean blocking)
+    public synchronized void setup(String sentryDSN, String proxy, int queueSize, boolean blocking, boolean naiveSsl)
     {
         queue = new LinkedBlockingQueue<LoggingEvent>(queueSize);
         this.blocking = blocking;
 
-        worker = new SentryWorker(queue, sentryDSN, proxy);
+        worker = new SentryWorker(queue, sentryDSN, proxy, naiveSsl);
         worker.start();
     }
 

--- a/src/main/java/net/kencochrane/sentry/SentryWorker.java
+++ b/src/main/java/net/kencochrane/sentry/SentryWorker.java
@@ -17,11 +17,11 @@ public class SentryWorker extends Thread
 
     private BlockingQueue<LoggingEvent> queue;
 
-    public SentryWorker(BlockingQueue<LoggingEvent> queue, String sentryDSN, String proxy)
+    public SentryWorker(BlockingQueue<LoggingEvent> queue, String sentryDSN, String proxy, boolean naiveSsl)
     {
         this.shouldShutdown = false;
         this.queue = queue;
-        this.client = new RavenClient(sentryDSN, proxy);
+        this.client = new RavenClient(sentryDSN, proxy, naiveSsl);
     }
 
     @Override

--- a/src/test/resources/log4j_configuration.txt
+++ b/src/test/resources/log4j_configuration.txt
@@ -20,4 +20,9 @@ log4j.appender.R.layout.ConversionPattern=%p %t %c - %m%n
 log4j.appender.sentry=net.kencochrane.sentry.SentryAppender
 log4j.appender.sentry.sentry_dsn=http://b4935bdd78624092ac2bc70fdcdb6f5a:7a37d9ad4765428180316bfec91a27ef@localhost:8000/1
 
-
+# If you're using Java 6 or earlier, you might encounter errors when connecting to a Sentry instance using a TLS (https)
+# connection since Server Name Indication support has only been available in Java since Java 7. You can either add
+# the corresponding certificate to your keystore (recommended!) or enable naiveSsl on the Sentry appender. This will
+# make the Raven client use a custom hostname verifier that *will* allow the JVM to connect with the host - in fact it
+# will let the Raven client connect to any host even if the certificate is invalid. Use at your own risk.
+# log4j.appender.sentry.naiveSsl=true


### PR DESCRIPTION
GetSentry.com uses Server Name Indication and Java versions before 7 do not support this. Through the naiveSsl configuration option users are able to work around this problem without having to add the SSL certificate to their keystore. 

This should only be used for testing purposes, but... yeah.
