### PR TITLE
Add hibernate proxy to in app frames blacklist.

### DIFF
--- a/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
@@ -33,6 +33,8 @@ public class StackTraceInterfaceBinding implements InterfaceBinding<StackTraceIn
         // skip CGLIB generated classes like Foo$$FastClassBySpringCGLIB$$4ed8b6b
         inAppBlacklistRegexps.add(Pattern.compile("\\$\\$FastClass[a-zA-Z]*CGLIB\\$\\$"));
         inAppBlacklistRegexps.add(Pattern.compile("\\$\\$Enhancer[a-zA-Z]*CGLIB\\$\\$"));
+        // skip hibernate generated class proxies like Foo$HibernateProxy$SzXDkaYB
+        inAppBlacklistRegexps.add(Pattern.compile("\\$HibernateProxy\\$"));
     }
 
     /**

--- a/sentry/src/test/java/io/sentry/marshaller/json/StackTraceInterfaceBindingTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/StackTraceInterfaceBindingTest.java
@@ -106,9 +106,13 @@ public class StackTraceInterfaceBindingTest extends BaseTest {
             "inAppModule.Blacklisted$$FastClassBySpringCGLIB$$", "blacklisted",
             "File.java", 3, null, null, null, null);
 
+        final SentryStackTraceElement stackTraceElement4 = new SentryStackTraceElement(
+                        "inAppModule.Blacklisted$HibernateProxy$", "blacklisted",
+                        "File.java", 4, null, null, null, null);
+
         new NonStrictExpectations() {{
             mockStackTraceInterface.getStackTrace();
-            result = new SentryStackTraceElement[]{stackTraceElement1, stackTraceElement2, stackTraceElement3};
+            result = new SentryStackTraceElement[]{stackTraceElement1, stackTraceElement2, stackTraceElement3, stackTraceElement4};
         }};
 
         List<String> inAppModules = new ArrayList<>();

--- a/sentry/src/test/resources/io/sentry/marshaller/json/StackTraceBlacklist.json
+++ b/sentry/src/test/resources/io/sentry/marshaller/json/StackTraceBlacklist.json
@@ -2,6 +2,13 @@
   "frames":[
     {
       "filename":"File.java",
+      "module":"inAppModule.Blacklisted$HibernateProxy$",
+      "in_app":false,
+      "function":"blacklisted",
+      "lineno":4
+    },
+    {
+      "filename":"File.java",
       "module":"inAppModule.Blacklisted$$FastClassBySpringCGLIB$$",
       "in_app":false,
       "function":"blacklisted",


### PR DESCRIPTION
Hibernate proxies is a subclass implemented at runtime to help with lazy loading. This non-deterministic class name will be removed from "in app" frames view.

fixes #698