### PR TITLE
Simplify registering traces sample callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Enhancement: Pass request to CustomSamplingContext in Spring integration (#1172)
 * Fix: Free Local Refs manually due to Android local ref. count limits
 * Enhancement: Add overload for `transaction/span.finish(SpanStatus)` (#1182)
+* Enhancement: Simplify registering traces sample callback in Spring integration (#1184)
 
 # 4.0.0-alpha.3
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.spring;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
+import io.sentry.SentryOptions.TracesSamplerCallback;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.BeansException;
@@ -29,6 +30,9 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
                 sentryUserProvider ->
                     options.addEventProcessor(
                         new SentryUserProviderEventProcessor(options, sentryUserProvider)));
+        applicationContext
+            .getBeanProvider(TracesSamplerCallback.class)
+            .ifAvailable(options::setTracesSampler);
       }
       Sentry.init(options);
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Simplify registering traces sample callback in Spring integration.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Similar to how `TracesSamplerCallback` is auto-configured in Spring Boot integration, Spring integration should detect if such bean exits and if so, set it on `SentryOptions`.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes