### PR TITLE
Fix: Makefile upload symbols and use jfrog cli to sync over to maven central

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,30 @@ compile:
 dryRelease:
 	./gradlew bintrayUpload -PbintrayUser=dryUser -PbintrayKey=dryKey
 
-# deploy the current build to bintray, jcenter and maven central
+# deploy the current build to bintray, jcenter and maven central, upload debug symbols to symbol collector
 doRelease:
-	./gradlew bintrayUpload -PbintrayUser="$(BINTRAY_USERNAME)" -PbintrayKey="$(BINTRAY_KEY)" -PmavenCentralUser="$(MAVEN_USER)" -PmavenCentralPassword="$(MAVEN_PASS)" -PmavenCentralSync=true -PdryRun=false --info
+	# bintray/jcenter upload
+	./gradlew bintrayUpload -PbintrayUser="$(BINTRAY_USERNAME)" -PbintrayKey="$(BINTRAY_KEY)" -PdryRun=false --info
+
+	# upload symbols
+	cd sentry-android-ndk
+	# be sure SymbolCollector.Console is in your $PATH
+	SymbolCollector.Console --upload directory --path ./ --batch-type android --bundle-id sentry-android-ndk-$VERSION --server-endpoint https://symbol-collector.services.sentry.io
+	cd ..
+
+	# maven central sync using jfrog cli
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-log4j2/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-logback/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-servlet/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-spring/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-apache-http-client-5/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-spring-boot-starter/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-jul/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-android/io.sentry:sentry-android/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-android/io.sentry:sentry-android-core/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-android/io.sentry:sentry-android-ndk/$VERSION
+	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-android/io.sentry:sentry-android-timber/$VERSION
 
 distZip:
 	./gradlew distZip

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ doRelease:
 
 	# upload symbols
 	cd sentry-android-ndk
-	# be sure SymbolCollector.Console is in your $PATH
+	# be sure SymbolCollector.Console is in your $PATH - https://github.com/getsentry/symbol-collector/releases
 	SymbolCollector.Console --upload directory --path ./ --batch-type android --bundle-id sentry-android-ndk-$VERSION --server-endpoint https://symbol-collector.services.sentry.io
 	cd ..
 
-	# maven central sync using jfrog cli
+	# maven central sync using jfrog cli - https://jfrog.com/getcli/
 	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry/$VERSION
 	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-log4j2/$VERSION
 	jfrog bt mcs --user=$BINTRAY_USERNAME --key=$BINTRAY_KEY --sonatype-username=$MAVEN_USER --sonatype-password=$MAVEN_PASS getsentry/sentry-java/io.sentry:sentry-logback/$VERSION


### PR DESCRIPTION
## :scroll: Description
Fix: Makefile upload symbols and use jfrog cli to sync over to maven central


## :bulb: Motivation and Context
we always need to remember uploading debug symbols.

maven central sync always fails via the gradle plugin, now we guarantee that upload is done to bintray/jcenter and we use the `jfrog cli` to sync over to maven central, which we could retry standalone if it fails.

you must export `$VERSION`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
Craft