### PR TITLE
Propagate the Lookup instance during the Sentry.init() and other initialization workflows.

### DIFF
--- a/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
+++ b/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
@@ -49,11 +49,12 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
 
     /**
      * Construct an AndroidSentryClientFactory using the base Context from the specified Android Application.
+     * <p>
+     * This uses a default lookup instance, use {@link #AndroidSentryClientFactory(Application, Lookup)} if
+     * you need to pass a specially configured lookup.
      *
      * @param app Android Application
-     * @deprecated uses a non-configurable lookup instance, use {@link #AndroidSentryClientFactory(Application, Lookup)}
      */
-    @Deprecated
     public AndroidSentryClientFactory(Application app) {
         this(app, Lookup.getDefault());
     }
@@ -73,11 +74,12 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
 
     /**
      * Construct an AndroidSentryClientFactory using the specified Android Context.
+     * <p>
+     * This uses a default lookup instance, use {@link #AndroidSentryClientFactory(Context, Lookup)} if
+     * you need to pass a specially configured lookup.
      *
      * @param ctx Android Context.
-     * @deprecated uses a non-configurable lookup instance, use {@link #AndroidSentryClientFactory(Context, Lookup)}
      */
-    @Deprecated
     public AndroidSentryClientFactory(Context ctx) {
         this(ctx, Lookup.getDefault());
     }

--- a/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
+++ b/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
@@ -50,8 +50,10 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
      * Construct an AndroidSentryClientFactory using the base Context from the specified Android Application.
      *
      * @param app Android Application
+     * @param lookup the lookup for locating the configuration
      */
