### PR TITLE
Fix for a thread safety issue, test case for ServletJSONProcessor and a trivial javadoc fix

### DIFF
--- a/raven-log4j/src/main/java/net/kencochrane/raven/log4j/SentryAppender.java
+++ b/raven-log4j/src/main/java/net/kencochrane/raven/log4j/SentryAppender.java
@@ -57,8 +57,7 @@ public class SentryAppender extends AppenderSkeleton {
      * Set a comma-separated list of fully qualified class names of
      * JSONProcessors to be used.
      *
-     * @param jsonProcessors a comma-separated list of fully qualified class
-     *                       names of JSONProcessors
+     * @param setting a comma-separated list of fully qualified class names of JSONProcessors
      */
     public void setJsonProcessors(String setting) {
         this.jsonProcessors = loadJSONProcessors(setting);

--- a/raven/src/main/java/net/kencochrane/raven/ext/ServletJSONProcessor.java
+++ b/raven/src/main/java/net/kencochrane/raven/ext/ServletJSONProcessor.java
@@ -32,11 +32,6 @@ public class ServletJSONProcessor implements JSONProcessor {
             return;
         }
 
-        if (RavenMDC.getInstance().get(HTTP_INTERFACE) != null) {
-            // an http object has been built; no need to build again
-            return;
-        }
-
         RavenMDC.getInstance().put(HTTP_INTERFACE, buildHttpObject(request));
     }
 
@@ -49,6 +44,7 @@ public class ServletJSONProcessor implements JSONProcessor {
         }
 
         json.put(HTTP_INTERFACE, http);
+        RavenMDC.getInstance().remove(HTTP_INTERFACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/raven/src/test/java/net/kencochrane/raven/ext/ServletJSONProcessorTest.java
+++ b/raven/src/test/java/net/kencochrane/raven/ext/ServletJSONProcessorTest.java
@@ -1,0 +1,148 @@
+package net.kencochrane.raven.ext;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import mockit.Mocked;
+import mockit.NonStrictExpectations;
+import net.kencochrane.raven.Client;
+import net.kencochrane.raven.SentryDsn;
+import net.kencochrane.raven.Events.LogLevel;
+import net.kencochrane.raven.spi.JSONProcessor;
+import net.kencochrane.raven.spi.RavenMDC;
+
+/**
+ * Check to see if ServletJSONProcessor correctly produces the desired http
+ * JSON object.
+ *
+ * @author vvasabi
+ */
+public class ServletJSONProcessorTest extends Client {
+
+    @Mocked
+    ServletContext mockServletContext;
+
+    @Mocked
+    HttpServletRequest mockHttpServletRequest;
+
+    public ServletJSONProcessorTest() {
+        super(SentryDsn.build("http://public:private@localhost:9000/1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testConstructHttpJsonResponse() {
+        List<JSONProcessor> processors = new ArrayList<JSONProcessor>();
+        JSONProcessor processor = new ServletJSONProcessor();
+        processors.add(processor);
+        setJSONProcessors(processors);
+
+        setHttpServletRequest();
+        new MockRavenMDC();
+
+        processor.prepareDiagnosticContext();
+        Message message = buildMessage("test",
+                formatTimestamp(new Date().getTime()), "test",
+                LogLevel.ERROR.intValue, "test", null, null);
+        JSONObject http = (JSONObject) message.json.get("sentry.interfaces.Http");
+        assertEquals("GET", http.get("method"));
+        assertEquals("test=abc", http.get("query_string"));
+        assertEquals("http://example.com/test?test=abc", http.get("url"));
+
+        JSONObject headers = new JSONObject();
+        headers.put("Test-Header", "test value");
+        assertEquals(headers, http.get("headers"));
+
+        JSONObject env = new JSONObject();
+        env.put("SERVER_PORT", 80);
+        env.put("REMOTE_ADDR", "127.0.0.1");
+        env.put("SERVER_PROTOCOL", "http");
+        env.put("SERVER_NAME", "localhost");
+        assertEquals(env, http.get("env"));
+
+        JSONObject cookies = new JSONObject();
+        cookies.put("test", "cookie");
+        assertEquals(cookies, http.get("cookies"));
+    }
+
+    private void setHttpServletRequest() {
+        new NonStrictExpectations() {
+            {
+                mockHttpServletRequest.getRequestURL();
+                returns(new StringBuffer("http://example.com/test"));
+
+                mockHttpServletRequest.getQueryString();
+                returns("test=abc");
+
+                mockHttpServletRequest.getMethod();
+                returns("GET");
+
+                mockHttpServletRequest.getHeaderNames();
+                List<String> headerNames = new ArrayList<String>();
+                headerNames.add("test-header");
+                returns(Collections.enumeration(headerNames));
+
+                mockHttpServletRequest.getHeader("test-header");
+                returns("test value");
+
+                mockHttpServletRequest.getRemoteAddr();
+                returns("127.0.0.1");
+
+                mockHttpServletRequest.getServerName();
+                returns("localhost");
+
+                mockHttpServletRequest.getServerPort();
+                returns(80);
+
+                mockHttpServletRequest.getProtocol();
+                returns("http");
+
+                mockHttpServletRequest.getCookies();
+                returns(new Cookie[] { new Cookie("test", "cookie") });
+            }
+        };
+        ServletRequestListener listener = new RavenServletRequestListener();
+        listener.requestInitialized(new ServletRequestEvent(mockServletContext, mockHttpServletRequest));
+    }
+
+    protected static class MockRavenMDC extends RavenMDC {
+
+        private Map<String, Object> values = new HashMap<String, Object>();
+
+        public MockRavenMDC() {
+            RavenMDC.setInstance(this);
+        }
+
+        @Override
+        public Object get(String key) {
+            return values.get(key);
+        }
+
+        @Override
+        public void put(String key, Object value) {
+            values.put(key, value);
+        }
+
+        @Override
+        public void remove(String key) {
+            values.remove(key);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request is for the refactoring branch. An attempt to use cached http JSON object in `ServletJSONProcessor` turns out not to be thread safe, as MDC implementations typically use `ThreadLocal` as the storage. When threads are pooled, http JSON objects stored in `ThreadLocal`s can leak to other requests. As a result, the optimization code is removed and the http JSON object is removed from RavenMDC when processing is done.
