### PR TITLE
Add the ability to register multiple OptionsConfiguration beans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Enhancement: Resolve in-app-includes and in-app-excludes parameters from the external configuration
 * Enhancement: Make InAppIncludesResolver public (#1084)
 * Ref: Change "op" to "operation" in @SentrySpan and @SentryTransaction
+* Enhancement: Add the ability to register multiple OptionsConfiguration beans (#1093)
 
 # 4.0.0-alpha.1
 

--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -5,6 +5,7 @@ public final class io/sentry/spring/boot/BuildConfig {
 
 public class io/sentry/spring/boot/InAppIncludesResolver : org/springframework/context/ApplicationContextAware {
 	public fun <init> ()V
+	public fun resolveInAppIncludes ()Ljava/util/List;
 	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
 }
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/InAppIncludesResolver.java
@@ -23,7 +23,7 @@ public class InAppIncludesResolver implements ApplicationContextAware {
   private @Nullable ApplicationContext applicationContext;
 
   @Nullable
-  List<String> resolveInAppIncludes() {
+  public List<String> resolveInAppIncludes() {
     if (applicationContext != null) {
       Map<String, Object> beansWithAnnotation =
           applicationContext.getBeansWithAnnotation(SpringBootConfiguration.class);

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -57,8 +58,9 @@ public class SentryAutoConfiguration {
   static class HubConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
-    public @NotNull Sentry.OptionsConfiguration<SentryOptions> optionsOptionsConfiguration(
+    @ConditionalOnMissingBean(name = "sentryOptionsConfiguration")
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public @NotNull Sentry.OptionsConfiguration<SentryOptions> sentryOptionsConfiguration(
         final @NotNull ObjectProvider<SentryOptions.BeforeSendCallback> beforeSendCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
@@ -92,10 +94,11 @@ public class SentryAutoConfiguration {
 
     @Bean
     public @NotNull IHub sentryHub(
-        final @NotNull Sentry.OptionsConfiguration<SentryOptions> optionsConfiguration,
+        final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<GitProperties> gitProperties) {
-      optionsConfiguration.configure(options);
+      optionsConfigurations.forEach(
+          optionsConfiguration -> optionsConfiguration.configure(options));
       gitProperties.ifAvailable(
           git -> {
             if (options.getRelease() == null && options.isUseGitCommitIdAsRelease()) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Followup to #1084. Makes it possible to register multiple `OptionsConfiguration`.

Additionally, makes `InAppIncludesResolver#resolveInAppIncludes` so that it can be used in custom auto-configurations by users.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue #1080.

Currently when creating custom `OptionsConfiguration` bean, users have to either opt-out from the default behavior or replicate it even when they need just to set single custom property.


## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