-    public AndroidSentryClientFactory(Application app) {
+    public AndroidSentryClientFactory(Application app, Lookup lookup) {
+        super(lookup);
         Log.d(TAG, "Construction of Android Sentry from Android Application.");
 
         this.ctx = app.getApplicationContext();
@@ -61,8 +63,10 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
      * Construct an AndroidSentryClientFactory using the specified Android Context.
      *
      * @param ctx Android Context.
+     * @param lookup the lookup for locating the configuration
      */
-    public AndroidSentryClientFactory(Context ctx) {
+    public AndroidSentryClientFactory(Context ctx, Lookup lookup) {
+        super(lookup);
         Log.d(TAG, "Construction of Android Sentry from Android Context.");
 
         this.ctx = ctx.getApplicationContext();
@@ -85,7 +89,7 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
             Log.w(TAG, "*** Couldn't find a suitable DSN, Sentry operations will do nothing!"
                 + " See documentation: https://docs.sentry.io/clients/java/modules/android/ ***");
         } else if (!(protocol.equalsIgnoreCase("http") || protocol.equalsIgnoreCase("https"))) {
-            String async = Lookup.lookup(DefaultSentryClientFactory.ASYNC_OPTION, dsn);
+            String async = lookup.get(DefaultSentryClientFactory.ASYNC_OPTION, dsn);
             if (async != null && async.equalsIgnoreCase("false")) {
                 throw new IllegalArgumentException("Sentry Android cannot use synchronous connections, remove '"
                     + DefaultSentryClientFactory.ASYNC_OPTION + "=false' from your options.");
@@ -98,10 +102,10 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
         SentryClient sentryClient = super.createSentryClient(dsn);
         sentryClient.addBuilderHelper(new AndroidEventBuilderHelper(ctx));
 
-        boolean enableAnrTracking = "true".equalsIgnoreCase(Lookup.lookup("anr.enable", dsn));
+        boolean enableAnrTracking = "true".equalsIgnoreCase(lookup.get("anr.enable", dsn));
         Log.d(TAG, "ANR is='" + String.valueOf(enableAnrTracking) + "'");
         if (enableAnrTracking && anrWatchDog == null) {
-            String timeIntervalMsConfig = Lookup.lookup("anr.timeoutIntervalMs", dsn);
+            String timeIntervalMsConfig = lookup.get("anr.timeoutIntervalMs", dsn);
             int timeoutIntervalMs = timeIntervalMsConfig != null
                     ? Integer.parseInt(timeIntervalMsConfig)
                     //CHECKSTYLE.OFF: MagicNumber
@@ -154,7 +158,7 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
     @Override
     protected Buffer getBuffer(Dsn dsn) {
         File bufferDir;
-        String bufferDirOpt = Lookup.lookup(BUFFER_DIR_OPTION, dsn);
+        String bufferDirOpt = lookup.get(BUFFER_DIR_OPTION, dsn);
         if (bufferDirOpt != null) {
             bufferDir = new File(bufferDirOpt);
         } else {

--- a/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
+++ b/sentry-android/src/main/java/io/sentry/android/AndroidSentryClientFactory.java
@@ -46,6 +46,18 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
 
     private Context ctx;
 
+
+    /**
+     * Construct an AndroidSentryClientFactory using the base Context from the specified Android Application.
+     *
+     * @param app Android Application
+     * @deprecated uses a non-configurable lookup instance, use {@link #AndroidSentryClientFactory(Application, Lookup)}
+     */
+    @Deprecated
+    public AndroidSentryClientFactory(Application app) {
+        this(app, Lookup.getDefault());
+    }
+
     /**
      * Construct an AndroidSentryClientFactory using the base Context from the specified Android Application.
      *
@@ -57,6 +69,17 @@ public class AndroidSentryClientFactory extends DefaultSentryClientFactory {
         Log.d(TAG, "Construction of Android Sentry from Android Application.");
 
         this.ctx = app.getApplicationContext();
+    }
+
+    /**
+     * Construct an AndroidSentryClientFactory using the specified Android Context.
+     *
+     * @param ctx Android Context.
+     * @deprecated uses a non-configurable lookup instance, use {@link #AndroidSentryClientFactory(Context, Lookup)}
+     */
+    @Deprecated
+    public AndroidSentryClientFactory(Context ctx) {
+        this(ctx, Lookup.getDefault());
     }
 
     /**

--- a/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
+++ b/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
@@ -30,9 +30,9 @@ public class SentryITActivityUsingApplication extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
-            new Dsn("http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1"),
-            new CustomAndroidSentryClientFactory(getApplication(), SentryOptions.getDefaultLookup())));
+        Sentry.init(new SentryOptions(Lookup.getDefault(),
+            "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1",
+            new CustomAndroidSentryClientFactory(getApplication(), Lookup.getDefault())));
     }
 
     public void sendEvent() {

--- a/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
+++ b/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
@@ -2,9 +2,12 @@ package io.sentry.android;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.Context;
 import android.os.Bundle;
 import io.sentry.Sentry;
+import io.sentry.SentryOptions;
+import io.sentry.config.Lookup;
+import io.sentry.dsn.Dsn;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SentryITActivityUsingApplication extends Activity {
@@ -18,8 +21,8 @@ public class SentryITActivityUsingApplication extends Activity {
          *
          * @param app Android Application
          */
-        CustomAndroidSentryClientFactory(Application app) {
-            super(app);
+        CustomAndroidSentryClientFactory(Application app, Lookup lookup) {
+            super(app, lookup);
             customFactoryUsed.set(true);
         }
     }
@@ -27,9 +30,9 @@ public class SentryITActivityUsingApplication extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Sentry.init(
-            "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1",
-            new CustomAndroidSentryClientFactory(getApplication()));
+        Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
+            new Dsn("http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1"),
+            new CustomAndroidSentryClientFactory(getApplication(), SentryOptions.getDefaultLookup())));
     }
 
     public void sendEvent() {

--- a/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
+++ b/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingApplication.java
@@ -30,7 +30,7 @@ public class SentryITActivityUsingApplication extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Sentry.init(new SentryOptions(Lookup.getDefault(),
+        Sentry.init(SentryOptions.from(Lookup.getDefault(),
             "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1",
             new CustomAndroidSentryClientFactory(getApplication(), Lookup.getDefault())));
     }

--- a/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingBaseContext.java
+++ b/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingBaseContext.java
@@ -30,9 +30,9 @@ public class SentryITActivityUsingBaseContext extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
-            new Dsn("http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1"),
-            new CustomAndroidSentryClientFactory(getBaseContext(), SentryOptions.getDefaultLookup())));
+        Sentry.init(new SentryOptions(Lookup.getDefault(),
+            "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1",
+            new CustomAndroidSentryClientFactory(getBaseContext(), Lookup.getDefault())));
     }
 
     public void sendEvent() {

--- a/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingBaseContext.java
+++ b/sentry-android/src/test/java/io/sentry/android/SentryITActivityUsingBaseContext.java
@@ -1,10 +1,13 @@
 package io.sentry.android;
 
 import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
 import io.sentry.Sentry;
+import io.sentry.SentryOptions;
+import io.sentry.config.Lookup;
+import io.sentry.dsn.Dsn;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SentryITActivityUsingBaseContext extends Activity {
@@ -18,8 +21,8 @@ public class SentryITActivityUsingBaseContext extends Activity {
          *
          * @param ctx Android Context
          */
-        CustomAndroidSentryClientFactory(Context ctx) {
-            super(ctx);
+        CustomAndroidSentryClientFactory(Context ctx, Lookup lookup) {
+            super(ctx, lookup);
             customFactoryUsed.set(true);
         }
     }
@@ -27,9 +30,9 @@ public class SentryITActivityUsingBaseContext extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Sentry.init(
-            "http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1",
-            new CustomAndroidSentryClientFactory(getBaseContext()));
+        Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
+            new Dsn("http://8292bf61d620417282e68a72ae03154a:e3908e05ad874b24b7a168992bfa3577@localhost:8080/1"),
+            new CustomAndroidSentryClientFactory(getBaseContext(), SentryOptions.getDefaultLookup())));
     }
 
     public void sendEvent() {

--- a/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
@@ -32,13 +32,19 @@ public class AppEngineSentryClientFactory extends DefaultSentryClientFactory {
 
     /**
      * This is provided for backwards compatibility but doesn't support custom lookup injection.
-     * @deprecated use {@link #AppEngineSentryClientFactory(Lookup)} instead
+     * <p>
+     * This uses a default lookup instance, use {@link #AppEngineSentryClientFactory(Lookup)} if you need to
+     * pass a specially configured lookup.
      */
-    @Deprecated
-    public AppEngineSentryClientFactory() {
+     public AppEngineSentryClientFactory() {
         this(Lookup.getDefault());
     }
 
+    /**
+     * Creates a new instance configured using the provided lookup instance.
+     *
+     * @param lookup the lookup instance to load configuration from
+     */
     public AppEngineSentryClientFactory(Lookup lookup) {
         super(lookup);
     }

--- a/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
@@ -30,6 +30,10 @@ public class AppEngineSentryClientFactory extends DefaultSentryClientFactory {
      */
     public static final String CONNECTION_IDENTIFIER = "sentry.async.gae.connectionid";
 
+    public AppEngineSentryClientFactory(Lookup lookup) {
+        super(lookup);
+    }
+
     @Override
     public SentryClient createSentryClient(Dsn dsn) {
         SentryClient sentryClientInstance = super.createSentryClient(dsn);
@@ -47,7 +51,7 @@ public class AppEngineSentryClientFactory extends DefaultSentryClientFactory {
      */
     @Override
     protected Connection createAsyncConnection(Dsn dsn, Connection connection) {
-        String connectionIdentifier = Lookup.lookup(CONNECTION_IDENTIFIER, dsn);
+        String connectionIdentifier = lookup.get(CONNECTION_IDENTIFIER, dsn);
         if (connectionIdentifier == null) {
             connectionIdentifier = AppEngineSentryClientFactory.class.getCanonicalName()
                 + dsn + SystemProperty.version.get();
@@ -55,7 +59,7 @@ public class AppEngineSentryClientFactory extends DefaultSentryClientFactory {
 
         AppEngineAsyncConnection asyncConnection = new AppEngineAsyncConnection(connectionIdentifier, connection);
 
-        String queueName = Lookup.lookup(QUEUE_NAME, dsn);
+        String queueName = lookup.get(QUEUE_NAME, dsn);
         if (queueName != null) {
             asyncConnection.setQueue(queueName);
         }

--- a/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/AppEngineSentryClientFactory.java
@@ -30,6 +30,15 @@ public class AppEngineSentryClientFactory extends DefaultSentryClientFactory {
      */
     public static final String CONNECTION_IDENTIFIER = "sentry.async.gae.connectionid";
 
+    /**
+     * This is provided for backwards compatibility but doesn't support custom lookup injection.
+     * @deprecated use {@link #AppEngineSentryClientFactory(Lookup)} instead
+     */
+    @Deprecated
+    public AppEngineSentryClientFactory() {
+        this(Lookup.getDefault());
+    }
+
     public AppEngineSentryClientFactory(Lookup lookup) {
         super(lookup);
     }

--- a/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
@@ -1,5 +1,6 @@
 package io.sentry.appengine;
 
+import io.sentry.config.Lookup;
 import mockit.*;
 import io.sentry.appengine.connection.AppEngineAsyncConnection;
 import io.sentry.connection.Connection;
@@ -19,6 +20,8 @@ public class AppEngineSentryClientFactoryTest {
     private Connection mockConnection;
     @Injectable
     private Dsn mockDsn;
+    @Injectable
+    private Lookup mockLookup;
 
     @Test
     public void asyncConnectionCreatedByAppEngineSentryClientFactoryIsForAppEngine() throws Exception {
@@ -74,8 +77,8 @@ public class AppEngineSentryClientFactoryTest {
             @Mocked final AppEngineAsyncConnection mockAppEngineAsyncConnection,
             @Injectable("queueName") final String mockQueueName) throws Exception {
         new NonStrictExpectations() {{
-            mockDsn.getOptions();
-            result = Collections.singletonMap(AppEngineSentryClientFactory.QUEUE_NAME, mockQueueName);
+            mockLookup.get(AppEngineSentryClientFactory.QUEUE_NAME, (Dsn) any);
+            result = mockQueueName;
         }};
 
         appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -241,10 +241,12 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
     /**
      * Provided only for backwards compatibility. Do not use this because it cannot take advantage of the customizable
      * lookup configuration.
+     * <p>
+     * This uses a default lookup instance, use {@link #DefaultSentryClientFactory(Lookup)} if you need to pass
+     * a specially configured lookup.
+     *
      * @see #DefaultSentryClientFactory(Lookup)
-     * @deprecated use {@link #DefaultSentryClientFactory(Lookup)} instead
      */
-    @Deprecated
     public DefaultSentryClientFactory() {
         this(Lookup.getDefault());
     }

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -238,6 +238,19 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
         REJECT_EXECUTION_HANDLERS.put(ASYNC_QUEUE_DISCARDOLD, new ThreadPoolExecutor.DiscardOldestPolicy());
     }
 
+    /**
+     * The {@link Lookup} instance to use for obtaining configuration.
+     */
+    protected final Lookup lookup;
+
+    /**
+     * Creates a new instance using the provided lookup to locate the configuration.
+     * @param lookup the lookup instance
+     */
+    public DefaultSentryClientFactory(Lookup lookup) {
+        this.lookup = lookup;
+    }
+
     @Override
     public SentryClient createSentryClient(Dsn dsn) {
         try {
@@ -528,7 +541,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return the list of package names to consider "in-app".
      */
     protected Collection<String> getInAppFrames(Dsn dsn) {
-        String inAppFramesOption = Lookup.lookup(IN_APP_FRAMES_OPTION, dsn);
+        String inAppFramesOption = lookup.get(IN_APP_FRAMES_OPTION, dsn);
         if (Util.isNullOrEmpty(inAppFramesOption)) {
             // Only warn if the user didn't set it at all
             if (inAppFramesOption == null) {
@@ -556,7 +569,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether or not to wrap the underlying connection in an {@link AsyncConnection}.
      */
     protected boolean getAsyncEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(ASYNC_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(ASYNC_OPTION, dsn));
     }
 
     /**
@@ -567,7 +580,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     protected RejectedExecutionHandler getRejectedExecutionHandler(Dsn dsn) {
         String overflowName = ASYNC_QUEUE_OVERFLOW_DEFAULT;
-        String asyncQueueOverflowOption = Lookup.lookup(ASYNC_QUEUE_OVERFLOW_OPTION, dsn);
+        String asyncQueueOverflowOption = lookup.get(ASYNC_QUEUE_OVERFLOW_OPTION, dsn);
         if (!Util.isNullOrEmpty(asyncQueueOverflowOption)) {
             overflowName = asyncQueueOverflowOption.toLowerCase();
         }
@@ -589,7 +602,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Maximum time to wait for {@link BufferedConnection} shutdown when closed, in milliseconds.
      */
     protected long getBufferedConnectionShutdownTimeout(Dsn dsn) {
-        return Util.parseLong(Lookup.lookup(BUFFER_SHUTDOWN_TIMEOUT_OPTION, dsn), BUFFER_SHUTDOWN_TIMEOUT_DEFAULT);
+        return Util.parseLong(lookup.get(BUFFER_SHUTDOWN_TIMEOUT_OPTION, dsn), BUFFER_SHUTDOWN_TIMEOUT_DEFAULT);
     }
 
     /**
@@ -599,7 +612,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether or not to attempt a graceful shutdown of the {@link BufferedConnection} upon close.
      */
     protected boolean getBufferedConnectionGracefulShutdownEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(BUFFER_GRACEFUL_SHUTDOWN_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(BUFFER_GRACEFUL_SHUTDOWN_OPTION, dsn));
     }
 
     /**
@@ -609,7 +622,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return ow long to wait between attempts to flush the disk buffer, in milliseconds.
      */
     protected long getBufferFlushtime(Dsn dsn) {
-        return Util.parseLong(Lookup.lookup(BUFFER_FLUSHTIME_OPTION, dsn), BUFFER_FLUSHTIME_DEFAULT);
+        return Util.parseLong(lookup.get(BUFFER_FLUSHTIME_OPTION, dsn), BUFFER_FLUSHTIME_DEFAULT);
     }
 
     /**
@@ -619,7 +632,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return The graceful shutdown timeout of the async executor, in milliseconds.
      */
     protected long getAsyncShutdownTimeout(Dsn dsn) {
-        return Util.parseLong(Lookup.lookup(ASYNC_SHUTDOWN_TIMEOUT_OPTION, dsn), ASYNC_SHUTDOWN_TIMEOUT_DEFAULT);
+        return Util.parseLong(lookup.get(ASYNC_SHUTDOWN_TIMEOUT_OPTION, dsn), ASYNC_SHUTDOWN_TIMEOUT_DEFAULT);
     }
 
     /**
@@ -629,7 +642,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether or not to attempt the graceful shutdown of the {@link AsyncConnection} upon close.
      */
     protected boolean getAsyncGracefulShutdownEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(ASYNC_GRACEFUL_SHUTDOWN_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(ASYNC_GRACEFUL_SHUTDOWN_OPTION, dsn));
     }
 
     /**
@@ -639,7 +652,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Maximum size of the async send queue.
      */
     protected int getAsyncQueueSize(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(ASYNC_QUEUE_SIZE_OPTION, dsn), QUEUE_SIZE_DEFAULT);
+        return Util.parseInteger(lookup.get(ASYNC_QUEUE_SIZE_OPTION, dsn), QUEUE_SIZE_DEFAULT);
     }
 
     /**
@@ -649,7 +662,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Priority of threads used for the async connection.
      */
     protected int getAsyncPriority(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(ASYNC_PRIORITY_OPTION, dsn), Thread.MIN_PRIORITY);
+        return Util.parseInteger(lookup.get(ASYNC_PRIORITY_OPTION, dsn), Thread.MIN_PRIORITY);
     }
 
     /**
@@ -659,7 +672,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return The number of threads used for the async connection.
      */
     protected int getAsyncThreads(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(ASYNC_THREADS_OPTION, dsn),
+        return Util.parseInteger(lookup.get(ASYNC_THREADS_OPTION, dsn),
             Runtime.getRuntime().availableProcessors());
     }
 
@@ -680,7 +693,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return The ratio of events to allow through to server, or null if sampling is disabled.
      */
     protected Double getSampleRate(Dsn dsn) {
-        return Util.parseDouble(Lookup.lookup(SAMPLE_RATE_OPTION, dsn), null);
+        return Util.parseDouble(lookup.get(SAMPLE_RATE_OPTION, dsn), null);
     }
 
     /**
@@ -690,7 +703,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return HTTP proxy port for Sentry connections.
      */
     protected int getProxyPort(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(HTTP_PROXY_PORT_OPTION, dsn), HTTP_PROXY_PORT_DEFAULT);
+        return Util.parseInteger(lookup.get(HTTP_PROXY_PORT_OPTION, dsn), HTTP_PROXY_PORT_DEFAULT);
     }
 
     /**
@@ -700,7 +713,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return HTTP proxy hostname for Sentry connections.
      */
     protected String getProxyHost(Dsn dsn) {
-        return Lookup.lookup(HTTP_PROXY_HOST_OPTION, dsn);
+        return lookup.get(HTTP_PROXY_HOST_OPTION, dsn);
     }
 
     /**
@@ -710,7 +723,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return HTTP proxy username for Sentry connections.
      */
     protected String getProxyUser(Dsn dsn) {
-        return Lookup.lookup(HTTP_PROXY_USER_OPTION, dsn);
+        return lookup.get(HTTP_PROXY_USER_OPTION, dsn);
     }
 
     /**
@@ -720,7 +733,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return HTTP proxy password for Sentry connections.
      */
     protected String getProxyPass(Dsn dsn) {
-        return Lookup.lookup(HTTP_PROXY_PASS_OPTION, dsn);
+        return lookup.get(HTTP_PROXY_PASS_OPTION, dsn);
     }
 
     /**
@@ -731,7 +744,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Application version to send with {@link io.sentry.event.Event}s.
      */
     protected String getRelease(Dsn dsn) {
-        return Lookup.lookup(RELEASE_OPTION, dsn);
+        return lookup.get(RELEASE_OPTION, dsn);
     }
 
     /**
@@ -742,7 +755,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Application version to send with {@link io.sentry.event.Event}s.
      */
     protected String getDist(Dsn dsn) {
-        return Lookup.lookup(DIST_OPTION, dsn);
+        return lookup.get(DIST_OPTION, dsn);
     }
 
     /**
@@ -753,7 +766,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Application version to send with {@link io.sentry.event.Event}s.
      */
     protected String getEnvironment(Dsn dsn) {
-        return Lookup.lookup(ENVIRONMENT_OPTION, dsn);
+        return lookup.get(ENVIRONMENT_OPTION, dsn);
     }
 
     /**
@@ -764,7 +777,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Server name to send with {@link io.sentry.event.Event}s.
      */
     protected String getServerName(Dsn dsn) {
-        return Lookup.lookup(SERVERNAME_OPTION, dsn);
+        return lookup.get(SERVERNAME_OPTION, dsn);
     }
 
     /**
@@ -774,7 +787,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Additional tags to send with {@link io.sentry.event.Event}s.
      */
     protected Map<String, String> getTags(Dsn dsn) {
-        return Util.parseTags(Lookup.lookup(TAGS_OPTION, dsn));
+        return Util.parseTags(lookup.get(TAGS_OPTION, dsn));
     }
 
     /**
@@ -796,9 +809,9 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Tags to extract from the MDC system and set on {@link io.sentry.event.Event}s, where applicable.
      */
     protected Set<String> getMdcTags(Dsn dsn) {
-        String val = Lookup.lookup(MDCTAGS_OPTION, dsn);
+        String val = lookup.get(MDCTAGS_OPTION, dsn);
         if (Util.isNullOrEmpty(val)) {
-            val = Lookup.lookup(EXTRATAGS_OPTION, dsn);
+            val = lookup.get(EXTRATAGS_OPTION, dsn);
             if (!Util.isNullOrEmpty(val)) {
                 logger.warn("The '" + EXTRATAGS_OPTION + "' option is deprecated, please use"
                     + " the '" + MDCTAGS_OPTION + "' option instead.");
@@ -815,7 +828,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Extra data to send with {@link io.sentry.event.Event}s.
      */
     protected Map<String, String> getExtra(Dsn dsn) {
-        return Util.parseExtra(Lookup.lookup(EXTRA_OPTION, dsn));
+        return Util.parseExtra(lookup.get(EXTRA_OPTION, dsn));
     }
 
     /**
@@ -825,7 +838,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether to compress requests sent to the Sentry Server.
      */
     protected boolean getCompressionEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(COMPRESSION_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(COMPRESSION_OPTION, dsn));
     }
 
     /**
@@ -835,7 +848,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether to hide common stackframes with enclosing exceptions.
      */
     protected boolean getHideCommonFramesEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(HIDE_COMMON_FRAMES_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(HIDE_COMMON_FRAMES_OPTION, dsn));
     }
 
     /**
@@ -846,7 +859,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      */
     protected int getMaxMessageLength(Dsn dsn) {
         return Util.parseInteger(
-            Lookup.lookup(MAX_MESSAGE_LENGTH_OPTION, dsn), JsonMarshaller.DEFAULT_MAX_MESSAGE_LENGTH);
+            lookup.get(MAX_MESSAGE_LENGTH_OPTION, dsn), JsonMarshaller.DEFAULT_MAX_MESSAGE_LENGTH);
     }
 
     /**
@@ -856,7 +869,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Timeout for requests to the Sentry server, in milliseconds.
      */
     protected int getTimeout(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(CONNECTION_TIMEOUT_OPTION, dsn), CONNECTION_TIMEOUT_DEFAULT);
+        return Util.parseInteger(lookup.get(CONNECTION_TIMEOUT_OPTION, dsn), CONNECTION_TIMEOUT_DEFAULT);
     }
 
     /**
@@ -866,7 +879,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Read timeout for requests to the Sentry server, in milliseconds.
      */
     protected int getReadTimeout(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(READ_TIMEOUT_OPTION, dsn), READ_TIMEOUT_DEFAULT);
+        return Util.parseInteger(lookup.get(READ_TIMEOUT_OPTION, dsn), READ_TIMEOUT_DEFAULT);
     }
 
     /**
@@ -876,7 +889,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether or not buffering is enabled.
      */
     protected boolean getBufferEnabled(Dsn dsn) {
-        String bufferEnabled = Lookup.lookup(BUFFER_ENABLED_OPTION, dsn);
+        String bufferEnabled = lookup.get(BUFFER_ENABLED_OPTION, dsn);
         if (bufferEnabled != null) {
             return Boolean.parseBoolean(bufferEnabled);
         }
@@ -890,7 +903,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return the {@link Buffer} where events are stored when network is down.
      */
     protected Buffer getBuffer(Dsn dsn) {
-        String bufferDir = Lookup.lookup(BUFFER_DIR_OPTION, dsn);
+        String bufferDir = lookup.get(BUFFER_DIR_OPTION, dsn);
         if (bufferDir != null) {
             return new DiskBuffer(new File(bufferDir), getBufferSize(dsn));
         }
@@ -904,7 +917,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return the maximum number of events to cache offline when network is down.
      */
     protected int getBufferSize(Dsn dsn) {
-        return Util.parseInteger(Lookup.lookup(BUFFER_SIZE_OPTION, dsn), BUFFER_SIZE_DEFAULT);
+        return Util.parseInteger(lookup.get(BUFFER_SIZE_OPTION, dsn), BUFFER_SIZE_DEFAULT);
     }
 
     /**
@@ -914,7 +927,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @return Whether or not to enable a {@link SentryUncaughtExceptionHandler}.
      */
     protected boolean getUncaughtHandlerEnabled(Dsn dsn) {
-        return !FALSE.equalsIgnoreCase(Lookup.lookup(UNCAUGHT_HANDLER_ENABLED_OPTION, dsn));
+        return !FALSE.equalsIgnoreCase(lookup.get(UNCAUGHT_HANDLER_ENABLED_OPTION, dsn));
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -244,6 +244,17 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
     protected final Lookup lookup;
 
     /**
+     * Provided only for backwards compatibility. Do not use this because it cannot take advantage of the customizable
+     * lookup configuration.
+     * @see #DefaultSentryClientFactory(Lookup)
+     * @deprecated use {@link #DefaultSentryClientFactory(Lookup)} instead
+     */
+    @Deprecated
+    public DefaultSentryClientFactory() {
+        this(Lookup.getDefault());
+    }
+
+    /**
      * Creates a new instance using the provided lookup to locate the configuration.
      * @param lookup the lookup instance
      */

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -239,11 +239,6 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
     }
 
     /**
-     * The {@link Lookup} instance to use for obtaining configuration.
-     */
-    protected final Lookup lookup;
-
-    /**
      * Provided only for backwards compatibility. Do not use this because it cannot take advantage of the customizable
      * lookup configuration.
      * @see #DefaultSentryClientFactory(Lookup)
@@ -259,7 +254,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
      * @param lookup the lookup instance
      */
     public DefaultSentryClientFactory(Lookup lookup) {
-        this.lookup = lookup;
+        super(lookup);
     }
 
     @Override

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -102,9 +102,7 @@ public final class Sentry {
     @Deprecated
     public static SentryClient init(@Nullable String dsn, @Nullable SentryClientFactory sentryClientFactory) {
         SentryOptions options = SentryOptions.defaults(dsn);
-        if (sentryClientFactory != null) {
-            options.setClientFactory(sentryClientFactory);
-        }
+        options.setSentryClientFactory(sentryClientFactory);
         return init(options);
     }
 
@@ -134,7 +132,7 @@ public final class Sentry {
 
         // make sure to use the DSN configured in the options instead of the one that the factory can find in
         // its lookup
-        SentryClient client = sentryOptions.getClientFactory().createSentryClient(sentryOptions.getDsn());
+        SentryClient client = sentryOptions.getSentryClientFactory().createSentryClient(sentryOptions.getDsn());
         setStoredClient(client);
         return client;
     }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1,37 +1,33 @@
 package io.sentry;
 
-import io.sentry.config.ResourceLoader;
+import io.sentry.config.Lookup;
 import io.sentry.context.Context;
 import io.sentry.dsn.Dsn;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
 import io.sentry.event.EventBuilder;
 import io.sentry.event.User;
+import io.sentry.util.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Sentry provides easy access to a statically stored {@link SentryClient} instance.
  */
 public final class Sentry {
     private static final Logger logger = LoggerFactory.getLogger(Sentry.class);
+
+    /**
+     * A synchronization guard of the stored client. Not using the class as the guard because that could theoretically
+     * deadlock with 3rd party code if it also synced on the class.
+     */
+    private static final Object STORED_CLIENT_ACCESS = new Object();
+
     /**
      * The most recently constructed {@link SentryClient} instance, used by static helper
      * methods like {@link Sentry#capture(Event)}.
      */
-    private static volatile SentryClient storedClient = null;
-    /**
-     * Tracks whether the {@link #init()} method has already been attempted automatically
-     * by {@link #getStoredClient()}.
-     */
-    private static AtomicBoolean autoInitAttempted = new AtomicBoolean(false);
-
-    /**
-     * Optional override for the default resource loader used to look for properties.
-     */
-    private static ResourceLoader resourceLoader = null;
+    private static SentryClient storedClient = null;
 
     /**
      * Hide constructor.
@@ -42,23 +38,16 @@ public final class Sentry {
 
     /**
      * Initialize and statically store a {@link SentryClient} by looking up
-     * a {@link Dsn} and automatically choosing a {@link SentryClientFactory}.
-     *
-     * @return SentryClient
-     */
-    public static SentryClient init() {
-        return init(null, null);
-    }
-
-    /**
-     * Initialize and statically store a {@link SentryClient} by looking up
      * a {@link Dsn} and using the provided {@link SentryClientFactory}.
      *
      * @param sentryClientFactory SentryClientFactory to use.
      * @return SentryClient
+     *
+     * @deprecated use {@link #init(SentryOptions)}
      */
-    public static SentryClient init(SentryClientFactory sentryClientFactory) {
-        return init(null, sentryClientFactory);
+    @Deprecated
+    public static SentryClient init(@Nullable SentryClientFactory sentryClientFactory) {
+        return init(SentryOptions.from(SentryOptions.getDefaultLookup(), null, sentryClientFactory));
     }
 
     /**
@@ -67,81 +56,55 @@ public final class Sentry {
      *
      * @param dsn Data Source Name of the Sentry server.
      * @return SentryClient
+     *
+     * @deprecated use {@link #init(SentryOptions)}
      */
-    public static SentryClient init(String dsn) {
-        return init(dsn, null);
+    @Deprecated
+    public static SentryClient init(@Nullable String dsn) {
+        return init(SentryOptions.defaults(dsn));
     }
 
     /**
-     * Initialize and statically store a {@link SentryClient} by using the provided
-     * {@link Dsn} and {@link SentryClientFactory}.
-     * <p>
-     * Note that the Dsn or SentryClientFactory may be null, at which a best effort attempt
-     * is made to look up or choose the best value(s).
+     * Initializes a new Sentry client from the provided context.
      *
-     * @param dsn                 Data Source Name of the Sentry server.
-     * @param sentryClientFactory SentryClientFactory to use.
-     * @return SentryClient
-     */
-    public static SentryClient init(String dsn, SentryClientFactory sentryClientFactory) {
-        SentryOptions sentryOptions = new SentryOptions();
-        sentryOptions.setDsn(dsn);
-        sentryOptions.setSentryClientFactory(sentryClientFactory);
-        return init(sentryOptions);
-    }
-
-    /**
-     * Initialize and statically store a {@link SentryClient} by using the provided
-     * {@link SentryOptions}.
-     * <p>x
-     * Note that the Dsn or SentryClientFactory may be null, at which a best effort attempt
-     * is made to look up or choose the best value(s).
+     * <p>The canonical way of using this method is:
+     * <p></p>
+     * <pre>
+     * {@link Lookup} lookup = ... obtain or construct the instance of this class to be able to locate Sentry config
+     * String dsn = ... obtain the Sentry data source name or leave null for lookup in the configuration
+     * SentryClient client =
+     *   Sentry.init({@link SentryOptions}.{@link SentryOptions#from(Lookup, String) from(lookup, dsn))};
+     * </pre>
+     * If you want to rely on the default mechanisms to obtain the configuration, you can also use the
+     * {@link SentryOptions#defaults()} method which will use the default way of obtaining the configuration and DSN
+     * obtained from the configuration.
      *
-     * @param sentryOptions SentryOptions to take DSN and other options from.
-     * @return SentryClient
+     * @param sentryOptions the context using with to create the client
+     * @return the Sentry client
      */
     public static SentryClient init(SentryOptions sentryOptions) {
-        // Hack to allow Lookup.java access to a different resource locator before its static initializer runs.
-        // v2: Lookup won't be static and this hack will be removed.
-        // ResourceLocator will ba passed to Lookup upon instantiation
-        Sentry.resourceLoader = sentryOptions.getResourceLoader();
-
-        SentryClient sentryClient = SentryClientFactory.sentryClient(
-                sentryOptions.getDsn(),
-                sentryOptions.getSentryClientFactory());
-        setStoredClient(sentryClient);
-        return sentryClient;
+        SentryClient client = sentryOptions.createClient();
+        setStoredClient(client);
+        return client;
     }
 
     /**
      * Returns the last statically stored {@link SentryClient} instance. If no instance
-     * is already stored, the {@link #init()} method will be called one time in an attempt to
-     * create a {@link SentryClient}.
+     * is already stored, an attempt will be made to create a {@link SentryClient} from the configuration
+     * found in the environment.
      *
      * @return statically stored {@link SentryClient} instance, or null.
      */
     public static SentryClient getStoredClient() {
-        if (storedClient != null) {
-            return storedClient;
-        }
-
-        synchronized (Sentry.class) {
-            if (storedClient == null && !autoInitAttempted.get()) {
-                // attempt initialization by using configuration found in the environment
-                autoInitAttempted.set(true);
-                init();
+        synchronized (STORED_CLIENT_ACCESS) {
+            if (storedClient != null) {
+                return storedClient;
             }
+
+            init(SentryOptions.defaults());
         }
 
         return storedClient;
-    }
-
-    /**
-     * The {@link ResourceLoader} used to lookup properties.
-     * @return {link ResourceLoader}.
-     */
-    public static ResourceLoader getResourceLoader() {
-        return resourceLoader;
     }
 
     /**
@@ -166,11 +129,13 @@ public final class Sentry {
      * @param client {@link SentryClient} instance to store.
      */
     public static void setStoredClient(SentryClient client) {
-        if (storedClient != null) {
-            logger.warn("Overwriting statically stored SentryClient instance {} with {}.",
-                storedClient, client);
+        synchronized (STORED_CLIENT_ACCESS) {
+            if (storedClient != null) {
+                logger.warn("Overwriting statically stored SentryClient instance {} with {}.",
+                        storedClient, client);
+            }
+            storedClient = client;
         }
-        storedClient = client;
     }
 
     /**
@@ -241,15 +206,14 @@ public final class Sentry {
      * Close the stored {@link SentryClient}'s connections and remove it from static storage.
      */
     public static void close() {
-        if (storedClient == null) {
-            return;
+        synchronized (STORED_CLIENT_ACCESS) {
+            if (storedClient == null) {
+                return;
+            }
+
+            storedClient.closeConnection();
+            storedClient = null;
         }
-
-        storedClient.closeConnection();
-        storedClient = null;
-
-        // Allow the client to be auto initialized on the next use.
-        autoInitAttempted.set(false);
     }
 
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -50,11 +50,13 @@ public final class Sentry {
     /**
      * Initialize and statically store a {@link SentryClient} by looking up
      * a {@link Dsn} and automatically choosing a {@link SentryClientFactory}.
+     * <p>
+     * This uses a default lookup instance, use {@link #init(SentryOptions)} if you need to pass a specially
+     * configured lookup.
      *
      * @return SentryClient
-     * @deprecated use {@link #init(SentryOptions)}
+     * @see #init(SentryOptions)
      */
-    @Deprecated
     public static SentryClient init() {
         return init((String) null);
     }
@@ -62,13 +64,14 @@ public final class Sentry {
     /**
      * Initialize and statically store a {@link SentryClient} by looking up
      * a {@link Dsn} and using the provided {@link SentryClientFactory}.
+     * <p>
+     * This uses a default lookup instance, use {@link #init(SentryOptions)} if you need to pass a specially
+     * configured lookup.
      *
      * @param sentryClientFactory SentryClientFactory to use.
      * @return SentryClient
-     *
-     * @deprecated use {@link #init(SentryOptions)}
+     * @see #init(SentryOptions)
      */
-    @Deprecated
     public static SentryClient init(@Nullable SentryClientFactory sentryClientFactory) {
         return init(SentryOptions.from(Lookup.getDefault(), null, sentryClientFactory));
     }
@@ -76,13 +79,14 @@ public final class Sentry {
     /**
      * Initialize and statically store a {@link SentryClient} by using the provided
      * {@link Dsn} and automatically choosing a {@link SentryClientFactory}.
+     * <p>
+     * This uses a default lookup instance, use {@link #init(SentryOptions)} if you need to pass a specially
+     * configured lookup.
      *
      * @param dsn Data Source Name of the Sentry server.
      * @return SentryClient
-     *
-     * @deprecated use {@link #init(SentryOptions)}
+     * @see #init(SentryOptions)
      */
-    @Deprecated
     public static SentryClient init(@Nullable String dsn) {
         return init(SentryOptions.defaults(dsn));
     }
@@ -93,13 +97,15 @@ public final class Sentry {
      * <p>
      * Note that the Dsn or SentryClientFactory may be null, at which a best effort attempt
      * is made to look up or choose the best value(s).
+     * <p>
+     * This uses a default lookup instance, use {@link #init(SentryOptions)} if you need to pass a specially
+     * configured lookup.
      *
      * @param dsn                 Data Source Name of the Sentry server.
      * @param sentryClientFactory SentryClientFactory to use.
      * @return SentryClient
-     * @deprecated use {@link #init(SentryOptions)}
+     * @see #init(SentryOptions)
      */
-    @Deprecated
     public static SentryClient init(@Nullable String dsn, @Nullable SentryClientFactory sentryClientFactory) {
         SentryOptions options = SentryOptions.defaults(dsn);
         options.setSentryClientFactory(sentryClientFactory);

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -130,9 +130,9 @@ public final class Sentry {
         // ResourceLocator will ba passed to Lookup upon instantiation
         Sentry.resourceLoader = sentryOptions.getResourceLoader();
 
-        // make sure to use the DSN configured in the options instead of the one that the factory can find in
-        // its lookup
-        SentryClient client = sentryOptions.getSentryClientFactory().createSentryClient(sentryOptions.getDsn());
+        // make sure to use the DSN configured in the options instead of the one that the factory can find in its
+        // lookup
+        SentryClient client = sentryOptions.getSentryClientFactory().createClient(sentryOptions.getDsn());
         setStoredClient(client);
         return client;
     }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Sentry client, for sending {@link Event}s to a Sentry server.
  * <p>
  * It is recommended that you create an instance of Sentry through
- * {@link SentryClientFactory#createSentryClient(io.sentry.dsn.Dsn)}, which will use the best factory available.
+ * {@link SentryClientFactory#createClient(String)}, which will use the best factory available.
  */
 public class SentryClient {
     private static final Logger logger = LoggerFactory.getLogger(SentryClient.class);

--- a/sentry/src/main/java/io/sentry/SentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryClientFactory.java
@@ -36,22 +36,25 @@ public abstract class SentryClientFactory {
     }
 
     /**
-     * Do not use this constructor. This depends on the deprecated static initialization of the {@link Lookup} instance.
-     * @deprecated use {@link #SentryClientFactory(Lookup)} instead
+     * Creates a new instance with default configuration.
+     * <p>
+     * This uses a default lookup instance, use {@link #SentryClientFactory(Lookup)} if you need to pass
+     * a specially configured lookup.
+     *
+     * @see #SentryClientFactory(Lookup)
      */
-    @Deprecated
     protected SentryClientFactory() {
         this(Lookup.getDefault());
     }
 
     /**
      * Creates an instance of Sentry by discovering the DSN.
+     * <p>
+     * This uses a default lookup instance, use {@link #instantiateFrom(Lookup, String)}.{@link #createClient(String)}
+     * if you need to use a specially configured lookup
      *
      * @return an instance of Sentry.
-     * @deprecated use {@link SentryOptions sentryOptions}
-     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createClient(String)} instead
      */
-    @Deprecated
     @Nullable
     public static SentryClient sentryClient() {
         return sentryClient(null, null);
@@ -59,13 +62,13 @@ public abstract class SentryClientFactory {
 
     /**
      * Creates an instance of Sentry using the provided DSN.
+     * <p>
+     * This uses a default lookup instance, use {@link #instantiateFrom(Lookup, String)}.{@link #createClient(String)}
+     * if you need to use a specially configured lookup
      *
      * @param dsn Data Source Name of the Sentry server.
      * @return an instance of Sentry.
-     * @deprecated use {@link SentryOptions sentryOptions}
-     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createClient(String)} instead
      */
-    @Deprecated
     @Nullable
     public static SentryClient sentryClient(@Nullable String dsn) {
         return sentryClient(dsn, null);
@@ -73,14 +76,14 @@ public abstract class SentryClientFactory {
 
     /**
      * Creates an instance of Sentry using the provided DSN and the specified factory.
+     * <p>
+     * This uses a default lookup instance, use {@link #instantiateFrom(Lookup, String)}.{@link #createClient(String)}
+     * if you need to use a specially configured lookup
      *
      * @param dsn Data Source Name of the Sentry server.
      * @param sentryClientFactory SentryClientFactory instance to use, or null to do a config lookup.
      * @return SentryClient instance, or null if one couldn't be constructed.
-     * @deprecated use {@link SentryOptions sentryOptions}
-     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createClient(String)} instead
      */
-    @Deprecated
     @Nullable
     public static SentryClient sentryClient(@Nullable String dsn, @Nullable SentryClientFactory sentryClientFactory) {
         Lookup lookup = Lookup.getDefault();
@@ -152,20 +155,21 @@ public abstract class SentryClientFactory {
 
     /**
      * Creates an instance of Sentry given a DSN.
+     * <p>
+     * You may want to prefer the {@link #createClient(String)} method, which can accept a null DSN if the DSN from the
+     * lookup configuration should be used.
      *
      * @param dsn Data Source Name of the Sentry server to override the configuration of the factory
      * @return an instance of Sentry.
      * @throws RuntimeException when an instance couldn't be created.
-     *
-     * @deprecated use {@link #createClient(String)}
      */
-    @Deprecated
     public abstract SentryClient createSentryClient(Dsn dsn);
 
     /**
-     * Creates an instance of Sentry given a DSN.
+     * Creates an instance of Sentry given a DSN. Uses either the explicitly provided non-null DSN or the default
+     * DSN found in the configuration if {@code null} is provided.
      *
-     * @param dsn Data Source Name of the Sentry server to override the configuration of the factory
+     * @param dsn optional Data Source Name of the Sentry server to override the configuration of the factory
      * @return an instance of Sentry.
      * @throws RuntimeException when an instance couldn't be created.
      */

--- a/sentry/src/main/java/io/sentry/SentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryClientFactory.java
@@ -23,8 +23,8 @@ public abstract class SentryClientFactory {
      * Creates an instance of Sentry by discovering the DSN.
      *
      * @return an instance of Sentry.
-     * @deprecated use {@link SentryOptions sentryOptions}.{@link SentryOptions#getClientFactory() getClientFactory()}
-     * .{@link #createSentryClient(Dsn)} instead
+     * @deprecated use {@link SentryOptions sentryOptions}
+     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createSentryClient(Dsn)} instead
      */
     @Deprecated
     @Nullable
@@ -37,8 +37,8 @@ public abstract class SentryClientFactory {
      *
      * @param dsn Data Source Name of the Sentry server.
      * @return an instance of Sentry.
-     * @deprecated use {@link SentryOptions sentryOptions}.{@link SentryOptions#getClientFactory() getClientFactory()}
-     * .{@link #createSentryClient(Dsn)} instead
+     * @deprecated use {@link SentryOptions sentryOptions}
+     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createSentryClient(Dsn)} instead
      */
     @Deprecated
     @Nullable
@@ -52,8 +52,8 @@ public abstract class SentryClientFactory {
      * @param dsn Data Source Name of the Sentry server.
      * @param sentryClientFactory SentryClientFactory instance to use, or null to do a config lookup.
      * @return SentryClient instance, or null if one couldn't be constructed.
-     * @deprecated use {@link SentryOptions sentryOptions}.{@link SentryOptions#getClientFactory() getClientFactory()}
-     * .{@link #createSentryClient(Dsn)} instead
+     * @deprecated use {@link SentryOptions sentryOptions}
+     * .{@link SentryOptions#getSentryClientFactory() getClientFactory()}.{@link #createSentryClient(Dsn)} instead
      */
     @Deprecated
     @Nullable

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -17,7 +17,7 @@ public final class SentryOptions {
     private static final Logger logger = LoggerFactory.getLogger(SentryOptions.class);
 
     private Lookup lookup;
-    private SentryClientFactory clientFactory;
+    private SentryClientFactory sentryClientFactory;
     private String dsn;
 
     /**
@@ -35,22 +35,22 @@ public final class SentryOptions {
      *
      * @param lookup        the lookup to locate the configuration with
      * @param dsn           the DSN to use or null if the DSN should be found in the lookup
-     * @param clientFactory the client factory to use or null if the instance should be found in the lookup
+     * @param sentryClientFactory the client factory to use or null if the instance should be found in the lookup
      * @throws NullPointerException if lookup is null
      */
-    public SentryOptions(Lookup lookup, @Nullable String dsn, @Nullable SentryClientFactory clientFactory) {
+    public SentryOptions(Lookup lookup, @Nullable String dsn, @Nullable SentryClientFactory sentryClientFactory) {
         this.lookup = requireNonNull(lookup, "lookup");
         this.dsn = resolveDsn(lookup, dsn);
-        this.clientFactory = clientFactory == null
+        this.sentryClientFactory = sentryClientFactory == null
                 ? SentryClientFactory.instantiateFrom(this.lookup, this.dsn)
-                : clientFactory;
+                : sentryClientFactory;
         this.resourceLoader = null;
 
-        if (this.clientFactory == null) {
+        if (this.sentryClientFactory == null) {
             logger.error("Failed to find a Sentry client factory in the provided configuration. Will continue"
                     + " with a dummy implementation that will send no data.");
 
-            this.clientFactory = new InvalidSentryClientFactory();
+            this.sentryClientFactory = new InvalidSentryClientFactory();
         }
     }
 
@@ -118,19 +118,19 @@ public final class SentryOptions {
     }
 
     /**
-     * Gets the optionally set {@Link SentryClientFactory}.
+     * Gets the optionally set {@link SentryClientFactory}.
      * @return {@link SentryClientFactory}
      */
-    public SentryClientFactory getClientFactory() {
-        return clientFactory;
+    public SentryClientFactory getSentryClientFactory() {
+        return sentryClientFactory;
     }
 
     /**
      * Sets the {@link SentryClientFactory} to be used when initializing the SDK.
      * @param clientFactory Factory used to create a {@link SentryClient}.
      */
-    public void setClientFactory(@Nullable SentryClientFactory clientFactory) {
-        this.clientFactory = clientFactory == null
+    public void setSentryClientFactory(@Nullable SentryClientFactory clientFactory) {
+        this.sentryClientFactory = clientFactory == null
                 ? SentryClientFactory.instantiateFrom(getLookup(), getDsn())
                 : clientFactory;
     }
@@ -201,13 +201,13 @@ public final class SentryOptions {
     }
 
     /**
-     * Returns a new Sentry client obtained from the {@link #getClientFactory() factory}.
+     * Returns a new Sentry client obtained from the {@link #getSentryClientFactory() factory}.
      *
      * @return the new sentry client or null if the client factory is invalid
      */
     @Nullable
     public SentryClient createClient() {
-        return getClientFactory().createSentryClient(getDsn());
+        return getSentryClientFactory().createSentryClient(getDsn());
     }
 
     private static String resolveDsn(Lookup lookup, @Nullable String dsn) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1,60 +1,311 @@
 package io.sentry;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.sentry.config.CompoundResourceLoader;
+import io.sentry.config.ContextClassLoaderResourceLoader;
+import io.sentry.config.FileResourceLoader;
+import io.sentry.config.Lookup;
 import io.sentry.config.ResourceLoader;
+import io.sentry.config.location.CompoundResourceLocator;
+import io.sentry.config.location.ConfigurationResourceLocator;
+import io.sentry.config.location.EnvironmentBasedLocator;
+import io.sentry.config.location.StaticFileLocator;
+import io.sentry.config.location.SystemPropertiesBasedLocator;
+import io.sentry.config.provider.CompoundConfigurationProvider;
+import io.sentry.config.provider.ConfigurationProvider;
+import io.sentry.config.provider.EnvironmentConfigurationProvider;
+import io.sentry.config.provider.JndiConfigurationProvider;
+import io.sentry.config.provider.JndiSupport;
+import io.sentry.config.provider.LocatorBasedConfigurationProvider;
+import io.sentry.config.provider.SystemPropertiesConfigurationProvider;
+import io.sentry.dsn.Dsn;
+import io.sentry.util.Nullable;
+import io.sentry.util.Util;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * SentryOptions used to configure the Sentry SDK.
  */
-public class SentryOptions {
-    private SentryClientFactory sentryClientFactory;
-    private String dsn;
-    private ResourceLoader resourceLoader;
+public final class SentryOptions {
+    private static final Logger logger = LoggerFactory.getLogger(SentryOptions.class);
+
+    private final Lookup lookup;
+    private final Dsn dsn;
+    private final SentryClientFactory clientFactory;
 
     /**
-     * Gets the optionally set {@Link SentryClientFactory}.
-     * @return {@link SentryClientFactory}
+     * Creates a new instance of the options using the provided parameters.
+     *
+     * @param lookup        the lookup to locate the configuration with
+     * @param dsn           the dsn to use
+     * @param clientFactory the client factory to use
+     * @throws NullPointerException if any of the parameters is null
      */
-    public SentryClientFactory getSentryClientFactory() {
-        return sentryClientFactory;
+    public SentryOptions(Lookup lookup, Dsn dsn, SentryClientFactory clientFactory) {
+        this.lookup = requireNonNull(lookup, "lookup");
+        this.dsn = requireNonNull(dsn, "dsn");
+        this.clientFactory = requireNonNull(clientFactory, "clientFactory");
     }
 
     /**
-     * Sets the {@link SentryClientFactory} to be used when initializing the SDK.
-     * @param sentryClientFactory Factory used to create a {@link SentryClient}.
+     * Creates new options using the provided lookup instance. The DSN and the client factory are obtained using the
+     * provided lookup instance.
+     *
+     * @param lookup the lookup to locate the configuration with
+     * @return new instance of SentryOptions
      */
-    public void setSentryClientFactory(SentryClientFactory sentryClientFactory) {
-        this.sentryClientFactory = sentryClientFactory;
+    public static SentryOptions from(Lookup lookup) {
+        return from(lookup, (String) null, null);
     }
 
     /**
-     * Gets the DSN. If not DSN was set, the SDK will attempt to find one in the environment.
-     * @return Data Source Name.
+     * Creates new options using the provided lookup instance and optional DSN. If the provided DSN is null, the DSN
+     * to use is looked up using the provided lookup instance.
+     *
+     * @param lookup the lookup to locate the configuration with
+     * @param dsn    the optional dsn to use
+     * @return new instance of SentryOptions
      */
-    public String getDsn() {
+    public static SentryOptions from(Lookup lookup, @Nullable String dsn) {
+        return from(lookup, dsn, null);
+    }
+
+    /**
+     * Creates new options using the provided lookup instance and optional DSN and client factory. If the provided
+     * DSN or client factory is null, the DSN and client factory to use is looked up using the provided lookup instance.
+     *
+     * @param lookup  the lookup to locate the configuration with
+     * @param dsn     the optional dsn to use or null if the value should be located in the config
+     * @param factory the client factory to use or null if the value should be located in the config
+     * @return new instance of SentryOptions
+     */
+    public static SentryOptions from(Lookup lookup, @Nullable String dsn, @Nullable SentryClientFactory factory) {
+        return from(lookup, resolveDsn(lookup, dsn), factory);
+    }
+
+    private static SentryOptions from(Lookup lookup, Dsn dsn, @Nullable SentryClientFactory factory) {
+        if (factory == null) {
+            factory = SentryClientFactory.instantiateFrom(lookup, dsn);
+        }
+
+        if (factory == null) {
+            logger.error("Failed to find a Sentry client factory in the provided configuration. Will continue"
+                    + " with a dummy implementation that will send no data.");
+
+            factory = new InvalidSentryClientFactory();
+        }
+
+        return new SentryOptions(lookup, dsn, factory);
+    }
+
+    /**
+     * A convenience method to load the default SentryOptions using the default lookup instance.
+     *
+     * @see #getDefaultLookup()
+     *
+     * @return the default sentry options
+     */
+    public static SentryOptions defaults() {
+        return defaults(null);
+    }
+
+    /**
+     * A convenience method to load the default SentryOptions using the default lookup instance using the provided
+     * DSN instead of the one from the config.
+     *
+     * <p>Equivalent to {@code SentryOptions.defaults().withDsn(dsn)}.
+     *
+     * @param dsn the DSN to override the configured default with
+     *
+     * @see #getDefaultLookup()
+     *
+     * @return the default sentry options with the provided DSN
+     */
+    public static SentryOptions defaults(@Nullable String dsn) {
+        return from(getDefaultLookup(), dsn, null);
+    }
+
+    /**
+     * In the default lookup returned from this method, the configuration properties are looked up in the sources in the
+     * following order.
+     *
+     * <ol>
+     * <li>JNDI, if available
+     * <li>Java System Properties
+     * <li>System Environment Variables
+     * <li>DSN options, if a non-null DSN is provided
+     * <li>Sentry properties file found in resources
+     * </ol>
+     *
+     * @return the default lookup instance
+     */
+    public static Lookup getDefaultLookup() {
+        return new Lookup(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders()),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders()));
+    }
+
+    /**
+     * Similar to {@link #with(Dsn)} but uses just the string representation of the DSN. If the provided DSN is null,
+     * the one from the current instance is used.
+     *
+     * @param newDsn the DSN to use or null if it should remain the same.
+     * @return the new options instance (or this instance if the provided dsn is null)
+     */
+    public SentryOptions withDsn(@Nullable String newDsn) {
+        return newDsn == null ? this : with(new Dsn(newDsn));
+    }
+
+    /**
+     * Returns a copy of this options instance with the dsn set to the provided value.
+     *
+     * @param newDsn the dsn to use in the new options instance
+     * @return the new options instance
+     */
+    public SentryOptions with(Dsn newDsn) {
+        return from(getLookup(), requireNonNull(newDsn), null);
+    }
+
+    /**
+     * Returns a copy of this options instance with the lookup set to the provided value.
+     *
+     * @param newLookup the lookup to use in the new options instance
+     * @return the new options instance
+     */
+    public SentryOptions with(Lookup newLookup) {
+        return from(requireNonNull(newLookup), getDsn(), null);
+    }
+
+    /**
+     * Returns a copy of this options instance with the client factory set to the provided value.
+     *
+     * @param newClientFactory the client factory to use in the new options instance
+     * @return the new options instance
+     */
+    public SentryOptions with(SentryClientFactory newClientFactory) {
+        return from(getLookup(), getDsn(), requireNonNull(newClientFactory));
+    }
+
+    /**
+     * Gets the value of the configuration key using the {@link #getLookup() lookup} and {@link #getDsn() DSN}.
+     *
+     * @param key the name of the configuration key
+     * @return the value of the configuration key or null if not found
+     */
+    @Nullable
+    public String getConfigurationKey(String key) {
+        return lookup.get(key, dsn);
+    }
+
+    /**
+     * Gets the lookup instance used by this options instance.
+     *
+     * @return the configured lookup instance
+     */
+    public Lookup getLookup() {
+        return lookup;
+    }
+
+    /**
+     * Gets the DSN instance used by this options instance.
+     *
+     * @return the configured DSN instance
+     */
+    public Dsn getDsn() {
         return dsn;
     }
 
     /**
-     * Sets the DSN to be used by the {@link SentryClient}.
-     * @param dsn Sentry Data Source Name.
+     * Gets the Sentry client factory instance used by this options instance.
+     * @return the configured client factory instance
      */
-    public void setDsn(String dsn) {
-        this.dsn = dsn;
+    public SentryClientFactory getClientFactory() {
+        return clientFactory;
     }
 
     /**
-     * Gets the {@link ResourceLoader} to be used when looking for properties.
-     * @return {@link ResourceLoader}
+     * Returns a new Sentry client obtained from the {@link #getClientFactory() factory}.
+     *
+     * @return the new sentry client or null if the client factory is invalid
      */
-    public ResourceLoader getResourceLoader() {
-        return resourceLoader;
+    @Nullable
+    public SentryClient createClient() {
+        return getClientFactory().createSentryClient(getDsn());
+    }
+
+    private static Dsn resolveDsn(Lookup lookup, @Nullable String dsn) {
+        try {
+            if (Util.isNullOrEmpty(dsn)) {
+                dsn = Dsn.dsnFrom(lookup);
+            }
+
+            return new Dsn(dsn);
+        } catch (Exception e) {
+            logger.error("Error creating valid DSN from: '{}'.", dsn, e);
+            throw e;
+        }
+    }
+
+    // the below is support for instantiating the default lookup
+
+    private static List<ConfigurationResourceLocator> getDefaultResourceLocators() {
+        return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator(), new StaticFileLocator());
+    }
+
+    private static List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders() {
+        boolean jndiPresent = JndiSupport.isAvailable();
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        List<ConfigurationProvider> providers = new ArrayList<>(jndiPresent ? 3 : 2);
+
+        if (jndiPresent) {
+            providers.add(new JndiConfigurationProvider());
+        }
+
+        providers.add(new SystemPropertiesConfigurationProvider());
+        providers.add(new EnvironmentConfigurationProvider());
+
+        return providers;
+    }
+
+    private static List<ResourceLoader> getDefaultResourceLoaders() {
+        return Arrays.asList(new FileResourceLoader(), new ContextClassLoaderResourceLoader());
+    }
+
+    private static List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
+        try {
+            return singletonList((ConfigurationProvider)
+                    new LocatorBasedConfigurationProvider(new CompoundResourceLoader(getDefaultResourceLoaders()),
+                            new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
+        } catch (IOException e) {
+            logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
+            return emptyList();
+        }
     }
 
     /**
-     * Sets the {@link ResourceLoader} to be used when looking for properties.
-     * @param resourceLoader Optional {@link ResourceLoader} used to lookup properties.
+     * A dummy factory used in case of invalid configuration.
      */
-    public void setResourceLoader(ResourceLoader resourceLoader) {
-        this.resourceLoader = resourceLoader;
+    private static final class InvalidSentryClientFactory extends SentryClientFactory {
+        /**
+         * Returns null.
+         *
+         * @param dsn not used
+         * @return always null
+         */
+        @Override
+        public SentryClient createSentryClient(Dsn dsn) {
+            return null;
+        }
     }
 }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -216,15 +216,20 @@ public final class SentryOptions {
     /**
      * A dummy factory used in case of invalid configuration.
      */
-    private static final class InvalidSentryClientFactory extends SentryClientFactory {
+    private final class InvalidSentryClientFactory extends SentryClientFactory {
+
+        private InvalidSentryClientFactory() {
+            super(getLookup());
+        }
+
         /**
          * Returns null.
          *
-         * @param dsn not used
+         * @param newDsn not used
          * @return always null
          */
         @Override
-        public SentryClient createSentryClient(Dsn dsn) {
+        public SentryClient createSentryClient(Dsn newDsn) {
             return null;
         }
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -200,16 +200,6 @@ public final class SentryOptions {
         this.resourceLoader = resourceLoader;
     }
 
-    /**
-     * Returns a new Sentry client obtained from the {@link #getSentryClientFactory() factory}.
-     *
-     * @return the new sentry client or null if the client factory is invalid
-     */
-    @Nullable
-    public SentryClient createClient() {
-        return getSentryClientFactory().createSentryClient(getDsn());
-    }
-
     private static String resolveDsn(Lookup lookup, @Nullable String dsn) {
         try {
             if (Util.isNullOrEmpty(dsn)) {

--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -1,60 +1,21 @@
 package io.sentry.config;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import io.sentry.Sentry;
-import io.sentry.config.location.CompoundResourceLocator;
-import io.sentry.config.location.ConfigurationResourceLocator;
-import io.sentry.config.location.StaticFileLocator;
-import io.sentry.config.location.EnvironmentBasedLocator;
-import io.sentry.config.location.SystemPropertiesBasedLocator;
-import io.sentry.config.provider.CompoundConfigurationProvider;
 import io.sentry.config.provider.ConfigurationProvider;
-import io.sentry.config.provider.EnvironmentConfigurationProvider;
-import io.sentry.config.provider.JndiConfigurationProvider;
-import io.sentry.config.provider.JndiSupport;
-import io.sentry.config.provider.LocatorBasedConfigurationProvider;
-import io.sentry.config.provider.SystemPropertiesConfigurationProvider;
 import io.sentry.dsn.Dsn;
 import io.sentry.util.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handle lookup of configuration keys by trying JNDI, System Environment, and Java System Properties.
+ * Handle lookup of configuration keys from the various sources.
  *
- * By default (when instantiated using the default constructor), the sources from which the configuration
- * properties are consulted in the following order:
- *
- * 1. JNDI, if available
- * 2. Java System Properties
- * 3. System Environment Variables
- * 4. DSN options, if a non-null DSN is provided
- * 5. Sentry properties file found in resources
+ * @see io.sentry.SentryOptions for the options and defaults
  */
 public final class Lookup {
     private static final Logger logger = LoggerFactory.getLogger(Lookup.class);
-    private static final Object INSTANCE_LOCK = new Object();
-    private static Lookup instance;
 
     private final ConfigurationProvider highPriorityProvider;
     private final ConfigurationProvider lowPriorityProvider;
-
-    /**
-     * Constructs a new instance of Lookup with the default configuration providers.
-     */
-    public Lookup() {
-        this(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders()),
-                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders()));
-    }
 
     /**
      * Constructs a new Lookup instance.
@@ -69,89 +30,6 @@ public final class Lookup {
     public Lookup(ConfigurationProvider highPriorityProvider, ConfigurationProvider lowPriorityProvider) {
         this.highPriorityProvider = highPriorityProvider;
         this.lowPriorityProvider = lowPriorityProvider;
-    }
-
-    private static List<ConfigurationResourceLocator> getDefaultResourceLocators() {
-        return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator(), new StaticFileLocator());
-    }
-
-    private static List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders() {
-        boolean jndiPresent = JndiSupport.isAvailable();
-
-        @SuppressWarnings("checkstyle:MagicNumber")
-        List<ConfigurationProvider> providers = new ArrayList<>(jndiPresent ? 3 : 2);
-
-        if (jndiPresent) {
-            providers.add(new JndiConfigurationProvider());
-        }
-
-        providers.add(new SystemPropertiesConfigurationProvider());
-        providers.add(new EnvironmentConfigurationProvider());
-
-        return providers;
-    }
-
-    private static List<ResourceLoader> getDefaultResourceLoaders() {
-        ResourceLoader sentryLoader = Sentry.getResourceLoader();
-
-        return sentryLoader == null
-                ? Arrays.asList(new FileResourceLoader(), new ContextClassLoaderResourceLoader())
-                : Arrays.asList(new FileResourceLoader(), sentryLoader, new ContextClassLoaderResourceLoader());
-    }
-
-    private static List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
-        try {
-            return singletonList((ConfigurationProvider)
-                    new LocatorBasedConfigurationProvider(new CompoundResourceLoader(getDefaultResourceLoaders()),
-                            new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
-        } catch (IOException e) {
-            logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
-            return emptyList();
-        }
-    }
-
-    // for use in the deprecated methods
-    private static Lookup getDeprecatedInstance() {
-        synchronized (INSTANCE_LOCK) {
-            if (instance == null) {
-                instance = new Lookup();
-            }
-
-            return instance;
-        }
-    }
-
-    /**
-     * Attempt to lookup a configuration key, without checking any DSN options.
-     *
-     * @param key name of configuration key, e.g. "dsn"
-     * @return value of configuration key, if found, otherwise null
-     *
-     * @deprecated obtain an instance of this class and use {@link #get(String)}
-     */
-    @Deprecated
-    public static String lookup(String key) {
-        return lookup(key, null);
-    }
-
-    /**
-     * Attempt to lookup a configuration key using the following order:
-     *
-     * 1. JNDI, if available
-     * 2. Java System Properties
-     * 3. System Environment Variables
-     * 4. DSN options, if a non-null DSN is provided
-     * 5. Sentry properties file found in resources
-     *
-     * @param key name of configuration key, e.g. "dsn"
-     * @param dsn an optional DSN to retrieve options from
-     * @return value of configuration key, if found, otherwise null
-     *
-     * @deprecated obtain an instance of this class and use {@link #get(String, Dsn)}
-     */
-    @Deprecated
-    public static String lookup(String key, Dsn dsn) {
-        return getDeprecatedInstance().get(key, dsn);
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -1,6 +1,28 @@
 package io.sentry.config;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.sentry.Sentry;
+import io.sentry.config.location.CompoundResourceLocator;
+import io.sentry.config.location.ConfigurationResourceLocator;
+import io.sentry.config.location.EnvironmentBasedLocator;
+import io.sentry.config.location.StaticFileLocator;
+import io.sentry.config.location.SystemPropertiesBasedLocator;
+import io.sentry.config.provider.CompoundConfigurationProvider;
 import io.sentry.config.provider.ConfigurationProvider;
+import io.sentry.config.provider.EnvironmentConfigurationProvider;
+import io.sentry.config.provider.JndiConfigurationProvider;
+import io.sentry.config.provider.JndiSupport;
+import io.sentry.config.provider.LocatorBasedConfigurationProvider;
+import io.sentry.config.provider.SystemPropertiesConfigurationProvider;
 import io.sentry.dsn.Dsn;
 import io.sentry.util.Nullable;
 import org.slf4j.Logger;
@@ -9,7 +31,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Handle lookup of configuration keys from the various sources.
  *
- * @see io.sentry.SentryOptions for the options and defaults
+ * @see #getDefault() for obtaining the default instance
  */
 public final class Lookup {
     private static final Logger logger = LoggerFactory.getLogger(Lookup.class);
@@ -33,6 +55,98 @@ public final class Lookup {
     }
 
     /**
+     * In the default lookup returned from this method, the configuration properties are looked up in the sources in the
+     * following order.
+     *
+     * <ol>
+     * <li>JNDI, if available
+     * <li>Java System Properties
+     * <li>System Environment Variables
+     * <li>DSN options, if a non-null DSN is provided
+     * <li>Sentry properties file found in resources
+     * </ol>
+     *
+     * @return the default lookup instance
+     */
+    public static Lookup getDefault() {
+        return new Lookup(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders()),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders()));
+    }
+
+    private static List<ConfigurationResourceLocator> getDefaultResourceLocators() {
+        return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator(), new StaticFileLocator());
+    }
+
+    private static List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders() {
+        boolean jndiPresent = JndiSupport.isAvailable();
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        List<ConfigurationProvider> providers = new ArrayList<>(jndiPresent ? 3 : 2);
+
+        if (jndiPresent) {
+            providers.add(new JndiConfigurationProvider());
+        }
+
+        providers.add(new SystemPropertiesConfigurationProvider());
+        providers.add(new EnvironmentConfigurationProvider());
+
+        return providers;
+    }
+
+    private static List<ResourceLoader> getDefaultResourceLoaders() {
+        ResourceLoader sentryLoader = Sentry.getResourceLoader();
+
+        return sentryLoader == null
+                ? Arrays.asList(new FileResourceLoader(), new ContextClassLoaderResourceLoader())
+                : Arrays.asList(new FileResourceLoader(), sentryLoader, new ContextClassLoaderResourceLoader());
+    }
+
+    private static List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
+        try {
+            return singletonList((ConfigurationProvider)
+                    new LocatorBasedConfigurationProvider(new CompoundResourceLoader(getDefaultResourceLoaders()),
+                            new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
+        } catch (IOException e) {
+            logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
+            return emptyList();
+        }
+    }
+
+
+    /**
+     * Attempt to lookup a configuration key, without checking any DSN options.
+     *
+     * @param key name of configuration key, e.g. "dsn"
+     * @return value of configuration key, if found, otherwise null
+     *
+     * @deprecated obtain an instance of this class and use {@link #get(String)}
+     */
+    @Deprecated
+    public static String lookup(String key) {
+        return lookup(key, null);
+    }
+
+    /**
+     * Attempt to lookup a configuration key using the following order:
+     *
+     * 1. JNDI, if available
+     * 2. Java System Properties
+     * 3. System Environment Variables
+     * 4. DSN options, if a non-null DSN is provided
+     * 5. Sentry properties file found in resources
+     *
+     * @param key name of configuration key, e.g. "dsn"
+     * @param dsn an optional DSN to retrieve options from
+     * @return value of configuration key, if found, otherwise null
+     *
+     * @deprecated obtain an instance of this class and use {@link #get(String, Dsn)}
+     */
+    @Deprecated
+    public static String lookup(String key, Dsn dsn) {
+        return getDefault().get(key, dsn);
+    }
+
+    /**
      * Attempt to lookup a configuration key, without checking any DSN options.
      *
      * @param key name of configuration key, e.g. "dsn"
@@ -51,7 +165,7 @@ public final class Lookup {
      * @return value of configuration key, if found, otherwise null
      */
     @Nullable
-    public String get(String key, Dsn dsn) {
+    public String get(String key, @Nullable Dsn dsn) {
         String val = highPriorityProvider.getProperty(key);
 
         if (val == null && dsn != null) {

--- a/sentry/src/main/java/io/sentry/dsn/Dsn.java
+++ b/sentry/src/main/java/io/sentry/dsn/Dsn.java
@@ -74,12 +74,12 @@ public class Dsn {
 
     /**
      * Looks for a DSN configuration within JNDI, the System environment or Java properties.
+     * <p>
+     * This uses the default lookup. If you need a specially configured lookup instance, use {@link #dsnFrom(Lookup)}
+     * method.
      *
      * @return a DSN configuration or null if nothing could be found.
-     *
-     * @deprecated use {@link #dsnFrom(Lookup)} instead (kept because this is heavily used in tests)
      */
-    @Deprecated
     public static String dsnLookup() {
         return dsnFrom(Lookup.getDefault());
     }

--- a/sentry/src/main/java/io/sentry/dsn/Dsn.java
+++ b/sentry/src/main/java/io/sentry/dsn/Dsn.java
@@ -1,6 +1,5 @@
 package io.sentry.dsn;
 
-import io.sentry.SentryOptions;
 import io.sentry.config.Lookup;
 import io.sentry.util.Util;
 import org.slf4j.Logger;
@@ -82,7 +81,7 @@ public class Dsn {
      */
     @Deprecated
     public static String dsnLookup() {
-        return dsnFrom(SentryOptions.getDefaultLookup());
+        return dsnFrom(Lookup.getDefault());
     }
 
     /**

--- a/sentry/src/main/java/io/sentry/dsn/Dsn.java
+++ b/sentry/src/main/java/io/sentry/dsn/Dsn.java
@@ -1,5 +1,6 @@
 package io.sentry.dsn;
 
+import io.sentry.SentryOptions;
 import io.sentry.config.Lookup;
 import io.sentry.util.Util;
 import org.slf4j.Logger;
@@ -76,13 +77,26 @@ public class Dsn {
      * Looks for a DSN configuration within JNDI, the System environment or Java properties.
      *
      * @return a DSN configuration or null if nothing could be found.
+     *
+     * @deprecated use {@link #dsnFrom(Lookup)} instead (kept because this is heavily used in tests)
      */
+    @Deprecated
     public static String dsnLookup() {
-        String dsn = Lookup.lookup("dsn");
+        return dsnFrom(SentryOptions.getDefaultLookup());
+    }
+
+    /**
+     * Looks for the DSN configuration in the provided configuration lookup.
+     *
+     * @param lookup the lookup used to find the DSN configuration
+     * @return the DSN URI or the {@link #DEFAULT_DSN} if none found in the lookup
+     */
+    public static String dsnFrom(Lookup lookup) {
+        String dsn = lookup.get("dsn");
 
         if (Util.isNullOrEmpty(dsn)) {
             // check if the user accidentally set "dns" instead of "dsn"
-            dsn = Lookup.lookup("dns");
+            dsn = lookup.get("dns");
         }
 
         if (Util.isNullOrEmpty(dsn)) {

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -7,8 +7,6 @@ import java.util.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-import io.sentry.connection.NoopConnection;
-
 public class DefaultSentryClientFactoryTest extends BaseTest {
     @Test
     public void testFieldsFromDsn() throws Exception {
@@ -23,7 +21,7 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String dsn = String.format("https://user:pass@example.com/1?" +
             "release=%s&dist=%s&environment=%s&servername=%s&tags=%s&extratags=%s&extra=%s",
             release, dist, environment, serverName, tags, extraTags, extras);
-        SentryClient sentryClient = DefaultSentryClientFactory.sentryClient(dsn);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
 
         assertThat(sentryClient.getRelease(), is(release));
         assertThat(sentryClient.getDist(), is(dist));
@@ -51,7 +49,7 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String badTags = "foo:";
 
         String dsn = String.format("https://user:pass@example.com/1?tags=%s", badTags);
-        SentryClient sentryClient = DefaultSentryClientFactory.sentryClient(dsn);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
 
         assertThat(sentryClient, isA(SentryClient.class));
         assertThat(sentryClient.getContext(), notNullValue());

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -21,7 +21,8 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String dsn = String.format("https://user:pass@example.com/1?" +
             "release=%s&dist=%s&environment=%s&servername=%s&tags=%s&extratags=%s&extra=%s",
             release, dist, environment, serverName, tags, extraTags, extras);
-        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
+                .createSentryClient((String) null);
 
         assertThat(sentryClient.getRelease(), is(release));
         assertThat(sentryClient.getDist(), is(dist));
@@ -49,7 +50,8 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String badTags = "foo:";
 
         String dsn = String.format("https://user:pass@example.com/1?tags=%s", badTags);
-        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
+                .createSentryClient((String) null);
 
         assertThat(sentryClient, isA(SentryClient.class));
         assertThat(sentryClient.getContext(), notNullValue());

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -21,8 +21,9 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String dsn = String.format("https://user:pass@example.com/1?" +
             "release=%s&dist=%s&environment=%s&servername=%s&tags=%s&extratags=%s&extra=%s",
             release, dist, environment, serverName, tags, extraTags, extras);
-        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
 
+        assertThat(sentryClient, is(notNullValue()));
         assertThat(sentryClient.getRelease(), is(release));
         assertThat(sentryClient.getDist(), is(dist));
         assertThat(sentryClient.getEnvironment(), is(environment));
@@ -49,8 +50,9 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String badTags = "foo:";
 
         String dsn = String.format("https://user:pass@example.com/1?tags=%s", badTags);
-        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
 
+        assertThat(sentryClient, is(notNullValue()));
         assertThat(sentryClient, isA(SentryClient.class));
         assertThat(sentryClient.getContext(), notNullValue());
     }

--- a/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/DefaultSentryClientFactoryTest.java
@@ -21,8 +21,7 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String dsn = String.format("https://user:pass@example.com/1?" +
             "release=%s&dist=%s&environment=%s&servername=%s&tags=%s&extratags=%s&extra=%s",
             release, dist, environment, serverName, tags, extraTags, extras);
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
 
         assertThat(sentryClient.getRelease(), is(release));
         assertThat(sentryClient.getDist(), is(dist));
@@ -50,8 +49,7 @@ public class DefaultSentryClientFactoryTest extends BaseTest {
         String badTags = "foo:";
 
         String dsn = String.format("https://user:pass@example.com/1?tags=%s", badTags);
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
 
         assertThat(sentryClient, isA(SentryClient.class));
         assertThat(sentryClient.getContext(), notNullValue());

--- a/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
@@ -9,14 +9,16 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testSentryClientForFactoryNameSucceedsIfFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=io.sentry.TestFactory";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
+                .createSentryClient((String) null);
         assertThat(sentryClient.getRelease(), is(TestFactory.RELEASE));
     }
 
     @Test
     public void testSentryClientForFactoryReturnsNullIfNoFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=invalid";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
+                .createSentryClient((String) null);
         assertThat(sentryClient, is(nullValue()));
     }
 
@@ -27,7 +29,8 @@ public class SentryClientFactoryTest extends BaseTest {
         String previous = System.getProperty(propName);
         try {
             System.setProperty(propName, "noop://localhost/1?release=xyz");
-            sentryClient = SentryOptions.defaults().createClient();
+            sentryClient = SentryOptions.defaults().getSentryClientFactory()
+                .createSentryClient((String) null);
         } finally {
             if (previous == null) {
                 System.clearProperty(propName);
@@ -42,7 +45,8 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testCreateDsnIfStringProvided() throws Exception {
         final String dsn = "noop://localhost/1?release=abc";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
+                .createSentryClient((String) null);
         assertThat(sentryClient.getRelease(), is("abc"));
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import org.testng.annotations.Test;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -9,14 +10,15 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testSentryClientForFactoryNameSucceedsIfFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=io.sentry.TestFactory";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory().createClient(null);
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
+        assertThat(sentryClient, is(notNullValue()));
         assertThat(sentryClient.getRelease(), is(TestFactory.RELEASE));
     }
 
     @Test
     public void testSentryClientForFactoryReturnsNullIfNoFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=invalid";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory().createClient(null);
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
         assertThat(sentryClient, is(nullValue()));
     }
 
@@ -27,7 +29,7 @@ public class SentryClientFactoryTest extends BaseTest {
         String previous = System.getProperty(propName);
         try {
             System.setProperty(propName, "noop://localhost/1?release=xyz");
-            sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(null);
+            sentryClient = SentryClientFactory.sentryClient(null);
         } finally {
             if (previous == null) {
                 System.clearProperty(propName);
@@ -36,13 +38,15 @@ public class SentryClientFactoryTest extends BaseTest {
             }
         }
 
+        assertThat(sentryClient, is(notNullValue()));
         assertThat(sentryClient.getRelease(), is("xyz"));
     }
 
     @Test
     public void testCreateDsnIfStringProvided() throws Exception {
         final String dsn = "noop://localhost/1?release=abc";
-        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
+        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
+        assertThat(sentryClient, is(notNullValue()));
         assertThat(sentryClient.getRelease(), is("abc"));
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
@@ -9,16 +9,14 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testSentryClientForFactoryNameSucceedsIfFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=io.sentry.TestFactory";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory().createClient(null);
         assertThat(sentryClient.getRelease(), is(TestFactory.RELEASE));
     }
 
     @Test
     public void testSentryClientForFactoryReturnsNullIfNoFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=invalid";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory().createClient(null);
         assertThat(sentryClient, is(nullValue()));
     }
 
@@ -29,8 +27,7 @@ public class SentryClientFactoryTest extends BaseTest {
         String previous = System.getProperty(propName);
         try {
             System.setProperty(propName, "noop://localhost/1?release=xyz");
-            sentryClient = SentryOptions.defaults().getSentryClientFactory()
-                .createSentryClient((String) null);
+            sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(null);
         } finally {
             if (previous == null) {
                 System.clearProperty(propName);
@@ -45,8 +42,7 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testCreateDsnIfStringProvided() throws Exception {
         final String dsn = "noop://localhost/1?release=abc";
-        SentryClient sentryClient = SentryOptions.defaults(dsn).getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient sentryClient = SentryOptions.defaults().getSentryClientFactory().createClient(dsn);
         assertThat(sentryClient.getRelease(), is("abc"));
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryClientFactoryTest.java
@@ -1,19 +1,7 @@
 package io.sentry;
 
-import mockit.*;
-import io.sentry.dsn.Dsn;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.ServiceLoader;
-
-import static mockit.Deencapsulation.setField;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,14 +9,14 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testSentryClientForFactoryNameSucceedsIfFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=io.sentry.TestFactory";
-        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
         assertThat(sentryClient.getRelease(), is(TestFactory.RELEASE));
     }
 
     @Test
     public void testSentryClientForFactoryReturnsNullIfNoFactoryFound() throws Exception {
         String dsn = "noop://localhost/1?factory=invalid";
-        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
         assertThat(sentryClient, is(nullValue()));
     }
 
@@ -39,7 +27,7 @@ public class SentryClientFactoryTest extends BaseTest {
         String previous = System.getProperty(propName);
         try {
             System.setProperty(propName, "noop://localhost/1?release=xyz");
-            sentryClient = SentryClientFactory.sentryClient(null);
+            sentryClient = SentryOptions.defaults().createClient();
         } finally {
             if (previous == null) {
                 System.clearProperty(propName);
@@ -54,7 +42,7 @@ public class SentryClientFactoryTest extends BaseTest {
     @Test
     public void testCreateDsnIfStringProvided() throws Exception {
         final String dsn = "noop://localhost/1?release=abc";
-        SentryClient sentryClient = SentryClientFactory.sentryClient(dsn);
+        SentryClient sentryClient = SentryOptions.defaults(dsn).createClient();
         assertThat(sentryClient.getRelease(), is("abc"));
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryIT.java
+++ b/sentry/src/test/java/io/sentry/SentryIT.java
@@ -17,7 +17,8 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().createClient();
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
+                .createSentryClient((String) null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -33,7 +34,8 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().createClient();
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
+                .createSentryClient((String) null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -49,7 +51,8 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().createClient();
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
+                .createSentryClient((String) null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);

--- a/sentry/src/test/java/io/sentry/SentryIT.java
+++ b/sentry/src/test/java/io/sentry/SentryIT.java
@@ -17,7 +17,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryClientFactory.sentryClient();
+        SentryClient client = SentryOptions.defaults().createClient();
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -33,7 +33,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryClientFactory.sentryClient();
+        SentryClient client = SentryOptions.defaults().createClient();
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -49,7 +49,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryClientFactory.sentryClient();
+        SentryClient client = SentryOptions.defaults().createClient();
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);

--- a/sentry/src/test/java/io/sentry/SentryIT.java
+++ b/sentry/src/test/java/io/sentry/SentryIT.java
@@ -5,6 +5,7 @@ import io.sentry.connection.LockdownManager;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static mockit.Deencapsulation.getField;
 
@@ -17,7 +18,9 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
+        SentryClient client = SentryClientFactory.sentryClient();
+        assertNotNull(client);
+
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -33,7 +36,9 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
+        SentryClient client = SentryClientFactory.sentryClient();
+        assertNotNull(client);
+
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -49,7 +54,9 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
+        SentryClient client = SentryClientFactory.sentryClient();
+        assertNotNull(client);
+
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);

--- a/sentry/src/test/java/io/sentry/SentryIT.java
+++ b/sentry/src/test/java/io/sentry/SentryIT.java
@@ -17,8 +17,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -34,8 +33,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);
@@ -51,8 +49,7 @@ public class SentryIT extends BaseIT {
         verifyProject1PostRequestCount(0);
         verifyStoredEventCount(0);
 
-        SentryClient client = SentryOptions.defaults().getSentryClientFactory()
-                .createSentryClient((String) null);
+        SentryClient client = SentryOptions.defaults().getSentryClientFactory().createClient(null);
         client.sendMessage("Test");
 
         verifyProject1PostRequestCount(1);

--- a/sentry/src/test/java/io/sentry/SentryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryTest.java
@@ -132,7 +132,7 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init(SentryOptions.from(SentryOptions.getDefaultLookup(),
+        SentryClient sentryClient = Sentry.init(SentryOptions.from(Lookup.getDefault(),
                 "http://public:private@localhost:4567/1?async=false"));
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
@@ -149,9 +149,9 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsnAndFactory() throws Exception {
-        SentryClient sentryClient = Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
-                new Dsn("http://public:private@localhost:4567/1?async=false"),
-                new DefaultSentryClientFactory(SentryOptions.getDefaultLookup())));
+        SentryClient sentryClient = Sentry.init(new SentryOptions(Lookup.getDefault(),
+                "http://public:private@localhost:4567/1?async=false",
+                new DefaultSentryClientFactory(Lookup.getDefault())));
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
 

--- a/sentry/src/test/java/io/sentry/SentryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryTest.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.config.Lookup;
 import io.sentry.connection.Connection;
 import io.sentry.connection.HttpConnection;
 import io.sentry.connection.NoopConnection;
@@ -110,14 +111,14 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitNoDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init();
+        SentryClient sentryClient = Sentry.init(SentryOptions.defaults());
         Object connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(NoopConnection.class));
     }
 
     @Test
     public void testInitNullDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init((String) null);
+        SentryClient sentryClient = Sentry.init(SentryOptions.defaults());
         NoopConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(NoopConnection.class));
     }
@@ -131,7 +132,8 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init("http://public:private@localhost:4567/1?async=false");
+        SentryClient sentryClient = Sentry.init(SentryOptions.from(SentryOptions.getDefaultLookup(),
+                "http://public:private@localhost:4567/1?async=false"));
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
 
@@ -147,7 +149,9 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsnAndFactory() throws Exception {
-        SentryClient sentryClient = Sentry.init("http://public:private@localhost:4567/1?async=false", new DefaultSentryClientFactory());
+        SentryClient sentryClient = Sentry.init(new SentryOptions(SentryOptions.getDefaultLookup(),
+                new Dsn("http://public:private@localhost:4567/1?async=false"),
+                new DefaultSentryClientFactory(SentryOptions.getDefaultLookup())));
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
 

--- a/sentry/src/test/java/io/sentry/SentryTest.java
+++ b/sentry/src/test/java/io/sentry/SentryTest.java
@@ -111,14 +111,14 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitNoDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init(SentryOptions.defaults());
+        SentryClient sentryClient = Sentry.init();
         Object connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(NoopConnection.class));
     }
 
     @Test
     public void testInitNullDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init(SentryOptions.defaults());
+        SentryClient sentryClient = Sentry.init((String) null);
         NoopConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(NoopConnection.class));
     }
@@ -132,8 +132,7 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsn() throws Exception {
-        SentryClient sentryClient = Sentry.init(SentryOptions.from(Lookup.getDefault(),
-                "http://public:private@localhost:4567/1?async=false"));
+        SentryClient sentryClient = Sentry.init("http://public:private@localhost:4567/1?async=false");
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
 
@@ -149,9 +148,8 @@ public class SentryTest extends BaseTest {
 
     @Test
     public void testInitStringDsnAndFactory() throws Exception {
-        SentryClient sentryClient = Sentry.init(new SentryOptions(Lookup.getDefault(),
-                "http://public:private@localhost:4567/1?async=false",
-                new DefaultSentryClientFactory(Lookup.getDefault())));
+        SentryClient sentryClient = Sentry.init("http://public:private@localhost:4567/1?async=false",
+                new DefaultSentryClientFactory());
         HttpConnection connection = getField(sentryClient, "connection");
         assertThat(connection, instanceOf(HttpConnection.class));
 

--- a/sentry/src/test/java/io/sentry/TestFactory.java
+++ b/sentry/src/test/java/io/sentry/TestFactory.java
@@ -1,9 +1,15 @@
 package io.sentry;
 
+import io.sentry.config.Lookup;
 import io.sentry.dsn.Dsn;
 
 public class TestFactory extends DefaultSentryClientFactory {
     static final String RELEASE = "312407214120";
+
+    public TestFactory(Lookup lookup) {
+        super(lookup);
+    }
+
     @Override
     protected SentryClient configureSentryClient(SentryClient sentryClient, Dsn dsn) {
         sentryClient.setRelease(RELEASE);

--- a/sentry/src/test/java/io/sentry/dsn/DsnTest.java
+++ b/sentry/src/test/java/io/sentry/dsn/DsnTest.java
@@ -1,6 +1,7 @@
 package io.sentry.dsn;
 
 import io.sentry.BaseTest;
+import io.sentry.SentryOptions;
 import io.sentry.config.JndiLookup;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -137,7 +138,7 @@ public class DsnTest extends BaseTest {
             result = dsn;
         }};
 
-        assertThat(Dsn.dsnLookup(), is(Dsn.DEFAULT_DSN));
+        assertThat(Dsn.dsnFrom(SentryOptions.getDefaultLookup()), is(Dsn.DEFAULT_DSN));
     }
 
     @Test(expectedExceptions = InvalidDsnException.class)

--- a/sentry/src/test/java/io/sentry/dsn/DsnTest.java
+++ b/sentry/src/test/java/io/sentry/dsn/DsnTest.java
@@ -138,7 +138,7 @@ public class DsnTest extends BaseTest {
             result = dsn;
         }};
 
-        assertThat(Dsn.dsnFrom(Lookup.getDefault()), is(Dsn.DEFAULT_DSN));
+        assertThat(Dsn.dsnLookup(), is(Dsn.DEFAULT_DSN));
     }
 
     @Test(expectedExceptions = InvalidDsnException.class)

--- a/sentry/src/test/java/io/sentry/dsn/DsnTest.java
+++ b/sentry/src/test/java/io/sentry/dsn/DsnTest.java
@@ -1,8 +1,8 @@
 package io.sentry.dsn;
 
 import io.sentry.BaseTest;
-import io.sentry.SentryOptions;
 import io.sentry.config.JndiLookup;
+import io.sentry.config.Lookup;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
@@ -138,7 +138,7 @@ public class DsnTest extends BaseTest {
             result = dsn;
         }};
 
-        assertThat(Dsn.dsnFrom(SentryOptions.getDefaultLookup()), is(Dsn.DEFAULT_DSN));
+        assertThat(Dsn.dsnFrom(Lookup.getDefault()), is(Dsn.DEFAULT_DSN));
     }
 
     @Test(expectedExceptions = InvalidDsnException.class)


### PR DESCRIPTION
This should make us ready to have a fully customizable and composable configuration.

There are static helpers in `SentryOptions` (e.g. the `defaults()` method) that can help users get up and running quickly but the `SentryOptions` instance can be obtained using a fully configured `Lookup` instance and can also be supplied overrides for both `Dsn` and `SentryClientFactory`.

~~There should be just 1 behavioral change in this PR:~~

~~It is no longer possible to use `SentryOptions.resourceLoader` to inject the resource loader into the default Lookup instance. This needs to be done by manually constructing the `Lookup` instance, using it to construct `SentryOptions` instance and call `Sentry.init()` with that options instance.~~