### PR TITLE
Breadcrumbs in the SentryAppender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ docs/_build
 infer-out/
 agent/build/
 local.properties
+.gradle/
+.idea/
+gradle/
+gradlew
+gradlew.bat
+*.iml

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -89,6 +89,26 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         }
     }
 
+    /**
+     * Transforms a {@link Level} into an {@link Breadcrumb.Level}.
+     *
+     * @param level original level as defined in logback.
+     * @return log level used within sentry.
+     */
+    protected static Breadcrumb.Level formatBreadcrumbLevel(Level level) {
+        if (level.isGreaterOrEqual(Level.ERROR)) {
+            return Breadcrumb.Level.ERROR;
+        } else if (level.isGreaterOrEqual(Level.WARN)) {
+            return Breadcrumb.Level.WARNING;
+        } else if (level.isGreaterOrEqual(Level.INFO)) {
+            return Breadcrumb.Level.INFO;
+        } else if (level.isGreaterOrEqual(Level.ALL)) {
+            return Breadcrumb.Level.DEBUG;
+        } else {
+            return null;
+        }
+    }
+
     @Override
     protected void append(ILoggingEvent iLoggingEvent) {
         // Do not log the event if the current thread is managed by sentry
@@ -160,6 +180,12 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
         return eventBuilder;
     }
 
+    /**
+     * Builds a BreadcrumbBuilder based on the logging event.
+     *
+     * @param iLoggingEvent Log generated.
+     * @return BreadcrumbBuilder containing details provided by the logging system.
+     */
     protected BreadcrumbBuilder createBreadcrumbBuilder(ILoggingEvent iLoggingEvent) {
         BreadcrumbBuilder breadcrumb = new BreadcrumbBuilder()
                 .setLevel(formatBreadcrumbLevel(iLoggingEvent.getLevel()))
@@ -300,26 +326,6 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
                 return FilterReply.DENY;
             }
             return FilterReply.NEUTRAL;
-        }
-    }
-
-    /**
-     * Transforms a {@link Level} into an {@link Breadcrumb.Level}.
-     *
-     * @param level original level as defined in logback.
-     * @return log level used within sentry.
-     */
-    protected static Breadcrumb.Level formatBreadcrumbLevel(Level level) {
-        if (level.isGreaterOrEqual(Level.ERROR)) {
-            return Breadcrumb.Level.ERROR;
-        } else if (level.isGreaterOrEqual(Level.WARN)) {
-            return Breadcrumb.Level.WARNING;
-        } else if (level.isGreaterOrEqual(Level.INFO)) {
-            return Breadcrumb.Level.INFO;
-        } else if (level.isGreaterOrEqual(Level.ALL)) {
-            return Breadcrumb.Level.DEBUG;
-        } else {
-            return null;
         }
     }
 

--- a/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderIT.java
+++ b/sentry-logback/src/test/java/io/sentry/logback/SentryAppenderIT.java
@@ -33,6 +33,22 @@ public class SentryAppenderIT extends BaseIT {
     }
 
     @Test
+    public void testInfoAsBreadcrumbLog() throws Exception {
+        verifyProject1PostRequestCount(0);
+        verifyStoredEventCount(0);
+
+        logger.info("Some innocuous logging for a breadcrumb");
+
+        verifyProject1PostRequestCount(0);
+        verifyStoredEventCount(0);
+
+        logger.error("This is a test");
+
+        verifyProject1PostRequestCount(1);
+        verifyStoredEventCount(1);
+    }
+
+    @Test
     public void testChainedExceptions() throws Exception {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);

--- a/sentry-logback/src/test/resources/logback-integration.xml
+++ b/sentry-logback/src/test/resources/logback-integration.xml
@@ -6,9 +6,9 @@
     </appender>
 
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-        <!-- Set Sentry to WARNING level, as we recommend this as the lowest users go in their own configuration -->
+        <minLevel>WARN</minLevel>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>WARN</level>
+            <level>DEBUG</level>
         </filter>
     </appender>
 

--- a/sentry/src/test/java/io/sentry/BaseIT.java
+++ b/sentry/src/test/java/io/sentry/BaseIT.java
@@ -27,7 +27,7 @@ public class BaseIT extends BaseTest {
     public static final String PROJECT1_ID = "1";
     public static final String PROJECT1_STORE_URL = "/api/" + PROJECT1_ID + "/store/";
     public static final String AUTH_HEADER = "X-Sentry-Auth";
-    public static final StringValuePattern AUTH_HEADER_PATTERN = new RegexPattern("Sentry sentry_version=6,sentry_client=sentry-java/[\\w\\-\\.]+,sentry_key=8292bf61d620417282e68a72ae03154a,sentry_secret=e3908e05ad874b24b7a168992bfa3577");
+    public static final StringValuePattern AUTH_HEADER_PATTERN = new RegexPattern("Sentry sentry_version=6,sentry_client=sentry-java/[\\w\\-\\.]*,sentry_key=8292bf61d620417282e68a72ae03154a,sentry_secret=e3908e05ad874b24b7a168992bfa3577");
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8080));

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/UnmarshalledEvent.java
@@ -1,7 +1,7 @@
 package io.sentry.unmarshaller.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.sentry.event.Breadcrumb;
+import io.sentry.unmarshaller.event.interfaces.Breadcrumb;
 import io.sentry.unmarshaller.event.interfaces.ExceptionInterface;
 import io.sentry.unmarshaller.event.interfaces.MessageInterface;
 import io.sentry.unmarshaller.event.interfaces.StackTraceInterface;
@@ -46,7 +46,7 @@ public class UnmarshalledEvent {
     @JsonProperty(value = "extra")
     private Map<String, Object> extras;
     @JsonProperty(value = "breadcrumbs")
-    private List<Breadcrumb> breadcrumbs;
+    private Map<String, List<Breadcrumb>> breadcrumbs;
     @JsonProperty(value = "contexts")
     private Map<String, Map<String, String>> contexts;
     @JsonProperty(value = "sentry.interfaces.Message")

--- a/sentry/src/test/java/io/sentry/unmarshaller/event/interfaces/Breadcrumb.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/event/interfaces/Breadcrumb.java
@@ -1,0 +1,20 @@
+package io.sentry.unmarshaller.event.interfaces;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Breadcrumb {
+	@JsonProperty("type")
+	private String type;
+	@JsonProperty("timestamp")
+	private String timestamp;
+	@JsonProperty("level")
+	private String level;
+	@JsonProperty("message")
+	private String message;
+	@JsonProperty("category")
+	private String category;
+	@JsonProperty("data")
+	private Map<String, String> data;
+}


### PR DESCRIPTION
This is an alternate approach to #579. This undeprecates (reprecates?) minLevel and uses it as the level at which the SentryAppender sends an Event to sentry. All logging that goes to the appender below minLevel will be stored as breadcrumbs.

Users who do not wish breadcrumb behavior can leave minLevel as the default null.
Users who want only breadcrumbs and never to send from the appender can set minLevel to `OFF`