### PR TITLE
fix: look for prop file directly under flavor dir

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -199,9 +199,11 @@ class SentryPlugin implements Plugin<Project> {
                         def propName = "sentry.properties"
                         def possibleProps = [
                                 "${project.projectDir}/src/${variantName}/${propName}",
+                                "${project.projectDir}/src/${flavorName}/${propName}",
                                 "${project.projectDir}/src/${variantName}/${flavorName}/${propName}",
                                 "${project.projectDir}/src/${flavorName}/${variantName}/${propName}",
                                 "${project.rootDir.toPath()}/src/${variantName}/${propName}",
+                                "${project.rootDir.toPath()}/src/${flavorName}/${propName}",
                                 "${project.rootDir.toPath()}/src/${variantName}/${flavorName}/${propName}",
                                 "${project.rootDir.toPath()}/src/${flavorName}/${variantName}/${propName}",
                                 "${project.rootDir.toPath()}/${propName}"


### PR DESCRIPTION
This seems to be the behavior of at least e.g [the google-services gradle plugin](https://developers.google.com/android/guides/google-services-plugin). Would be nice to not have to duplicate files when you want to use the same `sentry.properties` for different build variants I think.