### PR TITLE
Bring back support for setting transaction name without ongoing transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Enchancement: Support SENTRY_TRACES_SAMPLE_RATE conf. via env variables (#1171)
 * Enhancement: Pass request to CustomSamplingContext in Spring integration (#1172)
 * Fix: Free Local Refs manually due to Android local ref. count limits
-
+* Fix: Bring back support for setting transaction name without ongoing transaction (#1183)
 # 4.0.0-alpha.3
 
 * Feat: Add maxAttachmentSize to SentryOptions (#1138)

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -109,9 +109,8 @@ public final class Scope implements Cloneable {
     final ITransaction tx = this.transaction;
     if (tx != null) {
       tx.setName(transaction);
-    } else {
-      this.transactionName = transaction;
     }
+    this.transactionName = transaction;
   }
 
   /**
@@ -271,6 +270,7 @@ public final class Scope implements Cloneable {
   /** Clears the transaction. */
   public void clearTransaction() {
     transaction = null;
+    transactionName = null;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -24,6 +24,9 @@ public final class Scope implements Cloneable {
   /** Scope's {@link ITransaction}. */
   private @Nullable ITransaction transaction;
 
+  /** Scope's transaction name. Used when using error reporting without the performance feature. */
+  private @Nullable String transactionName;
+
   /** Scope's user */
   private @Nullable User user;
 
@@ -94,7 +97,7 @@ public final class Scope implements Cloneable {
    */
   public @Nullable String getTransactionName() {
     final ITransaction tx = this.transaction;
-    return tx != null ? tx.getTransaction() : null;
+    return tx != null ? tx.getTransaction() : transactionName;
   }
 
   /**
@@ -106,6 +109,8 @@ public final class Scope implements Cloneable {
     final ITransaction tx = this.transaction;
     if (tx != null) {
       tx.setName(transaction);
+    } else {
+      this.transactionName = transaction;
     }
   }
 

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -623,7 +623,7 @@ class HubTest {
     }
 
     @Test
-    fun `when setTransaction is called, and transaction is not set, transaction name is not changed`() {
+    fun `when setTransaction is called, and transaction is not set, transaction name is changed`() {
         val hub = generateHub()
         var scope: Scope? = null
         hub.configureScope {
@@ -631,7 +631,7 @@ class HubTest {
         }
 
         hub.setTransaction("test")
-        assertNull(scope?.transactionName)
+        assertEquals("test", scope?.transactionName)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -692,4 +692,15 @@ class ScopeTest {
         sentryTransaction.setName("another-name")
         assertEquals("another-name", scope.transactionName)
     }
+
+    @Test
+    fun `when transaction is set after transaction name is set, clearing transaction does not bring back old transaction name`() {
+        val scope = Scope(SentryOptions())
+        scope.setTransaction("transaction-a")
+        val sentryTransaction = SentryTransaction("transaction-name")
+        scope.setTransaction(sentryTransaction)
+        assertEquals("transaction-name", scope.transactionName)
+        scope.clearTransaction()
+        assertNull(scope.transactionName)
+    }
 }

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -672,4 +672,24 @@ class ScopeTest {
 
         assertNotNull(scope.fingerprint)
     }
+
+    @Test
+    fun `when transaction is not started, sets transaction name on the field`() {
+        val scope = Scope(SentryOptions())
+        scope.setTransaction("transaction-name")
+        assertEquals("transaction-name", scope.transactionName)
+        assertNull(scope.transaction)
+    }
+
+    @Test
+    fun `when transaction is started, sets transaction name on the transaction object`() {
+        val scope = Scope(SentryOptions())
+        val sentryTransaction = SentryTransaction("transaction-name")
+        scope.setTransaction(sentryTransaction)
+        assertEquals("transaction-name", scope.transactionName)
+        scope.setTransaction("new-name")
+        assertEquals("new-name", scope.transactionName)
+        sentryTransaction.setName("another-name")
+        assertEquals("another-name", scope.transactionName)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discussion in: https://github.com/getsentry/develop/issues/246

Even if performance event is not used, users still must be able to set the transaction name on the scope in order to apply it on the events.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes