### PR TITLE
Fix: Disable Gson HTML escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Enchancement: Improve EventProcessor nullability annotations (#1229).
+* Fix: Disable Gson HTML escaping
 
 # 4.1.0
 

--- a/sentry/src/main/java/io/sentry/EnvelopeReader.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeReader.java
@@ -24,6 +24,7 @@ public final class EnvelopeReader implements IEnvelopeReader {
           .registerTypeAdapter(SentryEnvelopeHeader.class, new SentryEnvelopeHeaderAdapter())
           .registerTypeAdapter(
               SentryEnvelopeItemHeader.class, new SentryEnvelopeItemHeaderAdapter())
+          .disableHtmlEscaping()
           .create();
 
   public @Override @Nullable SentryEnvelope read(final @NotNull InputStream stream)

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -99,6 +99,7 @@ public final class GsonSerializer implements ISerializer {
         .registerTypeAdapter(SpanId.class, new SpanIdSerializerAdapter(logger))
         .registerTypeAdapter(SpanStatus.class, new SpanStatusDeserializerAdapter(logger))
         .registerTypeAdapter(SpanStatus.class, new SpanStatusSerializerAdapter(logger))
+        .disableHtmlEscaping()
         .create();
   }
 


### PR DESCRIPTION
## :scroll: Description
Fix: Disable Gson HTML escaping


## :bulb: Motivation and Context
We want Gson processing as little as possible.
Escaping HTML is user's responsibility, not SDKs


## :green_heart: How did you test it?
setting random HTML values like `&lt; &gt;`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
