### PR TITLE
Refactor creating Json Marshaller to be more friendly to extensions

### DIFF
--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -478,6 +478,12 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
         return marshaller;
     }
 
+    /**
+     * Create a {@link JsonMarshaller}. This method makes it easier to provide a custom implementation.
+     *
+     * @param maxMessageLength of the whole json output
+     * @return new marshaller
+     */
     @SuppressWarnings("WeakerAccess")
     protected JsonMarshaller createJsonMarshaller(int maxMessageLength) {
         return new JsonMarshaller(maxMessageLength);

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -454,7 +454,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     protected Marshaller createMarshaller(Dsn dsn) {
         int maxMessageLength = getMaxMessageLength(dsn);
-        JsonMarshaller marshaller = new JsonMarshaller(maxMessageLength);
+        JsonMarshaller marshaller = createJsonMarshaller(maxMessageLength);
 
         // Set JSON marshaller bindings
         StackTraceInterfaceBinding stackTraceBinding = new StackTraceInterfaceBinding();
@@ -476,6 +476,11 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
         marshaller.setCompression(getCompressionEnabled(dsn));
 
         return marshaller;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    protected JsonMarshaller createJsonMarshaller(int maxMessageLength) {
+        return new JsonMarshaller(maxMessageLength);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
@@ -170,6 +170,14 @@ public class JsonMarshaller implements Marshaller {
         }
     }
 
+    /**
+     * Creates the {@link JsonGenerator} used to marshall to json.
+     * This method makes it easier to provide a custom implementation.
+     *
+     * @param destination used to read the content
+     * @return a new instance
+     * @throws IOException on error reading the stream
+     */
     @SuppressWarnings("WeakerAccess")
     protected JsonGenerator createJsonGenerator(OutputStream destination) throws IOException {
         return new SentryJsonGenerator(jsonFactory.createGenerator(destination));

--- a/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
@@ -157,7 +157,7 @@ public class JsonMarshaller implements Marshaller {
             destination = new GZIPOutputStream(destination);
         }
 
-        try (SentryJsonGenerator generator = new SentryJsonGenerator(jsonFactory.createGenerator(destination))) {
+        try (JsonGenerator generator = createJsonGenerator(destination)) {
             writeContent(generator, event);
         } catch (IOException e) {
             logger.error("An exception occurred while serialising the event.", e);
@@ -168,6 +168,11 @@ public class JsonMarshaller implements Marshaller {
                 logger.error("An exception occurred while serialising the event.", e);
             }
         }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    protected JsonGenerator createJsonGenerator(OutputStream destination) throws IOException {
+        return new SentryJsonGenerator(jsonFactory.createGenerator(destination));
     }
 
     @Override


### PR DESCRIPTION
So we are using Sentry with our own infrastructure, so we are able to send reports with our own report length limitations. To do that, one has to extend the `JsonMarshaller`, since the Limitation are hardcoded in `SentyJsonGenerator#MAX*` (btw. the the [doc ](https://docs.sentry.io/learn/quotas/) says "each item is capped at 512 bytes", but currently it caps at 400 chars, which might, depending on the content depending on the content).

This was kind of hacky with the current implementation because one needed to copy a lot of code, which would make maintenance hell. I just extracted 2 methods to make it easier for an inheriting class to provide their own JsonMarshaller or JsonFactory.