### PR TITLE
Fix: Set release and environment on Transactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix: Resolving dashed properties from external configuration
 * Feat: Read `uncaught.handler.enabled` property from the external configuration
 * Fix: Consider {{ auto }} as a default ip address (#1015) 
+* Fix: Set release and environment on Transactions (#1152) 
 
 # 4.0.0-alpha.2
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -498,14 +498,18 @@ public abstract class io/sentry/SentryBaseEvent {
 	protected fun <init> ()V
 	protected fun <init> (Lio/sentry/protocol/SentryId;)V
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getEnvironment ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getRelease ()Ljava/lang/String;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getSdk ()Lio/sentry/protocol/SdkVersion;
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun removeTag (Ljava/lang/String;)V
 	public fun setContexts (Lio/sentry/protocol/Contexts;)V
+	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setEventId (Lio/sentry/protocol/SentryId;)V
+	public fun setRelease (Ljava/lang/String;)V
 	public fun setRequest (Lio/sentry/protocol/Request;)V
 	public fun setSdk (Lio/sentry/protocol/SdkVersion;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
@@ -587,7 +591,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getBreadcrumbs ()Ljava/util/List;
 	public fun getDebugMeta ()Lio/sentry/protocol/DebugMeta;
 	public fun getDist ()Ljava/lang/String;
-	public fun getEnvironment ()Ljava/lang/String;
 	public fun getExceptions ()Ljava/util/List;
 	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getFingerprints ()Ljava/util/List;
@@ -596,7 +599,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getMessage ()Lio/sentry/protocol/Message;
 	public fun getModule (Ljava/lang/String;)Ljava/lang/String;
 	public fun getPlatform ()Ljava/lang/String;
-	public fun getRelease ()Ljava/lang/String;
 	public fun getServerName ()Ljava/lang/String;
 	public fun getThreads ()Ljava/util/List;
 	public fun getTimestamp ()Ljava/util/Date;
@@ -610,7 +612,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun setBreadcrumbs (Ljava/util/List;)V
 	public fun setDebugMeta (Lio/sentry/protocol/DebugMeta;)V
 	public fun setDist (Ljava/lang/String;)V
-	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setExceptions (Ljava/util/List;)V
 	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setExtras (Ljava/util/Map;)V
@@ -621,7 +622,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun setModule (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setModules (Ljava/util/Map;)V
 	public fun setPlatform (Ljava/lang/String;)V
-	public fun setRelease (Ljava/lang/String;)V
 	public fun setServerName (Ljava/lang/String;)V
 	public fun setThreads (Ljava/util/List;)V
 	public fun setTransaction (Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -43,6 +43,21 @@ public abstract class SentryBaseEvent {
    */
   private Map<String, String> tags;
 
+  /**
+   * The release version of the application.
+   *
+   * <p>**Release versions must be unique across all projects in your organization.** This value can
+   * be the git SHA for the given project, or a product identifier with a semantic version.
+   */
+  private String release;
+
+  /**
+   * The environment name, such as `production` or `staging`.
+   *
+   * <p>```json { "environment": "production" } ```
+   */
+  private String environment;
+
   /** The captured Throwable */
   protected transient @Nullable Throwable throwable;
 
@@ -130,5 +145,21 @@ public abstract class SentryBaseEvent {
       tags = new HashMap<>();
     }
     tags.put(key, value);
+  }
+
+  public String getRelease() {
+    return release;
+  }
+
+  public void setRelease(String release) {
+    this.release = release;
+  }
+
+  public String getEnvironment() {
+    return environment;
+  }
+
+  public void setEnvironment(String environment) {
+    this.environment = environment;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -360,7 +360,8 @@ public final class SentryClient implements ISentryClient {
     SentryId sentryId = transaction.getEventId();
 
     if (transaction instanceof SentryTransaction) {
-      final SentryTransaction sentryTransaction = (SentryTransaction) transaction;
+      final SentryTransaction sentryTransaction =
+          processTransaction((SentryTransaction) transaction);
       try {
         final SentryEnvelope envelope =
             buildEnvelope(sentryTransaction, getAttachmentsFromScope(scope));
@@ -383,6 +384,16 @@ public final class SentryClient implements ISentryClient {
     }
 
     return sentryId;
+  }
+
+  private @NotNull SentryTransaction processTransaction(final @NotNull SentryTransaction transaction) {
+    if (transaction.getRelease() == null) {
+      transaction.setRelease(options.getRelease());
+    }
+    if (transaction.getEnvironment() == null) {
+      transaction.setEnvironment(options.getEnvironment());
+    }
+    return transaction;
   }
 
   private @Nullable SentryEvent applyScope(

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -386,7 +386,8 @@ public final class SentryClient implements ISentryClient {
     return sentryId;
   }
 
-  private @NotNull SentryTransaction processTransaction(final @NotNull SentryTransaction transaction) {
+  private @NotNull SentryTransaction processTransaction(
+      final @NotNull SentryTransaction transaction) {
     if (transaction.getRelease() == null) {
       transaction.setRelease(options.getRelease());
     }

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -49,13 +49,7 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
    * `ruby`
    */
   private String platform;
-  /**
-   * The release version of the application.
-   *
-   * <p>**Release versions must be unique across all projects in your organization.** This value can
-   * be the git SHA for the given project, or a product identifier with a semantic version.
-   */
-  private String release;
+
   /**
    * Program's distribution identifier.
    *
@@ -87,12 +81,7 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
    * `UserView`), in a task queue it might be the function + module name.
    */
   private String transaction;
-  /**
-   * The environment name, such as `production` or `staging`.
-   *
-   * <p>```json { "environment": "production" } ```
-   */
-  private String environment;
+
   /** Information about the user who triggered this event. */
   private User user;
   /**
@@ -186,14 +175,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
     this.platform = platform;
   }
 
-  public String getRelease() {
-    return release;
-  }
-
-  public void setRelease(String release) {
-    this.release = release;
-  }
-
   public String getDist() {
     return dist;
   }
@@ -244,14 +225,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void setTransaction(String transaction) {
     this.transaction = transaction;
-  }
-
-  public String getEnvironment() {
-    return environment;
-  }
-
-  public void setEnvironment(String environment) {
-    this.environment = environment;
   }
 
   public User getUser() {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -785,6 +785,30 @@ class SentryClientTest {
         assertEquals(span, event.contexts.trace)
     }
 
+    @Test
+    fun `when transaction does not have environment and release set, and the environment is set on options, options values are applied to transactions`() {
+        fixture.sentryOptions.release = "optionsRelease"
+        fixture.sentryOptions.environment = "optionsEnvironment"
+        val sut = fixture.getSut()
+        val transaction = SentryTransaction("name")
+        sut.captureTransaction(transaction)
+        assertEquals("optionsRelease", transaction.release)
+        assertEquals("optionsEnvironment", transaction.environment)
+    }
+
+    @Test
+    fun `when transaction has environment and release set, and the environment is set on options, options values are not applied to transactions`() {
+        fixture.sentryOptions.release = "optionsRelease"
+        fixture.sentryOptions.environment = "optionsEnvironment"
+        val sut = fixture.getSut()
+        val transaction = SentryTransaction("name")
+        transaction.release = "transactionRelease"
+        transaction.environment = "transactionEnvironment"
+        sut.captureTransaction(transaction)
+        assertEquals("transactionRelease", transaction.release)
+        assertEquals("transactionEnvironment", transaction.environment)
+    }
+
     private fun createScope(): Scope {
         return Scope(SentryOptions()).apply {
             addBreadcrumb(Breadcrumb().apply {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Set release and environment on Transactions.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1147

Both release and environment have to be set on transactions independently from how they are set on SentryEvents since transactions are not a subject of event processing.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes