### PR TITLE
Allow logs to appear on the Messages view

### DIFF
--- a/src/main/java/net/kencochrane/sentry/RavenClient.java
+++ b/src/main/java/net/kencochrane/sentry/RavenClient.java
@@ -92,9 +92,9 @@ public class RavenClient {
      * @param loggerClass The class associated with the log message
      * @param logLevel    int value for Log level for message (DEBUG, ERROR, INFO, etc.)
      * @param culprit     Who we think caused the problem.
-     * @return JSON String of message body
+     * @return JSON message body
      */
-    private String buildJSON(String message, String timestamp, String loggerClass, int logLevel, String culprit, Throwable exception) {
+    protected JSONObject buildJSON(String message, String timestamp, String loggerClass, int logLevel, String culprit, Throwable exception) {
         JSONObject obj = new JSONObject();
         String lastID = RavenUtils.getRandomUUID();
         obj.put("event_id", lastID); //Hexadecimal string representing a uuid4 value.
@@ -114,7 +114,7 @@ public class RavenClient {
         obj.put("logger", loggerClass);
         obj.put("server_name", RavenUtils.getHostname());
         setLastID(lastID);
-        return obj.toJSONString();
+        return obj;
     }
 
     /**
@@ -219,7 +219,7 @@ public class RavenClient {
      */
     private String buildMessage(String message, String timestamp, String loggerClass, int logLevel, String culprit, Throwable exception) {
         // get the json version of the body
-        String jsonMessage = buildJSON(message, timestamp, loggerClass, logLevel, culprit, exception);
+        String jsonMessage = buildJSON(message, timestamp, loggerClass, logLevel, culprit, exception).toJSONString();
 
         // compress and encode the json message.
         return buildMessageBody(jsonMessage);

--- a/src/test/java/net/kencochrane/sentry/SentyClientJsonTest.java
+++ b/src/test/java/net/kencochrane/sentry/SentyClientJsonTest.java
@@ -1,0 +1,46 @@
+package net.kencochrane.sentry;
+
+import java.util.Date;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * This test validates JSON message bodies created by RavenClient.
+ * 
+ * @author vvasabi
+ */
+public class SentyClientJsonTest extends RavenClient {
+
+    public SentyClientJsonTest() {
+        super("http://public:secret@example.com/path/1");
+    }
+
+    @Test
+    public void testMessageInterfaceObjectAdded() {
+        String messageString = "Test";
+        String timestamp = RavenUtils.getTimestampString(new Date().getTime());
+        String logger = "sentry.test";
+        JSONObject result = buildJSON(messageString, timestamp, logger, 20, messageString, null);
+        assertTrue(result.containsKey("sentry.interfaces.Message"));
+        
+        JSONObject message = (JSONObject)result.get("sentry.interfaces.Message");
+        assertEquals(message.get("message"), messageString);
+        assertTrue(message.get("params") instanceof JSONArray);
+    }
+
+    @Test
+    public void testMessageInterfaceObjectNotAdded() {
+        // when there is an exception, Message interface object should not be added
+        String messageString = "Test";
+        String timestamp = RavenUtils.getTimestampString(new Date().getTime());
+        String logger = "sentry.test";
+        Throwable exception = new Exception("Test");
+        JSONObject result = buildJSON(messageString, timestamp, logger, 20, messageString, exception);
+        assertFalse(result.containsKey("sentry.interfaces.Message"));
+    }
+
+}


### PR DESCRIPTION
This pull request adds a sentry.interfaces.Message object to the JSON request, allowing logs without an exception to appear on the Messages view.
