### PR TITLE
Use mergeAssetsProvider instead of mergeAssets on AGP 3.4.0

### DIFF
--- a/sentry-android-gradle-plugin/build.gradle
+++ b/sentry-android-gradle-plugin/build.gradle
@@ -18,9 +18,9 @@ compileGroovy {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile 'com.android.tools.build:gradle:2.3.3'
+    compileOnly gradleApi()
+    compileOnly localGroovy()
+    compileOnly 'com.android.tools.build:gradle:3.4.0'
 }
 
 publishing {

--- a/sentry-android-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/sentry-android-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -144,7 +144,11 @@ class SentryPlugin implements Plugin<Project> {
      * @return
      */
     static String getDebugMetaPropPath(Project project, ApplicationVariant variant) {
-        return "${variant.mergeAssets.outputDir}/sentry-debug-meta.properties"
+        if (variant.hasProperty("mergeAssetsProvider")) {
+            return variant.mergeAssetsProvider.get().outputDir.get().file("sentry-debug-meta.properties")
+        } else { // Keep this for when the plugin is applied on a pre 3.4.0 project
+            return "${variant.mergeAssets.outputDir}/sentry-debug-meta.properties"
+        }
     }
 
     void apply(Project project) {


### PR DESCRIPTION
This fixes the issue created here https://github.com/getsentry/sentry-java/issues/702 by checking if the new `mergeAssetsProvider` is available and using that instead of `mergeAssets.outputDir`. 

When the new property is not available, previous behavior will be used to not break any usages of the plugin combined with a pre 3.4.0 version.

Also changes the dependency inclusion of the plugin to use compileOnly, since otherwise clients would transitively start using 3.4.0.