### PR TITLE
Optimize DateUtils performance.

### DIFF
--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -17,18 +17,30 @@ public final class DateUtils {
   private static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
   private static final String ISO_FORMAT_WITH_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT_WITH_MILLIS_UTC =
-      ThreadLocal.withInitial(
-          () -> {
-            final TimeZone tz = TimeZone.getTimeZone(UTC);
-            final SimpleDateFormat simpleDateFormat =
-                new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
-            simpleDateFormat.setTimeZone(tz);
-            return simpleDateFormat;
-          });
+      new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+          final TimeZone tz = TimeZone.getTimeZone(UTC);
+          final SimpleDateFormat simpleDateFormat =
+              new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
+          simpleDateFormat.setTimeZone(tz);
+          return simpleDateFormat;
+        }
+      };
   private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT_WITH_MILLIS =
-      ThreadLocal.withInitial(() -> new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT));
+      new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+          return new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
+        }
+      };
   private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT =
-      ThreadLocal.withInitial(() -> new SimpleDateFormat(ISO_FORMAT, Locale.ROOT));
+      new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+          return new SimpleDateFormat(ISO_FORMAT, Locale.ROOT);
+        }
+      };
 
   private DateUtils() {}
 

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -16,6 +16,19 @@ public final class DateUtils {
   private static final String UTC = "UTC";
   private static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
   private static final String ISO_FORMAT_WITH_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+  private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT_WITH_MILLIS_UTC =
+      ThreadLocal.withInitial(
+          () -> {
+            final TimeZone tz = TimeZone.getTimeZone(UTC);
+            final SimpleDateFormat simpleDateFormat =
+                new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
+            simpleDateFormat.setTimeZone(tz);
+            return simpleDateFormat;
+          });
+  private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT_WITH_MILLIS =
+      ThreadLocal.withInitial(() -> new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT));
+  private static final ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT =
+      ThreadLocal.withInitial(() -> new SimpleDateFormat(ISO_FORMAT, Locale.ROOT));
 
   private DateUtils() {}
 
@@ -26,10 +39,7 @@ public final class DateUtils {
    * @return the ISO formatted UTC date with millis precision.
    */
   public static @NotNull String getTimestampIsoFormat(final @NotNull Date date) {
-    final TimeZone tz = TimeZone.getTimeZone(UTC);
-    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
-    df.setTimeZone(tz);
-    return df.format(date);
+    return SDF_ISO_FORMAT_WITH_MILLIS_UTC.get().format(date);
   }
 
   /**
@@ -66,11 +76,11 @@ public final class DateUtils {
   public static @NotNull Date getDateTime(final @NotNull String timestamp)
       throws IllegalArgumentException {
     try {
-      return new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT).parse(timestamp);
+      return SDF_ISO_FORMAT_WITH_MILLIS.get().parse(timestamp);
     } catch (ParseException e) {
       try {
         // to keep compatibility with older envelopes
-        return new SimpleDateFormat(ISO_FORMAT, Locale.ROOT).parse(timestamp);
+        return SDF_ISO_FORMAT.get().parse(timestamp);
       } catch (ParseException ignored) {
         // invalid timestamp format
       }
@@ -105,7 +115,7 @@ public final class DateUtils {
    * @return the ISO formatted date with millis precision.
    */
   public static @NotNull String getTimestamp(final @NotNull Date date) {
-    final DateFormat df = new SimpleDateFormat(ISO_FORMAT_WITH_MILLIS, Locale.ROOT);
+    final DateFormat df = SDF_ISO_FORMAT_WITH_MILLIS.get();
     return df.format(date);
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Improves `DateUtils` performance. See benchmark results here: https://github.com/maciej-scratches/simple-date-format-benchmark.

While this improves the current state, we can consider also opting-out from using SDF completely and rely on `Calendar` class instead similar to: https://askldjd.wordpress.com/2013/03/04/simpledateformat-is-slow/


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I noticed getting current timestamp in UTC takes significant amount of CPU time while running benchmarks for the performance feature. 

This class has been also pointed in https://github.com/getsentry/sentry-java/issues/1081


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes