### PR TITLE
feat: Drop invalid attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Feat: Drop invalid attachments #1134
 * Ref: Make Attachment immutable (#1120)
 * Fix inheriting sampling decision from parent (#1100)
 * Fixes and Tests: Session serialization and deserialization

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -547,7 +547,7 @@ public final class io/sentry/SentryEnvelopeHeaderAdapter : com/google/gson/TypeA
 }
 
 public final class io/sentry/SentryEnvelopeItem {
-	public static fun fromAttachment (Lio/sentry/ILogger;Lio/sentry/Attachment;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromAttachment (Lio/sentry/Attachment;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromEvent (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromSession (Lio/sentry/ISerializer;Lio/sentry/Session;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromUserFeedback (Lio/sentry/ISerializer;Lio/sentry/UserFeedback;)Lio/sentry/SentryEnvelopeItem;
@@ -1097,6 +1097,10 @@ public final class io/sentry/exception/InvalidDsnException : java/lang/RuntimeEx
 public final class io/sentry/exception/InvalidSentryTraceHeaderException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getSentryTraceHeader ()Ljava/lang/String;
+}
+
+public final class io/sentry/exception/SentryEnvelopeException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
 }
 
 public abstract interface class io/sentry/hints/ApplyScopeData {

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -169,13 +169,20 @@ public final class GsonSerializer implements ISerializer {
       writer.write("\n");
 
       for (final SentryEnvelopeItem item : envelope.getItems()) {
-        gson.toJson(item.getHeader(), SentryEnvelopeItemHeader.class, writer);
-        writer.write("\n");
-        writer.flush();
+        try {
+          final byte[] data = item.getData();
 
-        outputStream.write(item.getData());
+          gson.toJson(item.getHeader(), SentryEnvelopeItemHeader.class, writer);
+          writer.write("\n");
+          writer.flush();
 
-        writer.write("\n");
+          outputStream.write(data);
+
+          writer.write("\n");
+        } catch (Exception exception) {
+          logger.log(
+              SentryLevel.ERROR, "Failed to get data for envelope item. Dropping it.", exception);
+        }
       }
       writer.flush();
     }

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -180,8 +180,7 @@ public final class GsonSerializer implements ISerializer {
 
           writer.write("\n");
         } catch (Exception exception) {
-          logger.log(
-              SentryLevel.ERROR, "Failed to get data for envelope item. Dropping it.", exception);
+          logger.log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);
         }
       }
       writer.flush();

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -170,6 +170,7 @@ public final class GsonSerializer implements ISerializer {
 
       for (final SentryEnvelopeItem item : envelope.getItems()) {
         try {
+          // When this throws we don't write anything and continue with the next item.
           final byte[] data = item.getData();
 
           gson.toJson(item.getHeader(), SentryEnvelopeItemHeader.class, writer);

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -167,8 +167,7 @@ public final class SentryClient implements ISentryClient {
 
     if (attachments != null) {
       for (final Attachment attachment : attachments) {
-        final SentryEnvelopeItem attachmentItem =
-            SentryEnvelopeItem.fromAttachment(options.getLogger(), attachment);
+        final SentryEnvelopeItem attachmentItem = SentryEnvelopeItem.fromAttachment(attachment);
         envelopeItems.add(attachmentItem);
       }
     }

--- a/sentry/src/main/java/io/sentry/exception/SentryEnvelopeException.java
+++ b/sentry/src/main/java/io/sentry/exception/SentryEnvelopeException.java
@@ -1,0 +1,10 @@
+package io.sentry.exception;
+
+public final class SentryEnvelopeException extends Exception {
+
+  private static final long serialVersionUID = -8307801916948173232L;
+
+  public SentryEnvelopeException(String message) {
+    super(message);
+  }
+}

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -1,15 +1,14 @@
 package io.sentry
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import io.sentry.exception.SentryEnvelopeException
 import io.sentry.protocol.User
 import io.sentry.test.injectForField
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.Assert.assertArrayEquals
@@ -45,7 +44,7 @@ class SentryEnvelopeItemTest {
         val bytes = "hello".toByteArray()
         val attachment = Attachment(bytes, fixture.pathname)
 
-        val item = SentryEnvelopeItem.fromAttachment(mock(), attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
         assertAttachment(attachment, bytes, item)
     }
@@ -56,7 +55,7 @@ class SentryEnvelopeItemTest {
         file.writeBytes(fixture.bytes)
         val attachment = Attachment(file.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(mock(), attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
         assertAttachment(attachment, fixture.bytes, item)
     }
@@ -68,21 +67,21 @@ class SentryEnvelopeItemTest {
         file.writeBytes(twoMB)
         val attachment = Attachment(file.absolutePath)
 
-        val item = SentryEnvelopeItem.fromAttachment(mock(), attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
         assertAttachment(attachment, twoMB, item)
     }
 
     @Test
     fun `fromAttachment with non existent file`() {
-        val logger = mock<ILogger>()
         val attachment = Attachment("I don't exist", "file.txt")
 
-        val item = SentryEnvelopeItem.fromAttachment(logger, attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertAttachment(attachment,
-                "Reading the attachment ${attachment.pathname} failed, because the file located at " +
-                        "the path is not a file.", item)
+        assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed, because the file located at " +
+                "the path is not a file.") {
+            item.data
+        }
     }
 
     @Test
@@ -93,13 +92,14 @@ class SentryEnvelopeItemTest {
         // On CI it can happen that we don't have the permission to the file permission to read only
         val changedFileReadPermission = file.setReadable(false)
         if (changedFileReadPermission) {
-            val logger = mock<ILogger>()
             val attachment = Attachment(file.path, "file.txt")
 
-            val item = SentryEnvelopeItem.fromAttachment(logger, attachment)
+            val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-            assertAttachment(attachment, "Reading the attachment ${attachment.pathname} failed, " +
-                    "because can't read the file.", item)
+            assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed, " +
+                    "because can't read the file.") {
+                item.data
+            }
         } else {
             println("Was not able to change file access permission. Skipping test.")
         }
@@ -110,16 +110,16 @@ class SentryEnvelopeItemTest {
         val file = File(fixture.pathname)
         file.writeBytes(fixture.bytes)
 
-        val logger = mock<ILogger>()
         val attachment = Attachment(file.path, "file.txt")
 
         val securityManager = DenyReadFileSecurityManager(fixture.pathname)
         System.setSecurityManager(securityManager)
 
-        val item = SentryEnvelopeItem.fromAttachment(logger, attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertAttachment(attachment, "Reading the attachment ${attachment.pathname} failed.", item)
-        verifyLogException<SecurityException>(logger, attachment.pathname ?: "")
+        assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed.") {
+            item.data
+        }
 
         System.setSecurityManager(null)
     }
@@ -134,10 +134,12 @@ class SentryEnvelopeItemTest {
         // reflection instead.
         attachment.injectForField("pathname", null)
 
-        val item = SentryEnvelopeItem.fromAttachment(mock(), attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertAttachment(attachment, "Couldn't attach the attachment ${attachment.filename}.\n" +
-                "Please check that either bytes or a path is set.", item)
+        assertFailsWith(SentryEnvelopeException::class, "Couldn't attach the attachment ${attachment.filename}.\n" +
+                "Please check that either bytes or a path is set.") {
+            item.data
+        }
     }
 
     @Test
@@ -145,7 +147,7 @@ class SentryEnvelopeItemTest {
         val image = this::class.java.classLoader.getResource("Tongariro.jpg")!!
         val attachment = Attachment(image.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(mock(), attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment)
         assertAttachment(attachment, image.readBytes(), item)
     }
 
@@ -161,21 +163,5 @@ class SentryEnvelopeItemTest {
         assertEquals(attachment.contentType, actualItem.header.contentType)
         assertEquals(attachment.filename, actualItem.header.fileName)
         assertArrayEquals(expectedBytes, actualItem.data)
-    }
-
-    private fun assertAttachment(
-        attachment: Attachment,
-        expectedErrorMessage: String,
-        actualItem: SentryEnvelopeItem
-    ) {
-        assertEquals(attachment.contentType, actualItem.header.contentType)
-        assertEquals(attachment.filename, actualItem.header.fileName)
-        assertEquals(expectedErrorMessage, String(actualItem.data))
-    }
-
-    private inline fun <reified T : Exception> verifyLogException(logger: ILogger, pathname: String) {
-        verify(logger)
-            .log(eq(SentryLevel.ERROR), any<T>(),
-                eq("Reading the attachment $pathname failed."))
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -78,7 +78,7 @@ class SentryEnvelopeItemTest {
 
         val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed, because the file located at " +
+        assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed, because the file located at " +
                 "the path is not a file.") {
             item.data
         }
@@ -96,7 +96,7 @@ class SentryEnvelopeItemTest {
 
             val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-            assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed, " +
+            assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed, " +
                     "because can't read the file.") {
                 item.data
             }
@@ -117,7 +117,7 @@ class SentryEnvelopeItemTest {
 
         val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertFailsWith(SentryEnvelopeException::class, "Reading the attachment ${attachment.pathname} failed.") {
+        assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed.") {
             item.data
         }
 
@@ -136,7 +136,7 @@ class SentryEnvelopeItemTest {
 
         val item = SentryEnvelopeItem.fromAttachment(attachment)
 
-        assertFailsWith(SentryEnvelopeException::class, "Couldn't attach the attachment ${attachment.filename}.\n" +
+        assertFailsWith<SentryEnvelopeException>("Couldn't attach the attachment ${attachment.filename}.\n" +
                 "Please check that either bytes or a path is set.") {
             item.data
         }


### PR DESCRIPTION


## :scroll: Description
SentryEnvelopeItem.fromAttachment throws now a SentryEnvelopeException when it fails
to create an envelope item from an attachment. The GsonSerializer logs the exception
and drops the envelope item. So we avoid ingesting empty attachments.

This should have been a draft PR. It is not completely finished yet.

## :bulb: Motivation and Context
Fixes GH-1123


## :green_heart: How did you test it?
Unit tests and emulator

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps
