### PR TITLE
Blacklist other frameworks using cglib dynamic classes, like Guice

### DIFF
--- a/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
@@ -89,9 +89,9 @@ public class StackTraceInterfaceBinding implements InterfaceBinding<StackTraceIn
     }
 
     private boolean classIsBlacklisted(String className) {
-        return (className.contains("$$EnhancerBy") ||
-                className.contains("$$FastClassBy") ||
-                className.contains("$Hibernate"))
+        return (className.contains("$$EnhancerBy")
+                || className.contains("$$FastClassBy")
+                || className.contains("$Hibernate"))
             && IN_APP_BLACKLIST.matcher(className).find();
     }
 

--- a/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/StackTraceInterfaceBinding.java
@@ -27,7 +27,8 @@ public class StackTraceInterfaceBinding implements InterfaceBinding<StackTraceIn
     private static final String PLATFORM_PARAMTER = "platform";
     private static final Pattern IN_APP_BLACKLIST = Pattern.compile("\\$+" // match $ (one or more)
         + "(?:" // start outer group
-        + "(?:(?:FastClass|Enhancer)[a-zA-Z]*CGLIB)" // Match Spring's FastClass and Enhancer classes
+        + "(?:EnhancerBy[a-zA-Z]*)"  // Match Enhancer classes
+        + "|(?:FastClassBy[a-zA-Z]*)" // Match FastClass
         + "|(?:HibernateProxy)" // match Hibernate proxies
         + ")\\$+"); // end outer group and match $ (one or more)
     private Collection<String> inAppFrames = Collections.emptyList();
@@ -88,7 +89,9 @@ public class StackTraceInterfaceBinding implements InterfaceBinding<StackTraceIn
     }
 
     private boolean classIsBlacklisted(String className) {
-        return (className.contains("CGLIB") || className.contains("Hibernate"))
+        return (className.contains("$$EnhancerBy") ||
+                className.contains("$$FastClassBy") ||
+                className.contains("$Hibernate"))
             && IN_APP_BLACKLIST.matcher(className).find();
     }
 

--- a/sentry/src/test/java/io/sentry/marshaller/json/StackTraceInterfaceBindingTest.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/StackTraceInterfaceBindingTest.java
@@ -91,7 +91,13 @@ public class StackTraceInterfaceBindingTest extends BaseTest {
                 "File.java", 4, null, null, null, null),
             new SentryStackTraceElement(
                 "inAppModule.Blacklisted$$EnhancerBySpringCGLIB$$", "blacklisted",
-                "File.java", 5, null, null, null, null)
+                "File.java", 5, null, null, null, null),
+            new SentryStackTraceElement(
+                "inAppModule.Blacklisted$$EnhancerByGuice$$3e9263f5$$FastClassByGuice$$19497ba4", "blacklisted",
+                "File.java", 6, null, null, null, null),
+            new SentryStackTraceElement(
+                "inAppModule.Blacklisted$$EnhancerByGuice$$3e9263f5.CGLIB$", "blacklisted",
+                "File.java", 7, null, null, null, null)
         );
 
         when(mockStackTraceInterface.getStackTrace())

--- a/sentry/src/test/resources/io/sentry/marshaller/json/StackTraceBlacklist.json
+++ b/sentry/src/test/resources/io/sentry/marshaller/json/StackTraceBlacklist.json
@@ -1,6 +1,20 @@
 {
   "frames": [
     {
+      "filename":"File.java",
+      "module":"inAppModule.Blacklisted$$EnhancerByGuice$$3e9263f5.CGLIB$",
+      "in_app":false,
+      "function":"blacklisted",
+      "lineno":7
+    },
+    {
+      "filename":"File.java",
+      "module":"inAppModule.Blacklisted$$EnhancerByGuice$$3e9263f5$$FastClassByGuice$$19497ba4",
+      "in_app":false,
+      "function":"blacklisted",
+      "lineno":6
+    },
+    {
       "filename": "File.java",
       "module": "inAppModule.Blacklisted$$EnhancerBySpringCGLIB$$",
       "in_app": false,


### PR DESCRIPTION
Hi Sentry,

please review my change list to ignore more cglib generated dynamic classes like Guice.

Thanks and Best Regards,

James