### PR TITLE
Add non blocking Apache HttpClient 5 based Transport.

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -57,6 +57,8 @@ object Config {
         val springAop = "org.springframework:spring-aop"
         val aspectj = "org.aspectj:aspectjweaver"
         val servletApi = "javax.servlet:javax.servlet-api"
+
+        val apacheHttpClient = "org.apache.httpcomponents.client5:httpclient5:5.0.3"
     }
 
     object AnnotationProcessors {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1,3 +1,9 @@
+public final class io/sentry/ApacheHttpClientTransportFactory : io/sentry/ITransportFactory {
+	public fun <init> ()V
+	public fun <init> (Lorg/apache/hc/core5/util/TimeValue;)V
+	public fun create (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;)Lio/sentry/transport/ITransport;
+}
+
 public final class io/sentry/Attachment {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -1576,6 +1582,12 @@ public final class io/sentry/protocol/User : io/sentry/IUnknownPropertiesConsume
 	public fun setIpAddress (Ljava/lang/String;)V
 	public fun setOthers (Ljava/util/Map;)V
 	public fun setUsername (Ljava/lang/String;)V
+}
+
+public final class io/sentry/transport/ApacheHttpClientTransport : io/sentry/transport/ITransport {
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;Lorg/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient;Lio/sentry/transport/RateLimiter;)V
+	public fun close ()V
+	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
 
 public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/ITransport {

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -19,6 +19,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
 dependencies {
     // Envelopes require JSON. Until a parse is done without GSON, we'll depend on it explicitly here
     implementation(Config.Libs.gson)
+    implementation(Config.Libs.apacheHttpClient)
 
     compileOnly(Config.CompileOnly.nopen)
     errorprone(Config.CompileOnly.nopenChecker)

--- a/sentry/src/main/java/io/sentry/ApacheHttpClientTransportFactory.java
+++ b/sentry/src/main/java/io/sentry/ApacheHttpClientTransportFactory.java
@@ -1,0 +1,55 @@
+package io.sentry;
+
+import io.sentry.transport.ApacheHttpClientTransport;
+import io.sentry.transport.ITransport;
+import io.sentry.transport.RateLimiter;
+import io.sentry.util.Objects;
+import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.util.TimeValue;
+import org.jetbrains.annotations.NotNull;
+
+/** Creates {@link ApacheHttpClientTransport}. */
+public final class ApacheHttpClientTransportFactory implements ITransportFactory {
+  private final @NotNull TimeValue connectionTimeToLive;
+
+  public ApacheHttpClientTransportFactory() {
+    this(TimeValue.ofMinutes(1));
+  }
+
+  public ApacheHttpClientTransportFactory(final @NotNull TimeValue connectionTimeToLive) {
+    this.connectionTimeToLive =
+        Objects.requireNonNull(connectionTimeToLive, "connectionTimeToLive is required");
+  }
+
+  @Override
+  public ITransport create(
+      final @NotNull SentryOptions options, final @NotNull RequestDetails requestDetails) {
+    Objects.requireNonNull(options, "options is required");
+    Objects.requireNonNull(requestDetails, "requestDetails is required");
+
+    final PoolingAsyncClientConnectionManager connectionManager =
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setConnectionTimeToLive(connectionTimeToLive)
+            .setMaxConnTotal(options.getMaxQueueSize())
+            .setMaxConnPerRoute(options.getMaxQueueSize())
+            .build();
+
+    final CloseableHttpAsyncClient httpclient =
+        HttpAsyncClients.custom()
+            .setKeepAliveStrategy(DefaultConnectionKeepAliveStrategy.INSTANCE)
+            .setConnectionManager(connectionManager)
+            .setConnectionReuseStrategy(DefaultConnectionReuseStrategy.INSTANCE)
+            .build();
+
+    final RateLimiter rateLimiter = new RateLimiter(options.getLogger());
+
+    return new ApacheHttpClientTransport(options, requestDetails, httpclient, rateLimiter);
+  }
+}

--- a/sentry/src/main/java/io/sentry/transport/ApacheHttpClientTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ApacheHttpClientTransport.java
@@ -1,0 +1,145 @@
+package io.sentry.transport;
+
+import static io.sentry.SentryLevel.*;
+
+import io.sentry.RequestDetails;
+import io.sentry.SentryEnvelope;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.util.Objects;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.GZIPOutputStream;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequests;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.util.TimeValue;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link ITransport} implementation that executes request asynchronously in a non-blocking manner
+ * using Apache Http Client 5.
+ */
+public final class ApacheHttpClientTransport implements ITransport {
+  private final @NotNull SentryOptions options;
+  private final @NotNull RequestDetails requestDetails;
+  private final @NotNull CloseableHttpAsyncClient httpclient;
+  private final @NotNull RateLimiter rateLimiter;
+  private final @NotNull AtomicInteger currentlyRunning;
+
+  public ApacheHttpClientTransport(
+      final @NotNull SentryOptions options,
+      final @NotNull RequestDetails requestDetails,
+      final @NotNull CloseableHttpAsyncClient httpclient,
+      final @NotNull RateLimiter rateLimiter) {
+    this(options, requestDetails, httpclient, rateLimiter, new AtomicInteger());
+  }
+
+  ApacheHttpClientTransport(
+      final @NotNull SentryOptions options,
+      final @NotNull RequestDetails requestDetails,
+      final @NotNull CloseableHttpAsyncClient httpclient,
+      final @NotNull RateLimiter rateLimiter,
+      final @NotNull AtomicInteger currentlyRunning) {
+    this.options = Objects.requireNonNull(options, "options is required");
+    this.requestDetails = Objects.requireNonNull(requestDetails, "requestDetails is required");
+    this.httpclient = Objects.requireNonNull(httpclient, "httpclient is required");
+    this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter is required");
+    this.currentlyRunning =
+        Objects.requireNonNull(currentlyRunning, "currentlyRunning is required");
+    this.httpclient.start();
+  }
+
+  @Override
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void send(SentryEnvelope envelope, Object hint) throws IOException {
+    if (isSchedulingAllowed()) {
+      final SentryEnvelope filteredEnvelope = rateLimiter.filter(envelope, hint);
+
+      if (filteredEnvelope != null) {
+        currentlyRunning.incrementAndGet();
+
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            final GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+          options.getSerializer().serialize(filteredEnvelope, gzip);
+
+          final SimpleHttpRequest request =
+              SimpleHttpRequests.post(requestDetails.getUrl().toString());
+          request.setBody(outputStream.toByteArray(), ContentType.APPLICATION_JSON);
+          request.setHeader("Content-Encoding", "gzip");
+          request.setHeader("Content-Type", "application/x-sentry-envelope");
+          request.setHeader("Accept", "application/json");
+
+          for (Map.Entry<String, String> header : requestDetails.getHeaders().entrySet()) {
+            request.setHeader(header.getKey(), header.getValue());
+          }
+
+          if (options.getLogger().isEnabled(DEBUG)) {
+            options.getLogger().log(DEBUG, "Currently running %d requests", currentlyRunning.get());
+          }
+
+          httpclient.execute(
+              request,
+              new FutureCallback<SimpleHttpResponse>() {
+                @Override
+                public void completed(SimpleHttpResponse response) {
+                  currentlyRunning.decrementAndGet();
+                  if (response.getCode() != 200) {
+                    options
+                        .getLogger()
+                        .log(ERROR, "Request failed, API returned %s", response.getCode());
+                  } else {
+                    options.getLogger().log(INFO, "Envelope sent successfully.");
+                  }
+                  final Header retryAfter = response.getFirstHeader("Retry-After");
+                  final Header rateLimits = response.getFirstHeader("X-Sentry-Rate-Limits");
+                  rateLimiter.updateRetryAfterLimits(
+                      rateLimits != null ? rateLimits.getValue() : null,
+                      retryAfter != null ? retryAfter.getValue() : null,
+                      response.getCode());
+                }
+
+                @Override
+                public void failed(Exception ex) {
+                  currentlyRunning.decrementAndGet();
+                  options.getLogger().log(ERROR, "Error while sending an envelope", ex);
+                }
+
+                @Override
+                public void cancelled() {
+                  currentlyRunning.decrementAndGet();
+                  options.getLogger().log(WARNING, "Request cancelled");
+                }
+              });
+        } catch (Exception e) {
+          options.getLogger().log(ERROR, "Error when sending envelope", e);
+        }
+      }
+    } else {
+      options.getLogger().log(SentryLevel.WARNING, "Submit cancelled");
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    options.getLogger().log(DEBUG, "Shutting down");
+    try {
+      httpclient.awaitShutdown(TimeValue.ofSeconds(1));
+      httpclient.close(CloseMode.GRACEFUL);
+    } catch (InterruptedException e) {
+      options.getLogger().log(DEBUG, "Thread interrupted while closing the connection.");
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private boolean isSchedulingAllowed() {
+    return currentlyRunning.get() < options.getMaxQueueSize();
+  }
+}

--- a/sentry/src/test/java/io/sentry/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/ApacheHttpClientTransportFactoryTest.kt
@@ -1,0 +1,21 @@
+package io.sentry
+
+import com.nhaarman.mockitokotlin2.mock
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ApacheHttpClientTransportFactoryTest {
+
+    @Test
+    fun `creates ApacheHttpClientTransport`() {
+        val factory = ApacheHttpClientTransportFactory()
+        val options = SentryOptions().apply {
+            setLogger(mock())
+            setSerializer(mock())
+        }
+        val requestDetails = mock<RequestDetails>()
+
+        val transport = factory.create(options, requestDetails)
+        assertNotNull(transport)
+    }
+}

--- a/sentry/src/test/java/io/sentry/transport/ApacheHttpClientTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/ApacheHttpClientTransportTest.kt
@@ -1,0 +1,102 @@
+package io.sentry.transport
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.RequestDetails
+import io.sentry.SentryEnvelope
+import io.sentry.SentryEvent
+import io.sentry.SentryOptions
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.core5.concurrent.FutureCallback
+import org.apache.hc.core5.io.CloseMode
+
+class ApacheHttpClientTransportTest {
+
+    class Fixture {
+        val options = SentryOptions().apply {
+            setSerializer(mock())
+            setLogger(mock())
+        }
+        val rateLimiter = mock<RateLimiter>()
+        val requestDetails = RequestDetails("http://key@localhost/proj", mapOf("header-name" to "header-value"))
+        val client = mock<CloseableHttpAsyncClient>()
+        val currentlyRunning = mock<AtomicInteger>()
+
+        init {
+            whenever(rateLimiter.filter(any(), anyOrNull())).thenAnswer { it.arguments[0] }
+        }
+
+        fun getSut(response: SimpleHttpResponse? = null, queueFull: Boolean = false): ApacheHttpClientTransport {
+            val transport = ApacheHttpClientTransport(options, requestDetails, client, rateLimiter, currentlyRunning)
+
+            if (response != null) {
+                whenever(client.execute(any(), any())).thenAnswer {
+                    (it.arguments[1] as FutureCallback<SimpleHttpResponse>).completed(response)
+                    CompletableFuture.completedFuture(response)
+                }
+            }
+
+            if (queueFull) {
+                whenever(currentlyRunning.get()).thenReturn(options.maxQueueSize)
+            }
+            return transport
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `updates retry on rate limiter`() {
+        val response = SimpleHttpResponse(200)
+        response.addHeader("Retry-After", "10")
+        response.addHeader("X-Sentry-Rate-Limits", "1000")
+
+        val sut = fixture.getSut(response = response)
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+
+        verify(fixture.rateLimiter).updateRetryAfterLimits("1000", "10", 200)
+    }
+
+    @Test
+    fun `uses common headers and url`() {
+        val sut = fixture.getSut(response = SimpleHttpResponse(200))
+
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+
+        verify(fixture.client).execute(check {
+            assertEquals("http://localhost/proj", it.uri.toString())
+            assertEquals("header-value", it.getFirstHeader("header-name").value)
+        }, any())
+    }
+
+    @Test
+    fun `does not submit when queue is full`() {
+        val sut = fixture.getSut(queueFull = true)
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+        verify(fixture.client, never()).execute(any(), any())
+    }
+
+    @Test
+    fun `close waits for shutdown`() {
+        val sut = fixture.getSut()
+        sut.close()
+        verify(fixture.client).awaitShutdown(any())
+    }
+
+    @Test
+    fun `close shuts down gracefully`() {
+        val sut = fixture.getSut()
+        sut.close()
+        verify(fixture.client).close(CloseMode.GRACEFUL)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add non blocking Apache HttpClient 5 based Transport suitable for high traffic backend applications.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current AsyncTransport can perform up to 3 requests per second which is too little for performance feature running in backend applications.

## :green_heart: How did you test it?

Unit tests plus sample app for running performance tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Auto-configure new transport in Spring Boot auto-configuration when apache http client is on the classpath.