### PR TITLE
Add a flag to disable proguard uploads

### DIFF
--- a/gradle/download-sentry-cli.sh
+++ b/gradle/download-sentry-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd $(dirname "$0")
 REPO=getsentry/sentry-cli
-VERSION=1.14.0
+VERSION=1.15.0
 PLATFORMS="Darwin-x86_64 Linux-i686 Linux-x86_64 Windows-i686"
 
 rm -f src/main/resources/bin/sentry-cli-*

--- a/gradle/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/gradle/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -174,6 +174,10 @@ class SentryPlugin implements Plugin<Project> {
                         mappingFile
                     ]
 
+                    if (!project.sentry.autoUpload) {
+                        args.push("--no-upload")
+                    }
+
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine("cmd", "/c", *args)
                     } else {

--- a/gradle/src/main/groovy/io/sentry/android/gradle/SentryPluginExtension.groovy
+++ b/gradle/src/main/groovy/io/sentry/android/gradle/SentryPluginExtension.groovy
@@ -2,4 +2,5 @@ package io.sentry.android.gradle
 
 class SentryPluginExtension {
     def boolean autoProguardConfig = true;
+    def boolean autoUpload = true;
 }


### PR DESCRIPTION
This adds a way to disable proguard uploads and bumps sentry-cli to 1.15.0 which fixes a bug with skipping uploads.