### PR TITLE
Fix Javadocs generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,31 +105,6 @@ jobs:
           zeus upload -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -t "application/zip+maven" *.zip
           zeus job update --status=passed -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA
 
-
-  build-and-deploy-javadocs:
-    ## Only run on a release branch
-    if: github.event_name == 'push' && contains(github.ref, 'refs/heads/release')
-    name: Build and deploy Javadocs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: Generate Aggregate Javadocs
-        run: |
-          ./gradlew aggregateJavadocs
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/docs/javadoc
-          CLEAN: true
-          
   check-formatting:
     name: Check Formatting
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-javadocs.yml
+++ b/.github/workflows/generate-javadocs.yml
@@ -1,0 +1,29 @@
+name: Generate Javadocs
+on:
+  release:
+    types: [published]
+
+env:
+  CMAKE_VERSION: "3.10.2.4988404"
+
+jobs:
+  build-and-deploy-javadocs:
+    name: Build and deploy Javadocs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Generate Aggregate Javadocs
+        run: |
+          ./gradlew aggregateJavadocs
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build/docs/javadoc
+          CLEAN: true


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Javadocs generation has to be triggered on the Github "release" event instead of running on specific branch/tag.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Javadocs page is not currently updated when the release is made.


## :green_heart: How did you test it?

On forked repository.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes