### PR TITLE
Add TransportFactory to SentryOptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Ref: `ITransport` implementations are now responsible for executing request in asynchronous or synchronous way (#1118)
+* Ref: Add option to set `TransportFactory` instead of `ITransport` on `SentryOptions` (#1124) 
 
 # 4.0.0-alpha.2
 

--- a/sentry-log4j2/api/sentry-log4j2.api
+++ b/sentry-log4j2/api/sentry-log4j2.api
@@ -4,7 +4,7 @@ public final class io/sentry/log4j2/BuildConfig {
 }
 
 public final class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
-	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Lio/sentry/transport/ITransport;Lio/sentry/IHub;)V
+	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Lio/sentry/TransportFactory;Lio/sentry/IHub;)V
 	public fun append (Lorg/apache/logging/log4j/core/LogEvent;)V
 	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;)Lio/sentry/log4j2/SentryAppender;
 	public fun start ()V

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -8,9 +8,9 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.TransportFactory;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
-import io.sentry.transport.ITransport;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
 @Plugin(name = "Sentry", category = "Core", elementType = "appender", printObject = true)
 public final class SentryAppender extends AbstractAppender {
   private final @Nullable String dsn;
-  private final @Nullable ITransport transport;
+  private final @Nullable TransportFactory transportFactory;
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.ERROR;
   private final @NotNull IHub hub;
@@ -47,7 +47,7 @@ public final class SentryAppender extends AbstractAppender {
       final @Nullable String dsn,
       final @Nullable Level minimumBreadcrumbLevel,
       final @Nullable Level minimumEventLevel,
-      final @Nullable ITransport transport,
+      final @Nullable TransportFactory transportFactory,
       final @NotNull IHub hub) {
     super(name, filter, null, true, null);
     this.dsn = dsn;
@@ -57,7 +57,7 @@ public final class SentryAppender extends AbstractAppender {
     if (minimumEventLevel != null) {
       this.minimumEventLevel = minimumEventLevel;
     }
-    this.transport = transport;
+    this.transportFactory = transportFactory;
     this.hub = hub;
   }
 
@@ -103,7 +103,7 @@ public final class SentryAppender extends AbstractAppender {
               options.setDsn(dsn);
               options.setSentryClientName(BuildConfig.SENTRY_LOG4J2_SDK_NAME);
               options.setSdkVersion(createSdkVersion(options));
-              Optional.ofNullable(transport).ifPresent(options::setTransport);
+              Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
             });
       } catch (IllegalArgumentException e) {
         LOGGER.info("Failed to init Sentry during appender initialization: " + e.getMessage());

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -10,9 +10,9 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.TransportFactory;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
-import io.sentry.transport.ITransport;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 /** Appender for logback in charge of sending the logged events to a Sentry server. */
 public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @NotNull SentryOptions options = new SentryOptions();
-  private @Nullable ITransport transport;
+  private @Nullable TransportFactory transportFactory;
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.ERROR;
 
@@ -39,7 +39,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
       options.setEnableExternalConfiguration(true);
       options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
       options.setSdkVersion(createSdkVersion(options));
-      Optional.ofNullable(transport).ifPresent(options::setTransport);
+      Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
       try {
         Sentry.init(options);
       } catch (IllegalArgumentException e) {
@@ -179,7 +179,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   }
 
   @ApiStatus.Internal
-  void setTransport(@Nullable ITransport transport) {
-    this.transport = transport;
+  void setTransportFactory(final @Nullable TransportFactory transportFactory) {
+    this.transportFactory = transportFactory;
   }
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -7,6 +7,7 @@ import io.sentry.IHub;
 import io.sentry.Integration;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
+import io.sentry.TransportFactory;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryRequestResolver;
@@ -18,7 +19,6 @@ import io.sentry.spring.tracing.SentrySpanAdvice;
 import io.sentry.spring.tracing.SentryTracingFilter;
 import io.sentry.spring.tracing.SentryTransaction;
 import io.sentry.spring.tracing.SentryTransactionAdvice;
-import io.sentry.transport.ITransport;
 import io.sentry.transport.ITransportGate;
 import java.util.List;
 import org.aopalliance.aop.Advice;
@@ -69,7 +69,7 @@ public class SentryAutoConfiguration {
         final @NotNull List<Integration> integrations,
         final @NotNull ObjectProvider<ITransportGate> transportGate,
         final @NotNull List<SentryUserProvider> sentryUserProviders,
-        final @NotNull ObjectProvider<ITransport> transport,
+        final @NotNull ObjectProvider<TransportFactory> transportFactory,
         final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
@@ -82,7 +82,7 @@ public class SentryAutoConfiguration {
                 options.addEventProcessor(
                     new SentryUserProviderEventProcessor(sentryUserProvider)));
         transportGate.ifAvailable(options::setTransportGate);
-        transport.ifAvailable(options::setTransport);
+        transportFactory.ifAvailable(options::setTransportFactory);
         inAppPackagesResolver.resolveInAppIncludes().forEach(options::addInAppInclude);
       };
     }

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.boot
 
 import com.acme.MainBootClass
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -14,6 +15,7 @@ import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
+import io.sentry.TransportFactory
 import io.sentry.protocol.User
 import io.sentry.spring.HttpServletRequestSentryUserProvider
 import io.sentry.spring.SentryUserProvider
@@ -476,8 +478,17 @@ class SentryAutoConfigurationTest {
     @Configuration(proxyBeanMethods = false)
     open class MockTransportConfiguration {
 
+        private val transport = mock<ITransport>()
+
         @Bean
-        open fun sentryTransport() = mock<ITransport>()
+        open fun mockTransportFactory(): TransportFactory {
+            val factory = mock<TransportFactory>()
+            whenever(factory.create(any())).thenReturn(transport)
+            return factory
+        }
+
+        @Bean
+        open fun sentryTransport() = transport
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryHubRegistrar.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryHubRegistrar.java
@@ -35,8 +35,8 @@ public class SentryHubRegistrar implements ImportBeanDefinitionRegistrar {
     final BeanDefinitionBuilder builder =
         BeanDefinitionBuilder.genericBeanDefinition(SentryOptions.class);
 
-    if (registry.containsBeanDefinition("mockTransport")) {
-      builder.addPropertyReference("transport", "mockTransport");
+    if (registry.containsBeanDefinition("mockTransportFactory")) {
+      builder.addPropertyReference("transportFactory", "mockTransportFactory");
     }
     builder.addPropertyValue("dsn", annotationAttributes.getString("dsn"));
     builder.addPropertyValue("enableExternalConfiguration", true);

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
@@ -1,11 +1,14 @@
 package io.sentry.spring
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.Sentry
+import io.sentry.TransportFactory
 import io.sentry.test.checkEvent
 import io.sentry.transport.ITransport
 import java.lang.RuntimeException
@@ -140,8 +143,17 @@ class SentrySpringIntegrationTest {
 @EnableSentry(dsn = "http://key@localhost/proj", sendDefaultPii = true, exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE)
 open class App {
 
+    private val transport = mock<ITransport>()
+
     @Bean
-    open fun mockTransport() = mock<ITransport>()
+    open fun mockTransportFactory(): TransportFactory {
+        val factory = mock<TransportFactory>()
+        whenever(factory.create(any())).thenReturn(transport)
+        return factory
+    }
+
+    @Bean
+    open fun mockTransport() = transport
 }
 
 @RestController

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorIntegrationTest.kt
@@ -1,12 +1,15 @@
 package io.sentry.spring
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
+import io.sentry.TransportFactory
 import io.sentry.protocol.User
 import io.sentry.test.checkEvent
 import io.sentry.transport.ITransport
@@ -88,8 +91,17 @@ class SentryUserProviderEventProcessorIntegrationTest {
     @EnableSentry(dsn = "http://key@localhost/proj")
     open class AppConfig {
 
+        private val transport = mock<ITransport>()
+
         @Bean
-        open fun mockTransport() = mock<ITransport>()
+        open fun mockTransportFactory(): TransportFactory {
+            val factory = mock<TransportFactory>()
+            whenever(factory.create(any())).thenReturn(transport)
+            return factory
+        }
+
+        @Bean
+        open fun mockTransport() = transport
     }
 
     @Configuration

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -312,6 +312,11 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public final class io/sentry/NoOpTransportFactory : io/sentry/TransportFactory {
+	public fun create (Lio/sentry/SentryOptions;)Lio/sentry/transport/ITransport;
+	public static fun getInstance ()Lio/sentry/NoOpTransportFactory;
+}
+
 public final class io/sentry/OptionsContainer {
 	public static fun create (Ljava/lang/Class;)Lio/sentry/OptionsContainer;
 	public fun createInstance ()Ljava/lang/Object;
@@ -646,7 +651,7 @@ public class io/sentry/SentryOptions {
 	public fun getTags ()Ljava/util/Map;
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracesSampler ()Lio/sentry/SentryOptions$TracesSamplerCallback;
-	public fun getTransport ()Lio/sentry/transport/ITransport;
+	public fun getTransportFactory ()Lio/sentry/TransportFactory;
 	public fun getTransportGate ()Lio/sentry/transport/ITransportGate;
 	public fun isAttachStacktrace ()Z
 	public fun isAttachThreads ()Z
@@ -697,7 +702,7 @@ public class io/sentry/SentryOptions {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
-	public fun setTransport (Lio/sentry/transport/ITransport;)V
+	public fun setTransportFactory (Lio/sentry/TransportFactory;)V
 	public fun setTransportGate (Lio/sentry/transport/ITransportGate;)V
 }
 
@@ -885,6 +890,10 @@ public final class io/sentry/TransactionContext : io/sentry/SpanContext {
 	public fun getName ()Ljava/lang/String;
 	public fun getParentSampled ()Ljava/lang/Boolean;
 	public fun setParentSampled (Ljava/lang/Boolean;)V
+}
+
+public abstract interface class io/sentry/TransportFactory {
+	public abstract fun create (Lio/sentry/SentryOptions;)Lio/sentry/transport/ITransport;
 }
 
 public final class io/sentry/UncaughtExceptionHandlerIntegration : io/sentry/Integration, java/io/Closeable, java/lang/Thread$UncaughtExceptionHandler {
@@ -1516,7 +1525,7 @@ public final class io/sentry/protocol/User : io/sentry/IUnknownPropertiesConsume
 	public fun setUsername (Ljava/lang/String;)V
 }
 
-public final class io/sentry/transport/BlockingHttpTransport : io/sentry/transport/ITransport {
+public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/IConnectionConfigurator;Ljava/net/URL;)V
 	public fun <init> (Ljava/util/concurrent/ExecutorService;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V

--- a/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
+++ b/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
@@ -9,11 +9,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import org.jetbrains.annotations.NotNull;
 
-final class AsyncHttpTransportFactory {
+/** Creates {@link AsyncHttpTransport}. */
+final class AsyncHttpTransportFactory implements TransportFactory {
 
-  private AsyncHttpTransportFactory() {}
-
-  static ITransport create(final @NotNull SentryOptions options) {
+  @Override
+  public ITransport create(final @NotNull SentryOptions options) {
     Objects.requireNonNull(options, "options is required");
     final Dsn parsedDsn = new Dsn(options.getDsn());
     final IConnectionConfigurator credentials =

--- a/sentry/src/main/java/io/sentry/NoOpTransportFactory.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransportFactory.java
@@ -1,0 +1,23 @@
+package io.sentry;
+
+import io.sentry.transport.ITransport;
+import io.sentry.transport.NoOpTransport;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+public final class NoOpTransportFactory implements TransportFactory {
+
+  private static final NoOpTransportFactory instance = new NoOpTransportFactory();
+
+  public static NoOpTransportFactory getInstance() {
+    return instance;
+  }
+
+  private NoOpTransportFactory() {}
+
+  @Override
+  public ITransport create(@NotNull SentryOptions options) {
+    return NoOpTransport.getInstance();
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -3,7 +3,6 @@ package io.sentry;
 import io.sentry.hints.DiskFlushNotification;
 import io.sentry.protocol.SentryId;
 import io.sentry.transport.ITransport;
-import io.sentry.transport.NoOpTransport;
 import io.sentry.util.ApplyScopeUtils;
 import io.sentry.util.Objects;
 import java.io.IOException;
@@ -40,12 +39,12 @@ public final class SentryClient implements ISentryClient {
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
     this.enabled = true;
 
-    ITransport transport = options.getTransport();
-    if (transport instanceof NoOpTransport) {
-      transport = AsyncHttpTransportFactory.create(options);
-      options.setTransport(transport);
+    TransportFactory transportFactory = options.getTransportFactory();
+    if (transportFactory instanceof NoOpTransportFactory) {
+      transportFactory = new AsyncHttpTransportFactory();
+      options.setTransportFactory(transportFactory);
     }
-    this.transport = transport;
+    transport = transportFactory.create(options);
     this.random = options.getSampleRate() == null ? null : new Random();
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -4,10 +4,8 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.cache.IEnvelopeCache;
 import io.sentry.config.PropertiesProvider;
 import io.sentry.protocol.SdkVersion;
-import io.sentry.transport.ITransport;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
-import io.sentry.transport.NoOpTransport;
 import io.sentry.transport.NoOpTransportGate;
 import java.io.File;
 import java.util.ArrayList;
@@ -166,8 +164,11 @@ public class SentryOptions {
    */
   private final @NotNull List<String> inAppIncludes = new CopyOnWriteArrayList<>();
 
-  /** The transport is an internal construct of the client that abstracts away the event sending. */
-  private @NotNull ITransport transport = NoOpTransport.getInstance();
+  /**
+   * The transport factory creates instances of {@link io.sentry.transport.ITransport} - internal
+   * construct of the client that abstracts away the event sending.
+   */
+  private @NotNull TransportFactory transportFactory = NoOpTransportFactory.getInstance();
 
   /**
    * Implementations of this interface serve as gatekeepers that allow or disallow sending of the
@@ -722,21 +723,22 @@ public class SentryOptions {
   }
 
   /**
-   * Returns the Transport interface
+   * Returns the TransportFactory interface
    *
-   * @return the transport
+   * @return the transport factory
    */
-  public @NotNull ITransport getTransport() {
-    return transport;
+  public @NotNull TransportFactory getTransportFactory() {
+    return transportFactory;
   }
 
   /**
-   * Sets the Transport interface
+   * Sets the TransportFactory interface
    *
-   * @param transport the transport
+   * @param transportFactory the transport factory
    */
-  public void setTransport(@Nullable ITransport transport) {
-    this.transport = transport != null ? transport : NoOpTransport.getInstance();
+  public void setTransportFactory(@Nullable TransportFactory transportFactory) {
+    this.transportFactory =
+        transportFactory != null ? transportFactory : NoOpTransportFactory.getInstance();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/TransportFactory.java
+++ b/sentry/src/main/java/io/sentry/TransportFactory.java
@@ -1,0 +1,9 @@
+package io.sentry;
+
+import io.sentry.transport.ITransport;
+import org.jetbrains.annotations.NotNull;
+
+/** Creates instances of {@link ITransport}. */
+public interface TransportFactory {
+  ITransport create(final @NotNull SentryOptions options);
+}

--- a/sentry/src/test/java/io/sentry/AsyncHttpTransportFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/AsyncHttpTransportFactoryTest.kt
@@ -9,7 +9,7 @@ class AsyncHttpTransportFactoryTest {
 
     @Test
     fun `When HttpTransportFactory doesn't have a valid DSN, it throws InvalidDsnException`() {
-        assertFailsWith<InvalidDsnException> { AsyncHttpTransportFactory.create(SentryOptions()) }
+        assertFailsWith<InvalidDsnException> { AsyncHttpTransportFactory().create(SentryOptions()) }
     }
 
     @Test
@@ -17,7 +17,7 @@ class AsyncHttpTransportFactoryTest {
         val options = SentryOptions().apply {
             dsn = "ttps://key@sentry.io/proj"
         }
-        assertFailsWith<IllegalArgumentException> { AsyncHttpTransportFactory.create(options) }
+        assertFailsWith<IllegalArgumentException> { AsyncHttpTransportFactory().create(options) }
     }
 
     @Test
@@ -25,7 +25,7 @@ class AsyncHttpTransportFactoryTest {
         val options = SentryOptions().apply {
             dsn = "https://key@sentry.io/proj"
         }
-        val transport = AsyncHttpTransportFactory.create(options)
+        val transport = AsyncHttpTransportFactory().create(options)
         assertNotNull(transport)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -21,9 +21,8 @@ import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryException
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
-import io.sentry.transport.AsyncHttpTransport
+import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
-import io.sentry.transport.NoOpTransport
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -47,6 +46,8 @@ import org.junit.Assert.assertArrayEquals
 class SentryClientTest {
 
     class Fixture {
+        var transport = mock<ITransport>()
+        var factory = mock<TransportFactory>()
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
             sdkVersion = SdkVersion().apply {
@@ -57,7 +58,11 @@ class SentryClientTest {
             setDiagnosticLevel(SentryLevel.DEBUG)
             setSerializer(GsonSerializer(mock(), envelopeReader))
             setLogger(mock())
-            setTransport(mock())
+            setTransportFactory(factory)
+        }
+
+        init {
+            whenever(factory.create(any())).thenReturn(transport)
         }
 
         var attachment = Attachment("hello".toByteArray(), "hello.txt")
@@ -83,7 +88,7 @@ class SentryClientTest {
 
     @Test
     fun `when dsn is an invalid string, client throws`() {
-        fixture.sentryOptions.setTransport(NoOpTransport.getInstance())
+        fixture.sentryOptions.setTransportFactory(NoOpTransportFactory.getInstance())
         fixture.sentryOptions.dsn = "invalid-dsn"
         assertFailsWith<InvalidDsnException> { fixture.getSut() }
     }
@@ -133,7 +138,7 @@ class SentryClientTest {
         val sut = fixture.getSut()
         val event = SentryEvent()
         sut.captureEvent(event)
-        verify(fixture.sentryOptions.transport, never()).send(any())
+        verify(fixture.transport, never()).send(any())
     }
 
     @Test
@@ -145,11 +150,11 @@ class SentryClientTest {
         val sut = fixture.getSut()
         val actual = SentryEvent()
         sut.captureEvent(actual)
-        verify(fixture.sentryOptions.transport).send(check {
+        verify(fixture.transport).send(check {
             val event = getEventFromData(it.items.first().data)
             assertEquals("test", event.tags["test"])
         }, anyOrNull())
-        verifyNoMoreInteractions(fixture.sentryOptions.transport)
+        verifyNoMoreInteractions(fixture.transport)
     }
 
     @Test
@@ -175,7 +180,7 @@ class SentryClientTest {
         val sut = fixture.getSut()
         val expectedHint = Object()
         sut.captureEvent(event, expectedHint)
-        verify(fixture.sentryOptions.transport).send(any(), eq(expectedHint))
+        verify(fixture.transport).send(any(), eq(expectedHint))
     }
 
     @Test
@@ -349,7 +354,7 @@ class SentryClientTest {
 
         val allEvents = 10
         (0..allEvents).forEach { _ -> sut.captureEvent(SentryEvent()) }
-        assertTrue(allEvents > mockingDetails(fixture.sentryOptions.transport).invocations.size)
+        assertTrue(allEvents > mockingDetails(fixture.transport).invocations.size)
     }
 
     @Test
@@ -359,7 +364,7 @@ class SentryClientTest {
 
         val allEvents = 10
         (0..allEvents).forEach { _ -> sut.captureEvent(SentryEvent()) }
-        assertEquals(allEvents, mockingDetails(fixture.sentryOptions.transport).invocations.size - 1) // 1 extra invocation outside .send()
+        assertEquals(allEvents, mockingDetails(fixture.transport).invocations.size - 1) // 1 extra invocation outside .send()
     }
 
     @Test
@@ -377,7 +382,7 @@ class SentryClientTest {
 
         sut.captureUserFeedback(UserFeedback(SentryId.EMPTY_ID))
 
-        verify(fixture.sentryOptions.transport, never()).send(any())
+        verify(fixture.transport, never()).send(any())
     }
 
     @Test
@@ -386,7 +391,7 @@ class SentryClientTest {
 
         sut.captureUserFeedback(userFeedback)
 
-        verify(fixture.sentryOptions.transport).send(check { actual ->
+        verify(fixture.transport).send(check { actual ->
             assertEquals(userFeedback.eventId, actual.header.eventId)
             assertEquals(fixture.sentryOptions.sdkVersion, actual.header.sdkVersion)
 
@@ -412,7 +417,7 @@ class SentryClientTest {
         val sut = fixture.getSut()
 
         val exception = IOException("No connection")
-        whenever(fixture.sentryOptions.transport.send(any())).thenThrow(exception)
+        whenever(fixture.transport.send(any())).thenThrow(exception)
 
         val logger = mock<ILogger>()
         fixture.sentryOptions.setLogger(logger)
@@ -473,23 +478,23 @@ class SentryClientTest {
     }
 
     @Test
-    fun `when transport is NoOp, it should initialize it`() {
-        fixture.sentryOptions.setTransport(NoOpTransport.getInstance())
+    fun `when transport factory is NoOp, it should initialize it`() {
+        fixture.sentryOptions.setTransportFactory(NoOpTransportFactory.getInstance())
         fixture.getSut()
-        assertTrue(fixture.sentryOptions.transport is AsyncHttpTransport)
+        assertTrue(fixture.sentryOptions.transportFactory is AsyncHttpTransportFactory)
     }
 
     @Test
-    fun `when transport is set on options, it should use the custom transport`() {
+    fun `when transport factory is set on options, it should use the custom transport factory`() {
         val sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
         }
-        val transport = mock<AsyncHttpTransport>()
-        sentryOptions.setTransport(transport)
+        val transportFactory = mock<TransportFactory>()
+        sentryOptions.setTransportFactory(transportFactory)
 
         SentryClient(sentryOptions)
 
-        assertEquals(transport, sentryOptions.transport)
+        assertEquals(transportFactory, sentryOptions.transportFactory)
     }
 
     @Test
@@ -545,26 +550,26 @@ class SentryClientTest {
     @Test
     fun `when captureSession and no release is set, do nothing`() {
         fixture.getSut().captureSession(createSession(""))
-        verify(fixture.sentryOptions.transport, never()).send(any<SentryEnvelope>())
+        verify(fixture.transport, never()).send(any<SentryEnvelope>())
     }
 
     @Test
     fun `when captureSession and release is set, send an envelope`() {
         fixture.getSut().captureSession(createSession())
-        verify(fixture.sentryOptions.transport).send(any<SentryEnvelope>(), anyOrNull())
+        verify(fixture.transport).send(any<SentryEnvelope>(), anyOrNull())
     }
 
     @Test
     fun `when captureSession, sdkInfo should be in the envelope header`() {
         fixture.getSut().captureSession(createSession())
-        verify(fixture.sentryOptions.transport).send(check<SentryEnvelope> {
+        verify(fixture.transport).send(check<SentryEnvelope> {
             assertNotNull(it.header.sdkVersion)
         }, anyOrNull())
     }
 
     @Test
     fun `when captureEnvelope and thres an exception, returns empty sentryId`() {
-        whenever(fixture.sentryOptions.transport.send(any(), anyOrNull())).thenThrow(IOException())
+        whenever(fixture.transport.send(any(), anyOrNull())).thenThrow(IOException())
 
         val envelope = SentryEnvelope(SentryId(UUID.randomUUID()), null, setOf())
         val sentryId = fixture.getSut().captureEnvelope(envelope)
@@ -703,7 +708,7 @@ class SentryClientTest {
         scope.setContexts("key", "abc")
         scope.startSession().current
         sut.captureEvent(SentryEvent(), scope, null)
-        verify(fixture.sentryOptions.transport).send(check {
+        verify(fixture.transport).send(check {
             val event = getEventFromData(it.items.first().data)
             val map = event.contexts["key"] as Map<*, *>
             assertEquals("abc", map["value"])
@@ -720,7 +725,7 @@ class SentryClientTest {
         scope.setContexts("key", "scope value")
         scope.startSession().current
         sut.captureEvent(event, scope, null)
-        verify(fixture.sentryOptions.transport).send(check {
+        verify(fixture.transport).send(check {
             val eventFromData = getEventFromData(it.items.first().data)
             assertEquals("event value", eventFromData.contexts["key"])
         }, anyOrNull())
@@ -737,7 +742,7 @@ class SentryClientTest {
     fun `transactions are sent using connection`() {
         val sut = fixture.getSut()
         sut.captureTransaction(SentryTransaction("a-transaction"), mock(), null)
-        verify(fixture.sentryOptions.transport).send(check {
+        verify(fixture.transport).send(check {
             val transaction = it.items.first().getTransaction(fixture.sentryOptions.serializer)
             assertNotNull(transaction)
             assertEquals("a-transaction", transaction.transaction)
@@ -856,7 +861,7 @@ class SentryClientTest {
     }
 
     private fun verifyAttachmentsInEnvelope(eventId: SentryId?) {
-        verify(fixture.sentryOptions.transport).send(check { actual ->
+        verify(fixture.transport).send(check { actual ->
             assertEquals(eventId, actual.header.eventId)
 
             assertEquals(fixture.sentryOptions.sdkVersion, actual.header.sdkVersion)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Replace `ITransport` on `SentryOptions` with `TransportFactory`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change, users will be able to easily set factory classes that create implementations of `ITransport`.

## :green_heart: How did you test it?

Unit & Integration tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
