### PR TITLE
fix: Remove method reference in SentryEnvelopeItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Fix: Remove method reference in SentryEnvelopeItem (#1091)
 * Enhancement: Set transaction name on events and transactions sent using Spring integration (#1067) 
 * Fix: Set current thread only if there are no exceptions
 * Enhancement: Set global tags on SentryOptions and load them from external configuration (#1066)

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -73,6 +73,7 @@ public final class SentryEnvelopeItem {
         new SentryEnvelopeItemHeader(
             SentryItemType.Session, () -> cachedItem.getBytes().length, "application/json", null);
 
+    // Don't use method reference. This can cause issues on Android
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -109,6 +110,7 @@ public final class SentryEnvelopeItem {
             "application/json",
             null);
 
+    // Don't use method reference. This can cause issues on Android
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -145,7 +147,8 @@ public final class SentryEnvelopeItem {
             "application/json",
             null);
 
-    return new SentryEnvelopeItem(itemHeader, cachedItem::getBytes);
+    // Don't use method reference. This can cause issues on Android
+    return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
   private static class CachedItem {


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The method reference in SentryEnvelopeItem could cause problems on Android. This is fixed with
replacing it with a lambda.


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-java/pull/1082/files#r535113142


## :green_heart: How did you test it?
CI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
