### PR TITLE
Build distribution zip files & upload to Zeus

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.diffplug.spotless.LineEnding
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
@@ -53,6 +54,20 @@ allprojects {
         withType<JavaCompile> {
             options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing"))
         }
+    }
+}
+
+subprojects {
+    if (!this.name.contains("sample") && this.name != "sentry-test-support") {
+        apply<DistributionPlugin>()
+
+        configure<DistributionContainer> {
+            this.getByName("main").contents {
+                from("build/libs")
+                from("build/publications/maven")
+            }
+        }
+        tasks.named("distZip").dependsOn("publishToMavenLocal")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.diffplug.spotless.LineEnding
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,15 @@ subprojects {
                 from("build/publications/release")
             }
         }
-        tasks.named("distZip").dependsOn("publishToMavenLocal")
+        tasks.named("distZip").configure {
+            this.dependsOn("publishToMavenLocal")
+            this.doLast {
+                val distributionFilePath = "${this.project.buildDir}/distributions/${this.project.name}-${this.project.version}.zip"
+                val file = File(distributionFilePath)
+                if (!file.exists()) throw IllegalStateException("Distribution file: $distributionFilePath does not exist")
+                if (file.length() == 0L) throw IllegalStateException("Distribution file: $distributionFilePath is empty")
+            }
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,8 +63,12 @@ subprojects {
 
         configure<DistributionContainer> {
             this.getByName("main").contents {
+                // non android modules
                 from("build/libs")
                 from("build/publications/maven")
+                // android modules
+                from("build/outputs/aar")
+                from("build/publications/release")
             }
         }
         tasks.named("distZip").dependsOn("publishToMavenLocal")

--- a/scripts/zeus.sh
+++ b/scripts/zeus.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Redirect stderr to stdout to avoid weird Powershell errors
+exec 2>&1
+set -x
+
+export PATH=./node_modules/.bin:$PATH
+
+upload_artifacts() {
+  zeus upload -t "application/x-java-archive" ./*/build/distributions/*.zip
+  zeus job update --status=passed
+}
+
+
+report_pending() {
+  zeus job update --status=pending
+}
+
+
+report_failed() {
+  zeus job update --status=failed
+}
+
+
+check_branch() {
+  # Ignore errors if not on release branch
+  if [[ ! "${APPVEYOR_REPO_BRANCH:-}" =~ ^main/ ]]; then
+    trap - EXIT
+    echo "Not on a release branch, ignoring all errors, if any."
+    exit 0
+  fi
+}
+
+trap check_branch EXIT
+
+command="${1:-}"
+if [[ "$command" == "upload_artifacts" ]]; then
+  upload_artifacts
+elif [[ "$command" == "report_pending" ]]; then
+  report_pending
+elif [[ "$command" == "report_failed" ]]; then
+  report_failed
+else
+  echo "Invalid command"
+  exit 1
+fi

--- a/sentry-android/build.gradle.kts
+++ b/sentry-android/build.gradle.kts
@@ -5,6 +5,17 @@ plugins {
     kotlin("android")
     id(Config.Deploy.novodaBintray)
     id(Config.QualityPlugins.gradleVersions)
+    distribution
+}
+
+// overwrite distributions config from the root project
+distributions {
+    main {
+        contents {
+            from("build/outputs/aar")
+            from("build/publications/release")
+        }
+    }
 }
 
 android {

--- a/sentry-android/build.gradle.kts
+++ b/sentry-android/build.gradle.kts
@@ -5,17 +5,6 @@ plugins {
     kotlin("android")
     id(Config.Deploy.novodaBintray)
     id(Config.QualityPlugins.gradleVersions)
-    distribution
-}
-
-// overwrite distributions config from the root project
-distributions {
-    main {
-        contents {
-            from("build/outputs/aar")
-            from("build/publications/release")
-        }
-    }
 }
 
 android {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Build distribution zip files containing all files needed to be published to Maven.

Executing `./gradlew distZip` creates in each module that is meant to be published (not in samples or support modules) a file `build/distributions/<module-name>-<version>.zip`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Solves #950, #951 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
Find out how to publish files to Maven repository using either plain HTTP requests, Maven or Gradle (#952).