### PR TITLE
Default dsn when set to an empty string

### DIFF
--- a/sentry/src/main/java/io/sentry/dsn/Dsn.java
+++ b/sentry/src/main/java/io/sentry/dsn/Dsn.java
@@ -1,6 +1,7 @@
 package io.sentry.dsn;
 
 import io.sentry.config.Lookup;
+import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,12 +80,12 @@ public class Dsn {
     public static String dsnLookup() {
         String dsn = Lookup.lookup("dsn");
 
-        if (dsn == null) {
+        if (Util.isNullOrEmpty(dsn)) {
             // check if the user accidentally set "dns" instead of "dsn"
             dsn = Lookup.lookup("dns");
         }
 
-        if (dsn == null) {
+        if (Util.isNullOrEmpty(dsn)) {
             logger.warn("*** Couldn't find a suitable DSN, Sentry operations will do nothing!"
                 + " See documentation: https://docs.sentry.io/clients/java/ ***");
             dsn = DEFAULT_DSN;

--- a/sentry/src/test/java/io/sentry/dsn/DsnTest.java
+++ b/sentry/src/test/java/io/sentry/dsn/DsnTest.java
@@ -116,6 +116,17 @@ public class DsnTest extends BaseTest {
         assertThat(Dsn.dsnLookup(), is(dsn));
     }
 
+    @Test
+    public void testDsnLookupWithEmptyEnvironmentVariable(@Mocked("getenv") final System system) throws Exception {
+        final String dsn = "";
+        new NonStrictExpectations() {{
+            System.getenv("SENTRY_DSN");
+            result = dsn;
+        }};
+
+        assertThat(Dsn.dsnLookup(), is(Dsn.DEFAULT_DSN));
+    }
+
     @Test(expectedExceptions = InvalidDsnException.class)
     public void testMissingSecretKeyInvalid() throws Exception {
         new Dsn("http://publicKey:@host/9");


### PR DESCRIPTION
This is so environment variable `SENTRY_DSN` can be set to an empty string without failing.