### PR TITLE
Add shouldSendEvent callback

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 1.1.1
 - Add support for handling and uploading Proguard files to Sentry (for Android applications).
 - Cleanup thread local context in ``ThreadLocalContextManager`` after each servlet request finishes.
 - Change the ``EventBuilder`` hostname lookup code to only run one thread at a time.
+- Add ``ShouldSendEventCallback``, which can be added to each ``SentryClient`` instance.
 
 Version 1.1.0
 -------------

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -29,6 +29,10 @@ public class SentryClient {
     // CHECKSTYLE.OFF: ConstantName
     private static final Logger lockdownLogger = LoggerFactory.getLogger(SentryClient.class.getName() + ".lockdown");
     // CHECKSTYLE.ON: ConstantName
+    /**
+     * Internal static callback before send event.
+     */
+    private static ShouldSendEventCallback mShouldSendEventCallback = null;
 
     /**
      * Identifies the version of the application.
@@ -80,11 +84,6 @@ public class SentryClient {
      * such as {@link io.sentry.event.Breadcrumb}s.
      */
     private final ContextManager contextManager;
-
-    /**
-     * Internal static callback before send event
-     */
-    public static ShouldSendEventCallback mShouldSendEventCallback = null;
 
     /**
      * Constructs a {@link SentryClient} instance using the provided connection.
@@ -337,6 +336,11 @@ public class SentryClient {
         connection.addEventSendCallback(eventSendCallback);
     }
 
+    /**
+     * Add a callback that is called before an event is sent.
+     *
+     * @param shouldSendEventCallback callback instance
+     */
     void addShouldSendEvent(ShouldSendEventCallback shouldSendEventCallback) {
         mShouldSendEventCallback = shouldSendEventCallback;
     }

--- a/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
+++ b/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
@@ -1,0 +1,14 @@
+package io.sentry.event.helper;
+
+import io.sentry.event.Event;
+
+public interface ShouldSendEventCallback {
+
+    /**
+     * Called before an event will be sent to the server,
+     *
+     * @param event Event that was sent
+     * @return boolen return false to prevent the event from being sent
+     */
+    boolean shouldSend(Event event);
+}

--- a/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
+++ b/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
@@ -2,10 +2,13 @@ package io.sentry.event.helper;
 
 import io.sentry.event.Event;
 
+/**
+ * Callback for preventing an event from being sent to sentry.
+ */
 public interface ShouldSendEventCallback {
 
     /**
-     * Called before an event will be sent to the server,
+     * Called before an event will be sent to the server.
      *
      * @param event Event that was sent
      * @return boolen return false to prevent the event from being sent

--- a/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
+++ b/sentry/src/main/java/io/sentry/event/helper/ShouldSendEventCallback.java
@@ -3,15 +3,15 @@ package io.sentry.event.helper;
 import io.sentry.event.Event;
 
 /**
- * Callback for preventing an event from being sent to sentry.
+ * Callback that decides whether or not an {@link Event} should be sent to Sentry.
  */
 public interface ShouldSendEventCallback {
 
     /**
-     * Called before an event will be sent to the server.
+     * Callback that decides whether or not an {@link Event} should be sent to Sentry.
      *
-     * @param event Event that was sent
-     * @return boolen return false to prevent the event from being sent
+     * @param event {@link Event} that may be sent.
+     * @return true if the {@link Event} should be sent, false otherwise.
      */
     boolean shouldSend(Event event);
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.context.ContextManager;
 import io.sentry.context.SingletonContextManager;
+import io.sentry.event.helper.ShouldSendEventCallback;
 import mockit.Injectable;
 import mockit.NonStrictExpectations;
 import mockit.Tested;
@@ -187,6 +188,39 @@ public class SentryClientTest extends BaseTest {
             assertThat(event.getDist(), equalTo(dist));
             assertThat(event.getRelease(), equalTo(release));
             assertThat(event.getTags(), equalTo(tags));
+        }};
+    }
+
+    @Test
+    public void testShouldNotSendEvent() throws Exception {
+        sentryClient.addShouldSendEvent(new ShouldSendEventCallback() {
+            @Override
+            public boolean shouldSend(Event event) {
+                return false;
+            }
+        });
+
+        sentryClient.sendEvent(mockEvent);
+
+        new Verifications() {{
+            SentryClient.mShouldSendEventCallback.shouldSend(mockEvent);
+        }};
+    }
+
+    @Test
+    public void testShouldSendEvent() throws Exception {
+        sentryClient.addShouldSendEvent(new ShouldSendEventCallback() {
+            @Override
+            public boolean shouldSend(Event event) {
+                return true;
+            }
+        });
+
+        sentryClient.sendEvent(mockEvent);
+
+        new Verifications() {{
+            SentryClient.mShouldSendEventCallback.shouldSend(mockEvent);
+            mockConnection.send(mockEvent);
         }};
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.java
@@ -196,15 +196,13 @@ public class SentryClientTest extends BaseTest {
         sentryClient.addShouldSendEvent(new ShouldSendEventCallback() {
             @Override
             public boolean shouldSend(Event event) {
+                assert true;
                 return false;
             }
         });
 
         sentryClient.sendEvent(mockEvent);
-
-        new Verifications() {{
-            SentryClient.mShouldSendEventCallback.shouldSend(mockEvent);
-        }};
+        sentryClient.addShouldSendEvent(null);
     }
 
     @Test
@@ -212,6 +210,7 @@ public class SentryClientTest extends BaseTest {
         sentryClient.addShouldSendEvent(new ShouldSendEventCallback() {
             @Override
             public boolean shouldSend(Event event) {
+                assert true;
                 return true;
             }
         });
@@ -219,8 +218,8 @@ public class SentryClientTest extends BaseTest {
         sentryClient.sendEvent(mockEvent);
 
         new Verifications() {{
-            SentryClient.mShouldSendEventCallback.shouldSend(mockEvent);
             mockConnection.send(mockEvent);
         }};
+        sentryClient.addShouldSendEvent(null);
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.java
@@ -204,7 +204,7 @@ public class SentryClientTest extends BaseTest {
         });
 
         sentryClient.sendEvent(mockEvent);
-        
+
         new Verifications() {{
             mockConnection.send(mockEvent); times = 0;
             assertThat(called.get(), is(true));


### PR DESCRIPTION
This adds a shouldSendEvent callback the be able to prevent sending of specific events.
e.g.:
```
sentryClient.addShouldSendEvent(new ShouldSendEventCallback() {
            @Override
            public boolean shouldSend(Event event) {
                // We don't want to send events that are from ExceptionsManagerModule.
                // Because we sent it already from raven.
                if (event.getSentryInterfaces().containsKey(ExceptionInterface.EXCEPTION_INTERFACE)) {
                    ExceptionInterface exceptionInterface = ((ExceptionInterface)event.getSentryInterfaces().get(ExceptionInterface.EXCEPTION_INTERFACE));
                    if (exceptionInterface.getExceptions().getFirst().getExceptionClassName().contains("JavascriptException")) {
                        return false;
                    }
                }
                return true;
            }
        });
```