### PR TITLE
Patch for a minor memory leak

### DIFF
--- a/raven-log4j/src/main/java/net/kencochrane/raven/log4j/AsyncSentryAppender.java
+++ b/raven-log4j/src/main/java/net/kencochrane/raven/log4j/AsyncSentryAppender.java
@@ -51,8 +51,9 @@ public class AsyncSentryAppender extends AsyncAppender {
 
     @Override
     public void append(LoggingEvent event) {
-        appender.notifyProcessors();
+        appender.notifyProcessorsBeforeAppending();
         super.append(event);
+        appender.notifyProcessorsAfterAppending();
     }
 
     @Override

--- a/raven-log4j/src/test/java/net/kencochrane/raven/log4j/AsyncSentryAppenderTest.java
+++ b/raven-log4j/src/test/java/net/kencochrane/raven/log4j/AsyncSentryAppenderTest.java
@@ -1,6 +1,8 @@
 package net.kencochrane.raven.log4j;
 
 import net.kencochrane.raven.Utils;
+import net.kencochrane.raven.spi.RavenMDC;
+
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
@@ -146,6 +148,17 @@ public class AsyncSentryAppenderTest {
         Logger.getLogger("logger").info("test");
         JSONObject json = SentryAppenderTest.fetchJSONObject(sentry);
         assertEquals(1, ((Long)json.get("Test")).longValue());
+    }
+
+    @Test
+    public void testClearMDC() throws IOException, ParseException {
+        RavenMDC mdc = RavenMDC.getInstance();
+        mdc.put("test", "test");
+        assertNotNull(mdc.get("test"));
+        setSentryDSN("6");
+        configureLog4J();
+        Logger.getLogger("logger").info("test");
+        assertNull(RavenMDC.getInstance().get("test"));
     }
 
     protected void setSentryDSN(String projectId) {

--- a/raven-log4j/src/test/java/net/kencochrane/raven/log4j/SentryAppenderTest.java
+++ b/raven-log4j/src/test/java/net/kencochrane/raven/log4j/SentryAppenderTest.java
@@ -2,6 +2,8 @@ package net.kencochrane.raven.log4j;
 
 import net.kencochrane.raven.Utils;
 import net.kencochrane.raven.spi.JSONProcessor;
+import net.kencochrane.raven.spi.RavenMDC;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Level;
@@ -155,6 +157,17 @@ public class SentryAppenderTest {
         assertEquals(1, ((Long) json.get("Test")).longValue());
     }
 
+    @Test
+    public void testClearMDC() throws IOException, ParseException {
+        RavenMDC mdc = RavenMDC.getInstance();
+        mdc.put("test", "test");
+        assertNotNull(mdc.get("test"));
+        setSentryDSN("6");
+        configureLog4J();
+        Logger.getLogger("logger").info("test");
+        assertNull(RavenMDC.getInstance().get("test"));
+    }
+
     protected void setSentryDSN(String projectId) {
         System.setProperty(Utils.SENTRY_DSN, String.format("udp://public:private@%s:%d/%s", sentry.host, sentry.port, projectId));
     }
@@ -219,6 +232,11 @@ public class SentryAppenderTest {
         public void prepareDiagnosticContext() {
             // this is done to ensure prepareDiagnosticContext is called exactly once
             value++;
+        }
+
+        @Override
+        public void clearDiagnosticContext() {
+            RavenMDC.getInstance().remove("test");
         }
 
         @Override

--- a/raven/src/main/java/net/kencochrane/raven/ext/ServletJSONProcessor.java
+++ b/raven/src/main/java/net/kencochrane/raven/ext/ServletJSONProcessor.java
@@ -36,6 +36,11 @@ public class ServletJSONProcessor implements JSONProcessor {
     }
 
     @Override
+    public void clearDiagnosticContext() {
+        RavenMDC.getInstance().remove(HTTP_INTERFACE);
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public void process(JSONObject json, Throwable exception) {
         JSONObject http = (JSONObject)RavenMDC.getInstance().get(HTTP_INTERFACE);
@@ -44,7 +49,6 @@ public class ServletJSONProcessor implements JSONProcessor {
         }
 
         json.put(HTTP_INTERFACE, http);
-        RavenMDC.getInstance().remove(HTTP_INTERFACE);
     }
 
     @SuppressWarnings("unchecked")

--- a/raven/src/main/java/net/kencochrane/raven/spi/JSONProcessor.java
+++ b/raven/src/main/java/net/kencochrane/raven/spi/JSONProcessor.java
@@ -16,12 +16,24 @@ public interface JSONProcessor {
 
     /**
      * This is called when a message is logged. Since
-     * {@link #process(JSONObject, Throwable)} may be executed on a different thread, this
-     * method should copy any data the processor needs into {@link RavenMDC}.
+     * {@link #process(JSONObject, Throwable)} may be executed on a different
+     * thread, this method should copy any data the processor needs into
+     * {@link RavenMDC}.
      *
      * For each message logged, this method should be called exactly once.
      */
     void prepareDiagnosticContext();
+
+    /**
+     * This is called after the message logged is processed (in synchronous
+     * mode), or after the message has been sent to the processing queue (in
+     * asynchronous mode). The intention of this method is to clear the data
+     * put in {@link RavenMDC} by {@link #prepareDiagnosticContext()} to prevent
+     * memory leak.
+     *
+     * For each message logged, this method should be called exactly once.
+     */
+    void clearDiagnosticContext();
 
     /**
      * Modify the JSON request object specified before it is sent to Sentry.

--- a/raven/src/test/java/net/kencochrane/raven/JSONProcessorTest.java
+++ b/raven/src/test/java/net/kencochrane/raven/JSONProcessorTest.java
@@ -55,6 +55,11 @@ public class JSONProcessorTest extends Client {
         }
 
         @Override
+        public void clearDiagnosticContext() {
+            testValue = null;
+        }
+
+        @Override
         @SuppressWarnings("unchecked")
         public void process(JSONObject json, Throwable exception) {
             json.put("Test", testValue);

--- a/raven/src/test/java/net/kencochrane/raven/ext/ServletJSONProcessorTest.java
+++ b/raven/src/test/java/net/kencochrane/raven/ext/ServletJSONProcessorTest.java
@@ -53,9 +53,10 @@ public class ServletJSONProcessorTest extends Client {
         setJSONProcessors(processors);
 
         setHttpServletRequest();
-        new MockRavenMDC();
+       RavenMDC mdc = new MockRavenMDC();
 
         processor.prepareDiagnosticContext();
+        assertNotNull(mdc.get("sentry.interfaces.Http"));
         Message message = buildMessage("test",
                 formatTimestamp(new Date().getTime()), "test",
                 LogLevel.ERROR.intValue, "test", null, null);
@@ -78,6 +79,9 @@ public class ServletJSONProcessorTest extends Client {
         JSONObject cookies = new JSONObject();
         cookies.put("test", "cookie");
         assertEquals(cookies, http.get("cookies"));
+
+        processor.clearDiagnosticContext();
+        assertNull(mdc.get("sentry.interfaces.Http"));
     }
 
     private void setHttpServletRequest() {


### PR DESCRIPTION
Because servlet containers can reuse threads, data stored in ThreadLocal may not be removed after request processing is done. This patch allows RavenMDC content to be cleared after a message has been appended or sent to the async processing queue. This prevents memory leak for ThreadLocal-based MDC when servlet container that pools threads is used.
