### PR TITLE
Deprecate ``extratags`` in favor of the more clear ``mdctags``.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 1.2.3
 -------------
 
--
+- Deprecate ``extratags`` in favor of the more clear ``mdctags``.
 
 Version 1.2.2
 -------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -190,19 +190,27 @@ comma separated pairs of keys and values that are joined by a colon:
 
     tags=tag1:value1,tag2:value2
 
-Extra Tags
-~~~~~~~~~~
+MDC Tags
+~~~~~~~~
 
-To set extras that are extracted and used as additional tags, use the
-``extratags`` option with comma separated key names.
+To set tag names that are extracted from the SLF4J MDC system, use the
+``mdctags`` option with comma separated key names. Note that this option
+is only useful when are you using one of the logging integrations.
 
 ::
 
-    extratags=foo,bar
+    mdctags=foo,bar
 
-Note that how these extra tags are used depends on which integration you are
-using. For example: when using a logging integration any SLF4J MDC keys that
-are in the extra tags set will be extracted and set as tags on events.
+.. sourcecode:: java
+
+    import org.slf4j.MDC;
+
+    MDC.put("foo", "value1");
+    MDC.put("bar", "value2");
+
+    // This sends an event where the 'foo' and 'bar' MDC values are set as additional tags
+    logger.error("This is a test");
+
 
 "In Application" Stack Frames
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/modules/log4j.rst
+++ b/docs/modules/log4j.rst
@@ -115,7 +115,7 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extratags`` option in your configuration you can
+specifying the ``mdctags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
 

--- a/docs/modules/log4j2.rst
+++ b/docs/modules/log4j2.rst
@@ -87,7 +87,7 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extratags`` option in your configuration you can
+specifying the ``mdctags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
 

--- a/docs/modules/logback.rst
+++ b/docs/modules/logback.rst
@@ -90,7 +90,7 @@ Mapped Tags
 ~~~~~~~~~~~
 
 By default all MDC parameters are stored under the "Additional Data" tab in Sentry. By
-specifying the ``extratags`` option in your configuration you can
+specifying the ``mdctags`` option in your configuration you can
 choose which MDC keys to send as tags instead, which allows them to be used as
 filters within the Sentry UI.
 

--- a/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
+++ b/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
@@ -135,7 +135,7 @@ public class SentryAppender extends AppenderSkeleton {
             eventBuilder.withExtra(LOG4J_NDC, loggingEvent.getNDC());
         }
 
-        Set<String> extraTags = Sentry.getStoredClient().getExtraTags();
+        Set<String> extraTags = Sentry.getStoredClient().getMdcTags();
         @SuppressWarnings("unchecked")
         Map<String, Object> properties = (Map<String, Object>) loggingEvent.getProperties();
         for (Map.Entry<String, Object> mdcEntry : properties.entrySet()) {

--- a/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j/src/test/java/io/sentry/log4j/SentryAppenderEventBuildingTest.java
@@ -3,7 +3,6 @@ package io.sentry.log4j;
 import io.sentry.BaseTest;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
-import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.interfaces.SentryStackTraceElement;
 import mockit.*;
 import io.sentry.event.Event;
@@ -246,7 +245,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
         properties.put("other_property", "10ebc4f6-a915-46d0-bb60-75bc9bd71371");
 
         new NonStrictExpectations() {{
-            mockSentryClient.getExtraTags();
+            mockSentryClient.getMdcTags();
             result = extraTags;
         }};
 
@@ -270,7 +269,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
         new NonStrictExpectations() {{
             extraTagValue.toString();
             result = "3c8981b4-01ad-47ec-8a3a-77a0bbcb42e2";
-            mockSentryClient.getExtraTags();
+            mockSentryClient.getMdcTags();
             result = extraTags;
         }};
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -183,7 +183,7 @@ public class SentryAppender extends AbstractAppender {
 
         if (event.getContextMap() != null) {
             for (Map.Entry<String, String> contextEntry : event.getContextMap().entrySet()) {
-                if (Sentry.getStoredClient().getExtraTags().contains(contextEntry.getKey())) {
+                if (Sentry.getStoredClient().getMdcTags().contains(contextEntry.getKey())) {
                     eventBuilder.withTag(contextEntry.getKey(), contextEntry.getValue());
                 } else {
                     eventBuilder.withExtra(contextEntry.getKey(), contextEntry.getValue());

--- a/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
+++ b/sentry-log4j2/src/test/java/io/sentry/log4j2/SentryAppenderEventBuildingTest.java
@@ -3,7 +3,6 @@ package io.sentry.log4j2;
 import io.sentry.BaseTest;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
-import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.interfaces.*;
 import mockit.Injectable;
 import mockit.NonStrictExpectations;
@@ -251,7 +250,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
         mdc.put("other_property", "395856e8-fa1d-474f-8fa9-c062b4886527");
 
         new NonStrictExpectations() {{
-            mockSentryClient.getExtraTags();
+            mockSentryClient.getMdcTags();
             result = extraTags;
         }};
 

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -153,7 +153,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         }
 
         for (Map.Entry<String, String> mdcEntry : iLoggingEvent.getMDCPropertyMap().entrySet()) {
-            if (Sentry.getStoredClient().getExtraTags().contains(mdcEntry.getKey())) {
+            if (Sentry.getStoredClient().getMdcTags().contains(mdcEntry.getKey())) {
                 eventBuilder.withTag(mdcEntry.getKey(), mdcEntry.getValue());
             } else {
                 eventBuilder.withExtra(mdcEntry.getKey(), mdcEntry.getValue());

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderEventBuildingTest.java
@@ -8,7 +8,6 @@ import ch.qos.logback.core.status.OnConsoleStatusListener;
 import io.sentry.BaseTest;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
-import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.interfaces.*;
 import mockit.Injectable;
 import mockit.NonStrictExpectations;
@@ -283,7 +282,7 @@ public class SentryAppenderEventBuildingTest extends BaseTest {
         mdcPropertyMap.put("other_property", "cb9c92a1-0182-4e9c-866f-b06b271cd196");
 
         new NonStrictExpectations() {{
-            mockSentryClient.getExtraTags();
+            mockSentryClient.getMdcTags();
             result = extraTags;
         }};
 

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -752,6 +752,10 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
         String val = Lookup.lookup(MDCTAGS_OPTION, dsn);
         if (Util.isNullOrEmpty(val)) {
             val = Lookup.lookup(EXTRATAGS_OPTION, dsn);
+            if (!Util.isNullOrEmpty(val)) {
+                logger.warn("The '" + EXTRATAGS_OPTION + "' option is deprecated, please use"
+                    + " the '" + MDCTAGS_OPTION + "' option instead.");
+            }
         }
 
         return Util.parseMdcTags(val);

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -7,7 +7,6 @@ import io.sentry.connection.*;
 import io.sentry.context.ContextManager;
 import io.sentry.context.ThreadLocalContextManager;
 import io.sentry.dsn.Dsn;
-import io.sentry.event.Event;
 import io.sentry.event.helper.ContextBuilderHelper;
 import io.sentry.event.helper.HttpEventBuilderHelper;
 import io.sentry.event.interfaces.*;
@@ -203,9 +202,15 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     public static final String TAGS_OPTION = "tags";
     /**
-     * Option to set extras to extract and send as tags, where applicable.
+     * Option to set tags that are extracted from the MDC system, where applicable.
+     * @deprecated prefer {@link DefaultSentryClientFactory#MDCTAGS_OPTION}
      */
+    @Deprecated
     public static final String EXTRATAGS_OPTION = "extratags";
+    /**
+     * Option to set tags that are extracted from the MDC system, where applicable.
+     */
+    public static final String MDCTAGS_OPTION = "mdctags";
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultSentryClientFactory.class);
     private static final String FALSE = Boolean.FALSE.toString();
@@ -269,10 +274,10 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
             }
         }
 
-        Set<String> extraTags = getExtraTags(dsn);
-        if (!extraTags.isEmpty()) {
-            for (String extraTag : extraTags) {
-                sentryClient.addExtraTag(extraTag);
+        Set<String> mdcTags = getMdcTags(dsn);
+        if (!mdcTags.isEmpty()) {
+            for (String mdcTag : mdcTags) {
+                sentryClient.addMdcTag(mdcTag);
             }
         }
 
@@ -716,16 +721,30 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
     }
 
     /**
-     * Extras to extract and send as tags on {@link io.sentry.event.Event}s, where applicable.
-     * <p>
-     * For example: when using a logging integration any {@link org.slf4j.MDC} keys that are in
-     * the {@link #getExtraTags(Dsn)} set will be extracted and set as tags on the {@link Event}.
+     * Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
      *
      * @param dsn Sentry server DSN which may contain options.
-     * @return Extras to use as tags on {@link io.sentry.event.Event}s, where applicable.
+     * @return Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
+     * @deprecated prefer {@link DefaultSentryClientFactory#getMdcTags(Dsn)}
      */
+    @Deprecated
     protected Set<String> getExtraTags(Dsn dsn) {
-        return Util.parseExtraTags(Lookup.lookup(EXTRATAGS_OPTION, dsn));
+        return getMdcTags(dsn);
+    }
+
+    /**
+     * Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
+     *
+     * @param dsn Sentry server DSN which may contain options.
+     * @return Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
+     */
+    protected Set<String> getMdcTags(Dsn dsn) {
+        String val = Lookup.lookup(MDCTAGS_OPTION, dsn);
+        if (Util.isNullOrEmpty(val)) {
+            val = Lookup.lookup(EXTRATAGS_OPTION, dsn);
+        }
+
+        return Util.parseMdcTags(val);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -60,12 +60,9 @@ public class SentryClient {
      */
     protected Map<String, String> tags = new HashMap<>();
     /**
-     * Extras to extract and use as tags, where applicable.
-     * <p>
-     * For example: when using a logging integration any {@link org.slf4j.MDC} keys that are in
-     * the {@link #extraTags} set will be extracted and set as tags on the {@link Event}.
+     * Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
      */
-    protected Set<String> extraTags = new HashSet<>();
+    protected Set<String> mdcTags = new HashSet<>();
     /**
      * Set of callbacks that are checked before each {@link Event} is sent to Sentry.
      */
@@ -257,8 +254,8 @@ public class SentryClient {
         return Collections.unmodifiableMap(tags);
     }
 
-    public Set<String> getExtraTags() {
-        return Collections.unmodifiableSet(extraTags);
+    public Set<String> getMdcTags() {
+        return Collections.unmodifiableSet(mdcTags);
     }
 
     public void setRelease(String release) {
@@ -301,31 +298,47 @@ public class SentryClient {
     }
 
     /**
-     * Set the extras to extract and send as tags on all future {@link Event}s, where applicable.
-     * <p>
-     * For example: when using a logging integration any {@link org.slf4j.MDC} keys that are in
-     * the {@link #extraTags} set will be extracted and set as tags on the {@link Event}.
+     * Set the tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
      *
-     * @param extraTags Set of extras
+     * @param extraTags Set of tags to extract from the MDC system
+     * @deprecated prefer {@link SentryClient#setMdcTags(Set)}
      */
+    @Deprecated
     public void setExtraTags(Set<String> extraTags) {
-        if (extraTags == null) {
-            this.extraTags = new HashSet<>();
+        setMdcTags(extraTags);
+    }
+
+    /**
+     * Set the tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
+     *
+     * @param mdcTags Set of tags to extract from the MDC system
+     */
+    public void setMdcTags(Set<String> mdcTags) {
+        if (mdcTags == null) {
+            this.mdcTags = new HashSet<>();
         } else {
-            this.extraTags = extraTags;
+            this.mdcTags = mdcTags;
         }
     }
 
     /**
-     * Add an extra to extract and send as tags on all future {@link Event}s, where applicable.
-     * <p>
-     * For example: when using a logging integration any {@link org.slf4j.MDC} keys that are in
-     * the {@link #extraTags} set will be extracted and set as tags on the {@link Event}.
+     * Add a tag to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
      *
-     * @param extraName Extra name
+     * @param extraName Tag name to extract from the MDC system
+     * @deprecated prefer {@link SentryClient#addMdcTag(String)}
      */
+    @Deprecated
     public void addExtraTag(String extraName) {
-        this.extraTags.add(extraName);
+        addMdcTag(extraName);
+    }
+
+    /**
+     * Add a tag to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
+     *
+     * @param tagName Tag name to extract from the MDC system
+     */
+    public void addMdcTag(String tagName) {
+        this.mdcTags.add(tagName);
     }
 
     /**
@@ -354,7 +367,7 @@ public class SentryClient {
             + ", environment='" + environment + '\''
             + ", serverName='" + serverName + '\''
             + ", tags=" + tags
-            + ", extraTags=" + extraTags
+            + ", mdcTags=" + mdcTags
             + ", connection=" + connection
             + ", builderHelpers=" + builderHelpers
             + ", contextManager=" + contextManager

--- a/sentry/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry/src/main/java/io/sentry/jul/SentryHandler.java
@@ -152,7 +152,7 @@ public class SentryHandler extends Handler {
         Map<String, String> mdc = MDC.getMDCAdapter().getCopyOfContextMap();
         if (mdc != null) {
             for (Map.Entry<String, String> mdcEntry : mdc.entrySet()) {
-                if (Sentry.getStoredClient().getExtraTags().contains(mdcEntry.getKey())) {
+                if (Sentry.getStoredClient().getMdcTags().contains(mdcEntry.getKey())) {
                     eventBuilder.withTag(mdcEntry.getKey(), mdcEntry.getValue());
                 } else {
                     eventBuilder.withExtra(mdcEntry.getKey(), mdcEntry.getValue());

--- a/sentry/src/main/java/io/sentry/util/Util.java
+++ b/sentry/src/main/java/io/sentry/util/Util.java
@@ -51,18 +51,31 @@ public final class Util {
     }
 
     /**
-     * Parses the provided extraTags string into a Set of Strings.
+     * Parses the provided Strings into a Set of Strings.
      *
      * @param extraTagsString comma-delimited tags
      * @return Set of Strings representing extra tags
+     * @deprecated prefer {@link Util#parseMdcTags(String)}
      */
+    @Deprecated
     public static Set<String> parseExtraTags(String extraTagsString) {
-        if (isNullOrEmpty(extraTagsString)) {
+        return parseMdcTags(extraTagsString);
+    }
+
+    /**
+     * Parses the provided Strings into a Set of Strings.
+     *
+     * @param mdcTagsString comma-delimited tags
+     * @return Set of Strings representing mdc tags
+     */
+    public static Set<String> parseMdcTags(String mdcTagsString) {
+        if (isNullOrEmpty(mdcTagsString)) {
             return Collections.emptySet();
         }
 
-        return new HashSet<>(Arrays.asList(extraTagsString.split(",")));
+        return new HashSet<>(Arrays.asList(mdcTagsString.split(",")));
     }
+
 
     /**
      * Parses the provided string value into an integer value.

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -6,7 +6,6 @@ import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class DefaultSentryClientFactoryTest extends BaseTest {
@@ -37,7 +36,7 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         Set<String> extraTagsSet = new HashSet<>();
         extraTagsSet.add("aaa");
         extraTagsSet.add("bbb");
-        assertThat(sentryClient.getExtraTags(), is(extraTagsSet));
+        assertThat(sentryClient.getMdcTags(), is(extraTagsSet));
 
     }
 }


### PR DESCRIPTION
Looks noisy, but this is just doing what it says on the tin (the old option will still work for now too).

#445 