### PR TITLE
Prevent Logback and Log4j2 integrations from re-initializing Sentry when Sentry is already initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.1
 
+* fix: Prevent Logback and Log4j2 integrations from re-initializing Sentry when Sentry is already initialized
 * Enhancement: Bind logging related SentryProperties to Slf4j Level instead of Logback to improve Log4j2 compatibility
 * fix: Make sure HttpServletRequestSentryUserProvider runs by default before custom SentryUserProvider beans
 * fix: fix setting up Sentry in Spring Webflux annotation by changing the scope of Spring WebMvc related dependencies

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -95,17 +95,19 @@ public final class SentryAppender extends AbstractAppender {
 
   @Override
   public void start() {
-    try {
-      Sentry.init(
-          options -> {
-            options.setEnableExternalConfiguration(true);
-            options.setDsn(dsn);
-            options.setSentryClientName(BuildConfig.SENTRY_LOG4J2_SDK_NAME);
-            options.setSdkVersion(createSdkVersion(options));
-            Optional.ofNullable(transport).ifPresent(options::setTransport);
-          });
-    } catch (IllegalArgumentException e) {
-      LOGGER.info("Failed to init Sentry during appender initialization: " + e.getMessage());
+    if (!Sentry.isEnabled()) {
+      try {
+        Sentry.init(
+            options -> {
+              options.setEnableExternalConfiguration(true);
+              options.setDsn(dsn);
+              options.setSentryClientName(BuildConfig.SENTRY_LOG4J2_SDK_NAME);
+              options.setSdkVersion(createSdkVersion(options));
+              Optional.ofNullable(transport).ifPresent(options::setTransport);
+            });
+      } catch (IllegalArgumentException e) {
+        LOGGER.info("Failed to init Sentry during appender initialization: " + e.getMessage());
+      }
     }
     super.start();
   }

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -35,16 +35,17 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
 
   @Override
   public void start() {
-    options.setEnableExternalConfiguration(true);
-    options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
-    options.setSdkVersion(createSdkVersion(options));
-    Optional.ofNullable(transport).ifPresent(options::setTransport);
-    try {
-      Sentry.init(options);
-    } catch (IllegalArgumentException e) {
-      addWarn("Failed to init Sentry during appender initialization: " + e.getMessage());
+    if (!Sentry.isEnabled()) {
+      options.setEnableExternalConfiguration(true);
+      options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
+      options.setSdkVersion(createSdkVersion(options));
+      Optional.ofNullable(transport).ifPresent(options::setTransport);
+      try {
+        Sentry.init(options);
+      } catch (IllegalArgumentException e) {
+        addWarn("Failed to init Sentry during appender initialization: " + e.getMessage());
+      }
     }
-
     super.start();
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Prevent Logback and Log4j2 integrations from re-initializing Sentry when Sentry is already initialized

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When `SENTRY_DSN` env property is provided, Logback integration overwrites configuration coming from Spring Boot integration.

When Logback and Spring Boot integrations are used together, Logback's SentryAppender should not re-initialize Sentry.

Same applies to Log4j2.

Fixes gh-988
Fixes gh-976

## :green_heart: How did you test it?

On the top of integration tests, tested with sample project on the side.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes