### PR TITLE
Enable Kotlin map-like access on CustomSamplingContext.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Enhancement: Polish Performance API (#1165)
 * Enhancement: Set "debug" through external properties (#1186)
 * Enhancement: Simplify Spring integration (#1188)
+* Enhancement: Enable Kotlin map-like access on CustomSamplingContext (#1192)
 
 # 4.0.0-alpha.3
 

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -89,7 +89,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
     final String name = request.getMethod() + " " + request.getRequestURI();
 
     final CustomSamplingContext customSamplingContext = new CustomSamplingContext();
-    customSamplingContext.put("request", request);
+    customSamplingContext.set("request", request);
 
     if (sentryTraceHeader != null) {
       try {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -49,7 +49,7 @@ public final class io/sentry/CustomSamplingContext {
 	public fun <init> ()V
 	public fun get (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getData ()Ljava/util/Map;
-	public fun put (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun set (Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class io/sentry/DateUtils {

--- a/sentry/src/main/java/io/sentry/CustomSamplingContext.java
+++ b/sentry/src/main/java/io/sentry/CustomSamplingContext.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 public final class CustomSamplingContext {
   private final @NotNull Map<String, Object> data = new HashMap<>();
 
-  public void put(final @NotNull String key, final @Nullable Object value) {
+  public void set(final @NotNull String key, final @Nullable Object value) {
     Objects.requireNonNull(key, "key is required");
     this.data.put(key, value);
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Enable Kotlin map-like access on CustomSamplingContext.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Use `set` method instead of `put` to let users put properties using `context["key"]` notation.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes