### PR TITLE
Fix: Exception only sets a stack trace if there are frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix inheriting sampling decision from parent (#1100)
 * Fixes and Tests: Session serialization and deserialization
+* Fix: Exception only sets a stack trace if there are frames
 
 # 4.0.0-alpha.2
 

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.SentryException;
+import io.sentry.protocol.SentryStackFrame;
 import io.sentry.protocol.SentryStackTrace;
 import io.sentry.util.Objects;
 import java.util.ArrayDeque;
@@ -82,13 +83,15 @@ final class SentryExceptionFactory {
     final String exceptionPackageName =
         exceptionPackage != null ? exceptionPackage.getName() : null;
 
-    final SentryStackTrace sentryStackTrace = new SentryStackTrace();
-    sentryStackTrace.setFrames(sentryStackTraceFactory.getStackFrames(throwable.getStackTrace()));
+    final List<SentryStackFrame> frames =
+        sentryStackTraceFactory.getStackFrames(throwable.getStackTrace());
+    if (frames != null && !frames.isEmpty()) {
+      exception.setStacktrace(new SentryStackTrace(frames));
+    }
 
     if (thread != null) {
       exception.setThreadId(thread.getId());
     }
-    exception.setStacktrace(sentryStackTrace);
     exception.setType(exceptionClassName);
     exception.setMechanism(exceptionMechanism);
     exception.setModule(exceptionPackageName);

--- a/sentry/src/main/java/io/sentry/SentryThreadFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryThreadFactory.java
@@ -79,7 +79,7 @@ final class SentryThreadFactory {
 
     final Thread currentThread = Thread.currentThread();
 
-    if (threads.size() > 0) {
+    if (!threads.isEmpty()) {
       result = new ArrayList<>();
 
       // https://issuetracker.google.com/issues/64122757
@@ -125,7 +125,7 @@ final class SentryThreadFactory {
     final List<SentryStackFrame> frames =
         sentryStackTraceFactory.getStackFrames(stackFramesElements);
 
-    if (options.isAttachStacktrace() && frames != null && frames.size() > 0) {
+    if (options.isAttachStacktrace() && frames != null && !frames.isEmpty()) {
       sentryThread.setStacktrace(new SentryStackTrace(frames));
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix: Exception only sets a stack trace if there are frames


## :bulb: Motivation and Context
frames are a mandatory value for stack traces object, Unity generates an exception without stack trace and frames


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes


## :crystal_ball: Next steps
