### PR TITLE
Add "data" property to Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Enchancement: Improve EventProcessor nullability annotations (#1229).
+* Enchancement: Add "data" property to Span (#1235).
 
 # 4.1.0
 

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -67,17 +67,6 @@ public class Main {
           // Performance configuration options
           // Set what percentage of traces should be collected
           options.setTracesSampleRate(1.0); // set 0.5 to send 50% of traces
-
-          // Determine traces sample rate based on the sampling context
-          options.setTracesSampler(
-              context -> {
-                // only 10% of transactions with "/product" prefix will be collected
-                if (!context.getTransactionContext().getName().startsWith("/products")) {
-                  return 0.1;
-                } else {
-                  return 0.5;
-                }
-              });
         });
 
     Sentry.addBreadcrumb(
@@ -139,8 +128,11 @@ public class Main {
     // Transactions collect execution time of the piece of code that's executed between the start
     // and finish of transaction.
     ITransaction transaction = Sentry.startTransaction("transaction name");
+    transaction.setData("data-key", "data-value");
+    Sentry.configureScope(scope -> scope.setTransaction(transaction));
     // Transactions can contain one or more Spans
     ISpan outerSpan = transaction.startChild("child");
+    outerSpan.setData("span-data-key", "span-data-value");
     Thread.sleep(100);
     // Spans create a tree structure. Each span can have one ore more spans inside.
     ISpan innerSpan = outerSpan.startChild("jdbc", "select * from product where id = :id");

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -282,12 +282,14 @@ public abstract interface class io/sentry/ISerializer {
 public abstract interface class io/sentry/ISpan {
 	public abstract fun finish ()V
 	public abstract fun finish (Lio/sentry/SpanStatus;)V
+	public abstract fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getOperation ()Ljava/lang/String;
 	public abstract fun getSpanContext ()Lio/sentry/SpanContext;
 	public abstract fun getStatus ()Lio/sentry/SpanStatus;
 	public abstract fun getThrowable ()Ljava/lang/Throwable;
 	public abstract fun isFinished ()Z
+	public abstract fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun setDescription (Ljava/lang/String;)V
 	public abstract fun setOperation (Ljava/lang/String;)V
 	public abstract fun setStatus (Lio/sentry/SpanStatus;)V
@@ -348,6 +350,7 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public fun finish ()V
 	public fun finish (Lio/sentry/SpanStatus;)V
+	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getDescription ()Ljava/lang/String;
 	public static fun getInstance ()Lio/sentry/NoOpSpan;
 	public fun getOperation ()Ljava/lang/String;
@@ -355,6 +358,7 @@ public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public fun getStatus ()Lio/sentry/SpanStatus;
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun isFinished ()Z
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
 	public fun setStatus (Lio/sentry/SpanStatus;)V
@@ -369,6 +373,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun finish ()V
 	public fun finish (Lio/sentry/SpanStatus;)V
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
 	public static fun getInstance ()Lio/sentry/NoOpTransaction;
@@ -383,6 +388,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun getTransaction ()Ljava/lang/String;
 	public fun isFinished ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
@@ -547,15 +553,19 @@ public abstract class io/sentry/SentryBaseEvent {
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getOriginThrowable ()Ljava/lang/Throwable;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getSdk ()Lio/sentry/protocol/SdkVersion;
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setEventId (Lio/sentry/protocol/SentryId;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setExtras (Ljava/util/Map;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setRequest (Lio/sentry/protocol/Request;)V
 	public fun setSdk (Lio/sentry/protocol/SdkVersion;)V
@@ -638,7 +648,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getDebugMeta ()Lio/sentry/protocol/DebugMeta;
 	public fun getDist ()Ljava/lang/String;
 	public fun getExceptions ()Ljava/util/List;
-	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getFingerprints ()Ljava/util/List;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getLogger ()Ljava/lang/String;
@@ -653,14 +662,11 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getUser ()Lio/sentry/protocol/User;
 	public fun isCrashed ()Z
 	public fun isErrored ()Z
-	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeModule (Ljava/lang/String;)V
 	public fun setBreadcrumbs (Ljava/util/List;)V
 	public fun setDebugMeta (Lio/sentry/protocol/DebugMeta;)V
 	public fun setDist (Ljava/lang/String;)V
 	public fun setExceptions (Ljava/util/List;)V
-	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setExtras (Ljava/util/Map;)V
 	public fun setFingerprints (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
 	public fun setLogger (Ljava/lang/String;)V
@@ -842,6 +848,7 @@ public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/s
 	public fun <init> (Ljava/lang/String;Lio/sentry/SpanContext;Lio/sentry/IHub;)V
 	public fun finish ()V
 	public fun finish (Lio/sentry/SpanStatus;)V
+	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getLatestActiveSpan ()Lio/sentry/Span;
 	public fun getName ()Ljava/lang/String;
@@ -852,6 +859,7 @@ public final class io/sentry/SentryTransaction : io/sentry/SentryBaseEvent, io/s
 	public fun getTransaction ()Ljava/lang/String;
 	public fun isFinished ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
@@ -911,11 +919,13 @@ public final class io/sentry/ShutdownHookIntegration : io/sentry/Integration {
 public final class io/sentry/Span : io/sentry/SpanContext, io/sentry/ISpan {
 	public fun finish ()V
 	public fun finish (Lio/sentry/SpanStatus;)V
+	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
 	public fun getStartTimestamp ()Ljava/util/Date;
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun isFinished ()Z
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setThrowable (Ljava/lang/Throwable;)V
 	public fun startChild (Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -119,6 +119,17 @@ public interface ISpan {
   void setTag(@NotNull String key, @NotNull String value);
 
   /**
+   * Set extra data on span on transaction
+   *
+   * @param key the data key
+   * @param value the data value
+   */
+  void setData(@NotNull String key, @NotNull Object value);
+
+  @Nullable
+  Object getData(@NotNull String key);
+
+  /**
    * Returns if span has finished.
    *
    * @return if span has finished.

--- a/sentry/src/main/java/io/sentry/NoOpSpan.java
+++ b/sentry/src/main/java/io/sentry/NoOpSpan.java
@@ -77,6 +77,14 @@ public final class NoOpSpan implements ISpan {
   public void setTag(@NotNull String key, @NotNull String value) {}
 
   @Override
+  public void setData(@NotNull String key, @NotNull Object value) {}
+
+  @Override
+  public @Nullable Object getData(@NotNull String key) {
+    return null;
+  }
+
+  @Override
   public boolean isFinished() {
     return false;
   }

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -130,4 +130,12 @@ public final class NoOpTransaction implements ITransaction {
 
   @Override
   public void setTag(@NotNull String key, @NotNull String value) {}
+
+  @Override
+  public void setData(@NotNull String key, @NotNull Object value) {}
+
+  @Override
+  public @Nullable Object getData(@NotNull String key) {
+    return null;
+  }
 }

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -7,6 +7,7 @@ import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -58,6 +59,13 @@ public abstract class SentryBaseEvent {
    * <p>```json { "environment": "production" } ```
    */
   private String environment;
+
+  /**
+   * Arbitrary extra information set by the user.
+   *
+   * <p>```json { "extra": { "my_key": 1, "some_other_value": "foo bar" } }```
+   */
+  private final Map<String, Object> extra = new ConcurrentHashMap<>();
 
   /** The captured Throwable */
   protected transient @Nullable Throwable throwable;
@@ -173,5 +181,28 @@ public abstract class SentryBaseEvent {
 
   public void setEnvironment(String environment) {
     this.environment = environment;
+  }
+
+  Map<String, Object> getExtras() {
+    return extra;
+  }
+
+  public void setExtras(Map<String, Object> extra) {
+    final Map<String, Object> copy = new HashMap<>(extra);
+    for (Map.Entry<String, Object> entry : copy.entrySet()) {
+      this.extra.put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  public void setExtra(String key, Object value) {
+    extra.put(key, value);
+  }
+
+  public void removeExtra(@NotNull String key) {
+    extra.remove(key);
+  }
+
+  public @Nullable Object getExtra(final @NotNull String key) {
+    return extra.get(key);
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -183,22 +183,29 @@ public abstract class SentryBaseEvent {
     this.environment = environment;
   }
 
+  @NotNull
   Map<String, Object> getExtras() {
     return extra;
   }
 
-  public void setExtras(Map<String, Object> extra) {
+  /**
+   * Copies extras from the map given by parameter to extras on the event. If key already exists,
+   * its value gets overwritten.
+   *
+   * @param extra - the extras
+   */
+  public void setExtras(final @NotNull Map<String, Object> extra) {
     final Map<String, Object> copy = new HashMap<>(extra);
     for (Map.Entry<String, Object> entry : copy.entrySet()) {
       this.extra.put(entry.getKey(), entry.getValue());
     }
   }
 
-  public void setExtra(String key, Object value) {
+  public void setExtra(final @NotNull String key, final @NotNull Object value) {
     extra.put(key, value);
   }
 
-  public void removeExtra(@NotNull String key) {
+  public void removeExtra(final @NotNull String key) {
     extra.remove(key);
   }
 

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -97,13 +97,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
   /** List of breadcrumbs recorded before this event. */
   private List<Breadcrumb> breadcrumbs;
 
-  /**
-   * Arbitrary extra information set by the user.
-   *
-   * <p>```json { "extra": { "my_key": 1, "some_other_value": "foo bar" } }```
-   */
-  private Map<String, Object> extra;
-
   private Map<String, Object> unknown;
   /**
    * Name and versions of all installed modules/packages/dependencies in the current
@@ -259,34 +252,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void addBreadcrumb(final @Nullable String message) {
     this.addBreadcrumb(new Breadcrumb(message));
-  }
-
-  Map<String, Object> getExtras() {
-    return extra;
-  }
-
-  public void setExtras(Map<String, Object> extra) {
-    this.extra = extra;
-  }
-
-  public void setExtra(String key, Object value) {
-    if (extra == null) {
-      extra = new HashMap<>();
-    }
-    extra.put(key, value);
-  }
-
-  public void removeExtra(@NotNull String key) {
-    if (extra != null) {
-      extra.remove(key);
-    }
-  }
-
-  public @Nullable Object getExtra(final @NotNull String key) {
-    if (extra != null) {
-      return extra.get(key);
-    }
-    return null;
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -24,6 +24,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
 
   /** A list of spans within this transaction. Can be empty. */
   private final @NotNull List<Span> spans = new CopyOnWriteArrayList<>();
+
   /**
    * A hub this transaction is attached to. Marked as transient to be ignored during JSON
    * serialization.
@@ -202,6 +203,16 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
   @Override
   public @NotNull SpanContext getSpanContext() {
     return this.context;
+  }
+
+  @Override
+  public void setData(@NotNull String key, @NotNull Object value) {
+    setExtra(key, value);
+  }
+
+  @Override
+  public @Nullable Object getData(@NotNull String key) {
+    return getExtra(key);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -3,6 +3,8 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
 import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +14,9 @@ public final class Span extends SpanContext implements ISpan {
   private final @NotNull Date startTimestamp;
   /** The moment in time when span has ended. */
   private @Nullable Date timestamp;
+
+  /** Arbitrary data associated with the Span. */
+  private final Map<String, Object> data = new ConcurrentHashMap<>();
 
   /**
    * A transaction this span is attached to. Marked as transient to be ignored during JSON
@@ -76,6 +81,16 @@ public final class Span extends SpanContext implements ISpan {
   @Override
   public @NotNull SpanContext getSpanContext() {
     return this;
+  }
+
+  @Override
+  public void setData(@NotNull String key, @NotNull Object value) {
+    data.put(key, value);
+  }
+
+  @Override
+  public @Nullable Object getData(@NotNull String key) {
+    return data.get(key);
   }
 
   @Override

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -46,16 +46,8 @@ class GsonSerializerTest {
         fixture = Fixture()
     }
 
-    private fun serializeToString(ev: SentryEvent): String {
+    private fun serializeToString(ev: Any): String {
         return this.serializeToString { wrt -> fixture.serializer.serialize(ev, wrt) }
-    }
-
-    private fun serializeToString(session: Session): String {
-        return this.serializeToString { wrt -> fixture.serializer.serialize(session, wrt) }
-    }
-
-    private fun serializeToString(userFeedback: UserFeedback): String {
-        return this.serializeToString { wrt -> fixture.serializer.serialize(userFeedback, wrt) }
     }
 
     private fun serializeToString(serialize: (StringWriter) -> Unit): String {
@@ -444,10 +436,7 @@ class GsonSerializerTest {
         transaction.setData("integer-data-key", 10)
         transaction.finish()
 
-        val stringWriter = StringWriter()
-        fixture.serializer.serialize(transaction, stringWriter)
-
-        val element = JsonParser().parse(stringWriter.toString()).asJsonObject
+        val element = JsonParser().parse(serializeToString(transaction)).asJsonObject
         assertEquals("transaction-name", element["transaction"].asString)
         assertEquals("transaction", element["type"].asString)
         assertNotNull(element["start_timestamp"].asString)
@@ -511,12 +500,7 @@ class GsonSerializerTest {
         span.setData("data-key", "data-value")
         span.finish()
 
-        val stringWriter = StringWriter()
-        fixture.serializer.serialize(span, stringWriter)
-
-        val toString = stringWriter.toString()
-        println(toString)
-        val element = JsonParser().parse(toString).asJsonObject
+        val element = JsonParser().parse(serializeToString(span)).asJsonObject
 
         assertEquals("data-value", element.get("data").asJsonObject.get("data-key").asString)
         assertEquals("data-value", element.get("data").asJsonObject.get("data-key").asString)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add "data" property to Span.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1233

What I discovered in meantime is that `transactions` do not support `data` attribute. It's been [suggested](https://discord.com/channels/621778831602221064/777210445442187274/808378671161278534) to use `extra` field on transactions to comply with `ISpan` interface.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes