### PR TITLE
feat: init overload dsn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Enhancement: Polish Performance API (#1165)
 * Enhancement: Set "debug" through external properties (#1186)
 * Enhancement: Simplify Spring integration (#1188)
+* Enhancement: Init overload with dsn (#1195)
 
 # 4.0.0-alpha.3
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -64,7 +64,7 @@ public final class Sentry {
    *
    * @param dsn The Sentry DSN
    */
-  public static void init(String dsn) {
+  public static void init(final @NotNull String dsn) {
     init(options -> options.setDsn(dsn));
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -62,6 +62,15 @@ public final class Sentry {
   /**
    * Initializes the SDK
    *
+   * @param dsn The Sentry DSN
+   */
+  public static void init(String dsn) {
+    init(options -> options.setDsn(dsn), GLOBAL_HUB_DEFAULT_MODE);
+  }
+
+  /**
+   * Initializes the SDK
+   *
    * @param clazz OptionsContainer for SentryOptions
    * @param optionsConfiguration configuration options callback
    * @param <T> class that extends SentryOptions

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -65,7 +65,7 @@ public final class Sentry {
    * @param dsn The Sentry DSN
    */
   public static void init(String dsn) {
-    init(options -> options.setDsn(dsn), GLOBAL_HUB_DEFAULT_MODE);
+    init(options -> options.setDsn(dsn));
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -106,6 +106,18 @@ class SentryTest {
     }
 
     @Test
+    fun `warns about multiple Sentry initializations with string overload`() {
+        val logger = mock<ILogger>()
+        Sentry.init(dsn)
+        Sentry.init {
+            it.dsn = dsn
+            it.setDebug(true)
+            it.setLogger(logger)
+        }
+        verify(logger).log(eq(SentryLevel.WARNING), eq("Sentry has been already initialized. Previous configuration will be overwritten."))
+    }
+
+    @Test
     fun `initializes Sentry using external properties`() {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Lower entry barrier and make samples look better with a simpler init method. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Existed on Java 1.7, on .NET and other SDKs that support parametric overloading.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
