### PR TITLE
Added ability to init SentryClient use Spring Boot auto-configuration 

### DIFF
--- a/sentry-spring-boot-starter/pom.xml
+++ b/sentry-spring-boot-starter/pom.xml
@@ -36,6 +36,12 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/sentry-spring-boot-starter/pom.xml
+++ b/sentry-spring-boot-starter/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/sentry-spring-boot-starter/pom.xml
+++ b/sentry-spring-boot-starter/pom.xml
@@ -1,55 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <artifactId>sentry-all</artifactId>
-    <groupId>io.sentry</groupId>
-    <version>1.7.29-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <artifactId>sentry-all</artifactId>
+        <groupId>io.sentry</groupId>
+        <version>1.7.29-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>sentry-spring-boot-starter</artifactId>
-  <packaging>jar</packaging>
+    <artifactId>sentry-spring-boot-starter</artifactId>
+    <packaging>jar</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.sentry</groupId>
-      <artifactId>sentry-spring</artifactId>
-      <version>1.7.29-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure-processor</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-
-  <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>1.5.17.RELEASE</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring</artifactId>
+            <version>1.7.29-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.17.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>

--- a/sentry-spring-boot-starter/pom.xml
+++ b/sentry-spring-boot-starter/pom.xml
@@ -1,62 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <artifactId>sentry-all</artifactId>
-        <groupId>io.sentry</groupId>
-        <version>1.7.29-SNAPSHOT</version>
-    </parent>
+  <parent>
+    <artifactId>sentry-all</artifactId>
+    <groupId>io.sentry</groupId>
+    <version>1.7.29-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>sentry-spring-boot-starter</artifactId>
-    <packaging>jar</packaging>
+  <artifactId>sentry-spring-boot-starter</artifactId>
+  <packaging>jar</packaging>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring</artifactId>
+      <version>1.7.29-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.sentry</groupId>
-            <artifactId>sentry-spring</artifactId>
-            <version>1.7.29-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>1.5.17.RELEASE</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.5.17.RELEASE</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  </dependencyManagement>
 
 </project>

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -74,19 +74,19 @@ public class SentryAutoConfiguration {
 
         SentryClient sentryClient = Sentry.init(properties.getDsn());
 
-        if (StringUtils.isEmpty(properties.getRelease())) {
+        if (!StringUtils.isEmpty(properties.getRelease())) {
             sentryClient.setRelease(properties.getRelease());
         }
 
-        if (StringUtils.isEmpty(properties.getDist())) {
+        if (!StringUtils.isEmpty(properties.getDist())) {
             sentryClient.setDist(properties.getDist());
         }
 
-        if (StringUtils.isEmpty(properties.getEnvironment())) {
+        if (!StringUtils.isEmpty(properties.getEnvironment())) {
             sentryClient.setEnvironment(properties.getEnvironment());
         }
 
-        if (StringUtils.isEmpty(properties.getServerName())) {
+        if (!StringUtils.isEmpty(properties.getServerName())) {
             sentryClient.setServerName(properties.getServerName());
         }
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -1,28 +1,40 @@
 package io.sentry.spring.autoconfigure;
 
+import io.sentry.Sentry;
+import io.sentry.SentryClient;
+import io.sentry.connection.EventSendCallback;
+import io.sentry.event.helper.EventBuilderHelper;
+import io.sentry.event.helper.ShouldSendEventCallback;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryServletContextInitializer;
-
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Spring Auto Configuration for Sentry.
  */
 @Configuration
-@ConditionalOnClass({ HandlerExceptionResolver.class, SentryExceptionResolver.class })
+@ConditionalOnClass({HandlerExceptionResolver.class, SentryExceptionResolver.class})
+@EnableConfigurationProperties(SentryProperties.class)
 @ConditionalOnWebApplication
 @ConditionalOnProperty(name = "sentry.enabled", havingValue = "true", matchIfMissing = true)
 public class SentryAutoConfiguration {
 
     /**
      * Resolves a {@link HandlerExceptionResolver}.
+     *
      * @return a new instance of {@link HandlerExceptionResolver}.
      */
     @Bean
@@ -33,12 +45,88 @@ public class SentryAutoConfiguration {
 
     /**
      * Initializes a {@link ServletContextInitializer}.
+     *
      * @return a new instance of {@link SentryServletContextInitializer}.
      */
     @Bean
     @ConditionalOnMissingBean(SentryServletContextInitializer.class)
     public ServletContextInitializer sentryServletContextInitializer() {
         return new SentryServletContextInitializer();
+    }
+
+    /**
+     * Initializes a {@link SentryClient}.
+     *
+     * @return a new instance of {@link SentryClient}.
+     */
+    @Bean
+    @ConditionalOnMissingBean(SentryClient.class)
+    @ConditionalOnProperty(name = "sentry.init-default-client", havingValue = "true", matchIfMissing = true)
+    public SentryClient sentryClient(SentryProperties properties,
+                                     @Autowired(required = false) List<EventBuilderHelper> eventBuilderHelpers,
+                                     @Autowired(required = false) List<EventSendCallback> eventSendCallbacks,
+                                     @Autowired(required = false) List<ShouldSendEventCallback> shouldSendEventCallbacks) {
+        if (properties.getOptions() != null && !properties.getOptions().isEmpty()) {
+            for (Map.Entry<String, String> option : properties.getOptions().entrySet()) {
+                System.setProperty("sentry." + option.getKey(), option.getValue());
+            }
+        }
+
+        SentryClient sentryClient = Sentry.init(properties.getDsn());
+
+        if (StringUtils.isEmpty(properties.getRelease())) {
+            sentryClient.setRelease(properties.getRelease());
+        }
+
+        if (StringUtils.isEmpty(properties.getDist())) {
+            sentryClient.setDist(properties.getDist());
+        }
+
+        if (StringUtils.isEmpty(properties.getEnvironment())) {
+            sentryClient.setEnvironment(properties.getEnvironment());
+        }
+
+        if (StringUtils.isEmpty(properties.getServerName())) {
+            sentryClient.setServerName(properties.getServerName());
+        }
+
+        if (properties.getTags() != null && !properties.getTags().isEmpty()) {
+            for (Map.Entry<String, String> tag : properties.getTags().entrySet()) {
+                sentryClient.addTag(tag.getKey(), tag.getValue());
+            }
+        }
+
+        if (properties.getMdcTags() != null && !properties.getMdcTags().isEmpty()) {
+            for (String mdcTag : properties.getMdcTags()) {
+                sentryClient.addMdcTag(mdcTag);
+            }
+        }
+
+        if (properties.getExtra() != null && !properties.getExtra().isEmpty()) {
+            for (Map.Entry<String, Object> extra : properties.getExtra().entrySet()) {
+                sentryClient.addExtra(extra.getKey(), extra.getValue());
+            }
+        }
+
+        if (eventBuilderHelpers != null && !eventBuilderHelpers.isEmpty()) {
+            for (EventBuilderHelper eventBuilderHelper : eventBuilderHelpers) {
+                sentryClient.addBuilderHelper(eventBuilderHelper);
+            }
+        }
+
+        if (eventSendCallbacks != null && !eventSendCallbacks.isEmpty()) {
+            for (EventSendCallback eventSendCallback : eventSendCallbacks) {
+                sentryClient.addEventSendCallback(eventSendCallback);
+            }
+        }
+
+        if (shouldSendEventCallbacks != null && !shouldSendEventCallbacks.isEmpty()) {
+            for (ShouldSendEventCallback shouldSendEventCallback : shouldSendEventCallbacks) {
+                sentryClient.addShouldSendEventCallback(shouldSendEventCallback);
+            }
+        }
+
+        return sentryClient;
     }
 
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -23,7 +23,7 @@ public class SentryAutoConfiguration {
 
     /**
      * Resolves a {@link HandlerExceptionResolver}.
-     * @return a new instance of {@link SentryAutoConfiguration}.
+     * @return a new instance of {@link HandlerExceptionResolver}.
      */
     @Bean
     @ConditionalOnMissingBean(SentryExceptionResolver.class)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -156,18 +155,22 @@ public class SentryAutoConfiguration {
     }
 
     private List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders(SentryProperties properties) {
-        List<ConfigurationProvider> providers = new ArrayList<>(3);
-        providers.add(new SpringBootConfigurationProvider(properties));
-        providers.add(new SystemPropertiesConfigurationProvider());
-        providers.add(new EnvironmentConfigurationProvider());
-        return providers;
+        return asList(
+                new SpringBootConfigurationProvider(properties),
+                new SystemPropertiesConfigurationProvider(),
+                new EnvironmentConfigurationProvider()
+        );
     }
 
     private List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
         try {
-            return singletonList((ConfigurationProvider)
-                    new LocatorBasedConfigurationProvider(new ContextClassLoaderResourceLoader(),
-                            new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
+            ConfigurationProvider configurationProvider = new LocatorBasedConfigurationProvider(
+                    new ContextClassLoaderResourceLoader(),
+                    new CompoundResourceLocator(getDefaultResourceLocators()),
+                    Charset.defaultCharset()
+            );
+
+            return singletonList(configurationProvider);
         } catch (IOException e) {
             logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
             return emptyList();
@@ -175,7 +178,10 @@ public class SentryAutoConfiguration {
     }
 
     private List<ConfigurationResourceLocator> getDefaultResourceLocators() {
-        return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator());
+        return asList(
+                new SystemPropertiesBasedLocator(),
+                new EnvironmentBasedLocator()
+        );
     }
 
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -88,7 +88,9 @@ public class SentryAutoConfiguration {
                                      @Autowired(required = false) List<EventBuilderHelper> eventBuilderHelpers,
                                      @Autowired(required = false) List<EventSendCallback> eventSendCallbacks,
                                      @Autowired(required = false) List<ShouldSendEventCallback> shouldSendEventCallbacks) {
-        SentryOptions sentryOptions = SentryOptions.from(createLookup(properties), properties.getDsn(), null);
+        String dsn = properties.getDsn() != null ? properties.getDsn().toString() : null;
+
+        SentryOptions sentryOptions = SentryOptions.from(createLookup(properties), dsn, null);
 
         SentryClient sentryClient = Sentry.init(sentryOptions);
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -2,11 +2,25 @@ package io.sentry.spring.autoconfigure;
 
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
+import io.sentry.SentryOptions;
+import io.sentry.config.ContextClassLoaderResourceLoader;
+import io.sentry.config.Lookup;
+import io.sentry.config.location.CompoundResourceLocator;
+import io.sentry.config.location.ConfigurationResourceLocator;
+import io.sentry.config.location.EnvironmentBasedLocator;
+import io.sentry.config.location.SystemPropertiesBasedLocator;
+import io.sentry.config.provider.CompoundConfigurationProvider;
+import io.sentry.config.provider.ConfigurationProvider;
+import io.sentry.config.provider.EnvironmentConfigurationProvider;
+import io.sentry.config.provider.LocatorBasedConfigurationProvider;
+import io.sentry.config.provider.SystemPropertiesConfigurationProvider;
 import io.sentry.connection.EventSendCallback;
 import io.sentry.event.helper.EventBuilderHelper;
 import io.sentry.event.helper.ShouldSendEventCallback;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryServletContextInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -19,8 +33,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 /**
  * Spring Auto Configuration for Sentry.
@@ -31,6 +52,8 @@ import java.util.Map;
 @ConditionalOnWebApplication
 @ConditionalOnProperty(name = "sentry.enabled", havingValue = "true", matchIfMissing = true)
 public class SentryAutoConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(Lookup.class);
 
     /**
      * Resolves a {@link HandlerExceptionResolver}.
@@ -66,13 +89,9 @@ public class SentryAutoConfiguration {
                                      @Autowired(required = false) List<EventBuilderHelper> eventBuilderHelpers,
                                      @Autowired(required = false) List<EventSendCallback> eventSendCallbacks,
                                      @Autowired(required = false) List<ShouldSendEventCallback> shouldSendEventCallbacks) {
-        if (properties.getOptions() != null && !properties.getOptions().isEmpty()) {
-            for (Map.Entry<String, String> option : properties.getOptions().entrySet()) {
-                System.setProperty("sentry." + option.getKey(), option.getValue());
-            }
-        }
+        SentryOptions sentryOptions = SentryOptions.from(createLookup(properties), properties.getDsn(), null);
 
-        SentryClient sentryClient = Sentry.init(properties.getDsn());
+        SentryClient sentryClient = Sentry.init(sentryOptions);
 
         if (!StringUtils.isEmpty(properties.getRelease())) {
             sentryClient.setRelease(properties.getRelease());
@@ -127,6 +146,36 @@ public class SentryAutoConfiguration {
         }
 
         return sentryClient;
+    }
+
+    private Lookup createLookup(SentryProperties properties) {
+        return new Lookup(
+                new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(properties)),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders())
+        );
+    }
+
+    private List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders(SentryProperties properties) {
+        List<ConfigurationProvider> providers = new ArrayList<>(3);
+        providers.add(new SpringBootConfigurationProvider(properties));
+        providers.add(new SystemPropertiesConfigurationProvider());
+        providers.add(new EnvironmentConfigurationProvider());
+        return providers;
+    }
+
+    private List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
+        try {
+            return singletonList((ConfigurationProvider)
+                    new LocatorBasedConfigurationProvider(new ContextClassLoaderResourceLoader(),
+                            new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
+        } catch (IOException e) {
+            logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
+            return emptyList();
+        }
+    }
+
+    private List<ConfigurationResourceLocator> getDefaultResourceLocators() {
+        return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator());
     }
 
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryAutoConfiguration.java
@@ -3,24 +3,13 @@ package io.sentry.spring.autoconfigure;
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
 import io.sentry.SentryOptions;
-import io.sentry.config.ContextClassLoaderResourceLoader;
 import io.sentry.config.Lookup;
-import io.sentry.config.location.CompoundResourceLocator;
-import io.sentry.config.location.ConfigurationResourceLocator;
-import io.sentry.config.location.EnvironmentBasedLocator;
-import io.sentry.config.location.SystemPropertiesBasedLocator;
-import io.sentry.config.provider.CompoundConfigurationProvider;
 import io.sentry.config.provider.ConfigurationProvider;
-import io.sentry.config.provider.EnvironmentConfigurationProvider;
-import io.sentry.config.provider.LocatorBasedConfigurationProvider;
-import io.sentry.config.provider.SystemPropertiesConfigurationProvider;
 import io.sentry.connection.EventSendCallback;
 import io.sentry.event.helper.EventBuilderHelper;
 import io.sentry.event.helper.ShouldSendEventCallback;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryServletContextInitializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,14 +22,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 /**
  * Spring Auto Configuration for Sentry.
@@ -51,8 +35,6 @@ import static java.util.Collections.singletonList;
 @ConditionalOnWebApplication
 @ConditionalOnProperty(name = "sentry.enabled", havingValue = "true", matchIfMissing = true)
 public class SentryAutoConfiguration {
-
-    private static final Logger logger = LoggerFactory.getLogger(Lookup.class);
 
     /**
      * Resolves a {@link HandlerExceptionResolver}.
@@ -150,39 +132,9 @@ public class SentryAutoConfiguration {
     }
 
     private Lookup createLookup(SentryProperties properties) {
-        return new Lookup(
-                new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(properties)),
-                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders())
-        );
-    }
-
-    private List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders(SentryProperties properties) {
-        return asList(
-                new SpringBootConfigurationProvider(properties),
-                new SystemPropertiesConfigurationProvider(),
-                new EnvironmentConfigurationProvider()
-        );
-    }
-
-    private List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
-        try {
-            ConfigurationProvider configurationProvider = new LocatorBasedConfigurationProvider(
-                    new ContextClassLoaderResourceLoader(),
-                    new CompoundResourceLocator(getDefaultResourceLocators()),
-                    Charset.defaultCharset()
-            );
-
-            return singletonList(configurationProvider);
-        } catch (IOException e) {
-            logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
-            return emptyList();
-        }
-    }
-
-    private List<ConfigurationResourceLocator> getDefaultResourceLocators() {
-        return asList(
-                new SystemPropertiesBasedLocator(),
-                new EnvironmentBasedLocator()
+        return Lookup.getDefaultWithAdditionalProviders(
+                Collections.<ConfigurationProvider>singletonList(new SpringBootConfigurationProvider(properties)),
+                Collections.<ConfigurationProvider>emptyList()
         );
     }
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
@@ -2,6 +2,7 @@ package io.sentry.spring.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.net.URL;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -18,11 +19,11 @@ import java.util.Set;
  *     release: "1.0.1"
  *     dist: x86
  *     environment: staging
- *     serverName: megaServer
+ *     server-name: megaServer
  *     tags:
  *         firstTag: Hello
  *         secondTag: Awesome
- *     mdcTags: [mdcTagA, mdcTagB]
+ *     mdc-tags: [mdcTagA, mdcTagB]
  *     extra:
  *         extraTag: extra
  *     options:
@@ -40,7 +41,7 @@ public class SentryProperties {
      * https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn
      * More information about configuration via DSN https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn
      */
-    private String dsn;
+    private URL dsn;
 
     /**
      * The application version that will be sent with each event.
@@ -83,11 +84,11 @@ public class SentryProperties {
      */
     private Map<String, String> options = new LinkedHashMap<>();
 
-    public String getDsn() {
+    public URL getDsn() {
         return dsn;
     }
 
-    public void setDsn(String dsn) {
+    public void setDsn(URL dsn) {
         this.dsn = dsn;
     }
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
@@ -1,0 +1,158 @@
+package io.sentry.spring.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Configuration for Sentry, example:
+ *
+ * <pre>
+ * sentry:
+ *     enabled: true
+ *     init-default-client: true
+ *     dsn: https://00059966e6224d03a77ea5eca10fbe18@sentry.mycompany.com/14
+ *     release: "1.0.1"
+ *     dist: x86
+ *     environment: staging
+ *     serverName: megaServer
+ *     tags:
+ *         firstTag: Hello
+ *         secondTag: Awesome
+ *     mdcTags: [mdcTagA, mdcTagB]
+ *     extra:
+ *         extraTag: extra
+ *     options:
+ *         stacktrace.app.packages: com.mycompany,com.other.name
+ *         sample.rate: 0.75
+ *         uncaught.handler.enabled: false
+ * </pre>
+ */
+@ConfigurationProperties("sentry")
+public class SentryProperties {
+
+    /**
+     * Data source name
+     * All of the options can be configured by setting querystring parameters on the DSN itself.
+     * https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn
+     * More information about configuration via DSN https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn
+     */
+    private String dsn;
+
+    /**
+     * The application version that will be sent with each event.
+     */
+    private String release;
+
+    /**
+     * The application distribution that will be sent with each event.
+     * Note that the distribution is only useful (and used) if the release is also set.
+     */
+    private String dist;
+
+    /**
+     * The application environment that will be sent with each event.
+     */
+    private String environment;
+
+    /**
+     * The server name that will be sent with each event.
+     */
+    private String serverName;
+
+    /**
+     * Tags that will be sent with each event.
+     */
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    /**
+     * Set tag names that are extracted from the SLF4J MDC system.
+     */
+    private Set<String> mdcTags = new HashSet<>();
+
+    /**
+     * Set extra data that will be sent with each event (but not as tags).
+     */
+    private Map<String, Object> extra = new LinkedHashMap<>();
+
+    /**
+     * Additional options, check the <a href="https://docs.sentry.io/clients/java/config/">documentation</a>.
+     */
+    private Map<String, String> options = new LinkedHashMap<>();
+
+    public String getDsn() {
+        return dsn;
+    }
+
+    public void setDsn(String dsn) {
+        this.dsn = dsn;
+    }
+
+    public String getRelease() {
+        return release;
+    }
+
+    public void setRelease(String release) {
+        this.release = release;
+    }
+
+    public String getDist() {
+        return dist;
+    }
+
+    public void setDist(String dist) {
+        this.dist = dist;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
+    public String getServerName() {
+        return serverName;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public Set<String> getMdcTags() {
+        return mdcTags;
+    }
+
+    public void setMdcTags(Set<String> mdcTags) {
+        this.mdcTags = mdcTags;
+    }
+
+    public Map<String, Object> getExtra() {
+        return extra;
+    }
+
+    public void setExtra(Map<String, Object> extra) {
+        this.extra = extra;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+}

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SentryProperties.java
@@ -36,6 +36,16 @@ import java.util.Set;
 public class SentryProperties {
 
     /**
+     * Whether to enable sentry.
+     */
+    private boolean enabled = true;
+
+    /**
+     * Whether to initialize Sentry Client as a bean.
+     */
+    private boolean initDefaultClient = true;
+
+    /**
      * Data source name
      * All of the options can be configured by setting querystring parameters on the DSN itself.
      * https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn
@@ -83,6 +93,22 @@ public class SentryProperties {
      * Additional options, check the <a href="https://docs.sentry.io/clients/java/config/">documentation</a>.
      */
     private Map<String, String> options = new LinkedHashMap<>();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isInitDefaultClient() {
+        return initDefaultClient;
+    }
+
+    public void setInitDefaultClient(boolean initDefaultClient) {
+        this.initDefaultClient = initDefaultClient;
+    }
 
     public URL getDsn() {
         return dsn;

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
@@ -1,5 +1,6 @@
 package io.sentry.spring.autoconfigure;
 
+import io.sentry.DefaultSentryClientFactory;
 import io.sentry.config.provider.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,15 +17,56 @@ public class SpringBootConfigurationProvider implements ConfigurationProvider {
 
     @Override
     public String getProperty(String key) {
-        if (sentryProperties.getOptions() == null) {
+        switch (key) {
+            case DefaultSentryClientFactory.COMPRESSION_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getCompression());
+            case DefaultSentryClientFactory.MAX_MESSAGE_LENGTH_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getMaxMessageLength());
+            case DefaultSentryClientFactory.CONNECTION_TIMEOUT_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getTimeout());
+            case DefaultSentryClientFactory.SAMPLE_RATE_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getSampleRate());
+            case DefaultSentryClientFactory.UNCAUGHT_HANDLER_ENABLED_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getUncaughtHandlerEnabled());
+            case DefaultSentryClientFactory.HIDE_COMMON_FRAMES_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getStacktrace().getHideCommon());
+            case DefaultSentryClientFactory.IN_APP_FRAMES_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getStacktrace().getAppPackages());
+            case DefaultSentryClientFactory.BUFFER_DIR_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getBuffer().getDir());
+            case DefaultSentryClientFactory.BUFFER_SIZE_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getBuffer().getSize());
+            case DefaultSentryClientFactory.BUFFER_FLUSHTIME_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getBuffer().getFlushTime());
+            case DefaultSentryClientFactory.BUFFER_SHUTDOWN_TIMEOUT_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getBuffer().getShutdownTimeout());
+            case DefaultSentryClientFactory.BUFFER_GRACEFUL_SHUTDOWN_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getBuffer().getGracefulShutdown());
+            case DefaultSentryClientFactory.ASYNC_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getEnabled());
+            case DefaultSentryClientFactory.ASYNC_SHUTDOWN_TIMEOUT_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getShutdownTimeout());
+            case DefaultSentryClientFactory.ASYNC_GRACEFUL_SHUTDOWN_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getGracefulShutdown());
+            case DefaultSentryClientFactory.ASYNC_QUEUE_SIZE_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getQueueSize());
+            case DefaultSentryClientFactory.ASYNC_THREADS_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getThreads());
+            case DefaultSentryClientFactory.ASYNC_PRIORITY_OPTION:
+                return logAndReturnIfSet(key, sentryProperties.getAsync().getPriority());
+            default:
+                logger.debug("Unsupported option: {}", key);
+                return null;
+        }
+    }
+
+    private String logAndReturnIfSet(String key, Object value) {
+        if (value == null)
             return null;
-        }
 
-        String ret = sentryProperties.getOptions().get(key);
+        String ret = value.toString();
 
-        if (ret != null) {
-            logger.debug("Found {}={} in Spring Boot config.", key, ret);
-        }
+        logger.debug("Found {}={} in Spring Boot config.", key, ret);
 
         return ret;
     }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
@@ -1,8 +1,12 @@
 package io.sentry.spring.autoconfigure;
 
 import io.sentry.config.provider.ConfigurationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SpringBootConfigurationProvider implements ConfigurationProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(SpringBootConfigurationProvider.class);
 
     private final SentryProperties sentryProperties;
 
@@ -12,7 +16,17 @@ public class SpringBootConfigurationProvider implements ConfigurationProvider {
 
     @Override
     public String getProperty(String key) {
-        return sentryProperties.getOptions() != null ? sentryProperties.getOptions().get(key) : null;
+        if (sentryProperties.getOptions() == null) {
+            return null;
+        }
+
+        String ret = sentryProperties.getOptions().get(key);
+
+        if (ret != null) {
+            logger.debug("Found {}={} in Spring Boot config.", key, ret);
+        }
+
+        return ret;
     }
 
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
@@ -1,0 +1,18 @@
+package io.sentry.spring.autoconfigure;
+
+import io.sentry.config.provider.ConfigurationProvider;
+
+public class SpringBootConfigurationProvider implements ConfigurationProvider {
+
+    private final SentryProperties sentryProperties;
+
+    public SpringBootConfigurationProvider(SentryProperties sentryProperties) {
+        this.sentryProperties = sentryProperties;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return sentryProperties.getOptions() != null ? sentryProperties.getOptions().get(key) : null;
+    }
+
+}

--- a/sentry-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/sentry-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,6 +5,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether to enable sentry.",
       "defaultValue": "true"
+    },
+    {
+      "name": "sentry.init-default-client",
+      "type": "java.lang.Boolean",
+      "description": "Whether to initialize Sentry Client as a bean.",
+      "defaultValue": "true"
     }
   ]
 }

