### PR TITLE
Added request caching to add body to event

### DIFF
--- a/sentry-spring/src/main/java/io/sentry/spring/SentryFilterCachingRequest.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryFilterCachingRequest.java
@@ -1,0 +1,21 @@
+package io.sentry.spring;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class SentryFilterCachingRequest extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        ContentCachingRequestWrapper cacheRequest = new ContentCachingRequestWrapper(request);
+        filterChain.doFilter(cacheRequest, response);
+    }
+}


### PR DESCRIPTION
Hi Sentry,
This commit tries to solve the problem described in issues https://github.com/getsentry/sentry-java/issues/331 and https://github.com/getsentry/sentry-java/issues/273, namely the inability to see the body of the HTTP request in the web interface