### PR TITLE
Handle os.arch value of 'amd64' in the Android Gradle Plugin.

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -51,7 +51,11 @@ class SentryPlugin implements Plugin<Project> {
         if (osName.indexOf("mac") >= 0) {
             cliSuffix = "Darwin-x86_64"
         } else if (osName.indexOf("linux") >= 0) {
-            cliSuffix = "Linux-" + System.getProperty("os.arch")
+            def arch = System.getProperty("os.arch")
+            if (arch == "amd64") {
+                arch = "x86_64"
+            }
+            cliSuffix = "Linux-" + arch
         } else if (osName.indexOf("win") >= 0) {
             cliSuffix = "Windows-i686.exe"
         }


### PR DESCRIPTION
#453 

The issue wasn't the classloader, it's that `os.arch` is `amd64` and not `x86_64` as the `sentry-cli` binary is named and so the file isn't found.

It gets weird because it seems like some JVMs may actually report `x86_64`, so I just handled this one (common) case for now.