### PR TITLE
Changed buffer code to only retry in the case of HTTP 429 or connectivity issues.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Version 1.6.9
 - Don't log a full stacktrace when an HTTP 429 (Too Many Requests) is returned.
 - Fix parsing of Retry-After header which apparently changed to a floating point number.
 - Pass MDC context down to AsyncConnection worker threads.
+- Changed `buffer.size` default from 50 to 10.
+- When buffering is enabled, only retry sending events when the network is down or the project
+  is being throttled (HTTP 429).
 
 Version 1.6.8
 -------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -315,7 +315,7 @@ Sentry always requires write permission on the buffer directory itself.
 
     buffer.dir=sentry-events
 
-The maximum number of events that will be stored on disk defaults to 50,
+The maximum number of events that will be stored on disk defaults to 10,
 but can also be configured with the option buffer.size``:
 
 ::

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -71,9 +71,9 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     public static final String BUFFER_SIZE_OPTION = "buffer.size";
     /**
-     * Default number of events to cache offline when network is down.
+     * Default number of events to cache offline when network is down or project is throttled.
      */
-    public static final int BUFFER_SIZE_DEFAULT = 50;
+    public static final int BUFFER_SIZE_DEFAULT = 10;
     /**
      * Option for how long to wait between attempts to flush the disk buffer, in milliseconds.
      */

--- a/sentry/src/main/java/io/sentry/connection/ConnectionException.java
+++ b/sentry/src/main/java/io/sentry/connection/ConnectionException.java
@@ -11,30 +11,32 @@ public class ConnectionException extends RuntimeException {
      */
     private Long recommendedLockdownTime = null;
 
+    /**
+     * HTTP response status code, if available.
+     */
+    private Integer responseCode = null;
+
     //CHECKSTYLE.OFF: JavadocMethod
     public ConnectionException() {
 
-    }
-
-    public ConnectionException(String message) {
-        super(message);
     }
 
     public ConnectionException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public ConnectionException(String message, Throwable cause, Long recommendedLockdownTime) {
+    public ConnectionException(String message, Throwable cause, Long recommendedLockdownTime, Integer responseCode) {
         super(message, cause);
         this.recommendedLockdownTime = recommendedLockdownTime;
-    }
-
-    public ConnectionException(Throwable cause) {
-        super(cause);
+        this.responseCode = responseCode;
     }
 
     public Long getRecommendedLockdownTime() {
         return recommendedLockdownTime;
+    }
+
+    public Integer getResponseCode() {
+        return responseCode;
     }
     //CHECKSTYLE.ON: JavadocMethod
 }

--- a/sentry/src/main/java/io/sentry/connection/TooManyRequestsException.java
+++ b/sentry/src/main/java/io/sentry/connection/TooManyRequestsException.java
@@ -6,16 +6,12 @@ package io.sentry.connection;
 public class TooManyRequestsException extends ConnectionException {
 
     //CHECKSTYLE.OFF: JavadocMethod
-    public TooManyRequestsException(String message) {
-        super(message);
-    }
-
-    public TooManyRequestsException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public TooManyRequestsException(String message, Throwable cause, Long recommendedLockdownTime) {
-        super(message, cause, recommendedLockdownTime);
+    public TooManyRequestsException(
+            String message,
+            Throwable cause,
+            Long recommendedLockdownTime,
+            Integer responseCode) {
+        super(message, cause, recommendedLockdownTime, responseCode);
     }
     //CHECKSTYLE.ON: JavadocMethod
 

--- a/sentry/src/test/java/io/sentry/connection/AbstractConnectionTest.java
+++ b/sentry/src/test/java/io/sentry/connection/AbstractConnectionTest.java
@@ -202,7 +202,7 @@ public class AbstractConnectionTest extends BaseTest {
         final long recommendedLockdownWaitTime = 12345L;
         new NonStrictExpectations() {{
             abstractConnection.doSend((Event) any);
-            result = new ConnectionException("Message", null, recommendedLockdownWaitTime);
+            result = new ConnectionException("Message", null, recommendedLockdownWaitTime, HttpConnection.HTTP_TOO_MANY_REQUESTS);
         }};
 
         try {


### PR DESCRIPTION
This should bring `sentry-java` in line with other mobile SDKs and the relay.

@HazAT or @mitsuhiko not sure if you can glance at this? It's pretty simple and has tests. I mostly want to make sure it's in line with what we want mobile to do.