### PR TITLE
Do not exclude stack trace elements from samples.

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -39,7 +39,7 @@ final class SentryStackTraceFactory {
 
           // we don't want to add our own frames
           final String className = item.getClassName();
-          if (className.startsWith("io.sentry.")) {
+          if (className.startsWith("io.sentry.") && !className.startsWith("io.sentry.samples.")) {
             continue;
           }
 

--- a/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
@@ -3,6 +3,7 @@ package io.sentry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -144,11 +145,22 @@ class SentryStackTraceFactoryTest {
 
     @Test
     fun `when getStackFrames is called, remove sentry classes`() {
-        val stacktrace = Thread.currentThread().stackTrace
+        var stacktrace = Thread.currentThread().stackTrace
         val sentryElement = StackTraceElement("io.sentry.element", "test", "test.java", 1)
-        stacktrace.plusElement(sentryElement)
+        stacktrace = stacktrace.plusElement(sentryElement)
 
         assertNull(sut.getStackFrames(stacktrace)!!.find {
+            it.module.startsWith("io.sentry")
+        })
+    }
+
+    @Test
+    fun `when getStackFrames is called, does not remove sentry samples classes`() {
+        var stacktrace = Thread.currentThread().stackTrace
+        val sentryElement = StackTraceElement("io.sentry.samples.element", "test", "test.java", 1)
+        stacktrace = stacktrace.plusElement(sentryElement)
+
+        assertNotNull(sut.getStackFrames(stacktrace)!!.find {
             it.module.startsWith("io.sentry")
         })
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Do not exclude stack trace elements from samples. 

Bonus: fixed test.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It took me a while to figure out why errors reported in samples do not have the actual class that triggered the exception in the stack trace when running samples.

## :green_heart: How did you test it?

Unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes