### PR TITLE
fix: Do not pull sentry-logback dependency in projects using Spring Boot Starter

### DIFF
--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     compileOnly(Config.CompileOnly.jetbrainsAnnotations)
 
     // tests
+    testImplementation(project(":sentry-logback"))
     testImplementation(project(":sentry-test-support"))
     testImplementation(kotlin(Config.kotlinStdLib))
     testImplementation(Config.TestLibs.kotlinTestJunit)

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
     api(project(":sentry"))
     api(project(":sentry-spring"))
-    implementation(project(":sentry-logback"))
+    compileOnly(project(":sentry-logback"))
     implementation(Config.Libs.springBootStarter)
     implementation(Config.Libs.springWeb)
     implementation(Config.Libs.servletApi)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Change the dependency scope to `compileOnly` making it optional to use `sentry-logback` with Sentry Spring Boot Starter.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As [discussed](https://discordapp.com/channels/621778831602221064/621783601725308928/760775281148952626) with @marandaneto, following the [dependencies cost philosophy](https://develop.sentry.dev/sdk/philosophy/#dependencies-cost) using Logback with Spring Boot Starter should be an opt-in feature rather than a default behavior.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

Since Logback is the default logging framework in Spring Boot, and I believe most users would want to send error logs to Sentry I believe pulling `sentry-logback` with Sentry Spring Boot starter is a right behavior - even though it may violate the dependency cost philosophy. Users would have to add single dependency instead of two, wouldn't need to look in the docs on how to configure Logback once they have Spring Boot integration set up - the getting started experience would be better.

Perhaps we can discuss this again at one point and change the behaviour.