### PR TITLE
Decouple HttpInterface from Servlets

### DIFF
--- a/sentry/src/main/java/io/sentry/context/Context.java
+++ b/sentry/src/main/java/io/sentry/context/Context.java
@@ -2,6 +2,7 @@ package io.sentry.context;
 
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.User;
+import io.sentry.event.interfaces.HttpInterface;
 import io.sentry.util.CircularFifoQueue;
 
 import java.io.Serializable;
@@ -43,6 +44,12 @@ public class Context implements Serializable {
     private volatile Map<String, Object> extra;
 
     /**
+     * HTTP data to add to any future {@link io.sentry.event.Event}s.
+     */
+    private volatile HttpInterface http;
+
+
+    /**
      * Create a new (empty) Context object with the default Breadcrumb limit.
      */
     public Context() {
@@ -67,6 +74,7 @@ public class Context implements Serializable {
         clearUser();
         clearTags();
         clearExtra();
+        clearHttp();
     }
 
     /**
@@ -176,6 +184,32 @@ public class Context implements Serializable {
      */
     public synchronized void clearExtra() {
         extra = null;
+    }
+
+
+    /**
+     * Store the http information in the context.
+     *
+     * @param http Http data to store in context.
+     */
+    public synchronized void setHttp(HttpInterface http) {
+        this.http = http;
+    }
+
+    /**
+     * Gets the http information from the context.
+     *
+     * @return HttpInterface currently stored in context.
+     */
+    public synchronized HttpInterface getHttp() {
+        return http;
+    }
+
+    /**
+     * Clear the http data from this context.
+     */
+    public synchronized void clearHttp() {
+        http = null;
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/event/helper/ContextBuilderHelper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/ContextBuilderHelper.java
@@ -39,6 +39,10 @@ public class ContextBuilderHelper implements EventBuilderHelper {
             eventBuilder.withBreadcrumbs(breadcrumbs);
         }
 
+        if (context.getHttp() != null) {
+            eventBuilder.withSentryInterface(context.getHttp());
+        }
+
         if (context.getUser() != null) {
             eventBuilder.withSentryInterface(fromUser(context.getUser()));
         }

--- a/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
@@ -94,6 +94,69 @@ public class HttpInterface implements SentryInterface {
         this.body = body;
     }
 
+    // CHECKSTYLE.OFF: ParameterNumber
+
+    /**
+     * Creates an HTTP element for an {@link io.sentry.event.Event}.
+     *
+     * @param requestUrl   The full url including the scheme, host, path and query parameters
+     * @param method       The HTTP method
+     * @param parameters   Extra request parameters from either the query string or posted form data.
+     * @param queryString  The query string
+     * @param cookies      Collection of values for each cookie
+     * @param remoteAddr   The remote ip address
+     * @param serverName   The server's hostname
+     * @param serverPort   The port from the server's hostname
+     * @param localAddr    The IP that received the request
+     * @param localName    The hostname of the IP that received the request
+     * @param localPort    The port that received the request
+     * @param protocol     The protocol name and version
+     * @param secure       True if the request was made using a secure channel
+     * @param asyncStarted Servlet specific
+     * @param authType     Servlet specific
+     * @param remoteUser   The login of the user making the request
+     * @param headers      The headers sent with the request
+     * @param body         The request body
+     */
+    public HttpInterface(String requestUrl,
+                         String method,
+                         Map<String, Collection<String>> parameters,
+                         String queryString, Map<String, String> cookies,
+                         String remoteAddr,
+                         String serverName,
+                         int serverPort,
+                         String localAddr,
+                         String localName,
+                         int localPort,
+                         String protocol,
+                         boolean secure,
+                         boolean asyncStarted,
+                         String authType,
+                         String remoteUser,
+                         Map<String, Collection<String>> headers,
+                         String body) {
+
+        this.requestUrl = requestUrl;
+        this.method = method;
+        this.parameters = parameters;
+        this.queryString = queryString;
+        this.cookies = cookies;
+        this.remoteAddr = remoteAddr;
+        this.serverName = serverName;
+        this.serverPort = serverPort;
+        this.localAddr = localAddr;
+        this.localName = localName;
+        this.localPort = localPort;
+        this.protocol = protocol;
+        this.secure = secure;
+        this.asyncStarted = asyncStarted;
+        this.authType = authType;
+        this.remoteUser = remoteUser;
+        this.headers = headers;
+        this.body = body;
+    }
+    // CHECKSTYLE.ON: ParameterNumber
+
     @Override
     public String getInterfaceName() {
         return HTTP_INTERFACE;


### PR DESCRIPTION
Allow the creation of the HttpInterface object from just primitive objects.

Add HttpInterface to the context and ContextBuilderHelper, allowing integration with other web frameworks that are not Servlets. I have a proof of concept integration with Finatra but I'll keep that for a separate pr. 


First pass at addressing https://github.com/getsentry/sentry-java/issues/685