### PR TITLE
Do not return null from startTransaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix: Exception only sets a stack trace if there are frames
 * Feat: set isSideLoaded info tags
 * Enhancement: Read tracesSampleRate from AndroidManifest
+* Ref: Return NoOpTransaction instead of null (#1126)
 
 # 4.0.0-alpha.2
 

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -2,10 +2,10 @@ package io.sentry.samples.console;
 
 import io.sentry.Breadcrumb;
 import io.sentry.EventProcessor;
+import io.sentry.ITransaction;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
-import io.sentry.SentryTransaction;
 import io.sentry.Span;
 import io.sentry.SpanStatus;
 import io.sentry.protocol.Message;
@@ -138,7 +138,7 @@ public class Main {
     //
     // Transactions collect execution time of the piece of code that's executed between the start
     // and finish of transaction.
-    SentryTransaction transaction = Sentry.startTransaction("transaction name");
+    ITransaction transaction = Sentry.startTransaction("transaction name");
     // Transactions can contain one or more Spans
     Span outerSpan = transaction.startChild();
     Thread.sleep(100);

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -2,6 +2,7 @@ package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IHub;
+import io.sentry.ITransaction;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SentryTraceHeader;
@@ -22,7 +23,7 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 
 /**
- * Creates {@link io.sentry.SentryTransaction} around HTTP request executions.
+ * Creates {@link ITransaction} around HTTP request executions.
  *
  * <p>Only requests that have {@link HandlerMapping#BEST_MATCHING_PATTERN_ATTRIBUTE} request
  * attribute set are turned into transactions. This attribute is set in {@link
@@ -59,7 +60,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
     final String sentryTraceHeader = httpRequest.getHeader(SentryTraceHeader.SENTRY_TRACE_HEADER);
 
     // at this stage we are not able to get real transaction name
-    final io.sentry.SentryTransaction transaction =
+    final ITransaction transaction =
         startTransaction(
             httpRequest.getMethod() + " " + httpRequest.getRequestURI(), sentryTraceHeader);
     try {
@@ -79,7 +80,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
     }
   }
 
-  private io.sentry.SentryTransaction startTransaction(
+  private ITransaction startTransaction(
       final @NotNull String name, final @Nullable String sentryTraceHeader) {
     if (sentryTraceHeader != null) {
       try {

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -3,6 +3,7 @@ package io.sentry.spring.tracing;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IHub;
 import io.sentry.ISpan;
+import io.sentry.ITransaction;
 import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,7 +42,7 @@ public class SentryTransactionAdvice implements MethodInterceptor {
       // transaction is already active, we do not start new transaction
       return invocation.proceed();
     } else {
-      final io.sentry.SentryTransaction transaction = hub.startTransaction(name);
+      final ITransaction transaction = hub.startTransaction(name);
       if (sentryTransaction != null && !StringUtils.isEmpty(sentryTransaction.operation())) {
         transaction.setOperation(sentryTransaction.operation());
       }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -99,7 +99,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/ITransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -124,8 +124,8 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
-	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -137,7 +137,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/ITransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -163,9 +163,9 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
-	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
-	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
+	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
+	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -192,8 +192,8 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/SentryTransaction;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/ITransaction;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/ITransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun clearBreadcrumbs ()V
 	public abstract fun clone ()Lio/sentry/IHub;
@@ -217,10 +217,10 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun setTransaction (Ljava/lang/String;)V
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
 	public abstract fun startSession ()V
-	public abstract fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
-	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
-	public fun startTransaction (Ljava/lang/String;)Lio/sentry/SentryTransaction;
-	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public abstract fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
+	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
+	public fun startTransaction (Ljava/lang/String;)Lio/sentry/ITransaction;
+	public fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
 	public abstract fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -256,8 +256,8 @@ public abstract interface class io/sentry/ISentryClient {
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
 	public abstract fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
-	public fun captureTransaction (Lio/sentry/SentryTransaction;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/ITransaction;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/ITransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun close ()V
 	public abstract fun flush (J)V
@@ -286,6 +286,22 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }
 
+public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
+	public abstract fun getContexts ()Lio/sentry/protocol/Contexts;
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getEventId ()Lio/sentry/protocol/SentryId;
+	public abstract fun getLatestActiveSpan ()Lio/sentry/Span;
+	public abstract fun getRequest ()Lio/sentry/protocol/Request;
+	public abstract fun getSpans ()Ljava/util/List;
+	public abstract fun getTransaction ()Ljava/lang/String;
+	public abstract fun isSampled ()Ljava/lang/Boolean;
+	public abstract fun setContexts (Lio/sentry/protocol/Contexts;)V
+	public abstract fun setName (Ljava/lang/String;)V
+	public abstract fun setRequest (Lio/sentry/protocol/Request;)V
+	public abstract fun startChild (Lio/sentry/SpanId;)Lio/sentry/Span;
+	public abstract fun startChild (Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
+}
+
 public abstract interface class io/sentry/IUnknownPropertiesConsumer {
 	public abstract fun acceptUnknownProperties (Ljava/util/Map;)V
 }
@@ -309,6 +325,34 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
+	public fun <init> ()V
+	public fun finish ()V
+	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getDescription ()Ljava/lang/String;
+	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getLatestActiveSpan ()Lio/sentry/Span;
+	public fun getRequest ()Lio/sentry/protocol/Request;
+	public fun getSpanContext ()Lio/sentry/SpanContext;
+	public fun getSpans ()Ljava/util/List;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun getTransaction ()Ljava/lang/String;
+	public fun isSampled ()Ljava/lang/Boolean;
+	public fun setContexts (Lio/sentry/protocol/Contexts;)V
+	public fun setDescription (Ljava/lang/String;)V
+	public fun setName (Ljava/lang/String;)V
+	public fun setOperation (Ljava/lang/String;)V
+	public fun setRequest (Lio/sentry/protocol/Request;)V
+	public fun setStatus (Lio/sentry/SpanStatus;)V
+	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setThrowable (Ljava/lang/Throwable;)V
+	public fun startChild ()Lio/sentry/Span;
+	public fun startChild (Lio/sentry/SpanId;)Lio/sentry/Span;
+	public fun startChild (Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
+	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
+	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }
 
 public final class io/sentry/OptionsContainer {
@@ -342,7 +386,7 @@ public final class io/sentry/Scope : java/lang/Cloneable {
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getSpan ()Lio/sentry/ISpan;
-	public fun getTransaction ()Lio/sentry/SentryTransaction;
+	public fun getTransaction ()Lio/sentry/ITransaction;
 	public fun getTransactionName ()Ljava/lang/String;
 	public fun getUser ()Lio/sentry/protocol/User;
 	public fun removeContexts (Ljava/lang/String;)V
@@ -356,7 +400,7 @@ public final class io/sentry/Scope : java/lang/Cloneable {
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
-	public fun setTransaction (Lio/sentry/SentryTransaction;)V
+	public fun setTransaction (Lio/sentry/ITransaction;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 }
@@ -432,10 +476,10 @@ public final class io/sentry/Sentry {
 	public static fun setTransaction (Ljava/lang/String;)V
 	public static fun setUser (Lio/sentry/protocol/User;)V
 	public static fun startSession ()V
-	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/SentryTransaction;
-	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
-	public static fun startTransaction (Ljava/lang/String;)Lio/sentry/SentryTransaction;
-	public static fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/SentryTransaction;
+	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
+	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
+	public static fun startTransaction (Ljava/lang/String;)Lio/sentry/ITransaction;
+	public static fun startTransaction (Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
 	public static fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public static fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -469,7 +513,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
-	public fun captureTransaction (Lio/sentry/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/ITransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun close ()V
 	public fun flush (J)V
@@ -510,7 +554,7 @@ public final class io/sentry/SentryEnvelopeItem {
 	public fun getData ()[B
 	public fun getEvent (Lio/sentry/ISerializer;)Lio/sentry/SentryEvent;
 	public fun getHeader ()Lio/sentry/SentryEnvelopeItemHeader;
-	public fun getTransaction (Lio/sentry/ISerializer;)Lio/sentry/SentryTransaction;
+	public fun getTransaction (Lio/sentry/ISerializer;)Lio/sentry/ITransaction;
 }
 
 public final class io/sentry/SentryEnvelopeItemHeader {
@@ -738,18 +782,22 @@ public final class io/sentry/SentryTraceHeader {
 	public fun isSampled ()Ljava/lang/Boolean;
 }
 
-public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/sentry/ISpan {
+public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/sentry/ITransaction {
 	public fun <init> (Ljava/lang/String;Lio/sentry/SpanContext;Lio/sentry/IHub;)V
 	public fun finish ()V
 	public fun getDescription ()Ljava/lang/String;
+	public fun getLatestActiveSpan ()Lio/sentry/Span;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
 	public fun getSpans ()Ljava/util/List;
 	public fun getTransaction ()Ljava/lang/String;
+	public fun isSampled ()Ljava/lang/Boolean;
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
 	public fun setStatus (Lio/sentry/SpanStatus;)V
 	public fun startChild ()Lio/sentry/Span;
+	public fun startChild (Lio/sentry/SpanId;)Lio/sentry/Span;
+	public fun startChild (Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Span;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -557,7 +557,7 @@ public final class Hub implements IHub {
     boolean samplingDecision = tracingSampler.sample(samplingContext);
     transactionContexts.setSampled(samplingDecision);
 
-    ITransaction transaction = null;
+    ITransaction transaction;
     if (!isEnabled()) {
       options
           .getLogger()

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -154,12 +154,12 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public SentryId captureTransaction(ITransaction transaction, Object hint) {
+  public @NotNull SentryId captureTransaction(ITransaction transaction, Object hint) {
     return Sentry.getCurrentHub().captureTransaction(transaction, hint);
   }
 
   @Override
-  public ITransaction startTransaction(TransactionContext transactionContexts) {
+  public @NotNull ITransaction startTransaction(TransactionContext transactionContexts) {
     return Sentry.startTransaction(transactionContexts);
   }
 

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -164,13 +164,13 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public SentryTransaction startTransaction(
+  public @NotNull SentryTransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext) {
     return Sentry.startTransaction(transactionContexts, customSamplingContext);
   }
 
   @Override
-  public SentryTransaction startTransaction(
+  public @NotNull SentryTransaction startTransaction(
       String name, CustomSamplingContext customSamplingContext) {
     return Sentry.startTransaction(name, customSamplingContext);
   }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -154,23 +154,23 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public SentryId captureTransaction(SentryTransaction transaction, Object hint) {
+  public SentryId captureTransaction(ITransaction transaction, Object hint) {
     return Sentry.getCurrentHub().captureTransaction(transaction, hint);
   }
 
   @Override
-  public SentryTransaction startTransaction(TransactionContext transactionContexts) {
+  public ITransaction startTransaction(TransactionContext transactionContexts) {
     return Sentry.startTransaction(transactionContexts);
   }
 
   @Override
-  public @NotNull SentryTransaction startTransaction(
+  public @NotNull ITransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext) {
     return Sentry.startTransaction(transactionContexts, customSamplingContext);
   }
 
   @Override
-  public @NotNull SentryTransaction startTransaction(
+  public @NotNull ITransaction startTransaction(
       String name, CustomSamplingContext customSamplingContext) {
     return Sentry.startTransaction(name, customSamplingContext);
   }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -266,7 +266,7 @@ public interface IHub {
    * @return transaction's id
    */
   @ApiStatus.Internal
-  SentryId captureTransaction(SentryTransaction transaction, Object hint);
+  SentryId captureTransaction(ITransaction transaction, Object hint);
 
   /**
    * Captures the transaction and enqueues it for sending to Sentry server.
@@ -275,7 +275,7 @@ public interface IHub {
    * @return transaction's id
    */
   @ApiStatus.Internal
-  default SentryId captureTransaction(SentryTransaction transaction) {
+  default SentryId captureTransaction(ITransaction transaction) {
     return captureTransaction(transaction, null);
   }
 
@@ -285,7 +285,7 @@ public interface IHub {
    * @param transactionContexts the transaction contexts
    * @return created transaction
    */
-  SentryTransaction startTransaction(TransactionContext transactionContexts);
+  ITransaction startTransaction(TransactionContext transactionContexts);
 
   /**
    * Creates a Transaction bound to the current hub and returns the instance. Based on the passed
@@ -296,7 +296,7 @@ public interface IHub {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  default @NotNull SentryTransaction startTransaction(
+  default @NotNull ITransaction startTransaction(
       String name, CustomSamplingContext customSamplingContext) {
     return startTransaction(new TransactionContext(name), customSamplingContext);
   }
@@ -311,7 +311,7 @@ public interface IHub {
    * @return created transaction.
    */
   @NotNull
-  SentryTransaction startTransaction(
+  ITransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext);
 
   /**
@@ -322,7 +322,7 @@ public interface IHub {
    * @param name the transaction name
    * @return created transaction
    */
-  default @NotNull SentryTransaction startTransaction(final @NotNull String name) {
+  default @NotNull ITransaction startTransaction(final @NotNull String name) {
     return startTransaction(name, null);
   }
 

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -296,7 +296,7 @@ public interface IHub {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  default SentryTransaction startTransaction(
+  default @NotNull SentryTransaction startTransaction(
       String name, CustomSamplingContext customSamplingContext) {
     return startTransaction(new TransactionContext(name), customSamplingContext);
   }
@@ -310,6 +310,7 @@ public interface IHub {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
+  @NotNull
   SentryTransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext);
 
@@ -321,7 +322,7 @@ public interface IHub {
    * @param name the transaction name
    * @return created transaction
    */
-  default SentryTransaction startTransaction(final @NotNull String name) {
+  default @NotNull SentryTransaction startTransaction(final @NotNull String name) {
     return startTransaction(name, null);
   }
 

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -189,20 +189,20 @@ public interface ISentryClient {
   /**
    * Captures a transaction.
    *
-   * @param transaction the {@link SentryTransaction} to send
+   * @param transaction the {@link ITransaction} to send
    * @param scope An optional scope to be applied to the event.
    * @param hint SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
-  SentryId captureTransaction(SentryTransaction transaction, Scope scope, Object hint);
+  SentryId captureTransaction(ITransaction transaction, Scope scope, Object hint);
 
   /**
    * Captures a transaction without scope nor hint.
    *
-   * @param transaction the {@link SentryTransaction} to send
+   * @param transaction the {@link ITransaction} to send
    * @return The Id (SentryId object) of the event
    */
-  default SentryId captureTransaction(SentryTransaction transaction) {
+  default SentryId captureTransaction(ITransaction transaction) {
     return captureTransaction(transaction, null, null);
   }
 }

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -1,0 +1,100 @@
+package io.sentry;
+
+import io.sentry.protocol.Contexts;
+import io.sentry.protocol.Request;
+import io.sentry.protocol.SentryId;
+import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+
+public interface ITransaction extends ISpan {
+
+  /**
+   * Sets transaction name.
+   *
+   * @param name - transaction name
+   */
+  void setName(@NotNull String name);
+
+  /**
+   * Starts a child Span.
+   *
+   * @return a new transaction span
+   */
+  @NotNull
+  Span startChild(final @NotNull SpanId parentSpanId);
+
+  /**
+   * Starts a child Span with given trace id and parent span id.
+   *
+   * @param parentSpanId - parent span id
+   * @param operation - span operation name
+   * @param description - span description
+   * @return a new transaction span
+   */
+  @NotNull
+  Span startChild(
+      final @NotNull SpanId parentSpanId,
+      final @NotNull String operation,
+      final @NotNull String description);
+
+  /**
+   * Attaches request information to the transaction.
+   *
+   * @param request the request
+   */
+  void setRequest(Request request);
+
+  /**
+   * Returns the request information from the transaction
+   *
+   * @return the request or {@code null} if not set
+   */
+  Request getRequest();
+
+  Contexts getContexts();
+
+  void setContexts(Contexts contexts);
+
+  /**
+   * Returns the transaction's description.
+   *
+   * @return the description
+   */
+  @Nullable
+  String getDescription();
+
+  @NotNull
+  @TestOnly
+  List<Span> getSpans();
+
+  /**
+   * Returns if transaction is sampled.
+   *
+   * @return is sampled
+   */
+  @Nullable
+  Boolean isSampled();
+
+  /**
+   * Returns the latest span that is not finished.
+   *
+   * @return span or null if not found.
+   */
+  @Nullable
+  Span getLatestActiveSpan();
+
+  /**
+   * Returns transaction's event id.
+   *
+   * @return the event id
+   */
+  @Nullable
+  SentryId getEventId();
+
+  @Nullable
+  @ApiStatus.Internal
+  String getTransaction();
+}

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -118,12 +118,12 @@ final class NoOpHub implements IHub {
   }
 
   @Override
-  public SentryTransaction startTransaction(TransactionContext transactionContexts) {
+  public @NotNull SentryTransaction startTransaction(TransactionContext transactionContexts) {
     return new SentryTransaction(transactionContexts, NoOpHub.getInstance());
   }
 
   @Override
-  public SentryTransaction startTransaction(
+  public @NotNull SentryTransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext) {
     return new SentryTransaction(transactionContexts, NoOpHub.getInstance());
   }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -113,17 +113,17 @@ final class NoOpHub implements IHub {
 
   @Override
   public SentryId captureTransaction(
-      final @NotNull SentryTransaction transaction, final @Nullable Object hint) {
+      final @NotNull ITransaction transaction, final @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 
   @Override
-  public @NotNull SentryTransaction startTransaction(TransactionContext transactionContexts) {
+  public @NotNull ITransaction startTransaction(TransactionContext transactionContexts) {
     return new SentryTransaction(transactionContexts, NoOpHub.getInstance());
   }
 
   @Override
-  public @NotNull SentryTransaction startTransaction(
+  public @NotNull ITransaction startTransaction(
       TransactionContext transactionContexts, CustomSamplingContext customSamplingContext) {
     return new SentryTransaction(transactionContexts, NoOpHub.getInstance());
   }

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -41,7 +41,7 @@ final class NoOpSentryClient implements ISentryClient {
   }
 
   @Override
-  public SentryId captureTransaction(SentryTransaction transaction, Scope scope, Object hint) {
+  public SentryId captureTransaction(ITransaction transaction, Scope scope, Object hint) {
     return SentryId.EMPTY_ID;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -1,0 +1,115 @@
+package io.sentry;
+
+import io.sentry.protocol.Contexts;
+import io.sentry.protocol.Request;
+import io.sentry.protocol.SentryId;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpTransaction implements ITransaction {
+
+  @Override
+  public void setName(@NotNull String name) {}
+
+  @Override
+  public Span startChild() {
+    return new Span(SentryId.EMPTY_ID, SpanId.EMPTY_ID, this, NoOpHub.getInstance());
+  }
+
+  @Override
+  public Span startChild(String operation, String description) {
+    return startChild();
+  }
+
+  @Override
+  public @NotNull Span startChild(@NotNull SpanId parentSpanId) {
+    return startChild();
+  }
+
+  @Override
+  public @NotNull Span startChild(
+      @NotNull SpanId parentSpanId, @NotNull String operation, @NotNull String description) {
+    return startChild();
+  }
+
+  @Override
+  public void setRequest(Request request) {}
+
+  @Override
+  public Request getRequest() {
+    return null;
+  }
+
+  @Override
+  public Contexts getContexts() {
+    return null;
+  }
+
+  @Override
+  public void setContexts(Contexts contexts) {}
+
+  @Override
+  public @Nullable String getDescription() {
+    return null;
+  }
+
+  @Override
+  public @NotNull List<Span> getSpans() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public @Nullable Boolean isSampled() {
+    return null;
+  }
+
+  @Override
+  public @Nullable Span getLatestActiveSpan() {
+    return null;
+  }
+
+  @Override
+  public @Nullable SentryId getEventId() {
+    return null;
+  }
+
+  @Override
+  public @Nullable String getTransaction() {
+    return null;
+  }
+
+  @Override
+  public SentryTraceHeader toSentryTrace() {
+    return null;
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void setOperation(@Nullable String operation) {}
+
+  @Override
+  public void setDescription(@Nullable String description) {}
+
+  @Override
+  public void setStatus(@Nullable SpanStatus status) {}
+
+  @Override
+  public void setThrowable(@Nullable Throwable throwable) {}
+
+  @Override
+  public @Nullable Throwable getThrowable() {
+    return null;
+  }
+
+  @Override
+  public @NotNull SpanContext getSpanContext() {
+    return startChild();
+  }
+
+  @Override
+  public void setTag(@NotNull String key, @NotNull String value) {}
+}

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -21,8 +21,8 @@ public final class Scope implements Cloneable {
   /** Scope's SentryLevel */
   private @Nullable SentryLevel level;
 
-  /** Scope's {@link SentryTransaction}. */
-  private @Nullable SentryTransaction transaction;
+  /** Scope's {@link ITransaction}. */
+  private @Nullable ITransaction transaction;
 
   /** Scope's user */
   private @Nullable User user;
@@ -93,7 +93,7 @@ public final class Scope implements Cloneable {
    * @return the transaction
    */
   public @Nullable String getTransactionName() {
-    final SentryTransaction tx = this.transaction;
+    final ITransaction tx = this.transaction;
     return tx != null ? tx.getTransaction() : null;
   }
 
@@ -103,7 +103,7 @@ public final class Scope implements Cloneable {
    * @param transaction the transaction
    */
   public void setTransaction(final @NotNull String transaction) {
-    final SentryTransaction tx = this.transaction;
+    final ITransaction tx = this.transaction;
     if (tx != null) {
       tx.setName(transaction);
     }
@@ -116,7 +116,7 @@ public final class Scope implements Cloneable {
    */
   @Nullable
   public ISpan getSpan() {
-    final SentryTransaction tx = transaction;
+    final ITransaction tx = transaction;
     if (tx != null) {
       final Span span = tx.getLatestActiveSpan();
 
@@ -132,7 +132,7 @@ public final class Scope implements Cloneable {
    *
    * @param transaction the transaction
    */
-  public void setTransaction(final @NotNull SentryTransaction transaction) {
+  public void setTransaction(final @NotNull ITransaction transaction) {
     this.transaction = Objects.requireNonNull(transaction, "transaction is required");
   }
 
@@ -271,7 +271,7 @@ public final class Scope implements Cloneable {
    * @return the transaction
    */
   @Nullable
-  public SentryTransaction getTransaction() {
+  public ITransaction getTransaction() {
     return this.transaction;
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -495,7 +495,7 @@ public final class Sentry {
    * @param name the transaction name
    * @return created transaction
    */
-  public static @NotNull SentryTransaction startTransaction(final @NotNull String name) {
+  public static @NotNull ITransaction startTransaction(final @NotNull String name) {
     return getCurrentHub().startTransaction(name);
   }
 
@@ -505,7 +505,7 @@ public final class Sentry {
    * @param transactionContexts the transaction contexts
    * @return created transaction
    */
-  public static @NotNull SentryTransaction startTransaction(
+  public static @NotNull ITransaction startTransaction(
       final @NotNull TransactionContext transactionContexts) {
     return getCurrentHub().startTransaction(transactionContexts);
   }
@@ -519,7 +519,7 @@ public final class Sentry {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  public static @NotNull SentryTransaction startTransaction(
+  public static @NotNull ITransaction startTransaction(
       final @NotNull String name, final @NotNull CustomSamplingContext customSamplingContext) {
     return getCurrentHub().startTransaction(name, customSamplingContext);
   }
@@ -533,7 +533,7 @@ public final class Sentry {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  public static @NotNull SentryTransaction startTransaction(
+  public static @NotNull ITransaction startTransaction(
       final @NotNull TransactionContext transactionContexts,
       final @NotNull CustomSamplingContext customSamplingContext) {
     return getCurrentHub().startTransaction(transactionContexts, customSamplingContext);

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -493,9 +493,9 @@ public final class Sentry {
    * Creates a Transaction bound to the current hub and returns the instance.
    *
    * @param name the transaction name
-   * @return created transaction or {@code null} if {@link Hub} is disabled.
+   * @return created transaction
    */
-  public static @Nullable SentryTransaction startTransaction(final @NotNull String name) {
+  public static @NotNull SentryTransaction startTransaction(final @NotNull String name) {
     return getCurrentHub().startTransaction(name);
   }
 
@@ -505,7 +505,7 @@ public final class Sentry {
    * @param transactionContexts the transaction contexts
    * @return created transaction
    */
-  public static @Nullable SentryTransaction startTransaction(
+  public static @NotNull SentryTransaction startTransaction(
       final @NotNull TransactionContext transactionContexts) {
     return getCurrentHub().startTransaction(transactionContexts);
   }
@@ -519,7 +519,7 @@ public final class Sentry {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  public static @Nullable SentryTransaction startTransaction(
+  public static @NotNull SentryTransaction startTransaction(
       final @NotNull String name, final @NotNull CustomSamplingContext customSamplingContext) {
     return getCurrentHub().startTransaction(name, customSamplingContext);
   }
@@ -533,7 +533,7 @@ public final class Sentry {
    * @param customSamplingContext the sampling context
    * @return created transaction.
    */
-  public static @Nullable SentryTransaction startTransaction(
+  public static @NotNull SentryTransaction startTransaction(
       final @NotNull TransactionContext transactionContexts,
       final @NotNull CustomSamplingContext customSamplingContext) {
     return getCurrentHub().startTransaction(transactionContexts, customSamplingContext);

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -117,7 +117,7 @@ public final class SentryEnvelopeItem {
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
-  public @Nullable SentryTransaction getTransaction(final @NotNull ISerializer serializer)
+  public @Nullable ITransaction getTransaction(final @NotNull ISerializer serializer)
       throws Exception {
     if (header == null || header.getType() != SentryItemType.Transaction) {
       return null;

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -12,7 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-public final class SentryTransaction extends SentryBaseEvent implements ISpan {
+@ApiStatus.Internal
+public final class SentryTransaction extends SentryBaseEvent implements ITransaction {
   /** The transaction name. */
   private @Nullable String transaction;
 
@@ -67,6 +68,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    *
    * @param name - transaction name
    */
+  @Override
   public void setName(final @NotNull String name) {
     Objects.requireNonNull(name, "name is required");
     this.transaction = name;
@@ -104,7 +106,8 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    * @param parentSpanId - parent span id
    * @return a new transaction span
    */
-  Span startChild(final @NotNull SpanId parentSpanId) {
+  @Override
+  public @NotNull Span startChild(final @NotNull SpanId parentSpanId) {
     Objects.requireNonNull(parentSpanId, "parentSpanId is required");
     final Span span = new Span(getTraceId(), parentSpanId, this, this.hub);
     this.spans.add(span);
@@ -119,8 +122,8 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    * @param description - span description
    * @return a new transaction span
    */
-  @NotNull
-  Span startChild(
+  @Override
+  public @NotNull Span startChild(
       final @NotNull SpanId parentSpanId,
       final @NotNull String operation,
       final @NotNull String description) {
@@ -145,8 +148,8 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
     return getContexts().getTrace().getTraceId();
   }
 
-  @Nullable
-  Boolean isSampled() {
+  @Override
+  public @Nullable Boolean isSampled() {
     return getContexts().getTrace().getSampled();
   }
 
@@ -179,6 +182,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
     this.getContexts().getTrace().setDescription(description);
   }
 
+  @Override
   public @Nullable String getDescription() {
     return this.getContexts().getTrace().getDescription();
   }
@@ -203,9 +207,9 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
    *
    * @return transaction name.
    */
-  @Nullable
+  @Override
   @ApiStatus.Internal
-  public String getTransaction() {
+  public @Nullable String getTransaction() {
     return transaction;
   }
 
@@ -219,15 +223,15 @@ public final class SentryTransaction extends SentryBaseEvent implements ISpan {
     return timestamp;
   }
 
-  @NotNull
+  @Override
   @TestOnly
-  public List<Span> getSpans() {
+  public @NotNull List<Span> getSpans() {
     return spans;
   }
 
   /** @return the latest span that is not finished or null if not found. */
-  @Nullable
-  Span getLatestActiveSpan() {
+  @Override
+  public @Nullable Span getLatestActiveSpan() {
     final List<Span> spans = new ArrayList<>(this.spans);
     if (!spans.isEmpty()) {
       for (int i = spans.size() - 1; i >= 0; i--) {

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -17,7 +17,7 @@ public final class Span extends SpanContext implements ISpan {
    * A transaction this span is attached to. Marked as transient to be ignored during JSON
    * serialization.
    */
-  private final transient @NotNull SentryTransaction transaction;
+  private final transient @NotNull ITransaction transaction;
 
   /** A throwable thrown during the execution of the span. */
   private transient @Nullable Throwable throwable;
@@ -27,7 +27,7 @@ public final class Span extends SpanContext implements ISpan {
   Span(
       final @NotNull SentryId traceId,
       final @NotNull SpanId parentSpanId,
-      final @NotNull SentryTransaction transaction,
+      final @NotNull ITransaction transaction,
       final @NotNull IHub hub) {
     super(traceId, new SpanId(), parentSpanId, transaction.isSampled());
     this.transaction = Objects.requireNonNull(transaction, "transaction is required");

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -975,7 +975,7 @@ class HubTest {
         val contexts = TransactionContext("name")
 
         val transaction = hub.startTransaction(contexts)
-
+        assertTrue(transaction is SentryTransaction)
         assertEquals(contexts, transaction.contexts.trace)
     }
 

--- a/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
@@ -1,0 +1,22 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class NoOpTransactionTest {
+
+    private val transaction = NoOpTransaction()
+
+    @Test
+    fun `startChild does not return null`() {
+        assertNotNull(transaction.startChild())
+        assertNotNull(transaction.startChild(SpanId.EMPTY_ID))
+        assertNotNull(transaction.startChild(SpanId.EMPTY_ID, "op", "desc"))
+        assertNotNull(transaction.startChild("op", "desc"))
+    }
+
+    @Test
+    fun `getSpanContext does not return null`() {
+        assertNotNull(transaction.spanContext)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Changes `startTransaction` method to never return `null`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`null` could have been returned only if hub is closed or if stack contains zero items.

- when hub is closed, transaction will not be captured anyway since `captureTransaction` does the check for closed hub anyways
- it's not technically possible that `stack` contains zero items

## :green_heart: How did you test it?

Tests already cover it.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Create abstraction over stack to make sure that stack can never be empty.
