### PR TITLE
feat: Support DexGuard

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -106,10 +106,12 @@ class SentryPlugin implements Plugin<Project> {
         def names = [
                 // Android Studio 3.3 includes the R8 shrinker.
                 "transformClassesAndResourcesWithR8For${variant.name.capitalize()}",
+                //Dexguard introduces a step pre-dex transformation.
+                "transformClassesWithPreDexFor${variant.name.capitalize()}",
                 "transformClassesAndResourcesWithProguardFor${variant.name.capitalize()}"
         ]
 
-        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[1]}")
+        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[2]}")
     }
 
     /**

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -106,12 +106,10 @@ class SentryPlugin implements Plugin<Project> {
         def names = [
                 // Android Studio 3.3 includes the R8 shrinker.
                 "transformClassesAndResourcesWithR8For${variant.name.capitalize()}",
-                //Dexguard introduces a step pre-dex transformation.
-                "transformClassesWithPreDexFor${variant.name.capitalize()}",
                 "transformClassesAndResourcesWithProguardFor${variant.name.capitalize()}"
         ]
 
-        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[2]}")
+        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[1]}")
     }
 
     /**
@@ -124,7 +122,9 @@ class SentryPlugin implements Plugin<Project> {
     static Task getDexTask(Project project, ApplicationVariant variant) {
         def names = [
             "transformClassesWithDexFor${variant.name.capitalize()}",
-            "transformClassesWithDexBuilderFor${variant.name.capitalize()}"
+            "transformClassesWithDexBuilderFor${variant.name.capitalize()}",
+            //Dexguard uses a pre-dex step
+            "transformClassesWithPreDexFor${variant.name.capitalize()}",
         ]
 
         def rv = null

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -104,12 +104,14 @@ class SentryPlugin implements Plugin<Project> {
      */
     static Task getProguardTask(Project project, ApplicationVariant variant) {
         def names = [
+                "transformClassesAndResourcesWithProguardFor${variant.name.capitalize()}",
                 // Android Studio 3.3 includes the R8 shrinker.
                 "transformClassesAndResourcesWithR8For${variant.name.capitalize()}",
-                "transformClassesAndResourcesWithProguardFor${variant.name.capitalize()}"
+                //Dexguard's task
+                "transformDexWithDexFor${variant.name.capitalize()}",
         ]
 
-        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[1]}")
+        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[0]}")
     }
 
     /**
@@ -123,8 +125,8 @@ class SentryPlugin implements Plugin<Project> {
         def names = [
             "transformClassesWithDexFor${variant.name.capitalize()}",
             "transformClassesWithDexBuilderFor${variant.name.capitalize()}",
-            //Dexguard uses a pre-dex step
-            "transformClassesWithPreDexFor${variant.name.capitalize()}",
+            //Pre-dex step for DexGuard
+            "transformClassesWithPreDexFor${variant.name.capitalize()}"
         ]
 
         def rv = null
@@ -135,7 +137,7 @@ class SentryPlugin implements Plugin<Project> {
             }
         }
 
-        return project.tasks.findByName("dex${names[0]}")
+        return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("dex${names[0]}")
     }
 
     /**


### PR DESCRIPTION
Sentry Android gradle plugin doesn't currently support [DexGuard](dexguard.com)

This is because DexGuard doesn't use the same `transformClasses` steps as proguard.

When running with proguard, `./gradlew -m assembleRelease` gives:

```
:app:preBuild SKIPPED
:app:extractProguardFiles SKIPPED
//....
:app:addSentryProguardSettingsForRelease SKIPPED
:app:processReleaseJavaRes SKIPPED
:app:transformResourcesWithMergeJavaResForRelease SKIPPED
:app:transformClassesAndResourcesWithProguardForRelease SKIPPED
:app:persistSentryProguardUuidsForRelease SKIPPED
:app:transformClassesWithDexForRelease SKIPPED
:app:transformClassesWithShrinkResForRelease SKIPPED
:app:mergeReleaseJniLibFolders SKIPPED
:app:transformNativeLibsWithMergeJniLibsForRelease SKIPPED
:app:transformNativeLibsWithStripDebugSymbolForRelease SKIPPED
:app:validateSigningRelease SKIPPED
//...
```

With DexGuard, the output of that command is:

```
:app:preBuild SKIPPED
:app:preReleaseBuild SKIPPED
//...
:app:transformClassesWithPreDexForRelease SKIPPED
:app:transformDexWithDexForRelease SKIPPED
:app:mergeReleaseJniLibFolders SKIPPED
:app:transformNativeLibsWithMergeJniLibsForRelease SKIPPED
:app:transformNativeLibsWithStripDebugSymbolForRelease SKIPPED
:app:processReleaseJavaRes SKIPPED
:app:transformResourcesWithMergeJavaResForRelease SKIPPED
:app:validateSigningRelease SKIPPED
:app:zipTempAssetsRelease SKIPPED
:app:setupDexguardRelease SKIPPED
:app:dexguardRelease SKIPPED
```

This PR simply makes the plugin look for the `transformClassesWithPreDex` and `tranformDexWithDex` for "dex" and "proguard" tasks, respectively.