### PR TITLE
fix: read sample rate correctly from manifest meta data

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -84,8 +84,8 @@ final class ManifestMetadataReader {
         options.setEnableSessionTracking(sessionTrackingEnabled);
 
         if (options.getSampleRate() == null) {
-          // TODO: it needs to read a Float I guess
-          Double sampleRate = metadata.getDouble(SAMPLE_RATE, -1);
+          // manifest meta-data only reads floats
+          final Double sampleRate = ((Float) metadata.getFloat(SAMPLE_RATE, -1)).doubleValue();
           options.getLogger().log(SentryLevel.DEBUG, "sampleRate read: %s", sampleRate);
           if (sampleRate != -1) {
             options.setSampleRate(sampleRate);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -46,35 +46,35 @@ class ManifestMetadataReaderTest {
     fun `applyMetadata reads sampleRate from metadata`() {
         // Arrange
         val options = SentryAndroidOptions()
-        val expectedSampleRate = 0.99
+        val expectedSampleRate = 0.99f
 
         val bundle = Bundle()
         val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
-        bundle.putDouble(ManifestMetadataReader.SAMPLE_RATE, expectedSampleRate)
+        bundle.putFloat(ManifestMetadataReader.SAMPLE_RATE, expectedSampleRate)
 
         // Act
         ManifestMetadataReader.applyMetadata(mockContext, options)
 
         // Assert
-        assertEquals(expectedSampleRate, options.sampleRate)
+        assertEquals(expectedSampleRate.toDouble(), options.sampleRate)
     }
 
     @Test
     fun `applyMetadata does not override sampleRate from options`() {
         // Arrange
-        val expectedSampleRate = 0.99
+        val expectedSampleRate = 0.99f
         val options = SentryAndroidOptions()
-        options.sampleRate = expectedSampleRate
+        options.sampleRate = expectedSampleRate.toDouble()
 
         val bundle = Bundle()
         val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
-        bundle.putDouble(ManifestMetadataReader.SAMPLE_RATE, 0.1)
+        bundle.putFloat(ManifestMetadataReader.SAMPLE_RATE, 0.1f)
 
         // Act
         ManifestMetadataReader.applyMetadata(mockContext, options)
 
         // Assert
-        assertEquals(expectedSampleRate, options.sampleRate)
+        assertEquals(expectedSampleRate.toDouble(), options.sampleRate)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: read sample rate correctly from manifest meta data


## :bulb: Motivation and Context
sample rate from manifest was not being applied correctly
https://developer.android.com/guide/topics/manifest/meta-data-element


## :green_heart: How did you test it?
fixed unit tests and ran it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
