### PR TITLE
Make InAppIncludesResolver public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Enhancement: Add more convenient method to start a child span (#1073)
 * Enhancement: Autoconfigure traces callback in Spring Boot integration (#1074)
 * Enhancement: Resolve in-app-includes and in-app-excludes parameters from the external configuration
+* Enhancement: Make InAppIncludesResolver public (#1084)
 
 # 4.0.0-alpha.1
 

--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -3,6 +3,11 @@ public final class io/sentry/spring/boot/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
+public class io/sentry/spring/boot/InAppIncludesResolver : org/springframework/context/ApplicationContextAware {
+	public fun <init> ()V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
 public class io/sentry/spring/boot/SentryAutoConfiguration {
 	public fun <init> ()V
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
@@ -19,7 +19,7 @@ import org.springframework.context.ApplicationContextAware;
  * SpringBootConfiguration} like {@link SpringBootApplication}.
  */
 @Open
-class InAppIncludesResolver implements ApplicationContextAware {
+public class InAppIncludesResolver implements ApplicationContextAware {
   private @Nullable ApplicationContext applicationContext;
 
   @Nullable


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Make InAppIncludesResolver public.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1080.

In case users want to overwrite `OptionsConfiguration` before this change they do not have an option to use `InAppIncludesResolver`. 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes