### PR TITLE
Overhaul documentation for new configuration style.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -193,7 +193,8 @@ To set the application distribution that will be sent with each event, use the
 
 ::
 
-    release=1.0.0&dist=x86
+    release=1.0.0
+    dist=x86
 
 Note that the distribution is only useful (and used) if the ``release`` is also
 set.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,13 +1,95 @@
+.. _configuration:
+
 Configuration
 =============
 
 **Note:** Sentry's library and framework integration documentation explains how to to do
-basic Sentry configuration for each of the supported integrations. The configuration
-below is typically for more advanced use cases and can be used in combination any of the other
-integrations *once you set Sentry up with the integration*. Please check the integration
-documentation before you attempt to do any advanced configuration.
+the initial Sentry configuration for each of the supported integrations. The configuration
+below can be used in combination with any of the integrations *once you set Sentry up with
+the integration*. Please check :ref:`the integration documentation <integrations>` before
+you attempt to do any advanced configuration.
 
-Most of Sentry's advanced configuration happens by setting options in your DSN, as seen below.
+Configuration via properties file
+---------------------------------
+
+The ``sentry-java`` SDK can be configured via a ``sentry.properties`` file placed at the root of
+your classpath, which is typically achieved by adding a ``src/main/resources/sentry.properties`` file
+to your project. This file follows the standard `.properties file format <https://en.wikipedia.org/wiki/.properties>`_
+and thus contains one option per line.
+
+Because this file is bundled with your application, the values cannot be changed easily at
+runtime. For this reason, the properties file is useful for setting defaults or options
+that you don't expect to change often. The properties file is the last place checked for
+each option value, so runtime configuration (described below) will override it if available.
+
+Option names in the property file exactly match the examples given below. For example, to enable
+sampling, in your ``sentry.properties`` file:
+
+.. sourcecode:: properties
+
+    sample.rate=0.75
+
+Configuration via the runtime environment
+-----------------------------------------
+
+This is the most flexible method for configuring the Sentry client
+because it can be easily changed based on the environment you run your
+application in.
+
+Two methods are available for runtime configuration, checked in this order: Java System Properties
+and System Environment Variables.
+
+Java System Property option names are exactly like the examples given below except that they are
+prefixed with ``sentry.``. For example, to enable sampling:
+
+.. sourcecode:: shell
+
+    java -Dsentry.sample.rate=0.75 -jar app.jar
+
+System Environment Variable option names require that you replace the ``.`` with ``_``, capitalize
+them, and add a ``SENTRY_`` prefix. For example, to enable sampling:
+
+.. sourcecode:: shell
+
+    SENTRY_SAMPLE_RATE=0.75 java -jar app.jar
+
+Configuration via the DSN
+-------------------------
+
+The SDK can also be configured by setting querystring parameters on the DSN itself. This is a bit
+recursive because your DSN itself is an option that you must set somewhere (and not in the DSN!).
+
+Option names in the DSN exactly match the examples given below. For example, to enable sampling
+if you are setting your DSN via the environment:
+
+.. sourcecode:: shell
+
+    SENTRY_DSN=http://public:private@host:port/1?sample.rate=0.75 java -jar app.jar
+
+DSN (Data Source Name)
+======================
+
+The DSN is the first and most important option to configure because it tells the SDK where
+to send events. You can find a basic DSN in the "Client Keys" section of your "Project Settings"
+in Sentry. It can be configured anywhere except for in the DSN itself.
+
+In your ``sentry.properties``:
+
+.. sourcecode:: properties
+
+    dsn=http://public:private@host:port/1
+
+Via the Java System Properties:
+
+.. sourcecode:: shell
+
+    java -Dsentry.dsn=http://public:private@host:port/1 -jar app.jar
+
+Via a System Environment Variable:
+
+.. sourcecode:: shell
+
+    SENTRY_DSN=http://public:private@host:port/1 java -jar app.jar
 
 Connection and Protocol
 -----------------------
@@ -51,7 +133,7 @@ It is possible to use an unencrypted connection to Sentry via HTTP:
 If not provided, the port will default to ``80``.
 
 Using a Proxy
-~~~~~~~~~~~~~
+-------------
 
 If your application needs to send outbound requests through an HTTP proxy,
 you can configure the proxy information via JVM networking properties or
