### PR TITLE
Fix potential NPE by separating transaction contexts.

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -292,7 +292,7 @@ public abstract interface class io/sentry/ISpan {
 }
 
 public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
-	public abstract fun getContexts ()Lio/sentry/protocol/Contexts;
+	public abstract fun getContexts ()Lio/sentry/TransactionContexts;
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getEventId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getLatestActiveSpan ()Lio/sentry/Span;
@@ -343,7 +343,7 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun <init> ()V
 	public fun finish ()V
-	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getContexts ()Lio/sentry/TransactionContexts;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
 	public fun getLatestActiveSpan ()Lio/sentry/Span;
@@ -515,7 +515,6 @@ public abstract class io/sentry/SentryBaseEvent {
 	protected field throwable Ljava/lang/Throwable;
 	protected fun <init> ()V
 	protected fun <init> (Lio/sentry/protocol/SentryId;)V
-	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
 	public fun getRelease ()Ljava/lang/String;
@@ -605,6 +604,7 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
 	public fun addBreadcrumb (Ljava/lang/String;)V
 	public fun getBreadcrumbs ()Ljava/util/List;
+	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getDebugMeta ()Lio/sentry/protocol/DebugMeta;
 	public fun getDist ()Ljava/lang/String;
 	public fun getExceptions ()Ljava/util/List;
@@ -811,6 +811,7 @@ public final class io/sentry/SentryTraceHeader {
 public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/sentry/ITransaction {
 	public fun <init> (Ljava/lang/String;Lio/sentry/SpanContext;Lio/sentry/IHub;)V
 	public fun finish ()V
+	public fun getContexts ()Lio/sentry/TransactionContexts;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getLatestActiveSpan ()Lio/sentry/Span;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
@@ -961,6 +962,26 @@ public final class io/sentry/TransactionContext : io/sentry/SpanContext {
 	public fun setParentSampled (Ljava/lang/Boolean;)V
 }
 
+public final class io/sentry/TransactionContexts {
+	public fun <init> (Lio/sentry/SpanContext;)V
+	public fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getApp ()Lio/sentry/protocol/App;
+	public fun getBrowser ()Lio/sentry/protocol/Browser;
+	public fun getDevice ()Lio/sentry/protocol/Device;
+	public fun getGpu ()Lio/sentry/protocol/Gpu;
+	public fun getOperatingSystem ()Lio/sentry/protocol/OperatingSystem;
+	public fun getOther ()Ljava/util/Map;
+	public fun getRuntime ()Lio/sentry/protocol/SentryRuntime;
+	public fun getTrace ()Lio/sentry/SpanContext;
+	public fun set (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun setApp (Lio/sentry/protocol/App;)V
+	public fun setBrowser (Lio/sentry/protocol/Browser;)V
+	public fun setDevice (Lio/sentry/protocol/Device;)V
+	public fun setGpu (Lio/sentry/protocol/Gpu;)V
+	public fun setOperatingSystem (Lio/sentry/protocol/OperatingSystem;)V
+	public fun setRuntime (Lio/sentry/protocol/SentryRuntime;)V
+}
+
 public final class io/sentry/UncaughtExceptionHandlerIntegration : io/sentry/Integration, java/io/Closeable, java/lang/Thread$UncaughtExceptionHandler {
 	public fun <init> ()V
 	public fun close ()V
@@ -1075,6 +1096,18 @@ public final class io/sentry/adapters/TimeZoneSerializerAdapter : com/google/gso
 	public fun <init> (Lio/sentry/ILogger;)V
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public fun serialize (Ljava/util/TimeZone;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+}
+
+public final class io/sentry/adapters/TransactionContextsDeserializerAdapter : com/google/gson/JsonDeserializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/TransactionContexts;
+	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+}
+
+public final class io/sentry/adapters/TransactionContextsSerializerAdapter : com/google/gson/JsonSerializer {
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun serialize (Lio/sentry/TransactionContexts;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
+	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -19,6 +19,8 @@ import io.sentry.adapters.SpanStatusDeserializerAdapter;
 import io.sentry.adapters.SpanStatusSerializerAdapter;
 import io.sentry.adapters.TimeZoneDeserializerAdapter;
 import io.sentry.adapters.TimeZoneSerializerAdapter;
+import io.sentry.adapters.TransactionContextsDeserializerAdapter;
+import io.sentry.adapters.TransactionContextsSerializerAdapter;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Device;
 import io.sentry.protocol.SentryId;
@@ -99,6 +101,10 @@ public final class GsonSerializer implements ISerializer {
         .registerTypeAdapter(SpanId.class, new SpanIdSerializerAdapter(logger))
         .registerTypeAdapter(SpanStatus.class, new SpanStatusDeserializerAdapter(logger))
         .registerTypeAdapter(SpanStatus.class, new SpanStatusSerializerAdapter(logger))
+        .registerTypeAdapter(
+            TransactionContexts.class, new TransactionContextsDeserializerAdapter(logger))
+        .registerTypeAdapter(
+            TransactionContexts.class, new TransactionContextsSerializerAdapter(logger))
         .create();
   }
 

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -1,6 +1,5 @@
 package io.sentry;
 
-import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
 import java.util.List;
@@ -57,7 +56,7 @@ public interface ITransaction extends ISpan {
   Request getRequest();
 
   @NotNull
-  Contexts getContexts();
+  TransactionContexts getContexts();
 
   /**
    * Returns the transaction's description.

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -1,6 +1,5 @@
 package io.sentry;
 
-import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
 import java.util.Collections;
@@ -46,8 +45,8 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
-  public @NotNull Contexts getContexts() {
-    return new Contexts();
+  public @NotNull TransactionContexts getContexts() {
+    return new TransactionContexts(new SpanContext());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -1,6 +1,5 @@
 package io.sentry;
 
-import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
@@ -30,8 +29,7 @@ public abstract class SentryBaseEvent {
    * <p>```json { "event_id": "fc6d8c0c43fc4630ad850ee518f1b9d0" } ```
    */
   private @Nullable SentryId eventId;
-  /** Contexts describing the environment (e.g. device, os or browser). */
-  private final @NotNull Contexts contexts = new Contexts();
+
   /** Information about the Sentry SDK that generated this event. */
   private @Nullable SdkVersion sdk;
   /** Information about a web request that occurred during the event. */
@@ -75,10 +73,6 @@ public abstract class SentryBaseEvent {
 
   public void setEventId(@Nullable SentryId eventId) {
     this.eventId = eventId;
-  }
-
-  public @NotNull Contexts getContexts() {
-    return contexts;
   }
 
   public @Nullable SdkVersion getSdk() {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -97,6 +97,9 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
   /** List of breadcrumbs recorded before this event. */
   private List<Breadcrumb> breadcrumbs;
 
+  /** Contexts describing the environment (e.g. device, os or browser). */
+  private final @NotNull Contexts contexts = new Contexts();
+
   /**
    * Arbitrary extra information set by the user.
    *
@@ -259,6 +262,10 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void addBreadcrumb(final @Nullable String message) {
     this.addBreadcrumb(new Breadcrumb(message));
+  }
+
+  public @NotNull Contexts getContexts() {
+    return contexts;
   }
 
   Map<String, Object> getExtras() {

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -34,6 +34,8 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
   @SuppressWarnings("UnusedVariable")
   private @NotNull final String type = "transaction";
 
+  private final @NotNull TransactionContexts contexts;
+
   /** Creates transaction. */
   SentryTransaction(final @NotNull String name) {
     this(name, new SpanContext(), NoOpHub.getInstance());
@@ -57,7 +59,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
     this.transaction = Objects.requireNonNull(name, "name is required");
     this.startTimestamp = DateUtils.getCurrentDateTime();
     this.hub = Objects.requireNonNull(hub, "hub is required");
-    this.getContexts().setTrace(contexts);
+    this.contexts = new TransactionContexts(contexts);
   }
 
   /**
@@ -131,23 +133,28 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
   }
 
   @Override
+  public @NotNull TransactionContexts getContexts() {
+    return contexts;
+  }
+
+  @Override
   public @NotNull SentryTraceHeader toSentryTrace() {
     return new SentryTraceHeader(getTraceId(), getSpanId(), isSampled());
   }
 
   @NotNull
   SpanId getSpanId() {
-    return getContexts().getTrace().getSpanId();
+    return contexts.getTrace().getSpanId();
   }
 
   @NotNull
   SentryId getTraceId() {
-    return getContexts().getTrace().getTraceId();
+    return contexts.getTrace().getTraceId();
   }
 
   @Override
   public @Nullable Boolean isSampled() {
-    return getContexts().getTrace().getSampled();
+    return contexts.getTrace().getSampled();
   }
 
   @Override
@@ -166,7 +173,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
    */
   @Override
   public void setOperation(@Nullable String op) {
-    this.getContexts().getTrace().setOperation(op);
+    contexts.getTrace().setOperation(op);
   }
 
   /**
@@ -176,17 +183,17 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
    */
   @Override
   public void setDescription(@Nullable String description) {
-    this.getContexts().getTrace().setDescription(description);
+    contexts.getTrace().setDescription(description);
   }
 
   @Override
   public @Nullable String getDescription() {
-    return this.getContexts().getTrace().getDescription();
+    return contexts.getTrace().getDescription();
   }
 
   @Override
   public @NotNull SpanContext getSpanContext() {
-    return this.getContexts().getTrace();
+    return contexts.getTrace();
   }
 
   /**
@@ -196,7 +203,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
    */
   @Override
   public void setStatus(@Nullable SpanStatus spanStatus) {
-    this.getContexts().getTrace().setStatus(spanStatus);
+    contexts.getTrace().setStatus(spanStatus);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/TransactionContexts.java
+++ b/sentry/src/main/java/io/sentry/TransactionContexts.java
@@ -1,1 +1,93 @@
+package io.sentry;
 
+import io.sentry.protocol.App;
+import io.sentry.protocol.Browser;
+import io.sentry.protocol.Device;
+import io.sentry.protocol.Gpu;
+import io.sentry.protocol.OperatingSystem;
+import io.sentry.protocol.SentryRuntime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class TransactionContexts {
+  private @Nullable App app;
+  private @Nullable Browser browser;
+  private @Nullable Device device;
+  private @Nullable OperatingSystem operatingSystem;
+  private @Nullable SentryRuntime runtime;
+  private @Nullable Gpu gpu;
+  private final @NotNull SpanContext trace;
+  private final @NotNull Map<String, Object> other = new ConcurrentHashMap<>();
+
+  public TransactionContexts(final @NotNull SpanContext trace) {
+    this.trace = trace;
+  }
+
+  public @Nullable App getApp() {
+    return app;
+  }
+
+  public void setApp(@Nullable App app) {
+    this.app = app;
+  }
+
+  public @Nullable Browser getBrowser() {
+    return browser;
+  }
+
+  public void setBrowser(@Nullable Browser browser) {
+    this.browser = browser;
+  }
+
+  public @Nullable Device getDevice() {
+    return device;
+  }
+
+  public void setDevice(@Nullable Device device) {
+    this.device = device;
+  }
+
+  public @Nullable OperatingSystem getOperatingSystem() {
+    return operatingSystem;
+  }
+
+  public void setOperatingSystem(@Nullable OperatingSystem operatingSystem) {
+    this.operatingSystem = operatingSystem;
+  }
+
+  public @Nullable SentryRuntime getRuntime() {
+    return runtime;
+  }
+
+  public void setRuntime(@Nullable SentryRuntime runtime) {
+    this.runtime = runtime;
+  }
+
+  public @Nullable Gpu getGpu() {
+    return gpu;
+  }
+
+  public void setGpu(@Nullable Gpu gpu) {
+    this.gpu = gpu;
+  }
+
+  public @NotNull SpanContext getTrace() {
+    return trace;
+  }
+
+  public Object get(final @NotNull String key) {
+    return other.get(key);
+  }
+
+  public @Nullable Object set(final @NotNull String key, final @NotNull Object value) {
+    return other.put(key, value);
+  }
+
+  @ApiStatus.Internal
+  public @NotNull Map<String, Object> getOther() {
+    return other;
+  }
+}

--- a/sentry/src/main/java/io/sentry/adapters/TransactionContextsDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TransactionContextsDeserializerAdapter.java
@@ -1,0 +1,122 @@
+package io.sentry.adapters;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.SpanContext;
+import io.sentry.TransactionContext;
+import io.sentry.TransactionContexts;
+import io.sentry.protocol.App;
+import io.sentry.protocol.Browser;
+import io.sentry.protocol.Device;
+import io.sentry.protocol.Gpu;
+import io.sentry.protocol.OperatingSystem;
+import io.sentry.protocol.SentryRuntime;
+import java.lang.reflect.Type;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class TransactionContextsDeserializerAdapter
+    implements JsonDeserializer<TransactionContexts> {
+
+  private final @NotNull ILogger logger;
+
+  public TransactionContextsDeserializerAdapter(@NotNull final ILogger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public TransactionContexts deserialize(
+      JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    try {
+      if (json != null && !json.isJsonNull()) {
+
+        final JsonObject jsonObject = json.getAsJsonObject();
+
+        if (jsonObject != null && !jsonObject.isJsonNull()) {
+          final TransactionContext transactionContext =
+              parseObject(context, jsonObject, SpanContext.TYPE, TransactionContext.class);
+          if (transactionContext != null) {
+            final TransactionContexts contexts = new TransactionContexts(transactionContext);
+            for (final String key : jsonObject.keySet()) {
+              switch (key) {
+                case App.TYPE:
+                  App app = parseObject(context, jsonObject, key, App.class);
+                  if (app != null) {
+                    contexts.setApp(app);
+                  }
+                  break;
+                case Browser.TYPE:
+                  Browser browser = parseObject(context, jsonObject, key, Browser.class);
+                  if (browser != null) {
+                    contexts.setBrowser(browser);
+                  }
+                  break;
+                case Device.TYPE:
+                  Device device = parseObject(context, jsonObject, key, Device.class);
+                  if (device != null) {
+                    contexts.setDevice(device);
+                  }
+                  break;
+                case OperatingSystem.TYPE:
+                  OperatingSystem os = parseObject(context, jsonObject, key, OperatingSystem.class);
+                  if (os != null) {
+                    contexts.setOperatingSystem(os);
+                  }
+                  break;
+                case SentryRuntime.TYPE:
+                  SentryRuntime runtime =
+                      parseObject(context, jsonObject, key, SentryRuntime.class);
+                  if (runtime != null) {
+                    contexts.setRuntime(runtime);
+                  }
+                  break;
+                case Gpu.TYPE:
+                  Gpu gpu = parseObject(context, jsonObject, key, Gpu.class);
+                  if (gpu != null) {
+                    contexts.setGpu(gpu);
+                  }
+                  break;
+                default:
+                  final JsonElement element = jsonObject.get(key);
+                  if (element != null && !element.isJsonNull()) {
+                    try {
+                      final Object object = context.deserialize(element, Object.class);
+                      contexts.set(key, object);
+                    } catch (JsonParseException e) {
+                      logger.log(SentryLevel.ERROR, e, "Error when deserializing the %s key.", key);
+                    }
+                  }
+                  break;
+              }
+            }
+            return contexts;
+          }
+        }
+      }
+    } catch (Exception e) {
+      logger.log(SentryLevel.ERROR, "Error when deserializing Contexts", e);
+    }
+    return null;
+  }
+
+  private @Nullable <T> T parseObject(
+      final @NotNull JsonDeserializationContext context,
+      final @NotNull JsonObject jsonObject,
+      final @NotNull String key,
+      final @NotNull Class<T> clazz)
+      throws JsonParseException {
+    final JsonObject object = jsonObject.getAsJsonObject(key);
+    if (object != null && !object.isJsonNull()) {
+      return context.deserialize(object, clazz);
+    }
+    return null;
+  }
+}

--- a/sentry/src/main/java/io/sentry/adapters/TransactionContextsSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TransactionContextsSerializerAdapter.java
@@ -1,0 +1,62 @@
+package io.sentry.adapters;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.SpanContext;
+import io.sentry.TransactionContexts;
+import io.sentry.protocol.App;
+import io.sentry.protocol.Browser;
+import io.sentry.protocol.Device;
+import io.sentry.protocol.Gpu;
+import io.sentry.protocol.OperatingSystem;
+import io.sentry.protocol.SentryRuntime;
+import java.lang.reflect.Type;
+import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+public final class TransactionContextsSerializerAdapter
+    implements JsonSerializer<TransactionContexts> {
+
+  private final @NotNull ILogger logger;
+
+  public TransactionContextsSerializerAdapter(@NotNull final ILogger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public JsonElement serialize(
+      TransactionContexts src, Type typeOfSrc, JsonSerializationContext context) {
+    if (src == null) {
+      return null;
+    }
+
+    final JsonObject object = new JsonObject();
+    object.add(SpanContext.TYPE, context.serialize(src.getTrace(), Object.class));
+    object.add(App.TYPE, context.serialize(src.getApp(), Object.class));
+    object.add(Browser.TYPE, context.serialize(src.getBrowser(), Object.class));
+    object.add(OperatingSystem.TYPE, context.serialize(src.getOperatingSystem(), Object.class));
+    object.add(Device.TYPE, context.serialize(src.getDevice(), Object.class));
+    object.add(Gpu.TYPE, context.serialize(src.getGpu(), Object.class));
+    object.add(SentryRuntime.TYPE, context.serialize(src.getRuntime(), Object.class));
+    for (final Map.Entry<String, Object> entry : src.getOther().entrySet()) {
+      if (!object.has(entry.getKey())) {
+        try {
+          final JsonElement element = context.serialize(entry.getValue(), Object.class);
+          if (element != null) {
+            object.add(entry.getKey(), element);
+          }
+        } catch (JsonParseException e) {
+          logger.log(SentryLevel.ERROR, "%s context key isn't serializable.");
+        }
+      }
+    }
+    return object;
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Fix potential NPE by separating transaction contexts from event contexts.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even though event contexts look similar to transaction contexts, there are different nullability constraints - with transactions, its guaranteed that trace cannot be null. With this change, we fix potential NPE reported in #1160.


## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes


## :crystal_ball: Next steps

Perhaps change the `Contexts` class to also not inherit from the HashMap?