### PR TITLE
Add GitHub Action to validate presence of a changelog in a PR

### DIFF
--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -1,0 +1,31 @@
+name: changelog
+
+on: [pull_request]
+
+jobs:
+  validate-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Ensure Changelog.md was modified
+        shell: pwsh
+        run: |
+          $merge_base = git merge-base HEAD origin/${{ github.base_ref }}
+          $changes = git --no-pager diff --name-only HEAD $merge_base
+
+          echo 'Changed files:'
+          echo $changes
+
+          $contains_changelog = $changes -split '\n' -contains 'CHANGELOG.md'
+
+          if (-not $contains_changelog) {
+            echo '::error::Changelog has not been modified!'
+            exit 1
+          }
+
+          exit 0


### PR DESCRIPTION
## :loudspeaker: Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

GitHub Actions workflow that runs on PRs and fails if `CHANGELOG.md` was not modified as part of that PR. Should be merged after #961.

## :bulb: Motivation and Context

#960

## :green_heart: How did you test it?

I copy-pasted it from sentry-dotnet where it's already working

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Related to #960 #961