### PR TITLE
Unregister shutdown hooks on close

### DIFF
--- a/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
@@ -3,6 +3,7 @@ package io.sentry.connection;
 import io.sentry.SentryClient;
 import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.Event;
+import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,6 +111,7 @@ public class AsyncConnection implements Connection {
     @Override
     public void close() throws IOException {
         if (gracefulShutdown) {
+            Util.safelyRemoveShutdownHook(shutDownHook);
             shutDownHook.enabled = false;
         }
 

--- a/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
@@ -3,6 +3,7 @@ package io.sentry.connection;
 import io.sentry.buffer.Buffer;
 import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.Event;
+import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +115,7 @@ public class BufferedConnection implements Connection {
     @SuppressWarnings("checkstyle:magicnumber")
     public void close() throws IOException {
         if (gracefulShutdown) {
+            Util.safelyRemoveShutdownHook(shutDownHook);
             shutDownHook.enabled = false;
         }
 

--- a/sentry/src/main/java/io/sentry/util/Util.java
+++ b/sentry/src/main/java/io/sentry/util/Util.java
@@ -154,4 +154,23 @@ public final class Util {
         }
     }
 
+    /**
+     * Try to remove the shutDownHook, handling the case where the VM is in shutdown process.
+     * @param shutDownHook the shutDownHook to remove
+     * @return true if the hook was removed, false otherwise
+     */
+    public static boolean safelyRemoveShutdownHook(Thread shutDownHook) {
+        try {
+            return Runtime.getRuntime().removeShutdownHook(shutDownHook);
+        } catch (IllegalStateException e) {
+            // CHECKSTYLE.OFF: EmptyBlock
+            if (e.getMessage().equals("Shutdown in progress")) {
+                // ignore
+            } else {
+                throw e;
+            }
+            // CHECKSTYLE.ON: EmptyBlock
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
PR related to issue https://github.com/getsentry/sentry-java/issues/548

I noticed there are two places registering shutdown hooks (AsyncConnection and BufferedConnection), following the same pattern, so I added a method to Util to centralize the handling.