### PR TITLE
Enha: SU logging was too verbose

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/util/RootChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/util/RootChecker.java
@@ -139,7 +139,7 @@ public final class RootChecker {
         return reader.readLine() != null;
       }
     } catch (IOException e) {
-      logger.log(SentryLevel.DEBUG, "SU doesn't exist.", e);
+      logger.log(SentryLevel.DEBUG, "SU isn't found on this Device.");
     } catch (Exception e) {
       logger.log(SentryLevel.DEBUG, "Error when trying to check if SU exists.", e);
     } finally {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Enha: SU logging was too verbose


## :bulb: Motivation and Context
We don't need to see the full stack trace if `su` is just not found, that's the expected behavior.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
