### PR TITLE
ref: Make Attachment immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Ref: Make Attachment immutable (#1120)
 * Fix inheriting sampling decision from parent (#1100)
 * Fixes and Tests: Session serialization and deserialization
 * Fix: Exception only sets a stack trace if there are frames

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/MainActivity.java
@@ -42,8 +42,7 @@ public class MainActivity extends AppCompatActivity {
       Sentry.captureException(e);
     }
 
-    Attachment image = new Attachment(imageFile.getAbsolutePath());
-    image.setContentType("image/png");
+    Attachment image = new Attachment(imageFile.getAbsolutePath(), "sentry.png", "image/png");
     Sentry.configureScope(
         scope -> {
           scope.addAttachment(image);

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1,12 +1,13 @@
 public final class io/sentry/Attachment {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> ([BLjava/lang/String;)V
+	public fun <init> ([BLjava/lang/String;Ljava/lang/String;)V
 	public fun getBytes ()[B
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFilename ()Ljava/lang/String;
 	public fun getPathname ()Ljava/lang/String;
-	public fun setContentType (Ljava/lang/String;)V
 }
 
 public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -12,7 +12,7 @@ public final class Attachment {
   private @Nullable byte[] bytes;
   private @Nullable String pathname;
   private final @NotNull String filename;
-  private @NotNull String contentType;
+  private final @NotNull String contentType;
 
   /**
    * We could use Files.probeContentType(path) to determine the content type of the filename. This
@@ -24,15 +24,29 @@ public final class Attachment {
   private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
   /**
-   * Initializes an Attachment with bytes.
+   * Initializes an Attachment with bytes and a filename.
    *
    * @param bytes The bytes of file.
    * @param filename The name of the attachment to display in Sentry.
    */
   public Attachment(final @NotNull byte[] bytes, final @NotNull String filename) {
+    this(bytes, filename, DEFAULT_CONTENT_TYPE);
+  }
+
+  /**
+   * Initializes an Attachment with bytes, filename and content type.
+   *
+   * @param bytes The bytes of file.
+   * @param filename The name of the attachment to display in Sentry.
+   * @param contentType The content type of the attachment.
+   */
+  public Attachment(
+      final @NotNull byte[] bytes,
+      final @NotNull String filename,
+      final @NotNull String contentType) {
     this.bytes = bytes;
     this.filename = filename;
-    this.contentType = DEFAULT_CONTENT_TYPE;
+    this.contentType = contentType;
   }
 
   /**
@@ -59,9 +73,27 @@ public final class Attachment {
    * @param filename The name of the attachment to display in Sentry.
    */
   public Attachment(final @NotNull String pathname, final @NotNull String filename) {
+    this(pathname, filename, DEFAULT_CONTENT_TYPE);
+  }
+
+  /**
+   * Initializes an Attachment with a path, a filename and a content type.
+   *
+   * <p>The file located at the pathname is read lazily when the SDK captures an event or
+   * transaction not when the attachment is initialized. The pathname string is converted into an
+   * abstract pathname before reading the file.
+   *
+   * @param pathname The pathname string of the file to upload as an attachment.
+   * @param filename The name of the attachment to display in Sentry.
+   * @param contentType The content type of the attachment.
+   */
+  public Attachment(
+      final @NotNull String pathname,
+      final @NotNull String filename,
+      final @NotNull String contentType) {
     this.pathname = pathname;
     this.filename = filename;
-    this.contentType = DEFAULT_CONTENT_TYPE;
+    this.contentType = contentType;
   }
 
   /**
@@ -98,14 +130,5 @@ public final class Attachment {
    */
   public @NotNull String getContentType() {
     return contentType;
-  }
-
-  /**
-   * Sets the content type of the attachment. Default is "application/octet-stream".
-   *
-   * @param contentType the content type of the attachment.
-   */
-  public void setContentType(final @NotNull String contentType) {
-    this.contentType = contentType;
   }
 }

--- a/sentry/src/test/java/io/sentry/AttachmentTest.kt
+++ b/sentry/src/test/java/io/sentry/AttachmentTest.kt
@@ -65,8 +65,10 @@ class AttachmentTest {
 
     @Test
     fun `set content type`() {
-        val attachment = Attachment(fixture.pathname)
-        attachment.contentType = fixture.contentType
-        assertEquals(fixture.contentType, attachment.contentType)
+        val fileAttachment = Attachment(fixture.pathname, fixture.filename, fixture.contentType)
+        assertEquals(fixture.contentType, fileAttachment.contentType)
+
+        val byteAttachment = Attachment(fixture.bytes, fixture.filename, fixture.contentType)
+        assertEquals(fixture.contentType, byteAttachment.contentType)
     }
 }

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -90,7 +90,6 @@ class ScopeTest {
 
         val attachment = Attachment("path/log.txt")
         scope.addAttachment(attachment)
-        attachment.contentType = "application/json" // shallow copy, same reference
 
         val clone = scope.clone()
 
@@ -180,10 +179,8 @@ class ScopeTest {
         assertNull(clone.span)
 
         scope.addAttachment(Attachment("path/image.png"))
-        attachment.contentType = "application/json"
 
         assertEquals(1, clone.attachments.size)
-        assertEquals("application/json", clone.attachments.first().contentType)
         assertTrue(clone.attachments is CopyOnWriteArrayList)
     }
 


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Removed the setter for contentType and added two new constructors. Now Attachment is immutable.




## :bulb: Motivation and Context
Fixes GH-1120


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
