### PR TITLE
Add support for buildTypes and flavors in the Android Gradle plugin. …

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -162,7 +162,31 @@ class SentryPlugin implements Plugin<Project> {
                         type: Exec) {
                     description "Write references to proguard UUIDs to the android assets."
                     workingDir project.rootDir
-                    environment("SENTRY_PROPERTIES", "${project.rootDir.toPath()}/sentry.properties")
+
+                    def variantName = variant.buildType.name
+                    def flavorName = variant.flavorName
+                    def propName = "sentry.properties"
+                    def possibleProps = [
+                            "${project.rootDir.toPath()}/app/src/${variantName}/${propName}",
+                            "${project.rootDir.toPath()}/app/src/${variantName}/${flavorName}/${propName}",
+                            "${project.rootDir.toPath()}/app/src/${flavorName}/${variantName}/${propName}",
+                            "${project.rootDir.toPath()}/src/${variantName}/${propName}",
+                            "${project.rootDir.toPath()}/src/${variantName}/${flavorName}/${propName}",
+                            "${project.rootDir.toPath()}/src/${flavorName}/${variantName}/${propName}",
+                            "${project.rootDir.toPath()}/${propName}"
+                    ]
+
+                    def propsFile = null
+                    possibleProps.each {
+                        if (propsFile == null && new File(it).isFile()) {
+                            propsFile = it
+                        }
+                    }
+
+                    if (propsFile != null) {
+                        println("Setting SENTRY_PROPERTIES = " + propsFile)
+                        environment("SENTRY_PROPERTIES", propsFile)
+                    }
 
                     def args = [
                         cli,

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -184,7 +184,6 @@ class SentryPlugin implements Plugin<Project> {
                     }
 
                     if (propsFile != null) {
-                        println("Setting SENTRY_PROPERTIES = " + propsFile)
                         environment("SENTRY_PROPERTIES", propsFile)
                     }
 


### PR DESCRIPTION
…#437

I check all of the directory combinations I thought were reasonable. I couldn't find a way to automatically get the "source dir for a given flavor."

(For what it's worth I found conflicting examples of `buildType/flavor` and `flavor/buildType` dirs, so I just check for both.)

/cc @AndrewJack