### PR TITLE
TracesSamplerCallback allows returning a nullable Double.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Enhancement: TracesSamplerCallback allows returning a nullable Double (#1206)
+
 # 4.0.0-beta.1
 
 * Feat: Add addToTransactions to Attachment (#1191)

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1260,9 +1260,9 @@ public class SentryOptions {
      * backend.
      *
      * @param samplingContext the sampling context
-     * @return sampling value
+     * @return sampling value or {@code null} if decision has not been taken
      */
-    @NotNull
+    @Nullable
     Double sample(@NotNull SamplingContext samplingContext);
   }
 

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -22,15 +22,20 @@ final class TracesSampler {
   boolean sample(final @NotNull SamplingContext samplingContext) {
     if (samplingContext.getTransactionContext().getSampled() != null) {
       return samplingContext.getTransactionContext().getSampled();
-    } else if (options.getTracesSampler() != null) {
-      return sample(options.getTracesSampler().sample(samplingContext));
-    } else if (samplingContext.getTransactionContext().getParentSampled() != null) {
-      return samplingContext.getTransactionContext().getParentSampled();
-    } else if (options.getTracesSampleRate() != null) {
-      return sample(options.getTracesSampleRate());
-    } else {
-      return false;
     }
+    if (options.getTracesSampler() != null) {
+      final Double samplerResult = options.getTracesSampler().sample(samplingContext);
+      if (samplerResult != null) {
+        return sample(samplerResult);
+      }
+    }
+    if (samplingContext.getTransactionContext().getParentSampled() != null) {
+      return samplingContext.getTransactionContext().getParentSampled();
+    }
+    if (options.getTracesSampleRate() != null) {
+      return sample(options.getTracesSampleRate());
+    }
+    return false;
   }
 
   private boolean sample(final @NotNull Double aDouble) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
TracesSamplerCallback allows returning a nullable Double.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1204

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes