### PR TITLE
Fix: Mark stacktrace as snapshot if captured at arbitrary moment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Fix: Mark stacktrace as snapshot if captured at arbitrary moment #1231
+
 # 4.1.0
 
 * Improve Kotlin compatibility for SdkVersion (#1213)

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -136,6 +136,6 @@ final class ANRWatchDog extends Thread {
      *
      * @param error The error describing the ANR.
      */
-    void onAppNotResponding(ApplicationNotResponding error);
+    void onAppNotResponding(@NotNull ApplicationNotResponding error);
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -82,10 +82,10 @@ public final class AnrIntegration implements Integration, Closeable {
       final @NotNull ApplicationNotResponding error) {
     logger.log(SentryLevel.INFO, "ANR triggered with message: %s", error.getMessage());
 
-    Mechanism mechanism = new Mechanism();
+    final Mechanism mechanism = new Mechanism();
     mechanism.setType("ANR");
-    ExceptionMechanismException throwable =
-        new ExceptionMechanismException(mechanism, error, error.getThread());
+    final ExceptionMechanismException throwable =
+        new ExceptionMechanismException(mechanism, error, error.getThread(), true);
 
     hub.captureException(throwable);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
@@ -16,15 +16,15 @@ import org.jetbrains.annotations.NotNull;
 final class ApplicationNotResponding extends RuntimeException {
   private static final long serialVersionUID = 252541144579117016L;
 
-  private final Thread thread;
+  private final @NotNull Thread thread;
 
-  ApplicationNotResponding(@NotNull String message, @NotNull Thread thread) {
+  ApplicationNotResponding(final @NotNull String message, final @NotNull Thread thread) {
     super(message);
     this.thread = Objects.requireNonNull(thread, "Thread must be provided.");
     setStackTrace(this.thread.getStackTrace());
   }
 
-  public Thread getThread() {
+  public @NotNull Thread getThread() {
     return thread;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ApplicationNotResponding.java
@@ -4,6 +4,7 @@ package io.sentry.android.core;
 
 import io.sentry.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Error thrown by ANRWatchDog when an ANR is detected. Contains the stack trace of the frozen UI
@@ -18,7 +19,7 @@ final class ApplicationNotResponding extends RuntimeException {
 
   private final @NotNull Thread thread;
 
-  ApplicationNotResponding(final @NotNull String message, final @NotNull Thread thread) {
+  ApplicationNotResponding(final @Nullable String message, final @NotNull Thread thread) {
     super(message);
     this.thread = Objects.requireNonNull(thread, "Thread must be provided.");
     setStackTrace(this.thread.getStackTrace());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/IHandler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/IHandler.java
@@ -1,10 +1,12 @@
 package io.sentry.android.core;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
 @TestOnly
 interface IHandler {
-  void post(Runnable runnable);
+  void post(@NotNull Runnable runnable);
 
+  @NotNull
   Thread getThread();
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/MainLooperHandler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/MainLooperHandler.java
@@ -2,21 +2,28 @@ package io.sentry.android.core;
 
 import android.os.Handler;
 import android.os.Looper;
+import io.sentry.util.Objects;
+import org.jetbrains.annotations.NotNull;
 
 final class MainLooperHandler implements IHandler {
-  private final Handler handler;
+  private final @NotNull Handler handler;
 
   MainLooperHandler() {
-    handler = new Handler(Looper.getMainLooper());
+    this(Looper.getMainLooper());
+  }
+
+  MainLooperHandler(final @NotNull Looper looper) {
+    Objects.requireNonNull(looper, "Looper is required");
+    handler = new Handler(looper);
   }
 
   @Override
-  public void post(Runnable runnable) {
+  public void post(final @NotNull Runnable runnable) {
     handler.post(runnable);
   }
 
   @Override
-  public Thread getThread() {
+  public @NotNull Thread getThread() {
     return handler.getLooper().getThread();
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/MainLooperHandler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/MainLooperHandler.java
@@ -2,7 +2,6 @@ package io.sentry.android.core;
 
 import android.os.Handler;
 import android.os.Looper;
-import io.sentry.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 final class MainLooperHandler implements IHandler {
@@ -13,7 +12,6 @@ final class MainLooperHandler implements IHandler {
   }
 
   MainLooperHandler(final @NotNull Looper looper) {
-    Objects.requireNonNull(looper, "Looper is required");
     handler = new Handler(looper);
   }
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -43,7 +43,10 @@ public final class SentryHandler extends Handler {
     this(new SentryOptions(), true);
   }
 
-  /** Creates an instance of SentryHandler. */
+  /**
+   * Creates an instance of SentryHandler.
+   * @param options the SentryOptions
+   */
   public SentryHandler(final @NotNull SentryOptions options) {
     this(options, true);
   }

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -45,6 +45,7 @@ public final class SentryHandler extends Handler {
 
   /**
    * Creates an instance of SentryHandler.
+   *
    * @param options the SentryOptions
    */
   public SentryHandler(final @NotNull SentryOptions options) {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1145,9 +1145,11 @@ public final class io/sentry/config/PropertiesProviderFactory {
 
 public final class io/sentry/exception/ExceptionMechanismException : java/lang/RuntimeException {
 	public fun <init> (Lio/sentry/protocol/Mechanism;Ljava/lang/Throwable;Ljava/lang/Thread;)V
+	public fun <init> (Lio/sentry/protocol/Mechanism;Ljava/lang/Throwable;Ljava/lang/Thread;Z)V
 	public fun getExceptionMechanism ()Lio/sentry/protocol/Mechanism;
 	public fun getThread ()Ljava/lang/Thread;
 	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun isSnapshot ()Z
 }
 
 public final class io/sentry/exception/InvalidDsnException : java/lang/RuntimeException {
@@ -1597,8 +1599,10 @@ public final class io/sentry/protocol/SentryStackTrace : io/sentry/IUnknownPrope
 	public fun acceptUnknownProperties (Ljava/util/Map;)V
 	public fun getFrames ()Ljava/util/List;
 	public fun getRegisters ()Ljava/util/Map;
+	public fun getSnapshot ()Ljava/lang/Boolean;
 	public fun setFrames (Ljava/util/List;)V
 	public fun setRegisters (Ljava/util/Map;)V
+	public fun setSnapshot (Ljava/lang/Boolean;)V
 }
 
 public final class io/sentry/protocol/SentryThread : io/sentry/IUnknownPropertiesConsumer {

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -62,7 +62,7 @@ final class SentryExceptionFactory {
    * @param exceptionMechanism The optional {@link Mechanism} of the {@code throwable}. Or null if
    *     none exist.
    * @param thread The optional {@link Thread} which the exception originated. Or null if not known.
-   * @param snapshot If the captured {@link Thread} is a snapshot.
+   * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot.
    */
   private @NotNull SentryException getSentryException(
       @NotNull final Throwable throwable,

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -66,7 +66,8 @@ final class SentryExceptionFactory {
   private @NotNull SentryException getSentryException(
       @NotNull final Throwable throwable,
       @Nullable final Mechanism exceptionMechanism,
-      @Nullable final Thread thread) {
+      @Nullable final Thread thread,
+      boolean snapshot) {
 
     final Package exceptionPackage = throwable.getClass().getPackage();
     final String fullClassName = throwable.getClass().getName();
@@ -86,7 +87,11 @@ final class SentryExceptionFactory {
     final List<SentryStackFrame> frames =
         sentryStackTraceFactory.getStackFrames(throwable.getStackTrace());
     if (frames != null && !frames.isEmpty()) {
-      exception.setStacktrace(new SentryStackTrace(frames));
+      final SentryStackTrace sentryStackTrace = new SentryStackTrace(frames);
+      if (snapshot) {
+        sentryStackTrace.setSnapshot(true);
+      }
+      exception.setStacktrace(sentryStackTrace);
     }
 
     if (thread != null) {
@@ -120,6 +125,7 @@ final class SentryExceptionFactory {
 
     // Stack the exceptions to send them in the reverse order
     while (currentThrowable != null && circularityDetector.add(currentThrowable)) {
+      boolean snapshot = false;
       if (currentThrowable instanceof ExceptionMechanismException) {
         // this is for ANR I believe
         ExceptionMechanismException exceptionMechanismThrowable =
@@ -127,12 +133,14 @@ final class SentryExceptionFactory {
         exceptionMechanism = exceptionMechanismThrowable.getExceptionMechanism();
         currentThrowable = exceptionMechanismThrowable.getThrowable();
         thread = exceptionMechanismThrowable.getThread();
+        snapshot = exceptionMechanismThrowable.isSnapshot();
       } else {
         exceptionMechanism = null;
         thread = Thread.currentThread();
       }
 
-      SentryException exception = getSentryException(currentThrowable, exceptionMechanism, thread);
+      SentryException exception =
+          getSentryException(currentThrowable, exceptionMechanism, thread, snapshot);
       exceptions.addFirst(exception);
       currentThrowable = currentThrowable.getCause();
     }

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -62,6 +62,7 @@ final class SentryExceptionFactory {
    * @param exceptionMechanism The optional {@link Mechanism} of the {@code throwable}. Or null if
    *     none exist.
    * @param thread The optional {@link Thread} which the exception originated. Or null if not known.
+   * @param snapshot If the captured {@link Thread} is a snapshot.
    */
   private @NotNull SentryException getSentryException(
       @NotNull final Throwable throwable,

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -68,7 +68,7 @@ final class SentryExceptionFactory {
       @NotNull final Throwable throwable,
       @Nullable final Mechanism exceptionMechanism,
       @Nullable final Thread thread,
-      boolean snapshot) {
+      final boolean snapshot) {
 
     final Package exceptionPackage = throwable.getClass().getPackage();
     final String fullClassName = throwable.getClass().getName();

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -62,7 +62,8 @@ final class SentryExceptionFactory {
    * @param exceptionMechanism The optional {@link Mechanism} of the {@code throwable}. Or null if
    *     none exist.
    * @param thread The optional {@link Thread} which the exception originated. Or null if not known.
-   * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot.
+   * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot, See {@link
+   *     SentryStackTrace#getSnapshot()}
    */
   private @NotNull SentryException getSentryException(
       @NotNull final Throwable throwable,

--- a/sentry/src/main/java/io/sentry/SentryThreadFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryThreadFactory.java
@@ -126,7 +126,11 @@ final class SentryThreadFactory {
         sentryStackTraceFactory.getStackFrames(stackFramesElements);
 
     if (options.isAttachStacktrace() && frames != null && !frames.isEmpty()) {
-      sentryThread.setStacktrace(new SentryStackTrace(frames));
+      final SentryStackTrace sentryStackTrace = new SentryStackTrace(frames);
+      // threads are always gotten either via Thread.currentThread() or Thread.getAllStackTraces()
+      sentryStackTrace.setSnapshot(true);
+
+      sentryThread.setStacktrace(sentryStackTrace);
     }
 
     return sentryThread;

--- a/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
+++ b/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
@@ -24,14 +24,14 @@ public final class ExceptionMechanismException extends RuntimeException {
    * @param mechanism The {@link Mechanism}.
    * @param throwable The {@link java.lang.Throwable}.
    * @param thread The {@link java.lang.Thread}.
-   * @param snapshot if the captured {@link java.lang.Thread} is a snapshot.
+   * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot.
    */
   public ExceptionMechanismException(
       @NotNull Mechanism mechanism,
       @NotNull Throwable throwable,
       @NotNull Thread thread,
       final boolean snapshot) {
-    this.exceptionMechanism = Objects.requireNonNull(mechanism, "Mechanism is required.");
+    exceptionMechanism = Objects.requireNonNull(mechanism, "Mechanism is required.");
     this.throwable = Objects.requireNonNull(throwable, "Throwable is required.");
     this.thread = Objects.requireNonNull(thread, "Thread is required.");
     this.snapshot = snapshot;

--- a/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
+++ b/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
@@ -1,8 +1,9 @@
 package io.sentry.exception;
 
 import io.sentry.protocol.Mechanism;
+import io.sentry.util.Objects;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A throwable decorator that holds an {@link io.sentry.protocol.Mechanism} related to the decorated
@@ -12,9 +13,29 @@ import org.jetbrains.annotations.Nullable;
 public final class ExceptionMechanismException extends RuntimeException {
   private static final long serialVersionUID = 142345454265713915L;
 
-  private final Mechanism exceptionMechanism;
-  private final Throwable throwable;
-  private final Thread thread;
+  private final @NotNull Mechanism exceptionMechanism;
+  private final @NotNull Throwable throwable;
+  private final @NotNull Thread thread;
+  private final boolean snapshot;
+
+  /**
+   * A {@link Throwable} that decorates another with a Sentry {@link Mechanism}.
+   *
+   * @param mechanism The {@link Mechanism}.
+   * @param throwable The {@link java.lang.Throwable}.
+   * @param thread The {@link java.lang.Thread}.
+   * @param snapshot if the captured {@link java.lang.Thread} is a snapshot.
+   */
+  public ExceptionMechanismException(
+      @NotNull Mechanism mechanism,
+      @NotNull Throwable throwable,
+      @NotNull Thread thread,
+      final boolean snapshot) {
+    this.exceptionMechanism = Objects.requireNonNull(mechanism, "Mechanism is required.");
+    this.throwable = Objects.requireNonNull(throwable, "Throwable is required.");
+    this.thread = Objects.requireNonNull(thread, "Thread is required.");
+    this.snapshot = snapshot;
+  }
 
   /**
    * A {@link Throwable} that decorates another with a Sentry {@link Mechanism}.
@@ -24,21 +45,23 @@ public final class ExceptionMechanismException extends RuntimeException {
    * @param thread The {@link java.lang.Thread}.
    */
   public ExceptionMechanismException(
-      @Nullable Mechanism mechanism, @Nullable Throwable throwable, @Nullable Thread thread) {
-    this.exceptionMechanism = mechanism;
-    this.throwable = throwable;
-    this.thread = thread;
+      @NotNull Mechanism mechanism, @NotNull Throwable throwable, @NotNull Thread thread) {
+    this(mechanism, throwable, thread, false);
   }
 
-  public Mechanism getExceptionMechanism() {
+  public @NotNull Mechanism getExceptionMechanism() {
     return exceptionMechanism;
   }
 
-  public Throwable getThrowable() {
+  public @NotNull Throwable getThrowable() {
     return throwable;
   }
 
-  public Thread getThread() {
+  public @NotNull Thread getThread() {
     return thread;
+  }
+
+  public boolean isSnapshot() {
+    return snapshot;
   }
 }

--- a/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
+++ b/sentry/src/main/java/io/sentry/exception/ExceptionMechanismException.java
@@ -27,9 +27,9 @@ public final class ExceptionMechanismException extends RuntimeException {
    * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot.
    */
   public ExceptionMechanismException(
-      @NotNull Mechanism mechanism,
-      @NotNull Throwable throwable,
-      @NotNull Thread thread,
+      final @NotNull Mechanism mechanism,
+      final @NotNull Throwable throwable,
+      final @NotNull Thread thread,
       final boolean snapshot) {
     exceptionMechanism = Objects.requireNonNull(mechanism, "Mechanism is required.");
     this.throwable = Objects.requireNonNull(throwable, "Throwable is required.");
@@ -45,22 +45,44 @@ public final class ExceptionMechanismException extends RuntimeException {
    * @param thread The {@link java.lang.Thread}.
    */
   public ExceptionMechanismException(
-      @NotNull Mechanism mechanism, @NotNull Throwable throwable, @NotNull Thread thread) {
+      final @NotNull Mechanism mechanism,
+      final @NotNull Throwable throwable,
+      final @NotNull Thread thread) {
     this(mechanism, throwable, thread, false);
   }
 
+  /**
+   * Returns the encapsulated Mechanism
+   *
+   * @return the Mechanism
+   */
   public @NotNull Mechanism getExceptionMechanism() {
     return exceptionMechanism;
   }
 
+  /**
+   * Returns the encapsulated Throwable
+   *
+   * @return the Throwable
+   */
   public @NotNull Throwable getThrowable() {
     return throwable;
   }
 
+  /**
+   * Returns the encapsulated Thread
+   *
+   * @return the Thread
+   */
   public @NotNull Thread getThread() {
     return thread;
   }
 
+  /**
+   * Returns true if its a snapshot or false otherwise
+   *
+   * @return true or false
+   */
   public boolean isSnapshot() {
     return snapshot;
   }

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
@@ -4,6 +4,7 @@ import io.sentry.IUnknownPropertiesConsumer;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A stack trace of a single thread.
@@ -40,21 +41,27 @@ public final class SentryStackTrace implements IUnknownPropertiesConsumer {
    * Required. A non-empty list of stack frames. The list is ordered from caller to callee, or
    * oldest to youngest. The last frame is the one creating the exception.
    */
-  private List<SentryStackFrame> frames;
+  private @Nullable List<SentryStackFrame> frames;
   /**
    * Register values of the thread (top frame).
    *
    * <p>A map of register names and their values. The values should contain the actual register
    * values of the thread, thus mapping to the last frame in the list.
    */
-  private Map<String, String> registers;
+  private @Nullable Map<String, String> registers;
+
+  /**
+   * This flag indicates that this stack trace is captured at an arbitrary moment in time and this
+   * would affect the quality of grouping, Sentry will special case if this is set to true.
+   */
+  private @Nullable Boolean snapshot;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private @Nullable Map<String, Object> unknown;
 
   public SentryStackTrace() {}
 
-  public SentryStackTrace(List<SentryStackFrame> frames) {
+  public SentryStackTrace(final @Nullable List<SentryStackFrame> frames) {
     this.frames = frames;
   }
 
@@ -63,7 +70,7 @@ public final class SentryStackTrace implements IUnknownPropertiesConsumer {
    *
    * @return the frames.
    */
-  public List<SentryStackFrame> getFrames() {
+  public @Nullable List<SentryStackFrame> getFrames() {
     return frames;
   }
 
@@ -72,21 +79,29 @@ public final class SentryStackTrace implements IUnknownPropertiesConsumer {
    *
    * @param frames the frames.
    */
-  public void setFrames(List<SentryStackFrame> frames) {
+  public void setFrames(final @Nullable List<SentryStackFrame> frames) {
     this.frames = frames;
   }
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(final @Nullable Map<String, Object> unknown) {
     this.unknown = unknown;
   }
 
-  public Map<String, String> getRegisters() {
+  public @Nullable Map<String, String> getRegisters() {
     return registers;
   }
 
-  public void setRegisters(Map<String, String> registers) {
+  public void setRegisters(final @Nullable Map<String, String> registers) {
     this.registers = registers;
+  }
+
+  public @Nullable Boolean getSnapshot() {
+    return snapshot;
+  }
+
+  public void setSnapshot(final @Nullable Boolean snapshot) {
+    this.snapshot = snapshot;
   }
 }

--- a/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
@@ -34,13 +34,13 @@ class DuplicateEventDetectionEventProcessorTest {
         val event = SentryEvent(RuntimeException())
         processor.process(event, null)
 
-        val result = processor.process(SentryEvent(ExceptionMechanismException(Mechanism(), event.throwable, null)), null)
+        val result = processor.process(SentryEvent(ExceptionMechanismException(Mechanism(), event.throwable!!, Thread.currentThread())), null)
         assertNull(result)
     }
 
     @Test
     fun `drops event with exception that has already been processed with event with mechanism exception`() {
-        val sentryEvent = SentryEvent(ExceptionMechanismException(Mechanism(), RuntimeException(), null))
+        val sentryEvent = SentryEvent(ExceptionMechanismException(Mechanism(), RuntimeException(), Thread.currentThread()))
         processor.process(sentryEvent, null)
 
         val result = processor.process(SentryEvent((sentryEvent.throwable as ExceptionMechanismException).throwable), null)

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -78,7 +78,7 @@ class SentryEventTest {
     fun `when throwable is a ExceptionMechanismException, getOriginThrowable unwraps original throwable`() {
         val event = SentryEvent()
         val ex = RuntimeException()
-        event.throwable = ExceptionMechanismException(null, ex, null)
+        event.throwable = ExceptionMechanismException(Mechanism(), ex, Thread.currentThread())
         assertEquals(ex, event.originThrowable)
     }
 

--- a/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
@@ -41,13 +41,19 @@ class SentryThreadFactoryTest {
     @Test
     fun `when currentThreads is called, some thread stack frames are captured`() {
         val sut = fixture.getSut()
-        assertTrue(sut.getCurrentThreads(null)!!.filter { it.stacktrace != null }.any { it.stacktrace.frames.count() > 0 })
+        assertTrue(sut.getCurrentThreads(null)!!.filter { it.stacktrace != null }.any { it.stacktrace.frames!!.count() > 0 })
+    }
+
+    @Test
+    fun `when currentThreads is called, stack traces are snapshot`() {
+        val sut = fixture.getSut()
+        assertTrue(sut.getCurrentThreads(null)!!.filter { it.stacktrace != null }.any { it.stacktrace.snapshot == true })
     }
 
     @Test
     fun `when currentThreads and attachStacktrace is disabled, stack frames are not captured`() {
         val sut = fixture.getSut(false)
-        assertFalse(sut.getCurrentThreads(null)!!.filter { it.stacktrace != null }.any { it.stacktrace.frames.count() > 0 })
+        assertFalse(sut.getCurrentThreads(null)!!.filter { it.stacktrace != null }.any { it.stacktrace.frames!!.count() > 0 })
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Fix: Mark stacktrace as snapshot if captured at arbitrary moment


## :bulb: Motivation and Context
ANR stack traces and the thread list attach a stack trace captured at an arbitrary moment and this could affect grouping, this flag will be used for better grouping, maybe using hierarchical grouping or something else on the server-side.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
