### PR TITLE
Fix returning Sentry trace header from Span.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Feat: Support logging via JUL (#1211)
+* Fix: Fix returning Sentry trace header from Span (#1217)
 
 # 4.0.0
 

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -45,7 +45,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
     span.setDescription(
         request.getMethodValue() + " " + ensureLeadingSlash(urlTemplate.get().poll()));
 
-    final SentryTraceHeader sentryTraceHeader = activeSpan.toSentryTrace();
+    final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
     request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
     try {
       final ClientHttpResponse response = execution.execute(request, body);

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -937,8 +937,10 @@ public class io/sentry/SpanContext : java/lang/Cloneable {
 	public fun getOperation ()Ljava/lang/String;
 	public fun getParentSpanId ()Lio/sentry/SpanId;
 	public fun getSampled ()Ljava/lang/Boolean;
+	public fun getSpanId ()Lio/sentry/SpanId;
 	public fun getStatus ()Lio/sentry/SpanStatus;
 	public fun getTags ()Ljava/util/Map;
+	public fun getTraceId ()Lio/sentry/protocol/SentryId;
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
 	public fun setStatus (Lio/sentry/SpanStatus;)V

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -56,7 +56,7 @@ public final class Span extends SpanContext implements ISpan {
 
   @Override
   public @NotNull SentryTraceHeader toSentryTrace() {
-    return transaction.toSentryTrace();
+    return new SentryTraceHeader(getTraceId(), getSpanId(), getSampled());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -80,12 +80,12 @@ public class SpanContext implements Cloneable {
   }
 
   @NotNull
-  SentryId getTraceId() {
+  public SentryId getTraceId() {
     return traceId;
   }
 
   @NotNull
-  SpanId getSpanId() {
+  public SpanId getSpanId() {
     return spanId;
   }
 

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -51,6 +51,20 @@ class SpanTest {
     }
 
     @Test
+    fun `converts to Sentry trace header`() {
+        val traceId = SentryId()
+        val parentSpanId = SpanId()
+        val hub = mock<IHub>()
+        val span = Span(traceId, parentSpanId, SentryTransaction(TransactionContext("name", true), hub), hub)
+        val sentryTrace = span.toSentryTrace()
+        assertEquals(traceId, sentryTrace.traceId)
+        assertEquals(span.spanId, sentryTrace.spanId)
+        assertNotNull(sentryTrace.isSampled) {
+            assertTrue(it)
+        }
+    }
+
+    @Test
     fun `starting a child with details adds span to transaction`() {
         val transaction = SentryTransaction("name")
         val span = transaction.startChild("operation", "description")


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix returning Sentry trace header from Span.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

SpanId for Sentry header should be taken from the Span itself and not from the parent transaction.

Fix #1216

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes