### PR TITLE
Initialize Logback after context refreshes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix: Exception only sets a stack trace if there are frames
 * Feat: set isSideLoaded info tags
 * Enhancement: Read tracesSampleRate from AndroidManifest
+* Fix: Initialize Logback after context refreshes (#1129)
 
 # 4.0.0-alpha.2
 

--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -13,9 +13,9 @@ public class io/sentry/spring/boot/SentryAutoConfiguration {
 	public fun <init> ()V
 }
 
-public class io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration : org/springframework/beans/factory/InitializingBean {
+public class io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration {
 	public fun <init> ()V
-	public fun afterPropertiesSet ()V
+	public fun sentryLogbackInitializer (Lio/sentry/spring/boot/SentryProperties;)Lio/sentry/spring/boot/SentryLogbackInitializer;
 }
 
 public class io/sentry/spring/boot/SentryProperties : io/sentry/SentryOptions {

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration.java
@@ -1,20 +1,13 @@
 package io.sentry.spring.boot;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Appender;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.logback.SentryAppender;
-import java.util.Iterator;
-import java.util.Optional;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** Auto-configures {@link SentryAppender}. */
@@ -23,40 +16,11 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnClass({LoggerContext.class, SentryAppender.class})
 @ConditionalOnProperty(name = "sentry.logging.enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnBean(SentryProperties.class)
-public class SentryLogbackAppenderAutoConfiguration implements InitializingBean {
+public class SentryLogbackAppenderAutoConfiguration {
 
-  @Autowired private SentryProperties sentryProperties;
-
-  @Override
-  public void afterPropertiesSet() {
-    Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-
-    if (!isSentryAppenderRegistered(rootLogger)) {
-      SentryAppender sentryAppender = new SentryAppender();
-      sentryAppender.setName("SENTRY_APPENDER");
-      sentryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
-
-      Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
-          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
-          .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);
-      Optional.ofNullable(sentryProperties.getLogging().getMinimumEventLevel())
-          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
-          .ifPresent(sentryAppender::setMinimumEventLevel);
-
-      sentryAppender.start();
-      rootLogger.addAppender(sentryAppender);
-    }
-  }
-
-  private boolean isSentryAppenderRegistered(Logger logger) {
-    Iterator<Appender<ILoggingEvent>> it = logger.iteratorForAppenders();
-    while (it.hasNext()) {
-      Appender<ILoggingEvent> appender = it.next();
-
-      if (appender.getClass().equals(SentryAppender.class)) {
-        return true;
-      }
-    }
-    return false;
+  @Bean
+  public @NotNull SentryLogbackInitializer sentryLogbackInitializer(
+      final @NotNull SentryProperties sentryProperties) {
+    return new SentryLogbackInitializer(sentryProperties);
   }
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
@@ -20,7 +20,7 @@ import org.springframework.core.ResolvableType;
 /** Registers {@link SentryAppender} after Spring context gets refreshed. */
 @Open
 class SentryLogbackInitializer implements GenericApplicationListener {
-  private final SentryProperties sentryProperties;
+  private final @NotNull SentryProperties sentryProperties;
 
   public SentryLogbackInitializer(final @NotNull SentryProperties sentryProperties) {
     this.sentryProperties = Objects.requireNonNull(sentryProperties, "properties are required");

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
@@ -56,7 +56,7 @@ class SentryLogbackInitializer implements GenericApplicationListener {
   private boolean isSentryAppenderRegistered(final @NotNull Logger logger) {
     final Iterator<Appender<ILoggingEvent>> it = logger.iteratorForAppenders();
     while (it.hasNext()) {
-      Appender<ILoggingEvent> appender = it.next();
+      final Appender<ILoggingEvent> appender = it.next();
 
       if (appender.getClass().equals(SentryAppender.class)) {
         return true;

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
@@ -1,0 +1,67 @@
+package io.sentry.spring.boot;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.logback.SentryAppender;
+import io.sentry.util.Objects;
+import java.util.Iterator;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.GenericApplicationListener;
+import org.springframework.core.ResolvableType;
+
+/** Registers {@link SentryAppender} after Spring context gets refreshed. */
+@Open
+class SentryLogbackInitializer implements GenericApplicationListener {
+  private final SentryProperties sentryProperties;
+
+  public SentryLogbackInitializer(final @NotNull SentryProperties sentryProperties) {
+    this.sentryProperties = Objects.requireNonNull(sentryProperties, "properties are required");
+  }
+
+  @Override
+  public boolean supportsEventType(final @NotNull ResolvableType eventType) {
+    return eventType.getRawClass() != null
+        && ContextRefreshedEvent.class.isAssignableFrom(eventType.getRawClass());
+  }
+
+  @Override
+  public void onApplicationEvent(final @NotNull ApplicationEvent event) {
+    final Logger rootLogger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+
+    if (!isSentryAppenderRegistered(rootLogger)) {
+      final SentryAppender sentryAppender = new SentryAppender();
+      sentryAppender.setName("SENTRY_APPENDER");
+      sentryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+
+      Optional.ofNullable(sentryProperties.getLogging().getMinimumBreadcrumbLevel())
+          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
+          .ifPresent(sentryAppender::setMinimumBreadcrumbLevel);
+      Optional.ofNullable(sentryProperties.getLogging().getMinimumEventLevel())
+          .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
+          .ifPresent(sentryAppender::setMinimumEventLevel);
+
+      sentryAppender.start();
+      rootLogger.addAppender(sentryAppender);
+    }
+  }
+
+  private boolean isSentryAppenderRegistered(final @NotNull Logger logger) {
+    final Iterator<Appender<ILoggingEvent>> it = logger.iteratorForAppenders();
+    while (it.hasNext()) {
+      Appender<ILoggingEvent> appender = it.next();
+
+      if (appender.getClass().equals(SentryAppender.class)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Spring Context can be refreshed while application is running (for example using Spring Cloud Bus). Without this change, `SentryAppender` would not get registered once refresh happens.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#1128 

## :green_heart: How did you test it?

AFAIK It is not possible to trigger context refresh in Spring integration testing framework.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes