### PR TITLE
Get merge assets dir from provider to adapt to AGP 3.4

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -7,6 +7,7 @@ import org.apache.commons.compress.utils.IOUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Exec
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -144,7 +145,13 @@ class SentryPlugin implements Plugin<Project> {
      * @return
      */
     static String getDebugMetaPropPath(Project project, ApplicationVariant variant) {
-        return "${variant.mergeAssets.outputDir}/sentry-debug-meta.properties"
+        def outputDir
+        if (variant.mergeAssets.outputDir instanceof Provider) {
+            outputDir = variant.mergeAssets.outputDir.get()
+        } else {
+            outputDir = variant.mergeAssets.outputDir
+        }
+        return "${outputDir}/sentry-debug-meta.properties"
     }
 
     void apply(Project project) {


### PR DESCRIPTION
fix #702

To work correctly on AGP 3.4, I added checking the type of `variant.mergeAssets.outputDir` and get from Provider if its type is Provider.