### PR TITLE
Log backoff responses (HTTP 429 Too Many Requests) as a warning to th…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,10 @@
 Version 1.6.9
 -------------
 
-- Log backoff responses (HTTP 429 Too Many Requests) as a warning to the `lockdown` logger instead of an error.
+- Warn (once) when a client lockdown is first initiated and why.
+- Log events skipped by a lockdown at the DEBUG level.
+- Don't log a full stacktrace when an HTTP 429 (Too Many Requests) is returned.
+- Fix parsing of Retry-After header which apparently changed to a floating point number.
 
 Version 1.6.8
 -------------

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Version 1.6.9
 -------------
 
--
+- Log backoff responses (HTTP 429 Too Many Requests) as a warning to the `lockdown` logger instead of an error.
 
 Version 1.6.8
 -------------

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.connection.Connection;
 import io.sentry.connection.EventSendCallback;
 import io.sentry.connection.LockedDownException;
+import io.sentry.connection.TooManyRequestsException;
 import io.sentry.context.Context;
 import io.sentry.context.ContextManager;
 import io.sentry.event.Event;
@@ -132,8 +133,8 @@ public class SentryClient {
 
         try {
             connection.send(event);
-        } catch (LockedDownException e) {
-            lockdownLogger.warn("The connection to Sentry is currently locked down.", e);
+        } catch (LockedDownException | TooManyRequestsException e) {
+            logger.debug("Dropping an Event due to lockdown: " + event);
         } catch (Exception e) {
             logger.error("An exception occurred while sending the event to Sentry.", e);
         } finally {

--- a/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
@@ -171,8 +171,8 @@ public class AsyncConnection implements Connection {
             try {
                 // The current thread is managed by sentry
                 actualConnection.send(event);
-            } catch (LockedDownException e) {
-                lockdownLogger.warn("The connection to Sentry is currently locked down.", e);
+            } catch (LockedDownException | TooManyRequestsException e) {
+                logger.debug("Dropping an Event due to lockdown: " + event);
             } catch (Exception e) {
                 logger.error("An exception occurred while sending the event to Sentry.", e);
             } finally {

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -35,6 +35,10 @@ public class HttpConnection extends AbstractConnection {
      */
     private static final String SENTRY_AUTH = "X-Sentry-Auth";
     /**
+     * HTTP code `429 Too Many Requests`, which is not included in HttpURLConnection.
+     */
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+    /**
      * Default timeout of an HTTP connection to Sentry.
      */
     private static final int DEFAULT_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(1);
@@ -156,11 +160,33 @@ public class HttpConnection extends AbstractConnection {
             outputStream.close();
             connection.getInputStream().close();
         } catch (IOException e) {
+            Long retryAfterMs = null;
+            String retryAfterHeader = connection.getHeaderField("Retry-After");
+            if (retryAfterHeader != null) {
+                // CHECKSTYLE.OFF: EmptyCatchBlock
+                try {
+                    // CHECKSTYLE.OFF: MagicNumber
+                    retryAfterMs = (long) (Double.parseDouble(retryAfterHeader) * 1000L); // seconds -> milliseconds
+                    // CHECKSTYLE.ON: MagicNumber
+                } catch (NumberFormatException nfe) {
+                    // noop, use default retry
+                }
+                // CHECKSTYLE.ON: EmptyCatchBlock
+            }
+
             try {
                 int responseCode = connection.getResponseCode();
                 if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
                     logger.debug("Event '" + event.getId() + "' was rejected by the Sentry server due to a filter.");
                     return;
+                } else if (responseCode == HTTP_TOO_MANY_REQUESTS) {
+                    /*
+                    If the response is a 429 we rethrow as a TooManyRequestsException so that,
+                    1. We can avoid logging this at error level
+                    2. We can use a different logger so that users can filter the messages
+                     */
+                    throw new TooManyRequestsException(
+                            "Too many requests to Sentry: https://docs.sentry.io/learn/quotas/", e, retryAfterMs);
                 }
             } catch (IOException responseCodeException) {
                 // pass
@@ -173,20 +199,6 @@ public class HttpConnection extends AbstractConnection {
             }
             if (null == errorMessage || errorMessage.isEmpty()) {
                 errorMessage = "An exception occurred while submitting the event to the Sentry server.";
-            }
-
-            Long retryAfterMs = null;
-            String retryAfterHeader = connection.getHeaderField("Retry-After");
-            if (retryAfterHeader != null) {
-                // CHECKSTYLE.OFF: EmptyCatchBlock
-                try {
-                    // CHECKSTYLE.OFF: MagicNumber
-                    retryAfterMs = Long.parseLong(retryAfterHeader) * 1000L; // seconds -> milliseconds
-                    // CHECKSTYLE.ON: MagicNumber
-                } catch (NumberFormatException nfe) {
-                    // noop, use default retry
-                }
-                // CHECKSTYLE.ON: EmptyCatchBlock
             }
 
             throw new ConnectionException(errorMessage, e, retryAfterMs);

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -181,10 +181,9 @@ public class HttpConnection extends AbstractConnection {
                     return;
                 } else if (responseCode == HTTP_TOO_MANY_REQUESTS) {
                     /*
-                    If the response is a 429 we rethrow as a TooManyRequestsException so that,
-                    1. We can avoid logging this at error level
-                    2. We can use a different logger so that users can filter the messages
-                     */
+                    If the response is a 429 we rethrow as a TooManyRequestsException so that we can
+                    avoid logging this is an error.
+                    */
                     throw new TooManyRequestsException(
                             "Too many requests to Sentry: https://docs.sentry.io/learn/quotas/", e, retryAfterMs);
                 }

--- a/sentry/src/main/java/io/sentry/connection/LockdownManager.java
+++ b/sentry/src/main/java/io/sentry/connection/LockdownManager.java
@@ -70,7 +70,7 @@ public class LockdownManager {
     /**
      * Reset the lockdown state, disabling lockdown and setting the backoff time to zero.
      */
-    public synchronized void resetState() {
+    public synchronized void unlock() {
         lockdownTime = 0;
         lockdownStartTime = null;
     }
@@ -81,11 +81,12 @@ public class LockdownManager {
      *
      * @param connectionException ConnectionException to check for a recommended
      *                            lockdown time, may be null
+     * @return whether or not this call actually locked the system down
      */
-    public synchronized void setState(ConnectionException connectionException) {
+    public synchronized boolean lockdown(ConnectionException connectionException) {
         // If we are already in a lockdown state, don't change anything
         if (isLockedDown()) {
-            return;
+            return false;
         }
 
         if (connectionException != null && connectionException.getRecommendedLockdownTime() != null) {
@@ -98,6 +99,8 @@ public class LockdownManager {
 
         lockdownTime = Math.min(maxLockdownTime, lockdownTime);
         lockdownStartTime = clock.date();
+
+        return true;
     }
 
     public synchronized void setBaseLockdownTime(long baseLockdownTime) {

--- a/sentry/src/main/java/io/sentry/connection/LockedDownException.java
+++ b/sentry/src/main/java/io/sentry/connection/LockedDownException.java
@@ -5,13 +5,4 @@ package io.sentry.connection;
  */
 public class LockedDownException extends RuntimeException {
 
-    /**
-     * Construct a LockedDownException with a message.
-     *
-     * @param message Exception message.
-     */
-    public LockedDownException(String message) {
-        super(message);
-    }
-
 }

--- a/sentry/src/main/java/io/sentry/connection/TooManyRequestsException.java
+++ b/sentry/src/main/java/io/sentry/connection/TooManyRequestsException.java
@@ -1,0 +1,22 @@
+package io.sentry.connection;
+
+/**
+ * Exception thrown when attempting to send Events while in a lockdown.
+ */
+public class TooManyRequestsException extends ConnectionException {
+
+    //CHECKSTYLE.OFF: JavadocMethod
+    public TooManyRequestsException(String message) {
+        super(message);
+    }
+
+    public TooManyRequestsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TooManyRequestsException(String message, Throwable cause, Long recommendedLockdownTime) {
+        super(message, cause, recommendedLockdownTime);
+    }
+    //CHECKSTYLE.ON: JavadocMethod
+
+}

--- a/sentry/src/test/java/io/sentry/connection/HttpConnectionTest.java
+++ b/sentry/src/test/java/io/sentry/connection/HttpConnectionTest.java
@@ -163,14 +163,14 @@ public class HttpConnectionTest extends BaseTest {
             mockUrlConnection.getErrorStream();
             result = new ByteArrayInputStream(httpErrorMessage.getBytes());
             mockUrlConnection.getHeaderField("Retry-After");
-            result = "12345";
+            result = "12345.25";
         }};
 
         try {
             httpConnection.doSend(mockEvent);
             fail();
         } catch (ConnectionException e) {
-            assertThat(e.getRecommendedLockdownTime(), is(12345L * 1000L));
+            assertThat(e.getRecommendedLockdownTime(), is(12345250L));
         }
     }
 


### PR DESCRIPTION
…e `lockdown` logger instead of an error.