### PR TITLE
Fix: consider {{ auto }} as a default ip address.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 * Fix: Initialize Logback after context refreshes (#1129)
 * Ref: Return NoOpTransaction instead of null (#1126)
 * Fix: Do not crash when passing null values to @Nullable methods, eg User and Scope
-* Enhancement: Send user.ip_address = {{auto}} when sendDefaultPii is true
+* Enhancement: Send user.ip_address = {{auto}} when sendDefaultPii is true (#1015)
 * Fix: Resolving dashed properties from external configuration
-* Feat: Read `uncaught.handler.enabled` property from the external configuration 
+* Feat: Read `uncaught.handler.enabled` property from the external configuration
+* Fix: Consider {{ auto }} as a default ip address (#1015) 
 
 # 4.0.0-alpha.2
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
@@ -1,7 +1,7 @@
 package io.sentry.spring;
 
 import io.sentry.EventProcessor;
-import io.sentry.MainEventProcessor;
+import io.sentry.IpAddressUtils;
 import io.sentry.SentryEvent;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.User;
@@ -46,8 +46,7 @@ public final class SentryUserProviderEventProcessor implements EventProcessor {
     }
     if (options.isSendDefaultPii()) {
       final User existingUser = event.getUser();
-      if (existingUser != null
-          && MainEventProcessor.DEFAULT_IP_ADDRESS.equals(existingUser.getIpAddress())) {
+      if (existingUser != null && IpAddressUtils.isDefault(existingUser.getIpAddress())) {
         // unset {{auto}} as it would set the server's ip address as a user ip address
         existingUser.setIpAddress(null);
       }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -310,6 +310,10 @@ public abstract interface class io/sentry/Integration {
 	public abstract fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 }
 
+public final class io/sentry/IpAddressUtils {
+	public static fun isDefault (Ljava/lang/String;)Z
+}
+
 public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor {
 	public static final field DEFAULT_IP_ADDRESS Ljava/lang/String;
 	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;

--- a/sentry/src/main/java/io/sentry/IpAddressUtils.java
+++ b/sentry/src/main/java/io/sentry/IpAddressUtils.java
@@ -1,0 +1,19 @@
+package io.sentry;
+
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class IpAddressUtils {
+  static final String DEFAULT_IP_ADDRESS = "{{auto}}";
+  private static final List<String> DEFAULT_IP_ADDRESS_VALID_VALUES =
+      Arrays.asList(DEFAULT_IP_ADDRESS, "{{ auto }}");
+
+  private IpAddressUtils() {}
+
+  public static boolean isDefault(final @Nullable String ipAddress) {
+    return ipAddress != null && DEFAULT_IP_ADDRESS_VALID_VALUES.contains(ipAddress);
+  }
+}

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -133,10 +133,10 @@ public final class MainEventProcessor implements EventProcessor {
     if (options.isSendDefaultPii()) {
       if (event.getUser() == null) {
         final User user = new User();
-        user.setIpAddress(DEFAULT_IP_ADDRESS);
+        user.setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
         event.setUser(user);
       } else if (event.getUser().getIpAddress() == null) {
-        event.getUser().setIpAddress(DEFAULT_IP_ADDRESS);
+        event.getUser().setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
       }
     }
   }

--- a/sentry/src/test/java/io/sentry/IpAddressUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/IpAddressUtilsTest.kt
@@ -1,0 +1,23 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IpAddressUtilsTest {
+
+    @Test
+    fun `{{auto}} is considered a default address`() {
+        assertTrue(IpAddressUtils.isDefault("{{auto}}"))
+    }
+
+    @Test
+    fun `{{ auto }} is considered a default address`() {
+        assertTrue(IpAddressUtils.isDefault("{{ auto }}"))
+    }
+
+    @Test
+    fun `real ip address is considered not a default address`() {
+        assertFalse(IpAddressUtils.isDefault("192.168.0.1"))
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

In addition to `{{auto}}`, consider `{{ auto }}` as a default ip address.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow up to https://github.com/getsentry/sentry-java/pull/1144


## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes