### PR TITLE
Sentry appengine test rewrite

### DIFF
--- a/sentry-appengine/pom.xml
+++ b/sentry-appengine/pom.xml
@@ -63,4 +63,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <appengine.spi.useThreadContextClassLoader>true</appengine.spi.useThreadContextClassLoader>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sentry-appengine/pom.xml
+++ b/sentry-appengine/pom.xml
@@ -33,11 +33,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
@@ -45,11 +40,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/sentry-appengine/pom.xml
+++ b/sentry-appengine/pom.xml
@@ -52,5 +52,15 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
@@ -33,7 +33,10 @@ import static com.google.appengine.api.taskqueue.TaskOptions.Builder.withPayload
  */
 public class AppEngineAsyncConnection implements Connection {
     private static final Logger logger = LoggerFactory.getLogger(AppEngineAsyncConnection.class);
-    private static final Map<String, AppEngineAsyncConnection> APP_ENGINE_ASYNC_CONNECTIONS = new HashMap<>();
+
+    // visible for testing
+    static final Map<String, AppEngineAsyncConnection> APP_ENGINE_ASYNC_CONNECTIONS = new HashMap<>();
+
     /**
      * Identifier of the async connection.
      */
@@ -107,13 +110,24 @@ public class AppEngineAsyncConnection implements Connection {
     /**
      * Simple DeferredTask using the {@link #send(Event)} method of the {@link #actualConnection}.
      */
-    private static final class EventSubmitter implements DeferredTask {
+    // visible for testing
+    static final class EventSubmitter implements DeferredTask {
         private final String connectionId;
         private final Event event;
 
         private EventSubmitter(String connectionId, Event event) {
             this.connectionId = connectionId;
             this.event = event;
+        }
+
+        // visible for testing
+        String getConnectionId() {
+            return connectionId;
+        }
+
+        // visible for testing
+        Event getEvent() {
+            return event;
         }
 
         @Override

--- a/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
@@ -108,6 +108,14 @@ public class AppEngineAsyncConnection implements Connection {
     }
 
     /**
+     * Gets the queue that the events are sent to.
+     * @return the App Engine Queue used by this connection
+     */
+    public String getQueue() {
+        return queue == null ? null : queue.getQueueName();
+    }
+
+    /**
      * Simple DeferredTask using the {@link #send(Event)} method of the {@link #actualConnection}.
      */
     // visible for testing

--- a/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/AppEngineSentryClientFactoryTest.java
@@ -1,90 +1,101 @@
 package io.sentry.appengine;
 
+import com.google.appengine.api.taskqueue.Queue;
+import com.google.appengine.api.utils.SystemProperty;
+import io.sentry.appengine.connection.ConnectionsInfo;
 import io.sentry.config.Lookup;
-import mockit.*;
+import io.sentry.config.provider.ConfigurationProvider;
 import io.sentry.appengine.connection.AppEngineAsyncConnection;
 import io.sentry.connection.Connection;
 import io.sentry.dsn.Dsn;
-import org.testng.annotations.Test;
-
-import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AppEngineSentryClientFactoryTest {
-    @Tested
     private AppEngineSentryClientFactory appEngineSentryClientFactory;
-    @Injectable
     private Connection mockConnection;
-    @Injectable
-    private Dsn mockDsn;
-    @Injectable
-    private Lookup mockLookup;
+    private ConfigurationProvider mockLookupConfig;
+
+    @Before
+    public void setup() {
+        TestQueueFactoryProvider.reset();
+        mockLookupConfig = mock(ConfigurationProvider.class);
+        Lookup mockLookup = new Lookup(mockLookupConfig, mock(ConfigurationProvider.class));
+        mockConnection = mock(Connection.class);
+        appEngineSentryClientFactory = new AppEngineSentryClientFactory(mockLookup);
+    }
 
     @Test
     public void asyncConnectionCreatedByAppEngineSentryClientFactoryIsForAppEngine() throws Exception {
-        Connection connection = appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
+        Connection connection = appEngineSentryClientFactory.createAsyncConnection(mock(Dsn.class), mockConnection);
 
         assertThat(connection, is(instanceOf(AppEngineAsyncConnection.class)));
     }
 
     @Test
     public void asyncConnectionWithoutConnectionIdGeneratesDefaultId() throws Exception {
-        final String dnsString = "a1fe25d3-bc41-4040-8aa2-484e5aae87c5";
-        new NonStrictExpectations() {{
-            mockDsn.toString();
-            result = dnsString;
-        }};
+        Dsn mockDsn = new Dsn("noop://localhost?key=lsdfjop");
 
-        appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
+        AppEngineAsyncConnection conn = (AppEngineAsyncConnection) appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
 
-        new Verifications() {{
-            String connectionId = AppEngineSentryClientFactory.class.getCanonicalName() + dnsString;
-            new AppEngineAsyncConnection(connectionId, mockConnection);
-        }};
+        String expectedId = AppEngineSentryClientFactory.class.getCanonicalName() + mockDsn.toString()
+                + SystemProperty.version.get();
+
+        AppEngineAsyncConnection foundConnection = ConnectionsInfo.getExistingConnectionById(expectedId);
+
+        assertSame(conn, foundConnection);
     }
 
     @Test
-    public void asyncConnectionWithConnectionIdUsesId(
-            @Injectable("543afd41-379d-41cb-8c99-8ce73e83a0cc") final String connectionId) throws Exception {
-        new NonStrictExpectations() {{
-            mockDsn.getOptions();
-            result = Collections.singletonMap(AppEngineSentryClientFactory.CONNECTION_IDENTIFIER, connectionId);
-        }};
+    public void asyncConnectionWithConnectionIdUsesId() throws Exception {
+        String connectionId = "543afd41-379d-41cb-8c99-8ce73e83a0cc";
+        Dsn dsn = new Dsn(Dsn.DEFAULT_DSN + "?" + AppEngineSentryClientFactory.CONNECTION_IDENTIFIER + "="
+                + connectionId);
 
-        appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
+        String expectedId = AppEngineSentryClientFactory.class.getCanonicalName()
+                + dsn + SystemProperty.version.get();
 
-        new Verifications() {{
-            new AppEngineAsyncConnection(connectionId, mockConnection);
-        }};
+        Connection conn = appEngineSentryClientFactory.createAsyncConnection(dsn, mockConnection);
+
+        AppEngineAsyncConnection foundConnection = ConnectionsInfo.getExistingConnectionById(expectedId);
+
+        assertSame(conn, foundConnection);
     }
 
     @Test
-    public void asyncConnectionWithoutQueueNameKeepsDefaultQueue(
-            @Mocked final AppEngineAsyncConnection mockAppEngineAsyncConnection) throws Exception {
-        appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
+    public void asyncConnectionWithoutQueueNameKeepsDefaultQueue() throws Exception {
+        Dsn dsn = new Dsn(Dsn.DEFAULT_DSN);
+        AppEngineAsyncConnection conn = (AppEngineAsyncConnection) appEngineSentryClientFactory
+                .createAsyncConnection(dsn, mockConnection);
 
-        new Verifications() {{
-            mockAppEngineAsyncConnection.setQueue(anyString);
-            times = 0;
-        }};
+        assertNull(conn.getQueue());
     }
 
     @Test
-    public void asyncConnectionWithQueueNameSetsQueue(
-            @Mocked final AppEngineAsyncConnection mockAppEngineAsyncConnection,
-            @Injectable("queueName") final String mockQueueName) throws Exception {
-        new NonStrictExpectations() {{
-            mockLookup.get(AppEngineSentryClientFactory.QUEUE_NAME, (Dsn) any);
-            result = mockQueueName;
-        }};
+    public void asyncConnectionWithQueueNameSetsQueue() throws Exception {
+        String mockQueueName = "queueName";
 
-        appEngineSentryClientFactory.createAsyncConnection(mockDsn, mockConnection);
+        Queue mockQueue = mock(Queue.class);
+        when(mockQueue.getQueueName()).thenReturn(mockQueueName);
 
-        new Verifications() {{
-            mockAppEngineAsyncConnection.setQueue(mockQueueName);
-        }};
+        TestQueueFactoryProvider.registerQueue(mockQueueName, mockQueue);
+
+        when(mockLookupConfig.getProperty(eq(AppEngineSentryClientFactory.QUEUE_NAME)))
+                .thenReturn(mockQueueName);
+
+        AppEngineAsyncConnection conn = (AppEngineAsyncConnection) appEngineSentryClientFactory
+                .createAsyncConnection(mock(Dsn.class), mockConnection);
+
+        assertEquals(mockQueueName, conn.getQueue());
     }
 }

--- a/sentry-appengine/src/test/java/io/sentry/appengine/TestQueueFactoryProvider.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/TestQueueFactoryProvider.java
@@ -1,0 +1,36 @@
+package io.sentry.appengine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.appengine.api.taskqueue.IQueueFactory;
+import com.google.appengine.api.taskqueue.Queue;
+import com.google.appengine.spi.FactoryProvider;
+
+public class TestQueueFactoryProvider extends FactoryProvider<IQueueFactory> {
+    private static Map<String, Queue> QUEUES = new HashMap<>();
+
+    private final IQueueFactory factory = new IQueueFactory() {
+        @Override
+        public Queue getQueue(String s) {
+            return QUEUES.get(s);
+        }
+    };
+
+    public TestQueueFactoryProvider() {
+        super(IQueueFactory.class);
+    }
+
+    public static void registerQueue(String name, Queue queue) {
+        QUEUES.put(name, queue);
+    }
+
+    public static void reset() {
+        QUEUES.clear();
+    }
+
+    @Override
+    protected IQueueFactory getFactoryInstance() {
+        return factory;
+    }
+}

--- a/sentry-appengine/src/test/java/io/sentry/appengine/connection/ConnectionsInfo.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/connection/ConnectionsInfo.java
@@ -1,0 +1,16 @@
+package io.sentry.appengine.connection;
+
+import io.sentry.util.Nullable;
+
+/**
+ * This is a helper class to extract information about the {@link AppEngineAsyncConnection} for the test purposes.
+ *
+ * This is used by the tests living outside of this package to be able to access package-private information.
+ */
+public class ConnectionsInfo {
+
+    @Nullable
+    public static AppEngineAsyncConnection getExistingConnectionById(String id) {
+        return AppEngineAsyncConnection.APP_ENGINE_ASYNC_CONNECTIONS.get(id);
+    }
+}

--- a/sentry-appengine/src/test/resources/META-INF/services/com.google.appengine.spi.FactoryProvider
+++ b/sentry-appengine/src/test/resources/META-INF/services/com.google.appengine.spi.FactoryProvider
@@ -1,0 +1,1 @@
+io.sentry.appengine.TestQueueFactoryProvider


### PR DESCRIPTION
This rewrites the unit tests in the `sentry-appengine` module to use JUnit and Mockito without any static method or constructor mocking.

This required a small addition to the public API of the `AppEngineAsyncConnection` class and a couple of additions in the test code to use a thread-context classloader and a custom test-specific appengine queue factory to be able to test the stuff that we used to test with static method mocking.