### PR TITLE
groupId in pom.xml; see issue #50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>net.kencochrane</groupId>
+    <groupId>net.kencochrane.raven</groupId>
     <artifactId>raven-all</artifactId>
     <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
Changed groupId to "net.kencochrane.raven" to better describe the project for Maven Central.  See http://maven.apache.org/ref/3.0.3/maven-model/maven.html#class_project

From issue #50, new groupId as proposed by @ColinHebert
