### PR TITLE
Check for stored SentryClient before caching any frames.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 infer-out/
 agent/build/
+agent/.vscode/
 local.properties


### PR DESCRIPTION
This should improve application startup. I still want to cache the class references but I'm having trouble getting that working so we can do it this in a few phases.

Oh, agent users need to actively call `Sentry.init();` when their app has completed startup. That was already the case (it's how we know which packages to look for), and documentation needs to be improved.

Related #617 