### PR TITLE
ref: remove log level as RN do not use it anymore

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidLogger.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidLogger.java
@@ -36,7 +36,6 @@ final class AndroidLogger implements ILogger {
       case FATAL:
         Log.wtf(tag, message, throwable);
         break;
-      case LOG:
       case DEBUG:
       default:
         Log.d(tag, message, throwable);
@@ -52,7 +51,6 @@ final class AndroidLogger implements ILogger {
         return Log.WARN;
       case FATAL:
         return Log.ASSERT;
-      case LOG:
       case DEBUG:
       default:
         return Log.DEBUG;

--- a/sentry/src/main/java/io/sentry/SentryLevel.java
+++ b/sentry/src/main/java/io/sentry/SentryLevel.java
@@ -2,8 +2,6 @@ package io.sentry;
 
 /** the SentryLevel */
 public enum SentryLevel {
-  /** LOG is used as a level in breadcrumbs from console.log in JS */
-  LOG,
   DEBUG,
   INFO,
   WARNING,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
ref: remove log level as RN do not use it anymore


## :bulb: Motivation and Context
we had level.LOG because of RN, but now we don't need it anymore, RN removed LOG and CRITICAL to be compatible with the unified API.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
