### PR TITLE
Resolve HTTP Proxy parameters from the external configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Increase max cached events to 30 (#1029)
 * Normalize DSN URI (#1030)
+* Enhancement: Resolve HTTP Proxy parameters from the external configuration (#1028)
 
 # 3.1.2
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -92,7 +92,11 @@ class SentryAutoConfigurationTest {
             "sentry.dist=my-dist",
             "sentry.attach-threads=true",
             "sentry.attach-stacktrace=true",
-            "sentry.server-name=host-001"
+            "sentry.server-name=host-001",
+            "sentry.proxy.host=example.proxy.com",
+            "sentry.proxy.port=8090",
+            "sentry.proxy.user=proxy-user",
+            "sentry.proxy.pass=proxy-pass"
         ).run {
             val options = it.getBean(SentryOptions::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -110,6 +114,11 @@ class SentryAutoConfigurationTest {
             assertThat(options.isAttachThreads).isEqualTo(true)
             assertThat(options.isAttachStacktrace).isEqualTo(true)
             assertThat(options.serverName).isEqualTo("host-001")
+            assertThat(options.proxy).isNotNull()
+            assertThat(options.proxy!!.host).isEqualTo("example.proxy.com")
+            assertThat(options.proxy!!.port).isEqualTo("8090")
+            assertThat(options.proxy!!.user).isEqualTo("proxy-user")
+            assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
         }
     }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -26,6 +26,9 @@ public class SentryOptions {
   /** Default Log level if not specified Default is DEBUG */
   static final SentryLevel DEFAULT_DIAGNOSTIC_LEVEL = SentryLevel.DEBUG;
 
+  /** The default HTTP proxy port to use if an HTTP Proxy hostname is set but port is not. */
+  private static final String PROXY_PORT_DEFAULT = "80";
+
   /**
    * Are callbacks that run for every event. They can either return a new event which in most cases
    * means just adding data OR return null in case the event will be dropped and not sent.
@@ -241,9 +244,9 @@ public class SentryOptions {
     final String proxyHost = propertiesProvider.getProperty("proxy.host");
     final String proxyUser = propertiesProvider.getProperty("proxy.user");
     final String proxyPass = propertiesProvider.getProperty("proxy.pass");
-    final String proxyPort = propertiesProvider.getProperty("proxy.port");
+    final String proxyPort = propertiesProvider.getProperty("proxy.port", PROXY_PORT_DEFAULT);
 
-    if (proxyHost != null && proxyPort != null) {
+    if (proxyHost != null) {
       options.setProxy(new Proxy(proxyHost, proxyPort, proxyUser, proxyPass));
     }
     return options;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -10,7 +10,6 @@ import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.transport.NoOpTransport;
 import io.sentry.transport.NoOpTransportGate;
 import java.io.File;
-import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -238,6 +237,15 @@ public class SentryOptions {
     options.setRelease(propertiesProvider.getProperty("release"));
     options.setDist(propertiesProvider.getProperty("dist"));
     options.setServerName(propertiesProvider.getProperty("servername"));
+
+    final String proxyHost = propertiesProvider.getProperty("proxy.host");
+    final String proxyUser = propertiesProvider.getProperty("proxy.user");
+    final String proxyPass = propertiesProvider.getProperty("proxy.pass");
+    final String proxyPort = propertiesProvider.getProperty("proxy.port");
+
+    if (proxyHost != null && proxyPort != null) {
+      options.setProxy(new Proxy(proxyHost, proxyPort, proxyUser, proxyPass));
+    }
     return options;
   }
 
@@ -1129,6 +1137,9 @@ public class SentryOptions {
     if (options.getServerName() != null) {
       setServerName(options.getServerName());
     }
+    if (options.getProxy() != null) {
+      setProxy(options.getProxy());
+    }
   }
 
   private @NotNull SdkVersion createSdkVersion() {
@@ -1140,5 +1151,63 @@ public class SentryOptions {
     sdkVersion.addPackage("maven:sentry", version);
 
     return sdkVersion;
+  }
+
+  public static final class Proxy {
+    private @Nullable String host;
+    private @Nullable String port;
+    private @Nullable String user;
+    private @Nullable String pass;
+
+    public Proxy(
+        final @Nullable String host,
+        final @Nullable String port,
+        final @Nullable String user,
+        final @Nullable String pass) {
+      this.host = host;
+      this.port = port;
+      this.user = user;
+      this.pass = pass;
+    }
+
+    public Proxy() {
+      this(null, null, null, null);
+    }
+
+    public Proxy(@Nullable String host, @Nullable String port) {
+      this(host, port, null, null);
+    }
+
+    public @Nullable String getHost() {
+      return host;
+    }
+
+    public void setHost(final @Nullable String host) {
+      this.host = host;
+    }
+
+    public @Nullable String getPort() {
+      return port;
+    }
+
+    public void setPort(final @Nullable String port) {
+      this.port = port;
+    }
+
+    public @Nullable String getUser() {
+      return user;
+    }
+
+    public void setUser(final @Nullable String user) {
+      this.user = user;
+    }
+
+    public @Nullable String getPass() {
+      return pass;
+    }
+
+    public void setPass(final @Nullable String pass) {
+      this.pass = pass;
+    }
   }
 }

--- a/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
@@ -12,4 +12,17 @@ public interface PropertiesProvider {
    */
   @Nullable
   String getProperty(@NotNull String property);
+
+  /**
+   * Resolves property given by it's name.
+   *
+   * @param property - the property name
+   * @param defaultValue - the default value if property is not set
+   * @return property value or the default value if not found.
+   */
+  @NotNull
+  default String getProperty(@NotNull String property, @NotNull String defaultValue) {
+    final String result = getProperty(property);
+    return result != null ? result : defaultValue;
+  }
 }

--- a/sentry/src/main/java/io/sentry/transport/AuthenticatorWrapper.java
+++ b/sentry/src/main/java/io/sentry/transport/AuthenticatorWrapper.java
@@ -1,4 +1,4 @@
-§package io.sentry.transport;
+package io.sentry.transport;
 
 import java.net.Authenticator;
 import org.jetbrains.annotations.NotNull;

--- a/sentry/src/main/java/io/sentry/transport/AuthenticatorWrapper.java
+++ b/sentry/src/main/java/io/sentry/transport/AuthenticatorWrapper.java
@@ -1,0 +1,19 @@
+§package io.sentry.transport;
+
+import java.net.Authenticator;
+import org.jetbrains.annotations.NotNull;
+
+/** Wraps {@link Authenticator} in order to make classes that use it testable. */
+final class AuthenticatorWrapper {
+  private static final AuthenticatorWrapper instance = new AuthenticatorWrapper();
+
+  public static AuthenticatorWrapper getInstance() {
+    return instance;
+  }
+
+  private AuthenticatorWrapper() {}
+
+  public void setDefault(final @NotNull Authenticator authenticator) {
+    Authenticator.setDefault(authenticator);
+  }
+}

--- a/sentry/src/main/java/io/sentry/transport/ProxyAuthenticator.java
+++ b/sentry/src/main/java/io/sentry/transport/ProxyAuthenticator.java
@@ -1,0 +1,38 @@
+package io.sentry.transport;
+
+import io.sentry.util.Objects;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import org.jetbrains.annotations.NotNull;
+
+final class ProxyAuthenticator extends Authenticator {
+  private final @NotNull String user;
+  private final @NotNull String password;
+
+  /**
+   * Proxy authenticator.
+   *
+   * @param user proxy username
+   * @param password proxy password
+   */
+  ProxyAuthenticator(final @NotNull String user, final @NotNull String password) {
+    this.user = Objects.requireNonNull(user, "user is required");
+    this.password = Objects.requireNonNull(password, "password is required");
+  }
+
+  @Override
+  protected PasswordAuthentication getPasswordAuthentication() {
+    if (getRequestorType() == RequestorType.PROXY) {
+      return new PasswordAuthentication(user, password.toCharArray());
+    }
+    return null;
+  }
+
+  String getUser() {
+    return user;
+  }
+
+  String getPassword() {
+    return password;
+  }
+}

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -211,4 +211,24 @@ class SentryOptionsTest {
             temporaryFolder.delete()
         }
     }
+
+    @Test
+    fun `when proxy port is not set default proxy port is used`() {
+        // create a sentry.properties file in temporary folder
+        val temporaryFolder = TemporaryFolder()
+        temporaryFolder.create()
+        val file = temporaryFolder.newFile("sentry.properties")
+        file.appendText("proxy.host=proxy.example.com\n")
+        // set location of the sentry.properties file
+        System.setProperty("sentry.properties.file", file.absolutePath)
+
+        try {
+            val options = SentryOptions.from(PropertiesProviderFactory.create())
+            assertNotNull(options.proxy)
+            assertEquals("proxy.example.com", options.proxy!!.host)
+            assertEquals("80", options.proxy!!.port)
+        } finally {
+            temporaryFolder.delete()
+        }
+    }
 }

--- a/sentry/src/test/java/io/sentry/config/PropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/PropertiesProviderTest.kt
@@ -1,0 +1,26 @@
+package io.sentry.config
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PropertiesProviderTest {
+
+    private val propertiesProvider = spy<PropertiesProvider>()
+
+    @Test
+    fun `when property is set returns the property value`() {
+        whenever(propertiesProvider.getProperty(any())).thenReturn("value")
+        val result = propertiesProvider.getProperty("prop", "defaultValue")
+        assertEquals("value", result)
+    }
+
+    @Test
+    fun `when property not set returns the default value`() {
+        whenever(propertiesProvider.getProperty(any())).thenReturn(null)
+        val result = propertiesProvider.getProperty("prop", "defaultValue")
+        assertEquals("defaultValue", result)
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Resolve HTTP Proxy parameters from the external configuration.

In order to make Proxy properties resolution in non-Spring Boot application the same as in Spring Boot application, the names of the environment variables had to be changed from ones in 1.7.x

- `SENTRY_PROXY_HOST`
- `SENTRY_PROXY_PORT`
- `SENTRY_PROXY_USER`
- `SENTRY_PROXY_PASS`

In addition to that - `SentryOptions#proxy` object had to be changed into Java bean so that we are able to bind properties via Spring Boot environment.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1028


## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes