### PR TITLE
Add `Hub#getSpan` method.

### DIFF
--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentrySpanClientHttpRequestInterceptor.java
@@ -11,7 +11,6 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.core.NamedThreadLocal;
@@ -37,7 +36,7 @@ class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequestInterce
       @NotNull byte[] body,
       @NotNull ClientHttpRequestExecution execution)
       throws IOException {
-    final ISpan activeSpan = resolveActiveSpan();
+    final ISpan activeSpan = hub.getSpan();
     if (activeSpan == null) {
       return execution.execute(request, body);
     }
@@ -59,22 +58,6 @@ class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequestInterce
         urlTemplate.remove();
       }
     }
-  }
-
-  // TODO: this method ideally gets extracted or moves to Hub itself
-  private @Nullable ISpan resolveActiveSpan() {
-    final AtomicReference<ISpan> spanRef = new AtomicReference<>();
-
-    hub.configureScope(
-        scope -> {
-          final ISpan span = scope.getSpan();
-
-          if (span != null) {
-            spanRef.set(span);
-          }
-        });
-
-    return spanRef.get();
   }
 
   UriTemplateHandler createUriTemplateHandler(final @NotNull UriTemplateHandler delegate) {

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -1,11 +1,9 @@
 package io.sentry.spring.boot
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.IHub
 import io.sentry.Scope
-import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
 import io.sentry.SentryTransaction
 import io.sentry.SpanContext
@@ -35,9 +33,7 @@ class SentrySpanRestTemplateCustomizerTest {
             if (isTransactionActive) {
                 val scope = Scope(SentryOptions())
                 scope.setTransaction(transaction)
-                whenever(hub.configureScope(any())).thenAnswer {
-                    (it.arguments[0] as ScopeCallback).run(scope)
-                }
+                whenever(hub.span).thenReturn(transaction)
 
                 mockServer.expect(MockRestRequestMatchers.requestTo("/test/123"))
                     .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
@@ -6,7 +6,6 @@ import io.sentry.ISpan;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.lang.reflect.Method;
-import java.util.concurrent.atomic.AtomicReference;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.jetbrains.annotations.NotNull;
@@ -29,7 +28,7 @@ public class SentrySpanAdvice implements MethodInterceptor {
 
   @Override
   public Object invoke(final @NotNull MethodInvocation invocation) throws Throwable {
-    final ISpan activeSpan = resolveActiveSpan();
+    final ISpan activeSpan = hub.getSpan();
 
     if (activeSpan == null) {
       // there is no active transaction, we do not start new span
@@ -65,20 +64,5 @@ public class SentrySpanAdvice implements MethodInterceptor {
     return sentrySpan == null || StringUtils.isEmpty(sentrySpan.value())
         ? targetClass.getSimpleName() + "." + method.getName()
         : sentrySpan.value();
-  }
-
-  private @Nullable ISpan resolveActiveSpan() {
-    final AtomicReference<ISpan> spanRef = new AtomicReference<>();
-
-    hub.configureScope(
-        scope -> {
-          final ISpan span = scope.getSpan();
-
-          if (span != null) {
-            spanRef.set(span);
-          }
-        });
-
-    return spanRef.get();
   }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentrySpanAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentrySpanAdviceTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.IHub
 import io.sentry.Scope
-import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
 import io.sentry.SentryTransaction
 import io.sentry.SpanContext
@@ -50,9 +49,7 @@ class SentrySpanAdviceTest {
         val tx = SentryTransaction("aTransaction", SpanContext(), hub)
         scope.setTransaction(tx)
 
-        whenever(hub.configureScope(any())).thenAnswer {
-            (it.arguments[0] as ScopeCallback).run(scope)
-        }
+        whenever(hub.span).thenReturn(tx)
         val result = sampleService.methodWithSpanDescriptionSet()
         assertEquals(1, result)
         assertEquals(1, tx.spans.size)
@@ -66,9 +63,7 @@ class SentrySpanAdviceTest {
         val tx = SentryTransaction("aTransaction", SpanContext(), hub)
         scope.setTransaction(tx)
 
-        whenever(hub.configureScope(any())).thenAnswer {
-            (it.arguments[0] as ScopeCallback).run(scope)
-        }
+        whenever(hub.span).thenReturn(tx)
         val result = sampleService.methodWithoutSpanDescriptionSet()
         assertEquals(2, result)
         assertEquals(1, tx.spans.size)
@@ -82,9 +77,7 @@ class SentrySpanAdviceTest {
         val tx = SentryTransaction("aTransaction", SpanContext(), hub)
         scope.setTransaction(tx)
 
-        whenever(hub.configureScope(any())).thenAnswer {
-            (it.arguments[0] as ScopeCallback).run(scope)
-        }
+        whenever(hub.span).thenReturn(tx)
         sampleService.methodWithSpanDescriptionSet()
         assertEquals(SpanStatus.OK, tx.spans.first().status)
     }
@@ -95,9 +88,7 @@ class SentrySpanAdviceTest {
         val tx = SentryTransaction("aTransaction", SpanContext(), hub)
         scope.setTransaction(tx)
 
-        whenever(hub.configureScope(any())).thenAnswer {
-            (it.arguments[0] as ScopeCallback).run(scope)
-        }
+        whenever(hub.span).thenReturn(tx)
         var throwable: Throwable? = null
         try {
             sampleService.methodThrowingException()
@@ -111,9 +102,7 @@ class SentrySpanAdviceTest {
     @Test
     fun `when method is annotated with @SentrySpan and there is no active transaction, span is not created and method is executed`() {
         val scope = Scope(SentryOptions())
-        whenever(hub.configureScope(any())).thenAnswer {
-            (it.arguments[0] as ScopeCallback).run(scope)
-        }
+        whenever(hub.span).thenReturn(null)
         val result = sampleService.methodWithSpanDescriptionSet()
         assertEquals(1, result)
     }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -735,4 +735,22 @@ public final class Hub implements IHub {
     }
     return traceHeader;
   }
+
+  @Override
+  public @Nullable ISpan getSpan() {
+    ISpan span = null;
+    if (!isEnabled()) {
+      options
+          .getLogger()
+          .log(SentryLevel.WARNING, "Instance is disabled and this 'getSpan' call is a no-op.");
+    } else {
+      final StackItem item = stack.peek();
+      if (item != null) {
+        span = item.scope.getSpan();
+      } else {
+        options.getLogger().log(SentryLevel.FATAL, "Stack peek was null when getSpan");
+      }
+    }
+    return span;
+  }
 }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -178,4 +178,9 @@ public final class HubAdapter implements IHub {
   public @Nullable SentryTraceHeader traceHeaders() {
     return Sentry.traceHeaders();
   }
+
+  @Override
+  public @Nullable ISpan getSpan() {
+    return Sentry.getCurrentHub().getSpan();
+  }
 }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -332,4 +332,12 @@ public interface IHub {
    */
   @Nullable
   SentryTraceHeader traceHeaders();
+
+  /**
+   * Gets the current active transaction or span.
+   *
+   * @return the active span or null when no active transaction is running
+   */
+  @Nullable
+  ISpan getSpan();
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -132,4 +132,9 @@ final class NoOpHub implements IHub {
   public @NotNull SentryTraceHeader traceHeaders() {
     return new SentryTraceHeader(SentryId.EMPTY_ID, SpanId.EMPTY_ID, true);
   }
+
+  @Override
+  public @Nullable ISpan getSpan() {
+    return null;
+  }
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -553,6 +553,15 @@ public final class Sentry {
   }
 
   /**
+   * Gets the current active transaction or span.
+   *
+   * @return the active span or null when no active transaction is running
+   */
+  public static @Nullable ISpan getSpan() {
+    return getCurrentHub().getSpan();
+  }
+
+  /**
    * Configuration options callback
    *
    * @param <T> a class that extends SentryOptions or SentryOptions itself.

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1036,6 +1036,29 @@ class HubTest {
     }
     //endregion
 
+    //region getSpan tests
+    @Test
+    fun `when there is no active transaction, getSpan returns null`() {
+        val hub = generateHub()
+        assertNull(hub.getSpan())
+    }
+
+    @Test
+    fun `when there is active transaction, getSpan returns active transaction`() {
+        val hub = generateHub()
+        val tx = hub.startTransaction("aTransaction")
+        assertEquals(tx, hub.getSpan())
+    }
+
+    @Test
+    fun `when there is active span within a transaction, getSpan returns active span`() {
+        val hub = generateHub()
+        val tx = hub.startTransaction("aTransaction")
+        val span = tx.startChild()
+        assertEquals(span, hub.getSpan())
+    }
+    // endregion
+
     private fun generateHub(): IHub {
         val options = SentryOptions().apply {
             dsn = "https://key@sentry.io/proj"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Adds a `getSpan` method on `Sentry` and `Hub` that returns current active transaction or span.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently it's very inconvenient to resolve active span or transaction - common thing when building framework integration. Other SDKs have similar methods.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes