### PR TITLE
feat: Add maxAttachmentSize to SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
-* Feat: Drop invalid attachments #1134
+* Feat: Add maxAttachmentSize to SentryOptions (#1138)
+* Feat: Drop invalid attachments (#1134)
 * Ref: Make Attachment immutable (#1120)
 * Fix inheriting sampling decision from parent (#1100)
 * Fixes and Tests: Session serialization and deserialization

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -547,7 +547,7 @@ public final class io/sentry/SentryEnvelopeHeaderAdapter : com/google/gson/TypeA
 }
 
 public final class io/sentry/SentryEnvelopeItem {
-	public static fun fromAttachment (Lio/sentry/Attachment;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromAttachment (Lio/sentry/Attachment;J)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromEvent (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromSession (Lio/sentry/ISerializer;Lio/sentry/Session;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromUserFeedback (Lio/sentry/ISerializer;Lio/sentry/UserFeedback;)Lio/sentry/SentryEnvelopeItem;
@@ -673,6 +673,7 @@ public class io/sentry/SentryOptions {
 	public fun getInAppIncludes ()Ljava/util/List;
 	public fun getIntegrations ()Ljava/util/List;
 	public fun getLogger ()Lio/sentry/ILogger;
+	public fun getMaxAttachmentSize ()J
 	public fun getMaxBreadcrumbs ()I
 	public fun getMaxQueueSize ()I
 	public fun getOutboxPath ()Ljava/lang/String;
@@ -724,6 +725,7 @@ public class io/sentry/SentryOptions {
 	public fun setFlushTimeoutMillis (J)V
 	public fun setHostnameVerifier (Ljavax/net/ssl/HostnameVerifier;)V
 	public fun setLogger (Lio/sentry/ILogger;)V
+	public fun setMaxAttachmentSize (J)V
 	public fun setMaxBreadcrumbs (I)V
 	public fun setMaxQueueSize (I)V
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -167,7 +167,8 @@ public final class SentryClient implements ISentryClient {
 
     if (attachments != null) {
       for (final Attachment attachment : attachments) {
-        final SentryEnvelopeItem attachmentItem = SentryEnvelopeItem.fromAttachment(attachment);
+        final SentryEnvelopeItem attachmentItem =
+            SentryEnvelopeItem.fromAttachment(attachment, options.getMaxAttachmentSize());
         envelopeItems.add(attachmentItem);
       }
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -247,6 +247,9 @@ public class SentryOptions {
   /** Tags applied to every event and transaction */
   private final @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
 
+  /** max attachment size in bytes. */
+  private long maxAttachmentSize = 20 * 1024 * 1024;
+
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
@@ -1153,6 +1156,26 @@ public class SentryOptions {
    */
   public void setTag(final @NotNull String key, final @NotNull String value) {
     this.tags.put(key, value);
+  }
+
+  /**
+   * Returns the maximum attachment size for each attachment in MiB.
+   *
+   * @return the maximum attachment size in MiB.
+   */
+  public long getMaxAttachmentSize() {
+    return maxAttachmentSize;
+  }
+
+  /**
+   * Sets the max attachment size for each attachment in bytes. Default is 20 MiB. Please also check
+   * the maximum attachment size of Relay to make sure your attachments don't get discarded there:
+   * https://docs.sentry.io/product/relay/options/
+   *
+   * @param maxAttachmentSize the max attachment size in bytes.
+   */
+  public void setMaxAttachmentSize(long maxAttachmentSize) {
+    this.maxAttachmentSize = maxAttachmentSize;
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -526,9 +526,9 @@ class GsonSerializerTest {
 
         val message = "hello"
         val attachment = Attachment(message.toByteArray(), "bytes.txt")
-        val validAttachmentItem = SentryEnvelopeItem.fromAttachment(attachment)
+        val validAttachmentItem = SentryEnvelopeItem.fromAttachment(attachment, 5)
 
-        val invalidAttachmentItem = SentryEnvelopeItem.fromAttachment(Attachment("no"))
+        val invalidAttachmentItem = SentryEnvelopeItem.fromAttachment(Attachment("no"), 5)
         val envelope = SentryEnvelope(header, listOf(invalidAttachmentItem, validAttachmentItem))
 
         val actualJson = serializeToString(envelope)

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -17,7 +17,12 @@ class SentryEnvelopeItemTest {
 
     private class Fixture {
         val pathname = "hello.txt"
+        val filename = pathname
         val bytes = "hello".toByteArray()
+        val maxAttachmentSize: Long = 5 * 1024 * 1024
+
+        val bytesAllowed = ByteArray(maxAttachmentSize.toInt()) { 0 }
+        val bytesTooBig = ByteArray((maxAttachmentSize + 1).toInt()) { 0 }
     }
 
     private val fixture = Fixture()
@@ -41,23 +46,22 @@ class SentryEnvelopeItemTest {
 
     @Test
     fun `fromAttachment with bytes`() {
-        val bytes = "hello".toByteArray()
-        val attachment = Attachment(bytes, fixture.pathname)
+        val attachment = Attachment(fixture.bytesAllowed, fixture.filename)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
-        assertAttachment(attachment, bytes, item)
+        assertAttachment(attachment, fixture.bytesAllowed, item)
     }
 
     @Test
     fun `fromAttachment with file`() {
         val file = File(fixture.pathname)
-        file.writeBytes(fixture.bytes)
+        file.writeBytes(fixture.bytesAllowed)
         val attachment = Attachment(file.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
-        assertAttachment(attachment, fixture.bytes, item)
+        assertAttachment(attachment, fixture.bytesAllowed, item)
     }
 
     @Test
@@ -67,7 +71,7 @@ class SentryEnvelopeItemTest {
         file.writeBytes(twoMB)
         val attachment = Attachment(file.absolutePath)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
         assertAttachment(attachment, twoMB, item)
     }
@@ -76,7 +80,7 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with non existent file`() {
         val attachment = Attachment("I don't exist", "file.txt")
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
         assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed, because the file located at " +
                 "the path is not a file.") {
@@ -94,7 +98,7 @@ class SentryEnvelopeItemTest {
         if (changedFileReadPermission) {
             val attachment = Attachment(file.path, "file.txt")
 
-            val item = SentryEnvelopeItem.fromAttachment(attachment)
+            val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
             assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed, " +
                     "because can't read the file.") {
@@ -110,12 +114,12 @@ class SentryEnvelopeItemTest {
         val file = File(fixture.pathname)
         file.writeBytes(fixture.bytes)
 
-        val attachment = Attachment(file.path, "file.txt")
+        val attachment = Attachment(file.path, fixture.filename)
 
         val securityManager = DenyReadFileSecurityManager(fixture.pathname)
         System.setSecurityManager(securityManager)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
         assertFailsWith<SentryEnvelopeException>("Reading the attachment ${attachment.pathname} failed.") {
             item.data
@@ -134,7 +138,7 @@ class SentryEnvelopeItemTest {
         // reflection instead.
         attachment.injectForField("pathname", null)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
 
         assertFailsWith<SentryEnvelopeException>("Couldn't attach the attachment ${attachment.filename}.\n" +
                 "Please check that either bytes or a path is set.") {
@@ -147,8 +151,36 @@ class SentryEnvelopeItemTest {
         val image = this::class.java.classLoader.getResource("Tongariro.jpg")!!
         val attachment = Attachment(image.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(attachment)
+        val item = SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize)
         assertAttachment(attachment, image.readBytes(), item)
+    }
+
+    @Test
+    fun `fromAttachment with bytes too big`() {
+        val attachment = Attachment(fixture.bytesTooBig, fixture.filename)
+        val exception = assertFailsWith<SentryEnvelopeException> {
+            SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize).data
+        }
+
+        assertEquals("Dropping attachment with filename '${fixture.filename}', because the " +
+                "size of the passed bytes with ${fixture.bytesTooBig.size} bytes is bigger " +
+                "than the maximum allowed attachment size of " +
+                "${fixture.maxAttachmentSize} bytes.", exception.message)
+    }
+
+    @Test
+    fun `fromAttachment with file too big`() {
+        val file = File(fixture.pathname)
+        file.writeBytes(fixture.bytesTooBig)
+        val attachment = Attachment(file.path)
+
+        val exception = assertFailsWith<SentryEnvelopeException> {
+            SentryEnvelopeItem.fromAttachment(attachment, fixture.maxAttachmentSize).data
+        }
+
+        assertEquals("Dropping attachment, because the size of the it located at " +
+                "'${fixture.pathname}' with ${file.length()} bytes is bigger than the maximum " +
+                "allowed attachment size of ${fixture.maxAttachmentSize} bytes.", exception.message)
     }
 
     private fun createSession(): Session {

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -292,4 +292,9 @@ class SentryOptionsTest {
             temporaryFolder.delete()
         }
     }
+
+    @Test
+    fun `when options are initialized, maxAttachmentSize is 20`() {
+        assertEquals(20 * 1024 * 1024, SentryOptions().maxAttachmentSize)
+    }
 }


### PR DESCRIPTION


## :scroll: Description
Drop attachments that are larger than the specified maxAttachmentSize in SentryOptions. I changed the units to bytes instead of having MiB. I need to change this in sentry-cocoa as well.


## :bulb: Motivation and Context
We want to give the users of the SDK the possibility to drop large attachments.


## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
