### PR TITLE
test: new dsn test org

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         </activity>
 
         <!--    NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard-->
-        <meta-data android:name="io.sentry.dsn" android:value="https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954" />
+        <meta-data android:name="io.sentry.dsn" android:value="https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559" />
 
         <!--    how to enable Sentry's debug mode-->
         <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -16,7 +16,7 @@ public class Main {
         options -> {
           // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in
           // your Sentry project/dashboard
-          options.setDsn("https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954");
+          options.setDsn("https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563");
 
           // All events get assigned to the release. See more at
           // https://docs.sentry.io/workflow/releases/

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
   <appender name="sentry" class="io.sentry.logback.SentryAppender">
     <options>
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
-      <dsn>https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954</dsn>
+      <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard
-sentry.dsn=https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954
+sentry.dsn=https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563
 sentry.send-default-pii=true
 # Sentry Spring Boot integration allows more fine-grained SentryOptions configuration
 sentry.max-breadcrumbs=150

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/SentryDemoApplication.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/SentryDemoApplication.java
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry
 // project/dashboard
 @EnableSentry(
-    dsn = "https://f7f320d5c3a54709be7b28e0f2ca7081@sentry.io/1808954",
+    dsn = "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563",
     sendDefaultPii = true)
 public class SentryDemoApplication {
   public static void main(String[] args) {


### PR DESCRIPTION
Changed the DSN for a new test org.
The Android example uses one DSN while the other projects assume Java and go to another project.

Would you prefer both on the same Sentry project instead?