### PR TITLE
Fixed loosing of interruption status in EventBuilder.

### DIFF
--- a/sentry-android/src/main/java/io/sentry/android/event/helper/AndroidEventBuilderHelper.java
+++ b/sentry-android/src/main/java/io/sentry/android/event/helper/AndroidEventBuilderHelper.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -168,7 +169,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             }
         } catch (FileNotFoundException e) {
             Log.d(TAG, "Proguard UUIDs file not found.");
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             Log.e(TAG, "Error getting Proguard UUIDs.", e);
         }
 
@@ -185,7 +186,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
     protected static PackageInfo getPackageInfo(Context ctx) {
         try {
             return ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0);
-        } catch (Exception e) {
+        } catch (PackageManager.NameNotFoundException | RuntimeException e) {
             Log.e(TAG, "Error getting package info.", e);
             return null;
         }
@@ -200,7 +201,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
     protected static String getFamily() {
         try {
             return Build.MODEL.split(" ")[0];
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting device family.", e);
             return null;
         }
@@ -221,7 +222,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 || Build.MANUFACTURER.contains("Genymotion")
                 || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
                 || "google_sdk".equals(Build.PRODUCT);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error checking whether application is running in an emulator.", e);
             return null;
         }
@@ -239,7 +240,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
             actManager.getMemoryInfo(memInfo);
             return memInfo;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting MemoryInfo.", e);
             return null;
         }
@@ -266,7 +267,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                     break;
             }
             return o;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting device orientation.", e);
             return null;
         }
@@ -297,7 +298,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             // CHECKSTYLE.ON: MagicNumber
 
             return ((float) level / (float) scale) * percentMultiplier;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting device battery level.", e);
             return null;
         }
@@ -318,7 +319,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
 
             int plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
             return plugged == BatteryManager.BATTERY_PLUGGED_AC || plugged == BatteryManager.BATTERY_PLUGGED_USB;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting device charging state.", e);
             return null;
         }
@@ -343,7 +344,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
 
             br = new BufferedReader(new FileReader(file));
             return br.readLine();
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             Log.e(TAG, errorMsg, e);
         } finally {
             if (br != null) {
@@ -392,7 +393,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 if (new File(probableRootPath).exists()) {
                     return true;
                 }
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 Log.e(TAG, "Exception while attempting to detect whether the device is rooted", e);
             }
         }
@@ -417,7 +418,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             long blockSize = stat.getBlockSize();
             long availableBlocks = stat.getAvailableBlocks();
             return availableBlocks * blockSize;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting unused internal storage amount.", e);
             return null;
         }
@@ -435,7 +436,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             long blockSize = stat.getBlockSize();
             long totalBlocks = stat.getBlockCount();
             return totalBlocks * blockSize;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting total internal storage amount.", e);
             return null;
         }
@@ -457,7 +458,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 long availableBlocks = stat.getAvailableBlocks();
                 return availableBlocks * blockSize;
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting unused external storage amount.", e);
         }
 
@@ -480,7 +481,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
                 long totalBlocks = stat.getBlockCount();
                 return totalBlocks * blockSize;
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting total external storage amount.", e);
         }
 
@@ -496,7 +497,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
     protected static DisplayMetrics getDisplayMetrics(Context ctx) {
         try {
             return ctx.getResources().getDisplayMetrics();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting DisplayMetrics.", e);
             return null;
         }
@@ -530,7 +531,7 @@ public class AndroidEventBuilderHelper implements EventBuilderHelper {
             } else {
                 return ctx.getString(stringId);
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             Log.e(TAG, "Error getting application name.", e);
         }
 

--- a/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
+++ b/sentry-appengine/src/main/java/io/sentry/appengine/connection/AppEngineAsyncConnection.java
@@ -151,7 +151,7 @@ public class AppEngineAsyncConnection implements Connection {
                     return;
                 }
                 connection.actualConnection.send(event);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("An exception occurred while sending the event to Sentry.", e);
             } finally {
                 SentryEnvironment.stopManagingThread();

--- a/sentry-appengine/src/test/java/io/sentry/appengine/connection/AppEngineAsyncConnectionTest.java
+++ b/sentry-appengine/src/test/java/io/sentry/appengine/connection/AppEngineAsyncConnectionTest.java
@@ -113,7 +113,7 @@ public class AppEngineAsyncConnectionTest {
                 TaskOptions taskOptions = invocation.getArgument(0);
                 try {
                     extractDeferredTask(taskOptions).run();
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     throw new RuntimeException("Couldn't extract the task", e);
                 }
                 return null;

--- a/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
+++ b/sentry-log4j/src/main/java/io/sentry/log4j/SentryAppender.java
@@ -83,7 +83,7 @@ public class SentryAppender extends AppenderSkeleton {
         try {
             EventBuilder eventBuilder = createEventBuilder(loggingEvent);
             Sentry.capture(eventBuilder);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             getErrorHandler().error("An exception occurred while creating a new event in Sentry", e,
                     ErrorCode.WRITE_FAILURE);
         } finally {
@@ -151,7 +151,7 @@ public class SentryAppender extends AppenderSkeleton {
             }
             this.closed = true;
             Sentry.close();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             getErrorHandler().error("An exception occurred while closing the Sentry connection", e,
                     ErrorCode.CLOSE_FAILURE);
         } finally {

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -131,7 +131,7 @@ public class SentryAppender extends AbstractAppender {
         try {
             EventBuilder eventBuilder = createEventBuilder(logEvent);
             Sentry.capture(eventBuilder);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             error("An exception occurred while creating a new event in Sentry", logEvent, e);
         } finally {
             SentryEnvironment.stopManagingThread();
@@ -201,7 +201,7 @@ public class SentryAppender extends AbstractAppender {
             }
             super.stop();
             Sentry.close();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             error("An exception occurred while closing the Sentry connection", e);
         } finally {
             SentryEnvironment.stopManagingThread();

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -113,7 +113,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
             EventBuilder eventBuilder = createEventBuilder(iLoggingEvent);
             Sentry.capture(eventBuilder);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             addError("An exception occurred while creating a new event in Sentry", e);
         } finally {
             SentryEnvironment.stopManagingThread();
@@ -301,7 +301,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             }
             super.stop();
             Sentry.close();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             addError("An exception occurred while closing the Sentry connection", e);
         } finally {
             SentryEnvironment.stopManagingThread();

--- a/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
+++ b/sentry/src/main/java/io/sentry/DefaultSentryClientFactory.java
@@ -275,7 +275,7 @@ public class DefaultSentryClientFactory extends SentryClientFactory {
             }
             sentryClient.addBuilderHelper(new ContextBuilderHelper(sentryClient));
             return configureSentryClient(sentryClient, dsn);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("Failed to initialize sentry, falling back to no-op client", e);
             return new SentryClient(new NoopConnection(), new ThreadLocalContextManager());
         }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -139,7 +139,7 @@ public class SentryClient {
             connection.send(event);
         } catch (LockedDownException | TooManyRequestsException e) {
             logger.debug("Dropping an Event due to lockdown: " + event);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("An exception occurred while sending the event to Sentry.", e);
         } finally {
             getContext().setLastEventId(event.getId());

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -207,7 +207,7 @@ public final class SentryOptions {
             }
 
             return dsn;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("Error creating valid DSN from: '{}'.", dsn, e);
             throw e;
         }

--- a/sentry/src/main/java/io/sentry/SentryUncaughtExceptionHandler.java
+++ b/sentry/src/main/java/io/sentry/SentryUncaughtExceptionHandler.java
@@ -53,7 +53,7 @@ public class SentryUncaughtExceptionHandler implements Thread.UncaughtExceptionH
 
             try {
                 Sentry.capture(eventBuilder);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Error sending uncaught exception to Sentry.", e);
             }
         }

--- a/sentry/src/main/java/io/sentry/buffer/DiskBuffer.java
+++ b/sentry/src/main/java/io/sentry/buffer/DiskBuffer.java
@@ -43,7 +43,7 @@ public class DiskBuffer implements Buffer {
             if (!bufferDir.isDirectory() || !bufferDir.canWrite()) {
                 throw new RuntimeException(errMsg);
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             throw new RuntimeException(errMsg, e);
         }
 
@@ -78,7 +78,7 @@ public class DiskBuffer implements Buffer {
         try (FileOutputStream fileOutputStream = new FileOutputStream(eventFile);
              ObjectOutputStream objectOutputStream = new ObjectOutputStream(fileOutputStream)) {
             objectOutputStream.writeObject(event);
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             logger.error("Error writing Event to offline storage: " + event.getId(), e);
         }
 
@@ -118,7 +118,7 @@ public class DiskBuffer implements Buffer {
         } catch (FileNotFoundException e) {
             // event was deleted while we were iterating the array of files
             return null;
-        } catch (Exception e) {
+        } catch (IOException | ClassNotFoundException | RuntimeException e) {
             logger.error("Error reading Event file: " + eventFile.getAbsolutePath(), e);
             if (!eventFile.delete()) {
                 logger.warn("Failed to delete Event: " + eventFile.getAbsolutePath());
@@ -128,7 +128,7 @@ public class DiskBuffer implements Buffer {
 
         try {
             return (Event) eventObj;
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("Error casting Object to Event: " + eventFile.getAbsolutePath(), e);
             if (!eventFile.delete()) {
                 logger.warn("Failed to delete Event: " + eventFile.getAbsolutePath());

--- a/sentry/src/main/java/io/sentry/connection/AbstractConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/AbstractConnection.java
@@ -93,7 +93,7 @@ public abstract class AbstractConnection implements Connection {
             for (EventSendCallback eventSendCallback : eventSendCallbacks) {
                 try {
                     eventSendCallback.onSuccess(event);
-                } catch (Exception exc) {
+                } catch (RuntimeException exc) {
                     logger.warn("An exception occurred while running an EventSendCallback.onSuccess: "
                         + eventSendCallback.getClass().getName(), exc);
                 }
@@ -102,7 +102,7 @@ public abstract class AbstractConnection implements Connection {
             for (EventSendCallback eventSendCallback : eventSendCallbacks) {
                 try {
                     eventSendCallback.onFailure(event, e);
-                } catch (Exception exc) {
+                } catch (RuntimeException exc) {
                     logger.warn("An exception occurred while running an EventSendCallback.onFailure: "
                         + eventSendCallback.getClass().getName(), exc);
                 }

--- a/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/AsyncConnection.java
@@ -187,7 +187,7 @@ public class AsyncConnection implements Connection {
                 actualConnection.send(event);
             } catch (LockedDownException | TooManyRequestsException e) {
                 logger.debug("Dropping an Event due to lockdown: " + event);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("An exception occurred while sending the event to Sentry.", e);
             } finally {
                 if (previous == null) {
@@ -218,7 +218,7 @@ public class AsyncConnection implements Connection {
             try {
                 // The current thread is managed by sentry
                 AsyncConnection.this.doClose();
-            } catch (Exception e) {
+            } catch (IOException | RuntimeException e) {
                 logger.error("An exception occurred while closing the connection.", e);
             } finally {
                 SentryEnvironment.stopManagingThread();

--- a/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/BufferedConnection.java
@@ -186,7 +186,7 @@ public class BufferedConnection implements Connection {
                 try {
                     // buffer before we attempt to send
                     buffer.add(event);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     logger.error("Exception occurred while attempting to add Event to buffer: ", e);
                 }
 
@@ -249,7 +249,7 @@ public class BufferedConnection implements Connection {
                         logger.trace("Flusher attempting to send Event: " + event.getId());
                         send(event);
                         logger.trace("Flusher successfully sent Event: " + event.getId());
-                    } catch (Exception e) {
+                    } catch (RuntimeException e) {
                         logger.debug("Flusher failed to send Event: " + event.getId(), e);
 
                         // Connectivity issues, give up until next Flusher run.
@@ -258,7 +258,7 @@ public class BufferedConnection implements Connection {
                     }
                 }
                 logger.trace("Flusher run exiting, no more events to send.");
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Error running Flusher: ", e);
             } finally {
                 SentryEnvironment.stopManagingThread();
@@ -283,7 +283,7 @@ public class BufferedConnection implements Connection {
             try {
                 // The current thread is managed by sentry
                 BufferedConnection.this.close();
-            } catch (Exception e) {
+            } catch (IOException | RuntimeException e) {
                 logger.error("An exception occurred while closing the connection.", e);
             } finally {
                 SentryEnvironment.stopManagingThread();

--- a/sentry/src/main/java/io/sentry/connection/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/connection/HttpConnection.java
@@ -233,7 +233,7 @@ public class HttpConnection extends AbstractConnection {
                 sb.append(line);
                 first = false;
             }
-        } catch (Exception e2) {
+        } catch (IOException | RuntimeException e2) {
             logger.error("Exception while reading the error message from the connection.", e2);
         }
         return sb.toString();

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -566,6 +566,9 @@ public class EventBuilder {
                 new Thread(futureTask).start();
                 futureTask.get(GET_HOSTNAME_TIMEOUT, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 expirationTimestamp = clock.millis() + TimeUnit.SECONDS.toMillis(1);
                 logger.debug("Localhost hostname lookup failed, keeping the value '{}'."
                     + " If this persists it may mean your DNS is incorrectly configured and"

--- a/sentry/src/main/java/io/sentry/event/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/event/EventBuilder.java
@@ -13,8 +13,10 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -565,16 +567,20 @@ public class EventBuilder {
                 FutureTask<Void> futureTask = new FutureTask<>(hostRetriever);
                 new Thread(futureTask).start();
                 futureTask.get(GET_HOSTNAME_TIMEOUT, TimeUnit.MILLISECONDS);
-            } catch (Exception e) {
-                if (e instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                }
-                expirationTimestamp = clock.millis() + TimeUnit.SECONDS.toMillis(1);
-                logger.debug("Localhost hostname lookup failed, keeping the value '{}'."
-                    + " If this persists it may mean your DNS is incorrectly configured and"
-                    + " you may want to hardcode your server name: https://docs.sentry.io/clients/java/config/",
-                    hostname, e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                handleCacheUpdateFailure(e);
+            } catch (ExecutionException | TimeoutException | RuntimeException e) {
+                handleCacheUpdateFailure(e);
             }
+        }
+
+        private void handleCacheUpdateFailure(Exception failure) {
+            expirationTimestamp = clock.millis() + TimeUnit.SECONDS.toMillis(1);
+            logger.debug("Localhost hostname lookup failed, keeping the value '{}'."
+                + " If this persists it may mean your DNS is incorrectly configured and"
+                + " you may want to hardcode your server name: https://docs.sentry.io/clients/java/config/",
+                hostname, failure);
         }
 
         /**

--- a/sentry/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry/src/main/java/io/sentry/jul/SentryHandler.java
@@ -87,7 +87,7 @@ public class SentryHandler extends Handler {
     private Level parseLevelOrDefault(String levelName) {
         try {
             return Level.parse(levelName.trim());
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             return Level.WARNING;
         }
     }
@@ -103,7 +103,7 @@ public class SentryHandler extends Handler {
         try {
             EventBuilder eventBuilder = createEventBuilder(record);
             Sentry.capture(eventBuilder);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             reportError("An exception occurred while creating a new event in Sentry", e, ErrorManager.WRITE_FAILURE);
         } finally {
             SentryEnvironment.stopManagingThread();
@@ -137,7 +137,7 @@ public class SentryHandler extends Handler {
             try {
                 formatted = formatMessage(message, record.getParameters());
                 topLevelMessage = formatted; // write out formatted as Event's message key
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 // local formatting failed, send message and parameters without formatted string
                 formatted = null;
             }
@@ -193,7 +193,7 @@ public class SentryHandler extends Handler {
         SentryEnvironment.startManagingThread();
         try {
             Sentry.close();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             reportError("An exception occurred while closing the Sentry connection", e, ErrorManager.CLOSE_FAILURE);
         } finally {
             SentryEnvironment.stopManagingThread();

--- a/sentry/src/main/java/io/sentry/marshaller/json/SentryJsonGenerator.java
+++ b/sentry/src/main/java/io/sentry/marshaller/json/SentryJsonGenerator.java
@@ -115,7 +115,7 @@ public class SentryJsonGenerator extends JsonGenerator {
                         value, value.getClass());
                 try {
                     generator.writeString(Util.trimString(value.toString(), maxLengthString));
-                } catch (Exception innerE) {
+                } catch (IOException | RuntimeException innerE) {
                     generator.writeString("<exception calling toString on object>");
                 }
             }

--- a/sentry/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -33,7 +33,7 @@ public class SentryServletRequestListener implements ServletRequestListener {
             if (sentryClient != null) {
                 sentryClient.clearContext();
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             logger.error("Error clearing Context state.", e);
         }
     }

--- a/sentry/src/main/java/io/sentry/util/Util.java
+++ b/sentry/src/main/java/io/sentry/util/Util.java
@@ -1,6 +1,7 @@
 package io.sentry.util;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -204,7 +205,7 @@ public final class Util {
         if (closeable != null) {
             try {
                 closeable.close();
-            } catch (Exception ignored) {
+            } catch (IOException | RuntimeException ignored) {
             }
         }
         // CHECKSTYLE.ON: EmptyCatchBlock

--- a/sentry/src/test/java/io/sentry/connection/BufferedConnectionTest.java
+++ b/sentry/src/test/java/io/sentry/connection/BufferedConnectionTest.java
@@ -177,7 +177,7 @@ public class BufferedConnectionTest extends BaseTest {
                 .when(mockConnection).send(any(Event.class));
         try {
             bufferedConnection.send(event);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
 
         }
         assertThat(bufferedEvents.size(), equalTo(0));
@@ -190,7 +190,7 @@ public class BufferedConnectionTest extends BaseTest {
                 .when(mockConnection).send(any(Event.class));
         try {
             bufferedConnection.send(event);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
 
         }
         assertThat(bufferedEvents.size(), equalTo(1));

--- a/sentry/src/test/java/io/sentry/jvmti/FrameCacheTest.java
+++ b/sentry/src/test/java/io/sentry/jvmti/FrameCacheTest.java
@@ -22,7 +22,7 @@ public class FrameCacheTest extends BaseTest {
 
         try {
             throw new RuntimeException("foo");
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             t = e;
 
             // throwable shouldn't exist in the cache at all, so we expect true

--- a/sentry/src/test/java/io/sentry/marshaller/json/JsonComparisonUtil.java
+++ b/sentry/src/test/java/io/sentry/marshaller/json/JsonComparisonUtil.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
 public final class JsonComparisonUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -40,7 +42,7 @@ public final class JsonComparisonUtil {
             closeStream();
             try {
                 return outputStream.toString("UTF-8");
-            } catch (Exception e) {
+            } catch (UnsupportedEncodingException | RuntimeException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -63,7 +65,7 @@ public final class JsonComparisonUtil {
             try {
                 jsonGenerator.close();
                 outputStream.close();
-            } catch (Exception e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -79,7 +81,7 @@ public final class JsonComparisonUtil {
         protected void closeStream() {
             try {
                 outputStream.close();
-            } catch (Exception e) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/sentry/src/test/java/io/sentry/unmarshaller/JsonDecoder.java
+++ b/sentry/src/test/java/io/sentry/unmarshaller/JsonDecoder.java
@@ -64,7 +64,7 @@ public class JsonDecoder {
                 parser.nextToken();
             } while (parser.hasCurrentToken());
             valid = true;
-        } catch (Exception e) {
+        } catch (IOException | RuntimeException e) {
             logger.log(Level.FINE, "An exception occurred while trying to parse an allegedly JSON document", e);
         }
 


### PR DESCRIPTION
We spent a week to find, why one thread of our application can't finish after interruption ;-)
The reason is EventBuilder.getHostname, who cleared Thread.interrupted status, when we tried to log error (we use Sentry with log4j2 integration).

I have added recovery of interruption in EventBuilder, and changed catch clauses from Exception to more specific exceptions in all other places.
Otherwise, it is very difficult to understand, where Thread.interrupted status can be cleared.