### PR TITLE
fix: if attach stack traces are enabled, it should attach current thread and its stack traces

### DIFF
--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -80,21 +80,21 @@ public final class MainEventProcessor implements EventProcessor {
       event.setSdk(options.getSdkVersion());
     }
 
-    // collecting threadIds that came from the exception mechanism, so we can mark threads as
-    // crashed properly
-    List<Long> mechanismThreadIds = null;
-    if (event.getExceptions() != null) {
-      for (SentryException item : event.getExceptions()) {
-        if (item.getMechanism() != null && item.getThreadId() != null) {
-          if (mechanismThreadIds == null) {
-            mechanismThreadIds = new ArrayList<>();
+    if (event.getThreads() == null) {
+      // collecting threadIds that came from the exception mechanism, so we can mark threads as
+      // crashed properly
+      List<Long> mechanismThreadIds = null;
+      if (event.getExceptions() != null) {
+        for (SentryException item : event.getExceptions()) {
+          if (item.getMechanism() != null && item.getThreadId() != null) {
+            if (mechanismThreadIds == null) {
+              mechanismThreadIds = new ArrayList<>();
+            }
+            mechanismThreadIds.add(item.getThreadId());
           }
-          mechanismThreadIds.add(item.getThreadId());
         }
       }
-    }
 
-    if (event.getThreads() == null) {
       if (options.isAttachThreads()) {
         event.setThreads(sentryThreadFactory.getCurrentThreads(mechanismThreadIds));
       } else if (options.isAttachStacktrace()) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -159,12 +159,13 @@ public class SentryOptions {
   /** Sets the distribution. Think about it together with release and environment */
   private @Nullable String dist;
 
-  /** When enabled, threads are automatically attached to all logged events. */
+  /** When enabled, all the threads are automatically attached to all logged events. */
   private boolean attachThreads;
 
   /**
    * When enabled, stack traces are automatically attached to all threads logged. Stack traces are
-   * always attached to exceptions but when this is set stack traces are also sent with threads
+   * always attached to exceptions but when this is set stack traces are also sent with threads. If
+   * no threads are logged, we log the current thread automatically.
    */
   private boolean attachStacktrace = true;
 

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -37,7 +37,7 @@ final class SentryStackTraceFactory {
       for (StackTraceElement item : elements) {
         if (item != null) {
 
-          // we don't want to add our own stack traces
+          // we don't want to add our own frames
           final String className = item.getClassName();
           if (className.startsWith("io.sentry.")) {
             continue;

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -36,10 +36,17 @@ final class SentryStackTraceFactory {
       sentryStackFrames = new ArrayList<>();
       for (StackTraceElement item : elements) {
         if (item != null) {
+
+          // we don't want to add our own stack traces
+          final String className = item.getClassName();
+          if (className.startsWith("io.sentry.")) {
+            continue;
+          }
+
           final SentryStackFrame sentryStackFrame = new SentryStackFrame();
           // https://docs.sentry.io/development/sdk-dev/features/#in-app-frames
-          sentryStackFrame.setInApp(isInApp(item.getClassName()));
-          sentryStackFrame.setModule(item.getClassName());
+          sentryStackFrame.setInApp(isInApp(className));
+          sentryStackFrame.setModule(className);
           sentryStackFrame.setFunction(item.getMethodName());
           sentryStackFrame.setFilename(item.getFileName());
           // Protocol doesn't accept negative line numbers.

--- a/sentry/src/main/java/io/sentry/SentryThreadFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryThreadFactory.java
@@ -5,6 +5,7 @@ import io.sentry.protocol.SentryStackTrace;
 import io.sentry.protocol.SentryThread;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -32,6 +33,22 @@ final class SentryThreadFactory {
     this.sentryStackTraceFactory =
         Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
     this.options = Objects.requireNonNull(options, "The SentryOptions is required");
+  }
+
+  /**
+   * Converts the current thread to a SentryThread, it assumes its being called from the captured
+   * thread.
+   *
+   * @param mechanismThreadIds list of threadIds that came from exception mechanism
+   * @return a list of SentryThread with a single item or null
+   */
+  @Nullable
+  List<SentryThread> getCurrentThread(final @Nullable List<Long> mechanismThreadIds) {
+    final Map<Thread, StackTraceElement[]> threads = new HashMap<>();
+    final Thread currentThread = Thread.currentThread();
+    threads.put(currentThread, currentThread.getStackTrace());
+
+    return getCurrentThreads(threads, mechanismThreadIds);
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -152,7 +152,7 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `when processing an event and attach threads is disabled, but attach threads is enabled, current thread should be set`() {
+    fun `when processing an event and attach threads is disabled, but attach stacktrace is enabled, current thread should be set`() {
         val sut = fixture.getSut(attachThreads = false, attachStackTrace = true)
 
         var event = SentryEvent()

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -25,8 +25,9 @@ class MainEventProcessorTest {
                 version = "1.2.3"
             }
         }
-        fun getSut(attachThreads: Boolean = true): MainEventProcessor {
+        fun getSut(attachThreads: Boolean = true, attachStackTrace: Boolean = true): MainEventProcessor {
             sentryOptions.isAttachThreads = attachThreads
+            sentryOptions.isAttachStacktrace = attachStackTrace
             return MainEventProcessor(sentryOptions)
         }
     }
@@ -132,7 +133,7 @@ class MainEventProcessorTest {
 
     @Test
     fun `when processing an event and attach threads is disabled, threads should not be set`() {
-        val sut = fixture.getSut(false)
+        val sut = fixture.getSut(attachThreads = false, attachStackTrace = false)
 
         var event = SentryEvent()
         event = sut.process(event, null)
@@ -148,6 +149,16 @@ class MainEventProcessorTest {
         event = sut.process(event, null)
 
         assertNotNull(event.threads)
+    }
+
+    @Test
+    fun `when processing an event and attach threads is disabled, but attach threads is enabled, current thread should be set`() {
+        val sut = fixture.getSut(attachThreads = false, attachStackTrace = true)
+
+        var event = SentryEvent()
+        event = sut.process(event, null)
+
+        assertEquals(1, event.threads.count())
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
@@ -3,8 +3,8 @@ package io.sentry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -23,7 +23,7 @@ class SentryThreadFactoryTest {
     fun `when getCurrentThreads is called, not empty result`() {
         val sut = fixture.getSut()
         val threads = sut.getCurrentThreads(null)
-        assertNotSame(0, threads!!.count())
+        assertNotEquals(0, threads!!.count())
     }
 
     @Test
@@ -81,5 +81,12 @@ class SentryThreadFactoryTest {
         val threads = sut.getCurrentThreads(threadList, threadIds)
 
         assertNotNull(threads!!.firstOrNull { it.isCrashed })
+    }
+
+    @Test
+    fun `when getCurrentThread is called, returns current thread`() {
+        val sut = fixture.getSut()
+        val threads = sut.getCurrentThread(null)
+        assertEquals(1, threads!!.count())
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: if attach stack traces are enabled, it should attach the current thread and its stack traces


## :bulb: Motivation and Context
we want the possibility to attach stack traces to improve grouping, but not all the threads, only the current one


## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
