### PR TITLE
Change logback appender to the unsynchronized version

### DIFF
--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -4,7 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.StackTraceElementProxy;
-import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import io.sentry.Sentry;
@@ -28,7 +28,7 @@ import java.util.Set;
 /**
  * Appender for logback in charge of sending the logged events to a Sentry server.
  */
-public class SentryAppender extends AppenderBase<ILoggingEvent> {
+public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     /**
      * Name of the {@link Event#extra} property containing Maker details.
@@ -44,7 +44,7 @@ public class SentryAppender extends AppenderBase<ILoggingEvent> {
      * @deprecated use logback filters.
      */
     @Deprecated
-    protected Level minLevel;
+    protected volatile Level minLevel;
 
     /**
      * Creates an instance of SentryAppender.


### PR DESCRIPTION
Hey, Sentry! We use logback appender and noticed recently a few events of thread starvation caused by the lock in `AppenderBase`. There is also an issue, https://github.com/getsentry/sentry-java/issues/151#issue-107916688, where synchronization was mentioned as a problem. 

![Screen Shot 2019-04-18 at 5 34 24 pm](https://user-images.githubusercontent.com/1780970/56344232-3cbc3480-6200-11e9-85f3-ea2a2dc70330.png)

I checked the code of `SentryAppender`, and it seems like the append method doesn't need to be synchronized. This PR changes `SentryAppender` to extend `UnsynchronizedAppenderBase`.

Cheers :)

