### PR TITLE
Change the ``EventBuilder`` hostname lookup code to only run one thre…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Version 1.1.1
 
 - Allow overriding the location of the properties file.
 - Add support for handling and uploading Proguard files to Sentry (for Android applications).
+- Change the ``EventBuilder`` hostname lookup code to only run one thread at a time.
 
 Version 1.1.0
 -------------

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -468,7 +468,7 @@ public class EventBuilder {
         /**
          * Time at which the cache should expire.
          */
-        private long expirationTimestamp;
+        private volatile long expirationTimestamp;
         /**
          * Whether a cache update thread is currently running or not.
          */

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -464,7 +464,7 @@ public class EventBuilder {
         /**
          * Current value for hostname (might change over time).
          */
-        private String hostname = DEFAULT_HOSTNAME;
+        private volatile String hostname = DEFAULT_HOSTNAME;
         /**
          * Time at which the cache should expire.
          */

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -12,6 +12,7 @@ import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
 
@@ -460,6 +461,7 @@ public class EventBuilder {
          * Time for which the cache is kept.
          */
         private final long cacheDuration;
+
         /**
          * Current value for hostname (might change over time).
          */
@@ -468,6 +470,10 @@ public class EventBuilder {
          * Time at which the cache should expire.
          */
         private long expirationTimestamp;
+        /**
+         * Whether a cache update thread is currently running or not.
+         */
+        private AtomicBoolean updateRunning = new AtomicBoolean(false);
 
         /**
          * Sets up a cache for the hostname.
@@ -486,7 +492,8 @@ public class EventBuilder {
          * @return the hostname of the current machine.
          */
         public String getHostname() {
-            if (expirationTimestamp < System.currentTimeMillis()) {
+            if (expirationTimestamp < System.currentTimeMillis()
+                && updateRunning.compareAndSet(false, true)) {
                 updateCache();
             }
 
@@ -497,26 +504,31 @@ public class EventBuilder {
          * Force an update of the cache to get the current value of the hostname.
          */
         public void updateCache() {
-            FutureTask<String> futureTask = new FutureTask<>(new HostRetriever());
-            try {
-                new Thread(futureTask).start();
-                logger.debug("Updating the hostname cache");
-                hostname = futureTask.get(GET_HOSTNAME_TIMEOUT, TimeUnit.MILLISECONDS);
-                expirationTimestamp = System.currentTimeMillis() + cacheDuration;
-            } catch (Exception e) {
-                futureTask.cancel(true);
-                expirationTimestamp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(1);
-                logger.warn("Localhost hostname lookup failed, keeping the value '{}'", hostname, e);
-            }
-        }
+            Callable<Void> hostRetriever = new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    try {
+                        hostname = InetAddress.getLocalHost().getCanonicalHostName();
+                        expirationTimestamp = System.currentTimeMillis() + cacheDuration;
+                    } finally {
+                        updateRunning.set(false);
+                    }
 
-        /**
-         * Task retrieving the current hostname.
-         */
-        private static final class HostRetriever implements Callable<String> {
-            @Override
-            public String call() throws Exception {
-                return InetAddress.getLocalHost().getCanonicalHostName();
+                    return null;
+                }
+            };
+
+            try {
+                logger.debug("Updating the hostname cache");
+                FutureTask<Void> futureTask = new FutureTask<>(hostRetriever);
+                new Thread(futureTask).start();
+                futureTask.get(GET_HOSTNAME_TIMEOUT, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                expirationTimestamp = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(1);
+                logger.warn("Localhost hostname lookup failed, keeping the value '{}'."
+                    + " If this persists it may mean your DNS is incorrectly configured and"
+                    + " you may want to hardcode your server name: https://docs.sentry.io/clients/java/config/",
+                    hostname, e);
             }
         }
     }

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -461,7 +461,6 @@ public class EventBuilder {
          * Time for which the cache is kept.
          */
         private final long cacheDuration;
-
         /**
          * Current value for hostname (might change over time).
          */


### PR DESCRIPTION
…ad at a time.

This changes the hostname cache for #421.

---

* Now only a single thread is allowed to be alive and running to attempt a hostname cache update.
* All other threads use the old (stored) value.
* Added volatile to fields accessed across threads.
* After 1 second (this is unchanged) wait for the one thread that is attempting the lookup, we still warn, but the warning has been approved.