### PR TITLE
Boot app packages fix

### DIFF
--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProvider.java
@@ -5,6 +5,9 @@ import io.sentry.config.provider.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Iterator;
+import java.util.Set;
+
 public class SpringBootConfigurationProvider implements ConfigurationProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(SpringBootConfigurationProvider.class);
@@ -31,7 +34,7 @@ public class SpringBootConfigurationProvider implements ConfigurationProvider {
             case DefaultSentryClientFactory.HIDE_COMMON_FRAMES_OPTION:
                 return logAndReturnIfSet(key, sentryProperties.getStacktrace().getHideCommon());
             case DefaultSentryClientFactory.IN_APP_FRAMES_OPTION:
-                return logAndReturnIfSet(key, sentryProperties.getStacktrace().getAppPackages());
+                return logAndReturnIfSet(key, join(sentryProperties.getStacktrace().getAppPackages()));
             case DefaultSentryClientFactory.BUFFER_DIR_OPTION:
                 return logAndReturnIfSet(key, sentryProperties.getBuffer().getDir());
             case DefaultSentryClientFactory.BUFFER_SIZE_OPTION:
@@ -58,6 +61,20 @@ public class SpringBootConfigurationProvider implements ConfigurationProvider {
                 logger.debug("Unsupported option: {}", key);
                 return null;
         }
+    }
+
+    private String join(Set<String> set) {
+        if (set == null || set.isEmpty()) {
+            return null;
+        }
+        // Java 7 has no built-in string join
+        StringBuilder sb = new StringBuilder();
+        Iterator<String> it = set.iterator();
+        sb.append(it.next());
+        while (it.hasNext()) {
+            sb.append(',').append(it.next());
+        }
+        return sb.toString();
     }
 
     private String logAndReturnIfSet(String key, Object value) {

--- a/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProviderTest.java
+++ b/sentry-spring-boot-starter/src/test/java/io/sentry/spring/autoconfigure/SpringBootConfigurationProviderTest.java
@@ -1,0 +1,21 @@
+package io.sentry.spring.autoconfigure;
+
+import io.sentry.DefaultSentryClientFactory;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringBootConfigurationProviderTest {
+
+    @Test
+    public void getAppPackages() {
+        SentryProperties properties = new SentryProperties();
+        properties.getStacktrace().setAppPackages(new LinkedHashSet<>(Arrays.asList("a", "b", "c")));
+        SpringBootConfigurationProvider provider = new SpringBootConfigurationProvider(properties);
+        assertThat(provider.getProperty(DefaultSentryClientFactory.IN_APP_FRAMES_OPTION))
+                .isEqualTo("a,b,c");
+    }
+}


### PR DESCRIPTION
The property sentry.stacktrace.app-packages isn't correctly converted to a string in lookup. Calling `toString()`on a Set adds `[]`around the elements, which wont match a package.