### PR TITLE
Fix #671 Use buildType.ext to override org and project 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Version 1.7.18
 --------------
 
 - Fix `--no-upload` option in Sentry Gradle Plugin under newer Groovy.
+- Allow overriding Sentry Organization and Project per buildType. (thanks nesterov-n)
 
 Version 1.7.17
 --------------

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -12,6 +12,8 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 class SentryPlugin implements Plugin<Project> {
     static final String GROUP_NAME = 'Sentry'
+    private static final String SENTRY_ORG_PARAMETER = "sentryOrg"
+    private static final String SENTRY_PROJECT_PARAMETER = "sentryProject"
 
     /**
      * Return the correct sentry-cli executable path to use for the given project.  This
@@ -244,7 +246,17 @@ class SentryPlugin implements Plugin<Project> {
                         ]
 
                         if (!extension.autoUpload) {
-                            args.push("--no-upload")
+                            args.add("--no-upload")
+                        }
+
+                        def buildTypeProperties = variant.buildType.ext
+                        if (buildTypeProperties.has(SENTRY_ORG_PARAMETER)) {
+                            args.add("--org")
+                            args.add(buildTypeProperties.get(SENTRY_ORG_PARAMETER).toString())
+                        }
+                        if (buildTypeProperties.has(SENTRY_PROJECT_PARAMETER)) {
+                            args.add("--project")
+                            args.add(buildTypeProperties.get(SENTRY_PROJECT_PARAMETER).toString())
                         }
 
                         if (Os.isFamily(Os.FAMILY_WINDOWS)) {


### PR DESCRIPTION
This fixes #671 

Adds ability to use separate sentry projects and orgs for different application build types. Use 
ext params of Android buildTypes: 
- `sentryOrg` 
- `sentryProject`


For example. Let's assume android project: 
`sentry.properties` in the project root: 
```
defaults.project=my-app
defaults.org=my-org
auth=<api_token>
```

and `build.gradle`:
```
...
android {
    buildTypes { 
         release { ... }
         staging {
            ext {
                set("sentryProject", "my-app-staging")
            }
         ....
         }
         experimental {
            ext {
                set("sentryProject", "my-app-experimental")
                set("sentryOrg", "my-org-experimental")
            }
         }

    }
```

Proguard mapping for release build type is uploaded to  `my-app` project of `my-org` (defaults)
staging to `my-app-staging` project of `my-org`
and experimental to `my-app-experimental` of `my-org-experimental`


The weakest point of this approach is using string parameter names for configuration. 
Another way: With gradle mixins, we can achieve strong typing:
```
experimental {
    sentryOrg "my-org-experimental"
    sentryProject "my-app-experimental"
}
```

But this approach requires the android application plugin being applied before the sentry plugin. 
build.gradle like this will fail: 
```
plugins {
    id("sentry")
    id("com.android.application")
}
```