### PR TITLE
Add java doc based on sentry-data-schemes project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump: AGP 4.1.1
 * Fix: use neutral Locale for String operations #1033
 * Update to sentry-native 0.4.4 and fix shared library builds (#1039)
+* Added java doc to protocol classes based on sentry-data-schemes project
 
 # 3.1.3
 

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -1,44 +1,160 @@
 package io.sentry;
 
 import io.sentry.protocol.*;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 public final class SentryEvent implements IUnknownPropertiesConsumer {
-  private SentryId eventId;
+  /**
+   * Timestamp when the event was created.
+   *
+   * <p>Indicates when the event was created in the Sentry SDK. The format is either a string as
+   * defined in [RFC 3339](https://tools.ietf.org/html/rfc3339) or a numeric (integer or float)
+   * value representing the number of seconds that have elapsed since the [Unix
+   * epoch](https://en.wikipedia.org/wiki/Unix_time).
+   *
+   * <p>Sub-microsecond precision is not preserved with numeric values due to precision limitations
+   * with floats (at least in our systems). With that caveat in mind, just send whatever is easiest
+   * to produce.
+   *
+   * <p>All timestamps in the event protocol are formatted this way.
+   *
+   * <p>```json { "timestamp": "2011-05-02T17:41:36Z" } { "timestamp": 1304358096.0 } ```
+   */
   private final Date timestamp;
-
+  /**
+   * Unique identifier of this event.
+   *
+   * <p>Hexadecimal string representing a uuid4 value. The length is exactly 32 characters. Dashes
+   * are not allowed. Has to be lowercase.
+   *
+   * <p>Even though this field is backfilled on the server with a new uuid4, it is strongly
+   * recommended to generate that uuid4 clientside. There are some features like user feedback which
+   * are easier to implement that way, and debugging in case events get lost in your Sentry
+   * installation is also easier.
+   *
+   * <p>Example:
+   *
+   * <p>```json { "event_id": "fc6d8c0c43fc4630ad850ee518f1b9d0" } ```
+   */
+  private SentryId eventId;
   /** The captured Throwable */
   private transient @Nullable Throwable throwable;
-
+  /** Custom parameterized message for this event. */
   private Message message;
+  /**
+   * Server or device name the event was generated on.
+   *
+   * <p>This is supposed to be a hostname.
+   */
   private String serverName;
+  /**
+   * Platform identifier of this event (defaults to "other").
+   *
+   * <p>A string representing the platform the SDK is submitting from. This will be used by the
+   * Sentry interface to customize various components in the interface, but also to enter or skip
+   * stacktrace processing.
+   *
+   * <p>Acceptable values are: `as3`, `c`, `cfml`, `cocoa`, `csharp`, `elixir`, `haskell`, `go`,
+   * `groovy`, `java`, `javascript`, `native`, `node`, `objc`, `other`, `perl`, `php`, `python`,
+   * `ruby`
+   */
   private String platform;
+  /**
+   * The release version of the application.
+   *
+   * <p>**Release versions must be unique across all projects in your organization.** This value can
+   * be the git SHA for the given project, or a product identifier with a semantic version.
+   */
   private String release;
+  /**
+   * Program's distribution identifier.
+   *
+   * <p>The distribution of the application.
+   *
+   * <p>Distributions are used to disambiguate build or deployment variants of the same release of
+   * an application. For example, the dist can be the build number of an XCode build or the version
+   * code of an Android build.
+   */
   private String dist;
+  /** Logger that created the event. */
   private String logger;
+  /** Threads that were active when the event occurred. */
   private SentryValues<SentryThread> threads;
+  /** One or multiple chained (nested) exceptions. */
   private SentryValues<SentryException> exception;
+  /**
+   * Severity level of the event. Defaults to `error`.
+   *
+   * <p>Example:
+   *
+   * <p>```json {"level": "warning"} ```
+   */
   private SentryLevel level;
+  /**
+   * Transaction name of the event.
+   *
+   * <p>For example, in a web app, this might be the route name (`"/users/<username>/"` or
+   * `UserView`), in a task queue it might be the function + module name.
+   */
   private String transaction;
+  /**
+   * The environment name, such as `production` or `staging`.
+   *
+   * <p>```json { "environment": "production" } ```
+   */
   private String environment;
+  /** Information about the user who triggered this event. */
   private User user;
+  /** Information about a web request that occurred during the event. */
   private Request request;
+  /** Information about the Sentry SDK that generated this event. */
   private SdkVersion sdk;
+  /** Contexts describing the environment (e.g. device, os or browser). */
   private Contexts contexts = new Contexts();
+  /**
+   * Manual fingerprint override.
+   *
+   * <p>A list of strings used to dictate how this event is supposed to be grouped with other events
+   * into issues. For more information about overriding grouping see [Customize Grouping with
+   * Fingerprints](https://docs.sentry.io/data-management/event-grouping/).
+   *
+   * <p>```json { "fingerprint": ["myrpc", "POST", "/foo.bar"] }
+   */
   private List<String> fingerprint;
+  /** List of breadcrumbs recorded before this event. */
   private List<Breadcrumb> breadcrumbs;
+  /**
+   * Custom tags for this event.
+   *
+   * <p>A map or list of tags for this event. Each tag must be less than 200 characters.
+   */
   private Map<String, String> tags;
+  /**
+   * Arbitrary extra information set by the user.
+   *
+   * <p>```json { "extra": { "my_key": 1, "some_other_value": "foo bar" } }```
+   */
   private Map<String, Object> extra;
+
   private Map<String, Object> unknown;
+  /**
+   * Name and versions of all installed modules/packages/dependencies in the current
+   * environment/application.
+   *
+   * <p>```json { "django": "3.0.0", "celery": "4.2.1" } ```
+   *
+   * <p>In Python this is a list of installed packages as reported by `pkg_resources` together with
+   * their reported version string.
+   *
+   * <p>This is primarily used for suggesting to enable certain SDK integrations from within the UI
+   * and for making informed decisions on which frameworks to support in future development efforts.
+   */
   private Map<String, String> modules;
+  /** Meta data for event processing and debugging. */
   private DebugMeta debugMeta;
 
   SentryEvent(SentryId eventId, final Date timestamp) {
@@ -69,6 +185,10 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
     return eventId;
   }
 
+  public void setEventId(SentryId eventId) {
+    this.eventId = eventId;
+  }
+
   @SuppressWarnings("JdkObsolete")
   public Date getTimestamp() {
     return (Date) timestamp.clone();
@@ -81,6 +201,15 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
    */
   public @Nullable Throwable getThrowable() {
     return throwable;
+  }
+
+  /**
+   * Sets the Throwable
+   *
+   * @param throwable the Throwable or null
+   */
+  public void setThrowable(final @Nullable Throwable throwable) {
+    this.throwable = throwable;
   }
 
   public Message getMessage() {
@@ -149,19 +278,6 @@ public final class SentryEvent implements IUnknownPropertiesConsumer {
 
   public void setExceptions(List<SentryException> exception) {
     this.exception = new SentryValues<>(exception);
-  }
-
-  public void setEventId(SentryId eventId) {
-    this.eventId = eventId;
-  }
-
-  /**
-   * Sets the Throwable
-   *
-   * @param throwable the Throwable or null
-   */
-  public void setThrowable(final @Nullable Throwable throwable) {
-    this.throwable = throwable;
   }
 
   public SentryLevel getLevel() {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -1,11 +1,16 @@
 package io.sentry;
 
 import io.sentry.protocol.*;
-import java.util.*;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class SentryEvent implements IUnknownPropertiesConsumer {
   /**

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -1,16 +1,15 @@
 package io.sentry;
 
 import io.sentry.protocol.*;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 public final class SentryEvent implements IUnknownPropertiesConsumer {
   /**

--- a/sentry/src/main/java/io/sentry/protocol/App.java
+++ b/sentry/src/main/java/io/sentry/protocol/App.java
@@ -12,12 +12,23 @@ import org.jetbrains.annotations.TestOnly;
 public final class App implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "app";
 
+  /** Version-independent application identifier, often a dotted bundle ID. */
   private String appIdentifier;
+  /**
+   * Start time of the app.
+   *
+   * <p>Formatted UTC timestamp when the user started the application.
+   */
   private Date appStartTime;
+  /** Application-specific device identifier. */
   private String deviceAppHash;
+  /** String identifying the kind of build. For example, `testflight`. */
   private String buildType;
+  /** Application name as it appears on the platform. */
   private String appName;
+  /** Application version as it appears on the platform. */
   private String appVersion;
+  /** Internal build ID as it appears on the platform. */
   private String appBuild;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/Browser.java
+++ b/sentry/src/main/java/io/sentry/protocol/Browser.java
@@ -10,7 +10,9 @@ import org.jetbrains.annotations.TestOnly;
 
 public final class Browser implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "browser";
+  /** Display name of the browser application. */
   private String name;
+  /** Version string of the browser. */
   private String version;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/DebugImage.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugImage.java
@@ -4,17 +4,148 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Legacy apple debug images (MachO).
+ *
+ * <p>This was also used for non-apple platforms with similar debug setups.
+ *
+ * <p>A generic (new-style) native platform debug information file.
+ *
+ * <p>The `type` key must be one of:
+ *
+ * <p>- `macho` - `elf`: ELF images are used on Linux platforms. Their structure is identical to
+ * other native images. - `pe`
+ *
+ * <p>Examples:
+ *
+ * <p>```json { "type": "elf", "code_id": "68220ae2c65d65c1b6aaa12fa6765a6ec2f5f434", "code_file":
+ * "/lib/x86_64-linux-gnu/libgcc_s.so.1", "debug_id": "e20a2268-5dc6-c165-b6aa-a12fa6765a6e",
+ * "image_addr": "0x7f5140527000", "image_size": 90112, "image_vmaddr": "0x40000", "arch": "x86_64"
+ * } ```
+ *
+ * <p>```json { "type": "pe", "code_id": "57898e12145000", "code_file":
+ * "C:\\Windows\\System32\\dbghelp.dll", "debug_id": "9c2a902b-6fdf-40ad-8308-588a41d572a0-1",
+ * "debug_file": "dbghelp.pdb", "image_addr": "0x70850000", "image_size": "1331200", "image_vmaddr":
+ * "0x40000", "arch": "x86" } ```
+ *
+ * <p>```json { "type": "macho", "debug_id": "84a04d24-0e60-3810-a8c0-90a65e2df61a", "debug_file":
+ * "libDiagnosticMessagesClient.dylib", "code_file": "/usr/lib/libDiagnosticMessagesClient.dylib",
+ * "image_addr": "0x7fffe668e000", "image_size": 8192, "image_vmaddr": "0x40000", "arch": "x86_64",
+ * } ```
+ *
+ * <p>Proguard mapping file.
+ *
+ * <p>Proguard images refer to `mapping.txt` files generated when Proguard obfuscates function
+ * names. The Java SDK integrations assign this file a unique identifier, which has to be included
+ * in the list of images.
+ */
 public final class DebugImage implements IUnknownPropertiesConsumer {
 
+  /**
+   * The unique UUID of the image.
+   *
+   * <p>UUID computed from the file contents, assigned by the Java SDK.
+   */
   private String uuid;
+
   private String type;
+  /**
+   * Unique debug identifier of the image.
+   *
+   * <p>- `elf`: Debug identifier of the dynamic library or executable. If a code identifier is
+   * available, the debug identifier is the little-endian UUID representation of the first 16-bytes
+   * of that identifier. Spaces are inserted for readability, note the byte order of the first
+   * fields:
+   *
+   * <p>```text code id: f1c3bcc0 2798 65fe 3058 404b2831d9e6 4135386c debug id:
+   * c0bcc3f1-9827-fe65-3058-404b2831d9e6 ```
+   *
+   * <p>If no code id is available, the debug id should be computed by XORing the first 4096 bytes
+   * of the `.text` section in 16-byte chunks, and representing it as a little-endian UUID (again
+   * swapping the byte order).
+   *
+   * <p>- `pe`: `signature` and `age` of the PDB file. Both values can be read from the CodeView
+   * PDB70 debug information header in the PE. The value should be represented as little-endian
+   * UUID, with the age appended at the end. Note that the byte order of the UUID fields must be
+   * swapped (spaces inserted for readability):
+   *
+   * <p>```text signature: f1c3bcc0 2798 65fe 3058 404b2831d9e6 age: 1 debug_id:
+   * c0bcc3f1-9827-fe65-3058-404b2831d9e6-1 ```
+   *
+   * <p>- `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID`
+   * load command in the Mach header, formatted as UUID.
+   */
   private String debugId;
+
+  /**
+   * Path and name of the debug companion file.
+   *
+   * <p>- `elf`: Name or absolute path to the file containing stripped debug information for this
+   * image. This value might be _required_ to retrieve debug files from certain symbol servers.
+   *
+   * <p>- `pe`: Name of the PDB file containing debug information for this image. This value is
+   * often required to retrieve debug files from specific symbol servers.
+   *
+   * <p>- `macho`: Name or absolute path to the dSYM file containing debug information for this
+   * image. This value might be required to retrieve debug files from certain symbol servers.
+   */
   private String debugFile;
-  private String codeFile;
-  private String imageAddr;
-  private Long imageSize;
-  private String arch;
+  /**
+   * Optional identifier of the code file.
+   *
+   * <p>- `elf`: If the program was compiled with a relatively recent compiler, this should be the
+   * hex representation of the `NT_GNU_BUILD_ID` program header (type `PT_NOTE`), or the value of
+   * the `.note.gnu.build-id` note section (type `SHT_NOTE`). Otherwise, leave this value empty.
+   *
+   * <p>Certain symbol servers use the code identifier to locate debug information for ELF images,
+   * in which case this field should be included if possible.
+   *
+   * <p>- `pe`: Identifier of the executable or DLL. It contains the values of the `time_date_stamp`
+   * from the COFF header and `size_of_image` from the optional header formatted together into a hex
+   * string using `%08x%X` (note that the second value is not padded):
+   *
+   * <p>```text time_date_stamp: 0x5ab38077 size_of_image: 0x9000 code_id: 5ab380779000 ```
+   *
+   * <p>The code identifier should be provided to allow server-side stack walking of binary crash
+   * reports, such as Minidumps.
+   *
+   * <p>
+   *
+   * <p>- `macho`: Identifier of the dynamic library or executable. It is the value of the `LC_UUID`
+   * load command in the Mach header, formatted as UUID. Can be empty for Mach images, as it is
+   * equivalent to the debug identifier.
+   */
   private String codeId;
+  /**
+   * Path and name of the image file (required).
+   *
+   * <p>The absolute path to the dynamic library or executable. This helps to locate the file if it
+   * is missing on Sentry.
+   *
+   * <p>- `pe`: The code file should be provided to allow server-side stack walking of binary crash
+   * reports, such as Minidumps.
+   */
+  private String codeFile;
+  /**
+   * Starting memory address of the image (required).
+   *
+   * <p>Memory address, at which the image is mounted in the virtual address space of the process.
+   * Should be a string in hex representation prefixed with `"0x"`.
+   */
+  private String imageAddr;
+  /**
+   * Size of the image in bytes (required).
+   *
+   * <p>The size of the image in virtual memory. If missing, Sentry will assume that the image spans
+   * up to the next image, which might lead to invalid stack traces.
+   */
+  private Long imageSize;
+  /**
+   * CPU architecture target.
+   *
+   * <p>Architecture of the module. If missing, this will be backfilled by Sentry.
+   */
+  private String arch;
 
   @SuppressWarnings("unused")
   private Map<String, Object> unknown;

--- a/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
@@ -5,8 +5,21 @@ import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Debugging and processing meta information.
+ *
+ * <p>The debug meta interface carries debug information for processing errors and crash reports.
+ * Sentry amends the information in this interface.
+ *
+ * <p>Example (look at field types to see more detail):
+ *
+ * <p>```json { "debug_meta": { "images": [], "sdk_info": { "sdk_name": "iOS", "version_major": 10,
+ * "version_minor": 3, "version_patchlevel": 0 } } } ```
+ */
 public final class DebugMeta implements IUnknownPropertiesConsumer {
+  /** Information about the system SDK (e.g. iOS SDK). */
   private SdkInfo sdkInfo;
+  /** List of debug information files (debug images). */
   private List<DebugImage> images;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -13,39 +13,90 @@ import org.jetbrains.annotations.TestOnly;
 public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "device";
 
+  /** Name of the device. */
   private String name;
+  /** Manufacturer of the device. */
   private String manufacturer;
+  /** Brand of the device. */
   private String brand;
+  /**
+   * Family of the device model.
+   *
+   * <p>This is usually the common part of model names across generations. For instance, `iPhone`
+   * would be a reasonable family, so would be `Samsung Galaxy`.
+   */
   private String family;
+  /**
+   * Device model.
+   *
+   * <p>This, for example, can be `Samsung Galaxy S3`.
+   */
   private String model;
+  /**
+   * Device model (internal identifier).
+   *
+   * <p>An internal hardware revision to identify the device exactly.
+   */
   private String modelId;
 
+  /** Native cpu architecture of the device. */
   @ApiStatus.ScheduledForRemoval @Deprecated private String arch;
 
+  /** Native cpu architecture of the device. */
   private String[] archs;
+  /**
+   * Current battery level in %.
+   *
+   * <p>If the device has a battery, this can be a floating point value defining the battery level
+   * (in the range 0-100).
+   */
   private Float batteryLevel;
+  /** Whether the device was charging or not. */
   private Boolean charging;
+  /** Whether the device was online or not. */
   private Boolean online;
+  /**
+   * Current screen orientation.
+   *
+   * <p>This can be a string `portrait` or `landscape` to define the orientation of a device.
+   */
   private DeviceOrientation orientation;
+  /** Simulator/prod indicator. */
   private Boolean simulator;
+  /** Total memory available in bytes. */
   private Long memorySize;
+  /** How much memory is still available in bytes. */
   private Long freeMemory;
+  /** How much memory is usable for the app in bytes. */
   private Long usableMemory;
+  /** Whether the device was low on memory. */
   private Boolean lowMemory;
+  /** Total storage size of the device in bytes. */
   private Long storageSize;
+  /** How much storage is free in bytes. */
   private Long freeStorage;
+  /** Total size of the attached external storage in bytes (eg: android SDK card). */
   private Long externalStorageSize;
+  /** Free size of the attached external storage in bytes (eg: android SDK card). */
   private Long externalFreeStorage;
-
+  /**
+   * Device screen resolution.
+   *
+   * <p>(e.g.: 800x600, 3040x1444)
+   */
   @ApiStatus.ScheduledForRemoval @Deprecated private String screenResolution;
 
   private Integer screenWidthPixels;
   private Integer screenHeightPixels;
-
+  /** Device screen density. */
   private Float screenDensity;
+  /** Screen density as dots-per-inch. */
   private Integer screenDpi;
+  /** Indicator when the device was booted. */
   private Date bootTime;
+  /** Timezone of the device. */
   private TimeZone timezone;
+
   private String id;
   private String language;
   private String connectionType;
@@ -107,8 +158,8 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   /**
    * Returns the arch String
    *
-   * @deprecated use {@link #getArchs} instead.
    * @return device architecture
+   * @deprecated use {@link #getArchs} instead.
    */
   @ApiStatus.ScheduledForRemoval
   @Deprecated
@@ -117,8 +168,8 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   }
 
   /**
-   * @deprecated use {@link #setArchs} instead.
    * @param arch device architecture
+   * @deprecated use {@link #setArchs} instead.
    */
   @ApiStatus.ScheduledForRemoval
   @Deprecated
@@ -233,8 +284,8 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   /**
    * Returns the screenResolution String
    *
-   * @deprecated use {@link #getScreenWidthPixels , #getScreenHeightPixels} instead.
    * @return screen resolution largest + smallest
+   * @deprecated use {@link #getScreenWidthPixels , #getScreenHeightPixels} instead.
    */
   @ApiStatus.ScheduledForRemoval
   @Deprecated
@@ -243,8 +294,8 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   }
 
   /**
-   * @deprecated use {@link #setScreenWidthPixels} , #getScreenHeightPixels} instead.
    * @param screenResolution screen resolution largest + smallest
+   * @deprecated use {@link #setScreenWidthPixels} , #getScreenHeightPixels} instead.
    */
   @ApiStatus.ScheduledForRemoval
   @Deprecated
@@ -342,11 +393,6 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
     this.batteryTemperature = batteryTemperature;
   }
 
-  public enum DeviceOrientation {
-    PORTRAIT,
-    LANDSCAPE
-  }
-
   @TestOnly
   Map<String, Object> getUnknown() {
     return unknown;
@@ -377,5 +423,10 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
     clone.unknown = CollectionUtils.shallowCopy(unknown);
 
     return clone;
+  }
+
+  public enum DeviceOrientation {
+    PORTRAIT,
+    LANDSCAPE
   }
 }

--- a/sentry/src/main/java/io/sentry/protocol/Gpu.java
+++ b/sentry/src/main/java/io/sentry/protocol/Gpu.java
@@ -11,14 +11,27 @@ import org.jetbrains.annotations.TestOnly;
 public final class Gpu implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "gpu";
 
+  /** The name of the graphics device. */
   private String name;
+  /** The PCI identifier of the graphics device. */
   private Integer id;
+  /** The PCI vendor identifier of the graphics device. */
   private Integer vendorId;
+  /** The vendor name as reported by the graphics device. */
   private String vendorName;
+  /** The total GPU memory available in Megabytes. */
   private Integer memorySize;
+  /**
+   * The device low-level API type.
+   *
+   * <p>Examples: `"Apple Metal"` or `"Direct3D11"`
+   */
   private String apiType;
+  /** Whether the GPU has multi-threaded rendering or not. */
   private Boolean multiThreadedRendering;
+  /** The Version of the graphics device. */
   private String version;
+  /** The Non-Power-Of-Two support. */
   private String npotSupport;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/Mechanism.java
+++ b/sentry/src/main/java/io/sentry/protocol/Mechanism.java
@@ -5,15 +5,62 @@ import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * The mechanism by which an exception was generated and handled.
+ *
+ * <p>The exception mechanism is an optional field residing in the [exception](#typedef-Exception).
+ * It carries additional information about the way the exception was created on the target system.
+ * This includes general exception values obtained from the operating system or runtime APIs, as
+ * well as mechanism-specific values.
+ */
 public final class Mechanism implements IUnknownPropertiesConsumer {
-  private String type;
-  private String description;
-  private String helpLink;
-  private Boolean handled;
-  private Map<String, Object> meta;
-  private Map<String, Object> data;
   private final transient Thread thread;
+  /**
+   * Mechanism type (required).
+   *
+   * <p>Required unique identifier of this mechanism determining rendering and processing of the
+   * mechanism data.
+   *
+   * <p>In the Python SDK this is merely the name of the framework integration that produced the
+   * exception, while for native it is e.g. `"minidump"` or `"applecrashreport"`.
+   */
+  private String type;
+  /**
+   * Optional human-readable description of the error mechanism.
+   *
+   * <p>May include a possible hint on how to solve this error.
+   */
+  private String description;
+  /** Link to online resources describing this error. */
+  private String helpLink;
+  /**
+   * Flag indicating whether this exception was handled.
+   *
+   * <p>This is a best-effort guess at whether the exception was handled by user code or not. For
+   * example:
+   *
+   * <p>- Exceptions leading to a 500 Internal Server Error or to a hard process crash are
+   * `handled=false`, as the SDK typically has an integration that automatically captures the error.
+   *
+   * <p>- Exceptions captured using `capture_exception` (called from user code) are `handled=true`
+   * as the user explicitly captured the exception (and therefore kind of handled it)
+   */
+  private Boolean handled;
+  /** Operating system or runtime meta information. */
+  private Map<String, Object> meta;
+  /**
+   * Arbitrary extra data that might help the user understand the error thrown by this mechanism.
+   */
+  private Map<String, Object> data;
+  /**
+   * If this is set then the exception is not a real exception but some form of synthetic error for
+   * instance from a signal handler, a hard segfault or similar where type and value are not useful
+   * for grouping or display purposes.
+   */
   private Boolean synthetic;
+
+  @SuppressWarnings("unused")
+  private Map<String, Object> unknown;
 
   public Mechanism() {
     this(null);
@@ -22,9 +69,6 @@ public final class Mechanism implements IUnknownPropertiesConsumer {
   public Mechanism(@Nullable Thread thread) {
     this.thread = thread;
   }
-
-  @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
 
   public String getType() {
     return type;

--- a/sentry/src/main/java/io/sentry/protocol/Message.java
+++ b/sentry/src/main/java/io/sentry/protocol/Message.java
@@ -7,9 +7,40 @@ import org.jetbrains.annotations.ApiStatus;
 
 // https://docs.sentry.io/development/sdk-dev/event-payloads/message/
 
+/**
+ * A log entry message.
+ *
+ * <p>A log message is similar to the `message` attribute on the event itself but can additionally
+ * hold optional parameters.
+ *
+ * <p>```json { "message": { "message": "My raw message with interpreted strings like %s", "params":
+ * ["this"] } } ```
+ *
+ * <p>```json { "message": { "message": "My raw message with interpreted strings like {foo}",
+ * "params": {"foo": "this"} } } ```
+ */
 public final class Message implements IUnknownPropertiesConsumer {
+  /**
+   * The formatted message. If `message` and `params` are given, Sentry will attempt to backfill
+   * `formatted` if empty.
+   *
+   * <p>It must not exceed 8192 characters. Longer messages will be truncated.
+   */
   private String formatted;
+  /**
+   * The log message with parameter placeholders.
+   *
+   * <p>This attribute is primarily used for grouping related events together into issues. Therefore
+   * this really should just be a string template, i.e. `Sending %d requests` instead of `Sending
+   * 9999 requests`. The latter is much better at home in `formatted`.
+   *
+   * <p>It must not exceed 8192 characters. Longer messages will be truncated.
+   */
   private String message;
+  /**
+   * Parameters to be interpolated into the log message. This can be an array of positional
+   * parameters as well as a mapping of named arguments to their values.
+   */
   private List<String> params;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
+++ b/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
@@ -11,11 +11,27 @@ import org.jetbrains.annotations.TestOnly;
 public final class OperatingSystem implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "os";
 
+  /** Name of the operating system. */
   private String name;
+  /** Version of the operating system. */
   private String version;
+  /**
+   * Unprocessed operating system info.
+   *
+   * <p>An unprocessed description string obtained by the operating system. For some well-known
+   * runtimes, Sentry will attempt to parse `name` and `version` from this string, if they are not
+   * explicitly given.
+   */
   private String rawDescription;
+  /** Internal build number of the operating system. */
   private String build;
+  /**
+   * Current kernel version.
+   *
+   * <p>This is typically the entire output of the `uname` syscall.
+   */
   private String kernelVersion;
+  /** Indicator if the OS is rooted (mobile mostly). */
   private Boolean rooted;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/Request.java
+++ b/sentry/src/main/java/io/sentry/protocol/Request.java
@@ -4,14 +4,92 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Http request information.
+ *
+ * <p>The Request interface contains information on a HTTP request related to the event. In client
+ * SDKs, this can be an outgoing request, or the request that rendered the current web page. On
+ * server SDKs, this could be the incoming web request that is being handled.
+ *
+ * <p>The data variable should only contain the request body (not the query string). It can either
+ * be a dictionary (for standard HTTP requests) or a raw request body.
+ *
+ * <p>### Ordered Maps
+ *
+ * <p>In the Request interface, several attributes can either be declared as string, object, or list
+ * of tuples. Sentry attempts to parse structured information from the string representation in such
+ * cases.
+ *
+ * <p>Sometimes, keys can be declared multiple times, or the order of elements matters. In such
+ * cases, use the tuple representation over a plain object.
+ *
+ * <p>Example of request headers as object:
+ *
+ * <p>```json { "content-type": "application/json", "accept": "application/json, application/xml" }
+ * ```
+ *
+ * <p>Example of the same headers as list of tuples:
+ *
+ * <p>```json [ ["content-type", "application/json"], ["accept", "application/json"], ["accept",
+ * "application/xml"] ] ```
+ *
+ * <p>Example of a fully populated request object:
+ *
+ * <p>```json { "request": { "method": "POST", "url": "http://absolute.uri/foo", "query_string":
+ * "query=foobar", "data": { "foo": "bar" }, "cookies": "PHPSESSID=298zf09hf012fh2;
+ * csrftoken=u32t4o3tb3gg43; _gat=1;", "headers": { "content-type": "text/html" }, "env": {
+ * "REMOTE_ADDR": "192.168.0.1" } } } ```
+ */
 public final class Request implements IUnknownPropertiesConsumer {
+  /**
+   * The URL of the request if available.
+   *
+   * <p>The query string can be declared either as part of the `url`, or separately in
+   * `query_string`.
+   */
   private String url;
+  /** HTTP request method. */
   private String method;
+  /**
+   * The query string component of the URL.
+   *
+   * <p>Can be given as unparsed string, dictionary, or list of tuples. (Currently only unparsed
+   * string is possible)
+   *
+   * <p>If the query string is not declared and part of the `url`, Sentry moves it to the query
+   * string.
+   */
   private String queryString;
+  /**
+   * Request data in any format that makes sense.
+   *
+   * <p>SDKs should discard large and binary bodies by default. Can be given as string or structural
+   * data of any format.
+   */
   private Object data;
+  /**
+   * The cookie values.
+   *
+   * <p>Can be given unparsed as string, as dictionary, or as a list of tuples.
+   */
   private String cookies;
+  /**
+   * A dictionary of submitted headers.
+   *
+   * <p>If a header appears multiple times it, needs to be merged according to the HTTP standard for
+   * header merging. Header names are treated case-insensitively by Sentry.
+   */
   private Map<String, String> headers;
+  /**
+   * Server environment data, such as CGI/WSGI.
+   *
+   * <p>A dictionary containing environment information passed from the server. This is where
+   * information such as CGI/WSGI/Rack keys go that are not HTTP headers.
+   *
+   * <p>Sentry will explicitly look for `REMOTE_ADDR` to extract an IP address.
+   */
   private Map<String, String> env;
+
   private Map<String, String> other;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SdkInfo.java
+++ b/sentry/src/main/java/io/sentry/protocol/SdkInfo.java
@@ -4,10 +4,20 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Holds information about the system SDK.
+ *
+ * <p>This is relevant for iOS and other platforms that have a system SDK. Not to be confused with
+ * the client SDK.
+ */
 public final class SdkInfo implements IUnknownPropertiesConsumer {
+  /** The internal name of the SDK. */
   private String sdkName;
+  /** The major version of the SDK as integer or 0. */
   private Integer versionMajor;
+  /** The minor version of the SDK as integer or 0. */
   private Integer versionMinor;
+  /** The patch version of the SDK as integer or 0. */
   private Integer versionPatchlevel;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SdkVersion.java
+++ b/sentry/src/main/java/io/sentry/protocol/SdkVersion.java
@@ -7,10 +7,48 @@ import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * The SDK Interface describes the Sentry SDK and its configuration used to capture and transmit an
+ * event.
+ */
 public final class SdkVersion implements IUnknownPropertiesConsumer {
+  /**
+   * Unique SDK name. _Required._
+   *
+   * <p>The name of the SDK. The format is `entity.ecosystem[.flavor]` where entity identifies the
+   * developer of the SDK, ecosystem refers to the programming language or platform where the SDK is
+   * to be used and the optional flavor is used to identify standalone SDKs that are part of a major
+   * ecosystem.
+   *
+   * <p>Official Sentry SDKs use the entity `sentry`, as in `sentry.python` or
+   * `sentry.javascript.react-native`. Please use a different entity for your own SDKs.
+   */
   private String name;
+  /**
+   * The version of the SDK. _Required._
+   *
+   * <p>It should have the [Semantic Versioning](https://semver.org/) format `MAJOR.MINOR.PATCH`,
+   * without any prefix (no `v` or anything else in front of the major version number).
+   *
+   * <p>Examples: `0.1.0`, `1.0.0`, `4.3.12`
+   */
   private String version;
+  /**
+   * List of installed and loaded SDK packages. _Optional._
+   *
+   * <p>A list of packages that were installed as part of this SDK or the activated integrations.
+   * Each package consists of a name in the format `source:identifier` and `version`. If the source
+   * is a Git repository, the `source` should be `git`, the identifier should be a checkout link and
+   * the version should be a Git reference (branch, tag or SHA).
+   */
   private List<SentryPackage> packages;
+  /**
+   * List of integrations that are enabled in the SDK. _Optional._
+   *
+   * <p>The list should have all enabled integrations, including default integrations. Default
+   * integrations are included because different SDK releases may contain different default
+   * integrations.
+   */
   private List<String> integrations;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SentryException.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryException.java
@@ -4,13 +4,41 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
-/** The Sentry Exception interface. */
+/**
+ * A single exception.
+ *
+ * <p>Multiple values inside of an [event](#typedef-Event) represent chained exceptions and should
+ * be sorted oldest to newest. For example, consider this Python code snippet:
+ *
+ * <p>```python try: raise Exception("random boring invariant was not met!") except Exception as e:
+ * raise ValueError("something went wrong, help!") from e ```
+ *
+ * <p>`Exception` would be described first in the values list, followed by a description of
+ * `ValueError`:
+ *
+ * <p>```json { "exception": { "values": [ {"type": "Exception": "value": "random boring invariant
+ * was not met!"}, {"type": "ValueError", "value": "something went wrong, help!"}, ] } } ```
+ */
 public final class SentryException implements IUnknownPropertiesConsumer {
+  /**
+   * Exception type, e.g. `ValueError`.
+   *
+   * <p>At least one of `type` or `value` is required, otherwise the exception is discarded.
+   */
   private String type;
+  /**
+   * Human readable display value.
+   *
+   * <p>At least one of `type` or `value` is required, otherwise the exception is discarded.
+   */
   private String value;
+  /** The optional module, or package which the exception type lives in. */
   private String module;
+  /** An optional value that refers to a [thread](#typedef-Thread). */
   private Long threadId;
+  /** Stack trace containing frames of this exception. */
   private SentryStackTrace stacktrace;
+  /** Mechanism by which this exception was generated and handled. */
   private Mechanism mechanism;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SentryPackage.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryPackage.java
@@ -4,8 +4,11 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
+/** An installed and loaded package as part of the Sentry SDK. */
 public final class SentryPackage implements IUnknownPropertiesConsumer {
+  /** Name of the package. */
   private String name;
+  /** Version of the package. */
   private String version;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
@@ -11,8 +11,17 @@ import org.jetbrains.annotations.TestOnly;
 public final class SentryRuntime implements IUnknownPropertiesConsumer, Cloneable {
   public static final String TYPE = "runtime";
 
+  /** Runtime name. */
   private String name;
+  /** Runtime version string. */
   private String version;
+  /**
+   * Unprocessed runtime info.
+   *
+   * <p>An unprocessed description string obtained by the runtime. For some well-known runtimes,
+   * Sentry will attempt to parse `name` and `version` from this string, if they are not explicitly
+   * given.
+   */
   private String rawDescription;
 
   @SuppressWarnings("unused")

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -6,19 +6,52 @@ import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
-/** The Sentry stack frame. */
+/**
+ * Holds information about a single stacktrace frame.
+ *
+ * <p>Each object should contain **at least** a `filename`, `function` or `instruction_addr`
+ * attribute. All values are optional, but recommended.
+ */
 public final class SentryStackFrame implements IUnknownPropertiesConsumer {
+  /** Source code leading up to `lineno`. */
   private List<String> preContext;
+  /** Source code of the lines after `lineno`. */
   private List<String> postContext;
+  /** Mapping of local variables and expression names that were available in this frame. */
   private Map<String, String> vars;
+
   private List<Integer> framesOmitted;
+  /** The source file name (basename only). */
   private String filename;
+  /**
+   * Name of the frame's function. This might include the name of a class.
+   *
+   * <p>This function name may be shortened or demangled. If not, Sentry will demangle and shorten
+   * it for some platforms. The original function name will be stored in `raw_function`.
+   */
   private String function;
+  /**
+   * Name of the module the frame is contained in.
+   *
+   * <p>Note that this might also include a class name if that is something the language natively
+   * considers to be part of the stack (for instance in Java).
+   */
   private String module;
+  /** Line number within the source file, starting at 1. */
   private Integer lineno;
+  /** Column number within the source file, starting at 1. */
   private Integer colno;
+  /** Absolute path to the source file. */
   private String absPath;
+  /** Source code of the current line (`lineno`). */
   private String contextLine;
+  /**
+   * Override whether this frame should be considered part of application code, or part of
+   * libraries/frameworks/dependencies.
+   *
+   * <p>Setting this attribute to `false` causes the frame to be hidden/collapsed by default and
+   * mostly ignored during issue grouping.
+   */
   private Boolean inApp;
 
   @SerializedName(value = "package")
@@ -27,14 +60,53 @@ public final class SentryStackFrame implements IUnknownPropertiesConsumer {
   @SerializedName(value = "native")
   private Boolean _native;
 
+  /**
+   * Which platform this frame is from.
+   *
+   * <p>This can override the platform for a single frame. Otherwise, the platform of the event is
+   * assumed. This can be used for multi-platform stack traces, such as in React Native.
+   */
   private String platform;
+
+  /** (C/C++/Native) Start address of the containing code module (image). */
   private String imageAddr;
+  /**
+   * (C/C++/Native) Start address of the frame's function.
+   *
+   * <p>We use the instruction address for symbolication, but this can be used to calculate an
+   * instruction offset automatically.
+   */
   private String symbolAddr;
+  /**
+   * (C/C++/Native) An optional instruction address for symbolication.
+   *
+   * <p>This should be a string with a hexadecimal number that includes a 0x prefix. If this is set
+   * and a known image is defined in the [Debug Meta Interface]({%- link
+   * _documentation/development/sdk-dev/event-payloads/debugmeta.md -%}), then symbolication can
+   * take place.
+   */
   private String instructionAddr;
 
   @SuppressWarnings("unused")
   private Map<String, Object> unknown;
 
+  /**
+   * A raw (but potentially truncated) function value.
+   *
+   * <p>The original function name, if the function name is shortened or demangled. Sentry shows the
+   * raw function when clicking on the shortened one in the UI.
+   *
+   * <p>If this has the same value as `function` it's best to be omitted. This exists because on
+   * many platforms the function itself contains additional information like overload specifies or a
+   * lot of generics which can make it exceed the maximum limit we provide for the field. In those
+   * cases then we cannot reliably trim down the function any more at a later point because the more
+   * valuable information has been removed.
+   *
+   * <p>The logic to be applied is that an intelligently trimmed function name should be stored in
+   * `function` and the value before trimming is stored in this field instead. However also this
+   * field will be capped at 256 characters at the moment which often means that not the entire
+   * original value can be stored.
+   */
   private String rawFunction;
 
   public List<String> getPreContext() {

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
@@ -5,9 +5,48 @@ import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
-/** The Sentry stacktrace. */
+/**
+ * A stack trace of a single thread.
+ *
+ * <p>A stack trace contains a list of frames, each with various bits (most optional) describing the
+ * context of that frame. Frames should be sorted from oldest to newest.
+ *
+ * <p>For the given example program written in Python:
+ *
+ * <p>```python def foo(): my_var = 'foo' raise ValueError()
+ *
+ * <p>def main(): foo() ```
+ *
+ * <p>A minimalistic stack trace for the above program in the correct order:
+ *
+ * <p>```json { "frames": [ {"function": "main"}, {"function": "foo"} ] } ```
+ *
+ * <p>The top frame fully symbolicated with five lines of source context:
+ *
+ * <p>```json { "frames": [{ "in_app": true, "function": "myfunction", "abs_path":
+ * "/real/file/name.py", "filename": "file/name.py", "lineno": 3, "vars": { "my_var": "'value'" },
+ * "pre_context": [ "def foo():", " my_var = 'foo'", ], "context_line": " raise ValueError()",
+ * "post_context": [ "", "def main():" ], }] } ```
+ *
+ * <p>A minimal native stack trace with register values. Note that the `package` event attribute
+ * must be "native" for these frames to be symbolicated.
+ *
+ * <p>```json { "frames": [ {"instruction_addr": "0x7fff5bf3456c"}, {"instruction_addr":
+ * "0x7fff5bf346c0"}, ], "registers": { "rip": "0x00007ff6eef54be2", "rsp": "0x0000003b710cd9e0" } }
+ * ```
+ */
 public final class SentryStackTrace implements IUnknownPropertiesConsumer {
+  /**
+   * Required. A non-empty list of stack frames. The list is ordered from caller to callee, or
+   * oldest to youngest. The last frame is the one creating the exception.
+   */
   private List<SentryStackFrame> frames;
+  /**
+   * Register values of the thread (top frame).
+   *
+   * <p>A map of register names and their values. The values should contain the actual register
+   * values of the thread, thus mapping to the last frame in the list.
+   */
   private Map<String, String> registers;
 
   @SuppressWarnings("unused")
@@ -18,6 +57,7 @@ public final class SentryStackTrace implements IUnknownPropertiesConsumer {
   public SentryStackTrace(List<SentryStackFrame> frames) {
     this.frames = frames;
   }
+
   /**
    * Gets the frames of this stacktrace.
    *

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -4,7 +4,20 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 
-/** Describes a thread in the Sentry protocol. */
+/**
+ * A process thread of an event.
+ *
+ * <p>The Threads Interface specifies threads that were running at the time an event happened. These
+ * threads can also contain stack traces.
+ *
+ * <p>An event may contain one or more threads in an attribute named `threads`.
+ *
+ * <p>The following example illustrates the threads part of the event payload and omits other
+ * attributes for simplicity.
+ *
+ * <p>```json { "threads": { "values": [ { "id": "0", "name": "main", "crashed": true, "stacktrace":
+ * {} } ] } } ```
+ */
 public final class SentryThread implements IUnknownPropertiesConsumer {
   private Long id;
   private Integer priority;

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -2,29 +2,38 @@ package io.sentry.protocol;
 
 import io.sentry.IUnknownPropertiesConsumer;
 import io.sentry.util.CollectionUtils;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-/** The user affected by an event. */
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Information about the user who triggered an event.
+ *
+ * <p>```json { "user": { "id": "unique_id", "username": "my_user", "email": "foo@example.com",
+ * "ip_address": "127.0.0.1", "subscription": "basic" } } ```
+ */
 public final class User implements Cloneable, IUnknownPropertiesConsumer {
 
-  /** User's email */
+  /** Email address of the user. */
   private @Nullable String email;
 
-  /** User's id */
+  /** Unique identifier of the user. */
   private @Nullable String id;
 
-  /** User's username */
+  /** Username of the user. */
   private @Nullable String username;
 
-  /** User's ipAddress */
+  /** Remote IP address of the user. Defaults to "{{auto}}". */
   private @Nullable String ipAddress;
 
-  /** User's others map */
+  /**
+   * Additional arbitrary fields, as stored in the database (and sometimes as sent by clients). All
+   * data from `self.other` should end up here after store normalization.
+   */
   private @Nullable Map<String, String> other;
 
   /** unknown fields, only internal usage. */

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -2,13 +2,12 @@ package io.sentry.protocol;
 
 import io.sentry.IUnknownPropertiesConsumer;
 import io.sentry.util.CollectionUtils;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Information about the user who triggered an event.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Added java docs to the protocol classes based on the https://github.com/getsentry/sentry-data-schemas project.


## :bulb: Motivation and Context
It improves accessibility of the SDK because all the important information is directly in the javadoc instead of in someones browser. 


## :green_heart: How did you test it?
`make compile` as I only added java docs.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
