### PR TITLE
meta: Remove type of change from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
-## :loudspeaker: Type of change
-<!--- Put an `x` in the boxes that apply -->
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Enhancement
-- [ ] Refactoring
-
-
 ## :scroll: Description
 <!--- Describe your changes in detail -->
 


### PR DESCRIPTION



## :scroll: Description
The prefix for the title of the PR already contains the type of change. Having to select the type
of change in the description of the PR duplicates this info and is not needed.


## :bulb: Motivation and Context
See description.


## :green_heart: How did you test it?
Didn't

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