@@ -79,97 +161,89 @@ See `Java Networking and
 Proxies <http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_
 for more information about the proxy properties.
 
-Alternatively, using the Sentry DSN (only affects the Sentry HTTP client,
+Alternatively, using Sentry options (only affects the Sentry HTTP client,
 useful inside shared application containers),
 
 ::
 
-    http://public:private@host:port/1?http.proxy.host=proxy.example.com&http.proxy.port=8080
+    http.proxy.host=proxy.example.com
+    http.proxy.port=8080
 
 Options
--------
+=======
 
-It is possible to enable some options by adding data to the query string of the
-DSN:
-
-::
-
-    http://public:private@host:port/1?option1=value1&option2&option3=value3
-
-Some options do not require a value, just being declared signifies that the
-option is enabled.
-
+The following options can all be configured as described above: via a ``sentry.properties`` file, via
+Java System Properties, via System Environment variables, or via the DSN.
 
 Release
-~~~~~~~
+-------
 
 To set the application version that will be sent with each event, use the
 ``release`` option:
 
 ::
 
-    http://public:private@host:port/1?release=1.0.0
-
+    release=1.0.0
 
 Distribution
-````````````
+~~~~~~~~~~~~
 
 To set the application distribution that will be sent with each event, use the
 ``dist`` option:
 
 ::
 
-    http://public:private@host:port/1?release=1.0.0&dist=x86
+    release=1.0.0&dist=x86
 
 Note that the distribution is only useful (and used) if the ``release`` is also
 set.
 
 Environment
-~~~~~~~~~~~
+-----------
 
 To set the application environment that will be sent with each event, use the
 ``environment`` option:
 
 ::
 
-    http://public:private@host:port/1?environment=staging
+    environment=staging
 
 Server Name
-~~~~~~~~~~~
+-----------
 
 To set the server name that will be sent with each event, use the
 ``servername`` option:
 
 ::
 
-    http://public:private@host:port/1?servername=host1
+    servername=host1
 
 Tags
-~~~~
+----
 
 To set tags that will be sent with each event, use the ``tags`` option with
 comma separated pairs of keys and values that are joined by a colon:
 
 ::
 
-    http://public:private@host:port/1?tags=tag1:value1,tag2:value2
+    tags=tag1:value1,tag2:value2
 
 Extra Tags
-``````````
+----------
 
 To set extras that are extracted and used as additional tags, use the
 ``extratags`` option with comma separated key names.
 
 ::
 
-    http://public:private@host:port/1?extratags=foo,bar
+    extratags=foo,bar
 
 Note that how these extra tags are used depends on which integration you are
 using. For example: when using a logging integration any SLF4J MDC keys that
 are in the extra tags set will be extracted and set as tags on events.
 
 Async Connection
-~~~~~~~~~~~~~~~~
+----------------
 
 In order to avoid performance issues due to a large amount of logs being
 generated or a slow connection to the Sentry server, an asynchronous connection
@@ -179,10 +253,10 @@ To disable the async mode, add async=false`` to the DSN:
 
 ::
 
-    http://public:private@host:port/1?async=false
+    async=false
 
 Graceful Shutdown (Advanced)
-````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to shutdown the asynchronous connection gracefully, a ``ShutdownHook``
 is created. By default, the asynchronous connection is given 1 second
@@ -191,7 +265,7 @@ async.shutdowntimeout`` (represented in milliseconds):
 
 ::
 
-    http://public:private@host:port/1?async.shutdowntimeout=5000
+    async.shutdowntimeout=5000
 
 The special value ``-1`` can be used to disable the timeout and wait
 indefinitely for the executor to terminate.
@@ -210,10 +284,10 @@ The option to do so is async.gracefulshutdown``:
 
 ::
 
-    http://public:private@host:port/1?async.gracefulshutdown=false
+    async.gracefulshutdown=false
 
 Queue Size (Advanced)
-`````````````````````
+~~~~~~~~~~~~~~~~~~~~~
 
 The default queue used to store unprocessed events is limited to 50
 items. Additional items added once the queue is full are dropped and
@@ -225,7 +299,7 @@ It is possible to set a maximum with the option async.queuesize``:
 
 ::
 
-    http://public:private@host:port/1?async.queuesize=100
+    async.queuesize=100
 
 This means that if the connection to the Sentry server is down, only the 100
 most recent events will be stored and processed as soon as the server is back up.
@@ -235,7 +309,7 @@ that network connectivity or Sentry server issues could mean your process
 will run out of memory.
 
 Threads Count (Advanced)
-````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default the thread pool used by the async connection contains one thread per
 processor available to the JVM.
@@ -245,10 +319,10 @@ only one thread) with the option async.threads``:
 
 ::
 
-    http://public:private@host:port/1?async.threads=1
+    async.threads=1
 
 Threads Priority (Advanced)
-```````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In most cases sending logs to Sentry isn't as important as an application
 running smoothly, so the threads have a
@@ -259,10 +333,10 @@ with the option async.priority``:
 
 ::
 
-    http://public:private@host:port/1?async.priority=10
+    async.priority=10
 
 Buffering Events to Disk
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Sentry can be configured to write events to a specified directory on disk
 anytime communication with the Sentry server fails with the buffer.dir``
@@ -272,14 +346,14 @@ Sentry always requires write permission on the buffer directory itself.
 
 ::
 
-    http://public:private@host:port/1?buffer.dir=sentry-events
+    buffer.dir=sentry-events
 
 The maximum number of events that will be stored on disk defaults to 50,
 but can also be configured with the option buffer.size``:
 
 ::
 
-    http://public:private@host:port/1?buffer.size=100
+    buffer.size=100
 
 If a buffer directory is provided, a background thread will periodically
 attempt to re-send the events that are found on disk. By default it will
@@ -288,10 +362,10 @@ buffer.flushtime`` option (in milliseconds):
 
 ::
 
-    http://public:private@host:port/1?buffer.flushtime=10000
+    buffer.flushtime=10000
 
 Graceful Shutdown (Advanced)
-````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to shutdown the buffer flushing thread gracefully, a ``ShutdownHook``
 is created. By default, the buffer flushing thread is given 1 second
@@ -300,7 +374,7 @@ buffer.shutdowntimeout`` (represented in milliseconds):
 
 ::
 
-    http://public:private@host:port/1?buffer.shutdowntimeout=5000
+    buffer.shutdowntimeout=5000
 
 The special value ``-1`` can be used to disable the timeout and wait
 indefinitely for the executor to terminate.
@@ -316,23 +390,23 @@ by setting the buffer.gracefulshutdown`` option:
 
 ::
 
-    http://public:private@host:port/1?buffer.gracefulshutdown=false
+    buffer.gracefulshutdown=false
 
 Event Sampling
-~~~~~~~~~~~~~~
+--------------
 
 Sentry can be configured to sample events with the sample.rate`` option:
 
 ::
 
-    http://public:private@host:port/1?sample.rate=0.75
+    sample.rate=0.75
 
 This option takes a number from 0.0 to 1.0, representing the percent of
 events to allow through to server (from 0% to 100%). By default all
 events will be sent to the Sentry server.
 
 "In Application" Stack Frames
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 Sentry differentiates stack frames that are directly related to your application
 ("in application") from stack frames that come from other packages such as the
@@ -345,10 +419,10 @@ stacktrace.app.packages`` option, which takes a comma separated list.
 
 ::
 
-    http://public:private@host:port/1?stacktrace.app.packages=com.mycompany,com.other.name
+    stacktrace.app.packages=com.mycompany,com.other.name
 
 Same Frame as Enclosing Exception
-`````````````````````````````````
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sentry can use the "in application" system to hide frames in chained exceptions. Usually when a
 StackTrace is printed, the result looks like this:
@@ -376,10 +450,10 @@ To enable a similar behaviour in Sentry use the stacktrace.hidecommon`` option.
 
 ::
 
-    http://public:private@host:port/1?stacktrace.hidecommon
+    stacktrace.hidecommon
 
 Compression
-~~~~~~~~~~~
+-----------
 
 By default the content sent to Sentry is compressed before being sent.
 However, compressing and encoding the data adds a small CPU and memory hit which
@@ -394,20 +468,20 @@ compression``
 
 ::
 
-    http://public:private@host:port/1?compression=false
+    compression=false
 
 Max Message Size
-~~~~~~~~~~~~~~~~
+----------------
 
 By default only the first 1000 characters of a message will be sent to
 the server. This can be changed with the maxmessagelength`` option.
 
 ::
 
-    http://public:private@host:port/1?maxmessagelength=1500
+    maxmessagelength=1500
 
 Timeout (Advanced)
-~~~~~~~~~~~~~~~~~~
+------------------
 
 A timeout is set to avoid blocking Sentry threads because establishing a
 connection is taking too long.
@@ -417,18 +491,17 @@ It's possible to manually set the timeout length with timeout``
 
 ::
 
-    http://public:private@host:port/1?timeout=10000
+    timeout=10000
 
 Custom SentryClientFactory
---------------------------
+==========================
 
 At times, you may require custom functionality that is not included in ``sentry-java``
 already. The most common way to do this is to create your own ``SentryClientFactory`` instance
-as seen in the example below. See the documentation for the integration you use to find out how to
-configure it to use your custom ``SentryClientFactory``.
+as seen in the example below.
 
 Implementation
-~~~~~~~~~~~~~~
+--------------
 
 .. sourcecode:: java
 
@@ -448,3 +521,14 @@ Implementation
         }
     }
 
+Usage
+-----
+
+To use your custom ``SentryClientFactory`` implementation, use the ``factory`` option:
+
+::
+
+    factory=my.company.SentryClientFactory
+
+Your factory class will need to be available on your classpath with a zero argument constructor
+or an error will be thrown.

--- a/docs/context.rst
+++ b/docs/context.rst
@@ -45,11 +45,11 @@ the current context.
 
         /**
          * Examples using the (recommended) static API.
-         *
-         * Note that the ``Sentry.init`` method must be called before the static API
-         * is used, otherwise a ``NullPointerException`` will be thrown.
          */
         public void staticAPIExample() {
+            // Manually initialize the static client, you may also pass in a DSN and/or
+            // SentryClientFactory to use. Note that the client will attempt to automatically
+            // initialize on the first use of the static API, so this isn't strictly necessary.
             Sentry.init();
 
             // Set the current user in the context.
@@ -72,6 +72,7 @@ the current context.
          * Examples that use the SentryClient instance directly.
          */
         public void instanceAPIExample() {
+            // Create a SentryClient instance that you manage manually.
             SentryClient sentryClient = SentryClientFactory.sentryClient();
 
             // Get the current context instance.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,11 @@ Sentry for Java (``sentry-java``) is the official Java SDK for Sentry. At its co
 a raw client for sending events to Sentry, but it is highly recommended that you
 use one of the included library or framework integrations listed below if at all possible.
 
+**Note:** ``raven-java`` is no longer maintained. It is highly recommended that
+you migrate to ``sentry-java`` (which this documentation covers). If you are still
+using ``raven-java`` you can
+`find the old documentation here <https://github.com/getsentry/sentry-java/tree/raven-java-8.x/docs>`_.
+
 .. toctree::
     :maxdepth: 2
     :titlesonly:

--- a/docs/modules/android.rst
+++ b/docs/modules/android.rst
@@ -12,7 +12,7 @@ Proguard only increased the release ``.apk`` size by approximately 200KB.
 Events will be `buffered to disk <https://docs.sentry.io/clients/java/config/#buffering-events-to-disk>`_
 (in the application's cache directory) by default. This allows events to be sent at a
 later time if the device does not have connectivity when an event is created. This can
-be disabled by setting the DSN option ``sentry.buffer.enabled`` to ``false``.
+be disabled by setting the DSN option ``buffer.enabled`` to ``false``.
 
 An ``UncaughtExceptionHandler`` is configured so that crash events will be
 stored to disk and sent the next time the application is run.

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -1,3 +1,5 @@
+.. _integrations:
+
 Integrations
 ============
 

--- a/docs/modules/log4j.rst
+++ b/docs/modules/log4j.rst
@@ -9,6 +9,11 @@ that sends logged exceptions to Sentry.
 The source can be found `on Github
 <https://github.com/getsentry/sentry-java/tree/master/sentry-log4j>`_.
 
+**Note:** ``raven-log4j`` is no longer maintained. It is highly recommended that
+you migrate to ``sentry-log4j`` (which this documentation covers). If you are still
+using ``raven-log4j`` you can
+`find the old documentation here <https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/log4j.rst>`_.
+
 Installation
 ------------
 
@@ -95,138 +100,7 @@ Alternatively, using  the ``log4j.xml`` format:
     </log4j:configuration>
 
 Next, **you'll need to configure your DSN** (client key) and optionally other values such as
-``environment`` and ``release``. See below for the two ways you can do this.
-
-Configuration via Runtime Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is the most flexible method for configuring the ``SentryAppender``,
-because it can be easily changed based on the environment you run your
-application in.
-
-The following can be set as System Environment variables:
-
-.. sourcecode:: shell
-
-    SENTRY_EXAMPLE=xxx java -jar app.jar
-
-Or as Java System Properties:
-
-.. sourcecode:: shell
-
-    java -Dsentry.example=xxx -jar app.jar
-
-Configuration parameters follow:
-
-======================== ======================== =============================== ===========
-Environment variable     Java System Property     Example value                   Description
-======================== ======================== =============================== ===========
-``SENTRY_DSN``           ``sentry.dsn``           ``https://host:port/1?options`` Your Sentry DSN (client key), if left blank Sentry will no-op
-``SENTRY_RELEASE``       ``sentry.release``       ``1.0.0``                       Optional, provide release version of your application
-``SENTRY_ENVIRONMENT``   ``sentry.environment``   ``production``                  Optional, provide environment your application is running in
-``SENTRY_SERVERNAME``    ``sentry.servername``    ``server1``                     Optional, override the server name (rather than looking it up dynamically)
-``SENTRY_FACTORY``       ``sentry.factory``       ``com.foo.SentryClientFactory`` Optional, select the SentryClientFactory class
-``SENTRY_TAGS``          ``sentry.tags``          ``tag1:value1,tag2:value2``     Optional, provide tags
-``SENTRY_EXTRATAGS``     ``sentry.extratags``     ``foo,bar,baz``                 Optional, provide tag names to be extracted from MDC
-======================== ======================== =============================== ===========
-
-Configuration via Static File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also configure everything statically within the ``log4j.properties`` or ``log4j.xml``
-file itself. This is less flexible and not recommended because it's more difficult to change
-the values when you run your application in different environments.
-
-Example configuration in the ``log4j.properties`` file:
-
-.. sourcecode:: ini
-
-    # Enable the Console and Sentry appenders
-    log4j.rootLogger=INFO, Console, Sentry
-
-    # Configure the Console appender
-    log4j.appender.Console=org.apache.log4j.ConsoleAppender
-    log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-    log4j.appender.Console.layout.ConversionPattern=%d{HH:mm:ss.SSS} [%t] %-5p: %m%n
-
-    # Configure the Sentry appender, overriding the logging threshold to the WARN level
-    log4j.appender.Sentry=io.sentry.log4j.SentryAppender
-    log4j.appender.Sentry.threshold=WARN
-
-    # Set the Sentry DSN
-    log4j.appender.Sentry.dsn=https://host:port/1?options
-
-    # Optional, provide release version of your application
-    log4j.appender.Sentry.release=1.0.0
-
-    # Optional, provide environment your application is running in
-    log4j.appender.Sentry.environment=production
-
-    # Optional, override the server name (rather than looking it up dynamically)
-    log4j.appender.Sentry.serverName=server1
-
-    # Optional, select the SentryClientFactory class
-    log4j.appender.Sentry.factory=com.foo.SentryClientFactory
-
-    # Optional, provide tags
-    log4j.appender.Sentry.tags=tag1:value1,tag2:value2
-
-    # Optional, provide tag names to be extracted from MDC
-    log4j.appender.Sentry.extraTags=foo,bar,baz
-
-Alternatively, using  the ``log4j.xml`` format:
-
-.. sourcecode:: xml
-
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-    <log4j:configuration debug="true"
-    	xmlns:log4j='http://jakarta.apache.org/log4j/'>
-
-        <!-- Configure the Console appender -->
-    	<appender name="Console" class="org.apache.log4j.ConsoleAppender">
-    	    <layout class="org.apache.log4j.PatternLayout">
-    		<param name="ConversionPattern"
-    		       value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
-    	    </layout>
-    	</appender>
-
-        <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
-        <appender name="Sentry" class="io.sentry.log4j.SentryAppender">
-            <!-- Override the Sentry handler log level to WARN -->
-            <filter class="org.apache.log4j.varia.LevelRangeFilter">
-                <param name="levelMin" value="WARN" />
-            </filter>
-
-            <!-- Set Sentry DSN -->
-            <param name="dsn" value="https://host:port/1?options" />
-
-            <!-- Optional, provide release version of your application -->
-            <param name="release" value="1.0.0" />
-
-            <!-- Optional, provide environment your application is running in -->
-            <param name="environment" value="production" />
-
-            <!-- Optional, override the server name (rather than looking it up dynamically) -->
-            <param name="serverName" value="server1" />
-
-            <!-- Optional, select the SentryClientFactory class -->
-            <param name="factory" value="com.foo.SentryClientFactory" />
-
-            <!-- Optional, provide tags -->
-            <param name="tags" value="tag1:value1,tag2:value2" />
-
-            <!-- Optional, provide tag names to be extracted from MDC -->
-            <param name="extraTags" value="foo,bar,baz" />
-        </appender>
-
-        <!-- Enable the Console and Sentry appenders, Console is provided as an example
-             of a non-Sentry logger that is set to a different logging threshold -->
-        <root level="INFO">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </root>
-    </log4j:configuration>
+``environment`` and ``release``. :ref:`See the configuration page <configuration>` for ways you can do this.
 
 Additional Data
 ---------------
@@ -241,13 +115,9 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extraTags`` parameter in your configuration file you can
+specifying the ``extratags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
-
-.. sourcecode:: ini
-
-    log4j.appender.SentryAppender.extraTags=Environment,OS
 
 .. sourcecode:: java
 
@@ -256,7 +126,7 @@ filters within the Sentry UI.
         MDC.put("Environment", "Development");
         MDC.put("OS", "Linux");
 
-        // This sends an event where the Environment and OS MDC values are set as tags
+        // This sends an event where the Environment and OS MDC values are set as additional data
         logger.error("This is a test");
     }
 

--- a/docs/modules/log4j2.rst
+++ b/docs/modules/log4j2.rst
@@ -9,6 +9,11 @@ that sends logged exceptions to Sentry.
 The source can be found `on Github
 <https://github.com/getsentry/sentry-java/tree/master/sentry-log4j2>`_.
 
+**Note:** ``raven-log4j2`` is no longer maintained. It is highly recommended that
+you migrate to ``sentry-log4j2`` (which this documentation covers). If you are still
+using ``raven-log4j2`` you can
+`find the old documentation here <https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/log4j2.rst>`_.
+
 Installation
 ------------
 
@@ -69,91 +74,7 @@ Example configuration using the ``log4j2.xml`` format:
     </configuration>
 
 Next, **you'll need to configure your DSN** (client key) and optionally other values such as
-``environment`` and ``release``. See below for the two ways you can do this.
-
-Configuration via Runtime Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is the most flexible method for configuring the ``SentryAppender``,
-because it can be easily changed based on the environment you run your
-application in.
-
-The following can be set as System Environment variables:
-
-.. sourcecode:: shell
-
-    SENTRY_EXAMPLE=xxx java -jar app.jar
-
-Or as Java System Properties:
-
-.. sourcecode:: shell
-
-    java -Dsentry.example=xxx -jar app.jar
-
-Configuration parameters follow:
-
-======================== ======================== =============================== ===========
-Environment variable     Java System Property     Example value                   Description
-======================== ======================== =============================== ===========
-``SENTRY_DSN``           ``sentry.dsn``           ``https://host:port/1?options`` Your Sentry DSN (client key), if left blank Sentry will no-op
-``SENTRY_RELEASE``       ``sentry.release``       ``1.0.0``                       Optional, provide release version of your application
-``SENTRY_ENVIRONMENT``   ``sentry.environment``   ``production``                  Optional, provide environment your application is running in
-``SENTRY_SERVERNAME``    ``sentry.servername``    ``server1``                     Optional, override the server name (rather than looking it up dynamically)
-``SENTRY_FACTORY``       ``sentry.factory``       ``com.foo.SentryClientFactory`` Optional, select the SentryClientFactory class
-``SENTRY_TAGS``          ``sentry.tags``          ``tag1:value1,tag2:value2``     Optional, provide tags
-``SENTRY_EXTRATAGS``     ``sentry.extratags``     ``foo,bar,baz``                 Optional, provide tag names to be extracted from MDC
-======================== ======================== =============================== ===========
-
-Configuration via Static File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also configure everything statically within the ``log4j2.xml``
-file itself. This is less flexible and not recommended because it's more difficult to change
-the values when you run your application in different environments.
-
-Example configuration in the ``log4j.properties`` file:
-
-.. sourcecode:: xml
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <configuration status="warn" packages="org.apache.logging.log4j.core,io.sentry.log4j2">
-        <appenders>
-            <Console name="Console" target="SYSTEM_OUT">
-                <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
-            </Console>
-
-            <Sentry name="Sentry">
-                <!-- Set Sentry DSN -->
-                <dsn>https://host:port/1?options</dsn>
-
-                <!-- Optional, provide release version of your application -->
-                <release>1.0.0</release>
-
-                <!-- Optional, provide environment your application is running in -->
-                <environment>production</environment>
-
-                <!-- Optional, override the server name (rather than looking it up dynamically) -->
-                <serverName>server1</serverName>
-
-                <!-- Optional, select the SentryClientFactory class -->
-                <factory>com.foo.SentryClientFactory</factory>
-
-                <!-- Optional, provide tags -->
-                <tags>tag1:value1,tag2:value2</tags>
-
-                <!-- Optional, provide tag names to be extracted from MDC -->
-                <extraTags>foo,bar,baz</extraTags>
-            </Sentry>
-        </appenders>
-
-        <loggers>
-            <root level="INFO">
-                <appender-ref ref="Console" />
-                <!-- Note that the Sentry logging threshold is overridden to the WARN level -->
-                <appender-ref ref="Sentry" level="WARN" />
-            </root>
-        </loggers>
-    </configuration>
+``environment`` and ``release``. :ref:`See the configuration page <configuration>` for ways you can do this.
 
 Additional Data
 ---------------
@@ -166,13 +87,9 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extraTags`` parameter in your configuration file you can
+specifying the ``extratags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
-
-.. sourcecode:: xml
-
-    <extraTags>Environment,OS</extraTags>
 
 .. sourcecode:: java
 
@@ -181,7 +98,7 @@ filters within the Sentry UI.
         MDC.put("Environment", "Development");
         MDC.put("OS", "Linux");
 
-        // This sends an event where the Environment and OS MDC values are set as tags
+        // This sends an event where the Environment and OS MDC values are set as additional data
         logger.error("This is a test");
     }
 

--- a/docs/modules/logback.rst
+++ b/docs/modules/logback.rst
@@ -9,6 +9,11 @@ that sends logged exceptions to Sentry.
 The source can be found `on Github
 <https://github.com/getsentry/sentry-java/tree/master/sentry-logback>`_.
 
+**Note:** ``raven-logback`` is no longer maintained. It is highly recommended that
+you migrate to ``sentry-logback`` (which this documentation covers). If you are still
+using ``raven-logback`` you can
+`find the old documentation here <https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/logback.rst>`_.
+
 Installation
 ------------
 
@@ -73,95 +78,7 @@ Example configuration using the ``logback.xml`` format:
     </configuration>
 
 Next, **you'll need to configure your DSN** (client key) and optionally other values such as
-``environment`` and ``release``. See below for the two ways you can do this.
-
-Configuration via Runtime Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is the most flexible method for configuring the ``SentryAppender``,
-because it can be easily changed based on the environment you run your
-application in.
-
-The following can be set as System Environment variables:
-
-.. sourcecode:: shell
-
-    SENTRY_EXAMPLE=xxx java -jar app.jar
-
-Or as Java System Properties:
-
-.. sourcecode:: shell
-
-    java -Dsentry.example=xxx -jar app.jar
-
-Configuration parameters follow:
-
-======================== ======================== =============================== ===========
-Environment variable     Java System Property     Example value                   Description
-======================== ======================== =============================== ===========
-``SENTRY_DSN``           ``sentry.dsn``           ``https://host:port/1?options`` Your Sentry DSN (client key), if left blank Sentry will no-op
-``SENTRY_RELEASE``       ``sentry.release``       ``1.0.0``                       Optional, provide release version of your application
-``SENTRY_ENVIRONMENT``   ``sentry.environment``   ``production``                  Optional, provide environment your application is running in
-``SENTRY_SERVERNAME``    ``sentry.servername``    ``server1``                     Optional, override the server name (rather than looking it up dynamically)
-``SENTRY_FACTORY``       ``sentry.factory``       ``com.foo.SentryClientFactory`` Optional, select the SentryClientFactory class
-``SENTRY_TAGS``          ``sentry.tags``          ``tag1:value1,tag2:value2``     Optional, provide tags
-``SENTRY_EXTRATAGS``     ``sentry.extratags``     ``foo,bar,baz``                 Optional, provide tag names to be extracted from MDC
-======================== ======================== =============================== ===========
-
-Configuration via Static File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also configure everything statically within the ``logback.xml``
-file itself. This is less flexible and not recommended because it's more difficult to change
-the values when you run your application in different environments.
-
-Example configuration in the ``logback.xml`` file:
-
-.. sourcecode:: xml
-
-    <configuration>
-        <!-- Configure the Console appender -->
-        <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder>
-                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-            </encoder>
-        </appender>
-
-        <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
-        <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                <level>WARN</level>
-            </filter>
-
-            <!-- Set Sentry DSN -->
-            <dsn>https://host:port/1?options</dsn>
-
-            <!-- Optional, provide release version of your application -->
-            <release>1.0.0</release>
-
-            <!-- Optional, provide environment your application is running in -->
-            <environment>production</environment>
-
-            <!-- Optional, override the server name (rather than looking it up dynamically) -->
-            <serverName>server1</serverName>
-
-            <!-- Optional, select the SentryClientFactory class -->
-            <factory>com.foo.SentryClientFactory</factory>
-
-            <!-- Optional, provide tags -->
-            <tags>tag1:value1,tag2:value2</tags>
-
-            <!-- Optional, provide tag names to be extracted from MDC -->
-            <extraTags>foo,bar,baz</extraTags>
-        </appender>
-
-        <!-- Enable the Console and Sentry appenders, Console is provided as an example
-             of a non-Sentry logger that is set to a different logging threshold -->
-        <root level="INFO">
-            <appender-ref ref="Console" />
-            <appender-ref ref="Sentry" />
-        </root>
-    </configuration>
+``environment`` and ``release``. :ref:`See the configuration page <configuration>` for ways you can do this.
 
 Additional Data
 ---------------
@@ -173,13 +90,9 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extraTags`` parameter in your configuration file you can
+specifying the ``extratags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
-
-.. sourcecode:: xml
-
-    <extraTags>Environment,OS</extraTags>
 
 .. sourcecode:: java
 
@@ -188,7 +101,7 @@ filters within the Sentry UI.
         MDC.put("Environment", "Development");
         MDC.put("OS", "Linux");
 
-        // This sends an event where the Environment and OS MDC values are set as tags
+        // This sends an event where the Environment and OS MDC values are set as additional data
         logger.error("This is a test");
     }
 

