### PR TITLE
Cleanup SentryEnvironment state to avoid memory leak warnings on Tomcat.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 1.5.3
 -------------
 
--
+- Cleanup SentryEnvironment state to avoid memory leak warnings on Tomcat.
 
 Version 1.5.2
 -------------

--- a/sentry/src/main/java/io/sentry/environment/SentryEnvironment.java
+++ b/sentry/src/main/java/io/sentry/environment/SentryEnvironment.java
@@ -73,7 +73,11 @@ public final class SentryEnvironment {
                 logger.warn("Thread not yet managed by Sentry");
             }
         } finally {
-            SENTRY_THREAD.get().decrementAndGet();
+            if (SENTRY_THREAD.get().decrementAndGet() == 0) {
+                // Remove the ThreadLocal so we don't log leak warnings on Tomcat.
+                // The next get/incr (if any) will re-initialize it to 0.
+                SENTRY_THREAD.remove();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes GH-487