### PR TITLE
Add Automatic-Module-Name to manifest so we have basic Java 9 support.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 1.6.7
 -------------
 
--
+- Add Automatic-Module-Name to manifest so we have basic Java 9 support.
 
 Version 1.6.6
 -------------

--- a/sentry-android/pom.xml
+++ b/sentry-android/pom.xml
@@ -108,6 +108,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.android</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/sentry-log4j/pom.xml
+++ b/sentry-log4j/pom.xml
@@ -112,6 +112,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.log4j</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/sentry-log4j2/pom.xml
+++ b/sentry-log4j2/pom.xml
@@ -117,6 +117,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.log4j2</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/sentry-logback/pom.xml
+++ b/sentry-logback/pom.xml
@@ -110,6 +110,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.logback</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/sentry-spring/pom.xml
+++ b/sentry-spring/pom.xml
@@ -115,6 +115,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.spring</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -138,6 +138,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
                 <executions>


### PR DESCRIPTION
#527

@kashike do you mind reviewing this?

I packaged and unzipped the `sentry-logback` JAR (as a sample), and:

```
grep Auto META-INF/MANIFEST.MF
Automatic-Module-Name: io.sentry.logback
```

I guess that's all we need for basic support?