### PR TITLE
Allow the static client to be auto-initialized again after a call to …

### DIFF
--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -195,6 +195,9 @@ public final class Sentry {
 
         storedClient.closeConnection();
         storedClient = null;
+
+        // Allow the client to be auto initialized on the next use.
+        autoInitAttempted.set(false);
     }
 
 }


### PR DESCRIPTION
…close.

The static `Sentry.___` API will auto-init using the configuration lookup code.

A `Sentry.close()` method is provided for users that aren't using an integration and want to flush the async queue (typically only used on shutdown).

BUT, if a user touches the `Sentry.___` API after a close they'll get NPEs rather than the client re-opening.

However, I could see arguments for always throwing errors after `close` is called... It seems nicer to me for `Sentry.___` to always just work though? This problem was mentioned in #407, I think maybe shutdown/restart is more common in full blown application servers?