### PR TITLE
WIP Initital stab at a Breadcrumb appender for logback

### DIFF
--- a/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
@@ -9,11 +9,17 @@ import io.sentry.Sentry;
 import io.sentry.environment.SentryEnvironment;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.BreadcrumbBuilder;
-import io.sentry.event.Event;
-import io.sentry.event.EventBuilder;
 
+/**
+ * A logback appender that turns logging events into Breadcrumbs on the ThreadLocal
+ * context
+ */
 public class SentryBreadcrumbAppender extends AppenderBase<ILoggingEvent> {
 
+    /**
+     * The append method for
+     * @param iLoggingEvent the event to transform into a breadcrumb
+     */
     @Override protected void append(ILoggingEvent iLoggingEvent) {
         // Do not log the event if the current thread is managed by sentry
         if (SentryEnvironment.isManagingThread()) {
@@ -27,14 +33,14 @@ public class SentryBreadcrumbAppender extends AppenderBase<ILoggingEvent> {
                     .setTimestamp(new Date(iLoggingEvent.getTimeStamp()));
             Sentry.getContext().recordBreadcrumb(breadcrumb.build());
         } catch (Exception e) {
-            addError("An exception occurred while creating a new event in Sentry", e);
+            addError("An exception occurred while creating a new breadcrumb in Sentry", e);
         } finally {
             SentryEnvironment.stopManagingThread();
         }
-   }
+    }
 
     /**
-     * Transforms a {@link Level} into an {@link Event.Level}.
+     * Transforms a {@link Level} into an {@link Breadcrumb.Level}.
      *
      * @param level original level as defined in logback.
      * @return log level used within sentry.

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
@@ -1,0 +1,55 @@
+package io.sentry.logback;
+
+import java.util.Date;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import io.sentry.Sentry;
+import io.sentry.environment.SentryEnvironment;
+import io.sentry.event.Breadcrumb;
+import io.sentry.event.BreadcrumbBuilder;
+import io.sentry.event.Event;
+import io.sentry.event.EventBuilder;
+
+public class SentryBreadcrumbAppender extends AppenderBase<ILoggingEvent> {
+
+    @Override protected void append(ILoggingEvent iLoggingEvent) {
+        // Do not log the event if the current thread is managed by sentry
+        if (SentryEnvironment.isManagingThread()) {
+            return;
+        }
+        SentryEnvironment.startManagingThread();
+        try {
+            BreadcrumbBuilder breadcrumb = new BreadcrumbBuilder()
+                    .setLevel(formatLevel(iLoggingEvent.getLevel()))
+                    .setMessage(iLoggingEvent.getFormattedMessage())
+                    .setTimestamp(new Date(iLoggingEvent.getTimeStamp()));
+            Sentry.getContext().recordBreadcrumb(breadcrumb.build());
+        } catch (Exception e) {
+            addError("An exception occurred while creating a new event in Sentry", e);
+        } finally {
+            SentryEnvironment.stopManagingThread();
+        }
+   }
+
+    /**
+     * Transforms a {@link Level} into an {@link Event.Level}.
+     *
+     * @param level original level as defined in logback.
+     * @return log level used within sentry.
+     */
+    protected static Breadcrumb.Level formatLevel(Level level) {
+        if (level.isGreaterOrEqual(Level.ERROR)) {
+            return Breadcrumb.Level.ERROR;
+        } else if (level.isGreaterOrEqual(Level.WARN)) {
+            return Breadcrumb.Level.WARNING;
+        } else if (level.isGreaterOrEqual(Level.INFO)) {
+            return Breadcrumb.Level.INFO;
+        } else if (level.isGreaterOrEqual(Level.ALL)) {
+            return Breadcrumb.Level.DEBUG;
+        } else {
+            return null;
+        }
+    }
+}

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
@@ -12,12 +12,13 @@ import io.sentry.event.BreadcrumbBuilder;
 
 /**
  * A logback appender that turns logging events into Breadcrumbs on the ThreadLocal
- * context
+ * context.
  */
 public class SentryBreadcrumbAppender extends AppenderBase<ILoggingEvent> {
 
     /**
-     * The append method for
+     * The append method for the SentryBreadcrumbAppender adds breadcrumbs to the context
+     * for all logging events that it receives
      * @param iLoggingEvent the event to transform into a breadcrumb
      */
     @Override protected void append(ILoggingEvent iLoggingEvent) {

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryBreadcrumbAppender.java
@@ -18,7 +18,7 @@ public class SentryBreadcrumbAppender extends AppenderBase<ILoggingEvent> {
 
     /**
      * The append method for the SentryBreadcrumbAppender adds breadcrumbs to the context
-     * for all logging events that it receives
+     * for all logging events that it receives.
      * @param iLoggingEvent the event to transform into a breadcrumb
      */
     @Override protected void append(ILoggingEvent iLoggingEvent) {

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderIT.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderIT.java
@@ -1,12 +1,16 @@
 package io.sentry.logback;
 
 import io.sentry.BaseIT;
+import io.sentry.unmarshaller.event.UnmarshalledEvent;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class SentryAppenderIT extends BaseIT {
     /*
@@ -30,6 +34,21 @@ public class SentryAppenderIT extends BaseIT {
 
         verifyProject1PostRequestCount(1);
         verifyStoredEventCount(1);
+    }
+
+    @Test
+    public void testInfoThenErrorLog() throws Exception {
+        verifyProject1PostRequestCount(0);
+        verifyStoredEventCount(0);
+
+        logger.info("Innocuous event");
+        logger.info("Another innocuous event");
+        logger.error("This is a test");
+
+        verifyProject1PostRequestCount(1);
+        verifyStoredEventCount(1);
+        UnmarshalledEvent event = getStoredEvents().get(0);
+        assertEquals(2, event.getBreadcrumbLength());
     }
 
     @Test

--- a/sentry-logback/src/test/resources/logback-integration.xml
+++ b/sentry-logback/src/test/resources/logback-integration.xml
@@ -12,6 +12,19 @@
         </filter>
     </appender>
 
+    <appender name="SentryBreadcrumb" class="io.sentry.logback.SentryBreadcrumbAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
+    </appender>
+
     <!-- Wiremock can throw WARN logs on shutdown which would trigger Sentry to send more events -->
     <!--<logger name="wiremock.org.eclipse.jetty.util.thread.QueuedThreadPool" level="OFF" />-->
     <!--<logger name="wiremock.org.eclipse.jetty.util.log.JettyAwareLogger" level="OFF" />-->
@@ -19,6 +32,7 @@
 
     <logger name="logback.SentryAppenderIT" level="INFO">
         <appender-ref ref="Sentry" />
+        <appender-ref ref="SentryBreadcrumb" />
     </logger>
 
     <root level="INFO">

--- a/sentry/src/test/java/io/sentry/BaseIT.java
+++ b/sentry/src/test/java/io/sentry/BaseIT.java
@@ -27,7 +27,7 @@ public class BaseIT extends BaseTest {
     public static final String PROJECT1_ID = "1";
     public static final String PROJECT1_STORE_URL = "/api/" + PROJECT1_ID + "/store/";
     public static final String AUTH_HEADER = "X-Sentry-Auth";
-    public static final StringValuePattern AUTH_HEADER_PATTERN = new RegexPattern("Sentry sentry_version=6,sentry_client=sentry-java/[\\w\\-\\.]+,sentry_key=8292bf61d620417282e68a72ae03154a,sentry_secret=e3908e05ad874b24b7a168992bfa3577");
+    public static final StringValuePattern AUTH_HEADER_PATTERN = new RegexPattern("Sentry sentry_version=6,sentry_client=sentry-java/[\\w\\-\\.]*,sentry_key=8292bf61d620417282e68a72ae03154a,sentry_secret=e3908e05ad874b24b7a168992bfa3577");
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8080));

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
@@ -1,7 +1,7 @@
 package io.sentry.unmarshaller.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.sentry.event.Breadcrumb;
+import io.sentry.unmarshaller.event.interfaces.Breadcrumb;
 import io.sentry.unmarshaller.event.interfaces.ExceptionInterface;
 import io.sentry.unmarshaller.event.interfaces.MessageInterface;
 import io.sentry.unmarshaller.event.interfaces.StackTraceInterface;

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
@@ -46,7 +46,7 @@ public class UnmarshalledEvent {
     @JsonProperty(value = "extra")
     private Map<String, Object> extras;
     @JsonProperty(value = "breadcrumbs")
-    private List<Breadcrumb> breadcrumbs;
+    private Map<String, List<Breadcrumb>> breadcrumbs;
     @JsonProperty(value = "contexts")
     private Map<String, Map<String, String>> contexts;
     @JsonProperty(value = "sentry.interfaces.Message")
@@ -72,5 +72,12 @@ public class UnmarshalledEvent {
     @JsonProperty(value = "sentry.interfaces.Stacktrace")
     public void setStackTraceInterfaceLong(StackTraceInterface stackTraceInterface) {
         this.stackTraceInterface = stackTraceInterface;
+    }
+
+    public int getBreadcrumbLength() {
+        if (breadcrumbs == null || !breadcrumbs.containsKey("values")) {
+            return 0;
+        }
+        return breadcrumbs.get("values").size();
     }
 }

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/interfaces/Breadcrumb.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/interfaces/Breadcrumb.java
@@ -1,0 +1,20 @@
+package io.sentry.unmarshaller.event.interfaces;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Breadcrumb {
+	@JsonProperty("type")
+	private String type;
+	@JsonProperty("timestamp")
+	private String timestamp;
+	@JsonProperty("level")
+	private String level;
+	@JsonProperty("message")
+	private String message;
+	@JsonProperty("category")
+	private String category;
+	@JsonProperty("data")
+	private Map<String, String> data;
+}


### PR DESCRIPTION
#485 (maybe also #450)

I ran this code on a local machine under basically no load and it did what I hoped. The IT works, but seems like it's polluting a bunch of classes that are doing other things. I think the actual interface for setting this up could be better. It seems like the common use case would be what's described in the issues (everything below WARN or ERROR is a breadcrumb, but then send when a high enough level is reached), and that can be achieved with native logback configuration, but the affordance of the API isn't great.

For Spredfast's use case this is actually fine, since we do all sentry captures in sf-webapp explicitly and I want to get all the logs on the thread before the exception ¯\_(ツ)_/¯