### PR TITLE
Spring: set transaction name on events also when performance feature is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Enhancement: Set transaction name on events and transactions sent using Spring integration (#1067) 
+
 # 4.0.0-alpha.1
 
 * Enhancement: Load `sentry.properties` from the application's current working directory (#1046)

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.spring;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
+import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
@@ -13,6 +14,8 @@ import org.jetbrains.annotations.Nullable;
 public class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   private final @NotNull HttpServletRequest request;
   private final @NotNull SentryRequestResolver sentryRequestResolver;
+  private final @NotNull TransactionNameProvider transactionNameProvider =
+      new TransactionNameProvider();
 
   public SentryRequestHttpServletRequestProcessor(
       final @NotNull HttpServletRequest request,
@@ -26,6 +29,9 @@ public class SentryRequestHttpServletRequestProcessor implements EventProcessor 
   public @NotNull SentryEvent process(
       final @NotNull SentryEvent event, final @Nullable Object hint) {
     event.setRequest(sentryRequestResolver.resolveSentryRequest(request));
+    if (event.getTransaction() == null) {
+      event.setTransaction(transactionNameProvider.provideTransactionName(request));
+    }
     return event;
   }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
@@ -111,6 +111,19 @@ class SentrySpringIntegrationTest {
     }
 
     @Test
+    fun `attaches transaction name to events`() {
+        val restTemplate = TestRestTemplate().withBasicAuth("user", "password")
+
+        restTemplate.getForEntity("http://localhost:$port/throws", String::class.java)
+
+        await.untilAsserted {
+            verify(transport).send(checkEvent { event ->
+                assertThat(event.transaction).isEqualTo("GET /throws")
+            })
+        }
+    }
+
+    @Test
     fun `does not send events for handled exceptions`() {
         val restTemplate = TestRestTemplate().withBasicAuth("user", "password")
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Spring: set transaction name on events also when performance feature is not active

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to https://github.com/getsentry/sentry-java/pull/513 compatible with SDK 3.x and the way we resolve transaction names in the performance feature.

## :green_heart: How did you test it?

Unit & Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
