### PR TITLE
Bump Jackson to address security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- dependencies versions -->
         <slf4j.version>1.7.24</slf4j.version>
-        <jackson.version>2.8.7</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <jmockit.version>1.14</jmockit.version>
         <testng.version>6.9.10</testng.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
Current version of Jackson (2.8.7) is outdated and has multiple known vulnerabilities:
- https://nvd.nist.gov/vuln/detail/CVE-2018-7489
- https://nvd.nist.gov/vuln/detail/CVE-2018-5968
- https://nvd.nist.gov/vuln/detail/CVE-2017-17485
- https://nvd.nist.gov/vuln/detail/CVE-2017-15095
- https://nvd.nist.gov/vuln/detail/CVE-2017-7525

I picked 2.9.7, because the 2.8.11.1 (that has the security fix backported) doesn't seem to have published artifacts.