### PR TITLE
enha: use AGP 4.1 and prefab to publish native libs

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -9,7 +9,7 @@ object Config {
     val springKotlinCompatibleLanguageVersion = "1.3"
 
     object BuildPlugins {
-        val androidGradle = "com.android.tools.build:gradle:4.0.2"
+        val androidGradle = "com.android.tools.build:gradle:4.1.0"
         val kotlinGradlePlugin = "gradle-plugin"
         val buildConfig = "com.github.gmazzo.buildconfig"
         val buildConfigVersion = "2.0.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,3 @@ android.defaults.buildfeatures.resvalues=false
 
 # disable automatically adding Kotlin stdlib to compile dependencies
 kotlin.stdlib.default.dependency=false
-
-# TODO: Enable Prefab https://android-developers.googleblog.com/2020/02/native-dependencies-in-android-studio-40.html
-# android.enablePrefab=true
-# android.prefabVersion=1.0.0

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -23,6 +23,7 @@ android {
         versionCode = project.properties[Config.Sentry.buildVersionCodeProp].toString().toInt()
 
         buildConfigField("String", "SENTRY_ANDROID_SDK_NAME", "\"${Config.Sentry.SENTRY_ANDROID_SDK_NAME}\"")
+        buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
     }
 
     buildTypes {
@@ -46,13 +47,13 @@ android {
         unitTests.apply {
             isReturnDefaultValues = true
             isIncludeAndroidResources = true
-            all(KotlinClosure1<Any, Test>({
-                (this as Test).also { testTask ->
-                    testTask.extensions
-                        .getByType(JacocoTaskExtension::class.java)
-                        .isIncludeNoLocationClasses = true
-                }
-            }, this))
+//            all(KotlinClosure1<Any, Test>({
+//                (this as Test).also { testTask ->
+//                    testTask.extensions
+//                        .getByType(JacocoTaskExtension::class.java)
+//                        .isIncludeNoLocationClasses = true
+//                }
+//            }, this))
         }
     }
 

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("android")
     jacoco
     id(Config.Deploy.novodaBintray)
-    id(Config.NativePlugins.nativeBundleExport)
+//    id(Config.NativePlugins.nativeBundleExport)
     id(Config.QualityPlugins.gradleVersions)
 }
 
@@ -39,15 +39,17 @@ android {
         }
 
         ndk {
-            setAbiFilters(Config.Android.abiFilters)
+            abiFilters.addAll(Config.Android.abiFilters)
             ndkVersion = Config.Android.ndkVersion
         }
+
+        buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
     }
 
     externalNativeBuild {
         cmake {
             version = Config.Android.cmakeVersion
-            setPath("CMakeLists.txt")
+            path("CMakeLists.txt")
         }
     }
 
@@ -72,13 +74,13 @@ android {
         unitTests.apply {
             isReturnDefaultValues = true
             isIncludeAndroidResources = true
-            all(KotlinClosure1<Any, Test>({
-                (this as Test).also { testTask ->
-                    testTask.extensions
-                        .getByType(JacocoTaskExtension::class.java)
-                        .isIncludeNoLocationClasses = true
-                }
-            }, this))
+//            all(KotlinClosure1<Any, Test>({
+//                (this as Test).also { testTask ->
+//                    testTask.extensions
+//                        .getByType(JacocoTaskExtension::class.java)
+//                        .isIncludeNoLocationClasses = true
+//                }
+//            }, this))
         }
     }
 
@@ -90,13 +92,23 @@ android {
         isCheckReleaseBuilds = false
     }
 
-    nativeBundleExport {
-        headerDir = "${project.projectDir}/$sentryNativeSrc/include"
-    }
+//    nativeBundleExport {
+//        headerDir = "${project.projectDir}/$sentryNativeSrc/include"
+//    }
 
     // needed because of Kotlin 1.4.x
     configurations.all {
         resolutionStrategy.force(Config.CompileOnly.jetbrainsAnnotations)
+    }
+
+    buildFeatures {
+        prefabPublishing = true
+    }
+
+    prefab {
+        create("sentry-android") {
+            headers = "$sentryNativeSrc/include"
+        }
     }
 }
 

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -23,6 +23,8 @@ android {
 
         versionName = project.version.toString()
         versionCode = project.properties[Config.Sentry.buildVersionCodeProp].toString().toInt()
+
+        buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
     }
 
     buildTypes {
@@ -46,13 +48,13 @@ android {
         unitTests.apply {
             isReturnDefaultValues = true
             isIncludeAndroidResources = true
-            all(KotlinClosure1<Any, Test>({
-                (this as Test).also { testTask ->
-                    testTask.extensions
-                            .getByType(JacocoTaskExtension::class.java)
-                            .isIncludeNoLocationClasses = true
-                }
-            }, this))
+//            all(KotlinClosure1<Any, Test>({
+//                (this as Test).also { testTask ->
+//                    testTask.extensions
+//                            .getByType(JacocoTaskExtension::class.java)
+//                            .isIncludeNoLocationClasses = true
+//                }
+//            }, this))
         }
     }
 

--- a/sentry-samples/sentry-samples-android/CMakeLists.txt
+++ b/sentry-samples/sentry-samples-android/CMakeLists.txt
@@ -3,11 +3,12 @@ project(Sentry-Sample LANGUAGES C CXX)
 
 add_library(native-sample SHARED src/main/cpp/native-sample.cpp)
 
-add_subdirectory(../../sentry-android-ndk/${SENTRY_NATIVE_SRC} sentry_build)
+#add_subdirectory(../../sentry-android-ndk/${SENTRY_NATIVE_SRC} sentry_build)
+find_package(sentry-android REQUIRED CONFIG)
 
 find_library(LOG_LIB log)
 
 target_link_libraries(native-sample PRIVATE
     ${LOG_LIB}
-    $<BUILD_INTERFACE:sentry::sentry>
+    sentry-android::sentry-android
 )

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         }
 
         ndk {
-            setAbiFilters(Config.Android.abiFilters)
+            abiFilters.addAll(Config.Android.abiFilters)
             ndkVersion = Config.Android.ndkVersion
         }
     }
@@ -49,7 +49,7 @@ android {
     externalNativeBuild {
         cmake {
             version = Config.Android.cmakeVersion
-            setPath("CMakeLists.txt")
+            path("CMakeLists.txt")
         }
     }
 
@@ -64,10 +64,10 @@ android {
 
     buildTypes {
         getByName("debug") {
-            manifestPlaceholders = mapOf(
+            addManifestPlaceholders(mapOf(
                 "sentryDebug" to true,
                 "sentryEnvironment" to "debug"
-            )
+            ))
         }
         getByName("release") {
             isMinifyEnabled = true
@@ -75,10 +75,10 @@ android {
             signingConfig = signingConfigs.getByName("debug") // to be able to run release mode
             isShrinkResources = true
 
-            manifestPlaceholders = mapOf(
+            addManifestPlaceholders(mapOf(
                 "sentryDebug" to false,
                 "sentryEnvironment" to "release"
-            )
+            ))
         }
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
enha: use AGP 4.1 and prefab to publish native libs


## :bulb: Motivation and Context
so people don't need to use a 3rd party plugin to copy the header file.
https://docs.sentry.io/platforms/android/usage/advanced-usage/#integrating-the-ndk


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
