### PR TITLE
support JUL handler level

### DIFF
--- a/sentry/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry/src/main/java/io/sentry/jul/SentryHandler.java
@@ -81,6 +81,15 @@ public class SentryHandler extends Handler {
         LogManager manager = LogManager.getLogManager();
         String className = SentryHandler.class.getName();
         setPrintfStyle(Boolean.valueOf(manager.getProperty(className + ".printfStyle")));
+        setLevel(parseLevelOrDefault(manager.getProperty(className + ".level")));
+    }
+
+    private Level parseLevelOrDefault(String levelName) {
+        try {
+            return Level.parse(levelName.trim());
+        } catch (Exception e) {
+            return Level.WARNING;
+        }
     }
 
     @Override

--- a/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
+++ b/sentry/src/test/java/io/sentry/jul/SentryHandlerEventBuildingTest.java
@@ -52,6 +52,7 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
         final Date date = new Date(1373883196416L);
         final long threadId = 12;
 
+        sentryHandler.setLevel(Level.INFO);
         sentryHandler.publish(newLogRecord(loggerName, Level.INFO, message, arguments, null, null, threadId, date.getTime()));
 
 
@@ -89,6 +90,7 @@ public class SentryHandlerEventBuildingTest extends BaseTest {
 
     @Test(dataProvider = "levels")
     public void testLevelConversion(final Event.Level expectedLevel, Level level) throws Exception {
+        sentryHandler.setLevel(Level.ALL);
         sentryHandler.publish(newLogRecord(null, level, null, null, null));
 
         new Verifications() {{


### PR DESCRIPTION
Handle JUL handler level correctly.
see https://stackoverflow.com/questions/46293943/sentry-io-tomcat-jul-all-logs-are-sent-to-sentry ,
https://forum.sentry.io/t/sentry-tomcat-integration/2370 and
https://forum.sentry.io/t/tomcat8-raven-jul-all-is-logged-why/438