### PR TITLE
fix README for java.util.logging configuration

### DIFF
--- a/raven/README.md
+++ b/raven/README.md
@@ -33,7 +33,7 @@ Relies on:
 In the `logging.properties` file set:
 
 ```properties
-level=WARN
+net.kencochrane.raven.jul.SentryHandler.level=WARN
 handlers=net.kencochrane.raven.jul.SentryHandler
 net.kencochrane.raven.jul.SentryHandler.dsn=https://publicKey:secretKey@host:port/1?options
 net.kencochrane.raven.jul.SentryHandler.tags=tag1:value1,tag2:value2


### PR DESCRIPTION
level needs to be set for the handler (or, if it's global, I believe it needs a dot prefix: ".level")
