### PR TITLE
Include log4j marker parent(s) in log4j marker tag

### DIFF
--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -186,7 +186,7 @@ public class SentryAppender extends AbstractAppender {
         }
 
         if (event.getMarker() != null) {
-            eventBuilder.withTag(LOG4J_MARKER, event.getMarker().getName());
+            eventBuilder.withTag(LOG4J_MARKER, event.getMarker().toString());
         }
 
         return eventBuilder;


### PR DESCRIPTION
Before this change, information about marker parents was not logged at all by sentry.

With this change, the Sentry appender will include marker & marker parent information in the same way as built-in log4j appenders (for example ConsoleAppender).