### PR TITLE
Safely close after sentry.properties file reading

### DIFF
--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -1,6 +1,7 @@
 package io.sentry.config;
 
 import io.sentry.dsn.Dsn;
+import io.sentry.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +34,9 @@ public final class Lookup {
 
     static {
         String filePath = getConfigFilePath();
+        InputStream input = null;
         try {
-            InputStream input = getInputStream(filePath);
+            input = getInputStream(filePath);
 
             if (input != null) {
                 configProps = new Properties();
@@ -44,6 +46,8 @@ public final class Lookup {
             }
         } catch (Exception e) {
             logger.error("Error loading Sentry configuration file '{}': ", filePath, e);
+        } finally {
+            Util.closeQuietly(input);
         }
     }
 

--- a/sentry/src/main/java/io/sentry/util/Util.java
+++ b/sentry/src/main/java/io/sentry/util/Util.java
@@ -1,5 +1,6 @@
 package io.sentry.util;
 
+import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -172,5 +173,20 @@ public final class Util {
             // CHECKSTYLE.ON: EmptyBlock
         }
         return false;
+    }
+
+    /**
+     * Closes an instance of Closeable and suppress all possible raised Exceptions.
+     * @param closeable an instance that needs to be closed. null value is supported.
+     */
+    public static void closeQuietly(Closeable closeable) {
+        // CHECKSTYLE.OFF: EmptyCatchBlock
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception ignored) {
+            }
+        }
+        // CHECKSTYLE.ON: EmptyCatchBlock
     }
 }


### PR DESCRIPTION
static initializer in `Lookup.java`opens input stream but doesn't close it. 
It's unsafe and crashes Android app with enabled StrictMode (StrictMode forces explicit close call for `Closeable` instances)

In this PR I close stream in `finally` block

Don't want to use try-with-resources as it's unsupported in old androids
