### PR TITLE
Fix resolving dashed properties from external configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix: Initialize Logback after context refreshes (#1129)
 * Ref: Return NoOpTransaction instead of null (#1126)
 * Fix: Do not crash when passing null values to @Nullable methods, eg User and Scope
+* Fix: Resolving dashed properties from external configuration
 
 # 4.0.0-alpha.2
 

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -45,6 +45,6 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
   }
 
   private @NotNull String propertyToEnvironmentVariableName(final @NotNull String property) {
-    return PREFIX + "_" + property.replace(".", "_").toUpperCase(Locale.ROOT);
+    return PREFIX + "_" + property.replace(".", "_").replace("-", "_").toUpperCase(Locale.ROOT);
   }
 }

--- a/sentry/src/test/java/io/sentry/config/EnvironmentVariablePropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/EnvironmentVariablePropertiesProviderTest.kt
@@ -8,9 +8,16 @@ class EnvironmentVariablePropertiesProviderTest {
     private val provider = EnvironmentVariablePropertiesProvider()
 
     @Test
-    fun `when system property is set resolves property`() {
+    fun `when system property is set resolves property replacing dots with underscores`() {
         // SENTRY_TEST_PROPERTY is set in Gradle build configuration
         val result = provider.getProperty("test.property")
+        assertEquals("some-value", result)
+    }
+
+    @Test
+    fun `when system property is set resolves property replacing dashes with underscores`() {
+        // SENTRY_TEST_PROPERTY is set in Gradle build configuration
+        val result = provider.getProperty("test-property")
         assertEquals("some-value", result)
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fix resolving dashed properties from external configuration using environment variables.

For example `in-app-includes` will be read now from `SENTRY_IN_APP_INCLUDES` variable.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since `in-app-includes` and `in-app-excludes` use dashes, it has not been possible to set them using environment variables (that do not allow dashes in names).

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes