### PR TITLE
enha: make getThrowable public and improve set contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.0.1
 
 * fix: Don't require `sentry.dsn` to be set when using `io.sentry:sentry-spring-boot-starter` and `io.sentry:sentry-logback` together
+* Enhancement: make getThrowable public and improve set contexts #967
 
 # 3.0.0
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -9,7 +9,7 @@ object Config {
     val springKotlinCompatibleLanguageVersion = "1.3"
 
     object BuildPlugins {
-        val androidGradle = "com.android.tools.build:gradle:4.0.1"
+        val androidGradle = "com.android.tools.build:gradle:4.0.2"
         val kotlinGradlePlugin = "gradle-plugin"
         val buildConfig = "com.github.gmazzo.buildconfig"
         val buildConfigVersion = "2.0.2"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -9,7 +9,7 @@ object Config {
     val springKotlinCompatibleLanguageVersion = "1.3"
 
     object BuildPlugins {
-        val androidGradle = "com.android.tools.build:gradle:4.0.2"
+        val androidGradle = "com.android.tools.build:gradle:4.0.1"
         val kotlinGradlePlugin = "gradle-plugin"
         val buildConfig = "com.github.gmazzo.buildconfig"
         val buildConfigVersion = "2.0.2"

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.Appender
-import io.sentry.IHub
 import io.sentry.logback.SentryAppender
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.User;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -334,6 +335,42 @@ public final class Scope implements Cloneable {
    */
   public void setContexts(final @NotNull String key, final @NotNull Object value) {
     this.contexts.put(key, value);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull Boolean value) {
+    final Map<String, Boolean> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull String value) {
+    final Map<String, String> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull Number value) {
+    final Map<String, Number> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -374,6 +374,15 @@ public final class Scope implements Cloneable {
   }
 
   /**
+   * Removes a value from the Scope's contexts
+   *
+   * @param key the Key
+   */
+  public void removeContexts(final @NotNull String key) {
+    contexts.remove(key);
+  }
+
+  /**
    * Creates a breadcrumb list with the max number of breadcrumbs
    *
    * @param maxBreadcrumb the max number of breadcrumbs

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -14,7 +14,10 @@ import org.jetbrains.annotations.TestOnly;
 public final class SentryEvent implements IUnknownPropertiesConsumer {
   private SentryId eventId;
   private final Date timestamp;
-  private transient Throwable throwable;
+
+  /** The captured Throwable */
+  private transient @Nullable Throwable throwable;
+
   private Message message;
   private String serverName;
   private String platform;
@@ -43,7 +46,12 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     this.timestamp = timestamp;
   }
 
-  public SentryEvent(Throwable throwable) {
+  /**
+   * SentryEvent ctor with the captured Throwable
+   *
+   * @param throwable the Throwable or null
+   */
+  public SentryEvent(final @Nullable Throwable throwable) {
     this();
     this.throwable = throwable;
   }
@@ -66,9 +74,12 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     return (Date) timestamp.clone();
   }
 
-  @Nullable
-  @ApiStatus.Internal
-  public Throwable getThrowable() {
+  /**
+   * Returns the captured Throwable or null
+   *
+   * @return the Throwable or null
+   */
+  public @Nullable Throwable getThrowable() {
     return throwable;
   }
 
@@ -144,7 +155,12 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     this.eventId = eventId;
   }
 
-  public void setThrowable(Throwable throwable) {
+  /**
+   * Sets the Throwable
+   *
+   * @param throwable the Throwable or null
+   */
+  public void setThrowable(final @Nullable Throwable throwable) {
     this.throwable = throwable;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -606,12 +606,13 @@ class SentryClientTest {
         val sut = fixture.getSut()
 
         val scope = Scope(fixture.sentryOptions)
-        scope.setContexts("key", "value")
+        scope.setContexts("key", "abc")
         scope.startSession().current
         sut.captureEvent(SentryEvent(), scope, null)
         verify(fixture.connection).send(check {
             val event = getEventFromData(it.items.first().data)
-            assertEquals("value", event.contexts["key"])
+            val map = event.contexts["key"] as Map<*, *>
+            assertEquals("abc", map["value"])
         }, anyOrNull())
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
enha: make getThrowable public and improve set contexts


## :bulb: Motivation and Context
`getThrowable` is useful to use `instanceof` for filtering.
`setContexts` now have overloads for the most common data types as they need to be an object.


## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
