### PR TITLE
Send tags as single strings where possible

### DIFF
--- a/raven/src/main/java/net/kencochrane/raven/marshaller/json/JsonMarshaller.java
+++ b/raven/src/main/java/net/kencochrane/raven/marshaller/json/JsonMarshaller.java
@@ -168,11 +168,15 @@ public class JsonMarshaller implements Marshaller {
     private void writeTags(JsonGenerator generator, Map<String, Set<String>> tags) throws IOException {
         generator.writeObjectFieldStart(TAGS);
         for (Map.Entry<String, Set<String>> tag : tags.entrySet()) {
-            generator.writeArrayFieldStart(tag.getKey());
-            for (String tagValue : tag.getValue()) {
-                generator.writeString(tagValue);
+            if (tag.getValue().size() == 1) {
+                generator.writeStringField(tag.getKey(), tag.getValue().iterator().next());
+            } else {
+                generator.writeArrayFieldStart(tag.getKey());
+                for (String tagValue : tag.getValue()) {
+                    generator.writeString(tagValue);
+                }
+                generator.writeEndArray();
             }
-            generator.writeEndArray();
         }
         generator.writeEndObject();
     }


### PR DESCRIPTION
If there is only one value for a tag then send it as a string instead of an array of strings.

This means tags appear in Sentry as `value` instead of as `[u'value']`.
