### PR TITLE
Support loading in-app-includes and in-app-excludes from the external configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Enhancement: Add API validator and remove deprecated methods
 * Enhancement: Add more convenient method to start a child span (#1073)
 * Enhancement: Autoconfigure traces callback in Spring Boot integration (#1074)
+* Enhancement: Resolve in-app-includes and in-app-excludes parameters from the external configuration
 
 # 4.0.0-alpha.1
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -95,8 +95,8 @@ class SentryAutoConfigurationTest {
             "sentry.release=1.0.3",
             "sentry.environment=production",
             "sentry.sample-rate=0.2",
-            "sentry.in-app-excludes[0]=org.springframework",
-            "sentry.in-app-includes[0]=com.myapp",
+            "sentry.in-app-includes=org.springframework,com.myapp",
+            "sentry.in-app-excludes=org.jboss,com.microsoft",
             "sentry.dist=my-dist",
             "sentry.attach-threads=true",
             "sentry.attach-stacktrace=true",
@@ -121,8 +121,8 @@ class SentryAutoConfigurationTest {
             assertThat(options.release).isEqualTo("1.0.3")
             assertThat(options.environment).isEqualTo("production")
             assertThat(options.sampleRate).isEqualTo(0.2)
-            assertThat(options.inAppExcludes).containsOnly("org.springframework")
-            assertThat(options.inAppIncludes).containsOnly("com.myapp")
+            assertThat(options.inAppIncludes).containsOnly("org.springframework", "com.myapp")
+            assertThat(options.inAppExcludes).containsOnly("com.microsoft", "org.jboss")
             assertThat(options.dist).isEqualTo("my-dist")
             assertThat(options.isAttachThreads).isEqualTo(true)
             assertThat(options.isAttachStacktrace).isEqualTo(true)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1008,6 +1008,7 @@ public abstract interface class io/sentry/cache/IEnvelopeCache : java/lang/Itera
 }
 
 public abstract interface class io/sentry/config/PropertiesProvider {
+	public fun getList (Ljava/lang/String;)Ljava/util/List;
 	public abstract fun getMap (Ljava/lang/String;)Ljava/util/Map;
 	public abstract fun getProperty (Ljava/lang/String;)Ljava/lang/String;
 	public fun getProperty (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -272,6 +272,13 @@ public class SentryOptions {
     if (proxyHost != null) {
       options.setProxy(new Proxy(proxyHost, proxyPort, proxyUser, proxyPass));
     }
+
+    for (final String inAppInclude : propertiesProvider.getList("in-app-includes")) {
+      options.addInAppInclude(inAppInclude);
+    }
+    for (final String inAppExclude : propertiesProvider.getList("in-app-excludes")) {
+      options.addInAppExclude(inAppExclude);
+    }
     return options;
   }
 

--- a/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/PropertiesProvider.java
@@ -1,5 +1,8 @@
 package io.sentry.config;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,6 +25,18 @@ public interface PropertiesProvider {
    */
   @NotNull
   Map<String, String> getMap(final @NotNull String property);
+
+  /**
+   * Resolves a list of values for a property given by it's name.
+   *
+   * @param property - the property name
+   * @return the list or empty list if not found
+   */
+  @NotNull
+  default List<String> getList(final @NotNull String property) {
+    final String value = getProperty(property);
+    return value != null ? Arrays.asList(value.split(",")) : Collections.emptyList();
+  }
 
   /**
    * Resolves property given by it's name.

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -267,4 +267,24 @@ class SentryOptionsTest {
             temporaryFolder.delete()
         }
     }
+
+    @Test
+    fun `creates options with inAppInclude and inAppExclude using external properties`() {
+        // create a sentry.properties file in temporary folder
+        val temporaryFolder = TemporaryFolder()
+        temporaryFolder.create()
+        val file = temporaryFolder.newFile("sentry.properties")
+        file.appendText("in-app-includes=org.springframework,com.myapp\n")
+        file.appendText("in-app-excludes=org.jboss,com.microsoft")
+        // set location of the sentry.properties file
+        System.setProperty("sentry.properties.file", file.absolutePath)
+
+        try {
+            val options = SentryOptions.from(PropertiesProviderFactory.create())
+            assertEquals(listOf("org.springframework", "com.myapp"), options.inAppIncludes)
+            assertEquals(listOf("org.jboss", "com.microsoft"), options.inAppExcludes)
+        } finally {
+            temporaryFolder.delete()
+        }
+    }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Adds an option to set `inAppIncludes` and `inAppExcludes` using external configuration.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Mentioned in #992. For users who use Logback or Log4j2 integration it simplifies life significantly in case they want to set `inAppIncludes` or `inAppIncludes`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
