### PR TITLE
feat: enable attach stack traces and disable attach threads by default

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -156,13 +156,13 @@ public class SentryOptions {
   private @Nullable String dist;
 
   /** When enabled, threads are automatically attached to all logged events. */
-  private boolean attachThreads = true;
+  private boolean attachThreads;
 
   /**
    * When enabled, stack traces are automatically attached to all threads logged. Stack traces are
    * always attached to exceptions but when this is set stack traces are also sent with threads
    */
-  private boolean attachStacktrace;
+  private boolean attachStacktrace = true;
 
   /** Whether to enable or disable automatic session tracking. */
   private boolean enableSessionTracking = true;

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -135,4 +135,14 @@ class SentryOptionsTest {
 
         assertEquals(clientName, sentryOptions.sentryClientName)
     }
+
+    @Test
+    fun `when options is initialized, attachThreads is false`() {
+        assertFalse(SentryOptions().isAttachThreads)
+    }
+
+    @Test
+    fun `when options is initialized, attachStacktrace is true`() {
+        assertTrue(SentryOptions().isAttachStacktrace)
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
feat: enable attach stack traces and disable attach threads by default


## :bulb: Motivation and Context
threads are not useful if no stack traces, so threads are disabled by default, but if enabled, you get stack traces by default


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