--- a/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SentryAutoConfigurationTest.java
+++ b/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SentryAutoConfigurationTest.java
@@ -82,9 +82,9 @@ public class SentryAutoConfigurationTest {
                 "sentry.release:1.0.1",
                 "sentry.dist:x86",
                 "sentry.environment:staging",
-                "sentry.serverName:megaServer",
+                "sentry.server-name:megaServer",
                 "sentry.tags.firstTag:Hello",
-                "sentry.mdcTags:mdcTagA",
+                "sentry.mdc-tags:mdcTagA",
                 "sentry.extra.extraTag:extra");
         this.context.refresh();
 

--- a/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SentryAutoConfigurationTest.java
+++ b/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SentryAutoConfigurationTest.java
@@ -5,7 +5,6 @@ import io.sentry.spring.SentryServletContextInitializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
@@ -16,50 +15,50 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SentryAutoConfigurationTest {
 
-	private AnnotationConfigEmbeddedWebApplicationContext context;
+    private AnnotationConfigEmbeddedWebApplicationContext context;
 
-	@Before
-	public void setup() {
-		if (this.context == null) {
-			this.context = new AnnotationConfigEmbeddedWebApplicationContext();
-		}
-	}
+    @Before
+    public void setup() {
+        if (this.context == null) {
+            this.context = new AnnotationConfigEmbeddedWebApplicationContext();
+        }
+    }
 
-	@After
-	public void teardown() {
-		if (this.context != null) {
-			this.context.close();
-		}
-	}
+    @After
+    public void teardown() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
 
-	@Test
-	public void testSentryExceptionResolverIsAvailable() {
-		load();
-		this.context.refresh();
-		String[] exceptionResolverBeans = this.context
-				.getBeanNamesForType(SentryExceptionResolver.class);
-		String[] servletContextInitialerBeans = this.context
-				.getBeanNamesForType(SentryServletContextInitializer.class);
+    @Test
+    public void testSentryExceptionResolverIsAvailable() {
+        load();
+        this.context.refresh();
+        String[] exceptionResolverBeans = this.context
+                .getBeanNamesForType(SentryExceptionResolver.class);
+        String[] servletContextInitialerBeans = this.context
+                .getBeanNamesForType(SentryServletContextInitializer.class);
 
-		assertThat(exceptionResolverBeans).contains("sentryExceptionResolver");
-		assertThat(servletContextInitialerBeans)
-				.contains("sentryServletContextInitializer");
-	}
+        assertThat(exceptionResolverBeans).contains("sentryExceptionResolver");
+        assertThat(servletContextInitialerBeans)
+                .contains("sentryServletContextInitializer");
+    }
 
-	@Test
-	public void testSentryAutoConfigurationIsEnabled() {
-		load();
-		EnvironmentTestUtils.addEnvironment(this.context, "sentry.enabled:false");
-		this.context.refresh();
-		String[] beans = this.context.getBeanNamesForType(SentryExceptionResolver.class);
-		assertThat(beans).isEmpty();
-	}
+    @Test
+    public void testSentryAutoConfigurationIsEnabled() {
+        load();
+        EnvironmentTestUtils.addEnvironment(this.context, "sentry.enabled:false");
+        this.context.refresh();
+        String[] beans = this.context.getBeanNamesForType(SentryExceptionResolver.class);
+        assertThat(beans).isEmpty();
+    }
 
-	private void load() {
-		this.context.register(EmbeddedServletContainerAutoConfiguration.class,
-				HttpMessageConvertersAutoConfiguration.class,
-				PropertyPlaceholderAutoConfiguration.class,
-				SentryAutoConfiguration.class);
-	}
+    private void load() {
+        this.context.register(EmbeddedServletContainerAutoConfiguration.class,
+                HttpMessageConvertersAutoConfiguration.class,
+                PropertyPlaceholderAutoConfiguration.class,
+                SentryAutoConfiguration.class);
+    }
 
 }

