### PR TITLE
Deprecate context-specific operations directly on the static Sentry c…

### DIFF
--- a/docs/context.rst
+++ b/docs/context.rst
@@ -53,10 +53,12 @@ the current context.
             Sentry.init();
 
             // Set the current user in the context.
-            Sentry.setUser(new UserBuilder().setUsername("user1").build());
+            Sentry.getContext().setUser(
+                new UserBuilder().setUsername("user1").build()
+            );
 
             // Record a breadcrumb without having to look up the context instance manually.
-            Sentry.record(
+            Sentry.getContext().recordBreadcrumb(
                 new BreadcrumbBuilder().setMessage("User did something specific again!").build()
             );
 

--- a/docs/modules/android.rst
+++ b/docs/modules/android.rst
@@ -99,10 +99,14 @@ Now you can use ``Sentry`` to capture events anywhere in your application:
             Record a breadcrumb in the current context which will be sent
             with the next event(s). By default the last 100 breadcrumbs are kept.
             */
-            Sentry.record(new BreadcrumbBuilder().setMessage("User made an action").build());
+            Sentry.getContext().recordBreadcrumb(
+                new BreadcrumbBuilder().setMessage("User made an action").build()
+            );
 
             // Set the user in the current context.
-            Sentry.setUser(new UserBuilder().setEmail("hello@sentry.io").build());
+            Sentry.getContext().setUser(
+                new UserBuilder().setEmail("hello@sentry.io").build()
+            );
 
             /*
             This sends a simple event to Sentry using the statically stored instance

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -91,10 +91,14 @@ your own ``SentryClient`` instance. An example of each style is shown below:
             Record a breadcrumb in the current context which will be sent
             with the next event(s). By default the last 100 breadcrumbs are kept.
             */
-            Sentry.record(new BreadcrumbBuilder().setMessage("User made an action").build());
+            Sentry.getContext().recordBreadcrumb(
+                new BreadcrumbBuilder().setMessage("User made an action").build()
+            );
 
             // Set the user in the current context.
-            Sentry.setUser(new UserBuilder().setEmail("hello@sentry.io").build());
+            Sentry.getContext().setUser(
+                new UserBuilder().setEmail("hello@sentry.io").build()
+            );
 
             /*
             This sends a simple event to Sentry using the statically stored instance

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.context.Context;
 import io.sentry.dsn.Dsn;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
@@ -106,6 +107,22 @@ public final class Sentry {
     }
 
     /**
+     * Returns the {@link Context} on the statically stored {@link SentryClient}.
+     *
+     * @return the {@link Context} on the statically stored {@link SentryClient}.
+     */
+    public static Context getContext() {
+        return getStoredClient().getContext();
+    }
+
+    /**
+     * Clears the current context.
+     */
+    public static void clearContext() {
+        getStoredClient().clearContext();
+    }
+
+    /**
      * Set the statically stored {@link SentryClient} instance.
      *
      * @param client {@link SentryClient} instance to store.
@@ -164,7 +181,9 @@ public final class Sentry {
      * Record a {@link Breadcrumb}.
      *
      * @param breadcrumb Breadcrumb to record.
+     * @deprecated use {@link Sentry#getContext()} and then {@link Context#recordBreadcrumb(Breadcrumb)}.
      */
+    @Deprecated
     public static void record(Breadcrumb breadcrumb) {
         getStoredClient().getContext().recordBreadcrumb(breadcrumb);
     }
@@ -173,16 +192,11 @@ public final class Sentry {
      * Set the {@link User} in the current context.
      *
      * @param user User to store.
+     * @deprecated use {@link Sentry#getContext()} and then {@link Context#setUser(User)}.
      */
+    @Deprecated
     public static void setUser(User user) {
         getStoredClient().getContext().setUser(user);
-    }
-
-    /**
-     * Clears the current context.
-     */
-    public static void clearContext() {
-        getStoredClient().clearContext();
     }
 
     /**


### PR DESCRIPTION
…lass (for clarity).

I'm going to add more methods/fields to `Context` and I think that,

1. Duplicating them all on the static `Sentry` class stinks.
2. It's unclear to users which methods/fields are context-based and which are "permanent."

So basically I'd prefer to tell people to `Sentry.getContext().__context_thing__`.

It's probably more clear to just see the documentation changes in the diff.