### PR TITLE
Drop events when the server returns an HTTP 429.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 1.7.10
 --------------
 
 - Android Plugin: Look for properties file directly under flavor directory. (thanks biggestT)
+- Drop events when the server returns an HTTP 429.
 
 Version 1.7.9
 -------------

--- a/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
@@ -107,10 +107,10 @@ public class BufferedConnection implements Connection {
             boolean notSerializable = e.getCause() instanceof NotSerializableException;
 
             Integer responseCode = e.getResponseCode();
-            if (notSerializable || (responseCode != null && responseCode != HttpConnection.HTTP_TOO_MANY_REQUESTS)) {
+            if (notSerializable || (responseCode != null)) {
                 // don't retry events (discard from the buffer) if:
                 // 1. they aren't serializable
-                // 2. the connection is up (valid response code was returned) and it's not an HTTP 429
+                // 2. the connection is up (valid response code was returned)
                 buffer.discard(event);
             }
 

--- a/sentry/src/test/java/io/sentry/connection/BufferedConnectionTest.java
+++ b/sentry/src/test/java/io/sentry/connection/BufferedConnectionTest.java
@@ -156,7 +156,7 @@ public class BufferedConnectionTest extends BaseTest {
     }
 
     @Test
-    public void test429IsBuffered() throws Exception {
+    public void test429IsNotBuffered() throws Exception {
         Event event = new EventBuilder().build();
         connectionException = new ConnectionException("429", new IOException(), null, HttpConnection.HTTP_TOO_MANY_REQUESTS);
         try {
@@ -164,7 +164,7 @@ public class BufferedConnectionTest extends BaseTest {
         } catch (Exception e) {
 
         }
-        assertThat(bufferedEvents.size(), equalTo(1));
+        assertThat(bufferedEvents.size(), equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
This adjusts some of the changes from #562 to bring the Java SDK inline with what new Sentry SDKs are doing.