### PR TITLE
fix: Enable Logback auto-configuration only when SentryAppender is on the classpath.

### DIFF
--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Configuration;
 /** Auto-configures {@link SentryAppender}. */
 @Configuration
 @Open
-@ConditionalOnClass(LoggerContext.class)
+@ConditionalOnClass({LoggerContext.class, SentryAppender.class})
 @ConditionalOnProperty(name = "sentry.logging.enabled", havingValue = "true", matchIfMissing = true)
 public class SentryLogbackAppenderAutoConfiguration implements InitializingBean {
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This change fixes following scenario:
When `sentry-logback` module was not on the classpath and Spring Boot application had dependency to `logback` (by default it has) application startup used to fail with `NoClassDefFoundException`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes