### PR TITLE
fix: remove chunked streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Auto-Configure `inAppIncludes` in Spring Boot integration #966
 * Enhancement: make getThrowable public and improve set contexts #967
 * Bump: Android Gradle Plugin 4.0.2 #968
-* Enhancement: accepted quoted values in properties from external configuration
+* Enhancement: accepted quoted values in properties from external configuration #972
+* fix: remove chunked streaming mode #974
 
 # 3.0.0
 

--- a/sentry/src/main/java/io/sentry/transport/HttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/HttpTransport.java
@@ -224,7 +224,6 @@ public class HttpTransport implements ITransport {
 
     connection.setRequestMethod("POST");
     connection.setDoOutput(true);
-    connection.setChunkedStreamingMode(0);
 
     connection.setRequestProperty("Content-Encoding", "gzip");
     connection.setRequestProperty("Content-Type", "application/x-sentry-envelope");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: remove chunked streaming mode


## :bulb: Motivation and Context
some http servers have limitations and this was experienced on on-premise v9.x
https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html#setChunkedStreamingMode-int-

reported by @ninniuz

## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
