### PR TITLE
Accept quotes in external configuration properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Auto-Configure `inAppIncludes` in Spring Boot integration #966
 * Enhancement: make getThrowable public and improve set contexts #967
 * Bump: Android Gradle Plugin 4.0.2 #968
+* Enhancement: accepted quoted values in properties from external configuration
 
 # 3.0.0
 

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -65,7 +65,7 @@ tasks {
         dependsOn(jacocoTestReport)
     }
     test {
-        environment["SENTRY_TEST_PROPERTY"] = "some-value"
+        environment["SENTRY_TEST_PROPERTY"] = "\"some-value\""
     }
 }
 

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -1,6 +1,8 @@
 package io.sentry.config;
 
 import java.util.Locale;
+
+import io.sentry.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +15,7 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
-    return System.getenv(
-        PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.getDefault()));
+    return StringUtils.removeSurrounding(System.getenv(
+        PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.getDefault())), "\"");
   }
 }

--- a/sentry/src/main/java/io/sentry/config/SimplePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/SimplePropertiesProvider.java
@@ -1,6 +1,8 @@
 package io.sentry.config;
 
 import java.util.Properties;
+
+import io.sentry.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,6 +16,6 @@ final class SimplePropertiesProvider implements PropertiesProvider {
 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
-    return properties.getProperty(property);
+    return StringUtils.removeSurrounding(properties.getProperty(property), "\"");
   }
 }

--- a/sentry/src/main/java/io/sentry/config/SystemPropertyPropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/SystemPropertyPropertiesProvider.java
@@ -1,5 +1,6 @@
 package io.sentry.config;
 
+import io.sentry.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,6 +12,6 @@ final class SystemPropertyPropertiesProvider implements PropertiesProvider {
 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
-    return System.getProperty(PREFIX + "." + property);
+    return StringUtils.removeSurrounding(System.getProperty(PREFIX + "." + property), "\"");
   }
 }

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -34,4 +34,19 @@ public final class StringUtils {
 
     return str.substring(0, 1).toUpperCase(Locale.ROOT) + str.substring(1).toLowerCase(Locale.ROOT);
   }
+
+  /**
+   * Removes character specified by the delimiter parameter from the beginning and the end of the string.
+   *
+   * @param str the String to remove surrounding string from
+   * @param delimiter the String that is meant to be removed
+   * @return a string without delimiter character at the beginning and the end of the string
+   */
+  public static @Nullable String removeSurrounding(@Nullable final String str, @Nullable final String delimiter) {
+    if (str != null && delimiter != null && str.startsWith(delimiter) && str.endsWith(delimiter)) {
+      return str.substring(delimiter.length(), str.length() - delimiter.length());
+    } else {
+      return str;
+    }
+  }
 }

--- a/sentry/src/test/java/io/sentry/config/SimplePropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/SimplePropertiesProviderTest.kt
@@ -10,7 +10,7 @@ class SimplePropertiesProviderTest {
     @Test
     fun `when system property is set resolves property`() {
         val properties = Properties()
-        properties["some-property"] = "some-value"
+        properties["some-property"] = "\"some-value\""
         val provider = SimplePropertiesProvider(properties)
 
         val result = provider.getProperty("some-property")

--- a/sentry/src/test/java/io/sentry/config/SystemPropertyPropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/SystemPropertyPropertiesProviderTest.kt
@@ -15,7 +15,7 @@ class SystemPropertyPropertiesProviderTest {
 
     @Test
     fun `when system property is set resolves property`() {
-        System.setProperty("sentry.dsn", "some-dsn")
+        System.setProperty("sentry.dsn", "\"some-dsn\"")
         val result = provider.getProperty("dsn")
         assertEquals("some-dsn", result)
     }

--- a/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
@@ -54,4 +54,24 @@ class StringUtilsTest {
     fun `capitalize returns itself if empty`() {
         assertEquals("", StringUtils.capitalize(""))
     }
+
+    @Test
+    fun `removeSurrounding returns null if argument is null`() {
+        assertNull(StringUtils.removeSurrounding(null, "\""))
+    }
+
+    @Test
+    fun `removeSurrounding returns itself if delimiter is null`() {
+        assertEquals("test", StringUtils.removeSurrounding("test", null))
+    }
+
+    @Test
+    fun `removeSurrounding returns itself if first char is different from the last char`() {
+        assertEquals("'test$", StringUtils.removeSurrounding("'test$", "'"))
+    }
+
+    @Test
+    fun `removeSurrounding returns trimmed string if first char is the same as the last char and equal to delimiter`() {
+        assertEquals("test", StringUtils.removeSurrounding("\"test\"", "\""))
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Accept quotes in external configuration properties, like `SENTRY_DSN="..."`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users who migrate from old Sentry SDK version have this issue that they used to pass quoted values and now they don't work.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
