### PR TITLE
Remove `IHub#getSpanContext` from public API.

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -118,7 +118,6 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getOptions ()Lio/sentry/SentryOptions;
 	public fun getSpan ()Lio/sentry/ISpan;
-	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public fun isEnabled ()Z
 	public fun popScope ()V
 	public fun pushScope ()V
@@ -158,7 +157,6 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getOptions ()Lio/sentry/SentryOptions;
 	public fun getSpan ()Lio/sentry/ISpan;
-	public fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public fun isEnabled ()Z
 	public fun popScope ()V
 	public fun pushScope ()V
@@ -213,7 +211,6 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getOptions ()Lio/sentry/SentryOptions;
 	public abstract fun getSpan ()Lio/sentry/ISpan;
-	public abstract fun getSpanContext (Ljava/lang/Throwable;)Lio/sentry/SpanContext;
 	public abstract fun isEnabled ()Z
 	public abstract fun popScope ()V
 	public abstract fun pushScope ()V
@@ -515,6 +512,7 @@ public final class io/sentry/Sentry {
 	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;)V
 	public static fun init (Lio/sentry/Sentry$OptionsConfiguration;Z)V
 	public static fun init (Lio/sentry/SentryOptions;)V
+	public static fun init (Ljava/lang/String;)V
 	public static fun isEnabled ()Z
 	public static fun popScope ()V
 	public static fun pushScope ()V

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -171,7 +171,7 @@ public final class Hub implements IHub {
   private void assignTraceContext(final @NotNull SentryEvent event) {
     if (event.getThrowable() != null) {
       final ISpan span = throwableToSpan.get(event.getThrowable());
-      if (span != null && span.getSpanContext() != null) {
+      if (span != null) {
         if (event.getContexts().getTrace() == null) {
           event.getContexts().setTrace(span.getSpanContext());
         }
@@ -627,8 +627,8 @@ public final class Hub implements IHub {
     this.throwableToSpan.put(throwable, span);
   }
 
-  @Override
-  public @Nullable SpanContext getSpanContext(final @NotNull Throwable throwable) {
+  @Nullable
+  SpanContext getSpanContext(final @NotNull Throwable throwable) {
     Objects.requireNonNull(throwable, "throwable is required");
     final ISpan span = this.throwableToSpan.get(throwable);
     if (span != null) {

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -186,11 +186,6 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @Nullable SpanContext getSpanContext(final @NotNull Throwable ex) {
-    return Sentry.getCurrentHub().getSpanContext(ex);
-  }
-
-  @Override
   public @Nullable ISpan getSpan() {
     return Sentry.getCurrentHub().getSpan();
   }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -344,17 +344,6 @@ public interface IHub {
   void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span);
 
   /**
-   * Gets the span context for the span that was active while the throwable given by parameter was
-   * thrown.
-   *
-   * @param throwable - the throwable
-   * @return span context or {@code null} if no corresponding span context found.
-   */
-  @ApiStatus.Internal
-  @Nullable
-  SpanContext getSpanContext(Throwable throwable);
-
-  /**
    * Gets the current active transaction or span.
    *
    * @return the active span or null when no active transaction is running

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -138,11 +138,6 @@ final class NoOpHub implements IHub {
       final @NotNull Throwable throwable, final @NotNull ISpan spanContext) {}
 
   @Override
-  public @Nullable SpanContext getSpanContext(final @NotNull Throwable throwable) {
-    return null;
-  }
-
-  @Override
   public @Nullable ISpan getSpan() {
     return null;
   }

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1144,7 +1144,7 @@ class HubTest {
     //region setSpanContext
     @Test
     fun `associates span context with throwable`() {
-        val hub = generateHub()
+        val hub = generateHub() as Hub
         val transaction = hub.startTransaction("aTransaction")
         val span = transaction.startChild("op")
         val exception = RuntimeException()
@@ -1154,7 +1154,7 @@ class HubTest {
 
     @Test
     fun `returns null when no span context associated with throwable`() {
-        val hub = generateHub()
+        val hub = generateHub() as Hub
         assertNull(hub.getSpanContext(RuntimeException()))
     }
     // endregion

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -85,10 +85,5 @@ class NoOpHubTest {
     }
 
     @Test
-    fun `getSpanContext returns null`() {
-        assertNull(sut.getSpanContext(RuntimeException()))
-    }
-
-    @Test
     fun `setSpanContext doesnt throw`() = sut.setSpanContext(RuntimeException(), mock())
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Remove `IHub#getSpanContext` from public API.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After recent refactoring, this method can be private in `Hub` and can be removed from the public APIs.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] No breaking changes

The change is breaking only for the recent alphas. Since this is just a part of polishing the API I believe we can skip the changelog entry.