### PR TITLE
Fix issue where Gradle tasks were not created

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -154,10 +154,6 @@ class SentryPlugin implements Plugin<Project> {
                                             variantOutput.processManifest.manifestOutputDirectory,
                                             variantOutput.dirName),
                                     "AndroidManifest.xml")
-                            if (!manifestPath.isFile()) {
-                                System.err.println("sentry-plugin: Cannot find AndroidManifst.xml")
-                                return
-                            }
                         }
                     }
 


### PR DESCRIPTION
This fixes the issue that was introduced after #530 


Basically when there were no manifests in `build/intermediates/...` directory (i.e. after project was cleaned) and Gradle ran configuration phase Sentry tasks `persistSentryProguardUuidsFor*` were not created at all because of this return.

I also removed unnecessary error logging since this always gets called for clean builds polluting output.  