### PR TITLE
allow subclasses of HttpConnection to read error

### DIFF
--- a/raven/src/main/java/net/kencochrane/raven/connection/HttpConnection.java
+++ b/raven/src/main/java/net/kencochrane/raven/connection/HttpConnection.java
@@ -135,7 +135,7 @@ public class HttpConnection extends AbstractConnection {
         }
     }
 
-    private String getErrorMessageFromStream(InputStream errorStream) {
+    protected String getErrorMessageFromStream(InputStream errorStream) {
         BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream, Charsets.UTF_8));
         StringBuilder sb = new StringBuilder();
         try {


### PR DESCRIPTION
I'm working on integrating Raven into my App Engine application. 

The problem with this is that since the platform does not support threads I need to split the whole process into 2 parts: (1) collect and marshal the event & (2) send it. The last part is being done with an asynchronous message queue.

So I subclassed `HttpConnection` in order to re-use most of the logic for sending the event. But my implementation receives a `String` and not an `Event`. So I wrote my own `doSend` method, but obviously want to re-use the `getErrorMessageFromStream` - hence this change.
