### PR TITLE
Auto-configure inAppIncludes in Spring Boot integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.1
+
+* Auto-Configure `inAppIncludes` in Spring Boot integration
+
 # 3.0.0
 
 # Java + Android

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
@@ -1,0 +1,43 @@
+package io.sentry.spring.boot;
+
+import com.jakewharton.nopen.annotation.Open;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.BeansException;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+/**
+ * Resolves {@link SentryProperties} inAppIncludes by getting a package name from a class annotated
+ * with {@link SpringBootConfiguration} or another annotation meta-annotated with {@link
+ * SpringBootConfiguration} like {@link SpringBootApplication}.
+ */
+@Open
+class InAppIncludesResolver implements ApplicationContextAware {
+  @Nullable private ApplicationContext applicationContext;
+
+  @Nullable
+  List<String> resolveInAppIncludes() {
+    if (applicationContext != null) {
+      Map<String, Object> beansWithAnnotation =
+          applicationContext.getBeansWithAnnotation(SpringBootConfiguration.class);
+      return beansWithAnnotation.values().stream()
+          .map(bean -> bean.getClass().getPackage().getName())
+          .collect(Collectors.toList());
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public void setApplicationContext(@NotNull ApplicationContext applicationContext)
+      throws BeansException {
+    this.applicationContext = applicationContext;
+  }
+}

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
@@ -20,7 +20,7 @@ import org.springframework.context.ApplicationContextAware;
  */
 @Open
 class InAppIncludesResolver implements ApplicationContextAware {
-  @Nullable private ApplicationContext applicationContext;
+  private @Nullable ApplicationContext applicationContext;
 
   @Nullable
   List<String> resolveInAppIncludes() {

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -46,7 +46,8 @@ public class SentryAutoConfiguration {
         final @NotNull List<Integration> integrations,
         final @NotNull ObjectProvider<ITransportGate> transportGate,
         final @NotNull ObjectProvider<SentryUserProvider> sentryUserProviders,
-        final @NotNull ObjectProvider<ITransport> transport) {
+        final @NotNull ObjectProvider<ITransport> transport,
+        final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
@@ -58,7 +59,13 @@ public class SentryAutoConfiguration {
                     new SentryUserProviderEventProcessor(sentryUserProvider)));
         transportGate.ifAvailable(options::setTransportGate);
         transport.ifAvailable(options::setTransport);
+        inAppPackagesResolver.resolveInAppIncludes().forEach(options::addInAppInclude);
       };
+    }
+
+    @Bean
+    public @NotNull InAppIncludesResolver inAppPackagesResolver() {
+      return new InAppIncludesResolver();
     }
 
     @Bean

--- a/sentry-spring-boot-starter/src/test/kotlin/com/acme/MainBootClass.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/com/acme/MainBootClass.kt
@@ -1,0 +1,6 @@
+package com.acme
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+open class MainBootClass

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.spring.boot
 
+import com.acme.MainBootClass
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -202,6 +203,16 @@ class SentryAutoConfigurationTest {
                         assertThat(event.release).isEqualTo("my-release")
                     })
                 }
+            }
+    }
+
+    @Test
+    fun `sets inAppIncludes on SentryOptions from a class annotated with @SpringBootApplication`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
+            .withUserConfiguration(MainBootClass::class.java)
+            .run {
+                assertThat(it.getBean(SentryProperties::class.java).inAppIncludes)
+                    .containsOnly("com.acme")
             }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Auto-configure `inAppIncludes` in Spring Boot integration by getting a package name from `@SpringBootApplication` or `@SpringBootConfiguration` annotated classes.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Less configuration and better experience for our users.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes
