### PR TITLE
Add OSGI support.

### DIFF
--- a/sentry-android/bnd.bnd
+++ b/sentry-android/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.android,\
+    io.sentry.android.event.helper

--- a/sentry-android/pom.xml
+++ b/sentry-android/pom.xml
@@ -91,6 +91,27 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/sentry-log4j/bnd.bnd
+++ b/sentry-log4j/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.log4j

--- a/sentry-log4j/pom.xml
+++ b/sentry-log4j/pom.xml
@@ -95,6 +95,27 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/sentry-log4j2/bnd.bnd
+++ b/sentry-log4j2/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.log4j2

--- a/sentry-log4j2/pom.xml
+++ b/sentry-log4j2/pom.xml
@@ -100,6 +100,27 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/sentry-logback/bnd.bnd
+++ b/sentry-logback/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.logback

--- a/sentry-logback/pom.xml
+++ b/sentry-logback/pom.xml
@@ -93,6 +93,27 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/sentry-spring/bnd.bnd
+++ b/sentry-spring/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.spring

--- a/sentry-spring/pom.xml
+++ b/sentry-spring/pom.xml
@@ -94,4 +94,30 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sentry/bnd.bnd
+++ b/sentry/bnd.bnd
@@ -15,6 +15,13 @@ Bundle-Description: ${project.description}
     io.sentry.jul,\
     io.sentry.jvmti,\
     io.sentry.marshaller,\
+    io.sentry.marshaller.json,\
     io.sentry.servlet,\
     io.sentry.time,\
     io.sentry.util
+
+Import-Package: \
+javax.servlet;resolution:=optional,\
+javax.servlet.http;resolution:=optional,\
+*
+

--- a/sentry/bnd.bnd
+++ b/sentry/bnd.bnd
@@ -1,0 +1,20 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry,\
+    io.sentry.buffer,\
+    io.sentry.config,\
+    io.sentry.connection,\
+    io.sentry.context,\
+    io.sentry.dsn,\
+    io.sentry.environment,\
+    io.sentry.event,\
+    io.sentry.event.helper,\
+    io.sentry.event.interfaces,\
+    io.sentry.jul,\
+    io.sentry.jvmti,\
+    io.sentry.marshaller,\
+    io.sentry.servlet,\
+    io.sentry.time,\
+    io.sentry.util

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -121,8 +121,25 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Here's a patch for #358.

This effectively marks all packages in `io.sentry` as publically available via OSGI.  If there are any packages that should not be exposed, the package should be removed from the `exportcontents` list in `bnd.bnd`.  Let me know if that's the case and I can make the change.

It also declares `javax.servlet` as an optional dependency.  I'm assuming that `javax.servlet` is not a required dependency if Sentry is not used in a servlet environment.