### PR TITLE
ApacheHttpClientTransportFactory auto-configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * Ref: `ITransport` implementations are now responsible for executing request in asynchronous or synchronous way (#1118)
 * Ref: Add option to set `TransportFactory` instead of `ITransport` on `SentryOptions` (#1124)
 * Ref: Simplify ITransport creation in ITransportFactory (#1135) 
-* Feat: Add non blocking Apache HttpClient 5 based Transport (#1136) 
+* Feat: Add non blocking Apache HttpClient 5 based Transport (#1136)
+* Enhancement: Autoconfigure Apache HttpClient 5 based Transport in Spring Boot integration (#1143)   
 
 # 4.0.0-alpha.2
 

--- a/sentry-apache-http-client-5/build.gradle.kts
+++ b/sentry-apache-http-client-5/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     api(project(":sentry"))
-    compileOnly(Config.Libs.apacheHttpClient)
+    api(Config.Libs.apacheHttpClient)
 
     compileOnly(Config.CompileOnly.nopen)
     errorprone(Config.CompileOnly.nopenChecker)

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(project(":sentry"))
     api(project(":sentry-spring"))
     compileOnly(project(":sentry-logback"))
+    compileOnly(project(":sentry-apache-http-client-5"))
     implementation(Config.Libs.springBootStarter)
     compileOnly(Config.Libs.springWeb)
     compileOnly(Config.Libs.servletApi)
@@ -50,6 +51,7 @@ dependencies {
 
     // tests
     testImplementation(project(":sentry-logback"))
+    testImplementation(project(":sentry-apache-http-client-5"))
     testImplementation(project(":sentry-test-support"))
     testImplementation(kotlin(Config.kotlinStdLib))
     testImplementation(Config.TestLibs.kotlinTestJunit)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -20,6 +20,7 @@ import io.sentry.spring.tracing.SentryTracingFilter;
 import io.sentry.spring.tracing.SentryTransaction;
 import io.sentry.spring.tracing.SentryTransactionAdvice;
 import io.sentry.transport.ITransportGate;
+import io.sentry.transport.apache.ApacheHttpClientTransportFactory;
 import java.util.List;
 import org.aopalliance.aop.Advice;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -207,6 +208,18 @@ public class SentryAutoConfiguration {
       @Bean
       public SentrySpanRestTemplateCustomizer sentrySpanRestTemplateCustomizer(IHub hub) {
         return new SentrySpanRestTemplateCustomizer(hub);
+      }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(ITransportFactory.class)
+    @ConditionalOnClass(ApacheHttpClientTransportFactory.class)
+    @Open
+    static class ApacheHttpClientTransportFactoryAutoconfiguration {
+
+      @Bean
+      public @NotNull ApacheHttpClientTransportFactory apacheHttpClientTransportFactory() {
+        return new ApacheHttpClientTransportFactory();
       }
     }
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -1,4 +1,4 @@
-package io.sentry.spring.boot
+package io.sentry.spring.boot.it
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1,3 +1,8 @@
+public final class io/sentry/AsyncHttpTransportFactory : io/sentry/ITransportFactory {
+	public fun <init> ()V
+	public fun create (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;)Lio/sentry/transport/ITransport;
+}
+
 public final class io/sentry/Attachment {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
+++ b/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
@@ -4,10 +4,12 @@ import io.sentry.transport.AsyncHttpTransport;
 import io.sentry.transport.ITransport;
 import io.sentry.transport.RateLimiter;
 import io.sentry.util.Objects;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Creates {@link AsyncHttpTransport}. */
-final class AsyncHttpTransportFactory implements ITransportFactory {
+@ApiStatus.Internal
+public final class AsyncHttpTransportFactory implements ITransportFactory {
 
   @Override
   public @NotNull ITransport create(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Autoconfigures `ApacheHttpClientTransportFactory` in Spring Boot integration when `sentry-apache-http-client-5` is on the classpath.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`ApacheHttpClientTransportFactory` was done primarily for backend integrations using the Performance feature. We should make it as easy as possible for users to use high performance transport in with Spring Boot.


## :green_heart: How did you test it?

Unit & Integration tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes