### PR TITLE
Fix SentryUserProvider execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.1
 
+* fix: Make sure HttpServletRequestSentryUserProvider runs by default before custom SentryUserProvider beans
 * fix: fix setting up Sentry in Spring Webflux annotation by changing the scope of Spring WebMvc related dependencies
 
 # 3.1.0

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -45,7 +45,7 @@ public class SentryAutoConfiguration {
         final @NotNull List<EventProcessor> eventProcessors,
         final @NotNull List<Integration> integrations,
         final @NotNull ObjectProvider<ITransportGate> transportGate,
-        final @NotNull ObjectProvider<SentryUserProvider> sentryUserProviders,
+        final @NotNull List<SentryUserProvider> sentryUserProviders,
         final @NotNull ObjectProvider<ITransport> transport,
         final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -24,6 +24,7 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
       if (applicationContext != null) {
         applicationContext
             .getBeanProvider(SentryUserProvider.class)
+            .orderedStream()
             .forEach(
                 sentryUserProvider ->
                     options.addEventProcessor(

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
@@ -7,6 +7,7 @@ import io.sentry.util.Objects;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -42,7 +43,8 @@ public final class SentryUserProviderEventProcessor implements EventProcessor {
   }
 
   @NotNull
-  SentryUserProvider getSentryUserProvider() {
+  @ApiStatus.Internal
+  public SentryUserProvider getSentryUserProvider() {
     return sentryUserProvider;
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryWebConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryWebConfiguration.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.annotation.Order;
 
 /** Registers Spring Web specific Sentry beans. */
 @Configuration
@@ -15,6 +16,7 @@ public class SentryWebConfiguration {
 
   @Bean
   @Lazy
+  @Order(0)
   public @NotNull HttpServletRequestSentryUserProvider httpServletRequestSentryUserProvider(
       final @NotNull SentryOptions sentryOptions) {
     return new HttpServletRequestSentryUserProvider(sentryOptions);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Make sure HttpServletRequestSentryUserProvider runs by default before custom SentryUserProvider beans. This lets custom user providers overwrite properties set before by built in SentryUserProviders. 

In addition to that, users now can define `@Order` on custom user provider beans deciding at the same time if they run before or after built in SentryUserProviders.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue reported by @bruno-garcia 


## :green_heart: How did you test it?

Added integration tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes
