### PR TITLE
Fix #1012 - Make public the Breadcrumb constructor that accepts a Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.1.2
 
 * Enhancement: Set environment to "production" by default.
+* Enhancement: Make public the Breadcrumb constructor that accepts a Date #1012
 
 # 3.1.1
 

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -39,7 +39,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
    *
    * @param timestamp the timestamp
    */
-  Breadcrumb(final @Nullable Date timestamp) {
+  public Breadcrumb(final @Nullable Date timestamp) {
     this.timestamp = timestamp;
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Make public the Breadcrumb constructor that accepts a Date. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Apps should be able to record breadcrumbs at a particular time and then store them for a while, before delivering them at a later point. The timestamp of their creation, not their delivery to Sentry, should be preserved. 

## :green_heart: How did you test it?
Ran `make compile` with Java 1.8 on OSX. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
