### PR TITLE
Fix inheriting sampling decision from parent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Fix inheriting sampling decision from parent (#1100)
+
 # 4.0.0-alpha.2
 
 * Feat: Add basic support for attachments (#1082)

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -685,7 +685,19 @@ public final class Hub implements IHub {
   @Override
   public @Nullable SentryTransaction startTransaction(
       final @NotNull TransactionContext transactionContexts) {
+    return this.startTransaction(transactionContexts, null);
+  }
+
+  @Override
+  public @Nullable SentryTransaction startTransaction(
+      final @NotNull TransactionContext transactionContexts,
+      final @Nullable CustomSamplingContext customSamplingContext) {
     Objects.requireNonNull(transactionContexts, "transactionContexts is required");
+
+    final SamplingContext samplingContext =
+        new SamplingContext(transactionContexts, customSamplingContext);
+    boolean samplingDecision = tracingSampler.sample(samplingContext);
+    transactionContexts.setSampled(samplingDecision);
 
     SentryTransaction transaction = null;
     if (!isEnabled()) {
@@ -704,17 +716,6 @@ public final class Hub implements IHub {
       }
     }
     return transaction;
-  }
-
-  @Override
-  public @Nullable SentryTransaction startTransaction(
-      final @NotNull TransactionContext transactionContexts,
-      final @Nullable CustomSamplingContext customSamplingContext) {
-    final SamplingContext samplingContext =
-        new SamplingContext(transactionContexts, customSamplingContext);
-    boolean samplingDecision = tracingSampler.sample(samplingContext);
-    transactionContexts.setSampled(samplingDecision);
-    return this.startTransaction(transactionContexts);
   }
 
   @Override

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1006,6 +1006,17 @@ class HubTest {
     }
 
     @Test
+    fun `when startTransaction with parent sampled and no traces sampler provided, transaction inherits sampling decision`() {
+        val hub = generateHub()
+        val transactionContext = TransactionContext("name")
+        transactionContext.parentSampled = true
+        val transaction = hub.startTransaction(transactionContext)
+        assertNotNull(transaction)
+        assertNotNull(transaction.isSampled)
+        assertTrue(transaction.isSampled!!)
+    }
+
+    @Test
     fun `Hub should close the sentry executor processor on close call`() {
         val executor = mock<ISentryExecutorService>()
         val options = SentryOptions().apply {


### PR DESCRIPTION
Fixes gh-1099

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fix inheriting sampling decision from parent.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When transaction was created from transaction context without providing custom sampling context, `tracingSampler` was not used.


## :green_heart: How did you test it?

Unit test.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
