### PR TITLE
Event processor nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # vNext
 
-* Enchancement: Improve EventProcessor nullability annotations.
+* Enchancement: Improve EventProcessor nullability annotations (#1229).
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Enchancement: Improve EventProcessor nullability annotations.
+
 # 4.1.0
 
 * Improve Kotlin compatibility for SdkVersion (#1213)

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -554,7 +554,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomEventProcessor : EventProcessor {
-        override fun process(event: SentryEvent?, hint: Any?) = null
+        override fun process(event: SentryEvent, hint: Any?) = null
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -1,8 +1,9 @@
 package io.sentry;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface EventProcessor {
   @Nullable
-  SentryEvent process(SentryEvent event, @Nullable Object hint);
+  SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint);
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Improve EventProcessor nullability annotations.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Implementing custom event processor in Kotlin currently forces users to handle the case when `event` can be null, even though its never the case.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

Update reference docs samples.