### PR TITLE
Add `BreadcrumbBuilder.withData` like `UserBuilder`

### DIFF
--- a/sentry/src/main/java/io/sentry/event/BreadcrumbBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/BreadcrumbBuilder.java
@@ -82,6 +82,22 @@ public class BreadcrumbBuilder {
         this.data = newData;
         return this;
     }
+    
+    /**
+     * Adds to the related data for the {@link breadcrumb}.
+     *
+     * @param name Name of the data
+     * @param value Value of the data
+     * @return current BreadcrumbBuilder
+     */
+    public BreadcrumbBuilder withData(String name, Object value) {
+        if (this.data == null) {
+            this.data = new HashMap<>();
+        }
+
+        this.data.put(name, value);
+        return this;
+    }
 
     /**
      * Build and return the {@link Breadcrumb} object.


### PR DESCRIPTION
`UserBuilder` has a very convenient `withData(String name, String value)` method that makes it very easy to set a few pieces of extra user data without manually building a `Map`.

`BreadcrumbBuilder` takes extra data the same way that `UserBuilder` does (with a `setData(Map map)` method), but it does not have the `withData` convenience method.

This PR adds the `withData` method.

Note: I did not add additional tests for this because there are currently no tests for the existing `BreadcrumbBuilder.setData` that I could see so I didn't feel the need. If you would like tests, I will add them.