### PR TITLE
Remove traces of JMockit and TestNG from the POMs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,6 @@
         <!-- dependencies versions -->
         <slf4j.version>1.7.24</slf4j.version>
         <jackson.version>2.9.9</jackson.version>
-        <jmockit.version>1.14</jmockit.version>
-        <testng.version>6.9.10</testng.version>
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.12</junit.version>
         <wiremock.version>2.5.1</wiremock.version>
@@ -162,16 +160,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jmockit</groupId>
-                <artifactId>jmockit</artifactId>
-                <version>${jmockit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${testng.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/sentry-spring/pom.xml
+++ b/sentry-spring/pom.xml
@@ -45,16 +45,6 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Just a simple removal of traces of JMockit and TestNG from the POMs.