### PR TITLE
Allow read timeout to be configured

### DIFF
--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -54,6 +54,14 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     public static final int TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(1);
     /**
+     * Option to set a read timeout for requests to the Sentry server, in milliseconds.
+     */
+    public static final String READ_TIMEOUT_OPTION = "readtimeout";
+    /**
+     * Default read timeout of an HTTP request to Sentry.
+     */
+    public static final int READ_TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(5);
+    /**
      * Option to enable or disable Event buffering. A buffering directory is also required.
      * This setting is mostly useful on Android where a buffering directory is set by default.
      */
@@ -429,6 +437,9 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
 
         int timeout = getTimeout(dsn);
         httpConnection.setConnectionTimeout(timeout);
+
+        int readTimeout = getReadTimeout(dsn);
+        httpConnection.setReadTimeout(readTimeout);
 
         boolean bypassSecurityEnabled = getBypassSecurityEnabled(dsn);
         httpConnection.setBypassSecurity(bypassSecurityEnabled);
@@ -846,6 +857,16 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     protected int getTimeout(Dsn dsn) {
         return Util.parseInteger(Lookup.lookup(TIMEOUT_OPTION, dsn), TIMEOUT_DEFAULT);
+    }
+
+    /**
+     * Read timeout for requests to the Sentry server, in milliseconds.
+     *
+     * @param dsn Sentry server DSN which may contain options.
+     * @return Read timeout for requests to the Sentry server, in milliseconds.
+     */
+    protected int getReadTimeout(Dsn dsn) {
+        return Util.parseInteger(Lookup.lookup(READ_TIMEOUT_OPTION, dsn), READ_TIMEOUT_DEFAULT);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -52,7 +52,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
     /**
      * Default timeout of an HTTP connection to Sentry.
      */
-    public static final int CONNENCTION_TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(1);
+    public static final int CONNECTION_TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(1);
     /**
      * Option to set a read timeout for requests to the Sentry server, in milliseconds.
      */
@@ -856,7 +856,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Timeout for requests to the Sentry server, in milliseconds.
      */
     protected int getTimeout(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(CONNECTION_TIMEOUT_OPTION, dsn), CONNENCTION_TIMEOUT_DEFAULT);
+        return Util.parseInteger(Lookup.lookup(CONNECTION_TIMEOUT_OPTION, dsn), CONNECTION_TIMEOUT_DEFAULT);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -46,13 +46,13 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     public static final String MAX_MESSAGE_LENGTH_OPTION = "maxmessagelength";
     /**
-     * Option to set a timeout for requests to the Sentry server, in milliseconds.
+     * Option to set a timeout for HTTP connections to the Sentry server, in milliseconds.
      */
-    public static final String TIMEOUT_OPTION = "timeout";
+    public static final String CONNECTION_TIMEOUT_OPTION = "timeout";
     /**
      * Default timeout of an HTTP connection to Sentry.
      */
-    public static final int TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(1);
+    public static final int CONNENCTION_TIMEOUT_DEFAULT = (int) TimeUnit.SECONDS.toMillis(1);
     /**
      * Option to set a read timeout for requests to the Sentry server, in milliseconds.
      */
@@ -856,7 +856,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Timeout for requests to the Sentry server, in milliseconds.
      */
     protected int getTimeout(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(TIMEOUT_OPTION, dsn), TIMEOUT_DEFAULT);
+        return Util.parseInteger(Lookup.lookup(CONNECTION_TIMEOUT_OPTION, dsn), CONNENCTION_TIMEOUT_DEFAULT);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -253,7 +253,7 @@ public class HttpConnection extends AbstractConnection {
 
     /**
      * This will set the timeout that is used in establishing a connection to the url.
-     * By default this is set to 5 second.
+     * By default this is set to 1 second.
      *
      * @param timeout New timeout to set. If 0 is used (java default) wait forever.
      */
@@ -263,7 +263,7 @@ public class HttpConnection extends AbstractConnection {
 
     /**
      * This will set the timeout that is used in reading data on an already established connection.
-     * By default this is set to 1 seconds.
+     * By default this is set to 5 seconds.
      *
      * @param timeout New timeout to set. If 0 is used (java default) wait forever.
      */


### PR DESCRIPTION
Hi,

we're currently dealing with some timeouts in our projects from the respective clients towards Sentry. While I could specify the general connect timeout via `sentry.properties`, I noticed that there is no convenient way of actually configuring the read timeout. This PR implements the desired functionality and fixes a documentation error in `HttpConnection` that I noticed while working on the PR.

Since this is my first contribution to this project, please let me know if there's anything I could have done differently or can do now to make everything more smooth.

Cheers,
Christoph