### PR TITLE
Bind logging related SentryProperties to Slf4j Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.1
 
+* Enhancement: Bind logging related SentryProperties to Slf4j Level instead of Logback to improve Log4j2 compatibility
 * fix: Make sure HttpServletRequestSentryUserProvider runs by default before custom SentryUserProvider beans
 * fix: fix setting up Sentry in Spring Webflux annotation by changing the scope of Spring WebMvc related dependencies
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
@@ -1,5 +1,6 @@
 package io.sentry.spring.boot;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -36,8 +37,10 @@ public class SentryLogbackAppenderAutoConfiguration implements InitializingBean 
       sentryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
 
       Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
+          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
           .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);
       Optional.ofNullable(sentryProperties.getLogging().getMinimumEventLevel())
+          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
           .ifPresent(sentryAppender::setMinimumEventLevel);
 
       sentryAppender.start();

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -1,10 +1,10 @@
 package io.sentry.spring.boot;
 
-import ch.qos.logback.classic.Level;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.SentryOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.event.Level;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** Configuration for Sentry integration. */


### PR DESCRIPTION

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Bind logging related SentryProperties to Slf4j Level instead of Logback to improve Log4j2 compatibility



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes gh-985

## :green_heart: How did you test it?

Integration tests cover it.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes