### PR TITLE
Add convenient method for accessing event's throwable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Enhancement: Enable Kotlin map-like access on CustomSamplingContext (#1192)
 * Enhancement: Auto register custom ITransportFactory in Spring integration (#1194)
 * Enhancement: Improve Kotlin property access in Performance API (#1193)
+* Enhancement: Add convenient method for accessing event's throwable (1202)
 
 # 4.0.0-alpha.3
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -515,6 +515,7 @@ public final class io/sentry/Sentry {
 	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;)V
 	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;Z)V
 	public static fun init (Lio/sentry/SentryOptions;)V
+	public static fun init (Ljava/lang/String;)V
 	public static fun isEnabled ()Z
 	public static fun popScope ()V
 	public static fun pushScope ()V
@@ -546,6 +547,7 @@ public abstract class io/sentry/SentryBaseEvent {
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getOriginThrowable ()Ljava/lang/Throwable;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getSdk ()Lio/sentry/protocol/SdkVersion;

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -1,6 +1,6 @@
 package io.sentry;
 
-  import io.sentry.util.Objects;
+import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SdkVersion;
@@ -104,6 +105,21 @@ public abstract class SentryBaseEvent {
    */
   public @Nullable Throwable getThrowable() {
     return throwable;
+  }
+
+  /**
+   * Returns the captured Throwable or null. If a throwable is wrapped in {@link
+   * ExceptionMechanismException}, returns unwrapped throwable.
+   *
+   * @return the Throwable or null
+   */
+  public @Nullable Throwable getOriginThrowable() {
+    final Throwable ex = throwable;
+    if (ex instanceof ExceptionMechanismException) {
+      return ((ExceptionMechanismException) ex).getThrowable();
+    } else {
+      return ex;
+    }
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -67,9 +67,26 @@ class SentryEventTest {
         assertFalse(event.isCrashed)
     }
 
+    @Test
     fun `adds breadcrumb with string as a parameter`() {
         val event = SentryEvent()
         event.addBreadcrumb("breadcrumb")
         assertEquals(1, event.breadcrumbs.filter { it.message == "breadcrumb" }.size)
+    }
+
+    @Test
+    fun `when throwable is a ExceptionMechanismException, getOriginThrowable unwraps original throwable`() {
+        val event = SentryEvent()
+        val ex = RuntimeException()
+        event.throwable = ExceptionMechanismException(null, ex, null)
+        assertEquals(ex, event.originThrowable)
+    }
+
+    @Test
+    fun `when throwable is not a ExceptionMechanismException, getOriginThrowable returns throwable`() {
+        val event = SentryEvent()
+        val ex = RuntimeException()
+        event.throwable = ex
+        assertEquals(ex, event.originThrowable)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add convenient method for accessing event's throwable.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1201

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes