### PR TITLE
feat(security): use default hostname verifier

### DIFF
--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -53,7 +53,7 @@ public class HttpConnection extends AbstractConnection {
     private static final HostnameVerifier NAIVE_VERIFIER = new HostnameVerifier() {
         @Override
         public boolean verify(String hostname, SSLSession sslSession) {
-            return true;
+            return HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, sslSession);
         }
     };
     /**


### PR DESCRIPTION
During a security audit, it was uncovered that `sentry-java` disables SSL hostname verification. It appears that this was [introduced nearly 7 years ago](https://github.com/getsentry/sentry-java/commit/5a599b6d368e2aa7b25b8d9ab564eb4f92e075e4) to allow HTTPS with invalid certificates.

This would likely be a breaking change for anyone that uses Sentry with invalid certificates, but it would be an improvement otherwise.