### PR TITLE
Fix: userId should be set for hard crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # vNext
 
-* Bump: AGP 4.1.1
+* Bump: AGP 4.1.1 (#1040)
 * Fix: use neutral Locale for String operations #1033
 * Update to sentry-native 0.4.4 and fix shared library builds (#1039)
-* Added java doc to protocol classes based on sentry-data-schemes project
+* Added java doc to protocol classes based on sentry-data-schemes project (#1045)
+* Enhancement: Make SentryExceptionResolver Order configurable to not send handled web exceptions (#1008)
+* Enhancement: Resolve HTTP Proxy parameters from the external configuration (#1028)
 
 # 3.1.3
 
 * Fix broken NDK integration on 3.1.2 (release failed on packaging a .so file)
 * Increase max cached events to 30 (#1029)
 * Normalize DSN URI (#1030)
-* Enhancement: Make SentryExceptionResolver Order configurable to not send handled web exceptions
-* Enhancement: Resolve HTTP Proxy parameters from the external configuration (#1028)
 
 # 3.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added java doc to protocol classes based on sentry-data-schemes project (#1045)
 * Enhancement: Make SentryExceptionResolver Order configurable to not send handled web exceptions (#1008)
 * Enhancement: Resolve HTTP Proxy parameters from the external configuration (#1028)
+* Fix: set userId for hard-crashes if no user is set
 
 # 3.1.3
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -143,7 +143,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     // userId should be set even if event is Cached as the userId is static and won't change anyway.
     if (event.getUser() == null) {
-      event.setUser(getUser());
+      event.setUser(getDefaultUser());
     }
 
     if (event.getContexts().getDevice() == null) {
@@ -809,7 +809,12 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     return null;
   }
 
-  public @NotNull User getUser() {
+  /**
+   * Sets the default user which contains only the userId.
+   *
+   * @return the User object
+   */
+  public @NotNull User getDefaultUser() {
     User user = new User();
     user.setId(getDeviceId());
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -141,6 +141,11 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           event.getEventId());
     }
 
+    // userId should be set even if event is Cached as the userId is static and won't change anyway.
+    if (event.getUser() == null) {
+      event.setUser(getUser());
+    }
+
     if (event.getContexts().getDevice() == null) {
       event.getContexts().setDevice(getDevice());
     }
@@ -153,10 +158,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   // Data to be applied to events that was created in the running process
   private void processNonCachedEvent(final @NotNull SentryEvent event) {
-    if (event.getUser() == null) {
-      event.setUser(getUser());
-    }
-
     App app = event.getContexts().getApp();
     if (app == null) {
       app = new App();

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -147,7 +147,7 @@ class DefaultAndroidEventProcessorTest {
     }
 
     @Test
-    fun `When userId is already set, do not overwrite`() {
+    fun `When user is already set, do not overwrite it`() {
         val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
         val user = User()
         var event = SentryEvent().apply {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -21,6 +21,7 @@ import io.sentry.android.core.DefaultAndroidEventProcessor.PROGUARD_UUID
 import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryThread
+import io.sentry.protocol.User
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -28,6 +29,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 
@@ -88,11 +90,9 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `When hint is not Cached, data should be applied`() {
         val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
-        var event = SentryEvent().apply {
-        }
+        var event = SentryEvent()
         // refactor and mock data later on
         event = processor.process(event, null)
-        assertNotNull(event.user)
         assertNotNull(event.contexts.app)
         assertEquals("test", event.debugMeta.images[0].uuid)
         assertNotNull(event.dist)
@@ -129,15 +129,33 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `When hint is Cached, data should not be applied`() {
         val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
-        var event = SentryEvent().apply {
-        }
+        var event = SentryEvent()
         // refactor and mock data later on
         event = processor.process(event, CachedEvent())
-        assertNull(event.user)
         assertNull(event.contexts.app)
         assertNull(event.debugMeta)
         assertNull(event.release)
         assertNull(event.dist)
+    }
+
+    @Test
+    fun `When hint is Cached, userId is applied anyway`() {
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
+        var event = SentryEvent()
+        event = processor.process(event, CachedEvent())
+        assertNotNull(event.user)
+    }
+
+    @Test
+    fun `When userId is already set, do not overwrite`() {
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
+        val user = User()
+        var event = SentryEvent().apply {
+            setUser(user)
+        }
+        event = processor.process(event, null)
+        assertNotNull(event.user)
+        assertSame(user, event.user)
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: userId should be set for hard crashes


## :bulb: Motivation and Context
we got reports that hard crashes were not making to user count.


## :green_heart: How did you test it?
ran the App, hard crash, Opened the App, an event on Sentry has userId.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
