### PR TITLE
Auto register custom ITransportFactory in Spring integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Enhancement: Polish Performance API (#1165)
 * Enhancement: Set "debug" through external properties (#1186)
 * Enhancement: Simplify Spring integration (#1188)
-* Enhancement: Auto register custom ITransportFactory in Spring integration.
+* Enhancement: Auto register custom ITransportFactory in Spring integration (#1194)
 
 # 4.0.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Enhancement: Polish Performance API (#1165)
 * Enhancement: Set "debug" through external properties (#1186)
 * Enhancement: Simplify Spring integration (#1188)
+* Enhancement: Auto register custom ITransportFactory in Spring integration.
 
 # 4.0.0-alpha.3
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -35,8 +35,8 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
             .getBeanProvider(TracesSamplerCallback.class)
             .ifAvailable(options::setTracesSampler);
         applicationContext
-          .getBeanProvider(ITransportFactory.class)
-          .ifAvailable(options::setTransportFactory);
+            .getBeanProvider(ITransportFactory.class)
+            .ifAvailable(options::setTransportFactory);
       }
       Sentry.init(options);
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -1,6 +1,7 @@
 package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.ITransportFactory;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.SentryOptions.TracesSamplerCallback;
@@ -33,6 +34,9 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
         applicationContext
             .getBeanProvider(TracesSamplerCallback.class)
             .ifAvailable(options::setTracesSampler);
+        applicationContext
+          .getBeanProvider(ITransportFactory.class)
+          .ifAvailable(options::setTransportFactory);
       }
       Sentry.init(options);
     }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
@@ -3,11 +3,9 @@ package io.sentry.spring
 import com.nhaarman.mockitokotlin2.mock
 import io.sentry.IHub
 import io.sentry.ITransportFactory
-import io.sentry.RequestDetails
 import io.sentry.SentryOptions
 import kotlin.test.Test
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.annotations.NotNull
 import org.springframework.boot.context.annotation.UserConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
@@ -1,9 +1,13 @@
 package io.sentry.spring
 
+import com.nhaarman.mockitokotlin2.mock
 import io.sentry.IHub
+import io.sentry.ITransportFactory
+import io.sentry.RequestDetails
 import io.sentry.SentryOptions
 import kotlin.test.Test
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.annotations.NotNull
 import org.springframework.boot.context.annotation.UserConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
@@ -92,6 +96,16 @@ class EnableSentryTest {
             }
     }
 
+    @Test
+    fun `configures custom TransportFactory`() {
+        ApplicationContextRunner().withConfiguration(UserConfigurations.of(AppConfigWithCustomTransportFactory::class.java))
+            .run {
+                val options = it.getBean(SentryOptions::class.java)
+                val transportFactory = it.getBean(ITransportFactory::class.java)
+                assertThat(options.transportFactory).isEqualTo(transportFactory)
+            }
+    }
+
     @EnableSentry(dsn = "http://key@localhost/proj")
     class AppConfig
 
@@ -113,5 +127,12 @@ class EnableSentryTest {
                 return@TracesSamplerCallback 1.0
             }
         }
+    }
+
+    @EnableSentry(dsn = "http://key@localhost/proj")
+    class AppConfigWithCustomTransportFactory {
+
+        @Bean
+        fun tracesSampler() = mock<ITransportFactory>()
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Auto register custom ITransportFactory in Spring integration.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For users who prefer to use Apache Http Client based transport, we have to provide convenient way of registering alternative transport factories.

## :green_heart: How did you test it?

Unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes