### PR TITLE
Enha: Add API validator and remove deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Enhancement: Set transaction name on events and transactions sent using Spring integration (#1067) 
 * Fix: Set current thread only if there are no exceptions
 * Enhancement: Set global tags on SentryOptions and load them from external configuration (#1066)
+* Enhancement: Add API validator and remove deprecated methods
 
 # 4.0.0-alpha.1
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ buildscript {
         google()
         jcenter()
         maven { setUrl("https://dl.bintray.com/maranda/maven/") }
+        maven { setUrl("https://kotlin.bintray.com/kotlinx") }
     }
     dependencies {
         classpath(Config.BuildPlugins.androidGradle)
@@ -30,8 +31,12 @@ buildscript {
 
         // add classpath of sentry android gradle plugin
         // classpath("io.sentry:sentry-android-gradle-plugin:{version}")
+
+        classpath(Config.QualityPlugins.binaryCompatibilityValidatorPlugin)
     }
 }
+
+apply(plugin = Config.QualityPlugins.binaryCompatibilityValidator)
 
 allprojects {
     repositories {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -91,6 +91,8 @@ object Config {
         val detekt = "io.gitlab.arturbosch.detekt"
         val detektVersion = "1.14.2"
         val detektPlugin = "io.gitlab.arturbosch.detekt"
+        val binaryCompatibilityValidatorPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.4"
+        val binaryCompatibilityValidator = "binary-compatibility-validator"
     }
 
     object Sentry {

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -1,0 +1,166 @@
+public final class io/sentry/android/core/ActivityBreadcrumbsIntegration : android/app/Application$ActivityLifecycleCallbacks, io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/app/Application;)V
+	public fun close ()V
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/AnrIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;)V
+	public fun close ()V
+	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/AppComponentsBreadcrumbsIntegration : android/content/ComponentCallbacks2, io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;)V
+	public fun close ()V
+	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
+	public fun onLowMemory ()V
+	public fun onTrimMemory (I)V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/AppLifecycleIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> ()V
+	public fun close ()V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field SENTRY_ANDROID_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/android/core/BuildInfoProvider : io/sentry/android/core/IBuildInfoProvider {
+	public fun <init> ()V
+	public fun getBuildTags ()Ljava/lang/String;
+	public fun getSdkInfoVersion ()I
+}
+
+public abstract class io/sentry/android/core/EnvelopeFileObserverIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> ()V
+	public fun close ()V
+	public static fun getOutboxFileObserver ()Lio/sentry/android/core/EnvelopeFileObserverIntegration;
+	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public abstract interface class io/sentry/android/core/IBuildInfoProvider {
+	public abstract fun getBuildTags ()Ljava/lang/String;
+	public abstract fun getSdkInfoVersion ()I
+}
+
+public abstract interface class io/sentry/android/core/IDebugImagesLoader {
+	public abstract fun clearDebugImages ()V
+	public abstract fun loadDebugImages ()Ljava/util/List;
+}
+
+public final class io/sentry/android/core/NdkIntegration : io/sentry/Integration {
+	public static final field SENTRY_NDK_CLASS_NAME Ljava/lang/String;
+	public fun <init> (Ljava/lang/Class;)V
+	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/PhoneStateBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;)V
+	public fun close ()V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/SentryAndroid {
+	public static fun init (Landroid/content/Context;)V
+	public static fun init (Landroid/content/Context;Lio/sentry/ILogger;)V
+	public static fun init (Landroid/content/Context;Lio/sentry/ILogger;Lio/sentry/Sentry$OptionsConfiguration;)V
+	public static fun init (Landroid/content/Context;Lio/sentry/Sentry$OptionsConfiguration;)V
+}
+
+public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/SentryOptions {
+	public fun <init> ()V
+	public fun enableAllAutoBreadcrumbs (Z)V
+	public fun getAnrTimeoutIntervalMillis ()J
+	public fun getDebugImagesLoader ()Lio/sentry/android/core/IDebugImagesLoader;
+	public fun isAnrEnabled ()Z
+	public fun isAnrReportInDebug ()Z
+	public fun isEnableActivityLifecycleBreadcrumbs ()Z
+	public fun isEnableAppComponentBreadcrumbs ()Z
+	public fun isEnableAppLifecycleBreadcrumbs ()Z
+	public fun isEnableSystemEventBreadcrumbs ()Z
+	public fun setAnrEnabled (Z)V
+	public fun setAnrReportInDebug (Z)V
+	public fun setAnrTimeoutIntervalMillis (J)V
+	public fun setDebugImagesLoader (Lio/sentry/android/core/IDebugImagesLoader;)V
+	public fun setEnableActivityLifecycleBreadcrumbs (Z)V
+	public fun setEnableAppComponentBreadcrumbs (Z)V
+	public fun setEnableAppLifecycleBreadcrumbs (Z)V
+	public fun setEnableSystemEventBreadcrumbs (Z)V
+}
+
+public final class io/sentry/android/core/SentryInitProvider : android/content/ContentProvider {
+	public fun <init> ()V
+	public fun attachInfo (Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V
+	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
+	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
+	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;
+	public fun onCreate ()Z
+	public fun query (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
+	public fun shutdown ()V
+	public fun update (Landroid/net/Uri;Landroid/content/ContentValues;Ljava/lang/String;[Ljava/lang/String;)I
+}
+
+public final class io/sentry/android/core/SystemEventsBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Ljava/util/List;)V
+	public fun close ()V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/TempSensorBreadcrumbsIntegration : android/hardware/SensorEventListener, io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;)V
+	public fun close ()V
+	public fun onAccuracyChanged (Landroid/hardware/Sensor;I)V
+	public fun onSensorChanged (Landroid/hardware/SensorEvent;)V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/core/util/ConnectivityChecker {
+	public static fun getConnectionStatus (Landroid/content/Context;Lio/sentry/ILogger;)Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static fun getConnectionType (Landroid/content/Context;Lio/sentry/ILogger;Lio/sentry/android/core/IBuildInfoProvider;)Ljava/lang/String;
+}
+
+public final class io/sentry/android/core/util/ConnectivityChecker$Status : java/lang/Enum {
+	public static final field CONNECTED Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static final field NOT_CONNECTED Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static final field NO_PERMISSION Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static final field UNKNOWN Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/android/core/util/ConnectivityChecker$Status;
+	public static fun values ()[Lio/sentry/android/core/util/ConnectivityChecker$Status;
+}
+
+public final class io/sentry/android/core/util/DeviceOrientations {
+	public static fun getOrientation (I)Lio/sentry/protocol/Device$DeviceOrientation;
+}
+
+public final class io/sentry/android/core/util/MainThreadChecker {
+	public static fun isMainThread ()Z
+	public static fun isMainThread (Lio/sentry/protocol/SentryThread;)Z
+	public static fun isMainThread (Ljava/lang/Thread;)Z
+}
+
+public final class io/sentry/android/core/util/Permissions {
+	public static fun hasPermission (Landroid/content/Context;Ljava/lang/String;)Z
+}
+
+public final class io/sentry/android/core/util/RootChecker {
+	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/IBuildInfoProvider;Lio/sentry/ILogger;)V
+	public fun isDeviceRooted ()Z
+}
+

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -246,11 +246,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setArchitectures(final @NotNull Device device) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       String[] supportedAbis = Build.SUPPORTED_ABIS;
-      device.setArch(supportedAbis[0]);
       device.setArchs(supportedAbis);
     } else {
       String[] supportedAbis = {getAbi(), getAbi2()};
-      device.setArch(supportedAbis[0]);
       device.setArchs(supportedAbis);
       // we were not checking CPU_ABI2, but I've added to the list now
     }
@@ -335,7 +333,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     DisplayMetrics displayMetrics = getDisplayMetrics();
     if (displayMetrics != null) {
-      setScreenResolution(device, displayMetrics);
       device.setScreenWidthPixels(displayMetrics.widthPixels);
       device.setScreenHeightPixels(displayMetrics.heightPixels);
       device.setScreenDensity(displayMetrics.density);
@@ -369,12 +366,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
   }
 
-  @SuppressWarnings("deprecation")
-  private void setScreenResolution(
-      final @NotNull Device device, final @NotNull DisplayMetrics displayMetrics) {
-    device.setScreenResolution(getResolution(displayMetrics));
-  }
-
   private TimeZone getTimeZone() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       LocaleList locales = context.getResources().getConfiguration().getLocales();
@@ -396,12 +387,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
     }
     return null;
-  }
-
-  private @NotNull String getResolution(final @NotNull DisplayMetrics displayMetrics) {
-    int largestSide = Math.max(displayMetrics.widthPixels, displayMetrics.heightPixels);
-    int smallestSide = Math.min(displayMetrics.widthPixels, displayMetrics.heightPixels);
-    return largestSide + "x" + smallestSide;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -8,7 +8,6 @@ import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.util.Objects;
 import java.util.Locale;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,9 +20,6 @@ final class ManifestMetadataReader {
   static final String SAMPLE_RATE = "io.sentry.sample-rate";
   static final String ANR_ENABLE = "io.sentry.anr.enable";
   static final String ANR_REPORT_DEBUG = "io.sentry.anr.report-debug";
-
-  @ApiStatus.ScheduledForRemoval @Deprecated
-  static final String ANR_TIMEOUT_INTERVAL_MILLS = "io.sentry.anr.timeout-interval-mills";
 
   static final String ANR_TIMEOUT_INTERVAL_MILLIS = "io.sentry.anr.timeout-interval-millis";
 
@@ -101,14 +97,10 @@ final class ManifestMetadataReader {
         options.getLogger().log(SentryLevel.DEBUG, "anrReportInDebug read: %s", anrReportInDebug);
         options.setAnrReportInDebug(anrReportInDebug);
 
-        // deprecated
-        final long anrTimeoutIntervalMills =
-            metadata.getInt(
-                ANR_TIMEOUT_INTERVAL_MILLS, (int) options.getAnrTimeoutIntervalMillis());
-
-        // reading new values, but deprecated one as fallback
+        // reading new values
         final long anrTimeoutIntervalMillis =
-            metadata.getInt(ANR_TIMEOUT_INTERVAL_MILLIS, (int) anrTimeoutIntervalMills);
+            metadata.getInt(
+                ANR_TIMEOUT_INTERVAL_MILLIS, (int) options.getAnrTimeoutIntervalMillis());
 
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -2,7 +2,6 @@ package io.sentry.android.core;
 
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Sentry SDK options for Android */
@@ -73,24 +72,6 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   public void setAnrEnabled(boolean anrEnabled) {
     this.anrEnabled = anrEnabled;
-  }
-
-  /**
-   * @deprecated use {@link #getAnrTimeoutIntervalMillis , #getAnrTimeoutIntervalMillis} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public long getAnrTimeoutIntervalMills() {
-    return getAnrTimeoutIntervalMillis();
-  }
-
-  /**
-   * @deprecated use {@link #setAnrTimeoutIntervalMillis , #setAnrTimeoutIntervalMillis} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public void setAnrTimeoutIntervalMills(long anrTimeoutIntervalMillis) {
-    setAnrTimeoutIntervalMillis(anrTimeoutIntervalMillis);
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -208,21 +208,6 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata reads anr deprecated interval to options`() {
-        // Arrange
-        val options = SentryAndroidOptions()
-        val bundle = Bundle()
-        val mockContext = ContextUtilsTest.mockMetaData(metaData = bundle)
-        bundle.putInt(ManifestMetadataReader.ANR_TIMEOUT_INTERVAL_MILLS, 1000)
-
-        // Act
-        ManifestMetadataReader.applyMetadata(mockContext, options)
-
-        // Assert
-        assertEquals(1000.toLong(), options.anrTimeoutIntervalMillis)
-    }
-
-    @Test
     fun `applyMetadata reads anr interval to options`() {
         // Arrange
         val options = SentryAndroidOptions()

--- a/sentry-android-ndk/api/sentry-android-ndk.api
+++ b/sentry-android-ndk/api/sentry-android-ndk.api
@@ -1,0 +1,22 @@
+public final class io/sentry/android/ndk/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/android/ndk/NdkScopeObserver : io/sentry/IScopeObserver {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public fun removeExtra (Ljava/lang/String;)V
+	public fun removeTag (Ljava/lang/String;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
+}
+
+public final class io/sentry/android/ndk/SentryNdk {
+	public static fun init (Lio/sentry/android/core/SentryAndroidOptions;)V
+}
+

--- a/sentry-android-timber/api/sentry-android-timber.api
+++ b/sentry-android-timber/api/sentry-android-timber.api
@@ -1,0 +1,22 @@
+public final class io/sentry/android/timber/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/android/timber/SentryTimberIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;)V
+	public synthetic fun <init> (Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun getMinBreadcrumbLevel ()Lio/sentry/SentryLevel;
+	public final fun getMinEventLevel ()Lio/sentry/SentryLevel;
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/android/timber/SentryTimberTree : timber/log/Timber$Tree {
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;)V
+}
+

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -65,6 +65,10 @@ tasks.withType<Test> {
     }
 }
 
+kotlin {
+    explicitApi()
+}
+
 dependencies {
     api(project(":sentry"))
 

--- a/sentry-log4j2/api/sentry-log4j2.api
+++ b/sentry-log4j2/api/sentry-log4j2.api
@@ -1,0 +1,12 @@
+public final class io/sentry/log4j2/BuildConfig {
+	public static final field SENTRY_LOG4J2_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+}
+
+public final class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
+	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Lio/sentry/transport/ITransport;Lio/sentry/IHub;)V
+	public fun append (Lorg/apache/logging/log4j/core/LogEvent;)V
+	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;)Lio/sentry/log4j2/SentryAppender;
+	public fun start ()V
+}
+

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -1,0 +1,15 @@
+public final class io/sentry/logback/BuildConfig {
+	public static final field SENTRY_LOGBACK_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+}
+
+public final class io/sentry/logback/SentryAppender : ch/qos/logback/core/UnsynchronizedAppenderBase {
+	public fun <init> ()V
+	public fun getMinimumBreadcrumbLevel ()Lch/qos/logback/classic/Level;
+	public fun getMinimumEventLevel ()Lch/qos/logback/classic/Level;
+	public fun setMinimumBreadcrumbLevel (Lch/qos/logback/classic/Level;)V
+	public fun setMinimumEventLevel (Lch/qos/logback/classic/Level;)V
+	public fun setOptions (Lio/sentry/SentryOptions;)V
+	public fun start ()V
+}
+

--- a/sentry-samples/sentry-samples-android/api/sentry-samples-android.api
+++ b/sentry-samples/sentry-samples-android/api/sentry-samples-android.api
@@ -1,0 +1,43 @@
+public final class io/sentry/samples/BuildConfig {
+	public static final field APPLICATION_ID Ljava/lang/String;
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public class io/sentry/samples/MainActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+	protected fun onCreate (Landroid/os/Bundle;)V
+}
+
+public class io/sentry/samples/MyApplication : android/app/Application {
+	public fun <init> ()V
+	public fun onCreate ()V
+}
+
+public class io/sentry/samples/NativeSample {
+	public fun <init> ()V
+	public static fun crash ()V
+	public static fun message ()V
+}
+
+public final class io/sentry/samples/databinding/ActivityMainBinding : androidx/viewbinding/ViewBinding {
+	public final field anr Landroid/widget/Button;
+	public final field breadcrumb Landroid/widget/Button;
+	public final field captureException Landroid/widget/Button;
+	public final field crashFromJava Landroid/widget/Button;
+	public final field nativeCapture Landroid/widget/Button;
+	public final field nativeCrash Landroid/widget/Button;
+	public final field sendMessage Landroid/widget/Button;
+	public final field sendUserFeedback Landroid/widget/Button;
+	public final field setUser Landroid/widget/Button;
+	public final field unsetUser Landroid/widget/Button;
+	public static fun bind (Landroid/view/View;)Lio/sentry/samples/databinding/ActivityMainBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lio/sentry/samples/databinding/ActivityMainBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lio/sentry/samples/databinding/ActivityMainBinding;
+}
+

--- a/sentry-samples/sentry-samples-spring-boot/api/sentry-samples-spring-boot.api
+++ b/sentry-samples/sentry-samples-spring-boot/api/sentry-samples-spring-boot.api
@@ -1,0 +1,43 @@
+public class io/sentry/samples/spring/boot/CustomEventProcessor : io/sentry/EventProcessor {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public class io/sentry/samples/spring/boot/Person {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun getFirstName ()Ljava/lang/String;
+	public fun getLastName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/sentry/samples/spring/boot/PersonController {
+	public fun <init> (Lio/sentry/samples/spring/boot/PersonService;)V
+}
+
+public class io/sentry/samples/spring/boot/PersonService {
+	public fun <init> ()V
+}
+
+public class io/sentry/samples/spring/boot/SecurityConfiguration : org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter {
+	public fun <init> ()V
+	protected fun configure (Lorg/springframework/security/config/annotation/web/builders/HttpSecurity;)V
+	public fun userDetailsService ()Lorg/springframework/security/core/userdetails/UserDetailsService;
+}
+
+public class io/sentry/samples/spring/boot/SentryDemoApplication {
+	public fun <init> ()V
+	public static fun main ([Ljava/lang/String;)V
+}
+
+public class io/sentry/samples/spring/boot/Todo {
+	public fun <init> (Ljava/lang/Long;Ljava/lang/String;Z)V
+	public fun getId ()Ljava/lang/Long;
+	public fun getTitle ()Ljava/lang/String;
+	public fun isCompleted ()Z
+}
+
+public class io/sentry/samples/spring/boot/TodoController {
+	public fun <init> (Lorg/springframework/web/client/RestTemplate;)V
+}
+

--- a/sentry-samples/sentry-samples-spring/api/sentry-samples-spring.api
+++ b/sentry-samples/sentry-samples-spring/api/sentry-samples-spring.api
@@ -1,0 +1,22 @@
+public class io/sentry/samples/spring/Person {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun getFirstName ()Ljava/lang/String;
+	public fun getLastName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/sentry/samples/spring/PersonController {
+	public fun <init> ()V
+}
+
+public class io/sentry/samples/spring/SecurityConfiguration : org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter {
+	public fun <init> ()V
+	protected fun configure (Lorg/springframework/security/config/annotation/web/builders/HttpSecurity;)V
+	public fun userDetailsService ()Lorg/springframework/security/core/userdetails/UserDetailsService;
+}
+
+public class io/sentry/samples/spring/SentryDemoApplication {
+	public fun <init> ()V
+	public static fun main ([Ljava/lang/String;)V
+}
+

--- a/sentry-servlet/api/sentry-servlet.api
+++ b/sentry-servlet/api/sentry-servlet.api
@@ -1,0 +1,12 @@
+public class io/sentry/servlet/SentryServletContainerInitializer : javax/servlet/ServletContainerInitializer {
+	public fun <init> ()V
+	public fun onStartup (Ljava/util/Set;Ljavax/servlet/ServletContext;)V
+}
+
+public class io/sentry/servlet/SentryServletRequestListener : javax/servlet/ServletRequestListener {
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
+	public fun requestDestroyed (Ljavax/servlet/ServletRequestEvent;)V
+	public fun requestInitialized (Ljavax/servlet/ServletRequestEvent;)V
+}
+

--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -1,0 +1,36 @@
+public final class io/sentry/spring/boot/BuildConfig {
+	public static final field SENTRY_SPRING_BOOT_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+}
+
+public class io/sentry/spring/boot/SentryAutoConfiguration {
+	public fun <init> ()V
+}
+
+public class io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration : org/springframework/beans/factory/InitializingBean {
+	public fun <init> ()V
+	public fun afterPropertiesSet ()V
+}
+
+public class io/sentry/spring/boot/SentryProperties : io/sentry/SentryOptions {
+	public fun <init> ()V
+	public fun getExceptionResolverOrder ()I
+	public fun getLogging ()Lio/sentry/spring/boot/SentryProperties$Logging;
+	public fun isEnableTracing ()Z
+	public fun isUseGitCommitIdAsRelease ()Z
+	public fun setEnableTracing (Z)V
+	public fun setExceptionResolverOrder (I)V
+	public fun setLogging (Lio/sentry/spring/boot/SentryProperties$Logging;)V
+	public fun setUseGitCommitIdAsRelease (Z)V
+}
+
+public class io/sentry/spring/boot/SentryProperties$Logging {
+	public fun <init> ()V
+	public fun getMinimumBreadcrumbLevel ()Lorg/slf4j/event/Level;
+	public fun getMinimumEventLevel ()Lorg/slf4j/event/Level;
+	public fun isEnabled ()Z
+	public fun setEnabled (Z)V
+	public fun setMinimumBreadcrumbLevel (Lorg/slf4j/event/Level;)V
+	public fun setMinimumEventLevel (Lorg/slf4j/event/Level;)V
+}
+

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -1,0 +1,99 @@
+public final class io/sentry/spring/BuildConfig {
+	public static final field SENTRY_SPRING_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+}
+
+public abstract interface annotation class io/sentry/spring/EnableSentry : java/lang/annotation/Annotation {
+	public abstract fun dsn ()Ljava/lang/String;
+	public abstract fun exceptionResolverOrder ()I
+	public abstract fun sendDefaultPii ()Z
+}
+
+public final class io/sentry/spring/HttpServletRequestSentryUserProvider : io/sentry/spring/SentryUserProvider {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun provideUser ()Lio/sentry/protocol/User;
+}
+
+public class io/sentry/spring/SentryExceptionResolver : org/springframework/core/Ordered, org/springframework/web/servlet/HandlerExceptionResolver {
+	public fun <init> (Lio/sentry/IHub;I)V
+	public fun getOrder ()I
+	public fun resolveException (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)Lorg/springframework/web/servlet/ModelAndView;
+}
+
+public class io/sentry/spring/SentryHubRegistrar : org/springframework/context/annotation/ImportBeanDefinitionRegistrar {
+	public fun <init> ()V
+	public fun registerBeanDefinitions (Lorg/springframework/core/type/AnnotationMetadata;Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+}
+
+public class io/sentry/spring/SentryInitBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor, org/springframework/context/ApplicationContextAware {
+	public fun <init> ()V
+	public fun postProcessAfterInitialization (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public class io/sentry/spring/SentryRequestHttpServletRequestProcessor : io/sentry/EventProcessor {
+	public fun <init> (Ljavax/servlet/http/HttpServletRequest;Lio/sentry/spring/SentryRequestResolver;)V
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public class io/sentry/spring/SentryRequestResolver {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun resolveSentryRequest (Ljavax/servlet/http/HttpServletRequest;)Lio/sentry/protocol/Request;
+}
+
+public class io/sentry/spring/SentrySpringRequestListener : javax/servlet/ServletRequestListener, org/springframework/core/Ordered {
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/SentryRequestResolver;)V
+	public fun getOrder ()I
+	public fun requestDestroyed (Ljavax/servlet/ServletRequestEvent;)V
+	public fun requestInitialized (Ljavax/servlet/ServletRequestEvent;)V
+}
+
+public abstract interface class io/sentry/spring/SentryUserProvider {
+	public abstract fun provideUser ()Lio/sentry/protocol/User;
+}
+
+public final class io/sentry/spring/SentryUserProviderEventProcessor : io/sentry/EventProcessor {
+	public fun <init> (Lio/sentry/spring/SentryUserProvider;)V
+	public fun getSentryUserProvider ()Lio/sentry/spring/SentryUserProvider;
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public class io/sentry/spring/SentryWebConfiguration {
+	public fun <init> ()V
+	public fun httpServletRequestSentryUserProvider (Lio/sentry/SentryOptions;)Lio/sentry/spring/HttpServletRequestSentryUserProvider;
+	public fun sentryRequestResolver (Lio/sentry/SentryOptions;)Lio/sentry/spring/SentryRequestResolver;
+	public fun sentrySpringRequestListener (Lio/sentry/IHub;Lio/sentry/spring/SentryRequestResolver;)Lio/sentry/spring/SentrySpringRequestListener;
+}
+
+public abstract interface annotation class io/sentry/spring/tracing/SentrySpan : java/lang/annotation/Annotation {
+	public abstract fun description ()Ljava/lang/String;
+	public abstract fun op ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public class io/sentry/spring/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
+	public fun <init> (Lio/sentry/IHub;)V
+	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
+}
+
+public class io/sentry/spring/tracing/SentryTracingFilter : org/springframework/web/filter/OncePerRequestFilter {
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/SentryOptions;Lio/sentry/spring/SentryRequestResolver;)V
+	protected fun doFilterInternal (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljavax/servlet/FilterChain;)V
+}
+
+public abstract interface annotation class io/sentry/spring/tracing/SentryTransaction : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+	public abstract fun op ()Ljava/lang/String;
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public class io/sentry/spring/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
+	public fun <init> (Lio/sentry/IHub;)V
+	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
+}
+
+public final class io/sentry/spring/tracing/TransactionNameProvider {
+	public fun <init> ()V
+	public fun provideTransactionName (Ljavax/servlet/http/HttpServletRequest;)Ljava/lang/String;
+}
+

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -1,0 +1,4 @@
+public final class io/sentry/test/AssertionsKt {
+	public static final fun checkEvent (Lkotlin/jvm/functions/Function1;)Lio/sentry/SentryEnvelope;
+}
+

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -266,6 +266,7 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setThrowable (Ljava/lang/Throwable;)V
 	public abstract fun startChild ()Lio/sentry/Span;
+	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
 	public abstract fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }
 
@@ -732,6 +733,7 @@ public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/s
 	public fun setOperation (Ljava/lang/String;)V
 	public fun setStatus (Lio/sentry/SpanStatus;)V
 	public fun startChild ()Lio/sentry/Span;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }
 
@@ -790,6 +792,7 @@ public final class io/sentry/Span : io/sentry/SpanContext, io/sentry/ISpan {
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun setThrowable (Ljava/lang/Throwable;)V
 	public fun startChild ()Lio/sentry/Span;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1,0 +1,1599 @@
+public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/Date;)V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/Breadcrumb;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getCategory ()Ljava/lang/String;
+	public fun getData ()Ljava/util/Map;
+	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getLevel ()Lio/sentry/SentryLevel;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getTimestamp ()Ljava/util/Date;
+	public fun getType ()Ljava/lang/String;
+	public static fun http (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public fun removeData (Ljava/lang/String;)V
+	public fun setCategory (Ljava/lang/String;)V
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setMessage (Ljava/lang/String;)V
+	public fun setType (Ljava/lang/String;)V
+}
+
+public final class io/sentry/BuildConfig {
+	public static final field SENTRY_JAVA_SDK_NAME Ljava/lang/String;
+	public static final field VERSION_NAME Ljava/lang/String;
+}
+
+public final class io/sentry/CustomSamplingContext {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getData ()Ljava/util/Map;
+	public fun put (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/DateUtils {
+	public static fun getCurrentDateTime ()Ljava/util/Date;
+	public static fun getCurrentDateTimeOrNull ()Ljava/util/Date;
+	public static fun getDateTime (Ljava/lang/String;)Ljava/util/Date;
+	public static fun getDateTime (Ljava/util/Date;)Ljava/util/Date;
+	public static fun getDateTimeWithMillisPrecision (Ljava/lang/String;)Ljava/util/Date;
+	public static fun getTimestamp (Ljava/util/Date;)Ljava/lang/String;
+	public static fun getTimestampIsoFormat (Ljava/util/Date;)Ljava/lang/String;
+}
+
+public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ILogger;)V
+	public fun getLogger ()Lio/sentry/ILogger;
+	public fun isEnabled (Lio/sentry/SentryLevel;)Z
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/DuplicateEventDetectionEventProcessor : io/sentry/EventProcessor {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public final class io/sentry/EnvelopeReader : io/sentry/IEnvelopeReader {
+	public fun <init> ()V
+	public fun read (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+}
+
+public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
+	public synthetic fun processDirectory (Ljava/io/File;)V
+	public fun processEnvelopeFile (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/EventProcessor {
+	public abstract fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public final class io/sentry/GsonSerializer : io/sentry/ISerializer {
+	public fun <init> (Lio/sentry/ILogger;Lio/sentry/IEnvelopeReader;)V
+	public fun deserialize (Ljava/io/Reader;Ljava/lang/Class;)Ljava/lang/Object;
+	public fun deserializeEnvelope (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+	public fun serialize (Lio/sentry/SentryEnvelope;Ljava/io/Writer;)V
+	public fun serialize (Ljava/lang/Object;Ljava/io/Writer;)V
+	public fun serialize (Ljava/util/Map;)Ljava/lang/String;
+}
+
+public final class io/sentry/Hub : io/sentry/IHub {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
+	public fun bindClient (Lio/sentry/ISentryClient;)V
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public fun clearBreadcrumbs ()V
+	public fun clone ()Lio/sentry/IHub;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun close ()V
+	public fun configureScope (Lio/sentry/ScopeCallback;)V
+	public fun endSession ()V
+	public fun flush (J)V
+	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public fun getSpan ()Lio/sentry/ISpan;
+	public fun isEnabled ()Z
+	public fun popScope ()V
+	public fun pushScope ()V
+	public fun removeExtra (Ljava/lang/String;)V
+	public fun removeTag (Ljava/lang/String;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setFingerprint (Ljava/util/List;)V
+	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTransaction (Ljava/lang/String;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
+	public fun startSession ()V
+	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public fun withScope (Lio/sentry/ScopeCallback;)V
+}
+
+public final class io/sentry/HubAdapter : io/sentry/IHub {
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
+	public fun bindClient (Lio/sentry/ISentryClient;)V
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public fun clearBreadcrumbs ()V
+	public fun clone ()Lio/sentry/IHub;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun close ()V
+	public fun configureScope (Lio/sentry/ScopeCallback;)V
+	public fun endSession ()V
+	public fun flush (J)V
+	public static fun getInstance ()Lio/sentry/HubAdapter;
+	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public fun getSpan ()Lio/sentry/ISpan;
+	public fun isEnabled ()Z
+	public fun popScope ()V
+	public fun pushScope ()V
+	public fun removeExtra (Ljava/lang/String;)V
+	public fun removeTag (Ljava/lang/String;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setFingerprint (Ljava/util/List;)V
+	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTransaction (Ljava/lang/String;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
+	public fun startSession ()V
+	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public fun withScope (Lio/sentry/ScopeCallback;)V
+}
+
+public abstract interface class io/sentry/IEnvelopeReader {
+	public abstract fun read (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+}
+
+public abstract interface class io/sentry/IEnvelopeSender {
+	public abstract fun processEnvelopeFile (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/IHub {
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public abstract fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
+	public fun addBreadcrumb (Ljava/lang/String;)V
+	public fun addBreadcrumb (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun bindClient (Lio/sentry/ISentryClient;)V
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/SentryTransaction;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public abstract fun clearBreadcrumbs ()V
+	public abstract fun clone ()Lio/sentry/IHub;
+	public abstract fun close ()V
+	public abstract fun configureScope (Lio/sentry/ScopeCallback;)V
+	public abstract fun endSession ()V
+	public abstract fun flush (J)V
+	public abstract fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public abstract fun getSpan ()Lio/sentry/ISpan;
+	public abstract fun isEnabled ()Z
+	public abstract fun popScope ()V
+	public abstract fun pushScope ()V
+	public abstract fun removeExtra (Ljava/lang/String;)V
+	public abstract fun removeTag (Ljava/lang/String;)V
+	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setFingerprint (Ljava/util/List;)V
+	public abstract fun setLevel (Lio/sentry/SentryLevel;)V
+	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setTransaction (Ljava/lang/String;)V
+	public abstract fun setUser (Lio/sentry/protocol/User;)V
+	public abstract fun startSession ()V
+	public abstract fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
+	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Ljava/lang/String;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public abstract fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
+}
+
+public abstract interface class io/sentry/ILogger {
+	public abstract fun isEnabled (Lio/sentry/SentryLevel;)Z
+	public abstract fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/IScopeObserver {
+	public abstract fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public abstract fun removeExtra (Ljava/lang/String;)V
+	public abstract fun removeTag (Ljava/lang/String;)V
+	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setUser (Lio/sentry/protocol/User;)V
+}
+
+public abstract interface class io/sentry/ISentryClient {
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
+	public fun captureSession (Lio/sentry/Session;)V
+	public abstract fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
+	public fun captureTransaction (Lio/sentry/SentryTransaction;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public abstract fun close ()V
+	public abstract fun flush (J)V
+	public abstract fun isEnabled ()Z
+}
+
+public abstract interface class io/sentry/ISerializer {
+	public abstract fun deserialize (Ljava/io/Reader;Ljava/lang/Class;)Ljava/lang/Object;
+	public abstract fun deserializeEnvelope (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+	public abstract fun serialize (Lio/sentry/SentryEnvelope;Ljava/io/Writer;)V
+	public abstract fun serialize (Ljava/lang/Object;Ljava/io/Writer;)V
+	public abstract fun serialize (Ljava/util/Map;)Ljava/lang/String;
+}
+
+public abstract interface class io/sentry/ISpan {
+	public abstract fun finish ()V
+	public abstract fun getSpanContext ()Lio/sentry/SpanContext;
+	public abstract fun getThrowable ()Ljava/lang/Throwable;
+	public abstract fun setDescription (Ljava/lang/String;)V
+	public abstract fun setOperation (Ljava/lang/String;)V
+	public abstract fun setStatus (Lio/sentry/SpanStatus;)V
+	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun setThrowable (Ljava/lang/Throwable;)V
+	public abstract fun startChild ()Lio/sentry/Span;
+	public abstract fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+}
+
+public abstract interface class io/sentry/IUnknownPropertiesConsumer {
+	public abstract fun acceptUnknownProperties (Ljava/util/Map;)V
+}
+
+public abstract interface class io/sentry/Integration {
+	public abstract fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor {
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
+	public static fun getInstance ()Lio/sentry/NoOpEnvelopeReader;
+	public fun read (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+}
+
+public final class io/sentry/NoOpLogger : io/sentry/ILogger {
+	public static fun getInstance ()Lio/sentry/NoOpLogger;
+	public fun isEnabled (Lio/sentry/SentryLevel;)Z
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/OptionsContainer {
+	public static fun create (Ljava/lang/Class;)Lio/sentry/OptionsContainer;
+	public fun createInstance ()Ljava/lang/Object;
+}
+
+public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/IEnvelopeReader;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
+	public synthetic fun processDirectory (Ljava/io/File;)V
+	public fun processEnvelopeFile (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/SamplingContext {
+	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)V
+	public fun getCustomSamplingContext ()Lio/sentry/CustomSamplingContext;
+	public fun getTransactionContexts ()Lio/sentry/TransactionContext;
+}
+
+public final class io/sentry/Scope : java/lang/Cloneable {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
+	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
+	public fun clear ()V
+	public fun clearBreadcrumbs ()V
+	public fun clearTransaction ()V
+	public fun clone ()Lio/sentry/Scope;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getLevel ()Lio/sentry/SentryLevel;
+	public fun getSpan ()Lio/sentry/ISpan;
+	public fun getTransaction ()Lio/sentry/SentryTransaction;
+	public fun getTransactionName ()Ljava/lang/String;
+	public fun getUser ()Lio/sentry/protocol/User;
+	public fun removeContexts (Ljava/lang/String;)V
+	public fun removeExtra (Ljava/lang/String;)V
+	public fun removeTag (Ljava/lang/String;)V
+	public fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V
+	public fun setContexts (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setContexts (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setFingerprint (Ljava/util/List;)V
+	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTransaction (Lio/sentry/SentryTransaction;)V
+	public fun setTransaction (Ljava/lang/String;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
+}
+
+public abstract interface class io/sentry/ScopeCallback {
+	public abstract fun run (Lio/sentry/Scope;)V
+}
+
+public final class io/sentry/SendCachedEnvelopeFireAndForgetIntegration : io/sentry/Integration {
+	public fun <init> (Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetFactory;)V
+	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public abstract interface class io/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget {
+	public abstract fun send ()V
+}
+
+public abstract interface class io/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetDirPath {
+	public abstract fun getDirPath ()Ljava/lang/String;
+}
+
+public abstract interface class io/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetFactory {
+	public abstract fun create (Lio/sentry/IHub;Lio/sentry/SentryOptions;)Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget;
+	public fun hasValidPath (Ljava/lang/String;Lio/sentry/ILogger;)Z
+	public fun processDir (Lio/sentry/DirectoryProcessor;Ljava/lang/String;Lio/sentry/ILogger;)Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget;
+}
+
+public final class io/sentry/SendFireAndForgetEnvelopeSender : io/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetFactory {
+	public fun <init> (Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetDirPath;)V
+	public fun create (Lio/sentry/IHub;Lio/sentry/SentryOptions;)Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget;
+}
+
+public final class io/sentry/SendFireAndForgetOutboxSender : io/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetFactory {
+	public fun <init> (Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForgetDirPath;)V
+	public fun create (Lio/sentry/IHub;Lio/sentry/SentryOptions;)Lio/sentry/SendCachedEnvelopeFireAndForgetIntegration$SendFireAndForget;
+}
+
+public final class io/sentry/Sentry {
+	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
+	public static fun addBreadcrumb (Ljava/lang/String;)V
+	public static fun addBreadcrumb (Ljava/lang/String;Ljava/lang/String;)V
+	public static fun bindClient (Lio/sentry/ISentryClient;)V
+	public static fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
+	public static fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public static fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
+	public static fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public static fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
+	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public static fun clearBreadcrumbs ()V
+	public static fun close ()V
+	public static fun configureScope (Lio/sentry/ScopeCallback;)V
+	public static fun endSession ()V
+	public static fun flush (J)V
+	public static fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public static fun getSpan ()Lio/sentry/ISpan;
+	public static fun init ()V
+	public static fun init (Lio/sentry/OptionsContainer;Lio/sentry/Sentry$OptionsConfiguration;)V
+	public static fun init (Lio/sentry/OptionsContainer;Lio/sentry/Sentry$OptionsConfiguration;Z)V
+	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;)V
+	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;Z)V
+	public static fun init (Lio/sentry/SentryOptions;)V
+	public static fun isEnabled ()Z
+	public static fun popScope ()V
+	public static fun pushScope ()V
+	public static fun removeExtra (Ljava/lang/String;)V
+	public static fun removeTag (Ljava/lang/String;)V
+	public static fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
+	public static fun setFingerprint (Ljava/util/List;)V
+	public static fun setLevel (Lio/sentry/SentryLevel;)V
+	public static fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public static fun setTransaction (Ljava/lang/String;)V
+	public static fun setUser (Lio/sentry/protocol/User;)V
+	public static fun startSession ()V
+	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
+	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public static fun startTransaction (Ljava/lang/String;)Lio/sentry/SentryTransaction;
+	public static fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public static fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public static fun withScope (Lio/sentry/ScopeCallback;)V
+}
+
+public abstract interface class io/sentry/Sentry$OptionsConfiguration {
+	public abstract fun configure (Lio/sentry/SentryOptions;)V
+}
+
+public abstract class io/sentry/SentryBaseEvent {
+	protected field throwable Ljava/lang/Throwable;
+	protected fun <init> ()V
+	protected fun <init> (Lio/sentry/protocol/SentryId;)V
+	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getRequest ()Lio/sentry/protocol/Request;
+	public fun getSdk ()Lio/sentry/protocol/SdkVersion;
+	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun removeTag (Ljava/lang/String;)V
+	public fun setContexts (Lio/sentry/protocol/Contexts;)V
+	public fun setEventId (Lio/sentry/protocol/SentryId;)V
+	public fun setRequest (Lio/sentry/protocol/Request;)V
+	public fun setSdk (Lio/sentry/protocol/SdkVersion;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTags (Ljava/util/Map;)V
+	public fun setThrowable (Ljava/lang/Throwable;)V
+}
+
+public final class io/sentry/SentryClient : io/sentry/ISentryClient {
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/Connection;)V
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
+	public fun captureTransaction (Lio/sentry/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
+	public fun close ()V
+	public fun flush (J)V
+	public fun isEnabled ()Z
+}
+
+public final class io/sentry/SentryEnvelope {
+	public fun <init> (Lio/sentry/SentryEnvelopeHeader;Ljava/lang/Iterable;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;Lio/sentry/SentryEnvelopeItem;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;Ljava/lang/Iterable;)V
+	public static fun from (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;Lio/sentry/protocol/SdkVersion;)Lio/sentry/SentryEnvelope;
+	public static fun from (Lio/sentry/ISerializer;Lio/sentry/Session;Lio/sentry/protocol/SdkVersion;)Lio/sentry/SentryEnvelope;
+	public fun getHeader ()Lio/sentry/SentryEnvelopeHeader;
+	public fun getItems ()Ljava/lang/Iterable;
+}
+
+public final class io/sentry/SentryEnvelopeHeader {
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/protocol/SentryId;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;)V
+	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getSdkVersion ()Lio/sentry/protocol/SdkVersion;
+}
+
+public final class io/sentry/SentryEnvelopeHeaderAdapter : com/google/gson/TypeAdapter {
+	public fun <init> ()V
+	public fun read (Lcom/google/gson/stream/JsonReader;)Lio/sentry/SentryEnvelopeHeader;
+	public synthetic fun read (Lcom/google/gson/stream/JsonReader;)Ljava/lang/Object;
+	public fun write (Lcom/google/gson/stream/JsonWriter;Lio/sentry/SentryEnvelopeHeader;)V
+	public synthetic fun write (Lcom/google/gson/stream/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/SentryEnvelopeItem {
+	public static fun fromEvent (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromSession (Lio/sentry/ISerializer;Lio/sentry/Session;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromUserFeedback (Lio/sentry/ISerializer;Lio/sentry/UserFeedback;)Lio/sentry/SentryEnvelopeItem;
+	public fun getData ()[B
+	public fun getEvent (Lio/sentry/ISerializer;)Lio/sentry/SentryEvent;
+	public fun getHeader ()Lio/sentry/SentryEnvelopeItemHeader;
+	public fun getTransaction (Lio/sentry/ISerializer;)Lio/sentry/SentryTransaction;
+}
+
+public final class io/sentry/SentryEnvelopeItemHeader {
+	public fun getContentType ()Ljava/lang/String;
+	public fun getFileName ()Ljava/lang/String;
+	public fun getLength ()I
+	public fun getType ()Lio/sentry/SentryItemType;
+}
+
+public final class io/sentry/SentryEnvelopeItemHeaderAdapter : com/google/gson/TypeAdapter {
+	public fun <init> ()V
+	public fun read (Lcom/google/gson/stream/JsonReader;)Lio/sentry/SentryEnvelopeItemHeader;
+	public synthetic fun read (Lcom/google/gson/stream/JsonReader;)Ljava/lang/Object;
+	public fun write (Lcom/google/gson/stream/JsonWriter;Lio/sentry/SentryEnvelopeItemHeader;)V
+	public synthetic fun write (Lcom/google/gson/stream/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/util/Date;)V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public fun addBreadcrumb (Ljava/lang/String;)V
+	public fun getBreadcrumbs ()Ljava/util/List;
+	public fun getDebugMeta ()Lio/sentry/protocol/DebugMeta;
+	public fun getDist ()Ljava/lang/String;
+	public fun getEnvironment ()Ljava/lang/String;
+	public fun getExceptions ()Ljava/util/List;
+	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getFingerprints ()Ljava/util/List;
+	public fun getLevel ()Lio/sentry/SentryLevel;
+	public fun getLogger ()Ljava/lang/String;
+	public fun getMessage ()Lio/sentry/protocol/Message;
+	public fun getModule (Ljava/lang/String;)Ljava/lang/String;
+	public fun getPlatform ()Ljava/lang/String;
+	public fun getRelease ()Ljava/lang/String;
+	public fun getServerName ()Ljava/lang/String;
+	public fun getThreads ()Ljava/util/List;
+	public fun getTimestamp ()Ljava/util/Date;
+	public fun getTransaction ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun getUser ()Lio/sentry/protocol/User;
+	public fun isCrashed ()Z
+	public fun isErrored ()Z
+	public fun removeExtra (Ljava/lang/String;)V
+	public fun removeModule (Ljava/lang/String;)V
+	public fun setBreadcrumbs (Ljava/util/List;)V
+	public fun setDebugMeta (Lio/sentry/protocol/DebugMeta;)V
+	public fun setDist (Ljava/lang/String;)V
+	public fun setEnvironment (Ljava/lang/String;)V
+	public fun setExceptions (Ljava/util/List;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setExtras (Ljava/util/Map;)V
+	public fun setFingerprints (Ljava/util/List;)V
+	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setLogger (Ljava/lang/String;)V
+	public fun setMessage (Lio/sentry/protocol/Message;)V
+	public fun setModule (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setModules (Ljava/util/Map;)V
+	public fun setPlatform (Ljava/lang/String;)V
+	public fun setRelease (Ljava/lang/String;)V
+	public fun setServerName (Ljava/lang/String;)V
+	public fun setThreads (Ljava/util/List;)V
+	public fun setTransaction (Ljava/lang/String;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
+}
+
+public final class io/sentry/SentryItemType : java/lang/Enum {
+	public static final field Attachment Lio/sentry/SentryItemType;
+	public static final field Event Lio/sentry/SentryItemType;
+	public static final field Session Lio/sentry/SentryItemType;
+	public static final field Transaction Lio/sentry/SentryItemType;
+	public static final field Unknown Lio/sentry/SentryItemType;
+	public static final field UserFeedback Lio/sentry/SentryItemType;
+	public fun getItemType ()Ljava/lang/String;
+	public static fun resolve (Ljava/lang/Object;)Lio/sentry/SentryItemType;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryItemType;
+	public static fun values ()[Lio/sentry/SentryItemType;
+}
+
+public final class io/sentry/SentryLevel : java/lang/Enum {
+	public static final field DEBUG Lio/sentry/SentryLevel;
+	public static final field ERROR Lio/sentry/SentryLevel;
+	public static final field FATAL Lio/sentry/SentryLevel;
+	public static final field INFO Lio/sentry/SentryLevel;
+	public static final field WARNING Lio/sentry/SentryLevel;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryLevel;
+	public static fun values ()[Lio/sentry/SentryLevel;
+}
+
+public class io/sentry/SentryOptions {
+	public fun <init> ()V
+	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
+	public fun addInAppExclude (Ljava/lang/String;)V
+	public fun addInAppInclude (Ljava/lang/String;)V
+	public fun addIntegration (Lio/sentry/Integration;)V
+	public fun addScopeObserver (Lio/sentry/IScopeObserver;)V
+	public static fun from (Lio/sentry/config/PropertiesProvider;)Lio/sentry/SentryOptions;
+	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
+	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
+	public fun getCacheDirPath ()Ljava/lang/String;
+	public fun getCacheDirSize ()I
+	public fun getConnectionTimeoutMillis ()I
+	public fun getDiagnosticLevel ()Lio/sentry/SentryLevel;
+	public fun getDist ()Ljava/lang/String;
+	public fun getDistinctId ()Ljava/lang/String;
+	public fun getDsn ()Ljava/lang/String;
+	public fun getEnvelopeDiskCache ()Lio/sentry/cache/IEnvelopeCache;
+	public fun getEnvelopeReader ()Lio/sentry/IEnvelopeReader;
+	public fun getEnvironment ()Ljava/lang/String;
+	public fun getEventProcessors ()Ljava/util/List;
+	public fun getFlushTimeoutMillis ()J
+	public fun getHostnameVerifier ()Ljavax/net/ssl/HostnameVerifier;
+	public fun getInAppExcludes ()Ljava/util/List;
+	public fun getInAppIncludes ()Ljava/util/List;
+	public fun getIntegrations ()Ljava/util/List;
+	public fun getLogger ()Lio/sentry/ILogger;
+	public fun getMaxBreadcrumbs ()I
+	public fun getMaxQueueSize ()I
+	public fun getOutboxPath ()Ljava/lang/String;
+	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
+	public fun getReadTimeoutMillis ()I
+	public fun getRelease ()Ljava/lang/String;
+	public fun getSampleRate ()Ljava/lang/Double;
+	public fun getSdkVersion ()Lio/sentry/protocol/SdkVersion;
+	public fun getSentryClientName ()Ljava/lang/String;
+	public fun getSerializer ()Lio/sentry/ISerializer;
+	public fun getServerName ()Ljava/lang/String;
+	public fun getSessionTrackingIntervalMillis ()J
+	public fun getShutdownTimeout ()J
+	public fun getSslSocketFactory ()Ljavax/net/ssl/SSLSocketFactory;
+	public fun getTags ()Ljava/util/Map;
+	public fun getTracesSampleRate ()Ljava/lang/Double;
+	public fun getTracesSampler ()Lio/sentry/SentryOptions$TracesSamplerCallback;
+	public fun getTransport ()Lio/sentry/transport/ITransport;
+	public fun getTransportGate ()Lio/sentry/transport/ITransportGate;
+	public fun isAttachStacktrace ()Z
+	public fun isAttachThreads ()Z
+	public fun isDebug ()Z
+	public fun isEnableExternalConfiguration ()Z
+	public fun isEnableNdk ()Z
+	public fun isEnableScopeSync ()Z
+	public fun isEnableSessionTracking ()Z
+	public fun isEnableUncaughtExceptionHandler ()Z
+	public fun isSendDefaultPii ()Z
+	public fun setAttachStacktrace (Z)V
+	public fun setAttachThreads (Z)V
+	public fun setBeforeBreadcrumb (Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;)V
+	public fun setBeforeSend (Lio/sentry/SentryOptions$BeforeSendCallback;)V
+	public fun setCacheDirPath (Ljava/lang/String;)V
+	public fun setCacheDirSize (I)V
+	public fun setConnectionTimeoutMillis (I)V
+	public fun setDebug (Z)V
+	public fun setDiagnosticLevel (Lio/sentry/SentryLevel;)V
+	public fun setDist (Ljava/lang/String;)V
+	public fun setDistinctId (Ljava/lang/String;)V
+	public fun setDsn (Ljava/lang/String;)V
+	public fun setEnableExternalConfiguration (Z)V
+	public fun setEnableNdk (Z)V
+	public fun setEnableScopeSync (Z)V
+	public fun setEnableSessionTracking (Z)V
+	public fun setEnableUncaughtExceptionHandler (Z)V
+	public fun setEnvelopeDiskCache (Lio/sentry/cache/IEnvelopeCache;)V
+	public fun setEnvelopeReader (Lio/sentry/IEnvelopeReader;)V
+	public fun setEnvironment (Ljava/lang/String;)V
+	public fun setFlushTimeoutMillis (J)V
+	public fun setHostnameVerifier (Ljavax/net/ssl/HostnameVerifier;)V
+	public fun setLogger (Lio/sentry/ILogger;)V
+	public fun setMaxBreadcrumbs (I)V
+	public fun setMaxQueueSize (I)V
+	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V
+	public fun setReadTimeoutMillis (I)V
+	public fun setRelease (Ljava/lang/String;)V
+	public fun setSampleRate (Ljava/lang/Double;)V
+	public fun setSdkVersion (Lio/sentry/protocol/SdkVersion;)V
+	public fun setSendDefaultPii (Z)V
+	public fun setSentryClientName (Ljava/lang/String;)V
+	public fun setSerializer (Lio/sentry/ISerializer;)V
+	public fun setServerName (Ljava/lang/String;)V
+	public fun setSessionTrackingIntervalMillis (J)V
+	public fun setShutdownTimeout (J)V
+	public fun setSslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTracesSampleRate (Ljava/lang/Double;)V
+	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
+	public fun setTransport (Lio/sentry/transport/ITransport;)V
+	public fun setTransportGate (Lio/sentry/transport/ITransportGate;)V
+}
+
+public abstract interface class io/sentry/SentryOptions$BeforeBreadcrumbCallback {
+	public abstract fun execute (Lio/sentry/Breadcrumb;Ljava/lang/Object;)Lio/sentry/Breadcrumb;
+}
+
+public abstract interface class io/sentry/SentryOptions$BeforeSendCallback {
+	public abstract fun execute (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+}
+
+public final class io/sentry/SentryOptions$Proxy {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun getHost ()Ljava/lang/String;
+	public fun getPass ()Ljava/lang/String;
+	public fun getPort ()Ljava/lang/String;
+	public fun getUser ()Ljava/lang/String;
+	public fun setHost (Ljava/lang/String;)V
+	public fun setPass (Ljava/lang/String;)V
+	public fun setPort (Ljava/lang/String;)V
+	public fun setUser (Ljava/lang/String;)V
+}
+
+public abstract interface class io/sentry/SentryOptions$TracesSamplerCallback {
+	public abstract fun sample (Lio/sentry/SamplingContext;)Ljava/lang/Double;
+}
+
+public final class io/sentry/SentryTraceHeader {
+	public static final field SENTRY_TRACE_HEADER Ljava/lang/String;
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Ljava/lang/Boolean;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getSpanId ()Lio/sentry/SpanId;
+	public fun getTraceId ()Lio/sentry/protocol/SentryId;
+	public fun getValue ()Ljava/lang/String;
+	public fun isSampled ()Ljava/lang/Boolean;
+}
+
+public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/sentry/ISpan {
+	public fun <init> (Ljava/lang/String;Lio/sentry/SpanContext;Lio/sentry/IHub;)V
+	public fun finish ()V
+	public fun getDescription ()Ljava/lang/String;
+	public fun getSpanContext ()Lio/sentry/SpanContext;
+	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
+	public fun getSpans ()Ljava/util/List;
+	public fun getTransaction ()Ljava/lang/String;
+	public fun setDescription (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setOperation (Ljava/lang/String;)V
+	public fun setStatus (Lio/sentry/SpanStatus;)V
+	public fun startChild ()Lio/sentry/Span;
+	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+}
+
+public final class io/sentry/Session {
+	public fun <init> (Lio/sentry/Session$State;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/UUID;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/sentry/protocol/User;Ljava/lang/String;Ljava/lang/String;)V
+	public fun clone ()Lio/sentry/Session;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun end ()V
+	public fun end (Ljava/util/Date;)V
+	public fun errorCount ()I
+	public fun getDistinctId ()Ljava/lang/String;
+	public fun getDuration ()Ljava/lang/Double;
+	public fun getEnvironment ()Ljava/lang/String;
+	public fun getInit ()Ljava/lang/Boolean;
+	public fun getIpAddress ()Ljava/lang/String;
+	public fun getRelease ()Ljava/lang/String;
+	public fun getSequence ()Ljava/lang/Long;
+	public fun getSessionId ()Ljava/util/UUID;
+	public fun getStarted ()Ljava/util/Date;
+	public fun getStatus ()Lio/sentry/Session$State;
+	public fun getTimestamp ()Ljava/util/Date;
+	public fun getUserAgent ()Ljava/lang/String;
+	public fun setInitAsTrue ()V
+	public fun update (Lio/sentry/Session$State;Ljava/lang/String;Z)Z
+}
+
+public final class io/sentry/Session$State : java/lang/Enum {
+	public static final field Abnormal Lio/sentry/Session$State;
+	public static final field Crashed Lio/sentry/Session$State;
+	public static final field Exited Lio/sentry/Session$State;
+	public static final field Ok Lio/sentry/Session$State;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/Session$State;
+	public static fun values ()[Lio/sentry/Session$State;
+}
+
+public final class io/sentry/SessionAdapter : com/google/gson/TypeAdapter {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun read (Lcom/google/gson/stream/JsonReader;)Lio/sentry/Session;
+	public synthetic fun read (Lcom/google/gson/stream/JsonReader;)Ljava/lang/Object;
+	public fun write (Lcom/google/gson/stream/JsonWriter;Lio/sentry/Session;)V
+	public synthetic fun write (Lcom/google/gson/stream/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/ShutdownHookIntegration : io/sentry/Integration {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Runtime;)V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/Span : io/sentry/SpanContext, io/sentry/ISpan {
+	public fun finish ()V
+	public fun getSpanContext ()Lio/sentry/SpanContext;
+	public fun getStartTimestamp ()Ljava/util/Date;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun getTimestamp ()Ljava/util/Date;
+	public fun setThrowable (Ljava/lang/Throwable;)V
+	public fun startChild ()Lio/sentry/Span;
+	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+}
+
+public class io/sentry/SpanContext : java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	protected field description Ljava/lang/String;
+	protected field op Ljava/lang/String;
+	protected field status Lio/sentry/SpanStatus;
+	protected field tags Ljava/util/Map;
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Lio/sentry/SpanId;Ljava/lang/Boolean;)V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public fun clone ()Lio/sentry/SpanContext;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getDescription ()Ljava/lang/String;
+	public fun getOperation ()Ljava/lang/String;
+	public fun getParentSpanId ()Lio/sentry/SpanId;
+	public fun getSampled ()Ljava/lang/Boolean;
+	public fun getStatus ()Lio/sentry/SpanStatus;
+	public fun getTags ()Ljava/util/Map;
+	public fun setDescription (Ljava/lang/String;)V
+	public fun setOperation (Ljava/lang/String;)V
+	public fun setSampled (Ljava/lang/Boolean;)V
+	public fun setStatus (Lio/sentry/SpanStatus;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class io/sentry/SpanId {
+	public static final field EMPTY_ID Lio/sentry/SpanId;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/sentry/SpanStatus : java/lang/Enum {
+	public static final field ABORTED Lio/sentry/SpanStatus;
+	public static final field ALREADY_EXISTS Lio/sentry/SpanStatus;
+	public static final field CANCELLED Lio/sentry/SpanStatus;
+	public static final field DATA_LOSS Lio/sentry/SpanStatus;
+	public static final field DEADLINE_EXCEEDED Lio/sentry/SpanStatus;
+	public static final field FAILED_PRECONDITION Lio/sentry/SpanStatus;
+	public static final field INTERNAL_ERROR Lio/sentry/SpanStatus;
+	public static final field INVALID_ARGUMENT Lio/sentry/SpanStatus;
+	public static final field NOT_FOUND Lio/sentry/SpanStatus;
+	public static final field OK Lio/sentry/SpanStatus;
+	public static final field OUT_OF_RANGE Lio/sentry/SpanStatus;
+	public static final field PERMISSION_DENIED Lio/sentry/SpanStatus;
+	public static final field RESOURCE_EXHAUSTED Lio/sentry/SpanStatus;
+	public static final field UNAUTHENTICATED Lio/sentry/SpanStatus;
+	public static final field UNAVAILABLE Lio/sentry/SpanStatus;
+	public static final field UNIMPLEMENTED Lio/sentry/SpanStatus;
+	public static final field UNKNOWN Lio/sentry/SpanStatus;
+	public static final field UNKNOWN_ERROR Lio/sentry/SpanStatus;
+	public static fun fromHttpStatusCode (I)Lio/sentry/SpanStatus;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SpanStatus;
+	public static fun values ()[Lio/sentry/SpanStatus;
+}
+
+public final class io/sentry/SystemOutLogger : io/sentry/ILogger {
+	public fun <init> ()V
+	public fun isEnabled (Lio/sentry/SentryLevel;)Z
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/TransactionContext : io/sentry/SpanContext {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Lio/sentry/SpanId;Ljava/lang/Boolean;)V
+	public static fun fromSentryTrace (Ljava/lang/String;Lio/sentry/SentryTraceHeader;)Lio/sentry/TransactionContext;
+	public fun getName ()Ljava/lang/String;
+	public fun getParentSampled ()Ljava/lang/Boolean;
+	public fun setParentSampled (Ljava/lang/Boolean;)V
+}
+
+public final class io/sentry/UncaughtExceptionHandlerIntegration : io/sentry/Integration, java/io/Closeable, java/lang/Thread$UncaughtExceptionHandler {
+	public fun <init> ()V
+	public fun close ()V
+	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+	public fun uncaughtException (Ljava/lang/Thread;Ljava/lang/Throwable;)V
+}
+
+public final class io/sentry/UserFeedback {
+	public fun <init> (Lio/sentry/protocol/SentryId;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun getComments ()Ljava/lang/String;
+	public fun getEmail ()Ljava/lang/String;
+	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getName ()Ljava/lang/String;
+	public fun setComments (Ljava/lang/String;)V
+	public fun setEmail (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/sentry/adapters/ContextsDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/Contexts;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/ContextsSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/protocol/Contexts;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/DateDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/util/Date;
+}
+
+public final class io/sentry/adapters/DateSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public fun serialize (Ljava/util/Date;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/OrientationDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/Device$DeviceOrientation;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/OrientationSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/protocol/Device$DeviceOrientation;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/SentryIdDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/SentryId;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/SentryIdSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/protocol/SentryId;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/SentryLevelDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SentryLevel;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/SentryLevelSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/SentryLevel;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/SpanIdDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SpanId;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/SpanIdSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/SpanId;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/SpanStatusDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SpanStatus;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/SpanStatusSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/SpanStatus;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/TimeZoneDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/util/TimeZone;
+}
+
+public final class io/sentry/adapters/TimeZoneSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public fun serialize (Ljava/util/TimeZone;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
+	public static final field PREFIX_CURRENT_SESSION_FILE Ljava/lang/String;
+	public static final field SUFFIX_ENVELOPE_FILE Ljava/lang/String;
+	protected static final field UTF_8 Ljava/nio/charset/Charset;
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun discard (Lio/sentry/SentryEnvelope;)V
+	public fun iterator ()Ljava/util/Iterator;
+	public fun store (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/cache/IEnvelopeCache : java/lang/Iterable {
+	public abstract fun discard (Lio/sentry/SentryEnvelope;)V
+	public fun store (Lio/sentry/SentryEnvelope;)V
+	public abstract fun store (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/config/PropertiesProvider {
+	public abstract fun getMap (Ljava/lang/String;)Ljava/util/Map;
+	public abstract fun getProperty (Ljava/lang/String;)Ljava/lang/String;
+	public fun getProperty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class io/sentry/config/PropertiesProviderFactory {
+	public fun <init> ()V
+	public static fun create ()Lio/sentry/config/PropertiesProvider;
+}
+
+public final class io/sentry/exception/ExceptionMechanismException : java/lang/RuntimeException {
+	public fun <init> (Lio/sentry/protocol/Mechanism;Ljava/lang/Throwable;Ljava/lang/Thread;)V
+	public fun getExceptionMechanism ()Lio/sentry/protocol/Mechanism;
+	public fun getThread ()Ljava/lang/Thread;
+	public fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class io/sentry/exception/InvalidDsnException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun getDsn ()Ljava/lang/String;
+}
+
+public final class io/sentry/exception/InvalidSentryTraceHeaderException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getSentryTraceHeader ()Ljava/lang/String;
+}
+
+public abstract interface class io/sentry/hints/ApplyScopeData {
+}
+
+public abstract interface class io/sentry/hints/Cached {
+}
+
+public abstract interface class io/sentry/hints/DiskFlushNotification {
+	public abstract fun markFlushed ()V
+}
+
+public abstract interface class io/sentry/hints/Flushable {
+	public abstract fun waitFlush ()Z
+}
+
+public abstract interface class io/sentry/hints/Retryable {
+	public abstract fun isRetry ()Z
+	public abstract fun setRetry (Z)V
+}
+
+public abstract interface class io/sentry/hints/SessionEnd {
+}
+
+public final class io/sentry/hints/SessionEndHint : io/sentry/hints/SessionEnd {
+	public fun <init> ()V
+}
+
+public abstract interface class io/sentry/hints/SessionStart {
+}
+
+public final class io/sentry/hints/SessionStartHint : io/sentry/hints/SessionStart {
+	public fun <init> ()V
+}
+
+public abstract interface class io/sentry/hints/SubmissionResult {
+	public abstract fun isSuccess ()Z
+	public abstract fun setResult (Z)V
+}
+
+public final class io/sentry/protocol/App : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/App;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getAppBuild ()Ljava/lang/String;
+	public fun getAppIdentifier ()Ljava/lang/String;
+	public fun getAppName ()Ljava/lang/String;
+	public fun getAppStartTime ()Ljava/util/Date;
+	public fun getAppVersion ()Ljava/lang/String;
+	public fun getBuildType ()Ljava/lang/String;
+	public fun getDeviceAppHash ()Ljava/lang/String;
+	public fun setAppBuild (Ljava/lang/String;)V
+	public fun setAppIdentifier (Ljava/lang/String;)V
+	public fun setAppName (Ljava/lang/String;)V
+	public fun setAppStartTime (Ljava/util/Date;)V
+	public fun setAppVersion (Ljava/lang/String;)V
+	public fun setBuildType (Ljava/lang/String;)V
+	public fun setDeviceAppHash (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/Browser : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/Browser;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getName ()Ljava/lang/String;
+	public fun getVersion ()Ljava/lang/String;
+	public fun setName (Ljava/lang/String;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/Contexts : java/util/concurrent/ConcurrentHashMap, java/lang/Cloneable {
+	public fun <init> ()V
+	public fun clone ()Lio/sentry/protocol/Contexts;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getApp ()Lio/sentry/protocol/App;
+	public fun getBrowser ()Lio/sentry/protocol/Browser;
+	public fun getDevice ()Lio/sentry/protocol/Device;
+	public fun getGpu ()Lio/sentry/protocol/Gpu;
+	public fun getOperatingSystem ()Lio/sentry/protocol/OperatingSystem;
+	public fun getRuntime ()Lio/sentry/protocol/SentryRuntime;
+	public fun getTrace ()Lio/sentry/SpanContext;
+	public fun setApp (Lio/sentry/protocol/App;)V
+	public fun setBrowser (Lio/sentry/protocol/Browser;)V
+	public fun setDevice (Lio/sentry/protocol/Device;)V
+	public fun setGpu (Lio/sentry/protocol/Gpu;)V
+	public fun setOperatingSystem (Lio/sentry/protocol/OperatingSystem;)V
+	public fun setRuntime (Lio/sentry/protocol/SentryRuntime;)V
+	public fun setTrace (Lio/sentry/SpanContext;)V
+}
+
+public final class io/sentry/protocol/DebugImage : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getArch ()Ljava/lang/String;
+	public fun getCodeFile ()Ljava/lang/String;
+	public fun getCodeId ()Ljava/lang/String;
+	public fun getDebugFile ()Ljava/lang/String;
+	public fun getDebugId ()Ljava/lang/String;
+	public fun getImageAddr ()Ljava/lang/String;
+	public fun getImageSize ()Ljava/lang/Long;
+	public fun getType ()Ljava/lang/String;
+	public fun getUuid ()Ljava/lang/String;
+	public fun setArch (Ljava/lang/String;)V
+	public fun setCodeFile (Ljava/lang/String;)V
+	public fun setCodeId (Ljava/lang/String;)V
+	public fun setDebugFile (Ljava/lang/String;)V
+	public fun setDebugId (Ljava/lang/String;)V
+	public fun setImageAddr (Ljava/lang/String;)V
+	public fun setImageSize (J)V
+	public fun setImageSize (Ljava/lang/Long;)V
+	public fun setType (Ljava/lang/String;)V
+	public fun setUuid (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/DebugMeta : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getImages ()Ljava/util/List;
+	public fun getSdkInfo ()Lio/sentry/protocol/SdkInfo;
+	public fun setImages (Ljava/util/List;)V
+	public fun setSdkInfo (Lio/sentry/protocol/SdkInfo;)V
+}
+
+public final class io/sentry/protocol/Device : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/Device;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getArchs ()[Ljava/lang/String;
+	public fun getBatteryLevel ()Ljava/lang/Float;
+	public fun getBatteryTemperature ()Ljava/lang/Float;
+	public fun getBootTime ()Ljava/util/Date;
+	public fun getBrand ()Ljava/lang/String;
+	public fun getConnectionType ()Ljava/lang/String;
+	public fun getExternalFreeStorage ()Ljava/lang/Long;
+	public fun getExternalStorageSize ()Ljava/lang/Long;
+	public fun getFamily ()Ljava/lang/String;
+	public fun getFreeMemory ()Ljava/lang/Long;
+	public fun getFreeStorage ()Ljava/lang/Long;
+	public fun getId ()Ljava/lang/String;
+	public fun getLanguage ()Ljava/lang/String;
+	public fun getManufacturer ()Ljava/lang/String;
+	public fun getMemorySize ()Ljava/lang/Long;
+	public fun getModel ()Ljava/lang/String;
+	public fun getModelId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getOrientation ()Lio/sentry/protocol/Device$DeviceOrientation;
+	public fun getScreenDensity ()Ljava/lang/Float;
+	public fun getScreenDpi ()Ljava/lang/Integer;
+	public fun getScreenHeightPixels ()Ljava/lang/Integer;
+	public fun getScreenWidthPixels ()Ljava/lang/Integer;
+	public fun getStorageSize ()Ljava/lang/Long;
+	public fun getTimezone ()Ljava/util/TimeZone;
+	public fun getUsableMemory ()Ljava/lang/Long;
+	public fun isCharging ()Ljava/lang/Boolean;
+	public fun isLowMemory ()Ljava/lang/Boolean;
+	public fun isOnline ()Ljava/lang/Boolean;
+	public fun isSimulator ()Ljava/lang/Boolean;
+	public fun setArchs ([Ljava/lang/String;)V
+	public fun setBatteryLevel (Ljava/lang/Float;)V
+	public fun setBatteryTemperature (Ljava/lang/Float;)V
+	public fun setBootTime (Ljava/util/Date;)V
+	public fun setBrand (Ljava/lang/String;)V
+	public fun setCharging (Ljava/lang/Boolean;)V
+	public fun setConnectionType (Ljava/lang/String;)V
+	public fun setExternalFreeStorage (Ljava/lang/Long;)V
+	public fun setExternalStorageSize (Ljava/lang/Long;)V
+	public fun setFamily (Ljava/lang/String;)V
+	public fun setFreeMemory (Ljava/lang/Long;)V
+	public fun setFreeStorage (Ljava/lang/Long;)V
+	public fun setId (Ljava/lang/String;)V
+	public fun setLanguage (Ljava/lang/String;)V
+	public fun setLowMemory (Ljava/lang/Boolean;)V
+	public fun setManufacturer (Ljava/lang/String;)V
+	public fun setMemorySize (Ljava/lang/Long;)V
+	public fun setModel (Ljava/lang/String;)V
+	public fun setModelId (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setOnline (Ljava/lang/Boolean;)V
+	public fun setOrientation (Lio/sentry/protocol/Device$DeviceOrientation;)V
+	public fun setScreenDensity (Ljava/lang/Float;)V
+	public fun setScreenDpi (Ljava/lang/Integer;)V
+	public fun setScreenHeightPixels (Ljava/lang/Integer;)V
+	public fun setScreenWidthPixels (Ljava/lang/Integer;)V
+	public fun setSimulator (Ljava/lang/Boolean;)V
+	public fun setStorageSize (Ljava/lang/Long;)V
+	public fun setTimezone (Ljava/util/TimeZone;)V
+	public fun setUsableMemory (Ljava/lang/Long;)V
+}
+
+public final class io/sentry/protocol/Device$DeviceOrientation : java/lang/Enum {
+	public static final field LANDSCAPE Lio/sentry/protocol/Device$DeviceOrientation;
+	public static final field PORTRAIT Lio/sentry/protocol/Device$DeviceOrientation;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/protocol/Device$DeviceOrientation;
+	public static fun values ()[Lio/sentry/protocol/Device$DeviceOrientation;
+}
+
+public final class io/sentry/protocol/Gpu : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/Gpu;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getApiType ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/Integer;
+	public fun getMemorySize ()Ljava/lang/Integer;
+	public fun getName ()Ljava/lang/String;
+	public fun getNpotSupport ()Ljava/lang/String;
+	public fun getVendorId ()Ljava/lang/Integer;
+	public fun getVendorName ()Ljava/lang/String;
+	public fun getVersion ()Ljava/lang/String;
+	public fun isMultiThreadedRendering ()Ljava/lang/Boolean;
+	public fun setApiType (Ljava/lang/String;)V
+	public fun setId (Ljava/lang/Integer;)V
+	public fun setMemorySize (Ljava/lang/Integer;)V
+	public fun setMultiThreadedRendering (Ljava/lang/Boolean;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setNpotSupport (Ljava/lang/String;)V
+	public fun setVendorId (Ljava/lang/Integer;)V
+	public fun setVendorName (Ljava/lang/String;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/Mechanism : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Thread;)V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getData ()Ljava/util/Map;
+	public fun getDescription ()Ljava/lang/String;
+	public fun getHelpLink ()Ljava/lang/String;
+	public fun getMeta ()Ljava/util/Map;
+	public fun getSynthetic ()Ljava/lang/Boolean;
+	public fun getType ()Ljava/lang/String;
+	public fun isHandled ()Ljava/lang/Boolean;
+	public fun setData (Ljava/util/Map;)V
+	public fun setDescription (Ljava/lang/String;)V
+	public fun setHandled (Ljava/lang/Boolean;)V
+	public fun setHelpLink (Ljava/lang/String;)V
+	public fun setMeta (Ljava/util/Map;)V
+	public fun setSynthetic (Ljava/lang/Boolean;)V
+	public fun setType (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/Message : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getFormatted ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getParams ()Ljava/util/List;
+	public fun setFormatted (Ljava/lang/String;)V
+	public fun setMessage (Ljava/lang/String;)V
+	public fun setParams (Ljava/util/List;)V
+}
+
+public final class io/sentry/protocol/OperatingSystem : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/OperatingSystem;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getBuild ()Ljava/lang/String;
+	public fun getKernelVersion ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getRawDescription ()Ljava/lang/String;
+	public fun getVersion ()Ljava/lang/String;
+	public fun isRooted ()Ljava/lang/Boolean;
+	public fun setBuild (Ljava/lang/String;)V
+	public fun setKernelVersion (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setRawDescription (Ljava/lang/String;)V
+	public fun setRooted (Ljava/lang/Boolean;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/Request : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getCookies ()Ljava/lang/String;
+	public fun getData ()Ljava/lang/Object;
+	public fun getEnvs ()Ljava/util/Map;
+	public fun getHeaders ()Ljava/util/Map;
+	public fun getMethod ()Ljava/lang/String;
+	public fun getOthers ()Ljava/util/Map;
+	public fun getQueryString ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun setCookies (Ljava/lang/String;)V
+	public fun setData (Ljava/lang/Object;)V
+	public fun setEnvs (Ljava/util/Map;)V
+	public fun setHeaders (Ljava/util/Map;)V
+	public fun setMethod (Ljava/lang/String;)V
+	public fun setOthers (Ljava/util/Map;)V
+	public fun setQueryString (Ljava/lang/String;)V
+	public fun setUrl (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/SdkInfo : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getSdkName ()Ljava/lang/String;
+	public fun getVersionMajor ()Ljava/lang/Integer;
+	public fun getVersionMinor ()Ljava/lang/Integer;
+	public fun getVersionPatchlevel ()Ljava/lang/Integer;
+	public fun setSdkName (Ljava/lang/String;)V
+	public fun setVersionMajor (Ljava/lang/Integer;)V
+	public fun setVersionMinor (Ljava/lang/Integer;)V
+	public fun setVersionPatchlevel (Ljava/lang/Integer;)V
+}
+
+public final class io/sentry/protocol/SdkVersion : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun addIntegration (Ljava/lang/String;)V
+	public fun addPackage (Ljava/lang/String;Ljava/lang/String;)V
+	public fun getIntegrations ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
+	public fun getPackages ()Ljava/util/List;
+	public fun getVersion ()Ljava/lang/String;
+	public fun setName (Ljava/lang/String;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/SentryException : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getMechanism ()Lio/sentry/protocol/Mechanism;
+	public fun getModule ()Ljava/lang/String;
+	public fun getStacktrace ()Lio/sentry/protocol/SentryStackTrace;
+	public fun getThreadId ()Ljava/lang/Long;
+	public fun getType ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
+	public fun setMechanism (Lio/sentry/protocol/Mechanism;)V
+	public fun setModule (Ljava/lang/String;)V
+	public fun setStacktrace (Lio/sentry/protocol/SentryStackTrace;)V
+	public fun setThreadId (Ljava/lang/Long;)V
+	public fun setType (Ljava/lang/String;)V
+	public fun setValue (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/SentryId {
+	public static final field EMPTY_ID Lio/sentry/protocol/SentryId;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/UUID;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/sentry/protocol/SentryPackage : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getVersion ()Ljava/lang/String;
+	public fun setName (Ljava/lang/String;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/SentryRuntime : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/SentryRuntime;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getName ()Ljava/lang/String;
+	public fun getRawDescription ()Ljava/lang/String;
+	public fun getVersion ()Ljava/lang/String;
+	public fun setName (Ljava/lang/String;)V
+	public fun setRawDescription (Ljava/lang/String;)V
+	public fun setVersion (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/SentryStackFrame : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getAbsPath ()Ljava/lang/String;
+	public fun getColno ()Ljava/lang/Integer;
+	public fun getContextLine ()Ljava/lang/String;
+	public fun getFilename ()Ljava/lang/String;
+	public fun getFramesOmitted ()Ljava/util/List;
+	public fun getFunction ()Ljava/lang/String;
+	public fun getImageAddr ()Ljava/lang/String;
+	public fun getInstructionAddr ()Ljava/lang/String;
+	public fun getLineno ()Ljava/lang/Integer;
+	public fun getModule ()Ljava/lang/String;
+	public fun getPackage ()Ljava/lang/String;
+	public fun getPlatform ()Ljava/lang/String;
+	public fun getPostContext ()Ljava/util/List;
+	public fun getPreContext ()Ljava/util/List;
+	public fun getRawFunction ()Ljava/lang/String;
+	public fun getSymbolAddr ()Ljava/lang/String;
+	public fun getVars ()Ljava/util/Map;
+	public fun isInApp ()Ljava/lang/Boolean;
+	public fun isNative ()Ljava/lang/Boolean;
+	public fun setAbsPath (Ljava/lang/String;)V
+	public fun setColno (Ljava/lang/Integer;)V
+	public fun setContextLine (Ljava/lang/String;)V
+	public fun setFilename (Ljava/lang/String;)V
+	public fun setFramesOmitted (Ljava/util/List;)V
+	public fun setFunction (Ljava/lang/String;)V
+	public fun setImageAddr (Ljava/lang/String;)V
+	public fun setInApp (Ljava/lang/Boolean;)V
+	public fun setInstructionAddr (Ljava/lang/String;)V
+	public fun setLineno (Ljava/lang/Integer;)V
+	public fun setModule (Ljava/lang/String;)V
+	public fun setNative (Ljava/lang/Boolean;)V
+	public fun setPackage (Ljava/lang/String;)V
+	public fun setPlatform (Ljava/lang/String;)V
+	public fun setPostContext (Ljava/util/List;)V
+	public fun setPreContext (Ljava/util/List;)V
+	public fun setRawFunction (Ljava/lang/String;)V
+	public fun setSymbolAddr (Ljava/lang/String;)V
+	public fun setVars (Ljava/util/Map;)V
+}
+
+public final class io/sentry/protocol/SentryStackTrace : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getFrames ()Ljava/util/List;
+	public fun getRegisters ()Ljava/util/Map;
+	public fun setFrames (Ljava/util/List;)V
+	public fun setRegisters (Ljava/util/Map;)V
+}
+
+public final class io/sentry/protocol/SentryThread : io/sentry/IUnknownPropertiesConsumer {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun getId ()Ljava/lang/Long;
+	public fun getName ()Ljava/lang/String;
+	public fun getPriority ()Ljava/lang/Integer;
+	public fun getStacktrace ()Lio/sentry/protocol/SentryStackTrace;
+	public fun getState ()Ljava/lang/String;
+	public fun isCrashed ()Ljava/lang/Boolean;
+	public fun isCurrent ()Ljava/lang/Boolean;
+	public fun isDaemon ()Ljava/lang/Boolean;
+	public fun setCrashed (Ljava/lang/Boolean;)V
+	public fun setCurrent (Ljava/lang/Boolean;)V
+	public fun setDaemon (Ljava/lang/Boolean;)V
+	public fun setId (Ljava/lang/Long;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setPriority (Ljava/lang/Integer;)V
+	public fun setStacktrace (Lio/sentry/protocol/SentryStackTrace;)V
+	public fun setState (Ljava/lang/String;)V
+}
+
+public final class io/sentry/protocol/User : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
+	public fun <init> ()V
+	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/User;
+	public synthetic fun clone ()Ljava/lang/Object;
+	public fun getEmail ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
+	public fun getIpAddress ()Ljava/lang/String;
+	public fun getOthers ()Ljava/util/Map;
+	public fun getUsername ()Ljava/lang/String;
+	public fun setEmail (Ljava/lang/String;)V
+	public fun setId (Ljava/lang/String;)V
+	public fun setIpAddress (Ljava/lang/String;)V
+	public fun setOthers (Ljava/util/Map;)V
+	public fun setUsername (Ljava/lang/String;)V
+}
+
+public final class io/sentry/transport/AsyncConnection : io/sentry/transport/Connection, java/io/Closeable {
+	public fun <init> (Lio/sentry/transport/ITransport;Lio/sentry/transport/ITransportGate;Lio/sentry/cache/IEnvelopeCache;ILio/sentry/SentryOptions;)V
+	public fun close ()V
+	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/transport/Connection {
+	public abstract fun close ()V
+	public fun send (Lio/sentry/SentryEnvelope;)V
+	public abstract fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/transport/CurrentDateProvider : io/sentry/transport/ICurrentDateProvider {
+	public final fun getCurrentTimeMillis ()J
+	public static fun getInstance ()Lio/sentry/transport/ICurrentDateProvider;
+}
+
+public class io/sentry/transport/HttpTransport : io/sentry/transport/ITransport {
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/IConnectionConfigurator;IILjavax/net/ssl/SSLSocketFactory;Ljavax/net/ssl/HostnameVerifier;Ljava/net/URL;)V
+	public fun close ()V
+	public fun isRetryAfter (Ljava/lang/String;)Z
+	protected fun open ()Ljava/net/HttpURLConnection;
+	public fun send (Lio/sentry/SentryEnvelope;)Lio/sentry/transport/TransportResult;
+}
+
+public abstract interface class io/sentry/transport/IConnectionConfigurator {
+	public abstract fun configure (Ljava/net/HttpURLConnection;)V
+}
+
+public abstract interface class io/sentry/transport/ICurrentDateProvider {
+	public abstract fun getCurrentTimeMillis ()J
+}
+
+public abstract interface class io/sentry/transport/ITransport : java/io/Closeable {
+	public abstract fun isRetryAfter (Ljava/lang/String;)Z
+	public abstract fun send (Lio/sentry/SentryEnvelope;)Lio/sentry/transport/TransportResult;
+}
+
+public abstract interface class io/sentry/transport/ITransportGate {
+	public abstract fun isConnected ()Z
+}
+
+public final class io/sentry/transport/NoOpEnvelopeCache : io/sentry/cache/IEnvelopeCache {
+	public fun <init> ()V
+	public fun discard (Lio/sentry/SentryEnvelope;)V
+	public static fun getInstance ()Lio/sentry/transport/NoOpEnvelopeCache;
+	public fun iterator ()Ljava/util/Iterator;
+	public fun store (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/transport/NoOpTransport : io/sentry/transport/ITransport {
+	public fun close ()V
+	public static fun getInstance ()Lio/sentry/transport/NoOpTransport;
+	public fun isRetryAfter (Ljava/lang/String;)Z
+	public fun send (Lio/sentry/SentryEnvelope;)Lio/sentry/transport/TransportResult;
+}
+
+public final class io/sentry/transport/NoOpTransportGate : io/sentry/transport/ITransportGate {
+	public static fun getInstance ()Lio/sentry/transport/NoOpTransportGate;
+	public fun isConnected ()Z
+}
+
+public final class io/sentry/transport/StdoutTransport : io/sentry/transport/ITransport {
+	public fun <init> (Lio/sentry/ISerializer;)V
+	public fun close ()V
+	public fun isRetryAfter (Ljava/lang/String;)Z
+	public fun send (Lio/sentry/SentryEnvelope;)Lio/sentry/transport/TransportResult;
+}
+
+public abstract class io/sentry/transport/TransportResult {
+	public static fun error ()Lio/sentry/transport/TransportResult;
+	public static fun error (I)Lio/sentry/transport/TransportResult;
+	public abstract fun getResponseCode ()I
+	public abstract fun isSuccess ()Z
+	public static fun success ()Lio/sentry/transport/TransportResult;
+}
+
+public final class io/sentry/util/ApplyScopeUtils {
+	public static fun shouldApplyScopeData (Ljava/lang/Object;)Z
+}
+
+public final class io/sentry/util/CollectionUtils {
+	public static fun shallowCopy (Ljava/util/Map;)Ljava/util/Map;
+	public static fun size (Ljava/lang/Iterable;)I
+}
+
+public final class io/sentry/util/LogUtils {
+	public fun <init> ()V
+	public static fun logIfNotFlushable (Lio/sentry/ILogger;Ljava/lang/Object;)V
+	public static fun logIfNotRetryable (Lio/sentry/ILogger;Ljava/lang/Object;)V
+}
+
+public final class io/sentry/util/Objects {
+	public static fun requireNonNull (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class io/sentry/util/StringUtils {
+	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
+	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;
+	public static fun removeSurrounding (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -48,6 +48,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    *
    * @param name - transaction name
    * @param contexts - transaction contexts
+   * @param hub - the hub
    */
   @TestOnly
   public SentryTransaction(

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -39,10 +39,7 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
    */
   private String modelId;
 
-  /** Native cpu architecture of the device. */
-  @ApiStatus.ScheduledForRemoval @Deprecated private String arch;
-
-  /** Native cpu architecture of the device. */
+  /** Supported CPU architectures of the device. */
   private String[] archs;
   /**
    * Current battery level in %.
@@ -79,14 +76,11 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   private Long externalStorageSize;
   /** Free size of the attached external storage in bytes (eg: android SDK card). */
   private Long externalFreeStorage;
-  /**
-   * Device screen resolution.
-   *
-   * <p>(e.g.: 800x600, 3040x1444)
-   */
-  @ApiStatus.ScheduledForRemoval @Deprecated private String screenResolution;
 
+  /** Device width screen resolution. */
   private Integer screenWidthPixels;
+
+  /** Device Height screen resolution. */
   private Integer screenHeightPixels;
   /** Device screen density. */
   private Float screenDensity;
@@ -153,28 +147,6 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
 
   public void setModelId(String modelId) {
     this.modelId = modelId;
-  }
-
-  /**
-   * Returns the arch String
-   *
-   * @return device architecture
-   * @deprecated use {@link #getArchs} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public String getArch() {
-    return arch;
-  }
-
-  /**
-   * @param arch device architecture
-   * @deprecated use {@link #setArchs} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public void setArch(String arch) {
-    this.arch = arch;
   }
 
   public Float getBatteryLevel() {
@@ -279,28 +251,6 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
 
   public void setExternalFreeStorage(Long externalFreeStorage) {
     this.externalFreeStorage = externalFreeStorage;
-  }
-
-  /**
-   * Returns the screenResolution String
-   *
-   * @return screen resolution largest + smallest
-   * @deprecated use {@link #getScreenWidthPixels , #getScreenHeightPixels} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public String getScreenResolution() {
-    return screenResolution;
-  }
-
-  /**
-   * @param screenResolution screen resolution largest + smallest
-   * @deprecated use {@link #setScreenWidthPixels} , #getScreenHeightPixels} instead.
-   */
-  @ApiStatus.ScheduledForRemoval
-  @Deprecated
-  public void setScreenResolution(String screenResolution) {
-    this.screenResolution = screenResolution;
   }
 
   public Float getScreenDensity() {

--- a/sentry/src/test/java/io/sentry/SpanContextTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanContextTest.kt
@@ -17,6 +17,6 @@ class SpanContextTest {
     fun `sets tag`() {
         val trace = SpanContext()
         trace.setTag("tagName", "tagValue")
-        assertEquals("tagValue", trace.tags!!["tagName"])
+        assertEquals("tagValue", trace.tags["tagName"])
     }
 }

--- a/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
@@ -74,9 +74,6 @@ class CacheStrategyTest {
 
     @Test
     fun `do not move init flag if state is not ok`() {
-        val options = SentryOptions().apply {
-            setSerializer(GsonSerializer(mock(), envelopeReader))
-        }
         val sut = fixture.getSUT(3, getOptionsWithRealSerializer())
 
         val files = createTempFilesSortByOldestToNewest()
@@ -173,7 +170,7 @@ class CacheStrategyTest {
     }
 
     private fun saveSessionToFile(file: File, sut: CacheStrategy, state: Session.State = Session.State.Ok, init: Boolean? = true) {
-        val okSession = createSessionMockData(Session.State.Ok, init)
+        val okSession = createSessionMockData(state, init)
         val okEnvelope = SentryEnvelope.from(sut.serializer, okSession, null)
         sut.serializer.serialize(okEnvelope, file.writer())
     }

--- a/sentry/src/test/java/io/sentry/protocol/DeviceTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/DeviceTest.kt
@@ -36,7 +36,6 @@ class DeviceTest {
         device.family = "family"
         device.model = "model"
         device.modelId = "modelId"
-        device.arch = "arch"
         device.archs = arrayOf("archs1", "archs2")
         device.batteryLevel = 3.14f
         device.isCharging = true
@@ -51,7 +50,6 @@ class DeviceTest {
         device.freeStorage = 512
         device.externalStorageSize = 768
         device.externalFreeStorage = 384
-        device.screenResolution = "1024x768"
         device.screenWidthPixels = 1024
         device.screenHeightPixels = 768
         device.screenDensity = 1.5f
@@ -73,7 +71,6 @@ class DeviceTest {
         assertEquals("family", clone.family)
         assertEquals("model", clone.model)
         assertEquals("modelId", clone.modelId)
-        assertEquals("arch", clone.arch)
         assertEquals(2, clone.archs.size)
         assertEquals("archs1", clone.archs[0])
         assertEquals("archs2", clone.archs[1])
@@ -90,7 +87,6 @@ class DeviceTest {
         assertEquals(512, clone.freeStorage)
         assertEquals(768, clone.externalStorageSize)
         assertEquals(384, clone.externalFreeStorage)
-        assertEquals("1024x768", clone.screenResolution)
         assertEquals(1024, clone.screenWidthPixels)
         assertEquals(768, clone.screenHeightPixels)
         assertEquals(1.5f, clone.screenDensity)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Enha: Add API vlaidator and remove deprecated methods


## :bulb: Motivation and Context
We'd like to know when our API is broken, it's not back compatible.
`./gradlew apiCheck` is part of `./gradlew build` which is running on CI, so we don't need to do anything.
`./gradlew apiDump` is gonna be needed if API has changed and we are fine with it, changes will need to be committed.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes

It's breaking changes, but it's @Deprecated since 2.0 and we are going to a Major bump (4.0)

## :crystal_ball: Next steps
