### PR TITLE
Cleanup thread local context in ``ThreadLocalContextManager`` after e…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@ Version 1.1.1
 -------------
 
 - Allow overriding the location of the properties file.
-- Add support for handling and uploading Proguard files to Sentry (for Android applications).
+- Add support for handling and uploading Proguard files to Sentry (for Android applications).'
+- Cleanup thread local context in ``ThreadLocalContextManager`` after each servlet request finishes.
 
 Version 1.1.0
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -2,9 +2,8 @@ Version 1.1.1
 -------------
 
 - Allow overriding the location of the properties file.
-- Add support for handling and uploading Proguard files to Sentry (for Android applications).'
-- Cleanup thread local context in ``ThreadLocalContextManager`` after each servlet request finishes.
 - Add support for handling and uploading Proguard files to Sentry (for Android applications).
+- Cleanup thread local context in ``ThreadLocalContextManager`` after each servlet request finishes.
 - Change the ``EventBuilder`` hostname lookup code to only run one thread at a time.
 
 Version 1.1.0

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -182,7 +182,7 @@ public final class Sentry {
      * Clears the current context.
      */
     public static void clearContext() {
-        getStoredClient().getContext().clear();
+        getStoredClient().clearContext();
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -215,6 +215,13 @@ public class SentryClient {
         }
     }
 
+    /**
+     * Clears the {@link ContextManager} data.
+     */
+    public void clearContext() {
+        contextManager.clear();
+    }
+
     public Context getContext() {
         return contextManager.getContext();
     }

--- a/sentry/src/main/java/io/sentry/context/ContextManager.java
+++ b/sentry/src/main/java/io/sentry/context/ContextManager.java
@@ -17,4 +17,9 @@ public interface ContextManager {
      */
     Context getContext();
 
+    /**
+     * Clear the underlying context data.
+     */
+    void clear();
+
 }

--- a/sentry/src/main/java/io/sentry/context/SingletonContextManager.java
+++ b/sentry/src/main/java/io/sentry/context/SingletonContextManager.java
@@ -16,4 +16,9 @@ public class SingletonContextManager implements ContextManager {
     public Context getContext() {
         return context;
     }
+
+    @Override
+    public void clear() {
+        context.clear();
+    }
 }

--- a/sentry/src/main/java/io/sentry/context/ThreadLocalContextManager.java
+++ b/sentry/src/main/java/io/sentry/context/ThreadLocalContextManager.java
@@ -21,4 +21,9 @@ public class ThreadLocalContextManager implements ContextManager {
         return context.get();
     }
 
+    @Override
+    public void clear() {
+        context.remove();
+    }
+
 }

--- a/sentry/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -31,7 +31,7 @@ public class SentryServletRequestListener implements ServletRequestListener {
         try {
             SentryClient sentryClient = Sentry.getStoredClient();
             if (sentryClient != null) {
-                sentryClient.getContext().clear();
+                sentryClient.clearContext();
             }
         } catch (Exception e) {
             logger.error("Error clearing Context state.", e);

--- a/sentry/src/test/java/io/sentry/SentryClientTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.java
@@ -35,7 +35,7 @@ public class SentryClientTest extends BaseTest {
 
     @BeforeMethod
     public void setup() {
-        contextManager.getContext().clear();
+        contextManager.clear();
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryTest.java
@@ -34,7 +34,7 @@ public class SentryTest extends BaseTest {
 
     @BeforeMethod
     public void setup() {
-        contextManager.getContext().clear();
+        contextManager.clear();
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/event/BreadcrumbTest.java
+++ b/sentry/src/test/java/io/sentry/event/BreadcrumbTest.java
@@ -28,7 +28,7 @@ public class BreadcrumbTest extends BaseTest {
 
     @BeforeMethod
     public void setup() {
-        contextManager.getContext().clear();
+        contextManager.clear();
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/event/UserTest.java
+++ b/sentry/src/test/java/io/sentry/event/UserTest.java
@@ -26,7 +26,7 @@ public class UserTest extends BaseTest {
 
     @BeforeMethod
     public void setup() {
-        contextManager.getContext().clear();
+        contextManager.clear();
     }
 
     @Test


### PR DESCRIPTION
…ach servlet request finishes.

---

This is for #420.

The issue was that threadlocals still held references to classes that were loaded with the old classloader -- and there was nothing to ever remove those old references.

I did some research, and there's no way to remove threadlocals except from the thread that created them (which makes sense). So for now, the only place we do cleanup is in the `SentryServletRequestListener`. That should cover most bases, because the most common use of "make a new classloader and reload my entire app" is in application servers that are using servlets.