### PR TITLE
fix: rename bintray repos name to sync jcenter and maven central sync

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -103,7 +103,7 @@ object Config {
         val description = "SDK for sentry.io"
         val website = "https://sentry.io"
         val userOrg = "getsentry"
-        val repoName = "maven"
+        val repoName = "sentry-android"
         val licence = "MIT"
         val licenceUrl = "http://www.opensource.org/licenses/mit-license.php"
         val issueTracker = "https://github.com/getsentry/sentry-java/issues"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: rename bintray repos name to sync jcenter and maven central sync


## :bulb: Motivation and Context
we want to sync releases to jcenter and maven central, so we can't move repos on bintray


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
