### PR TITLE
With Spring use controller method name as culprit/transaction

### DIFF
--- a/sentry-spring/src/main/java/io/sentry/spring/ControllerAsCulpritEventBuilderHelper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/ControllerAsCulpritEventBuilderHelper.java
@@ -1,0 +1,31 @@
+package io.sentry.spring;
+
+import io.sentry.event.EventBuilder;
+import io.sentry.event.helper.EventBuilderHelper;
+import org.springframework.web.method.HandlerMethod;
+
+public class ControllerAsCulpritEventBuilderHelper implements EventBuilderHelper
+{
+
+    private final DispatcherHandlerContextHolderInterceptor dispatcherHandlerContextHolderInterceptor;
+
+    public ControllerAsCulpritEventBuilderHelper(
+        final DispatcherHandlerContextHolderInterceptor dispatcherHandlerContextHolderInterceptor
+    )
+    {
+        this.dispatcherHandlerContextHolderInterceptor = dispatcherHandlerContextHolderInterceptor;
+    }
+
+    @Override
+    public void helpBuildingEvent(final EventBuilder eventBuilder)
+    {
+        Object handler = dispatcherHandlerContextHolderInterceptor.getHandler();
+        if (handler != null) {
+            if (HandlerMethod.class.isAssignableFrom(handler.getClass())) {
+                HandlerMethod handlerMethod = HandlerMethod.class.cast(handler);
+                eventBuilder.withCulprit(handlerMethod.getBeanType().getName() + "." + handlerMethod.getMethod().getName() + "()");
+            }
+        }
+    }
+
+}

--- a/sentry-spring/src/main/java/io/sentry/spring/DispatcherHandlerContextHolderInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/DispatcherHandlerContextHolderInterceptor.java
@@ -1,0 +1,39 @@
+package io.sentry.spring;
+
+import org.springframework.core.NamedThreadLocal;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class DispatcherHandlerContextHolderInterceptor implements HandlerInterceptor
+{
+
+    private static final ThreadLocal<Object> HANDLER_HOLDER = new NamedThreadLocal<>("RequestDispatcher Handler");
+
+    public Object getHandler()
+    {
+        return HANDLER_HOLDER.get();
+    }
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception
+    {
+        HANDLER_HOLDER.set(handler);
+        return true;
+    }
+
+    @Override
+    public void postHandle(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o, final ModelAndView modelAndView) throws Exception
+    {
+
+    }
+
+    @Override
+    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final Exception ex) throws Exception
+    {
+        HANDLER_HOLDER.remove();
+    }
+
+}


### PR DESCRIPTION
This is a proof of concept and I'm not sure I'm gonna have time to finish it properly, but I wanted to provide some working code, rather than just to open an issue.

```java
public class MyWebConfiguration implements WebMvcConfigurer
{

    @Override
    public void addInterceptors(final InterceptorRegistry registry)
    {
        registry.addInterceptor(getDispatcherHandlerContextHolderInterceptor());
    }

    @Bean
    public DispatcherHandlerContextHolderInterceptor getDispatcherHandlerContextHolderInterceptor()
    {
        return new DispatcherHandlerContextHolderInterceptor();
    }

    @Bean
    public ControllerAsCulpritEventBuilderHelper getControllerAsCulpritEventBuilderHelper()
    {
        return new ControllerAsCulpritEventBuilderHelper(
            getDispatcherHandlerContextHolderInterceptor()
        );
    }

}
```

Now you just register the helper (I do it with `ApplicationListener<ApplicationReadyEvent>`)

```java
SentryClient sentryClient = Sentry.getStoredClient();
sentryClient.addBuilderHelper(applicationContext.getBean(ControllerAsCulpritEventBuilderHelper.class));
```

And now Sentry is showing the controller with method name as the transaction, instead of `ErrorControllerAdvice`, or some other non-relevant place.

![screenshot from 2017-10-09 15-57-15](https://user-images.githubusercontent.com/158625/31341682-8c0f0794-ad0a-11e7-96c5-c693d6089466.png)

## Alternative

With access to `HttpServletRequest`, this could be reporting route name, instead of controller. Spring (or something along the way) is setting the info about matched route as one of request attributes.