### PR TITLE
Add spring boot configuration processor dependency

### DIFF
--- a/sentry-spring-boot-starter/pom.xml
+++ b/sentry-spring-boot-starter/pom.xml
@@ -31,6 +31,12 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This dependency generate metadata needed to help Spring Boot with the
startup time.