### PR TITLE
Set tags on SentryOptions through external configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Enhancement: Set global tags on SentryOptions and load them from external configuration (#1066)
+
 # 4.0.0-alpha.1
 
 * Enhancement: Load `sentry.properties` from the application's current working directory (#1046)

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -105,7 +105,9 @@ class SentryAutoConfigurationTest {
             "sentry.proxy.port=8090",
             "sentry.proxy.user=proxy-user",
             "sentry.proxy.pass=proxy-pass",
-            "sentry.enable-tracing=true"
+            "sentry.enable-tracing=true",
+            "sentry.tags.tag1=tag1-value",
+            "sentry.tags.tag2=tag2-value"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -130,6 +132,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.proxy!!.user).isEqualTo("proxy-user")
             assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
             assertThat(options.isEnableTracing).isTrue()
+            assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
         }
     }
 

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -63,6 +63,8 @@ tasks {
     }
     test {
         environment["SENTRY_TEST_PROPERTY"] = "\"some-value\""
+        environment["SENTRY_TEST_MAP_KEY1"] = "\"value1\""
+        environment["SENTRY_TEST_MAP_KEY2"] = "value2"
     }
 }
 

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -5,6 +5,7 @@ import io.sentry.util.ApplyScopeUtils;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -85,6 +86,12 @@ public final class MainEventProcessor implements EventProcessor {
     }
     if (event.getSdk() == null) {
       event.setSdk(options.getSdkVersion());
+    }
+
+    for (Map.Entry<String, String> tag : options.getTags().entrySet()) {
+      if (event.getTag(tag.getKey()) == null) {
+        event.setTag(tag.getKey(), tag.getValue());
+      }
     }
 
     if (event.getThreads() == null) {

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -88,7 +88,7 @@ public final class MainEventProcessor implements EventProcessor {
       event.setSdk(options.getSdkVersion());
     }
 
-    for (Map.Entry<String, String> tag : options.getTags().entrySet()) {
+    for (final Map.Entry<String, String> tag : options.getTags().entrySet()) {
       if (event.getTag(tag.getKey()) == null) {
         event.setTag(tag.getKey(), tag.getValue());
       }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -11,7 +11,10 @@ import io.sentry.transport.NoOpTransport;
 import io.sentry.transport.NoOpTransportGate;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -240,6 +243,9 @@ public class SentryOptions {
    */
   private boolean enableExternalConfiguration;
 
+  /** Tags applied to every event and transaction */
+  private @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
+
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
@@ -253,6 +259,7 @@ public class SentryOptions {
     options.setRelease(propertiesProvider.getProperty("release"));
     options.setDist(propertiesProvider.getProperty("dist"));
     options.setServerName(propertiesProvider.getProperty("servername"));
+    options.setTags(propertiesProvider.getMap("tags"));
 
     final String proxyHost = propertiesProvider.getProperty("proxy.host");
     final String proxyUser = propertiesProvider.getProperty("proxy.user");
@@ -1118,6 +1125,34 @@ public class SentryOptions {
     this.enableExternalConfiguration = enableExternalConfiguration;
   }
 
+  /**
+   * Returns tags applied to all events and transactions.
+   *
+   * @return the tags map
+   */
+  public @NotNull Map<String, String> getTags() {
+    return tags;
+  }
+
+  /**
+   * Sets tags applied to all events and transactions.
+   *
+   * @param tags the tags map
+   */
+  public void setTags(final @NotNull Map<String, String> tags) {
+    this.tags = tags;
+  }
+
+  /**
+   * Sets a tag that is applied to all events and transactions.
+   *
+   * @param key the key
+   * @param value the value
+   */
+  public void setTag(final @NotNull String key, final @NotNull String value) {
+    this.tags.put(key, value);
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -1202,6 +1237,10 @@ public class SentryOptions {
     }
     if (options.getProxy() != null) {
       setProxy(options.getProxy());
+    }
+    final Map<String, String> tags = new HashMap<>(options.getTags());
+    for (Map.Entry<String, String> tag : tags.entrySet()) {
+      this.tags.put(tag.getKey(), tag.getValue());
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -244,7 +244,7 @@ public class SentryOptions {
   private boolean enableExternalConfiguration;
 
   /** Tags applied to every event and transaction */
-  private @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
+  private final @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
 
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
@@ -259,7 +259,10 @@ public class SentryOptions {
     options.setRelease(propertiesProvider.getProperty("release"));
     options.setDist(propertiesProvider.getProperty("dist"));
     options.setServerName(propertiesProvider.getProperty("servername"));
-    options.setTags(propertiesProvider.getMap("tags"));
+    final Map<String, String> tags = propertiesProvider.getMap("tags");
+    for (final Map.Entry<String, String> tag : tags.entrySet()) {
+      options.setTag(tag.getKey(), tag.getValue());
+    }
 
     final String proxyHost = propertiesProvider.getProperty("proxy.host");
     final String proxyUser = propertiesProvider.getProperty("proxy.user");
@@ -1135,15 +1138,6 @@ public class SentryOptions {
   }
 
   /**
-   * Sets tags applied to all events and transactions.
-   *
-   * @param tags the tags map
-   */
-  public void setTags(final @NotNull Map<String, String> tags) {
-    this.tags = tags;
-  }
-
-  /**
    * Sets a tag that is applied to all events and transactions.
    *
    * @param key the key
@@ -1239,7 +1233,7 @@ public class SentryOptions {
       setProxy(options.getProxy());
     }
     final Map<String, String> tags = new HashMap<>(options.getTags());
-    for (Map.Entry<String, String> tag : tags.entrySet()) {
+    for (final Map.Entry<String, String> tag : tags.entrySet()) {
       this.tags.put(tag.getKey(), tag.getValue());
     }
   }

--- a/sentry/src/main/java/io/sentry/config/AbstractPropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/AbstractPropertiesProvider.java
@@ -26,7 +26,7 @@ abstract class AbstractPropertiesProvider implements PropertiesProvider {
   }
 
   @Override
-  public @Nullable String getProperty(@NotNull String property) {
+  public @Nullable String getProperty(final @NotNull String property) {
     return StringUtils.removeSurrounding(properties.getProperty(prefix + property), "\"");
   }
 

--- a/sentry/src/main/java/io/sentry/config/AbstractPropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/AbstractPropertiesProvider.java
@@ -1,0 +1,58 @@
+package io.sentry.config;
+
+import io.sentry.util.Objects;
+import io.sentry.util.StringUtils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base class for properties provider resolving properties from {@link Properties} based sources.
+ */
+abstract class AbstractPropertiesProvider implements PropertiesProvider {
+  private final @NotNull String prefix;
+  private final @NotNull Properties properties;
+
+  protected AbstractPropertiesProvider(
+      final @NotNull String prefix, final @NotNull Properties properties) {
+    this.prefix = Objects.requireNonNull(prefix, "prefix is required");
+    this.properties = Objects.requireNonNull(properties, "properties are required");
+  }
+
+  protected AbstractPropertiesProvider(final @NotNull Properties properties) {
+    this("", properties);
+  }
+
+  @Override
+  public @Nullable String getProperty(@NotNull String property) {
+    return StringUtils.removeSurrounding(properties.getProperty(prefix + property), "\"");
+  }
+
+  /**
+   * Gets property map based on the property name, where property name is a prefix for the expected
+   * property name. For example, when {@link #prefix} is set to {@code "sentry."} and following
+   * properties are set: sentry.tags.tag1=value1 and sentry.tags.tag2=value2, calling {@code
+   * getMap("tags")} returns a map containing pairs "tag1" => "value1" and "tag2" => "value2".
+   *
+   * @param property the property name
+   * @return the map or empty if no matching environment variables found.
+   */
+  @Override
+  public @NotNull Map<String, String> getMap(final @NotNull String property) {
+    final String prefix = this.prefix + property + ".";
+
+    final Map<String, String> result = new HashMap<>();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      if (entry.getKey() instanceof String && entry.getValue() instanceof String) {
+        final String key = (String) entry.getKey();
+        if (key.startsWith(prefix)) {
+          final String value = StringUtils.removeSurrounding((String) entry.getValue(), "\"");
+          result.put(key.substring(prefix.length()), value);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
@@ -30,7 +30,7 @@ final class CompositePropertiesProvider implements PropertiesProvider {
   }
 
   @Override
-  public @NotNull Map<String, String> getMap(@NotNull String property) {
+  public @NotNull Map<String, String> getMap(final @NotNull String property) {
     for (final PropertiesProvider provider : providers) {
       final Map<String, String> result = provider.getMap(property);
       if (!result.isEmpty()) {

--- a/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
@@ -1,6 +1,8 @@
 package io.sentry.config;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,5 +27,16 @@ final class CompositePropertiesProvider implements PropertiesProvider {
       }
     }
     return null;
+  }
+
+  @Override
+  public @NotNull Map<String, String> getMap(@NotNull String property) {
+    for (final PropertiesProvider provider : providers) {
+      final Map<String, String> result = provider.getMap(property);
+      if (!result.isEmpty()) {
+        return result;
+      }
+    }
+    return new ConcurrentHashMap<>();
   }
 }

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -2,6 +2,8 @@ package io.sentry.config;
 
 import io.sentry.util.StringUtils;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,6 +17,34 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
   @Override
   public @Nullable String getProperty(@NotNull String property) {
     return StringUtils.removeSurrounding(
-        System.getenv(PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT)), "\"");
+        System.getenv(propertyToEnvironmentVariableName(property)), "\"");
+  }
+
+  /**
+   * Gets property map based on the property name, where property name is a prefix for the expected
+   * environment variable name. For example, when following environment variables are set:
+   * SENTRY_TAGS_TAG_1=value1 and SENTRY_TAGS_TAG_2=value2, calling {@code getMap("tags")} returns a
+   * map containing pairs "tag1" => "value1" and "tag2" => "value2".
+   *
+   * @param property the property name
+   * @return the map or empty if no matching environment variables found.
+   */
+  @Override
+  public @NotNull Map<String, String> getMap(final @NotNull String property) {
+    final String prefix = propertyToEnvironmentVariableName(property) + "_";
+
+    final Map<String, String> result = new ConcurrentHashMap<>();
+    for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+      final String key = entry.getKey();
+      if (key.startsWith(prefix)) {
+        final String value = StringUtils.removeSurrounding(entry.getValue(), "\"");
+        result.put(key.substring(prefix.length()).toLowerCase(Locale.ROOT), value);
+      }
+    }
+    return result;
+  }
+
+  private @NotNull String propertyToEnvironmentVariableName(final @NotNull String property) {
+    return PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT);
   }
 }

--- a/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
@@ -1,5 +1,6 @@
 package io.sentry.config;
 
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +13,15 @@ public interface PropertiesProvider {
    */
   @Nullable
   String getProperty(@NotNull String property);
+
+  /**
+   * Resolves a map for a property given by it's name.
+   *
+   * @param property - the property name
+   * @return the map or empty map if not found
+   */
+  @NotNull
+  Map<String, String> getMap(final @NotNull String property);
 
   /**
    * Resolves property given by it's name.

--- a/sentry/src/main/java/io/sentry/config/SimplePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/SimplePropertiesProvider.java
@@ -1,20 +1,12 @@
 package io.sentry.config;
 
-import io.sentry.util.StringUtils;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /** {@link PropertiesProvider} implementation that delegates to {@link Properties}. */
-final class SimplePropertiesProvider implements PropertiesProvider {
-  private final @NotNull Properties properties;
+final class SimplePropertiesProvider extends AbstractPropertiesProvider {
 
   public SimplePropertiesProvider(final @NotNull Properties properties) {
-    this.properties = properties;
-  }
-
-  @Override
-  public @Nullable String getProperty(@NotNull String property) {
-    return StringUtils.removeSurrounding(properties.getProperty(property), "\"");
+    super(properties);
   }
 }

--- a/sentry/src/main/java/io/sentry/config/SystemPropertyPropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/SystemPropertyPropertiesProvider.java
@@ -1,17 +1,12 @@
 package io.sentry.config;
 
-import io.sentry.util.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 /**
  * {@link PropertiesProvider} implementation that resolves properties from Java system properties.
  */
-final class SystemPropertyPropertiesProvider implements PropertiesProvider {
-  private static final String PREFIX = "sentry";
+final class SystemPropertyPropertiesProvider extends AbstractPropertiesProvider {
+  private static final String PREFIX = "sentry.";
 
-  @Override
-  public @Nullable String getProperty(@NotNull String property) {
-    return StringUtils.removeSurrounding(System.getProperty(PREFIX + "." + property), "\"");
+  public SystemPropertyPropertiesProvider() {
+    super(PREFIX, System.getProperties());
   }
 }

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -28,7 +28,7 @@ class MainEventProcessorTest {
             sentryOptions.isAttachThreads = attachThreads
             sentryOptions.isAttachStacktrace = attachStackTrace
             sentryOptions.environment = environment
-            sentryOptions.tags = tags
+            tags.forEach { sentryOptions.setTag(it.key, it.value) }
             return MainEventProcessor(sentryOptions)
         }
     }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -173,7 +173,8 @@ class SentryOptionsTest {
         externalOptions.release = "release"
         externalOptions.serverName = "serverName"
         externalOptions.proxy = SentryOptions.Proxy("example.com", "8090")
-        externalOptions.tags = mapOf("tag1" to "value1", "tag2" to "value2")
+        externalOptions.setTag("tag1", "value1")
+        externalOptions.setTag("tag2", "value2")
         val options = SentryOptions()
 
         options.merge(externalOptions)
@@ -192,9 +193,11 @@ class SentryOptionsTest {
     @Test
     fun `merging options merges and overwrites existing tag values`() {
         val externalOptions = SentryOptions()
-        externalOptions.tags = mapOf("tag1" to "value1", "tag2" to "value2")
+        externalOptions.setTag("tag1", "value1")
+        externalOptions.setTag("tag2", "value2")
         val options = SentryOptions()
-        options.tags = mapOf("tag2" to "original-options-value", "tag3" to "value3")
+        options.setTag("tag2", "original-options-value")
+        options.setTag("tag3", "value3")
 
         options.merge(externalOptions)
 

--- a/sentry/src/test/java/io/sentry/config/EnvironmentVariablePropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/EnvironmentVariablePropertiesProviderTest.kt
@@ -19,4 +19,11 @@ class EnvironmentVariablePropertiesProviderTest {
         val result = provider.getProperty("not.set.property")
         assertNull(result)
     }
+
+    @Test
+    fun `resolves map properties`() {
+        // SENTRY_TEST_MAP_KEY1 and SENTRY_TEST_MAP_KEY2 are set in Gradle build configuration
+        val result = provider.getMap("test.map")
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), result)
+    }
 }

--- a/sentry/src/test/java/io/sentry/config/SimplePropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/SimplePropertiesProviderTest.kt
@@ -1,14 +1,14 @@
 package io.sentry.config
 
 import java.util.Properties
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import org.junit.Test
 
 class SimplePropertiesProviderTest {
 
     @Test
-    fun `when system property is set resolves property`() {
+    fun `when property is set resolves property`() {
         val properties = Properties()
         properties["some-property"] = "\"some-value\""
         val provider = SimplePropertiesProvider(properties)
@@ -18,10 +18,21 @@ class SimplePropertiesProviderTest {
     }
 
     @Test
-    fun `when system property is not set returns null`() {
+    fun `when property is not set returns null`() {
         val provider = SimplePropertiesProvider(Properties())
 
         val result = provider.getProperty("some-property")
         assertNull(result)
+    }
+
+    @Test
+    fun `resolves map properties`() {
+        val properties = Properties()
+        properties["some-property.key1"] = "\"value1\""
+        properties["some-property.key2"] = "\"value2\""
+        val provider = SimplePropertiesProvider(properties)
+
+        val result = provider.getMap("some-property")
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), result)
     }
 }

--- a/sentry/src/test/java/io/sentry/config/SystemPropertyPropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/SystemPropertyPropertiesProviderTest.kt
@@ -25,4 +25,13 @@ class SystemPropertyPropertiesProviderTest {
         val result = provider.getProperty("dsn")
         assertNull(result)
     }
+
+    @Test
+    fun `resolves map from system properties`() {
+        System.setProperty("sentry.some-property.key1", "\"value1\"")
+        System.setProperty("sentry.some-property.key2", "\"value2\"")
+
+        val result = provider.getMap("some-property")
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), result)
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Add an option to set tags on SentryOptions through external configuration.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes gh-981. Agreed with @bruno-garcia to add `tags` to `SentryOptions`.

## :green_heart: How did you test it?

Unit & integration tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes