### PR TITLE
Actively set connection timeout and read timeout for sentry connection.

### DIFF
--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -428,7 +428,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
         httpConnection.setMarshaller(marshaller);
 
         int timeout = getTimeout(dsn);
-        httpConnection.setTimeout(timeout);
+        httpConnection.setConnectionTimeout(timeout);
 
         boolean bypassSecurityEnabled = getBypassSecurityEnabled(dsn);
         httpConnection.setBypassSecurity(bypassSecurityEnabled);

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -75,11 +75,11 @@ public class HttpConnection extends AbstractConnection {
     /**
      * Timeout to connect of an HTTP connection to Sentry.
      */
-    private int connection_timeout = DEFAULT_CONNECTION_TIMEOUT;
+    private int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
     /**
      * Read timeout of an HTTP connection to Sentry.
      */
-    private int read_timeout = DEFAULT_READ_TIMEOUT;
+    private int readTimeout = DEFAULT_READ_TIMEOUT;
 
     /**
      * Setting allowing to bypass the security system which requires wildcard certificates
@@ -138,8 +138,8 @@ public class HttpConnection extends AbstractConnection {
             }
             connection.setRequestMethod("POST");
             connection.setDoOutput(true);
-            connection.setConnectTimeout(connection_timeout);
-            connection.setReadTimeout(read_timeout);
+            connection.setConnectTimeout(connectionTimeout);
+            connection.setReadTimeout(readTimeout);
             connection.setRequestProperty(USER_AGENT, SentryEnvironment.getSentryName());
             connection.setRequestProperty(SENTRY_AUTH, getAuthHeader());
 
@@ -239,9 +239,16 @@ public class HttpConnection extends AbstractConnection {
         return sb.toString();
     }
 
+    /**
+     * This will set the timeout that is used in establishing a connection to the url.
+     * By default this is set to 1 second.
+     *
+     * @deprecated Use setConnectionTimeout instead.
+     * @param timeout New timeout to set. If 0 is used (java default) wait forever.
+     */
     @Deprecated
     public void setTimeout(int timeout) {
-        this.connection_timeout = timeout;
+        this.connectionTimeout = timeout;
     }
 
     /**
@@ -251,7 +258,7 @@ public class HttpConnection extends AbstractConnection {
      * @param timeout New timeout to set. If 0 is used (java default) wait forever.
      */
     public void setConnectionTimeout(int timeout) {
-        this.connection_timeout = timeout;
+        this.connectionTimeout = timeout;
     }
 
     /**
@@ -261,7 +268,7 @@ public class HttpConnection extends AbstractConnection {
      * @param timeout New timeout to set. If 0 is used (java default) wait forever.
      */
     public void setReadTimeout(int timeout) {
-        this.read_timeout = timeout;
+        this.readTimeout = timeout;
     }
 
     public void setMarshaller(Marshaller marshaller) {

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -39,9 +39,14 @@ public class HttpConnection extends AbstractConnection {
      */
     private static final String SENTRY_AUTH = "X-Sentry-Auth";
     /**
-     * Default timeout of an HTTP connection to Sentry.
+     * Default connection timeout of an HTTP connection to Sentry.
      */
-    private static final int DEFAULT_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(1);
+    private static final int DEFAULT_CONNECTION_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(1);
+    /**
+     * Default read timeout of an HTTP connection to Sentry.
+     */
+    private static final int DEFAULT_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(1);
+
     /**
      * HostnameVerifier allowing wildcard certificates to work without adding them to the truststore.
      */
@@ -68,9 +73,14 @@ public class HttpConnection extends AbstractConnection {
      */
     private Marshaller marshaller;
     /**
-     * Timeout of an HTTP connection to Sentry.
+     * Timeout to connect of an HTTP connection to Sentry.
      */
-    private int timeout = DEFAULT_TIMEOUT;
+    private int connection_timeout = DEFAULT_CONNECTION_TIMEOUT;
+    /**
+     * Read timeout of an HTTP connection to Sentry.
+     */
+    private int read_timeout = DEFAULT_READ_TIMEOUT;
+
     /**
      * Setting allowing to bypass the security system which requires wildcard certificates
      * to be added to the truststore.
@@ -128,7 +138,8 @@ public class HttpConnection extends AbstractConnection {
             }
             connection.setRequestMethod("POST");
             connection.setDoOutput(true);
-            connection.setConnectTimeout(timeout);
+            connection.setConnectTimeout(connection_timeout);
+            connection.setReadTimeout(read_timeout);
             connection.setRequestProperty(USER_AGENT, SentryEnvironment.getSentryName());
             connection.setRequestProperty(SENTRY_AUTH, getAuthHeader());
 
@@ -228,8 +239,29 @@ public class HttpConnection extends AbstractConnection {
         return sb.toString();
     }
 
+    @Deprecated
     public void setTimeout(int timeout) {
-        this.timeout = timeout;
+        this.connection_timeout = timeout;
+    }
+
+    /**
+     * This will set the timeout that is used in establishing a connection to the url.
+     * By default this is set to 1 second.
+     *
+     * @param timeout New timeout to set. If 0 is used (java default) wait forever.
+     */
+    public void setConnectionTimeout(int timeout) {
+        this.connection_timeout = timeout;
+    }
+
+    /**
+     * This will set the timeout that is used in reading data on an already established connection.
+     * By default this is set to 1 seconds.
+     *
+     * @param timeout New timeout to set. If 0 is used (java default) wait forever.
+     */
+    public void setReadTimeout(int timeout) {
+        this.read_timeout = timeout;
     }
 
     public void setMarshaller(Marshaller marshaller) {

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -45,7 +45,7 @@ public class HttpConnection extends AbstractConnection {
     /**
      * Default read timeout of an HTTP connection to Sentry.
      */
-    private static final int DEFAULT_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(1);
+    private static final int DEFAULT_READ_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(5);
 
     /**
      * HostnameVerifier allowing wildcard certificates to work without adding them to the truststore.
@@ -253,7 +253,7 @@ public class HttpConnection extends AbstractConnection {
 
     /**
      * This will set the timeout that is used in establishing a connection to the url.
-     * By default this is set to 1 second.
+     * By default this is set to 5 second.
      *
      * @param timeout New timeout to set. If 0 is used (java default) wait forever.
      */

--- a/sentry/src/test/java/io/sentry/connection/HttpConnectionTest.java
+++ b/sentry/src/test/java/io/sentry/connection/HttpConnectionTest.java
@@ -62,9 +62,9 @@ public class HttpConnectionTest extends BaseTest {
     }
 
     @Test
-    public void testTimeout(@Injectable final Event mockEvent) throws Exception {
+    public void testConnectionTimeout(@Injectable final Event mockEvent) throws Exception {
         final int timeout = 12;
-        httpConnection.setTimeout(timeout);
+        httpConnection.setConnectionTimeout(timeout);
 
         httpConnection.send(mockEvent);
 
@@ -72,6 +72,19 @@ public class HttpConnectionTest extends BaseTest {
             mockUrlConnection.setConnectTimeout(timeout);
         }};
     }
+
+    @Test
+    public void testReadTimeout(@Injectable final Event mockEvent) throws Exception {
+        final int timeout = 42;
+        httpConnection.setReadTimeout(timeout);
+
+        httpConnection.send(mockEvent);
+
+        new Verifications() {{
+            mockUrlConnection.setReadTimeout(timeout);
+        }};
+    }
+
 
     @Test
     public void testByPassSecurityDefaultsToFalse(@Injectable final Event mockEvent) throws Exception {


### PR DESCRIPTION
Hi.

We are using sentry in our production environments and had a problem with one process hanging and never completing its workload. As this piece of software is heavily used and have been stable for weeks we looked at things that could happen seldom enough and have some outside stimuli.

Then I remembered a problem I had back in 2014 where java hanged when you got a problem with the connection and either the connection didn't connect or the data received never came. And we then found that in Java both Connection Timeout and Read Timeout is set to zero by default. This means that they will wait forever to either get a connection or read some data.

Looking into the sentry code you send code in the HttpConnection class and you never set the setDoInput to false so you expect there to be a response from the server. So I thought read timeout might be the problem we encountered. 

In this pull request, I added functions to set the connection timeout as well as the read timeout and deprecated the old function with a less distinct name.

Hope you'll consider this bug fix.

Best regards
Daniel