### PR TITLE
find dex task when shrinking resources

### DIFF
--- a/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
+++ b/sentry-android-gradle-plugin/src/main/groovy/io/sentry/android/gradle/SentryPlugin.groovy
@@ -122,7 +122,8 @@ class SentryPlugin implements Plugin<Project> {
     static Task getDexTask(Project project, ApplicationVariant variant) {
         def names = [
             "transformClassesWithDexFor${variant.name.capitalize()}",
-            "transformClassesWithDexBuilderFor${variant.name.capitalize()}"
+            "transformClassesWithDexBuilderFor${variant.name.capitalize()}",
+            "transformClassesAndDexWithShrinkResFor${variant.name.capitalize()}"
         ]
 
         def rv = null


### PR DESCRIPTION
I have an android project where my release builds also shrink unused resources using `shinkResources true`. Sentry isn't able to find my dex task since it becomes `transformClassesAndDexWithShrinkResForRelease`. 