### PR TITLE
fix: use neutral Locale for String operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Increase max cached events to 30 (#1029)
 * Normalize DSN URI (#1030)
+* fix: use neutral Locale for String operations #1033
 
 # 3.1.2
 

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -55,7 +55,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
     breadcrumb.setType("http");
     breadcrumb.setCategory("http");
     breadcrumb.setData("url", url);
-    breadcrumb.setData("method", method.toUpperCase(Locale.getDefault()));
+    breadcrumb.setData("method", method.toUpperCase(Locale.ROOT));
     return breadcrumb;
   }
 

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -15,7 +15,6 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
     return StringUtils.removeSurrounding(
-        System.getenv(PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT)),
-        "\"");
+        System.getenv(PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT)), "\"");
   }
 }

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -15,7 +15,7 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
     return StringUtils.removeSurrounding(
-        System.getenv(PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.getDefault())),
+        System.getenv(PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT)),
         "\"");
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: use neutral Locale for String operations


## :bulb: Motivation and Context
All the other String operations already a neutral Locale


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
