### PR TITLE
Android compatibility

### DIFF
--- a/old/src/main/java/net/kencochrane/sentry/RavenClient.java
+++ b/old/src/main/java/net/kencochrane/sentry/RavenClient.java
@@ -9,9 +9,10 @@ import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.String;
 import java.net.*;
 
-import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
 /**
  * User: ken cochrane
@@ -187,7 +188,7 @@ public class RavenClient {
         //return compressAndEncode(jsonMessage);
 
         // in the meantime just base64 encode it.
-        return encodeBase64String(jsonMessage.getBytes());
+        return new String(encodeBase64(jsonMessage.getBytes()));
 
     }
 

--- a/old/src/main/java/net/kencochrane/sentry/RavenUtils.java
+++ b/old/src/main/java/net/kencochrane/sentry/RavenUtils.java
@@ -7,6 +7,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.String;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.SignatureException;
@@ -16,7 +17,7 @@ import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 import java.util.zip.GZIPOutputStream;
 
-import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
 /**
  * User: ken Cochrane
@@ -226,7 +227,7 @@ public class RavenUtils {
             e.printStackTrace();
             //todo do something here better then this.
         }
-        return encodeBase64String(out.toByteArray());
+        return new String(encodeBase64(out.toByteArray());
     }
 
     public static byte[] toUtf8(String s) {

--- a/raven/src/main/java/net/kencochrane/raven/Client.java
+++ b/raven/src/main/java/net/kencochrane/raven/Client.java
@@ -9,6 +9,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.String;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -22,7 +23,7 @@ import java.util.logging.Logger;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
-import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
 /**
  * Raven client for Java, allowing sending of messages to Sentry.
@@ -480,7 +481,7 @@ public class Client {
             if (compress) {
                 raw = Utils.compress(raw);
             }
-            return encodeBase64String(raw);
+            return new String(encodeBase64(raw));
         }
 
         @Override


### PR DESCRIPTION
In Android environment, there is **commons-codec** version 1.4 without `encodeBase64String()` method.
