### PR TITLE
docs: Fix comment for cacheDirSize

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -521,7 +521,7 @@ public class SentryOptions {
   }
 
   /**
-   * Returns the cache dir. size Default is 10
+   * Returns the cache dir. size Default is 30
    *
    * @return the cache dir. size
    */
@@ -530,7 +530,7 @@ public class SentryOptions {
   }
 
   /**
-   * Sets the cache dir. size Default is 10
+   * Sets the cache dir. size Default is 30
    *
    * @param cacheDirSize the cache dir. size
    */


### PR DESCRIPTION
The default for `cacheDirSize` is 30. The comment for the getter and setter stated 10 instead
of 30. This is fixed now.