### PR TITLE
fix: Cached frame might miss a name

### DIFF
--- a/sentry/src/main/java/io/sentry/event/interfaces/SentryStackTraceElement.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/SentryStackTraceElement.java
@@ -144,7 +144,7 @@ public class SentryStackTraceElement implements Serializable {
             if (cachedFrames != null) {
                 // step through cachedFrames until we hit a match on the method in the stackTraceElement
                 while (j < cachedFrames.length
-                    && !cachedFrames[j].getMethod().getName().equals(stackTraceElement.getMethodName())) {
+                    && !stackTraceElement.getMethodName().equals(cachedFrames[j].getMethod().getName())) {
                     j++;
                 }
 


### PR DESCRIPTION
Seems like the cached data might be missing the frame's name.
I've fixed it so it won't be crashing anymore but I'm unsure why the agent is not resolving the functions' name.

Resolves #728 