### PR TITLE
fix: fix setting up Sentry in Spring Webflux annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1
+
+* fix: fix setting up Sentry in Spring Webflux annotation by changing the scope of Spring WebMvc related dependencies
+
 # 3.1.0
 
 * fix: Don't require `sentry.dsn` to be set when using `io.sentry:sentry-spring-boot-starter` and `io.sentry:sentry-logback` together #965

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     api(project(":sentry-spring"))
     compileOnly(project(":sentry-logback"))
     implementation(Config.Libs.springBootStarter)
-    implementation(Config.Libs.springWeb)
-    implementation(Config.Libs.servletApi)
+    compileOnly(Config.Libs.springWeb)
+    compileOnly(Config.Libs.servletApi)
 
     annotationProcessor(Config.AnnotationProcessors.springBootAutoConfigure)
     annotationProcessor(Config.AnnotationProcessors.springBootConfiguration)

--- a/sentry-spring/build.gradle.kts
+++ b/sentry-spring/build.gradle.kts
@@ -34,8 +34,8 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     api(project(":sentry"))
-    implementation(Config.Libs.springWeb)
-    implementation(Config.Libs.servletApi)
+    compileOnly(Config.Libs.springWeb)
+    compileOnly(Config.Libs.servletApi)
 
     compileOnly(Config.CompileOnly.nopen)
     errorprone(Config.CompileOnly.nopenChecker)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix setting up Sentry in Spring Webflux annotation by changing the scope of Spring WebMvc related dependencies.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Although we do not support decorating events with HTTP data in Spring Webflux, we should still auto-configure `Hub` and most importantly not cause application to fail to start.

Fixes gh-980


## :green_heart: How did you test it?

Sample project with both webflux and webmvc dependencies in all combinations.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
