### PR TITLE
Json facade for marshalling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     </prerequisites>
 
     <modules>
+        <module>sentry-json-connector</module>
         <module>sentry</module>
         <module>sentry-android</module>
         <module>sentry-appengine</module>
@@ -80,6 +81,8 @@
         <module>sentry-logback</module>
         <module>sentry-log4j2</module>
         <module>sentry-spring</module>
+        <module>sentry-gson-factory</module>
+        <module>sentry-jackson-factory</module>
     </modules>
 
     <scm>
@@ -119,6 +122,7 @@
         <!-- dependencies versions -->
         <slf4j.version>1.7.24</slf4j.version>
         <jackson.version>2.8.7</jackson.version>
+        <gson.version>2.8.1</gson.version>
         <jmockit.version>1.14</jmockit.version>
         <testng.version>6.9.10</testng.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -135,7 +139,23 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>sentry-json-connector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>sentry-jackson-factory</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>sentry</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>sentry-json-connector</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
             </dependency>
@@ -159,6 +179,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jmockit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>sentry-jackson-factory</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>sentry-json-connector</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>

--- a/sentry-android/pom.xml
+++ b/sentry-android/pom.xml
@@ -78,12 +78,22 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentry-gson-factory/README.md
+++ b/sentry-gson-factory/README.md
@@ -1,0 +1,3 @@
+# sentry-gson-factory
+
+See the [Sentry documentation](https://docs.sentry.io/clients/java/) for more information.

--- a/sentry-gson-factory/bnd.bnd
+++ b/sentry-gson-factory/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.marshaller.json.factory

--- a/sentry-gson-factory/pom.xml
+++ b/sentry-gson-factory/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-all</artifactId>
+        <version>1.7.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sentry-gson-factory</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Sentry-Java Gson Connector</name>
+    <description>Gson Connector for Sentry-Java client.</description>
+
+    <properties>
+        <junit.version>4.12</junit.version>
+        <robolectric.version>2.4</robolectric.version>
+        <maven-ant.version>2.1.3</maven-ant.version>
+        <easymock.version>3.5</easymock.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>${easymock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>${robolectric.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-ant-tasks</artifactId>
+            <version>${maven-ant.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Integration tests dependencies -->
+        <!-- Sentry Test-jar does not provide test dependencies transitively -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.gson.factory</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sentry-gson-factory/pom.xml
+++ b/sentry-gson-factory/pom.xml
@@ -107,6 +107,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
+++ b/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
@@ -7,6 +7,9 @@ import io.sentry.marshaller.json.generator.GsonGenerator;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * JsonFactory implementation for runtime Gson Injection.
+ */
 public class JsonFactoryImpl implements JsonFactory {
 
     @Override

--- a/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
+++ b/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
@@ -1,0 +1,16 @@
+package io.sentry.marshaller.json.factory;
+
+import io.sentry.marshaller.json.connector.JsonFactory;
+import io.sentry.marshaller.json.connector.JsonGenerator;
+import io.sentry.marshaller.json.generator.GsonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class JsonFactoryImpl implements JsonFactory {
+
+    @Override
+    public JsonGenerator createGenerator(OutputStream destination) throws IOException {
+        return new GsonGenerator(destination);
+    }
+}

--- a/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
+++ b/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
@@ -83,6 +83,7 @@ public class GsonGenerator implements JsonGenerator {
 
     /**
      * Tries to write object value to simple types or error out.
+     *
      * @param value any object value.
      * @throws IOException when there's and issue with output stream.
      */
@@ -90,30 +91,33 @@ public class GsonGenerator implements JsonGenerator {
         if (value == null) {
             this.writeNull();
         } else if (value instanceof String) {
-            this.writeString((String)value);
+            this.writeString((String) value);
         } else {
             if (value instanceof Number) {
-                Number n = (Number)value;
-                writeNumber(n);
+                Number n = (Number) value;
+                this.writeNumber(n);
                 return;
             } else {
                 if (value instanceof byte[]) {
-                    this.writeBinary((byte[])value);
+                    this.writeBinary((byte[]) value);
                     return;
                 }
 
                 if (value instanceof Boolean) {
-                    this.writeBoolean((Boolean)value);
+                    this.writeBoolean((Boolean) value);
                     return;
                 }
 
                 if (value instanceof AtomicBoolean) {
-                    this.writeBoolean(((AtomicBoolean)value).get());
+                    this.writeBoolean(((AtomicBoolean) value).get());
                     return;
                 }
             }
 
-            throw new IllegalStateException(GsonGenerator.class.getSimpleName() + " can only serialize simple wrapper types (type passed " + value.getClass().getName() + ")");
+            throw new IllegalStateException(GsonGenerator.class.getSimpleName()
+                    + " can only serialize simple wrapper types (type passed "
+                    + value.getClass().getName()
+                    + ")");
         }
     }
 
@@ -124,7 +128,8 @@ public class GsonGenerator implements JsonGenerator {
      * @param bytes byte array object.
      */
     private void writeBinary(byte[] bytes) {
-        throw new IllegalStateException(GsonGenerator.class.getSimpleName() + " don't support serializing byte[] yet.");
+        throw new IllegalStateException(GsonGenerator.class.getSimpleName()
+                + " don't support serializing byte[] yet.");
     }
 
     private void writeNumber(Number number) throws IOException {

--- a/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
+++ b/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
@@ -10,9 +10,17 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Gson Json Generator Facade, it just delegates directly to <code>com.fasterxml.jackson.core.JsonGenerator</code>.
+ */
 public class GsonGenerator implements JsonGenerator {
     private final JsonWriter writer;
 
+    /**
+     * Creates a new facade delegating to @{@code com.google.gson.stream.JsonWriter}.
+     *
+     * @param destination Destination OutputStream whose Json will be written.
+     */
     public GsonGenerator(OutputStream destination) {
         this.writer = new JsonWriter(new OutputStreamWriter(destination));
     }
@@ -73,6 +81,11 @@ public class GsonGenerator implements JsonGenerator {
         writeSimpleObject(value);
     }
 
+    /**
+     * Tries to write object value to simple types or error out.
+     * @param value any object value.
+     * @throws IOException when there's and issue with output stream.
+     */
     private void writeSimpleObject(Object value) throws IOException {
         if (value == null) {
             this.writeNull();
@@ -104,6 +117,12 @@ public class GsonGenerator implements JsonGenerator {
         }
     }
 
+    /**
+     * NOT SUPPORTED YET.
+     * Writes byte array to json output as field value.
+     *
+     * @param bytes byte array object.
+     */
     private void writeBinary(byte[] bytes) {
         throw new IllegalStateException(GsonGenerator.class.getSimpleName() + " don't support serializing byte[] yet.");
     }

--- a/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
+++ b/sentry-gson-factory/src/main/java/io/sentry/marshaller/json/generator/GsonGenerator.java
@@ -1,0 +1,208 @@
+package io.sentry.marshaller.json.generator;
+
+import com.google.gson.stream.JsonWriter;
+import io.sentry.marshaller.json.connector.JsonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class GsonGenerator implements JsonGenerator {
+    private final JsonWriter writer;
+
+    public GsonGenerator(OutputStream destination) {
+        this.writer = new JsonWriter(new OutputStreamWriter(destination));
+    }
+
+    @Override
+    public void writeStartObject() throws IOException {
+        writer.beginObject();
+    }
+
+    @Override
+    public void writeStringField(String fieldName, String value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeArrayFieldStart(String fieldName) throws IOException {
+        writer.name(fieldName).beginArray();
+    }
+
+    @Override
+    public void writeString(String value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeEndArray() throws IOException {
+        writer.endArray();
+    }
+
+    @Override
+    public void writeEndObject() throws IOException {
+        writer.endObject();
+    }
+
+    @Override
+    public void writeNull() throws IOException {
+        writer.nullValue();
+    }
+
+    @Override
+    public void writeStartArray() throws IOException {
+        writer.beginArray();
+    }
+
+    @Override
+    public void writeFieldName(String fieldName) throws IOException {
+        writer.name(fieldName);
+    }
+
+    @Override
+    public void writeObject(Object value) throws IOException {
+        writeSimpleObject(value);
+    }
+
+    @Override
+    public void writeObjectField(String fieldName, Object value) throws IOException {
+        writer.name(fieldName);
+        writeSimpleObject(value);
+    }
+
+    private void writeSimpleObject(Object value) throws IOException {
+        if (value == null) {
+            this.writeNull();
+        } else if (value instanceof String) {
+            this.writeString((String)value);
+        } else {
+            if (value instanceof Number) {
+                Number n = (Number)value;
+                writeNumber(n);
+                return;
+            } else {
+                if (value instanceof byte[]) {
+                    this.writeBinary((byte[])value);
+                    return;
+                }
+
+                if (value instanceof Boolean) {
+                    this.writeBoolean((Boolean)value);
+                    return;
+                }
+
+                if (value instanceof AtomicBoolean) {
+                    this.writeBoolean(((AtomicBoolean)value).get());
+                    return;
+                }
+            }
+
+            throw new IllegalStateException(GsonGenerator.class.getSimpleName() + " can only serialize simple wrapper types (type passed " + value.getClass().getName() + ")");
+        }
+    }
+
+    private void writeBinary(byte[] bytes) {
+        throw new IllegalStateException(GsonGenerator.class.getSimpleName() + " don't support serializing byte[] yet.");
+    }
+
+    private void writeNumber(Number number) throws IOException {
+        writer.value(number);
+    }
+
+    @Override
+    public void writeBoolean(boolean state) throws IOException {
+        writer.value(state);
+    }
+
+    @Override
+    public void writeBooleanField(String fieldName, boolean value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeObjectFieldStart(String fieldName) throws IOException {
+        writer.name(fieldName).beginObject();
+    }
+
+    @Override
+    public void writeNullField(String fieldName) throws IOException {
+        writer.name(fieldName).nullValue();
+    }
+
+    @Override
+    public void writeNumber(String encodedValue) throws IOException {
+        try {
+            writer.value(new BigInteger(encodedValue));
+        } catch (Exception iError) {
+            try {
+                writer.value(new BigDecimal(encodedValue));
+            } catch (Exception dError) {
+                writer.value(encodedValue);
+            }
+        }
+
+    }
+
+    @Override
+    public void writeNumber(BigDecimal value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeNumber(float value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeNumber(double value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeNumber(long value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeNumber(int value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, BigDecimal value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, float value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, double value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, long value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, int value) throws IOException {
+        writer.name(fieldName).value(value);
+    }
+
+    @Override
+    public void writeNumber(BigInteger value) throws IOException {
+        writer.value(value);
+    }
+
+    @Override
+    public void close() throws IOException {
+        writer.close();
+    }
+}

--- a/sentry-gson-factory/src/test/java/io/sentry/marshaller/json/connector/GsonTest.java
+++ b/sentry-gson-factory/src/test/java/io/sentry/marshaller/json/connector/GsonTest.java
@@ -1,0 +1,72 @@
+package io.sentry.marshaller.json.connector;
+
+import io.sentry.marshaller.json.factory.JsonFactoryImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertSame;
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GsonTest {
+
+    @Before
+    public void setup() {
+        JsonFactoryRuntimeClasspathLocator.JSON_FACTORY.set(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        JsonFactoryRuntimeClasspathLocator.JSON_FACTORY.set(null);
+    }
+
+    @Test
+    public void testClassIsNotAvailable() {
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected boolean isAvailable(String fqcn) {
+                return false;
+            }
+        };
+        try {
+            locator.getInstance();
+        } catch (Exception ex) {
+            assertEquals("Unable to discover any JsonFactory implementations on the classpath.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCompareAndSetFalse() {
+        final JsonFactory deserializer = createMock(JsonFactory.class);
+
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected boolean compareAndSet(JsonFactory factory) {
+                JSON_FACTORY.set(deserializer);
+                return false;
+            }
+        };
+
+        JsonFactory returned = locator.getInstance();
+        assertSame(deserializer, returned);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testLocateReturnsNull() {
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected JsonFactory locate() {
+                return null;
+            }
+        };
+        locator.getInstance();
+    }
+
+    @Test
+    public void testJackson() {
+        JsonFactory factory = new JsonFactoryRuntimeClasspathLocator().getInstance();
+        assertTrue(factory instanceof JsonFactoryImpl);
+    }
+}

--- a/sentry-jackson-factory/README.md
+++ b/sentry-jackson-factory/README.md
@@ -1,0 +1,3 @@
+# sentry-jackson-factory
+
+See the [Sentry documentation](https://docs.sentry.io/clients/java/) for more information.

--- a/sentry-jackson-factory/bnd.bnd
+++ b/sentry-jackson-factory/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.marshaller.json.factory

--- a/sentry-jackson-factory/pom.xml
+++ b/sentry-jackson-factory/pom.xml
@@ -102,6 +102,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sentry-jackson-factory/pom.xml
+++ b/sentry-jackson-factory/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-all</artifactId>
+        <version>1.7.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sentry-jackson-factory</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Sentry-Java Jackson Connector</name>
+    <description>Jackson Connector for Sentry-Java client.</description>
+
+    <properties>
+        <junit.version>4.12</junit.version>
+        <robolectric.version>2.4</robolectric.version>
+        <maven-ant.version>2.1.3</maven-ant.version>
+        <easymock.version>3.5</easymock.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>${robolectric.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-ant-tasks</artifactId>
+            <version>${maven-ant.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>${easymock.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Integration tests dependencies -->
+        <!-- Sentry Test-jar does not provide test dependencies transitively -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.jackson.factory</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
+++ b/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
@@ -1,0 +1,21 @@
+package io.sentry.marshaller.json.factory;
+
+import io.sentry.marshaller.json.connector.JsonFactory;
+import io.sentry.marshaller.json.connector.JsonGenerator;
+import io.sentry.marshaller.json.generator.JacksonGenerator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class JsonFactoryImpl implements JsonFactory {
+    private final com.fasterxml.jackson.core.JsonFactory jsonFactory = new com.fasterxml.jackson.core.JsonFactory();
+
+    @Override
+    public JsonGenerator createGenerator(OutputStream destination) throws IOException {
+        return wrap(jsonFactory.createGenerator(destination));
+    }
+
+    private JsonGenerator wrap(com.fasterxml.jackson.core.JsonGenerator generator) {
+        return new JacksonGenerator(generator);
+    }
+}

--- a/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
+++ b/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/factory/JsonFactoryImpl.java
@@ -7,6 +7,9 @@ import io.sentry.marshaller.json.generator.JacksonGenerator;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * JsonFactory implementation for runtime Jackson Injection.
+ */
 public class JsonFactoryImpl implements JsonFactory {
     private final com.fasterxml.jackson.core.JsonFactory jsonFactory = new com.fasterxml.jackson.core.JsonFactory();
 

--- a/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/generator/JacksonGenerator.java
+++ b/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/generator/JacksonGenerator.java
@@ -1,0 +1,155 @@
+package io.sentry.marshaller.json.generator;
+
+import io.sentry.marshaller.json.connector.JsonGenerator;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class JacksonGenerator implements JsonGenerator {
+    private final com.fasterxml.jackson.core.JsonGenerator generator;
+
+    public JacksonGenerator(com.fasterxml.jackson.core.JsonGenerator generator) {
+        this.generator = generator;
+    }
+
+    @Override
+    public void writeObject(Object value) throws IOException {
+        generator.writeObject(value);
+    }
+
+    @Override
+    public void writeStartArray() throws IOException {
+        generator.writeStartArray();
+    }
+
+    @Override
+    public void writeStringField(String fieldName, String value) throws IOException {
+        generator.writeStringField(fieldName, value);
+    }
+
+    @Override
+    public void writeArrayFieldStart(String fieldName) throws IOException {
+        generator.writeArrayFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeBooleanField(String fieldName, boolean value) throws IOException {
+        generator.writeBooleanField(fieldName, value);
+    }
+
+    @Override
+    public void writeObjectFieldStart(String fieldName) throws IOException {
+        generator.writeObjectFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeObjectField(String fieldName, Object value) throws IOException {
+        generator.writeObjectField(fieldName, value);
+    }
+
+    @Override
+    public void writeNullField(String fieldName) throws IOException {
+        generator.writeNullField(fieldName);
+    }
+
+    @Override
+    public void writeEndArray() throws IOException {
+        generator.writeEndArray();
+    }
+
+    @Override
+    public void writeStartObject() throws IOException {
+        generator.writeStartObject();
+    }
+
+    @Override
+    public void writeEndObject() throws IOException {
+        generator.writeEndObject();
+    }
+
+    @Override
+    public void writeFieldName(String name) throws IOException {
+        generator.writeFieldName(name);
+    }
+
+    @Override
+    public void writeString(String text) throws IOException {
+        generator.writeString(text);
+    }
+
+    @Override
+    public void writeNumber(int v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(long v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(BigInteger v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(double v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(float v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(BigDecimal v) throws IOException {
+        generator.writeNumber(v);
+    }
+
+    @Override
+    public void writeNumber(String encodedValue) throws IOException {
+        generator.writeNumber(encodedValue);
+    }
+
+    @Override
+    public void writeBoolean(boolean state) throws IOException {
+        generator.writeBoolean(state);
+    }
+
+    @Override
+    public void writeNull() throws IOException {
+        generator.writeNull();
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, BigDecimal value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, float value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, double value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, long value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, int value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void close() throws IOException {
+        generator.close();
+    }
+}

--- a/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/generator/JacksonGenerator.java
+++ b/sentry-jackson-factory/src/main/java/io/sentry/marshaller/json/generator/JacksonGenerator.java
@@ -6,9 +6,17 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+/**
+ * Jackson Json Generator Facade, it just delegates directly to <code>com.fasterxml.jackson.core.JsonGenerator</code>.
+ */
 public class JacksonGenerator implements JsonGenerator {
     private final com.fasterxml.jackson.core.JsonGenerator generator;
 
+    /**
+     * Creates a new facade delegating to parameter  generator.
+     *
+     * @param generator Jackson Core JsonGenerator instance.
+     */
     public JacksonGenerator(com.fasterxml.jackson.core.JsonGenerator generator) {
         this.generator = generator;
     }

--- a/sentry-jackson-factory/src/test/java/io/sentry/marshaller/json/connector/JacksonTest.java
+++ b/sentry-jackson-factory/src/test/java/io/sentry/marshaller/json/connector/JacksonTest.java
@@ -1,0 +1,72 @@
+package io.sentry.marshaller.json.connector;
+
+import io.sentry.marshaller.json.factory.JsonFactoryImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertSame;
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JacksonTest {
+
+    @Before
+    public void setup() {
+        JsonFactoryRuntimeClasspathLocator.JSON_FACTORY.set(null);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        JsonFactoryRuntimeClasspathLocator.JSON_FACTORY.set(null);
+    }
+
+    @Test
+    public void testClassIsNotAvailable() {
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected boolean isAvailable(String fqcn) {
+                return false;
+            }
+        };
+        try {
+            locator.getInstance();
+        } catch (Exception ex) {
+            assertEquals("Unable to discover any JsonFactory implementations on the classpath.", ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testCompareAndSetFalse() {
+        final JsonFactory deserializer = createMock(JsonFactory.class);
+
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected boolean compareAndSet(JsonFactory factory) {
+                JsonFactoryRuntimeClasspathLocator.JSON_FACTORY.set(deserializer);
+                return false;
+            }
+        };
+
+        JsonFactory returned = locator.getInstance();
+        assertSame(deserializer, returned);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testLocateReturnsNull() {
+        JsonFactoryRuntimeClasspathLocator locator = new JsonFactoryRuntimeClasspathLocator() {
+            @Override
+            protected JsonFactory locate() {
+                return null;
+            }
+        };
+        locator.getInstance();
+    }
+
+    @Test
+    public void testJackson() {
+        JsonFactory factory = new JsonFactoryRuntimeClasspathLocator().getInstance();
+        assertTrue(factory instanceof JsonFactoryImpl);
+    }
+}

--- a/sentry-json-connector/README.md
+++ b/sentry-json-connector/README.md
@@ -1,0 +1,3 @@
+# sentry-android
+
+See the [Sentry documentation](https://docs.sentry.io/clients/java/modules/android/) for more information.

--- a/sentry-json-connector/bnd.bnd
+++ b/sentry-json-connector/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: ${project.name}
+Bundle-Description: ${project.description}
+
+-exportcontents:\
+    io.sentry.marshaller.json.connector

--- a/sentry-json-connector/pom.xml
+++ b/sentry-json-connector/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.sentry</groupId>
+        <artifactId>sentry-all</artifactId>
+        <version>1.7.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sentry-json-connector</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Sentry-Java Json Connector Base</name>
+    <description>Json Connector Base for Sentry-Java client.</description>
+
+    <properties>
+        <junit.version>4.12</junit.version>
+        <robolectric.version>2.4</robolectric.version>
+        <maven-ant.version>2.1.3</maven-ant.version>
+    </properties>
+
+    <dependencies>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>${robolectric.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-ant-tasks</artifactId>
+            <version>${maven-ant.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.sentry.marshaller.json.connector</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sentry-json-connector/pom.xml
+++ b/sentry-json-connector/pom.xml
@@ -77,6 +77,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonFactory.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonFactory.java
@@ -1,0 +1,17 @@
+package io.sentry.marshaller.json.connector;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * JsonFactory allows to create Json Serializer from a json library dependency.
+ */
+public interface JsonFactory {
+    /**
+     * Creates a instance of <code>JsonGenerator</code> from the destination stream.
+     * @param destination Json serialization <code>OutputStream</code>
+     * @return A new instance of <code>JsonGenerator</code>
+     * @throws IOException when there are issues handling destination stream.
+     */
+    JsonGenerator createGenerator(OutputStream destination) throws IOException;
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonFactoryRuntimeClasspathLocator.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonFactoryRuntimeClasspathLocator.java
@@ -1,0 +1,85 @@
+package io.sentry.marshaller.json.connector;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.sentry.marshaller.json.connector.classloading.*;
+
+/**
+ * Find a JsonFactory facade during runtime. This enables us to use Jackson, Gson or any other implementation.
+ */
+public class JsonFactoryRuntimeClasspathLocator implements InstanceLocator<JsonFactory> {
+
+    /**
+     * JsonFactory instance found in classpath if any.
+     * Package-private for easier unit testing.
+     */
+    static final AtomicReference<JsonFactory> JSON_FACTORY = new AtomicReference<>();
+
+    private static final String JSON_FACTORY_NAME = "io.sentry.marshaller.json.factory.JsonFactoryImpl";
+//    private static final String JACKSON_FACTORY_NAME = "io.sentry.marshaller.json.factory.JsonFactoryImpl";
+//    private static final String GSON_FACTORY_NAME = "io.sentry.marshaller.json.factory.JsonFactoryImpl";
+
+    /**
+     * Gets JsonFactory instance from classpath.
+     * @return JsonFactory available at classpath
+     * @throws IllegalStateException when classpath has no JsonFactory implementations.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public JsonFactory getInstance() {
+        JsonFactory jsonFactory = JSON_FACTORY.get();
+        if (jsonFactory == null) {
+            jsonFactory = locate();
+            assertState(jsonFactory != null, "locate() cannot return null.");
+            if (!compareAndSet(jsonFactory)) {
+                jsonFactory = JSON_FACTORY.get();
+            }
+        }
+        assertState(jsonFactory != null, "factory cannot be null.");
+        return jsonFactory;
+    }
+
+    /**
+     * Locate class of JsonFactory available in classpath.
+     * @return New JsonFactory instance.
+     */
+    @SuppressWarnings("WeakerAccess") //to allow testing override
+    protected JsonFactory locate() {
+        if (isAvailable(JSON_FACTORY_NAME)) {
+            return Classes.newInstance(JSON_FACTORY_NAME);
+//        if (isAvailable(JACKSON_FACTORY_NAME)) {
+//            return Classes.newInstance(JACKSON_FACTORY_NAME);
+//        } else if (isAvailable(GSON_FACTORY_NAME)) {
+//            return Classes.newInstance(GSON_FACTORY_NAME);
+        } else {
+            throw new IllegalStateException("Unable to discover any JsonFactory implementations on the classpath.");
+        }
+    }
+
+    /**
+     * Update factory instance if not saved yet.
+     * @param factory new factory created.
+     * @return true if updated with new instance.
+     */
+    @SuppressWarnings("WeakerAccess") //to allow testing override
+    protected boolean compareAndSet(JsonFactory factory) {
+        return JSON_FACTORY.compareAndSet(null, factory);
+    }
+
+    /**
+     * Checks if classname is available in classpath.
+     * @see Classes#isAvailable(String)
+     * @param fullyQualifiedName classname to search for.
+     * @return true if found in classpath.
+     */
+    @SuppressWarnings({"WeakerAccess", "SameParameterValue"}) //to allow testing override
+    protected boolean isAvailable(String fullyQualifiedName) {
+        return Classes.isAvailable(fullyQualifiedName);
+    }
+
+    private static void assertState(boolean expression, String message) {
+        if (!expression) {
+            throw new IllegalStateException(message);
+        }
+    }
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonGenerator.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/JsonGenerator.java
@@ -1,0 +1,210 @@
+package io.sentry.marshaller.json.connector;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Json Facade to any Json Writer implementation.
+ */
+public interface JsonGenerator extends AutoCloseable {
+
+    /**
+     * Start property with field name.
+     * @param fieldName Name of the json property key.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeFieldName(String fieldName) throws IOException;
+
+    /**
+     * Start a json object block.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeStartObject() throws IOException;
+
+    /**
+     * Start json object property block.
+     * @param fieldName Name of the json property key.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeObjectFieldStart(String fieldName) throws IOException;
+
+    /**
+     * Set Object value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeObject(Object value) throws IOException;
+
+    /**
+     * Add object property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeObjectField(String fieldName, Object value) throws IOException;
+
+    /**
+     * Ends a Json object block.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeEndObject() throws IOException;
+
+    /**
+     * Start Json array block.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeStartArray() throws IOException;
+
+    /**
+     * Start Array property Json.
+     * @param fieldName Name of the json property key.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeArrayFieldStart(String fieldName) throws IOException;
+
+    /**
+     * Ends a Json array block.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeEndArray() throws IOException;
+
+    /**
+     * Add String property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeStringField(String fieldName, String value) throws IOException;
+
+    /**
+     * Set String value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeString(String value) throws IOException;
+
+    /**
+     * Set boolean value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeBoolean(boolean value) throws IOException;
+
+    /**
+     * Add boolean property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeBooleanField(String fieldName, boolean value) throws IOException;
+
+    /**
+     * Set Encoded Number value to Json.
+     * @param encodedValue Encoded Number value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(String encodedValue) throws IOException;
+
+    /**
+     * Set BidDecimal number value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(BigDecimal value) throws IOException;
+
+    /**
+     * Set float value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(float value) throws IOException;
+
+    /**
+     * Set double value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(double value) throws IOException;
+
+    /**
+     * Set long value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(long value) throws IOException;
+
+    /**
+     * Set int value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(int value) throws IOException;
+
+    /**
+     * Set BitInteger value to Json.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumber(BigInteger value) throws IOException;
+
+    /**
+     * Add BigDecimal property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumberField(String fieldName, BigDecimal value) throws IOException;
+
+    /**
+     * Add float property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumberField(String fieldName, float value) throws IOException;
+
+    /**
+     * Add double property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumberField(String fieldName, double value) throws IOException;
+
+    /**
+     * Add long property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumberField(String fieldName, long value) throws IOException;
+
+    /**
+     * Add int property to Json.
+     * @param fieldName Name of the json property key.
+     * @param value Value to set in json property.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNumberField(String fieldName, int value) throws IOException;
+
+
+    /**
+     * Set Null value to Json.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNull() throws IOException;
+
+    /**
+     * Add Null property to Json.
+     * @param fieldName Name of the json property key.
+     * @throws IOException when there's and issue with output stream.
+     */
+    void writeNullField(String fieldName) throws IOException;
+
+    /**
+     * Closes generator output stream.
+     * @throws IOException when issues with OutputStream.
+     */
+    void close() throws IOException;
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/Classes.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/Classes.java
@@ -1,0 +1,146 @@
+package io.sentry.marshaller.json.connector.classloading;
+
+/**
+ * A simple Classloader helper.
+ * <p>
+ * Based on:
+ * [https://github.com/jwtk/jjwt/
+ * blob/8afca0d0df6248a017f6004dfc6f692f0463545c/src/main/java/io/jsonwebtoken/lang/Classes.java]
+ */
+public final class Classes {
+    private static final Classes.ClassLoaderAccessor THREAD_CL_ACCESSOR = new Classes.ExceptionIgnoringAccessor() {
+        @Override
+        protected ClassLoader doGetClassLoader() throws Throwable {
+            return Thread.currentThread().getContextClassLoader();
+        }
+    };
+
+    private static final Classes.ClassLoaderAccessor CLASS_CL_ACCESSOR = new Classes.ExceptionIgnoringAccessor() {
+        @Override
+        protected ClassLoader doGetClassLoader() throws Throwable {
+            return Classes.class.getClassLoader();
+        }
+    };
+
+    private static final Classes.ClassLoaderAccessor SYSTEM_CL_ACCESSOR = new Classes.ExceptionIgnoringAccessor() {
+        @Override
+        protected ClassLoader doGetClassLoader() throws Throwable {
+            return ClassLoader.getSystemClassLoader();
+        }
+    };
+
+    private Classes() {
+    }
+
+    /**
+     * Attempts to load the specified class name from the current thread's
+     * {@link Thread#getContextClassLoader() context class loader}, then the
+     * current ClassLoader (<code>Classes.class.getClassLoader()</code>), then the system/application
+     * ClassLoader (<code>ClassLoader.getSystemClassLoader()</code>, in that order.  If any of them cannot locate
+     * the specified class, an <code>UnknownClassException</code> is thrown (our RuntimeException equivalent of
+     * the JRE's <code>ClassNotFoundException</code>.
+     *
+     * @param fullyQualifiedClassName the fully qualified class name to load
+     * @param <T> Class type found.
+     * @return the located class
+     * @throws UnknownClassException if the class cannot be found.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Class<T> forName(String fullyQualifiedClassName) throws UnknownClassException {
+
+        Class clazz = THREAD_CL_ACCESSOR.loadClass(fullyQualifiedClassName);
+
+        if (clazz == null) {
+            clazz = CLASS_CL_ACCESSOR.loadClass(fullyQualifiedClassName);
+        }
+
+        if (clazz == null) {
+            clazz = SYSTEM_CL_ACCESSOR.loadClass(fullyQualifiedClassName);
+        }
+
+        if (clazz == null) {
+            String msg = "Unable to load class named [" + fullyQualifiedClassName + "] from the thread context, "
+                    + "current, or system/application ClassLoaders.  "
+                    + "All heuristics have been exhausted.  Class could not be found.";
+
+            throw new UnknownClassException(msg);
+        }
+
+        return clazz;
+    }
+
+    /**
+     * Checks if classname is available in classpath.
+     *
+     * @param fullyQualifiedClassName classname to search for.
+     * @return if class is available in runtime.
+     */
+    public static boolean isAvailable(String fullyQualifiedClassName) {
+        try {
+            forName(fullyQualifiedClassName);
+            return true;
+        } catch (UnknownClassException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Instantiate class from given name using no-arguments constructor.
+     * @param fullyQualifiedClassName Classname to instantiate.
+     * @param <T> Class type.
+     * @return New T class instance.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T newInstance(String fullyQualifiedClassName) {
+        return (T) newInstance(forName(fullyQualifiedClassName));
+    }
+
+    /**
+     * Instantiate given Class using no-arguments constructor.
+     * @param clazz Class to instantiate.
+     * @param <T> Class type.
+     * @return New T class instance.
+     */
+    public static <T> T newInstance(Class<T> clazz) {
+        if (clazz == null) {
+            String msg = "Class method parameter cannot be null.";
+            throw new IllegalArgumentException(msg);
+        }
+        try {
+            return clazz.newInstance();
+        } catch (Exception e) {
+            throw new InstantiationException("Unable to instantiate class [" + clazz.getName() + "]", e);
+        }
+    }
+
+    private interface ClassLoaderAccessor {
+        Class loadClass(String fullyQualifiedClassName);
+    }
+
+    private abstract static class ExceptionIgnoringAccessor implements Classes.ClassLoaderAccessor {
+
+        public Class loadClass(String fqcn) {
+            Class clazz = null;
+            ClassLoader cl = getClassLoader();
+            if (cl != null) {
+                try {
+                    clazz = cl.loadClass(fqcn);
+                } catch (ClassNotFoundException e) {
+                    //Class couldn't be found by loader
+                }
+            }
+            return clazz;
+        }
+
+        protected final ClassLoader getClassLoader() {
+            try {
+                return doGetClassLoader();
+            } catch (Throwable t) {
+                //Unable to get ClassLoader
+            }
+            return null;
+        }
+
+        protected abstract ClassLoader doGetClassLoader() throws Throwable;
+    }
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/InstanceLocator.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/InstanceLocator.java
@@ -1,0 +1,13 @@
+package io.sentry.marshaller.json.connector.classloading;
+
+/**
+ * Classes implementing this interface must locate classes in runtime classpath.
+ * @param <T> Supertype of class to locate.
+ */
+public interface InstanceLocator<T> {
+    /**
+     * Gets located instance of T class.
+     * @return Located instance in classpath.
+     */
+    T getInstance();
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/InstantiationException.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/InstantiationException.java
@@ -1,0 +1,16 @@
+package io.sentry.marshaller.json.connector.classloading;
+
+/**
+ * Exception when classpath runtime instantiation fails.
+ */
+class InstantiationException extends RuntimeException {
+    /**
+     * Class instantiation failed issue.
+     *
+     * @param message Reason message.
+     * @param cause Original instantiation Throwable cause.
+     */
+    InstantiationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/UnknownClassException.java
+++ b/sentry-json-connector/src/main/java/io/sentry/marshaller/json/connector/classloading/UnknownClassException.java
@@ -1,0 +1,15 @@
+package io.sentry.marshaller.json.connector.classloading;
+
+/**
+ * Exception when class not found in runtime classpath.
+ */
+class UnknownClassException extends RuntimeException {
+    /**
+     * Class not found in runtime exception.
+     *
+     * @param msg Reason message.
+     */
+    UnknownClassException(String msg) {
+        super(msg);
+    }
+}

--- a/sentry-log4j/pom.xml
+++ b/sentry-log4j/pom.xml
@@ -70,6 +70,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/sentry-log4j2/pom.xml
+++ b/sentry-log4j2/pom.xml
@@ -75,6 +75,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/sentry-logback/pom.xml
+++ b/sentry-logback/pom.xml
@@ -79,6 +79,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/sentry-spring/pom.xml
+++ b/sentry-spring/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -20,12 +20,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -80,6 +80,11 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -200,6 +200,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <usedDependencies>
+                        <dependency>${project.groupId}:sentry-jackson-factory</dependency>
+                    </usedDependencies>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -93,7 +93,14 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-json-connector</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>sentry-jackson-factory</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>sentry-json-connector</artifactId>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>sentry-jackson-factory</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sentry/src/main/java/io/sentry/marshaller/json/DebugMetaInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/DebugMetaInterfaceBinding.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.DebugMetaInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 
 import java.io.IOException;
 

--- a/sentry/src/main/java/io/sentry/marshaller/json/ExceptionInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/ExceptionInterfaceBinding.java
@@ -1,9 +1,9 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.ExceptionInterface;
 import io.sentry.event.interfaces.SentryException;
 import io.sentry.event.interfaces.StackTraceInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 
 import java.io.IOException;
 import java.util.Deque;

--- a/sentry/src/main/java/io/sentry/marshaller/json/HttpInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/HttpInterfaceBinding.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.HttpInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 import io.sentry.util.Util;
 
 import java.io.IOException;

--- a/sentry/src/main/java/io/sentry/marshaller/json/InterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/InterfaceBinding.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.SentryInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 
 import java.io.IOException;
 

--- a/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/JsonMarshaller.java
@@ -1,12 +1,13 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
 import io.sentry.event.Sdk;
 import io.sentry.event.interfaces.SentryInterface;
 import io.sentry.marshaller.Marshaller;
+import io.sentry.marshaller.json.connector.JsonFactory;
+import io.sentry.marshaller.json.connector.JsonGenerator;
+import io.sentry.marshaller.json.connector.JsonFactoryRuntimeClasspathLocator;
 import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,7 +122,7 @@ public class JsonMarshaller implements Marshaller {
     };
 
     private static final Logger logger = LoggerFactory.getLogger(JsonMarshaller.class);
-    private final JsonFactory jsonFactory = new JsonFactory();
+    private final JsonFactory jsonFactory;
     private final Map<Class<? extends SentryInterface>, InterfaceBinding<?>> interfaceBindings = new HashMap<>();
     /**
      * Enables disables the compression of JSON.
@@ -146,6 +147,7 @@ public class JsonMarshaller implements Marshaller {
      */
     public JsonMarshaller(int maxMessageLength) {
         this.maxMessageLength = maxMessageLength;
+        jsonFactory = new JsonFactoryRuntimeClasspathLocator().getInstance();
     }
 
     @Override

--- a/sentry/src/main/java/io/sentry/marshaller/json/MessageInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/MessageInterfaceBinding.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.MessageInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 import io.sentry.util.Util;
 
 import java.io.IOException;

--- a/sentry/src/main/java/io/sentry/marshaller/json/SentryJsonGenerator.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/SentryJsonGenerator.java
@@ -1,12 +1,11 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.*;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
@@ -20,7 +19,7 @@ import java.util.Map;
  * Every method except {@link JsonGenerator#writeObject(Object)} is proxied to an
  * underlying {@link JsonGenerator}.
  */
-public class SentryJsonGenerator extends JsonGenerator {
+public class SentryJsonGenerator implements JsonGenerator {
     private static final Logger logger = LoggerFactory.getLogger(Util.class);
 
     private static final String RECURSION_LIMIT_HIT = "<recursion limit hit>";
@@ -216,53 +215,38 @@ public class SentryJsonGenerator extends JsonGenerator {
     }
 
     @Override
-    public JsonGenerator setCodec(ObjectCodec oc) {
-        return generator.setCodec(oc);
-    }
-
-    @Override
-    public ObjectCodec getCodec() {
-        return generator.getCodec();
-    }
-
-    @Override
-    public Version version() {
-        return generator.version();
-    }
-
-    @Override
-    public JsonGenerator enable(Feature f) {
-        return generator.enable(f);
-    }
-
-    @Override
-    public JsonGenerator disable(Feature f) {
-        return generator.disable(f);
-    }
-
-    @Override
-    public boolean isEnabled(Feature f) {
-        return generator.isEnabled(f);
-    }
-
-    @Override
-    public int getFeatureMask() {
-        return generator.getFeatureMask();
-    }
-
-    @Override
-    public JsonGenerator setFeatureMask(int values) {
-        return generator.setFeatureMask(values);
-    }
-
-    @Override
-    public JsonGenerator useDefaultPrettyPrinter() {
-        return generator.useDefaultPrettyPrinter();
-    }
-
-    @Override
     public void writeStartArray() throws IOException {
         generator.writeStartArray();
+    }
+
+    @Override
+    public void writeStringField(String fieldName, String value) throws IOException {
+        generator.writeStringField(fieldName, value);
+    }
+
+    @Override
+    public void writeArrayFieldStart(String fieldName) throws IOException {
+        generator.writeArrayFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeBooleanField(String fieldName, boolean value) throws IOException {
+        generator.writeBooleanField(fieldName, value);
+    }
+
+    @Override
+    public void writeObjectFieldStart(String fieldName) throws IOException {
+        generator.writeObjectFieldStart(fieldName);
+    }
+
+    @Override
+    public void writeObjectField(String fieldName, Object value) throws IOException {
+        generator.writeObjectField(fieldName, value);
+    }
+
+    @Override
+    public void writeNullField(String fieldName) throws IOException {
+        generator.writeNullField(fieldName);
     }
 
     @Override
@@ -286,78 +270,8 @@ public class SentryJsonGenerator extends JsonGenerator {
     }
 
     @Override
-    public void writeFieldName(SerializableString name) throws IOException {
-        generator.writeFieldName(name);
-    }
-
-    @Override
     public void writeString(String text) throws IOException {
         generator.writeString(text);
-    }
-
-    @Override
-    public void writeString(char[] text, int offset, int len) throws IOException {
-        generator.writeString(text, offset, len);
-    }
-
-    @Override
-    public void writeString(SerializableString text) throws IOException {
-        generator.writeString(text);
-    }
-
-    @Override
-    public void writeRawUTF8String(byte[] text, int offset, int length) throws IOException {
-        generator.writeRawUTF8String(text, offset, length);
-    }
-
-    @Override
-    public void writeUTF8String(byte[] text, int offset, int length) throws IOException {
-        generator.writeUTF8String(text, offset, length);
-    }
-
-    @Override
-    public void writeRaw(String text) throws IOException {
-        generator.writeRaw(text);
-    }
-
-    @Override
-    public void writeRaw(String text, int offset, int len) throws IOException {
-        generator.writeRaw(text, offset, len);
-    }
-
-    @Override
-    public void writeRaw(char[] text, int offset, int len) throws IOException {
-        generator.writeRaw(text, offset, len);
-    }
-
-    @Override
-    public void writeRaw(char c) throws IOException {
-        generator.writeRaw(c);
-    }
-
-    @Override
-    public void writeRawValue(String text) throws IOException {
-        generator.writeRawValue(text);
-    }
-
-    @Override
-    public void writeRawValue(String text, int offset, int len) throws IOException {
-        generator.writeRawValue(text, offset, len);
-    }
-
-    @Override
-    public void writeRawValue(char[] text, int offset, int len) throws IOException {
-        generator.writeRawValue(text, offset, len);
-    }
-
-    @Override
-    public void writeBinary(Base64Variant bv, byte[] data, int offset, int len) throws IOException {
-        generator.writeBinary(bv, data, offset, len);
-    }
-
-    @Override
-    public int writeBinary(Base64Variant bv, InputStream data, int dataLength) throws IOException {
-        return generator.writeBinary(bv, data, dataLength);
     }
 
     @Override
@@ -406,23 +320,28 @@ public class SentryJsonGenerator extends JsonGenerator {
     }
 
     @Override
-    public void writeTree(TreeNode rootNode) throws IOException {
-        generator.writeTree(rootNode);
+    public void writeNumberField(String fieldName, BigDecimal value) throws IOException {
+        generator.writeNumberField(fieldName, value);
     }
 
     @Override
-    public JsonStreamContext getOutputContext() {
-        return generator.getOutputContext();
+    public void writeNumberField(String fieldName, float value) throws IOException {
+        generator.writeNumberField(fieldName, value);
     }
 
     @Override
-    public void flush() throws IOException {
-        generator.flush();
+    public void writeNumberField(String fieldName, double value) throws IOException {
+        generator.writeNumberField(fieldName, value);
     }
 
     @Override
-    public boolean isClosed() {
-        return generator.isClosed();
+    public void writeNumberField(String fieldName, long value) throws IOException {
+        generator.writeNumberField(fieldName, value);
+    }
+
+    @Override
+    public void writeNumberField(String fieldName, int value) throws IOException {
+        generator.writeNumberField(fieldName, value);
     }
 
     @Override

--- a/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
@@ -1,8 +1,8 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.SentryStackTraceElement;
 import io.sentry.event.interfaces.StackTraceInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 
 import java.io.IOException;
 import java.util.*;

--- a/sentry/src/main/java/io/sentry/marshaller/json/UserInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/UserInterfaceBinding.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.event.interfaces.UserInterface;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 
 import java.io.IOException;
 import java.util.Map;

--- a/sentry/src/test/java/io/sentry/marshaller/json/ExceptionInterfaceBindingTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/ExceptionInterfaceBindingTest.java
@@ -1,7 +1,7 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import io.sentry.BaseTest;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 import mockit.Delegate;
 import mockit.Injectable;
 import mockit.NonStrictExpectations;

--- a/sentry/src/test/java/io/sentry/marshaller/json/JsonComparisonUtil.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/JsonComparisonUtil.java
@@ -1,9 +1,10 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.BaseTest;
+import io.sentry.marshaller.json.connector.JsonGenerator;
+import io.sentry.marshaller.json.connector.JsonFactoryRuntimeClasspathLocator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -51,7 +52,7 @@ public final class JsonComparisonUtil extends BaseTest {
         private final JsonGenerator jsonGenerator;
 
         private JsonGeneratorParser() throws Exception {
-            jsonGenerator = objectMapper.getFactory().createGenerator(outputStream);
+            jsonGenerator = new JsonFactoryRuntimeClasspathLocator().getInstance().createGenerator(outputStream);
         }
 
 

--- a/sentry/src/test/java/io/sentry/marshaller/json/JsonMarshallerTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/JsonMarshallerTest.java
@@ -1,12 +1,12 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.sentry.BaseTest;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.BreadcrumbBuilder;
 import io.sentry.event.Sdk;
+import io.sentry.marshaller.json.connector.JsonGenerator;
 import mockit.*;
 import io.sentry.event.Event;
 import io.sentry.event.interfaces.SentryInterface;

--- a/sentry/src/test/java/io/sentry/marshaller/json/SentryJsonGeneratorTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/SentryJsonGeneratorTest.java
@@ -1,7 +1,8 @@
 package io.sentry.marshaller.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import io.sentry.BaseTest;
+import io.sentry.marshaller.json.connector.JsonFactory;
+import io.sentry.marshaller.json.connector.JsonFactoryRuntimeClasspathLocator;
 import org.testng.annotations.Test;
 
 import java.io.OutputStream;
@@ -191,7 +192,7 @@ public class SentryJsonGeneratorTest extends BaseTest {
     }
 
     private void write(OutputStream destination, Object object) throws Exception {
-        final JsonFactory jsonFactory = new JsonFactory();
+        final JsonFactory jsonFactory = new JsonFactoryRuntimeClasspathLocator().getInstance();
 
         try (SentryJsonGenerator generator = new SentryJsonGenerator(jsonFactory.createGenerator(destination))) {
             configureGenerator(generator);

--- a/src/checkstyle/suppressions.xml
+++ b/src/checkstyle/suppressions.xml
@@ -5,4 +5,5 @@
 
 <suppressions>
     <suppress files="io.sentry/util/CircularFifoQueue\.java" checks=".*"/>
+    <suppress files="io.sentry/marshaller/json/connector/classloading/Classes\.java" checks="[IllegalThrows]"/>
 </suppressions>


### PR DESCRIPTION
This pull request relates to issues #461 and #462.

Still work-in-progress but I want your feedback about the implementation and the dependency strategy. Specially @friederbluemle and @bretthoerner that already where taking a look at this issues.

## Implementation overview

1. Instead of creating an instances of `JsonFactory` and `JsonGenerator` from Jackson, I made them interfaces
2. Then there's a `JsonFactoryRuntimeClasspathLocator`, that class tries to find the class with name `io.sentry.marshaller.json.factory.JsonFactoryImpl` in the classpath
3. It then creates a static reference to this factory and uses it later to create a new instance of `JsonGenerator`. At this point, `JsonGenerator` may be Jackson, Gson, whatever.
4. To support another Json library you just need to create a class implementing `JsonGenerator` and a 
`io.sentry.marshaller.json.factory.JsonFactoryImpl` to create your `JsonGenerator` class.

## Discussion
### Factory class loading
My first implementation actually had `JacksonFactory` and `GsonFactory`, so I could have had both implementations in classpath that way. I found it weird, but thinking about testability now, the tests could evolve to run in both `JsonFactory` implementations that way, using the same `JsonFactoryImpl` classname we cannot use both at the same time, it's harder to test it, but gives some end-user stability, given that if the user has multiple dependencies pointing to `JsonFactory`s it will give a compile time error instead of a runtime error which looks to me the right way to behave.

I would like to avoid using ServiceLoader as I saw some people reporting issues with it on Android.

### GsonGenerator ByteArray serialization
The GsonGenerator I made cannot serialize `byte[]` by now, and I don't know how Sentry backend expects this kind of data, maybe Base64 encoded?

### Dependencies and Publishing
Giving that it gets approval, it would be a breaking change migration or we will publish the main sentry lib with `JacksonFactory` and then people manually excludes the jackson-factory dependency when not wanted?

I am not sure about any naming, especially for the new modules and artifacts.

### Proguard
Must add new rule to proguard:
```
-keep class io.sentry.marshaller.json.factory.JsonFactoryImpl
```

Thanks