### PR TITLE
feat: Add addToTransactions to Attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Feat: Add addToTransactions to Attachment (#1191)
 * Enhancement: Support SENTRY_TRACES_SAMPLE_RATE conf. via env variables (#1171)
 * Enhancement: Pass request to CustomSamplingContext in Spring integration (#1172)
 * Ref: Set SpanContext on SentryTransaction to avoid potential NPE (#1173)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7,12 +7,15 @@ public final class io/sentry/Attachment {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public fun <init> ([BLjava/lang/String;)V
 	public fun <init> ([BLjava/lang/String;Ljava/lang/String;)V
+	public fun <init> ([BLjava/lang/String;Ljava/lang/String;Z)V
 	public fun getBytes ()[B
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFilename ()Ljava/lang/String;
 	public fun getPathname ()Ljava/lang/String;
+	public fun isAddToTransactions ()Z
 }
 
 public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -15,7 +15,6 @@ public final class io/sentry/Attachment {
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFilename ()Ljava/lang/String;
 	public fun getPathname ()Ljava/lang/String;
-	public fun isAddToTransactions ()Z
 }
 
 public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -13,6 +13,7 @@ public final class Attachment {
   private @Nullable String pathname;
   private final @NotNull String filename;
   private final @NotNull String contentType;
+  private final boolean addToTransactions;
 
   /**
    * We could use Files.probeContentType(path) to determine the content type of the filename. This
@@ -24,7 +25,8 @@ public final class Attachment {
   private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
   /**
-   * Initializes an Attachment with bytes and a filename.
+   * Initializes an Attachment with bytes and a filename. Sets addToTransaction to <code>false
+   * </code>.
    *
    * @param bytes The bytes of file.
    * @param filename The name of the attachment to display in Sentry.
@@ -34,7 +36,8 @@ public final class Attachment {
   }
 
   /**
-   * Initializes an Attachment with bytes, filename and content type.
+   * Initializes an Attachment with bytes, a filename, and a content type. Sets addToTransaction to
+   * <code>false</code>.
    *
    * @param bytes The bytes of file.
    * @param filename The name of the attachment to display in Sentry.
@@ -44,13 +47,32 @@ public final class Attachment {
       final @NotNull byte[] bytes,
       final @NotNull String filename,
       final @NotNull String contentType) {
+    this(bytes, filename, contentType, false);
+  }
+
+  /**
+   * Initializes an Attachment with bytes, a filename, a content type, and addToTransactions.
+   *
+   * @param bytes The bytes of file.
+   * @param filename The name of the attachment to display in Sentry.
+   * @param contentType The content type of the attachment.
+   * @param addToTransactions <code>true</code> if the SDK should add this attachment to every
+   *     {@link ITransaction} or set to <code>false</code> if it shouldn't.
+   */
+  public Attachment(
+      final @NotNull byte[] bytes,
+      final @NotNull String filename,
+      final @NotNull String contentType,
+      final boolean addToTransactions) {
     this.bytes = bytes;
     this.filename = filename;
     this.contentType = contentType;
+    this.addToTransactions = addToTransactions;
   }
 
   /**
    * Initializes an Attachment with a path. The filename of the file located at the path is used.
+   * Sets addToTransaction to <code>false</code>.
    *
    * <p>The file located at the pathname is read lazily when the SDK captures an event or
    * transaction not when the attachment is initialized. The pathname string is converted into an
@@ -63,7 +85,8 @@ public final class Attachment {
   }
 
   /**
-   * Initializes an Attachment with a path and a filename.
+   * Initializes an Attachment with a path and a filename. Sets addToTransaction to <code>false
+   * </code>.
    *
    * <p>The file located at the pathname is read lazily when the SDK captures an event or
    * transaction not when the attachment is initialized. The pathname string is converted into an
@@ -77,7 +100,8 @@ public final class Attachment {
   }
 
   /**
-   * Initializes an Attachment with a path, a filename and a content type.
+   * Initializes an Attachment with a path, a filename, and a content type. Sets addToTransaction to
+   * <code>false</code>.
    *
    * <p>The file located at the pathname is read lazily when the SDK captures an event or
    * transaction not when the attachment is initialized. The pathname string is converted into an
@@ -91,9 +115,31 @@ public final class Attachment {
       final @NotNull String pathname,
       final @NotNull String filename,
       final @NotNull String contentType) {
+    this(pathname, filename, contentType, false);
+  }
+
+  /**
+   * Initializes an Attachment with a path, a filename, a content type, and addToTransactions.
+   *
+   * <p>The file located at the pathname is read lazily when the SDK captures an event or
+   * transaction not when the attachment is initialized. The pathname string is converted into an
+   * abstract pathname before reading the file.
+   *
+   * @param pathname The pathname string of the file to upload as an attachment.
+   * @param filename The name of the attachment to display in Sentry.
+   * @param contentType The content type of the attachment.
+   * @param addToTransactions <code>true</code> if the SDK should add this attachment to every
+   *     {@link ITransaction} or set to <code>false</code> if it shouldn't.
+   */
+  public Attachment(
+      final @NotNull String pathname,
+      final @NotNull String filename,
+      final @NotNull String contentType,
+      final boolean addToTransactions) {
     this.pathname = pathname;
     this.filename = filename;
     this.contentType = contentType;
+    this.addToTransactions = addToTransactions;
   }
 
   /**
@@ -130,5 +176,15 @@ public final class Attachment {
    */
   public @NotNull String getContentType() {
     return contentType;
+  }
+
+  /**
+   * Returns <code>true</code> if the SDK should add this attachment to every {@link ITransaction}
+   * and <code>false</code> if it shouldn't. Default is <code>false</code>.
+   *
+   * @return <code>true</code> if attachment should be added to every {@link ITransaction}.
+   */
+  public boolean isAddToTransactions() {
+    return addToTransactions;
   }
 }

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -184,7 +184,7 @@ public final class Attachment {
    *
    * @return <code>true</code> if attachment should be added to every {@link ITransaction}.
    */
-  public boolean isAddToTransactions() {
+  boolean isAddToTransactions() {
     return addToTransactions;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -377,7 +377,7 @@ public final class SentryClient implements ISentryClient {
     return sentryId;
   }
 
-  private List<Attachment> filterForTransaction(List<Attachment> attachments) {
+  private @Nullable List<Attachment> filterForTransaction(@Nullable List<Attachment> attachments) {
     if (attachments == null) {
       return null;
     }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -357,7 +357,7 @@ public final class SentryClient implements ISentryClient {
           processTransaction((SentryTransaction) transaction);
       try {
         final SentryEnvelope envelope =
-            buildEnvelope(sentryTransaction, getAttachmentsFromScope(scope));
+            buildEnvelope(sentryTransaction, filterForTransaction(getAttachmentsFromScope(scope)));
         if (envelope != null) {
           transport.send(envelope, hint);
         } else {
@@ -375,6 +375,21 @@ public final class SentryClient implements ISentryClient {
     }
 
     return sentryId;
+  }
+
+  private List<Attachment> filterForTransaction(List<Attachment> attachments) {
+    if (attachments == null) {
+      return null;
+    }
+
+    List<Attachment> attachmentsToSend = new ArrayList<>();
+    for (Attachment attachment : attachments) {
+      if (attachment.isAddToTransactions()) {
+        attachmentsToSend.add(attachment);
+      }
+    }
+
+    return attachmentsToSend;
   }
 
   private @NotNull SentryTransaction processTransaction(

--- a/sentry/src/test/java/io/sentry/AttachmentTest.kt
+++ b/sentry/src/test/java/io/sentry/AttachmentTest.kt
@@ -2,7 +2,9 @@ package io.sentry
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class AttachmentTest {
 
@@ -70,5 +72,23 @@ class AttachmentTest {
 
         val byteAttachment = Attachment(fixture.bytes, fixture.filename, fixture.contentType)
         assertEquals(fixture.contentType, byteAttachment.contentType)
+    }
+
+    @Test
+    fun `default of addToTransactions is false`() {
+        val fileAttachment = Attachment(fixture.filename)
+        assertFalse(fileAttachment.isAddToTransactions)
+
+        val byteAttachment = Attachment(fixture.bytes, fixture.filename)
+        assertFalse(byteAttachment.isAddToTransactions)
+    }
+
+    @Test
+    fun `set addToTransactions`() {
+        val fileAttachment = Attachment(fixture.pathname, fixture.filename, fixture.contentType, true)
+        assertTrue(fileAttachment.isAddToTransactions)
+
+        val byteAttachment = Attachment(fixture.bytes, fixture.filename, fixture.contentType, true)
+        assertTrue(byteAttachment.isAddToTransactions)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -69,7 +69,7 @@ class SentryClientTest {
             whenever(factory.create(any(), any())).thenReturn(transport)
         }
 
-        var attachment = Attachment("hello".toByteArray(), "hello.txt")
+        var attachment = Attachment("hello".toByteArray(), "hello.txt", "text/plain", true)
 
         fun getSut() = SentryClient(sentryOptions)
     }
@@ -764,6 +764,17 @@ class SentryClientTest {
     }
 
     @Test
+    fun `when captureTransaction with attachments not added to transaction`() {
+        val transaction = SentryTransaction("a-transaction")
+
+        val scope = createScopeWithAttachments()
+        scope.addAttachment(Attachment("hello".toByteArray(), "application/octet-stream"))
+        fixture.getSut().captureTransaction(transaction, scope, null)
+
+        verifyAttachmentsInEnvelope(transaction.eventId)
+    }
+
+    @Test
     fun `when scope's active span is a transaction, transaction context is applied to an event`() {
         val event = SentryEvent()
         val sut = fixture.getSut()
@@ -834,7 +845,7 @@ class SentryClientTest {
             addAttachment(fixture.attachment)
 
             val bytesTooBig = ByteArray((fixture.maxAttachmentSize + 1).toInt()) { 0 }
-            addAttachment(Attachment(bytesTooBig, "will_get_dropped.txt"))
+            addAttachment(Attachment(bytesTooBig, "will_get_dropped.txt", "application/octet-stream", true))
         }
     }
 


### PR DESCRIPTION




## :scroll: Description
Add extra parameter addToTransaction to attachment, which specifies if the SDK adds
it to transactions or not. The default is false.


## :bulb: Motivation and Context
Fixes GH-1185


## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
