### PR TITLE
Fix so that raven-sentry compiles on JDK-6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 script: mvn verify
+jdk:
+  - oraclejdk7
+  - openjdk6

--- a/raven/src/test/java/net/kencochrane/raven/connection/HttpConnectionTest.java
+++ b/raven/src/test/java/net/kencochrane/raven/connection/HttpConnectionTest.java
@@ -6,6 +6,7 @@ import net.kencochrane.raven.event.Event;
 import net.kencochrane.raven.event.EventBuilder;
 import net.kencochrane.raven.marshaller.Marshaller;
 import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -119,13 +120,14 @@ public class HttpConnectionTest {
         httpConnection.send(new EventBuilder().build());
 
         verify(handler).publish(logRecordCaptor.capture());
-        assertThat(logRecordCaptor.getAllValues(),
-                hasItem(new CustomTypeSafeMatcher<LogRecord>("Looks for message '" + httpErrorMessage + "'") {
-                    @Override
-                    protected boolean matchesSafely(LogRecord logRecord) {
-                        return httpErrorMessage.equals(logRecord.getMessage());
-                    }
-                }));
+        Matcher<Iterable<? super LogRecord>> matcher = hasItem(
+                new CustomTypeSafeMatcher<LogRecord>("Looks for message '" + httpErrorMessage + "'") {
+            @Override
+            protected boolean matchesSafely(LogRecord logRecord) {
+                return httpErrorMessage.equals(logRecord.getMessage());
+            }
+        });
+        assertThat(logRecordCaptor.getAllValues(), matcher);
 
         Logger.getLogger(HttpConnection.class.getCanonicalName()).removeHandler(handler);
     }


### PR DESCRIPTION
Currently the top-level POM specifies only JDK 6 and raven-java wasn't compiling successfully against it. The error was:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:testCompile (default-testCompile) on project raven: Compilation failure
[ERROR] /Users/buckett/Documents/raven-java/raven/src/test/java/net/kencochrane/raven/connection/HttpConnectionTest.java:[122,8] cannot find symbol
[ERROR] symbol  : method assertThat(java.util.List<java.util.logging.LogRecord>,org.hamcrest.Matcher<java.lang.Iterable<? super java.lang.Object>>)
[ERROR] location: class net.kencochrane.raven.connection.HttpConnectionTest
