### PR TITLE
fix: Do not set cookies when send pii is set to false.

### DIFF
--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 @Open
 public class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   private static final List<String> SENSITIVE_HEADERS =
-      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIES");
+      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE");
 
   private final @NotNull HttpServletRequest request;
   private final @NotNull SentryOptions options;

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
@@ -93,7 +93,7 @@ class SentryRequestHttpServletRequestProcessorTest {
             .header("X-FORWARDED-FOR", "192.168.0.1")
             .header("authorization", "Token")
             .header("Authorization", "Token")
-            .header("Cookies", "some cookies")
+            .header("Cookie", "some cookies")
             .buildRequest(MockServletContext())
         val sentryOptions = SentryOptions()
         sentryOptions.isSendDefaultPii = false
@@ -105,7 +105,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         assertFalse(event.request.headers.containsKey("X-FORWARDED-FOR"))
         assertFalse(event.request.headers.containsKey("Authorization"))
         assertFalse(event.request.headers.containsKey("authorization"))
-        assertFalse(event.request.headers.containsKey("Cookies"))
+        assertFalse(event.request.headers.containsKey("Cookie"))
         assertTrue(event.request.headers.containsKey("some-header"))
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes not setting cookie on Sentry Event when `default-send-pii` is set to `false`.
`Cookies` header name instead of `Cookie` has been used before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
