### PR TITLE
Add task dependency to adapt Android App Bundle

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -137,6 +137,17 @@ class SentryPlugin implements Plugin<Project> {
     }
 
     /**
+     * Returns the bundle task for the given project and variant.
+     *
+     * @param project
+     * @param variant
+     * @return
+     */
+    static Task getBundleTask(Project project, ApplicationVariant variant) {
+        return project.tasks.findByName("build${variant.name.capitalize()}PreBundle")
+    }
+
+    /**
      * Returns the path to the debug meta properties file for the given variant.
      *
      * @param project
@@ -182,6 +193,7 @@ class SentryPlugin implements Plugin<Project> {
                     def mappingFile = variant.getMappingFile()
                     def proguardTask = getProguardTask(project, variant)
                     def dexTask = getDexTask(project, variant)
+                    def bundleTask = getBundleTask(project, variant)
 
                     if (proguardTask == null) {
                         return
@@ -276,6 +288,10 @@ class SentryPlugin implements Plugin<Project> {
                         dexTask.dependsOn persistIdsTask
                     } else {
                         proguardTask.finalizedBy(persistIdsTask)
+                    }
+                    // To include proguard uuid file into aab, run before bundle task.
+                    if (bundleTask != null) {
+                        bundleTask.dependsOn persistIdsTask
                     }
                     persistIdsTask.dependsOn proguardTask
                 }


### PR DESCRIPTION
When we create App Bundle, `sentry-debug-meta.properties` aren't included in aab.
So, I added task dependency to run persisting proguard uuid before packaging aab bundles. 