### PR TITLE
Fix: Append DebugImage list if the Event already has it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Enhancement: Resolve in-app-includes and in-app-excludes parameters from the external configuration
 * Enhancement: Make InAppIncludesResolver public (#1084)
 * Ref: Change "op" to "operation" in @SentrySpan and @SentryTransaction
+* Fix: Append DebugImage list if event already has it
 
 # 4.0.0-alpha.1
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -66,7 +66,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @TestOnly static final String ANDROID_ID = "androidId";
   @TestOnly static final String KERNEL_VERSION = "kernelVersion";
   @TestOnly static final String EMULATOR = "emulator";
-  @TestOnly static final String DEBUG_IMAGES = "debugImages";
 
   // it could also be a parameter and get from Sentry.init(...)
   private static final @Nullable Date appStartTime = DateUtils.getCurrentDateTimeOrNull();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -165,15 +165,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
     setAppExtras(app);
 
-    //    DebugMeta debugMeta = event.getDebugMeta();
-    //    final List<DebugImage> debugImages = getDebugImages();
-    //    if (debugMeta == null) {
-    //      debugMeta = new DebugMeta();
-    //    }
-    //    if (debugImages != null) {
-    //      debug
-    //      event.setDebugMeta(debugMeta);
-    //    }
     mergeDebugImages(event);
 
     PackageInfo packageInfo = ContextUtils.getPackageInfo(context, logger);
@@ -207,7 +198,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       debugMeta = new DebugMeta();
     }
 
-    // sets the imageList or append to the list if it alreadu exists
+    // sets the imageList or append to the list if it already exists
     if (debugMeta.getImages() == null) {
       debugMeta.setImages(debugImages);
     } else {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -66,6 +66,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @TestOnly static final String ANDROID_ID = "androidId";
   @TestOnly static final String KERNEL_VERSION = "kernelVersion";
   @TestOnly static final String EMULATOR = "emulator";
+  @TestOnly static final String DEBUG_IMAGES = "debugImages";
 
   // it could also be a parameter and get from Sentry.init(...)
   private static final @Nullable Date appStartTime = DateUtils.getCurrentDateTimeOrNull();
@@ -164,9 +165,16 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
     setAppExtras(app);
 
-    if (event.getDebugMeta() == null) {
-      event.setDebugMeta(getDebugMeta());
-    }
+    //    DebugMeta debugMeta = event.getDebugMeta();
+    //    final List<DebugImage> debugImages = getDebugImages();
+    //    if (debugMeta == null) {
+    //      debugMeta = new DebugMeta();
+    //    }
+    //    if (debugImages != null) {
+    //      debug
+    //      event.setDebugMeta(debugMeta);
+    //    }
+    mergeDebugImages(event);
 
     PackageInfo packageInfo = ContextUtils.getPackageInfo(context, logger);
     if (packageInfo != null) {
@@ -185,6 +193,27 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         thread.setCurrent(MainThreadChecker.isMainThread(thread));
       }
     }
+  }
+
+  private void mergeDebugImages(final @NotNull SentryEvent event) {
+    final List<DebugImage> debugImages = getDebugImages();
+    if (debugImages == null) {
+      return;
+    }
+
+    DebugMeta debugMeta = event.getDebugMeta();
+
+    if (debugMeta == null) {
+      debugMeta = new DebugMeta();
+    }
+
+    // sets the imageList or append to the list if it alreadu exists
+    if (debugMeta.getImages() == null) {
+      debugMeta.setImages(debugImages);
+    } else {
+      debugMeta.getImages().addAll(debugImages);
+    }
+    event.setDebugMeta(debugMeta);
   }
 
   private @Nullable List<DebugImage> getDebugImages() {
@@ -213,18 +242,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
 
     return images;
-  }
-
-  private @Nullable DebugMeta getDebugMeta() {
-    List<DebugImage> debugImages = getDebugImages();
-
-    if (debugImages == null) {
-      return null;
-    }
-
-    DebugMeta debugMeta = new DebugMeta();
-    debugMeta.setImages(debugImages);
-    return debugMeta;
   }
 
   private void setAppExtras(final @NotNull App app) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -19,6 +19,8 @@ import io.sentry.android.core.DefaultAndroidEventProcessor.EMULATOR
 import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
 import io.sentry.android.core.DefaultAndroidEventProcessor.PROGUARD_UUID
 import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
+import io.sentry.protocol.DebugImage
+import io.sentry.protocol.DebugMeta
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryThread
 import io.sentry.protocol.User
@@ -96,6 +98,38 @@ class DefaultAndroidEventProcessorTest {
         assertNotNull(event.contexts.app)
         assertEquals("test", event.debugMeta.images[0].uuid)
         assertNotNull(event.dist)
+    }
+
+    @Test
+    fun `When debug meta is not null, set the image list`() {
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
+        var event = SentryEvent().apply {
+            debugMeta = DebugMeta()
+        }
+        // refactor and mock data later on
+        event = processor.process(event, null)
+
+        assertEquals("test", event.debugMeta.images[0].uuid)
+    }
+
+    @Test
+    fun `When debug meta is not null and image list is not empty, append to the list`() {
+        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo)
+
+        val image = DebugImage().apply {
+            uuid = "abc"
+            type = "proguard"
+        }
+        var event = SentryEvent().apply {
+            debugMeta = DebugMeta().apply {
+                images = mutableListOf(image)
+            }
+        }
+        // refactor and mock data later on
+        event = processor.process(event, null)
+
+        assertEquals("abc", event.debugMeta.images.first().uuid)
+        assertEquals("test", event.debugMeta.images.last().uuid)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -106,7 +106,7 @@ class DefaultAndroidEventProcessorTest {
         var event = SentryEvent().apply {
             debugMeta = DebugMeta()
         }
-        // refactor and mock data later on
+
         event = processor.process(event, null)
 
         assertEquals("test", event.debugMeta.images[0].uuid)
@@ -125,7 +125,7 @@ class DefaultAndroidEventProcessorTest {
                 images = mutableListOf(image)
             }
         }
-        // refactor and mock data later on
+
         event = processor.process(event, null)
 
         assertEquals("abc", event.debugMeta.images.first().uuid)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Append DebugImage list if the Event already has it


## :bulb: Motivation and Context
Events that contain an ImageList should append the Proguard debug image instead of skipping it.
This is a fix for Flutter mainly, as we do have an ImageList but we still want to deobfuscate Java/Kotlin stack traces


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
Bump SDK on Flutter