### PR TITLE
Extract interfaces from servlet API to avoid servlet dependency in HttpInterface

### DIFF
--- a/sentry/src/main/java/io/sentry/event/helper/BasicRemoteAddressResolver.java
+++ b/sentry/src/main/java/io/sentry/event/helper/BasicRemoteAddressResolver.java
@@ -2,6 +2,8 @@ package io.sentry.event.helper;
 
 import javax.servlet.http.HttpServletRequest;
 
+import io.sentry.event.interfaces.HttpRequestInterface;
+
 /**
  * The simplest (and default) {@link RemoteAddressResolver}.
  */
@@ -13,7 +15,7 @@ public class BasicRemoteAddressResolver implements RemoteAddressResolver {
      * @param request HttpServletRequest
      * @return the IP address of the client or last proxy that sent the request.
      */
-    public String getRemoteAddress(HttpServletRequest request) {
+    public String getRemoteAddress(HttpRequestInterface request) {
         return request.getRemoteAddr();
     }
 

--- a/sentry/src/main/java/io/sentry/event/helper/ForwardedAddressResolver.java
+++ b/sentry/src/main/java/io/sentry/event/helper/ForwardedAddressResolver.java
@@ -1,8 +1,8 @@
 package io.sentry.event.helper;
 
+import io.sentry.event.interfaces.HttpRequestInterface;
 import io.sentry.util.Util;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,7 +28,7 @@ public class ForwardedAddressResolver implements RemoteAddressResolver {
     }
 
     @Override
-    public String getRemoteAddress(HttpServletRequest request) {
+    public String getRemoteAddress(HttpRequestInterface request) {
         String forwarded = request.getHeader("X-FORWARDED-FOR");
         if (!Util.isNullOrEmpty(forwarded)) {
             return firstAddress(forwarded);

--- a/sentry/src/main/java/io/sentry/event/helper/HttpEventBuilderHelper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/HttpEventBuilderHelper.java
@@ -2,6 +2,7 @@ package io.sentry.event.helper;
 
 import io.sentry.event.EventBuilder;
 import io.sentry.event.interfaces.HttpInterface;
+import io.sentry.event.interfaces.HttpRequestInterface;
 import io.sentry.event.interfaces.UserInterface;
 import io.sentry.servlet.SentryServletRequestListener;
 
@@ -40,15 +41,16 @@ public class HttpEventBuilderHelper implements EventBuilderHelper {
             return;
         }
 
-        addHttpInterface(eventBuilder, servletRequest);
-        addUserInterface(eventBuilder, servletRequest);
+        HttpServletRequestWrapper servletRequestWrapper = new HttpServletRequestWrapper(servletRequest);
+        addHttpInterface(eventBuilder, servletRequestWrapper);
+        addUserInterface(eventBuilder, servletRequestWrapper);
     }
 
-    private void addHttpInterface(EventBuilder eventBuilder, HttpServletRequest servletRequest) {
+    private void addHttpInterface(EventBuilder eventBuilder, HttpRequestInterface servletRequest) {
         eventBuilder.withSentryInterface(new HttpInterface(servletRequest, remoteAddressResolver), false);
     }
 
-    private void addUserInterface(EventBuilder eventBuilder, HttpServletRequest servletRequest) {
+    private void addUserInterface(EventBuilder eventBuilder, HttpRequestInterface servletRequest) {
         String username = null;
         if (servletRequest.getUserPrincipal() != null) {
             username = servletRequest.getUserPrincipal().getName();

--- a/sentry/src/main/java/io/sentry/event/helper/HttpEventBuilderHelper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/HttpEventBuilderHelper.java
@@ -41,7 +41,7 @@ public class HttpEventBuilderHelper implements EventBuilderHelper {
             return;
         }
 
-        HttpServletRequestWrapper servletRequestWrapper = new HttpServletRequestWrapper(servletRequest);
+        HttpRequestInterface servletRequestWrapper = new HttpServletRequestWrapper(servletRequest);
         addHttpInterface(eventBuilder, servletRequestWrapper);
         addUserInterface(eventBuilder, servletRequestWrapper);
     }

--- a/sentry/src/main/java/io/sentry/event/helper/HttpServletCookieWrapper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/HttpServletCookieWrapper.java
@@ -1,0 +1,32 @@
+package io.sentry.event.helper;
+
+import javax.servlet.http.Cookie;
+
+import io.sentry.event.interfaces.CookieInterface;
+
+/**
+ * Simply wraps a {@link Cookie} in a {@link CookieInterface}.
+ */
+public class HttpServletCookieWrapper implements CookieInterface {
+
+    private final Cookie cookie;
+
+    /**
+     * Creates a new {@link HttpServletCookieWrapper} from a {@link Cookie}.
+     *
+     * @param cookie the cookie to wrap
+     */
+    public HttpServletCookieWrapper(Cookie cookie) {
+        this.cookie = cookie;
+    }
+
+    @Override
+    public String getName() {
+        return cookie.getName();
+    }
+
+    @Override
+    public String getValue() {
+        return cookie.getValue();
+    }
+}

--- a/sentry/src/main/java/io/sentry/event/helper/HttpServletRequestWrapper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/HttpServletRequestWrapper.java
@@ -94,7 +94,6 @@ public class HttpServletRequestWrapper implements HttpRequestInterface {
         return request.getLocalPort();
     }
 
-
     @Override
     public String getProtocol() {
         return request.getProtocol();

--- a/sentry/src/main/java/io/sentry/event/helper/HttpServletRequestWrapper.java
+++ b/sentry/src/main/java/io/sentry/event/helper/HttpServletRequestWrapper.java
@@ -1,0 +1,142 @@
+package io.sentry.event.helper;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import io.sentry.event.interfaces.CookieInterface;
+import io.sentry.event.interfaces.HttpRequestInterface;
+
+/**
+ * Simply wraps a {@link HttpServletRequest} in a {@link HttpRequestInterface}.
+ */
+public class HttpServletRequestWrapper implements HttpRequestInterface {
+
+    private final HttpServletRequest request;
+
+    /**
+     * Constructor for wrapping a {@link HttpServletRequest}.
+     *
+     * @param request the request to wrap.
+     */
+    public HttpServletRequestWrapper(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return request.getRequestURL();
+    }
+
+    @Override
+    public String getQueryString() {
+        return request.getQueryString();
+    }
+
+    @Override
+    public CookieInterface[] getCookies() {
+
+        List<CookieInterface> cookies = new ArrayList<>();
+
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            cookies.add(new HttpServletCookieWrapper(cookie));
+
+        }
+        return cookies.toArray(new CookieInterface[cookies.size()]);
+    }
+
+    @Override
+    public String getMethod() {
+        return request.getMethod();
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return request.getParameterMap();
+    }
+
+    @Override
+    public String getServerName() {
+        return request.getServerName();
+    }
+
+    @Override
+    public int getServerPort() {
+        return request.getServerPort();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return request.getLocalAddr();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return request.getRemoteAddr();
+    }
+
+    @Override
+    public String getLocalName() {
+        return request.getLocalName();
+    }
+
+    @Override
+    public int getLocalPort() {
+        return request.getLocalPort();
+    }
+
+
+    @Override
+    public String getProtocol() {
+        return request.getProtocol();
+    }
+
+    @Override
+    public boolean isSecure() {
+        return request.isSecure();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return request.isAsyncStarted();
+    }
+
+    @Override
+    public String getAuthType() {
+        return request.getAuthType();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return request.getRemoteUser();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return request.getHeaderNames();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        return request.getHeaders(name);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return request.getHeader(name);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return request.getUserPrincipal();
+    }
+}

--- a/sentry/src/main/java/io/sentry/event/helper/RemoteAddressResolver.java
+++ b/sentry/src/main/java/io/sentry/event/helper/RemoteAddressResolver.java
@@ -12,7 +12,7 @@ public interface RemoteAddressResolver {
     /**
      * Returns the REMOTE_ADDR for the provided request.
      *
-     * @param request HttpServletRequest
+     * @param request HttpRequestInterface
      * @return String representing the desired REMOTE_ADDR.
      */
     String getRemoteAddress(HttpRequestInterface request);

--- a/sentry/src/main/java/io/sentry/event/helper/RemoteAddressResolver.java
+++ b/sentry/src/main/java/io/sentry/event/helper/RemoteAddressResolver.java
@@ -1,6 +1,7 @@
 package io.sentry.event.helper;
 
-import javax.servlet.http.HttpServletRequest;
+
+import io.sentry.event.interfaces.HttpRequestInterface;
 
 /**
  * Interface that allows users to define how the REMOTE_ADDR
@@ -14,6 +15,6 @@ public interface RemoteAddressResolver {
      * @param request HttpServletRequest
      * @return String representing the desired REMOTE_ADDR.
      */
-    String getRemoteAddress(HttpServletRequest request);
+    String getRemoteAddress(HttpRequestInterface request);
 
 }

--- a/sentry/src/main/java/io/sentry/event/interfaces/CookieInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/CookieInterface.java
@@ -1,0 +1,22 @@
+package io.sentry.event.interfaces;
+
+/**
+ * Simple interface to abstract cookie name/value retrieval.
+ */
+public interface CookieInterface {
+
+    /**
+     * Returns the cookie name.
+     *
+     * @return the cookie name
+     */
+    String getName();
+
+    /**
+     * Returns the cookie value.
+     *
+     * @return the cookie value
+     */
+    String getValue();
+
+}

--- a/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
@@ -35,7 +35,7 @@ public class HttpInterface implements SentryInterface {
     /**
      * This constructor is for compatibility reasons and should not be used.
      *
-     * @param request HttpServletRequest
+     * @param request HttpRequestInterface
      */
     public HttpInterface(HttpRequestInterface request) {
         this(request, new BasicRemoteAddressResolver());

--- a/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/HttpInterface.java
@@ -3,8 +3,6 @@ package io.sentry.event.interfaces;
 import io.sentry.event.helper.BasicRemoteAddressResolver;
 import io.sentry.event.helper.RemoteAddressResolver;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 
 /**
@@ -39,7 +37,7 @@ public class HttpInterface implements SentryInterface {
      *
      * @param request HttpServletRequest
      */
-    public HttpInterface(HttpServletRequest request) {
+    public HttpInterface(HttpRequestInterface request) {
         this(request, new BasicRemoteAddressResolver());
     }
 
@@ -49,7 +47,7 @@ public class HttpInterface implements SentryInterface {
      * @param request Captured HTTP request to send to Sentry.
      * @param remoteAddressResolver RemoteAddressResolver
      */
-    public HttpInterface(HttpServletRequest request, RemoteAddressResolver remoteAddressResolver) {
+    public HttpInterface(HttpRequestInterface request, RemoteAddressResolver remoteAddressResolver) {
         this(request, remoteAddressResolver, null);
     }
 
@@ -60,7 +58,7 @@ public class HttpInterface implements SentryInterface {
      * @param remoteAddressResolver RemoteAddressResolver
      * @param body HTTP request body (optional)
      */
-    public HttpInterface(HttpServletRequest request, RemoteAddressResolver remoteAddressResolver, String body) {
+    public HttpInterface(HttpRequestInterface request, RemoteAddressResolver remoteAddressResolver, String body) {
         this.requestUrl = request.getRequestURL().toString();
         this.method = request.getMethod();
         this.parameters = new HashMap<>();
@@ -70,7 +68,7 @@ public class HttpInterface implements SentryInterface {
         this.queryString = request.getQueryString();
         if (request.getCookies() != null) {
             this.cookies = new HashMap<>();
-            for (Cookie cookie : request.getCookies()) {
+            for (CookieInterface cookie : request.getCookies()) {
                 this.cookies.put(cookie.getName(), cookie.getValue());
             }
         } else {

--- a/sentry/src/main/java/io/sentry/event/interfaces/HttpRequestInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/HttpRequestInterface.java
@@ -4,7 +4,6 @@ import java.util.Enumeration;
 import java.util.Map;
 
 
-
 /**
  * Interface exposing http request methods.
  */

--- a/sentry/src/main/java/io/sentry/event/interfaces/HttpRequestInterface.java
+++ b/sentry/src/main/java/io/sentry/event/interfaces/HttpRequestInterface.java
@@ -1,0 +1,155 @@
+package io.sentry.event.interfaces;
+
+import java.util.Enumeration;
+import java.util.Map;
+
+
+
+/**
+ * Interface exposing http request methods.
+ */
+public interface HttpRequestInterface {
+
+    /**
+     * Gets the URL of the request.
+     *
+     * @return the request URL
+     */
+    StringBuffer getRequestURL();
+
+    /**
+     * Gets the query string.
+     *
+     * @return the query string
+     */
+    String getQueryString();
+
+    /**
+     * Gets the cookies.
+     *
+     * @return an array of {@link CookieInterface}
+     */
+    CookieInterface[] getCookies();
+
+    /**
+     * Gets the HTTP method.
+     *
+     * @return the HTTP method
+     */
+    String getMethod();
+
+    /**
+     * Gets the parameter map.
+     *
+     * @return the parameter map
+     */
+    Map<String, String[]> getParameterMap();
+
+    /**
+     * Gets the server name.
+     *
+     * @return the server name
+     */
+    String getServerName();
+
+    /**
+     * Gets the server port.
+     *
+     * @return the server port
+     */
+    int getServerPort();
+
+    /**
+     * Gets the local address.
+     *
+     * @return the local address
+     */
+    String getLocalAddr();
+
+    /**
+     * Gets the remote address.
+     *
+     * @return the remote address
+     */
+    String getRemoteAddr();
+
+    /**
+     * Gets the local name.
+     *
+     * @return the local name
+     */
+    String getLocalName();
+
+    /**
+     * Gets the local port.
+     *
+     * @return the local port
+     */
+    int getLocalPort();
+
+    /**
+     * Gets the protocol.
+     *
+     * @return the protocol
+     */
+    String getProtocol();
+
+    /**
+     * Returns a boolean indicating whether this request was made using a secure channel, such as HTTPS.
+     *
+     * @return a boolean indicating if the request was made using a secure channel
+     */
+    boolean isSecure();
+
+    /**
+     * Checks if this request has been put into asynchronous mode.
+     *
+     * @return true if this request has been put into asynchronous mode, false otherwise
+     */
+    boolean isAsyncStarted();
+
+    /**
+     * Returns the auth type.
+     *
+     * @return the auth type
+     */
+    String getAuthType();
+
+    /**
+     * Returns the remote user.
+     *
+     * @return the remote user
+     */
+    String getRemoteUser();
+
+    /**
+     * Returns the header names.
+     *
+     * @return the header name enumeration
+     */
+    Enumeration<String> getHeaderNames();
+
+    /**
+     * Returns the headers enumeration for a specific header name.
+     *
+     * @param name of the header
+     * @return the headers for a specific key
+     */
+    Enumeration<String> getHeaders(String name);
+
+    /**
+     * Returns a header for a specific header name.
+     *
+     * @param name of the header
+     * @return a header for a specific key
+     */
+    String getHeader(String name);
+
+    /**
+     * Returns the user {@link java.security.Principal}.
+     *
+     * @return the user principal
+     */
+    java.security.Principal getUserPrincipal();
+
+}

--- a/sentry/src/test/java/io/sentry/event/interfaces/HttpInterfaceTest.java
+++ b/sentry/src/test/java/io/sentry/event/interfaces/HttpInterfaceTest.java
@@ -19,6 +19,8 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import io.sentry.BaseTest;
+import io.sentry.event.helper.HttpServletRequestWrapper;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,7 +101,7 @@ public class HttpInterfaceTest extends BaseTest {
         when(mockHttpServletRequest.getHeaderNames()).thenReturn(enumeration(singleton(headerKey)));
         when(mockHttpServletRequest.getHeaders(eq(headerKey))).thenReturn(enumeration(singleton(headerValue)));
 
-        HttpInterface httpInterface = new HttpInterface(mockHttpServletRequest);
+        HttpInterface httpInterface = new HttpInterface(new HttpServletRequestWrapper(mockHttpServletRequest));
 
         assertThat(httpInterface.getRequestUrl(), is(requestUrl));
         assertThat(httpInterface.getMethod(), is(method));
@@ -121,7 +123,7 @@ public class HttpInterfaceTest extends BaseTest {
 
     @Test
     public void testNullCookies() throws Exception {
-        HttpInterface httpInterface = new HttpInterface(mockHttpServletRequest);
+        HttpInterface httpInterface = new HttpInterface(new HttpServletRequestWrapper(mockHttpServletRequest));
 
         assertThat(httpInterface.getCookies().size(), is(0));
     }

--- a/sentry/src/test/java/io/sentry/helper/RemoteAddressResolverTest.java
+++ b/sentry/src/test/java/io/sentry/helper/RemoteAddressResolverTest.java
@@ -3,6 +3,8 @@ package io.sentry.helper;
 import io.sentry.BaseTest;
 import io.sentry.event.helper.BasicRemoteAddressResolver;
 import io.sentry.event.helper.ForwardedAddressResolver;
+import io.sentry.event.helper.HttpServletRequestWrapper;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,7 +31,7 @@ public class RemoteAddressResolverTest extends BaseTest {
 
         when(request.getRemoteAddr()).thenReturn("1.2.3.4");
 
-        String remoteAddress = resolver.getRemoteAddress(request);
+        String remoteAddress = resolver.getRemoteAddress(new HttpServletRequestWrapper(request));
         assertThat(remoteAddress, is("1.2.3.4"));
     }
 
@@ -39,7 +41,7 @@ public class RemoteAddressResolverTest extends BaseTest {
         when(request.getRemoteAddr()).thenReturn("1.2.3.4");
         when(request.getHeader(eq("X-FORWARDED-FOR"))).thenReturn("9.9.9.9");
 
-        String remoteAddress = resolver.getRemoteAddress(request);
+        String remoteAddress = resolver.getRemoteAddress(new HttpServletRequestWrapper(request));
         assertThat(remoteAddress, is("1.2.3.4"));
 
         String xForwardedFor = request.getHeader("X-FORWARDED-FOR");
@@ -52,7 +54,7 @@ public class RemoteAddressResolverTest extends BaseTest {
 
         when(request.getHeader(eq("X-FORWARDED-FOR"))).thenReturn("9.9.9.9");
 
-        String remoteAddress = resolver.getRemoteAddress(request);
+        String remoteAddress = resolver.getRemoteAddress(new HttpServletRequestWrapper(request));
         assertThat(remoteAddress, is("9.9.9.9"));
     }
 
@@ -62,7 +64,7 @@ public class RemoteAddressResolverTest extends BaseTest {
 
         when(request.getRemoteAddr()).thenReturn("1.2.3.4");
 
-        String remoteAddress = resolver.getRemoteAddress(request);
+        String remoteAddress = resolver.getRemoteAddress(new HttpServletRequestWrapper(request));
         assertThat(remoteAddress, is("1.2.3.4"));
     }
 }


### PR DESCRIPTION
The HttpInterface currently ties in dependencies to javax.servlet, which makes it currently impossible to implement HttpEventBuilderHelpers for something like spring webflux (non servlet based http server). See https://github.com/getsentry/sentry-java/issues/640.

This PR extracts 2 interfaces `HttpRequestInterface` and `CookieInterface` which replace `javax.servlet.http.HttpServletRequest` and `javax.servlet.http.Cookie`.

Both interfaces get a servlet based implementation, wrapping the 2 types.

This would be a first step to provide better integration for non servlet based HTTP APIs.
