### PR TITLE
Fix 964

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.1
+
+* fix: Don't require `sentry.dsn` to be set when using `io.sentry:sentry-spring-boot-starter` and `io.sentry:sentry-logback` together
+
 # 3.0.0
 
 # Java + Android

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Configuration;
 @Open
 @ConditionalOnClass({LoggerContext.class, SentryAppender.class})
 @ConditionalOnProperty(name = "sentry.logging.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnBean(SentryProperties.class)
 public class SentryLogbackAppenderAutoConfiguration implements InitializingBean {
 
   @Autowired private SentryProperties sentryProperties;

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -29,10 +29,10 @@ class SentryLogbackAppenderAutoConfigurationTest {
     }
 
     @Test
-    fun `hub is not created when auto-configuration dsn is not set`() {
+    fun `does not configure SentryAppender when auto-configuration dsn is not set`() {
         contextRunner
             .run {
-                assertThat(it).doesNotHaveBean(IHub::class.java)
+                assertThat(rootLogger.getAppenders(SentryAppender::class.java)).isEmpty()
             }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

This only configures the logback appender when sentry is configured by making the sentry properties a dependency on the appender auto configuration being applied.

## :bulb: Motivation and Context

Make the configuration simpler when you don't want to use sentry (eg on developers machines)

## :green_heart: How did you test it?

- Built project locally and deployed to local maven repository and upgraded local project to 3.0.1-SNAPSHOT.
- Started up local project without `sentry.dsn` but with the sentry dependencies and checked it started.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
