### PR TITLE
fix: set oss email on releases

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -109,7 +109,7 @@ object Config {
         val issueTracker = "https://github.com/getsentry/sentry-java/issues"
         val repository = "https://github.com/getsentry/sentry-java"
         val devName = "Sentry Team and Contributors"
-        val devEmail = "accounts@sentry.io"
+        val devEmail = "oss@sentry.io"
         val scmConnection = "scm:git:git://github.com/getsentry/sentry-java.git"
         val scmDevConnection = "scm:git:ssh://github.com:getsentry/sentry-java.git"
         val scmUrl = "https://github.com/getsentry/sentry-java/tree/main"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: set oss email on releases


## :bulb: Motivation and Context
oss@sentry.io is a public email and its read by the oss team


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
