### PR TITLE
Ref: using Calendar to generate Dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix inheriting sampling decision from parent (#1100)
 * Fixes and Tests: Session serialization and deserialization
+* Ref: using Calendar to generate Dates
 
 # 4.0.0-alpha.2
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -387,7 +387,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @SuppressWarnings("JdkObsolete")
   private @Nullable Date getBootTime() {
     try {
-      // if user changes time, will give a wrong answer, consider ACTION_TIME_CHANGED
+      // if user changes the clock, will give a wrong answer, consider ACTION_TIME_CHANGED.
+      // currentTimeMillis returns UTC already
       return DateUtils.getDateTime(System.currentTimeMillis() - SystemClock.elapsedRealtime());
     } catch (IllegalArgumentException e) {
       logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -388,8 +388,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private @Nullable Date getBootTime() {
     try {
       // if user changes time, will give a wrong answer, consider ACTION_TIME_CHANGED
-      return DateUtils.getDateTime(
-          System.currentTimeMillis() - SystemClock.elapsedRealtime());
+      return DateUtils.getDateTime(System.currentTimeMillis() - SystemClock.elapsedRealtime());
     } catch (IllegalArgumentException e) {
       logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -68,7 +68,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @TestOnly static final String EMULATOR = "emulator";
 
   // it could also be a parameter and get from Sentry.init(...)
-  private static final @Nullable Date appStartTime = DateUtils.getCurrentDateTimeOrNull();
+  private static final @Nullable Date appStartTime = DateUtils.getCurrentDateTime();
 
   @TestOnly final Context context;
 
@@ -389,7 +389,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       // if user changes time, will give a wrong answer, consider ACTION_TIME_CHANGED
       return DateUtils.getDateTime(
-          new Date(System.currentTimeMillis() - SystemClock.elapsedRealtime()));
+          System.currentTimeMillis() - SystemClock.elapsedRealtime());
     } catch (IllegalArgumentException e) {
       logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
     }

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -14,7 +14,6 @@ import io.sentry.transport.ITransport;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -131,8 +130,7 @@ public final class SentryAppender extends AbstractAppender {
   // for the Android compatibility we must use old Java Date class
   @SuppressWarnings("JdkObsolete")
   final @NotNull SentryEvent createEvent(final @NotNull LogEvent loggingEvent) {
-    final SentryEvent event =
-        new SentryEvent(DateUtils.getDateTime(new Date(loggingEvent.getTimeMillis())));
+    final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeMillis()));
     final Message message = new Message();
     message.setMessage(loggingEvent.getMessage().getFormat());
     message.setFormatted(loggingEvent.getMessage().getFormattedMessage());

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -16,7 +16,6 @@ import io.sentry.transport.ITransport;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,8 +67,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   // for the Android compatibility we must use old Java Date class
   @SuppressWarnings("JdkObsolete")
   final @NotNull SentryEvent createEvent(@NotNull ILoggingEvent loggingEvent) {
-    final SentryEvent event =
-        new SentryEvent(DateUtils.getDateTime(new Date(loggingEvent.getTimeStamp())));
+    final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeStamp()));
     final Message message = new Message();
     message.setMessage(loggingEvent.getMessage());
     message.setFormatted(loggingEvent.getFormattedMessage());

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -46,12 +46,10 @@ public final class io/sentry/CustomSamplingContext {
 
 public final class io/sentry/DateUtils {
 	public static fun getCurrentDateTime ()Ljava/util/Date;
-	public static fun getCurrentDateTimeOrNull ()Ljava/util/Date;
+	public static fun getDateTime (J)Ljava/util/Date;
 	public static fun getDateTime (Ljava/lang/String;)Ljava/util/Date;
-	public static fun getDateTime (Ljava/util/Date;)Ljava/util/Date;
 	public static fun getDateTimeWithMillisPrecision (Ljava/lang/String;)Ljava/util/Date;
 	public static fun getTimestamp (Ljava/util/Date;)Ljava/lang/String;
-	public static fun getTimestampIsoFormat (Ljava/util/Date;)Ljava/lang/String;
 }
 
 public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -61,7 +61,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
 
   /** Breadcrumb ctor */
   public Breadcrumb() {
-    this(DateUtils.getCurrentDateTimeOrNull());
+    this(DateUtils.getCurrentDateTime());
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -44,8 +44,7 @@ public final class DateUtils {
       new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
-          final SimpleDateFormat simpleDateFormat =
-                  new SimpleDateFormat(ISO_FORMAT, Locale.ROOT);
+          final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(ISO_FORMAT, Locale.ROOT);
           simpleDateFormat.setTimeZone(UTC_TIMEZONE);
           return simpleDateFormat;
         }
@@ -54,9 +53,9 @@ public final class DateUtils {
   private DateUtils() {}
 
   /**
-   * Get the current date and time (UTC)
+   * Get the current Date (UTC)
    *
-   * @return the UTC date and time
+   * @return the UTC Date
    */
   @SuppressWarnings("JdkObsolete")
   public static @NotNull Date getCurrentDateTime() {
@@ -65,10 +64,10 @@ public final class DateUtils {
   }
 
   /**
-   * Get Java Date from UTC/ISO 8601 timestamp format
+   * Get the Date from UTC/ISO 8601 timestamp
    *
    * @param timestamp UTC/ISO 8601 format eg 2000-12-31T23:59:58Z or 2000-12-31T23:59:58.123Z
-   * @return the Date
+   * @return the UTC Date
    */
   public static @NotNull Date getDateTime(final @NotNull String timestamp)
       throws IllegalArgumentException {
@@ -86,10 +85,10 @@ public final class DateUtils {
   }
 
   /**
-   * Get Java Date from millis timestamp format
+   * Get the Date from millis timestamp
    *
-   * @param timestamp millis format eg 1581410911.988 (1581410911 seconds and 988 millis)
-   * @return the Date UTC timezone
+   * @param timestamp millis eg 1581410911.988 (1581410911 seconds and 988 millis)
+   * @return the UTC Date
    */
   @SuppressWarnings("JdkObsolete")
   public static @NotNull Date getDateTimeWithMillisPrecision(final @NotNull String timestamp)
@@ -106,16 +105,22 @@ public final class DateUtils {
   }
 
   /**
-   * Get date formatted as expected by Sentry.
+   * Get the UTC/ISO 8601 timestamp from Date
    *
-   * @param date already UTC format
-   * @return the ISO formatted date with millis precision.
+   * @param date the UTC Date
+   * @return the UTC/ISO 8601 timestamp
    */
   public static @NotNull String getTimestamp(final @NotNull Date date) {
     final DateFormat df = SDF_ISO_FORMAT_WITH_MILLIS_UTC.get();
     return df.format(date);
   }
 
+  /**
+   * Get the Date from millis timestamp
+   *
+   * @param millis the UTC millis from the epoch
+   * @return the UTC Date
+   */
   public static @NotNull Date getDateTime(final long millis) {
     final Calendar calendar = Calendar.getInstance(UTC_TIMEZONE);
     calendar.setTimeInMillis(millis);

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -18,16 +18,8 @@ public final class DateUtils {
   private static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
   private static final String ISO_FORMAT_WITH_MILLIS = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
-  private static @NotNull TimeZone getTimeZone() {
-    TimeZone timeZone = TimeZone.getTimeZone(UTC);
-    // if UTC is not available, let's get the current one and avoid NPE problems
-    if (timeZone == null) {
-      timeZone = TimeZone.getDefault();
-    }
-    return timeZone;
-  }
-
-  private static final @NotNull TimeZone UTC_TIMEZONE = getTimeZone();
+  // if UTC is not found, it fallback to "GMT" which is UTC equivalent
+  private static final @NotNull TimeZone UTC_TIMEZONE = TimeZone.getTimeZone(UTC);
 
   private static final @NotNull ThreadLocal<SimpleDateFormat> SDF_ISO_FORMAT_WITH_MILLIS_UTC =
       new ThreadLocal<SimpleDateFormat>() {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -149,7 +149,7 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
   }
 
   public SentryEvent() {
-    this(new SentryId(), DateUtils.getCurrentDateTimeOrNull());
+    this(new SentryId(), DateUtils.getCurrentDateTime());
   }
 
   @TestOnly

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -96,8 +96,8 @@ public final class Session {
       final @NotNull String release) {
     this(
         State.Ok,
-        DateUtils.getCurrentDateTimeOrNull(),
-        DateUtils.getCurrentDateTimeOrNull(),
+        DateUtils.getCurrentDateTime(),
+        DateUtils.getCurrentDateTime(),
         0,
         distinctId,
         UUID.randomUUID(),
@@ -176,7 +176,7 @@ public final class Session {
 
   /** Ends a session and update its values */
   public void end() {
-    end(DateUtils.getCurrentDateTimeOrNull());
+    end(DateUtils.getCurrentDateTime());
   }
 
   /**
@@ -196,7 +196,7 @@ public final class Session {
       if (timestamp != null) {
         this.timestamp = timestamp;
       } else {
-        this.timestamp = DateUtils.getCurrentDateTimeOrNull();
+        this.timestamp = DateUtils.getCurrentDateTime();
       }
 
       if (this.timestamp != null) {
@@ -246,7 +246,7 @@ public final class Session {
 
       if (sessionHasBeenUpdated) {
         init = null;
-        timestamp = DateUtils.getCurrentDateTimeOrNull();
+        timestamp = DateUtils.getCurrentDateTime();
         if (timestamp != null) {
           sequence = getSequenceTimestamp(timestamp);
         }

--- a/sentry/src/test/java/io/sentry/DateUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/DateUtilsTest.kt
@@ -1,27 +1,87 @@
 package io.sentry
 
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DateUtilsTest {
+
+    private val utcTimeZone: ZoneId = ZoneId.of("UTC")
+    private val isoFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 
     @Test
     fun `When ISO date has milliseconds`() {
         val date = DateUtils.getDateTime("2020-03-27T08:52:58.015Z")
-        val result = DateUtils.getTimestamp(date)
-        assertEquals("2020-03-27T08:52:58.015Z", result)
+
+        val utcDate = convertDate(date)
+        val timestamp = utcDate.format(isoFormat)
+
+        assertEquals("2020-03-27T08:52:58.015Z", timestamp)
     }
 
     @Test
     fun `When ISO date has only seconds`() {
         val date = DateUtils.getDateTime("2020-03-27T08:52:58Z")
-        val result = DateUtils.getTimestamp(date)
-        assertEquals("2020-03-27T08:52:58.000Z", result)
+
+        val utcDate = convertDate(date)
+        val timestamp = utcDate.format(isoFormat)
+
+        assertEquals("2020-03-27T08:52:58.000Z", timestamp)
     }
 
     @Test
-    fun `calendar test`() {
-        val date = DateUtils.getCurrentDateTime()
-        val result = DateUtils.getTimestamp(date)
+    fun `Converts from Date to ISO 8601 and back to Date`() {
+        val currentDate = DateUtils.getCurrentDateTime()
+        val currentDateISO = DateUtils.getTimestamp(currentDate)
+        val currentDate2 = DateUtils.getDateTime(currentDateISO)
+        val currentDateISO2 = DateUtils.getTimestamp(currentDate2)
+
+        assertEquals(currentDateISO, currentDateISO2)
+        assertEquals(currentDate, currentDate2)
+    }
+
+    @Test
+    fun `Millis timestamp with millis precision, it should be UTC`() {
+        // Jun 7, 2020 12:38:12 PM UTC
+        val dateIsoFormat = "1591533492.631"
+        val actual = DateUtils.getDateTimeWithMillisPrecision(dateIsoFormat)
+
+        val utcActual = convertDate(actual)
+        val timestamp = utcActual.format(isoFormat)
+
+        assertEquals("2020-06-07T12:38:12.631Z", timestamp)
+    }
+
+    @Test
+    fun `getCurrentDateTime returns UTC date`() {
+        val currentDate = DateUtils.getCurrentDateTime()
+        val utcCurrentDate = convertDate(currentDate)
+
+        val utcDate = LocalDateTime.now(utcTimeZone)
+
+        assertTrue { utcCurrentDate.plusSeconds(1).isAfter(utcDate) }
+        assertTrue { utcCurrentDate.minusSeconds(1).isBefore(utcDate) }
+    }
+
+    @Test
+    fun `Millis formats to Date`() {
+        val millis = 1591533492L * 1000L + 631
+        val actual = DateUtils.getDateTime(millis)
+
+        val utcActual = convertDate(actual)
+        val timestamp = utcActual.format(isoFormat)
+
+        assertEquals("2020-06-07T12:38:12.631Z", timestamp)
+    }
+
+    private fun convertDate(date: Date): LocalDateTime {
+        return Instant.ofEpochMilli(date.time)
+                .atZone(utcTimeZone)
+                .toLocalDateTime()
     }
 }

--- a/sentry/src/test/java/io/sentry/DateUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/DateUtilsTest.kt
@@ -18,4 +18,10 @@ class DateUtilsTest {
         val result = DateUtils.getTimestamp(date)
         assertEquals("2020-03-27T08:52:58.000Z", result)
     }
+
+    @Test
+    fun `calendar test`() {
+        val date = DateUtils.getCurrentDateTime()
+        val result = DateUtils.getTimestamp(date)
+    }
 }

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -105,7 +105,7 @@ class GsonSerializerTest {
     }
 
     @Test
-    fun `when deserializing mills timestamp, it should become a SentryEvent-Date`() {
+    fun `when deserializing millis timestamp, it should become a SentryEvent-Date`() {
         val dateIsoFormat = "1581410911"
         val expected = DateUtils.getDateTimeWithMillisPrecision(dateIsoFormat)
 
@@ -117,7 +117,7 @@ class GsonSerializerTest {
     }
 
     @Test
-    fun `when deserializing mills timestamp with mills precision, it should become a SentryEvent-Date`() {
+    fun `when deserializing millis timestamp with mills precision, it should become a SentryEvent-Date`() {
         val dateIsoFormat = "1581410911.988"
         val expected = DateUtils.getDateTimeWithMillisPrecision(dateIsoFormat)
 
@@ -126,17 +126,6 @@ class GsonSerializerTest {
         val actual = serializer.deserialize(StringReader(jsonEvent), SentryEvent::class.java)
 
         assertEquals(expected, actual!!.timestamp)
-    }
-
-    @Test
-    fun `when deserializing mills timestamp with mills precision, it should be UTC`() {
-        // Jun 7, 2020 12:38:12 PM UTC
-        val dateIsoFormat = "1591533492.631"
-        val actual = DateUtils.getDateTimeWithMillisPrecision(dateIsoFormat)
-
-        val expected = DateUtils.getTimestamp(actual)
-
-        assertEquals("2020-06-07T12:38:12.631Z", expected)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -30,16 +30,6 @@ class SentryEventTest {
             assertTrue(Instant.now().minus(1, ChronoUnit.HOURS).isBefore(Instant.parse(DateUtils.getTimestamp(SentryEvent().timestamp))))
 
     @Test
-    fun `timestamp is formatted in ISO 8601 in UTC with Z format`() {
-        // Sentry expects this format:
-        val expected = "2000-12-31T23:59:58.000Z"
-        val formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSX", Locale.ROOT)
-        val date = OffsetDateTime.parse(expected, formatter)
-        val actual = SentryEvent(null, Date(date.toInstant().toEpochMilli()))
-        assertEquals(expected, DateUtils.getTimestampIsoFormat(actual.timestamp))
-    }
-
-    @Test
     fun `if mechanism is not handled, it should return isCrashed=true`() {
         val mechanism = Mechanism()
         mechanism.isHandled = false

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -5,11 +5,7 @@ import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import java.util.Date
-import java.util.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Ref: using Calendar instead of Dates directly


## :bulb: Motivation and Context
this would avoid the Date/String parsing and improve the performance #1081


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