--- a/docs/modules/sentry.rst
+++ b/docs/modules/sentry.rst
@@ -5,8 +5,14 @@ The ``sentry`` library provides a `java.util.logging Handler
 <http://docs.oracle.com/javase/7/docs/api/java/util/logging/Handler.html>`_
 that sends logged exceptions to Sentry.
 
-The source for ``sentry-java`` can be found `on Github
+The source for ``sentry`` can be found `on Github
 <https://github.com/getsentry/sentry-java/tree/master/sentry>`_.
+
+**Note:** ``raven`` is no longer maintained. It is highly recommended that
+you migrate to ``sentry`` (which this documentation covers). If you are still
+using ``raven`` you can
+`find the old documentation here <https://github.com/getsentry/sentry-java/blob/raven-java-8.x/docs/modules/raven.rst>`_.
+\
 
 Installation
 ------------
@@ -64,81 +70,7 @@ its value::
     $ java -Djava.util.logging.config.file=/path/to/app.properties MyClass
 
 Next, **you'll need to configure your DSN** (client key) and optionally other values such as
-``environment`` and ``release``. See below for the two ways you can do this.
-
-Configuration via Runtime Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is the most flexible method for configuring the ``SentryHandler``,
-because it can be easily changed based on the environment you run your
-application in.
-
-The following can be set as System Environment variables:
-
-.. sourcecode:: shell
-
-    SENTRY_EXAMPLE=xxx java -jar app.jar
-
-Or as Java System Properties:
-
-.. sourcecode:: shell
-
-    java -Dsentry.example=xxx -jar app.jar
-
-Configuration parameters follow:
-
-======================== ======================== =============================== ===========
-Environment variable     Java System Property     Example value                   Description
-======================== ======================== =============================== ===========
-``SENTRY_DSN``           ``sentry.dsn``           ``https://host:port/1?options`` Your Sentry DSN (client key), if left blank Sentry will no-op
-``SENTRY_RELEASE``       ``sentry.release``       ``1.0.0``                       Optional, provide release version of your application
-``SENTRY_ENVIRONMENT``   ``sentry.environment``   ``production``                  Optional, provide environment your application is running in
-``SENTRY_SERVERNAME``    ``sentry.servername``    ``server1``                     Optional, override the server name (rather than looking it up dynamically)
-``SENTRY_FACTORY``       ``sentry.factory``       ``com.foo.SentryClientFactory`` Optional, select the SentryClientFactory class
-``SENTRY_TAGS``          ``sentry.tags``          ``tag1:value1,tag2:value2``     Optional, provide tags
-``SENTRY_EXTRATAGS``     ``sentry.extratags``     ``foo,bar,baz``                 Optional, provide tag names to be extracted from MDC
-======================== ======================== =============================== ===========
-
-Configuration via Static File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also configure everything statically within the ``logging.properties``
-file itself. This is less flexible and not recommended because it's more difficult to change
-the values when you run your application in different environments.
-
-Example configuration in the ``logging.properties`` file:
-
-.. sourcecode:: ini
-
-    # Enable the Console and Sentry handlers
-    handlers=java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler
-
-    # Set the default log level to INFO
-    .level=INFO
-
-    # Override the Sentry handler log level to WARNING
-    io.sentry.jul.SentryHandler.level=WARNING
-
-    # Set Sentry DSN
-    io.sentry.jul.SentryHandler.dsn=https://host:port/1?options
-
-    # Optional, provide tags
-    io.sentry.jul.SentryHandler.tags=tag1:value1,tag2:value2
-
-    # Optional, provide release version of your application
-    io.sentry.jul.SentryHandler.release=1.0.0
-
-    # Optional, provide environment your application is running in
-    io.sentry.jul.SentryHandler.environment=production
-
-    # Optional, override the server name (rather than looking it up dynamically)
-    io.sentry.jul.SentryHandler.serverName=server1
-
-    # Optional, select the SentryClientFactorclass
-    io.sentry.jul.SentryHandler.factory=com.foo.SentryClientFactory
-
-    # Optional, provide tag names to be extracted from MDC
-    io.sentry.jul.SentryHandler.extraTags=foo,bar,baz
+``environment`` and ``release``. :ref:`See the configuration page <configuration>` for ways you can do this.
 
 In Practice
 -----------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -167,6 +167,9 @@ For more complex messages, you'll need to build an ``Event`` with the
                             .withMessage("This is a test")
                             .withLevel(Event.Level.INFO)
                             .withLogger(MyClass.class.getName());
+
+            // Note that the *unbuilt* EventBuilder instance is passed in so that
+            // EventBuilderHelpers are run to add extra information to your event.
             Sentry.capture(eventBuilder);
         }
 
@@ -180,6 +183,9 @@ For more complex messages, you'll need to build an ``Event`` with the
                                 .withLevel(Event.Level.ERROR)
                                 .withLogger(MyClass.class.getName())
                                 .withSentryInterface(new ExceptionInterface(e));
+
+                // Note that the *unbuilt* EventBuilder instance is passed in so that
+                // EventBuilderHelpers are run to add extra information to your event.
                 Sentry.capture(eventBuilder);
             }
         }


### PR DESCRIPTION
Strips all the duplicate (and now invalid) config out of loggers and explains all the ways you can configure stuff in one place.

I reckon this is easier to skim review by `cd docs && make html` and look in your browser.