--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -114,9 +114,9 @@ public final class Lookup {
     ) {
         boolean jndiPresent = JndiSupport.isAvailable();
 
+        @SuppressWarnings("checkstyle:MagicNumber")
         int providersCount = jndiPresent ? 3 + additionalProviders.size() : 2 + additionalProviders.size();
 
-        @SuppressWarnings("checkstyle:MagicNumber")
         List<ConfigurationProvider> providers = new ArrayList<>(providersCount);
         providers.addAll(additionalProviders);
 

--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -1,8 +1,6 @@
 package io.sentry.config;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -72,8 +70,12 @@ public final class Lookup {
      */
     public static Lookup getDefault() {
         return new Lookup(
-                new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList())),
-                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList()))
+                new CompoundConfigurationProvider(
+                        getDefaultHighPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList())
+                ),
+                new CompoundConfigurationProvider(
+                        getDefaultLowPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList())
+                )
         );
     }
 
@@ -97,8 +99,10 @@ public final class Lookup {
      */
     public static Lookup getDefaultWithAdditionalProviders(Collection<ConfigurationProvider> highPriorityProviders,
                                                            Collection<ConfigurationProvider> lowPriorityProviders) {
-        return new Lookup(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(highPriorityProviders)),
-                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders(lowPriorityProviders)));
+        return new Lookup(
+                new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(highPriorityProviders)),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders(lowPriorityProviders))
+        );
     }
 
     private static List<ConfigurationResourceLocator> getDefaultResourceLocators() {

--- a/sentry/src/main/java/io/sentry/config/Lookup.java
+++ b/sentry/src/main/java/io/sentry/config/Lookup.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import io.sentry.Sentry;
@@ -69,19 +71,50 @@ public final class Lookup {
      * @return the default lookup instance
      */
     public static Lookup getDefault() {
-        return new Lookup(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders()),
-                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders()));
+        return new Lookup(
+                new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList())),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders(Collections.<ConfigurationProvider>emptyList()))
+        );
+    }
+
+    /**
+     * In the default lookup returned from this method, the configuration properties are looked up in the sources in the
+     * following order.
+     *
+     * <ol>
+     * <li>Additional high priority providers</li>
+     * <li>JNDI, if available
+     * <li>Java System Properties
+     * <li>System Environment Variables
+     * <li>Additional low priority providers</li>
+     * <li>DSN options, if a non-null DSN is provided
+     * <li>Sentry properties file found in resources
+     * </ol>
+     *
+     * @param highPriorityProviders the list of providers with high priority
+     * @param lowPriorityProviders the list of providers with low priority
+     * @return the default lookup instance
+     */
+    public static Lookup getDefaultWithAdditionalProviders(Collection<ConfigurationProvider> highPriorityProviders,
+                                                           Collection<ConfigurationProvider> lowPriorityProviders) {
+        return new Lookup(new CompoundConfigurationProvider(getDefaultHighPriorityConfigurationProviders(highPriorityProviders)),
+                new CompoundConfigurationProvider(getDefaultLowPriorityConfigurationProviders(lowPriorityProviders)));
     }
 
     private static List<ConfigurationResourceLocator> getDefaultResourceLocators() {
         return asList(new SystemPropertiesBasedLocator(), new EnvironmentBasedLocator(), new StaticFileLocator());
     }
 
-    private static List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders() {
+    private static List<ConfigurationProvider> getDefaultHighPriorityConfigurationProviders(
+            Collection<ConfigurationProvider> additionalProviders
+    ) {
         boolean jndiPresent = JndiSupport.isAvailable();
 
+        int providersCount = jndiPresent ? 3 + additionalProviders.size() : 2 + additionalProviders.size();
+
         @SuppressWarnings("checkstyle:MagicNumber")
-        List<ConfigurationProvider> providers = new ArrayList<>(jndiPresent ? 3 : 2);
+        List<ConfigurationProvider> providers = new ArrayList<>(providersCount);
+        providers.addAll(additionalProviders);
 
         if (jndiPresent) {
             providers.add(new JndiConfigurationProvider());
@@ -101,15 +134,20 @@ public final class Lookup {
                 : Arrays.asList(new FileResourceLoader(), sentryLoader, new ContextClassLoaderResourceLoader());
     }
 
-    private static List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders() {
+    private static List<ConfigurationProvider> getDefaultLowPriorityConfigurationProviders(
+            Collection<ConfigurationProvider> additionalProviders
+    ) {
+
+        List<ConfigurationProvider> providers = new ArrayList<>(additionalProviders.size());
+        providers.addAll(additionalProviders);
+
         try {
-            return singletonList((ConfigurationProvider)
-                    new LocatorBasedConfigurationProvider(new CompoundResourceLoader(getDefaultResourceLoaders()),
+            providers.add(new LocatorBasedConfigurationProvider(new CompoundResourceLoader(getDefaultResourceLoaders()),
                             new CompoundResourceLocator(getDefaultResourceLocators()), Charset.defaultCharset()));
         } catch (IOException e) {
             logger.debug("Failed to instantiate resource locator-based configuration provider.", e);
-            return emptyList();
         }
+        return providers;
     }
 
 

--- a/sentry/src/main/java/io/sentry/config/provider/ResourceLoaderConfigurationProvider.java
+++ b/sentry/src/main/java/io/sentry/config/provider/ResourceLoaderConfigurationProvider.java
@@ -9,10 +9,16 @@ import java.util.Properties;
 import io.sentry.config.ResourceLoader;
 import io.sentry.util.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A configuration provider that loads the properties from a {@link ResourceLoader}.
  */
 public class ResourceLoaderConfigurationProvider implements ConfigurationProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResourceLoaderConfigurationProvider.class);
+
     @Nullable
     private final Properties properties;
 
@@ -50,6 +56,17 @@ public class ResourceLoaderConfigurationProvider implements ConfigurationProvide
 
     @Override
     public String getProperty(String key) {
-        return properties == null ? null : properties.getProperty(key);
+        if (properties == null) {
+            return null;
+        }
+
+        String ret = properties.getProperty(key);
+
+        if (ret != null) {
+            logger.debug("Found {}={} in properties file.", key, ret);
+        }
+
+        return ret;
     }
+
 }


### PR DESCRIPTION
Hello!

It's the very common and quite standard way to use bean auto-configuration in Spring Boot application, many developers expect to see these configs parameters inside their `application.yml` or `application.properties` files. I have implemented this feature for the current `sentry-spring-boot-starter` module.

I hope you guys will like this idea and merge this PR.

Best regards,
  Alexey Zhokhov.