### PR TITLE
Performance: Refactor resolving SpanContext for Throwable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Fix: Set current thread only if theres no exceptions
+* Ref: Refactor resolving SpanContext for Throwable (#1068)
 
 # 4.0.0-alpha.1
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -4,13 +4,11 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IHub;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
-import io.sentry.SentryTransaction;
 import io.sentry.SpanContext;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
 import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
@@ -49,15 +47,12 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
         new ExceptionMechanismException(mechanism, ex, Thread.currentThread());
     final SentryEvent event = new SentryEvent(throwable);
     event.setLevel(SentryLevel.FATAL);
-    final SentryTransaction sentryTransaction = resolveActiveTransaction();
-    if (sentryTransaction != null) {
-      final SpanContext spanContext = sentryTransaction.getSpanContext(ex);
-      if (spanContext != null) {
-        // connects the event with a span
-        event.getContexts().setTrace(spanContext);
-      }
-      // connects the event with transaction
-      event.setTransaction(transactionNameProvider.provideTransactionName(request));
+    event.setTransaction(transactionNameProvider.provideTransactionName(request));
+
+    final SpanContext spanContext = hub.getSpanContext(ex);
+    if (spanContext != null) {
+      // connects the event with a span
+      event.getContexts().setTrace(spanContext);
     }
     hub.captureEvent(event);
 
@@ -68,20 +63,5 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
   @Override
   public int getOrder() {
     return order;
-  }
-
-  private @Nullable SentryTransaction resolveActiveTransaction() {
-    final AtomicReference<SentryTransaction> spanRef = new AtomicReference<>();
-
-    hub.configureScope(
-        scope -> {
-          final SentryTransaction transaction = scope.getTransaction();
-
-          if (transaction != null) {
-            spanRef.set(transaction);
-          }
-        });
-
-    return spanRef.get();
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -858,10 +858,6 @@ public final class io/sentry/SpanStatus : java/lang/Enum {
 	public static fun values ()[Lio/sentry/SpanStatus;
 }
 
-public abstract interface class io/sentry/SpanSupplier {
-	public abstract fun get (Lio/sentry/ISpan;)Ljava/lang/Object;
-}
-
 public final class io/sentry/SystemOutLogger : io/sentry/ILogger {
 	public fun <init> ()V
 	public fun isEnabled (Lio/sentry/SentryLevel;)Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -100,6 +100,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun flush (J)V
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getSpan ()Lio/sentry/ISpan;
+	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public fun isEnabled ()Z
 	public fun popScope ()V
 	public fun pushScope ()V
@@ -108,6 +109,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/SpanContext;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -137,6 +139,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public static fun getInstance ()Lio/sentry/HubAdapter;
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getSpan ()Lio/sentry/ISpan;
+	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public fun isEnabled ()Z
 	public fun popScope ()V
 	public fun pushScope ()V
@@ -145,6 +148,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/SpanContext;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -189,6 +193,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun flush (J)V
 	public abstract fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getSpan ()Lio/sentry/ISpan;
+	public abstract fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public abstract fun isEnabled ()Z
 	public abstract fun popScope ()V
 	public abstract fun pushScope ()V
@@ -197,6 +202,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setFingerprint (Ljava/util/List;)V
 	public abstract fun setLevel (Lio/sentry/SentryLevel;)V
+	public abstract fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/SpanContext;)V
 	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setTransaction (Ljava/lang/String;)V
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
@@ -725,7 +731,6 @@ public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/s
 	public fun finish ()V
 	public fun getDescription ()Ljava/lang/String;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
-	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public fun getSpans ()Ljava/util/List;
 	public fun getTransaction ()Ljava/lang/String;
 	public fun setDescription (Ljava/lang/String;)V
@@ -851,6 +856,10 @@ public final class io/sentry/SpanStatus : java/lang/Enum {
 	public static fun fromHttpStatusCode (I)Lio/sentry/SpanStatus;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SpanStatus;
 	public static fun values ()[Lio/sentry/SpanStatus;
+}
+
+public abstract interface class io/sentry/SpanSupplier {
+	public abstract fun get (Lio/sentry/ISpan;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SystemOutLogger : io/sentry/ILogger {

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -8,6 +8,7 @@ import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.util.Deque;
 import java.util.List;
+import java.util.WeakHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -30,6 +31,7 @@ public final class Hub implements IHub {
   private volatile boolean isEnabled;
   private final @NotNull Deque<StackItem> stack = new LinkedBlockingDeque<>();
   private final @NotNull TracingSampler tracingSampler;
+  private final @NotNull WeakHashMap<Throwable, SpanContext> throwableToSpanContext = new WeakHashMap<>();
 
   public Hub(final @NotNull SentryOptions options) {
     this(options, createRootStackItem(options));
@@ -734,5 +736,15 @@ public final class Hub implements IHub {
       }
     }
     return traceHeader;
+  }
+
+  @Override
+  public void setSpanContext(final @NotNull Throwable t, final @NotNull SpanContext sc) {
+    this.throwableToSpanContext.put(t, sc);
+  }
+
+  @Override
+  public @Nullable SpanContext getSpanContext(final @NotNull Throwable ex) {
+    return this.throwableToSpanContext.get(ex);
   }
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -739,12 +739,15 @@ public final class Hub implements IHub {
   }
 
   @Override
-  public void setSpanContext(final @NotNull Throwable t, final @NotNull SpanContext sc) {
-    this.throwableToSpanContext.put(t, sc);
+  public void setSpanContext(final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {
+    Objects.requireNonNull(throwable, "throwable is required");
+    Objects.requireNonNull(spanContext, "spanContext is required");
+    this.throwableToSpanContext.put(throwable, spanContext);
   }
 
   @Override
-  public @Nullable SpanContext getSpanContext(final @NotNull Throwable ex) {
-    return this.throwableToSpanContext.get(ex);
+  public @Nullable SpanContext getSpanContext(final @NotNull Throwable throwable) {
+    Objects.requireNonNull(throwable, "throwable is required");
+    return this.throwableToSpanContext.get(throwable);
   }
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -31,7 +31,8 @@ public final class Hub implements IHub {
   private volatile boolean isEnabled;
   private final @NotNull Deque<StackItem> stack = new LinkedBlockingDeque<>();
   private final @NotNull TracingSampler tracingSampler;
-  private final @NotNull WeakHashMap<Throwable, SpanContext> throwableToSpanContext = new WeakHashMap<>();
+  private final @NotNull WeakHashMap<Throwable, SpanContext> throwableToSpanContext =
+      new WeakHashMap<>();
 
   public Hub(final @NotNull SentryOptions options) {
     this(options, createRootStackItem(options));
@@ -739,7 +740,8 @@ public final class Hub implements IHub {
   }
 
   @Override
-  public void setSpanContext(final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {
+  public void setSpanContext(
+      final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {
     Objects.requireNonNull(throwable, "throwable is required");
     Objects.requireNonNull(spanContext, "spanContext is required");
     this.throwableToSpanContext.put(throwable, spanContext);

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -4,6 +4,7 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class HubAdapter implements IHub {
@@ -177,5 +178,15 @@ public final class HubAdapter implements IHub {
   @Override
   public @Nullable SentryTraceHeader traceHeaders() {
     return Sentry.traceHeaders();
+  }
+
+  @Override
+  public void setSpanContext(@NotNull Throwable t, @NotNull SpanContext sc) {
+    Sentry.getCurrentHub().setSpanContext(t, sc);
+  }
+
+  @Override
+  public @Nullable SpanContext getSpanContext(Throwable ex) {
+    return Sentry.getCurrentHub().getSpanContext(ex);
   }
 }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -181,12 +181,12 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void setSpanContext(@NotNull Throwable t, @NotNull SpanContext sc) {
+  public void setSpanContext(final @NotNull Throwable t, final @NotNull SpanContext sc) {
     Sentry.getCurrentHub().setSpanContext(t, sc);
   }
 
   @Override
-  public @Nullable SpanContext getSpanContext(Throwable ex) {
+  public @Nullable SpanContext getSpanContext(final @NotNull Throwable ex) {
     return Sentry.getCurrentHub().getSpanContext(ex);
   }
 

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -334,7 +334,8 @@ public interface IHub {
   SentryTraceHeader traceHeaders();
 
   /**
-   * Associates {@link SpanContext} with the {@link Throwable}. Used to determine in which trace the exception has been thrown in framework integrations.
+   * Associates {@link SpanContext} with the {@link Throwable}. Used to determine in which trace the
+   * exception has been thrown in framework integrations.
    *
    * @param throwable the throwable
    * @param spanContext the span context

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -333,6 +333,12 @@ public interface IHub {
   @Nullable
   SentryTraceHeader traceHeaders();
 
+  /**
+   * Associates {@link SpanContext} with the {@link Throwable}. Used to determine in which trace the exception has been thrown in framework integrations.
+   *
+   * @param throwable the throwable
+   * @param spanContext the span context
+   */
   @ApiStatus.Internal
   void setSpanContext(@NotNull Throwable throwable, @NotNull SpanContext spanContext);
 

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -332,4 +332,18 @@ public interface IHub {
    */
   @Nullable
   SentryTraceHeader traceHeaders();
+
+  @ApiStatus.Internal
+  void setSpanContext(@NotNull Throwable throwable, @NotNull SpanContext spanContext);
+
+  /**
+   * Gets the span context for the span that was active while the throwable given by parameter was
+   * thrown.
+   *
+   * @param throwable - the throwable
+   * @return span context or {@code null} if no corresponding span context found.
+   */
+  @ApiStatus.Internal
+  @Nullable
+  SpanContext getSpanContext(Throwable throwable);
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -134,7 +134,8 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public void setSpanContext(final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {}
+  public void setSpanContext(
+      final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {}
 
   @Override
   public @Nullable SpanContext getSpanContext(final @NotNull Throwable throwable) {

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -134,10 +134,10 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public void setSpanContext(@NotNull Throwable throwable, @NotNull SpanContext spanContext) {}
+  public void setSpanContext(final @NotNull Throwable throwable, final @NotNull SpanContext spanContext) {}
 
   @Override
-  public @Nullable SpanContext getSpanContext(Throwable throwable) {
+  public @Nullable SpanContext getSpanContext(final @NotNull Throwable throwable) {
     return null;
   }
 

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -134,10 +134,10 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public void setSpanContext(@NotNull Throwable t, @NotNull SpanContext sc) {}
+  public void setSpanContext(@NotNull Throwable throwable, @NotNull SpanContext spanContext) {}
 
   @Override
-  public @Nullable SpanContext getSpanContext(Throwable ex) {
+  public @Nullable SpanContext getSpanContext(Throwable throwable) {
     return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -132,4 +132,12 @@ final class NoOpHub implements IHub {
   public @NotNull SentryTraceHeader traceHeaders() {
     return new SentryTraceHeader(SentryId.EMPTY_ID, SpanId.EMPTY_ID, true);
   }
+
+  @Override
+  public void setSpanContext(@NotNull Throwable t, @NotNull SpanContext sc) {}
+
+  @Override
+  public @Nullable SpanContext getSpanContext(Throwable ex) {
+    return null;
+  }
 }

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -89,7 +89,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    */
   Span startChild(final @NotNull SpanId parentSpanId) {
     Objects.requireNonNull(parentSpanId, "parentSpanId is required");
-    final Span span = new Span(getTraceId(), parentSpanId, this);
+    final Span span = new Span(getTraceId(), parentSpanId, this, this.hub);
     this.spans.add(span);
     return span;
   }
@@ -117,6 +117,9 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
   @Override
   public void finish() {
     this.timestamp = DateUtils.getCurrentDateTime();
+    if (this.throwable != null) {
+      hub.setSpanContext(this.throwable, this.getSpanContext());
+    }
     this.hub.captureTransaction(this, null);
   }
 
@@ -198,28 +201,5 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
       }
     }
     return null;
-  }
-
-  /**
-   * Gets the span context for the span that was active while the throwable given by parameter was
-   * thrown.
-   *
-   * @param throwable - the throwable
-   * @return span context or {@code null} if no corresponding span context found.
-   */
-  public SpanContext getSpanContext(final @NotNull Throwable throwable) {
-    SpanContext context = null;
-    if (this.throwable == throwable) {
-      context = this.getSpanContext();
-    } else {
-      final List<Span> spans = new ArrayList<>(this.spans);
-      for (int i = spans.size() - 1; i >= 0; i--) {
-        if (throwable == spans.get(i).getThrowable()) {
-          context = spans.get(i);
-          break;
-        }
-      }
-    }
-    return context;
   }
 }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -22,13 +22,17 @@ public final class Span extends SpanContext implements ISpan {
   /** A throwable thrown during the execution of the span. */
   private transient @Nullable Throwable throwable;
 
+  private final transient @NotNull IHub hub;
+
   Span(
       final @NotNull SentryId traceId,
       final @NotNull SpanId parentSpanId,
-      final @NotNull SentryTransaction transaction) {
+      final @NotNull SentryTransaction transaction,
+      final @NotNull IHub hub) {
     super(traceId, new SpanId(), parentSpanId, transaction.isSampled());
     this.transaction = Objects.requireNonNull(transaction, "transaction is required");
     this.startTimestamp = DateUtils.getCurrentDateTime();
+    this.hub = hub;
   }
 
   public @NotNull Date getStartTimestamp() {
@@ -52,6 +56,9 @@ public final class Span extends SpanContext implements ISpan {
   @Override
   public void finish() {
     this.timestamp = DateUtils.getCurrentDateTime();
+    if (this.throwable != null) {
+      hub.setSpanContext(this.throwable, this);
+    }
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -55,9 +55,9 @@ public final class Span extends SpanContext implements ISpan {
 
   @Override
   public void finish() {
-    this.timestamp = DateUtils.getCurrentDateTime();
-    if (this.throwable != null) {
-      hub.setSpanContext(this.throwable, this);
+    timestamp = DateUtils.getCurrentDateTime();
+    if (throwable != null) {
+      hub.setSpanContext(throwable, this);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -32,7 +32,7 @@ public final class Span extends SpanContext implements ISpan {
     super(traceId, new SpanId(), parentSpanId, transaction.isSampled());
     this.transaction = Objects.requireNonNull(transaction, "transaction is required");
     this.startTimestamp = DateUtils.getCurrentDateTime();
-    this.hub = hub;
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   public @NotNull Date getStartTimestamp() {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1059,6 +1059,24 @@ class HubTest {
     }
     // endregion
 
+    //region setSpanContext
+    @Test
+    fun `associates span context with throwable`() {
+        val hub = generateHub()
+        val transaction = hub.startTransaction("aTransaction")
+        val span = transaction.startChild()
+        val exception = RuntimeException()
+        hub.setSpanContext(exception, span)
+        assertEquals(span, hub.getSpanContext(exception))
+    }
+
+    @Test
+    fun `returns null when no span context associated with throwable`() {
+        val hub = generateHub()
+        assertNull(hub.getSpanContext(RuntimeException()))
+    }
+    // endregion
+
     private fun generateHub(): IHub {
         val options = SentryOptions().apply {
             dsn = "https://key@sentry.io/proj"

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -1,10 +1,12 @@
 package io.sentry
 
+import com.nhaarman.mockitokotlin2.mock
 import io.sentry.protocol.SentryId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 class NoOpHubTest {
@@ -76,4 +78,17 @@ class NoOpHubTest {
     fun `traceHeaders is not null`() {
         assertNotNull(sut.traceHeaders())
     }
+
+    @Test
+    fun `getSpan returns null`() {
+        assertNull(sut.span)
+    }
+
+    @Test
+    fun `getSpanContext returns null`() {
+        assertNull(sut.getSpanContext(RuntimeException()))
+    }
+
+    @Test
+    fun `setSpanContext doesnt throw`() = sut.setSpanContext(RuntimeException(), mock())
 }

--- a/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
@@ -106,4 +106,11 @@ class SentryTransactionTest {
         transaction.setStatus(SpanStatus.ALREADY_EXISTS)
         assertEquals(SpanStatus.ALREADY_EXISTS, transaction.contexts.trace!!.status)
     }
+
+    @Test
+    fun `setName overwrites the transaction name`() {
+        val transaction = SentryTransaction("initial name")
+        transaction.setName("new name")
+        assertEquals("new name", transaction.transaction)
+    }
 }

--- a/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
@@ -106,30 +106,4 @@ class SentryTransactionTest {
         transaction.setStatus(SpanStatus.ALREADY_EXISTS)
         assertEquals(SpanStatus.ALREADY_EXISTS, transaction.contexts.trace!!.status)
     }
-
-    @Test
-    fun `when transaction has throwable set, returns transaction context`() {
-        val transaction = SentryTransaction("name")
-        val ex = RuntimeException()
-        transaction.setThrowable(ex)
-        assertEquals(transaction.contexts.trace, transaction.getSpanContext(ex))
-    }
-
-    @Test
-    fun `when transaction has a span with throwable, returns span`() {
-        val transaction = SentryTransaction("name")
-        val span = transaction.startChild()
-        val ex = RuntimeException()
-        span.throwable = ex
-        assertEquals(span, transaction.getSpanContext(ex))
-    }
-
-    @Test
-    fun `when neither transaction nor spans match throwable, returns null`() {
-        val transaction = SentryTransaction("name")
-        transaction.throwable = RuntimeException()
-        val span = transaction.startChild()
-        span.throwable = RuntimeException()
-        assertNull(transaction.getSpanContext(RuntimeException()))
-    }
 }

--- a/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTransactionTest.kt
@@ -49,6 +49,16 @@ class SentryTransactionTest {
     }
 
     @Test
+    fun `when transaction with throwable set is finished, span context is associated with throwable`() {
+        val hub = mock<IHub>()
+        val transaction = SentryTransaction("name", SpanContext(), hub)
+        val ex = RuntimeException()
+        transaction.setThrowable(ex)
+        transaction.finish()
+        verify(hub).setSpanContext(ex, transaction.spanContext)
+    }
+
+    @Test
     fun `returns sentry-trace header`() {
         val transaction = SentryTransaction("name")
 

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.nhaarman.mockitokotlin2.mock
 import io.sentry.protocol.SentryId
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,14 +12,14 @@ class SpanTest {
 
     @Test
     fun `finishing span sets the timestamp`() {
-        val span = Span(SentryId(), SpanId(), SentryTransaction("name"))
+        val span = Span(SentryId(), SpanId(), SentryTransaction("name"), mock())
         span.finish()
         assertNotNull(span.timestamp)
     }
 
     @Test
     fun `starting a child sets parent span id`() {
-        val span = Span(SentryId(), SpanId(), SentryTransaction("name"))
+        val span = Span(SentryId(), SpanId(), SentryTransaction("name"), mock())
         val child = span.startChild()
         assertEquals(span.spanId, child.parentSpanId)
     }

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -35,7 +35,7 @@ class SpanTest {
 
     @Test
     fun `starting a child creates a new span`() {
-        val span = Span(SentryId(), SpanId(), SentryTransaction("name"))
+        val span = Span(SentryId(), SpanId(), SentryTransaction("name"), mock())
         val child = span.startChild("op", "description")
         assertEquals(span.spanId, child.parentSpanId)
         assertEquals("op", child.operation)

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import io.sentry.protocol.SentryId
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,5 +46,16 @@ class SpanTest {
         val span = transaction.startChild()
         span.finish()
         assertTrue(span.isFinished)
+    }
+
+    @Test
+    fun `when span has throwable set set, it assigns itself to throwable on the Hub`() {
+        val hub = mock<IHub>()
+        val transaction = SentryTransaction(TransactionContext("name"), hub)
+        val span = transaction.startChild()
+        val ex = RuntimeException()
+        span.throwable = ex
+        span.finish()
+        verify(hub).setSpanContext(ex, span)
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Refactor resolving SpanContext for Throwable

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previous implementation would fail once we switch to sending individual spans. Here we keep an association between throwable and SpanContext on the `Hub` which is independent from transaction or span being still in memory. 

## :green_heart: How did you test it?

Integration tests cover it.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes