### PR TITLE
Improve ITransaction and ISpan null-safety compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix: Set release and environment on Transactions (#1152)
 * Fix: Do not set transaction on the scope automatically   
 * Enhancement: Automatically assign span context to captured events (#1156)
+* Enhancement: Improve ITransaction and ISpan null-safety compatibility (#1161)
 
 # 4.0.0-alpha.2
 

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -246,10 +246,12 @@ class SentryAppenderTest {
 
         await.untilAsserted {
             verify(fixture.transport).send(checkEvent { event ->
-                assertEquals(BuildConfig.SENTRY_LOG4J2_SDK_NAME, event.sdk.name)
-                assertEquals(BuildConfig.VERSION_NAME, event.sdk.version)
-                assertNotNull(event.sdk.packages)
-                assertTrue(event.sdk.packages!!.any { pkg ->
+                assertNotNull(event.sdk)
+                val sdk = event.sdk!!
+                assertEquals(BuildConfig.SENTRY_LOG4J2_SDK_NAME, sdk.name)
+                assertEquals(BuildConfig.VERSION_NAME, sdk.version)
+                assertNotNull(sdk.packages)
+                assertTrue(sdk.packages!!.any { pkg ->
                     "maven:sentry-log4j2" == pkg.name &&
                         BuildConfig.VERSION_NAME == pkg.version
                 })

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -246,15 +246,15 @@ class SentryAppenderTest {
 
         await.untilAsserted {
             verify(fixture.transport).send(checkEvent { event ->
-                assertNotNull(event.sdk)
-                val sdk = event.sdk!!
-                assertEquals(BuildConfig.SENTRY_LOG4J2_SDK_NAME, sdk.name)
-                assertEquals(BuildConfig.VERSION_NAME, sdk.version)
-                assertNotNull(sdk.packages)
-                assertTrue(sdk.packages!!.any { pkg ->
-                    "maven:sentry-log4j2" == pkg.name &&
-                        BuildConfig.VERSION_NAME == pkg.version
-                })
+                assertNotNull(event.sdk) {
+                    assertEquals(BuildConfig.SENTRY_LOG4J2_SDK_NAME, it.name)
+                    assertEquals(BuildConfig.VERSION_NAME, it.version)
+                    assertNotNull(it.packages)
+                    assertTrue(it.packages!!.any { pkg ->
+                        "maven:sentry-log4j2" == pkg.name &&
+                            BuildConfig.VERSION_NAME == pkg.version
+                    })
+                }
             }, anyOrNull())
         }
     }

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -222,15 +222,15 @@ class SentryAppenderTest {
 
         await.untilAsserted {
             verify(fixture.transport).send(checkEvent { event ->
-                assertNotNull(event.sdk)
-                val sdk = event.sdk!!
-                assertEquals(BuildConfig.SENTRY_LOGBACK_SDK_NAME, sdk.name)
-                assertEquals(BuildConfig.VERSION_NAME, sdk.version)
-                assertNotNull(sdk.packages)
-                assertTrue(sdk.packages!!.any { pkg ->
-                    "maven:sentry-logback" == pkg.name &&
-                        BuildConfig.VERSION_NAME == pkg.version
-                })
+                assertNotNull(event.sdk) {
+                    assertEquals(BuildConfig.SENTRY_LOGBACK_SDK_NAME, it.name)
+                    assertEquals(BuildConfig.VERSION_NAME, it.version)
+                    assertNotNull(it.packages)
+                    assertTrue(it.packages!!.any { pkg ->
+                        "maven:sentry-logback" == pkg.name &&
+                            BuildConfig.VERSION_NAME == pkg.version
+                    })
+                }
             }, anyOrNull())
         }
     }

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -222,10 +222,12 @@ class SentryAppenderTest {
 
         await.untilAsserted {
             verify(fixture.transport).send(checkEvent { event ->
-                assertEquals(BuildConfig.SENTRY_LOGBACK_SDK_NAME, event.sdk.name)
-                assertEquals(BuildConfig.VERSION_NAME, event.sdk.version)
-                assertNotNull(event.sdk.packages)
-                assertTrue(event.sdk.packages!!.any { pkg ->
+                assertNotNull(event.sdk)
+                val sdk = event.sdk!!
+                assertEquals(BuildConfig.SENTRY_LOGBACK_SDK_NAME, sdk.name)
+                assertEquals(BuildConfig.VERSION_NAME, sdk.version)
+                assertNotNull(sdk.packages)
+                assertTrue(sdk.packages!!.any { pkg ->
                     "maven:sentry-logback" == pkg.name &&
                         BuildConfig.VERSION_NAME == pkg.version
                 })

--- a/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
@@ -6,6 +6,7 @@ import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.springframework.mock.web.MockServletContext
@@ -25,13 +26,15 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertEquals("GET", event.request.method)
+        assertNotNull(event.request)
+        val eventRequest = event.request!!
+        assertEquals("GET", eventRequest.method)
         assertEquals(mapOf(
             "some-header" to "some-header value",
             "Accept" to "application/json"
-        ), event.request.headers)
-        assertEquals("http://example.com", event.request.url)
-        assertEquals("param1=xyz", event.request.queryString)
+        ), eventRequest.headers)
+        assertEquals("http://example.com", eventRequest.url)
+        assertEquals("param1=xyz", eventRequest.queryString)
     }
 
     @Test
@@ -46,9 +49,10 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
+        assertNotNull(event.request)
         assertEquals(mapOf(
             "another-header" to "another value,another value2"
-        ), event.request.headers)
+        ), event.request!!.headers)
     }
 
     @Test
@@ -64,7 +68,8 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertNull(event.request.cookies)
+        assertNotNull(event.request)
+        assertNull(event.request!!.cookies)
     }
 
     @Test
@@ -84,10 +89,12 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertFalse(event.request.headers.containsKey("X-FORWARDED-FOR"))
-        assertFalse(event.request.headers.containsKey("Authorization"))
-        assertFalse(event.request.headers.containsKey("authorization"))
-        assertFalse(event.request.headers.containsKey("Cookies"))
-        assertTrue(event.request.headers.containsKey("some-header"))
+        assertNotNull(event.request)
+        val eventRequest = event.request!!
+        assertFalse(eventRequest.headers.containsKey("X-FORWARDED-FOR"))
+        assertFalse(eventRequest.headers.containsKey("Authorization"))
+        assertFalse(eventRequest.headers.containsKey("authorization"))
+        assertFalse(eventRequest.headers.containsKey("Cookies"))
+        assertTrue(eventRequest.headers.containsKey("some-header"))
     }
 }

--- a/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
@@ -49,10 +49,11 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertNotNull(event.request)
-        assertEquals(mapOf(
-            "another-header" to "another value,another value2"
-        ), event.request!!.headers)
+        assertNotNull(event.request) {
+            assertEquals(mapOf(
+                "another-header" to "another value,another value2"
+            ), it.headers)
+        }
     }
 
     @Test
@@ -68,8 +69,9 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertNotNull(event.request)
-        assertNull(event.request!!.cookies)
+        assertNotNull(event.request) {
+            assertNull(it.cookies)
+        }
     }
 
     @Test
@@ -89,12 +91,12 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertNotNull(event.request)
-        val eventRequest = event.request!!
-        assertFalse(eventRequest.headers.containsKey("X-FORWARDED-FOR"))
-        assertFalse(eventRequest.headers.containsKey("Authorization"))
-        assertFalse(eventRequest.headers.containsKey("authorization"))
-        assertFalse(eventRequest.headers.containsKey("Cookies"))
-        assertTrue(eventRequest.headers.containsKey("some-header"))
+        assertNotNull(event.request) {
+            assertFalse(it.headers.containsKey("X-FORWARDED-FOR"))
+            assertFalse(it.headers.containsKey("Authorization"))
+            assertFalse(it.headers.containsKey("authorization"))
+            assertFalse(it.headers.containsKey("Cookies"))
+            assertTrue(it.headers.containsKey("some-header"))
+        }
     }
 }

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -187,9 +187,11 @@ class SentryAutoConfigurationTest {
                 val transport = it.getBean(ITransport::class.java)
                 await.untilAsserted {
                     verify(transport).send(checkEvent { event ->
-                        assertThat(event.sdk.version).isEqualTo(BuildConfig.VERSION_NAME)
-                        assertThat(event.sdk.name).isEqualTo(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME)
-                        assertThat(event.sdk.packages).anyMatch { pkg ->
+                        assertThat(event.sdk).isNotNull()
+                        val sdk = event.sdk!!
+                        assertThat(sdk.version).isEqualTo(BuildConfig.VERSION_NAME)
+                        assertThat(sdk.name).isEqualTo(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME)
+                        assertThat(sdk.packages).anyMatch { pkg ->
                             pkg.name == "maven:sentry-spring-boot-starter" && pkg.version == BuildConfig.VERSION_NAME
                         }
                     }, anyOrNull())

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -72,7 +72,7 @@ class SentrySpringIntegrationTest {
         await.untilAsserted {
             verify(transport).send(checkEvent { event ->
                 assertThat(event.request).isNotNull()
-                assertThat(event.request.url).isEqualTo("http://localhost:$port/hello")
+                assertThat(event.request!!.url).isEqualTo("http://localhost:$port/hello")
                 assertThat(event.user).isNotNull()
                 assertThat(event.user.username).isEqualTo("user")
                 assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
@@ -28,13 +28,15 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertEquals("GET", event.request.method)
-        assertEquals(mapOf(
-            "some-header" to "some-header value",
-            "Accept" to "application/json"
-        ), event.request.headers)
-        assertEquals("http://example.com", event.request.url)
-        assertEquals("param1=xyz", event.request.queryString)
+        assertNotNull(event.request) {
+            assertEquals("GET", it.method)
+            assertEquals(mapOf(
+                "some-header" to "some-header value",
+                "Accept" to "application/json"
+            ), it.headers)
+            assertEquals("http://example.com", it.url)
+            assertEquals("param1=xyz", it.queryString)
+        }
     }
 
     @Test
@@ -49,9 +51,11 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertEquals(mapOf(
-            "another-header" to "another value,another value2"
-        ), event.request.headers)
+        assertNotNull(event.request) {
+            assertEquals(mapOf(
+                "another-header" to "another value,another value2"
+            ), it.headers)
+        }
     }
 
     @Test
@@ -68,7 +72,9 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertEquals("name=value,name2=value2", event.request.cookies)
+        assertNotNull(event.request) {
+            assertEquals("name=value,name2=value2", it.cookies)
+        }
     }
 
     @Test
@@ -84,7 +90,9 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertNull(event.request.cookies)
+        assertNotNull(event.request) {
+            assertNull(it.cookies)
+        }
     }
 
     @Test
@@ -104,11 +112,13 @@ class SentryRequestHttpServletRequestProcessorTest {
 
         eventProcessor.process(event, null)
 
-        assertFalse(event.request.headers.containsKey("X-FORWARDED-FOR"))
-        assertFalse(event.request.headers.containsKey("Authorization"))
-        assertFalse(event.request.headers.containsKey("authorization"))
-        assertFalse(event.request.headers.containsKey("Cookie"))
-        assertTrue(event.request.headers.containsKey("some-header"))
+        assertNotNull(event.request) {
+            assertFalse(it.headers.containsKey("X-FORWARDED-FOR"))
+            assertFalse(it.headers.containsKey("Authorization"))
+            assertFalse(it.headers.containsKey("authorization"))
+            assertFalse(it.headers.containsKey("Cookie"))
+            assertTrue(it.headers.containsKey("some-header"))
+        }
     }
 
     @Test

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
@@ -74,7 +74,7 @@ class SentrySpringIntegrationTest {
         await.untilAsserted {
             verify(transport).send(checkEvent { event ->
                 assertThat(event.request).isNotNull()
-                assertThat(event.request.url).isEqualTo("http://localhost:$port/hello")
+                assertThat(event.request!!.url).isEqualTo("http://localhost:$port/hello")
                 assertThat(event.user).isNotNull()
                 assertThat(event.user.username).isEqualTo("user")
                 assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -300,7 +300,6 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 	public abstract fun getSpans ()Ljava/util/List;
 	public abstract fun getTransaction ()Ljava/lang/String;
 	public abstract fun isSampled ()Ljava/lang/Boolean;
-	public abstract fun setContexts (Lio/sentry/protocol/Contexts;)V
 	public abstract fun setName (Ljava/lang/String;)V
 	public abstract fun setRequest (Lio/sentry/protocol/Request;)V
 	public abstract fun startChild (Lio/sentry/SpanId;)Lio/sentry/Span;
@@ -354,7 +353,6 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun getTransaction ()Ljava/lang/String;
 	public fun isSampled ()Ljava/lang/Boolean;
-	public fun setContexts (Lio/sentry/protocol/Contexts;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
@@ -526,7 +524,6 @@ public abstract class io/sentry/SentryBaseEvent {
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun removeTag (Ljava/lang/String;)V
-	public fun setContexts (Lio/sentry/protocol/Contexts;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setEventId (Lio/sentry/protocol/SentryId;)V
 	public fun setRelease (Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -3,7 +3,6 @@ package io.sentry;
 import io.sentry.Stack.StackItem;
 import io.sentry.hints.SessionEndHint;
 import io.sentry.hints.SessionStartHint;
-import io.sentry.protocol.Contexts;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
@@ -174,10 +173,7 @@ public final class Hub implements IHub {
     if (event.getThrowable() != null) {
       final SpanContext spanContext = throwableToSpanContext.get(event.getThrowable());
       if (spanContext != null) {
-        if (event.getContexts() == null) {
-          event.setContexts(new Contexts());
-          event.getContexts().setTrace(spanContext);
-        } else if (event.getContexts().getTrace() == null) {
+        if (event.getContexts().getTrace() == null) {
           event.getContexts().setTrace(spanContext);
         }
       }

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -10,6 +10,7 @@ public interface ISpan {
    *
    * @return a new transaction span
    */
+  @NotNull
   Span startChild();
 
   /**
@@ -19,13 +20,15 @@ public interface ISpan {
    * @param description - new span description name
    * @return a new transaction span
    */
-  Span startChild(String operation, String description);
+  @NotNull
+  Span startChild(@NotNull String operation, @NotNull String description);
 
   /**
    * Returns a string that could be sent as a sentry-trace header.
    *
    * @return SentryTraceHeader.
    */
+  @NotNull
   SentryTraceHeader toSentryTrace();
 
   /** Sets span timestamp marking this span as finished. */

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -21,6 +21,7 @@ public interface ITransaction extends ISpan {
   /**
    * Starts a child Span.
    *
+   * @param parentSpanId - parent span id
    * @return a new transaction span
    */
   @NotNull
@@ -45,13 +46,14 @@ public interface ITransaction extends ISpan {
    *
    * @param request the request
    */
-  void setRequest(Request request);
+  void setRequest(@Nullable Request request);
 
   /**
    * Returns the request information from the transaction
    *
    * @return the request or {@code null} if not set
    */
+  @Nullable
   Request getRequest();
 
   Contexts getContexts();

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -56,9 +56,8 @@ public interface ITransaction extends ISpan {
   @Nullable
   Request getRequest();
 
+  @NotNull
   Contexts getContexts();
-
-  void setContexts(Contexts contexts);
 
   /**
    * Returns the transaction's description.

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -14,31 +14,34 @@ public final class NoOpTransaction implements ITransaction {
   public void setName(@NotNull String name) {}
 
   @Override
-  public Span startChild() {
+  public @NotNull Span startChild() {
     return new Span(SentryId.EMPTY_ID, SpanId.EMPTY_ID, this, NoOpHub.getInstance());
   }
 
   @Override
-  public Span startChild(String operation, String description) {
+  public @NotNull Span startChild(
+      final @NotNull String operation, final @NotNull String description) {
     return startChild();
   }
 
   @Override
-  public @NotNull Span startChild(@NotNull SpanId parentSpanId) {
+  public @NotNull Span startChild(final @NotNull SpanId parentSpanId) {
     return startChild();
   }
 
   @Override
   public @NotNull Span startChild(
-      @NotNull SpanId parentSpanId, @NotNull String operation, @NotNull String description) {
+      final @NotNull SpanId parentSpanId,
+      final @NotNull String operation,
+      final @NotNull String description) {
     return startChild();
   }
 
   @Override
-  public void setRequest(Request request) {}
+  public void setRequest(@Nullable Request request) {}
 
   @Override
-  public Request getRequest() {
+  public @Nullable Request getRequest() {
     return null;
   }
 
@@ -81,8 +84,8 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
-  public SentryTraceHeader toSentryTrace() {
-    return null;
+  public @NotNull SentryTraceHeader toSentryTrace() {
+    return new SentryTraceHeader(SentryId.EMPTY_ID, SpanId.EMPTY_ID, false);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -46,12 +46,9 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
-  public Contexts getContexts() {
-    return null;
+  public @NotNull Contexts getContexts() {
+    return new Contexts();
   }
-
-  @Override
-  public void setContexts(Contexts contexts) {}
 
   @Override
   public @Nullable String getDescription() {

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -85,19 +85,19 @@ public abstract class SentryBaseEvent {
     this.contexts = contexts;
   }
 
-  public SdkVersion getSdk() {
+  public @Nullable SdkVersion getSdk() {
     return sdk;
   }
 
-  public void setSdk(@Nullable SdkVersion sdk) {
+  public void setSdk(final @Nullable SdkVersion sdk) {
     this.sdk = sdk;
   }
 
-  public Request getRequest() {
+  public @Nullable Request getRequest() {
     return request;
   }
 
-  public void setRequest(Request request) {
+  public void setRequest(final @Nullable Request request) {
     this.request = request;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -31,7 +31,7 @@ public abstract class SentryBaseEvent {
    */
   private @Nullable SentryId eventId;
   /** Contexts describing the environment (e.g. device, os or browser). */
-  private Contexts contexts;
+  private final @NotNull Contexts contexts = new Contexts();
   /** Information about the Sentry SDK that generated this event. */
   private @Nullable SdkVersion sdk;
   /** Information about a web request that occurred during the event. */
@@ -77,12 +77,8 @@ public abstract class SentryBaseEvent {
     this.eventId = eventId;
   }
 
-  public Contexts getContexts() {
+  public @NotNull Contexts getContexts() {
     return contexts;
-  }
-
-  public void setContexts(Contexts contexts) {
-    this.contexts = contexts;
   }
 
   public @Nullable SdkVersion getSdk() {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -124,7 +124,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
   SentryEvent(SentryId eventId, final Date timestamp) {
     super(eventId);
     this.timestamp = timestamp;
-    this.setContexts(new Contexts());
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -1,6 +1,5 @@
 package io.sentry;
 
-import io.sentry.protocol.Contexts;
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
@@ -58,9 +57,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
     this.transaction = Objects.requireNonNull(name, "name is required");
     this.startTimestamp = DateUtils.getCurrentDateTime();
     this.hub = Objects.requireNonNull(hub, "hub is required");
-    Contexts ctx = new Contexts();
-    ctx.setTrace(contexts);
-    this.setContexts(ctx);
+    this.getContexts().setTrace(contexts);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -80,7 +80,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
    * @return a new transaction span
    */
   @Override
-  public Span startChild() {
+  public @NotNull Span startChild() {
     return this.startChild(getSpanId());
   }
 
@@ -134,7 +134,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
   }
 
   @Override
-  public SentryTraceHeader toSentryTrace() {
+  public @NotNull SentryTraceHeader toSentryTrace() {
     return new SentryTraceHeader(getTraceId(), getSpanId(), isSampled());
   }
 

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -49,12 +49,12 @@ public final class Span extends SpanContext implements ISpan {
   }
 
   @Override
-  public Span startChild(String operation, String description) {
+  public Span startChild(final @NotNull String operation, final @NotNull String description) {
     return transaction.startChild(super.getSpanId(), operation, description);
   }
 
   @Override
-  public SentryTraceHeader toSentryTrace() {
+  public @NotNull SentryTraceHeader toSentryTrace() {
     return transaction.toSentryTrace();
   }
 

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -41,7 +41,7 @@ public class SpanContext implements Cloneable {
   /** A map or list of tags for this event. Each tag must be less than 200 characters. */
   protected @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
 
-  public SpanContext(@Nullable Boolean sampled) {
+  public SpanContext(final @Nullable Boolean sampled) {
     this(new SentryId(), new SpanId(), null, sampled);
   }
 
@@ -71,11 +71,11 @@ public class SpanContext implements Cloneable {
     this.tags.put(name, value);
   }
 
-  public void setDescription(@Nullable String description) {
+  public void setDescription(final @Nullable String description) {
     this.description = description;
   }
 
-  public void setStatus(@Nullable SpanStatus status) {
+  public void setStatus(final @Nullable SpanStatus status) {
     this.status = status;
   }
 
@@ -115,7 +115,7 @@ public class SpanContext implements Cloneable {
     return sampled;
   }
 
-  public void setSampled(Boolean sampled) {
+  public void setSampled(final @Nullable Boolean sampled) {
     this.sampled = sampled;
   }
 

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -9,7 +9,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.exception.SentryEnvelopeException
-import io.sentry.protocol.Contexts
 import io.sentry.protocol.Device
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
@@ -78,7 +77,7 @@ class GsonSerializerTest {
 
         val actual = serializeToString(sentryEvent)
 
-        val expected = "{\"event_id\":\"${sentryEvent.eventId}\"}"
+        val expected = "{\"event_id\":\"${sentryEvent.eventId}\",\"contexts\":{}}"
 
         assertEquals(expected, actual)
     }
@@ -99,7 +98,7 @@ class GsonSerializerTest {
         val sentryEvent = generateEmptySentryEvent(DateUtils.getDateTime(dateIsoFormat))
         sentryEvent.eventId = null
 
-        val expected = "{\"timestamp\":\"$dateIsoFormat\"}"
+        val expected = "{\"timestamp\":\"$dateIsoFormat\",\"contexts\":{}}"
 
         val actual = serializeToString(sentryEvent)
 
@@ -195,7 +194,7 @@ class GsonSerializerTest {
 
         val actual = serializeToString(sentryEvent)
 
-        val expected = "{\"unknown\":{\"object\":{\"boolean\":true,\"int\":1}}}"
+        val expected = "{\"unknown\":{\"object\":{\"boolean\":true,\"int\":1}},\"contexts\":{}}"
 
         assertEquals(expected, actual)
     }
@@ -206,9 +205,7 @@ class GsonSerializerTest {
         sentryEvent.eventId = null
         val device = Device()
         device.timezone = TimeZone.getTimeZone("Europe/Vienna")
-        val contexts = Contexts()
-        contexts.device = device
-        sentryEvent.contexts = contexts
+        sentryEvent.contexts.device = device
 
         val expected = "{\"contexts\":{\"device\":{\"timezone\":\"Europe/Vienna\"}}}"
 
@@ -235,9 +232,7 @@ class GsonSerializerTest {
         sentryEvent.eventId = null
         val device = Device()
         device.orientation = Device.DeviceOrientation.LANDSCAPE
-        val contexts = Contexts()
-        contexts.device = device
-        sentryEvent.contexts = contexts
+        sentryEvent.contexts.device = device
 
         val expected = "{\"contexts\":{\"device\":{\"orientation\":\"landscape\"}}}"
 
@@ -264,7 +259,7 @@ class GsonSerializerTest {
         sentryEvent.eventId = null
         sentryEvent.level = SentryLevel.DEBUG
 
-        val expected = "{\"level\":\"debug\"}"
+        val expected = "{\"level\":\"debug\",\"contexts\":{}}"
 
         val actual = serializeToString(sentryEvent)
 
@@ -577,9 +572,7 @@ class GsonSerializerTest {
     }
 
     private fun generateEmptySentryEvent(date: Date? = null): SentryEvent =
-        SentryEvent(date).apply {
-            contexts = null
-        }
+        SentryEvent(date)
 
     private fun createSessionMockData(): Session =
         Session(

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -198,8 +198,8 @@ class MainEventProcessorTest {
         val event = SentryEvent()
         sut.process(event, null)
         assertNotNull(event.sdk)
-        assertEquals(event.sdk.name, "test")
-        assertEquals(event.sdk.version, "1.2.3")
+        assertEquals(event.sdk!!.name, "test")
+        assertEquals(event.sdk!!.version, "1.2.3")
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -654,9 +654,9 @@ class SentryClientTest {
         val scope = Scope(fixture.sentryOptions)
         scope.startSession().current
         val event = SentryEvent().apply {
-            request = Request()
-            request.headers = mutableMapOf()
-            request.headers["user-agent"] = "jamesBond"
+            request = Request().apply {
+                headers = mutableMapOf("user-agent" to "jamesBond")
+            }
         }
         fixture.getSut().updateSessionData(event, null, scope)
         scope.withSession {
@@ -670,8 +670,9 @@ class SentryClientTest {
         val session = scope.startSession().current
         val userAgent = session.userAgent
         val event = SentryEvent().apply {
-            request = Request()
-            request.headers = mutableMapOf()
+            request = Request().apply {
+                headers = mutableMapOf()
+            }
         }
         fixture.getSut().updateSessionData(event, null, scope)
         assertEquals(userAgent, session.userAgent)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Improve ITransaction and ISpan null-safety compatibility. Also makes `contexts` on `SentryBaseEvent` immutable which prevents cases when someone would set context to `null` on transactions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1159


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

Since in case of SentryEvents trace can be null, where for SentryTransactions trace cannot be null, I am considering refactoring `Contexts` class and create separate class for `TransactionContext`. The drawback would be the code duplication.