### PR TITLE
Don't put body in nested object if parameterMap is empty

### DIFF
--- a/sentry/src/main/java/io/sentry/marshaller/json/HttpInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/HttpInterfaceBinding.java
@@ -109,19 +109,23 @@ public class HttpInterfaceBinding implements InterfaceBinding<HttpInterface> {
             return;
         }
 
-        generator.writeStartObject();
-        if (body != null) {
-            generator.writeStringField(BODY, Util.trimString(body, MAX_BODY_LENGTH));
-        }
-        if (parameterMap != null) {
-            for (Map.Entry<String, Collection<String>> parameter : parameterMap.entrySet()) {
-                generator.writeArrayFieldStart(parameter.getKey());
-                for (String parameterValue : parameter.getValue()) {
-                    generator.writeString(parameterValue);
-                }
-                generator.writeEndArray();
+        if ((parameterMap == null || parameterMap.isEmpty()) && body != null) {
+            generator.writeString(Util.trimString(body, MAX_BODY_LENGTH));
+        } else {
+            generator.writeStartObject();
+            if (body != null) {
+                generator.writeStringField(BODY, Util.trimString(body, MAX_BODY_LENGTH));
             }
+            if (parameterMap != null) {
+                for (Map.Entry<String, Collection<String>> parameter : parameterMap.entrySet()) {
+                    generator.writeArrayFieldStart(parameter.getKey());
+                    for (String parameterValue : parameter.getValue()) {
+                        generator.writeString(parameterValue);
+                    }
+                    generator.writeEndArray();
+                }
+            }
+            generator.writeEndObject();
         }
-        generator.writeEndObject();
     }
 }

--- a/sentry/src/test/java/io/sentry/marshaller/json/HttpInterfaceBindingTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/HttpInterfaceBindingTest.java
@@ -65,4 +65,52 @@ public class HttpInterfaceBindingTest extends BaseTest {
         JsonNode value = jsonGeneratorParser.value();
         assertThat(value, is(jsonResource("/io/sentry/marshaller/json/Http1.json")));
     }
+
+    @Test
+    public void testBodyWithParameters() throws Exception {
+        final JsonGeneratorParser jsonGeneratorParser = newJsonGenerator();
+        final Map<String, Collection<String>> headers = new HashMap<>();
+        headers.put("Header1", Lists.newArrayList("Value1"));
+        headers.put("Header2", Lists.newArrayList("Value1", "Value2"));
+        final HashMap<String, String> cookies = new HashMap<>();
+        cookies.put("Cookie1", "Value1");
+        final HashMap<String, Collection<String>> parameters = new HashMap<>();
+        parameters.put("Parameter1", Lists.newArrayList("Value1"));
+        parameters.put("Parameter2", Lists.newArrayList("Value2", "Value3"));
+        new NonStrictExpectations() {{
+            mockMessageInterface.getHeaders();
+            result = headers;
+            mockMessageInterface.getRequestUrl();
+            result = "http://host/url";
+            mockMessageInterface.getMethod();
+            result = "GET";
+            mockMessageInterface.getQueryString();
+            result = "query";
+            mockMessageInterface.getCookies();
+            result = cookies;
+            mockMessageInterface.getRemoteAddr();
+            result = "1.2.3.4";
+            mockMessageInterface.getServerName();
+            result = "server-name";
+            mockMessageInterface.getServerPort();
+            result = 1234;
+            mockMessageInterface.getLocalPort();
+            result = 5678;
+            mockMessageInterface.getProtocol();
+            result = "HTTP";
+            mockMessageInterface.getLocalAddr();
+            result = "5.6.7.8";
+            mockMessageInterface.getLocalName();
+            result = "local-name";
+            mockMessageInterface.getBody();
+            result = "body";
+            mockMessageInterface.getParameters();
+            result = parameters;
+        }};
+
+        interfaceBinding.writeInterface(jsonGeneratorParser.generator(), mockMessageInterface);
+
+        JsonNode value = jsonGeneratorParser.value();
+        assertThat(value, is(jsonResource("/io/sentry/marshaller/json/Http2.json")));
+    }
 }

--- a/sentry/src/test/resources/io/sentry/marshaller/json/Http2.json
+++ b/sentry/src/test/resources/io/sentry/marshaller/json/Http2.json
@@ -1,7 +1,11 @@
 {
   "url": "http://host/url",
   "method": "GET",
-  "data": "body",
+  "data": {
+    "body": "body",
+    "Parameter1": ["Value1"],
+    "Parameter2": ["Value2","Value3"]
+  },
   "query_string": "query",
   "cookies": {
     "Cookie1": "Value1"


### PR DESCRIPTION
Since if there is only body present without the parameters,
there is no need to nest body in another object.
HttpInterfaceBinding now checks if the body is present without any parameters

Fixes #683