### PR TITLE
fix: Pop scope at the end of the request in Spring integration.

### DIFF
--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestFilter.java
@@ -38,7 +38,12 @@ public class SentryRequestFilter extends OncePerRequestFilter implements Ordered
         scope -> {
           scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(request, options));
         });
-    filterChain.doFilter(request, response);
+
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      hub.popScope();
+    }
   }
 
   @Override

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestFilterTest.kt
@@ -1,0 +1,50 @@
+package io.sentry.spring
+
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import io.sentry.Breadcrumb
+import io.sentry.IHub
+import io.sentry.SentryOptions
+import javax.servlet.FilterChain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class SentryRequestFilterTest {
+    private class Fixture {
+        val hub = mock<IHub>()
+        val filter = SentryRequestFilter(hub, SentryOptions())
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val filterChain = mock<FilterChain>()
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `pushes and pops scope in correct order`() {
+        fixture.filter.doFilterInternal(fixture.request, fixture.response, fixture.filterChain)
+
+        val inOrder = inOrder(fixture.filterChain, fixture.hub)
+        inOrder.verify(fixture.hub).pushScope()
+        inOrder.verify(fixture.filterChain).doFilter(fixture.request, fixture.response)
+        inOrder.verify(fixture.hub).popScope()
+    }
+
+    @Test
+    fun `adds breadcrumb when request gets initialized`() {
+        fixture.request.requestURI = "http://localhost:8080/some-uri"
+        fixture.request.method = "post"
+
+        fixture.filter.doFilterInternal(fixture.request, fixture.response, fixture.filterChain)
+
+        verify(fixture.hub).addBreadcrumb(check { it: Breadcrumb ->
+            assertEquals("http://localhost:8080/some-uri", it.getData("url"))
+            assertEquals("POST", it.getData("method"))
+            assertEquals("http", it.type)
+        })
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Pop scope at the end of the request in Spring integration.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Something we've missed before - scope should be popped at the end of the request.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes