### PR TITLE
Catch Throwable instead of Exception

### DIFF
--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -246,8 +246,8 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
             }
             sentryClient.addBuilderHelper(new ContextBuilderHelper(sentryClient));
             return configureSentryClient(sentryClient, dsn);
-        } catch (Exception e) {
-            logger.error("Failed to initialize sentry, falling back to no-op client", e);
+        } catch (Throwable t) {
+            logger.error("Failed to initialize sentry, falling back to no-op client", t);
             return new SentryClient(new NoopConnection(), new ThreadLocalContextManager());
         }
     }


### PR DESCRIPTION
Catching Throwable will give more information about possible errors that may occur while loading the client in a modular environment