### PR TITLE
Revert support for DexGuard

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -106,9 +106,7 @@ class SentryPlugin implements Plugin<Project> {
         def names = [
                 "transformClassesAndResourcesWithProguardFor${variant.name.capitalize()}",
                 // Android Studio 3.3 includes the R8 shrinker.
-                "transformClassesAndResourcesWithR8For${variant.name.capitalize()}",
-                //Dexguard's task
-                "transformDexWithDexFor${variant.name.capitalize()}",
+                "transformClassesAndResourcesWithR8For${variant.name.capitalize()}"
         ]
 
         return names.findResult { project.tasks.findByName(it) } ?: project.tasks.findByName("proguard${names[0]}")
@@ -124,9 +122,7 @@ class SentryPlugin implements Plugin<Project> {
     static Task getDexTask(Project project, ApplicationVariant variant) {
         def names = [
             "transformClassesWithDexFor${variant.name.capitalize()}",
-            "transformClassesWithDexBuilderFor${variant.name.capitalize()}",
-            //Pre-dex step for DexGuard
-            "transformClassesWithPreDexFor${variant.name.capitalize()}"
+            "transformClassesWithDexBuilderFor${variant.name.capitalize()}"
         ]
 
         def rv = null


### PR DESCRIPTION
This PR reverts the changes introduced in https://github.com/getsentry/sentry-java/pull/684

It turns out that DexGuard doesn't use those tasks for `mapping.txt` generation: rather, both the mapping and apk packaging are done within the same `dexguard<VARIANT>` task.

The aforementioned approach only worked when there was a cached `mapping.txt` present.

Sorry about the confusion about this. I have opened a question on the sentry forum to figure out how to do this the correct way. 
Apologies again