### PR TITLE
test: Add a test for Scope.clear

### DIFF
--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -164,6 +164,29 @@ class ScopeTest {
     }
 
     @Test
+    fun `clear scope resets scope to default state`() {
+        val scope = Scope(SentryOptions())
+        scope.level = SentryLevel.WARNING
+        scope.setTransaction(SentryTransaction(""))
+        scope.user = User()
+        scope.fingerprint = mutableListOf("finger")
+        scope.addBreadcrumb(Breadcrumb())
+        scope.setTag("some", "tag")
+        scope.setExtra("some", "extra")
+        scope.addEventProcessor { event, _ -> event }
+
+        scope.clear()
+
+        assertNull(scope.level)
+        assertNull(scope.transaction)
+        assertEquals(0, scope.fingerprint.size)
+        assertEquals(0, scope.breadcrumbs.size)
+        assertEquals(0, scope.tags.size)
+        assertEquals(0, scope.extras.size)
+        assertEquals(0, scope.eventProcessors.size)
+    }
+
+    @Test
     fun `when adding breadcrumb, executeBreadcrumb will be executed and breadcrumb will be added`() {
         val options = SentryOptions().apply {
             setBeforeBreadcrumb { breadcrumb, _ -> breadcrumb }


### PR DESCRIPTION

## :scroll: Description
`Scope.clear` is not covered by tests. This is fixed now by adding a test for it.


## :bulb: Motivation and Context
While adding the attachments to the scope I found out that `Scope.clear` is not covered by tests.


## :green_heart: How did you test it?
I added tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
