### PR TITLE
Fix: Sort breadcrumbs by Date if the event has breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Enhancement: Make InAppIncludesResolver public (#1084)
 * Ref: Change "op" to "operation" in @SentrySpan and @SentryTransaction
 * Fix: Append DebugImage list if event already has it
+* Fix: Sort breadcrumbs by Date if there are breadcrumbs already in the event
 
 # 4.0.0-alpha.1
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -426,8 +426,6 @@ public final class SentryClient implements ISentryClient {
       sortedBreadcrumbs.addAll(breadcrumbs);
       Collections.sort(sortedBreadcrumbs, sortBreadcrumbsByDate);
     }
-
-    event.setBreadcrumbs(sortedBreadcrumbs);
   }
 
   private @Nullable SentryEvent executeBeforeSend(

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -10,6 +10,7 @@ import io.sentry.util.Objects;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -423,7 +424,7 @@ public final class SentryClient implements ISentryClient {
 
     if (!breadcrumbs.isEmpty()) {
       sortedBreadcrumbs.addAll(breadcrumbs);
-      sortedBreadcrumbs.sort(sortBreadcrumbsByDate);
+      Collections.sort(sortedBreadcrumbs, sortBreadcrumbsByDate);
     }
 
     event.setBreadcrumbs(sortedBreadcrumbs);

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -420,8 +420,11 @@ public final class SentryClient implements ISentryClient {
   private void sortBreadcrumbsByDate(
       final @NotNull SentryEvent event, final @NotNull Collection<Breadcrumb> breadcrumbs) {
     final List<Breadcrumb> sortedBreadcrumbs = event.getBreadcrumbs();
-    sortedBreadcrumbs.addAll(breadcrumbs);
-    sortedBreadcrumbs.sort(sortBreadcrumbsByDate);
+
+    if (!breadcrumbs.isEmpty()) {
+      sortedBreadcrumbs.addAll(breadcrumbs);
+      sortedBreadcrumbs.sort(sortBreadcrumbsByDate);
+    }
 
     event.setBreadcrumbs(sortedBreadcrumbs);
   }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -252,18 +252,18 @@ class SentryClientTest {
 
     @Test
     fun `when breadcrumbs are not empty, sort them out by date`() {
+        val b1 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.001Z"))
         val b2 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.002Z"))
-        val b3 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.003Z"))
         val scope = Scope(SentryOptions()).apply {
             addBreadcrumb(b2)
-            addBreadcrumb(b3)
+            addBreadcrumb(b1)
         }
 
         val sut = fixture.getSut()
 
-        val b1 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.001Z"))
+        val b3 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.003Z"))
         val event = SentryEvent().apply {
-            breadcrumbs = mutableListOf(b1)
+            breadcrumbs = mutableListOf(b3)
         }
 
         sut.captureEvent(event, scope)

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -40,6 +40,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SentryClientTest {
@@ -247,6 +248,29 @@ class SentryClientTest {
         assertEquals("fp", event.fingerprints[0])
         assertEquals("id", event.user.id)
         assertEquals(SentryLevel.FATAL, event.level)
+    }
+
+    @Test
+    fun `when breadcrumbs are not empty, sort them out by date`() {
+        val b2 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.002Z"))
+        val b3 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.003Z"))
+        val scope = Scope(SentryOptions()).apply {
+            addBreadcrumb(b2)
+            addBreadcrumb(b3)
+        }
+
+        val sut = fixture.getSut()
+
+        val b1 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.001Z"))
+        val event = SentryEvent().apply {
+            breadcrumbs = mutableListOf(b1)
+        }
+
+        sut.captureEvent(event, scope)
+
+        assertSame(b1, event.breadcrumbs[0])
+        assertSame(b2, event.breadcrumbs[1])
+        assertSame(b3, event.breadcrumbs[2])
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Sort breadcrumbs by Date if the event has breadcrumbs


## :bulb: Motivation and Context
If an event captured on a top SDK like Flutter and later sent by the Android SDK, the Scope breadcrumbs are merged along with the breadcrumbs from the event, but it's not respecting the timeline.
Ideally, this would be solved by the Scope sync, but if the Scope sync. can be opt-out, the same problem would happen.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
