### PR TITLE
Fix Sentry Gradle Plugin asset directory so Proguard debug informatio…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,9 @@
 Version 1.7.14
 --------------
 
--
+- Fix Sentry Gradle Plugin asset directory so Proguard debug information
+  is written to the correct location when using newer versions of the
+  Android Gradle Plugin.
 
 Version 1.7.13
 --------------

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -133,7 +133,7 @@ class SentryPlugin implements Plugin<Project> {
      * @return
      */
     static String getDebugMetaPropPath(Project project, ApplicationVariant variant) {
-        return "${project.buildDir}/intermediates/assets/${variant.dirName}/sentry-debug-meta.properties"
+        return "${variant.mergeAssets.outputDir}/sentry-debug-meta.properties"
     }
 
     void apply(Project project) {


### PR DESCRIPTION
…n is written to the correct location when using newer versions of the  Android Gradle Plugin.

#631