### PR TITLE
Fix NullPointerException if exception is in the default package

### DIFF
--- a/raven/src/main/java/net/kencochrane/raven/marshaller/json/ExceptionInterfaceBinding.java
+++ b/raven/src/main/java/net/kencochrane/raven/marshaller/json/ExceptionInterfaceBinding.java
@@ -96,7 +96,10 @@ public class ExceptionInterfaceBinding implements InterfaceBinding<ExceptionInte
         generator.writeStartObject();
         generator.writeStringField(TYPE_PARAMETER, ewst.exception.getActualClass().getSimpleName());
         generator.writeStringField(VALUE_PARAMETER, ewst.exception.getMessage());
-        generator.writeStringField(MODULE_PARAMETER, ewst.exception.getActualClass().getPackage().getName());
+        // getPackage() can return null e.g. if the exception is in the default package
+        if (ewst.exception.getActualClass().getPackage() != null) {
+            generator.writeStringField(MODULE_PARAMETER, ewst.exception.getActualClass().getPackage().getName());
+        }
 
         generator.writeFieldName(STACKTRACE_PARAMETER);
         stackTraceInterfaceBinding.writeInterface(generator, ewst.stackTrace);


### PR DESCRIPTION
getPackage() returns null if the class is in the default package so
getPackage().getName() would result in a NullPointerException in
this scenario.

I discovered this when writing some example code for investigating an unrelated issue with Sentry.
It's a bit of an edge case but seems worth adding a fix for it.
