### PR TITLE
Add ability to flush events synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Enchancement: Improve EventProcessor nullability annotations (#1229).
+* Enchancement: Add ability to flush events synchronously.
 
 # 4.1.0
 

--- a/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
+++ b/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
@@ -1,6 +1,7 @@
 public final class io/sentry/transport/apache/ApacheHttpClientTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;Lorg/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient;Lio/sentry/transport/RateLimiter;)V
 	public fun close ()V
+	public fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
 

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -135,7 +135,11 @@ public final class ApacheHttpClientTransport implements ITransport {
   @Override
   public void flush(long timeoutMillis) {
     try {
-      currentlyRunning.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);
+      boolean b = currentlyRunning.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);
+      System.out.println(b);
+      if (!b) {
+        options.getLogger().log(WARNING, "Failed to flush all events within %s ms", timeoutMillis);
+      }
     } catch (InterruptedException e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to flush events", e);
     }

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -135,13 +135,12 @@ public final class ApacheHttpClientTransport implements ITransport {
   @Override
   public void flush(long timeoutMillis) {
     try {
-      boolean b = currentlyRunning.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);
-      System.out.println(b);
-      if (!b) {
+      if (!currentlyRunning.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS)) {
         options.getLogger().log(WARNING, "Failed to flush all events within %s ms", timeoutMillis);
       }
     } catch (InterruptedException e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to flush events", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -138,10 +138,10 @@ class ApacheHttpClientTransportTest {
         }
         sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
         sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
-        sut.flush(20)
+        sut.flush(50)
         sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
         sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
-        sut.flush(20)
+        sut.flush(50)
 
         verify(fixture.currentlyRunning, times(4)).decrement()
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1641,7 +1641,7 @@ public final class io/sentry/protocol/User : io/sentry/IUnknownPropertiesConsume
 
 public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/RequestDetails;)V
-	public fun <init> (Ljava/util/concurrent/ExecutorService;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
+	public fun <init> (Lio/sentry/transport/QueuedThreadPoolExecutor;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V
 	public fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1643,6 +1643,7 @@ public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/RequestDetails;)V
 	public fun <init> (Ljava/util/concurrent/ExecutorService;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V
+	public fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
 
@@ -1656,6 +1657,7 @@ public abstract interface class io/sentry/transport/ICurrentDateProvider {
 }
 
 public abstract interface class io/sentry/transport/ITransport : java/io/Closeable {
+	public abstract fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;)V
 	public abstract fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
@@ -1674,6 +1676,7 @@ public final class io/sentry/transport/NoOpEnvelopeCache : io/sentry/cache/IEnve
 
 public final class io/sentry/transport/NoOpTransport : io/sentry/transport/ITransport {
 	public fun close ()V
+	public fun flush (J)V
 	public static fun getInstance ()Lio/sentry/transport/NoOpTransport;
 	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
@@ -1690,9 +1693,20 @@ public final class io/sentry/transport/RateLimiter {
 	public fun updateRetryAfterLimits (Ljava/lang/String;Ljava/lang/String;I)V
 }
 
+public final class io/sentry/transport/ReusableCountLatch {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public fun decrement ()V
+	public fun getCount ()I
+	public fun increment ()V
+	public fun waitTillZero ()V
+	public fun waitTillZero (JLjava/util/concurrent/TimeUnit;)Z
+}
+
 public final class io/sentry/transport/StdoutTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/ISerializer;)V
 	public fun close ()V
+	public fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -525,7 +525,7 @@ public final class SentryClient implements ISentryClient {
 
   @Override
   public void flush(final long timeoutMillis) {
-    // TODO: Flush transport
+    transport.flush(timeoutMillis);
   }
 
   private boolean sample() {

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -86,7 +86,7 @@ public final class AsyncHttpTransport implements ITransport {
 
   @Override
   public void flush(long timeoutMillis) {
-    executor.waitTillIdle();
+    executor.waitTillIdle(timeoutMillis);
   }
 
   private static QueuedThreadPoolExecutor initExecutor(

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -85,6 +85,11 @@ public final class AsyncHttpTransport implements ITransport {
     }
   }
 
+  @Override
+  public void flush(long timeoutMillis) {
+    ((QueuedThreadPoolExecutor) executor).waitTillEmpty();
+  }
+
   private static QueuedThreadPoolExecutor initExecutor(
       final int maxQueueSize,
       final @NotNull IEnvelopeCache envelopeCache,

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -13,7 +13,6 @@ import io.sentry.hints.SubmissionResult;
 import io.sentry.util.LogUtils;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class AsyncHttpTransport implements ITransport {
 
-  private final @NotNull ExecutorService executor;
+  private final @NotNull QueuedThreadPoolExecutor executor;
   private final @NotNull IEnvelopeCache envelopeCache;
   private final @NotNull SentryOptions options;
   private final @NotNull RateLimiter rateLimiter;
@@ -48,7 +47,7 @@ public final class AsyncHttpTransport implements ITransport {
   }
 
   public AsyncHttpTransport(
-      final @NotNull ExecutorService executor,
+      final @NotNull QueuedThreadPoolExecutor executor,
       final @NotNull SentryOptions options,
       final @NotNull RateLimiter rateLimiter,
       final @NotNull ITransportGate transportGate,
@@ -87,7 +86,7 @@ public final class AsyncHttpTransport implements ITransport {
 
   @Override
   public void flush(long timeoutMillis) {
-    ((QueuedThreadPoolExecutor) executor).waitTillEmpty();
+    executor.waitTillIdle();
   }
 
   private static QueuedThreadPoolExecutor initExecutor(

--- a/sentry/src/main/java/io/sentry/transport/ITransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ITransport.java
@@ -11,4 +11,11 @@ public interface ITransport extends Closeable {
   default void send(SentryEnvelope envelope) throws IOException {
     send(envelope, null);
   }
+
+  /**
+   * Flushes events queued up, but keeps the client enabled. Not implemented yet.
+   *
+   * @param timeoutMillis time in milliseconds
+   */
+  void flush(long timeoutMillis);
 }

--- a/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
@@ -19,5 +19,8 @@ public final class NoOpTransport implements ITransport {
   public void send(SentryEnvelope envelope, Object hint) throws IOException {}
 
   @Override
+  public void flush(long timeoutMillis) {}
+
+  @Override
   public void close() throws IOException {}
 }

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -75,9 +75,9 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
   }
 
   /** Blocks the thread until there are no running tasks. */
-  void waitTillIdle() {
+  void waitTillIdle(final long timeoutMillis) {
     try {
-      unfinishedTasksCount.waitTillZero();
+      unfinishedTasksCount.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       logger.log(SentryLevel.ERROR, "Failed to wait till idle", e);
     }

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -9,7 +9,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,9 +22,8 @@ import org.jetbrains.annotations.Nullable;
  */
 final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
   private final int maxQueueSize;
-  private final AtomicInteger currentlyRunning;
   private final @NotNull ILogger logger;
-  final ReusableCountLatch latch = new ReusableCountLatch();
+  private final @NotNull ReusableCountLatch unfinishedTasksCount = new ReusableCountLatch();
 
   /**
    * Creates a new instance of the thread pool.
@@ -51,29 +49,18 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
         threadFactory,
         rejectedExecutionHandler);
     this.maxQueueSize = maxQueueSize;
-    this.currentlyRunning = new AtomicInteger();
     this.logger = logger;
   }
 
   @Override
   public Future<?> submit(final @NotNull Runnable task) {
     if (isSchedulingAllowed()) {
-      latch.increment();
+      unfinishedTasksCount.increment();
       return super.submit(task);
     } else {
       // if the thread pool is full, we don't cache it
       logger.log(SentryLevel.WARNING, "Submit cancelled");
       return new CancelledFuture<>();
-    }
-  }
-
-  @Override
-  protected void beforeExecute(final @NotNull Thread t, final @NotNull Runnable r) {
-    try {
-      System.out.println("Before execute");
-      super.beforeExecute(t, r);
-    } finally {
-      currentlyRunning.incrementAndGet();
     }
   }
 
@@ -83,22 +70,21 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
     try {
       super.afterExecute(r, t);
     } finally {
-      System.out.println("After execute");
-      currentlyRunning.decrementAndGet();
-      latch.decrement();
+      unfinishedTasksCount.decrement();
     }
   }
 
-  void waitTillEmpty() {
+  /** Blocks the thread until there are no running tasks. */
+  void waitTillIdle() {
     try {
-      latch.waitTillZero();
+      unfinishedTasksCount.waitTillZero();
     } catch (InterruptedException e) {
-      logger.log(SentryLevel.ERROR, "Failed to flush events");
+      logger.log(SentryLevel.ERROR, "Failed to wait till idle", e);
     }
   }
 
   private boolean isSchedulingAllowed() {
-    return getQueue().size() + currentlyRunning.get() < maxQueueSize;
+    return unfinishedTasksCount.getCount() < maxQueueSize;
   }
 
   private static final class CancelledFuture<T> implements Future<T> {

--- a/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
+++ b/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
@@ -2,61 +2,65 @@ package io.sentry.transport;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * A synchronization aid that allows one or more threads to wait until
- * a set of operations being performed in other threads completes.
+ * Class originally copied from <a
+ * href="https://github.com/MatejTymes/JavaFixes/blob/master/src/main/java/javafixes/concurrency/ReusableCountLatch.java">ReusableCountLatch.java</a>.
+ *
+ * <p>A synchronization aid that allows one or more threads to wait until a set of operations being
+ * performed in other threads completes.
+ *
  * <p>
- * <p>A {@code ReusableCountLatch} is initialized with a given <em>count</em>.
- * The {@link #waitTillZero} methods block until the current count reaches
- * zero due to invocations of the {@link #decrement} method, after which
- * all waiting threads are released. If zero has been reached any subsequent
- * invocations of {@link #waitTillZero} return immediately.
- * The coun cen be increased calling the {@link #increment()} method and
- * any subsequent thread calling the {@link #waitTillZero} method will be block
- * again until another zero is reached.
+ *
+ * <p>A {@code ReusableCountLatch} is initialized with a given <em>count</em>. The {@link
+ * #waitTillZero} methods block until the current count reaches zero due to invocations of the
+ * {@link #decrement} method, after which all waiting threads are released. If zero has been reached
+ * any subsequent invocations of {@link #waitTillZero} return immediately. The coun cen be increased
+ * calling the {@link #increment()} method and any subsequent thread calling the {@link
+ * #waitTillZero} method will be block again until another zero is reached.
+ *
  * <p>
- * <p>{@code ReusableCountLatch} provides more versatility than
- * {@link java.util.concurrent.CountDownLatch CountDownLatch} as the count
- * doesn't have to be known upfront and you can reuse this class as many times
- * as you want to.
- * It is also better than a {@link java.util.concurrent.Phaser Phaser} whose count
- * is limited to 65_535. {@code ReusableCountLatch} instead can count up to
- * 2_147_483_647 (2^31-1).
+ *
+ * <p>{@code ReusableCountLatch} provides more versatility than {@link
+ * java.util.concurrent.CountDownLatch CountDownLatch} as the count doesn't have to be known upfront
+ * and you can reuse this class as many times as you want to. It is also better than a {@link
+ * java.util.concurrent.Phaser Phaser} whose count is limited to 65_535. {@code ReusableCountLatch}
+ * instead can count up to 2_147_483_647 (2^31-1).
+ *
  * <p>
- * <p>Great use case for {@code ReusableCountLatch} is when you wait for tasks on
- * other threads to finish, but these tasks could trigger more tasks and it is
- * not know upfront how many will be triggered in total.
+ *
+ * <p>Great use case for {@code ReusableCountLatch} is when you wait for tasks on other threads to
+ * finish, but these tasks could trigger more tasks and it is not know upfront how many will be
+ * triggered in total.
  *
  * @author mtymes
  * @since 07/10/16 00:10 AM
  */
 public final class ReusableCountLatch {
 
-  private final Sync sync;
+  private final @NotNull Sync sync;
 
   /**
    * Constructs a {@code ReusableCountLatch} initialized with the given count.
    *
-   * @param initialCount the number of times {@link #decrement} must be invoked before threads can pass
-   *                     through {@link #waitTillZero}. For each additional call of the {@link #increment}
-   *                     method one more {@link #decrement} must be called.
+   * @param initialCount the number of times {@link #decrement} must be invoked before threads can
+   *     pass through {@link #waitTillZero}. For each additional call of the {@link #increment}
+   *     method one more {@link #decrement} must be called.
    * @throws IllegalArgumentException if {@code initialCount} is negative
    */
-  public ReusableCountLatch(int initialCount) {
+  public ReusableCountLatch(final int initialCount) {
     if (initialCount < 0) {
-      throw new IllegalArgumentException("negative initial count '" + initialCount + "' is not allowed");
+      throw new IllegalArgumentException(
+          "negative initial count '" + initialCount + "' is not allowed");
     }
     this.sync = new Sync(initialCount);
   }
 
-  /**
-   * Constructs a {@code ReusableCountLatch} with initial count set to 0.
-   */
+  /** Constructs a {@code ReusableCountLatch} with initial count set to 0. */
   public ReusableCountLatch() {
     this(0);
   }
-
 
   /**
    * Returns the current count.
@@ -68,13 +72,15 @@ public final class ReusableCountLatch {
   }
 
   /**
-   * Decrements the count of the latch, releasing all waiting threads if
-   * the count reaches zero.
+   * Decrements the count of the latch, releasing all waiting threads if the count reaches zero.
+   *
    * <p>
-   * <p>If the current count is greater than zero then it is decremented.
-   * If the new count is zero then all waiting threads are re-enabled for
-   * thread scheduling purposes.
+   *
+   * <p>If the current count is greater than zero then it is decremented. If the new count is zero
+   * then all waiting threads are re-enabled for thread scheduling purposes.
+   *
    * <p>
+   *
    * <p>If the current count equals zero then nothing happens.
    */
   public void decrement() {
@@ -82,35 +88,42 @@ public final class ReusableCountLatch {
   }
 
   /**
-   * Increments the count of the latch, which will make it possible to block
-   * all threads waiting till count reaches zero.
+   * Increments the count of the latch, which will make it possible to block all threads waiting
+   * till count reaches zero.
    */
   public void increment() {
     sync.increment();
   }
 
-
   /**
-   * Causes the current thread to wait until the latch has counted down to
-   * zero, unless the thread is {@linkplain Thread#interrupt interrupted}.
+   * Causes the current thread to wait until the latch has counted down to zero, unless the thread
+   * is {@linkplain Thread#interrupt interrupted}.
+   *
    * <p>
+   *
    * <p>If the current count is zero then this method returns immediately.
+   *
    * <p>
-   * <p>If the current count is greater than zero then the current
-   * thread becomes disabled for thread scheduling purposes and lies
-   * dormant until one of two things happen:
+   *
+   * <p>If the current count is greater than zero then the current thread becomes disabled for
+   * thread scheduling purposes and lies dormant until one of two things happen:
+   *
    * <ul>
-   * <li>The count reaches zero due to invocations of the {@link #decrement} method; or
-   * <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread.
+   *   <li>The count reaches zero due to invocations of the {@link #decrement} method; or
+   *   <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread.
    * </ul>
+   *
    * <p>
+   *
    * <p>If the current thread:
+   *
    * <ul>
-   * <li>has its interrupted status set on entry to this method; or
-   * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+   *   <li>has its interrupted status set on entry to this method; or
+   *   <li>is {@linkplain Thread#interrupt interrupted} while waiting,
    * </ul>
-   * then {@link InterruptedException} is thrown and the current thread's
-   * interrupted status is cleared.
+   *
+   * then {@link InterruptedException} is thrown and the current thread's interrupted status is
+   * cleared.
    *
    * @throws InterruptedException if the current thread is interrupted while waiting
    */
@@ -119,54 +132,62 @@ public final class ReusableCountLatch {
   }
 
   /**
-   * Causes the current thread to wait until the latch has counted down to
-   * zero, unless the thread is {@linkplain Thread#interrupt interrupted},
-   * or the specified waiting time elapses.
+   * Causes the current thread to wait until the latch has counted down to zero, unless the thread
+   * is {@linkplain Thread#interrupt interrupted}, or the specified waiting time elapses.
+   *
    * <p>
-   * <p>If the current count is zero then this method returns immediately
-   * with the value {@code true}.
+   *
+   * <p>If the current count is zero then this method returns immediately with the value {@code
+   * true}.
+   *
    * <p>
-   * <p>If the current count is greater than zero then the current
-   * thread becomes disabled for thread scheduling purposes and lies
-   * dormant until one of three things happen:
+   *
+   * <p>If the current count is greater than zero then the current thread becomes disabled for
+   * thread scheduling purposes and lies dormant until one of three things happen:
+   *
    * <ul>
-   * <li>The count reaches zero due to invocations of the {@link #decrement()} method; or
-   * <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread; or
-   * <li>The specified waiting time elapses.
+   *   <li>The count reaches zero due to invocations of the {@link #decrement()} method; or
+   *   <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread; or
+   *   <li>The specified waiting time elapses.
    * </ul>
+   *
    * <p>
+   *
    * <p>If the count reaches zero then the method returns with the value {@code true}.
+   *
    * <p>
+   *
    * <p>If the current thread:
+   *
    * <ul>
-   * <li>has its interrupted status set on entry to this method; or
-   * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+   *   <li>has its interrupted status set on entry to this method; or
+   *   <li>is {@linkplain Thread#interrupt interrupted} while waiting,
    * </ul>
-   * then {@link InterruptedException} is thrown and the current thread's
-   * interrupted status is cleared.
+   *
+   * then {@link InterruptedException} is thrown and the current thread's interrupted status is
+   * cleared.
+   *
    * <p>
-   * <p>If the specified waiting time elapses then the value {@code false}
-   * is returned.  If the time is less than or equal to zero, the method
-   * will not wait at all.
+   *
+   * <p>If the specified waiting time elapses then the value {@code false} is returned. If the time
+   * is less than or equal to zero, the method will not wait at all.
    *
    * @param timeout the maximum time to wait
-   * @param unit    the time unit of the {@code timeout} argument
-   * @return {@code true} if the count reached zero and {@code false}
-   * if the waiting time elapsed before the count reached zero
+   * @param unit the time unit of the {@code timeout} argument
+   * @return {@code true} if the count reached zero and {@code false} if the waiting time elapsed
+   *     before the count reached zero
    * @throws InterruptedException if the current thread is interrupted while waiting
    */
-  public boolean waitTillZero(long timeout, TimeUnit unit) throws InterruptedException {
+  public boolean waitTillZero(final long timeout, final @NotNull TimeUnit unit)
+      throws InterruptedException {
     return sync.tryAcquireSharedNanos(1, unit.toNanos(timeout));
   }
 
-  /**
-   * Synchronization control For ReusableCountLatch.
-   * Uses AQS state to represent count.
-   */
+  /** Synchronization control For ReusableCountLatch. Uses AQS state to represent count. */
   private static final class Sync extends AbstractQueuedSynchronizer {
     private static final long serialVersionUID = 5970133580157457018L;
 
-    Sync(int count) {
+    Sync(final int count) {
       setState(count);
     }
 
@@ -189,12 +210,12 @@ public final class ReusableCountLatch {
     }
 
     @Override
-    public int tryAcquireShared(int acquires) {
+    public int tryAcquireShared(final int acquires) {
       return (getState() == 0) ? 1 : -1;
     }
 
     @Override
-    public boolean tryReleaseShared(int releases) {
+    public boolean tryReleaseShared(final int releases) {
       // Decrement count; signal when transition to zero
       for (; ; ) {
         int oldCount = getState();

--- a/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
+++ b/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
@@ -1,0 +1,211 @@
+package io.sentry.transport;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+/**
+ * A synchronization aid that allows one or more threads to wait until
+ * a set of operations being performed in other threads completes.
+ * <p>
+ * <p>A {@code ReusableCountLatch} is initialized with a given <em>count</em>.
+ * The {@link #waitTillZero} methods block until the current count reaches
+ * zero due to invocations of the {@link #decrement} method, after which
+ * all waiting threads are released. If zero has been reached any subsequent
+ * invocations of {@link #waitTillZero} return immediately.
+ * The coun cen be increased calling the {@link #increment()} method and
+ * any subsequent thread calling the {@link #waitTillZero} method will be block
+ * again until another zero is reached.
+ * <p>
+ * <p>{@code ReusableCountLatch} provides more versatility than
+ * {@link java.util.concurrent.CountDownLatch CountDownLatch} as the count
+ * doesn't have to be known upfront and you can reuse this class as many times
+ * as you want to.
+ * It is also better than a {@link java.util.concurrent.Phaser Phaser} whose count
+ * is limited to 65_535. {@code ReusableCountLatch} instead can count up to
+ * 2_147_483_647 (2^31-1).
+ * <p>
+ * <p>Great use case for {@code ReusableCountLatch} is when you wait for tasks on
+ * other threads to finish, but these tasks could trigger more tasks and it is
+ * not know upfront how many will be triggered in total.
+ *
+ * @author mtymes
+ * @since 07/10/16 00:10 AM
+ */
+public final class ReusableCountLatch {
+
+  private final Sync sync;
+
+  /**
+   * Constructs a {@code ReusableCountLatch} initialized with the given count.
+   *
+   * @param initialCount the number of times {@link #decrement} must be invoked before threads can pass
+   *                     through {@link #waitTillZero}. For each additional call of the {@link #increment}
+   *                     method one more {@link #decrement} must be called.
+   * @throws IllegalArgumentException if {@code initialCount} is negative
+   */
+  public ReusableCountLatch(int initialCount) {
+    if (initialCount < 0) {
+      throw new IllegalArgumentException("negative initial count '" + initialCount + "' is not allowed");
+    }
+    this.sync = new Sync(initialCount);
+  }
+
+  /**
+   * Constructs a {@code ReusableCountLatch} with initial count set to 0.
+   */
+  public ReusableCountLatch() {
+    this(0);
+  }
+
+
+  /**
+   * Returns the current count.
+   *
+   * @return the current count
+   */
+  public int getCount() {
+    return sync.getCount();
+  }
+
+  /**
+   * Decrements the count of the latch, releasing all waiting threads if
+   * the count reaches zero.
+   * <p>
+   * <p>If the current count is greater than zero then it is decremented.
+   * If the new count is zero then all waiting threads are re-enabled for
+   * thread scheduling purposes.
+   * <p>
+   * <p>If the current count equals zero then nothing happens.
+   */
+  public void decrement() {
+    sync.decrement();
+  }
+
+  /**
+   * Increments the count of the latch, which will make it possible to block
+   * all threads waiting till count reaches zero.
+   */
+  public void increment() {
+    sync.increment();
+  }
+
+
+  /**
+   * Causes the current thread to wait until the latch has counted down to
+   * zero, unless the thread is {@linkplain Thread#interrupt interrupted}.
+   * <p>
+   * <p>If the current count is zero then this method returns immediately.
+   * <p>
+   * <p>If the current count is greater than zero then the current
+   * thread becomes disabled for thread scheduling purposes and lies
+   * dormant until one of two things happen:
+   * <ul>
+   * <li>The count reaches zero due to invocations of the {@link #decrement} method; or
+   * <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread.
+   * </ul>
+   * <p>
+   * <p>If the current thread:
+   * <ul>
+   * <li>has its interrupted status set on entry to this method; or
+   * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+   * </ul>
+   * then {@link InterruptedException} is thrown and the current thread's
+   * interrupted status is cleared.
+   *
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   */
+  public void waitTillZero() throws InterruptedException {
+    sync.acquireSharedInterruptibly(1);
+  }
+
+  /**
+   * Causes the current thread to wait until the latch has counted down to
+   * zero, unless the thread is {@linkplain Thread#interrupt interrupted},
+   * or the specified waiting time elapses.
+   * <p>
+   * <p>If the current count is zero then this method returns immediately
+   * with the value {@code true}.
+   * <p>
+   * <p>If the current count is greater than zero then the current
+   * thread becomes disabled for thread scheduling purposes and lies
+   * dormant until one of three things happen:
+   * <ul>
+   * <li>The count reaches zero due to invocations of the {@link #decrement()} method; or
+   * <li>Some other thread {@linkplain Thread#interrupt interrupts} the current thread; or
+   * <li>The specified waiting time elapses.
+   * </ul>
+   * <p>
+   * <p>If the count reaches zero then the method returns with the value {@code true}.
+   * <p>
+   * <p>If the current thread:
+   * <ul>
+   * <li>has its interrupted status set on entry to this method; or
+   * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+   * </ul>
+   * then {@link InterruptedException} is thrown and the current thread's
+   * interrupted status is cleared.
+   * <p>
+   * <p>If the specified waiting time elapses then the value {@code false}
+   * is returned.  If the time is less than or equal to zero, the method
+   * will not wait at all.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit    the time unit of the {@code timeout} argument
+   * @return {@code true} if the count reached zero and {@code false}
+   * if the waiting time elapsed before the count reached zero
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   */
+  public boolean waitTillZero(long timeout, TimeUnit unit) throws InterruptedException {
+    return sync.tryAcquireSharedNanos(1, unit.toNanos(timeout));
+  }
+
+  /**
+   * Synchronization control For ReusableCountLatch.
+   * Uses AQS state to represent count.
+   */
+  private static final class Sync extends AbstractQueuedSynchronizer {
+    private static final long serialVersionUID = 5970133580157457018L;
+
+    Sync(int count) {
+      setState(count);
+    }
+
+    private int getCount() {
+      return getState();
+    }
+
+    private void increment() {
+      for (; ; ) {
+        int oldCount = getState();
+        int newCount = oldCount + 1;
+        if (compareAndSetState(oldCount, newCount)) {
+          return;
+        }
+      }
+    }
+
+    private void decrement() {
+      releaseShared(1);
+    }
+
+    @Override
+    public int tryAcquireShared(int acquires) {
+      return (getState() == 0) ? 1 : -1;
+    }
+
+    @Override
+    public boolean tryReleaseShared(int releases) {
+      // Decrement count; signal when transition to zero
+      for (; ; ) {
+        int oldCount = getState();
+        if (oldCount == 0) {
+          return false;
+        }
+        int newCount = oldCount - 1;
+        if (compareAndSetState(oldCount, newCount)) {
+          return newCount == 0;
+        }
+      }
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
+++ b/sentry/src/main/java/io/sentry/transport/ReusableCountLatch.java
@@ -1,3 +1,5 @@
+// Apache-2:
+// https://github.com/MatejTymes/JavaFixes/blob/37e74b9d0a29f7a47485c6d1bb1307f01fb93634/LICENSE
 package io.sentry.transport;
 
 import java.util.concurrent.TimeUnit;
@@ -6,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Class originally copied from <a
- * href="https://github.com/MatejTymes/JavaFixes/blob/master/src/main/java/javafixes/concurrency/ReusableCountLatch.java">ReusableCountLatch.java</a>.
+ * href="https://github.com/MatejTymes/JavaFixes/blob/37e74b9d0a29f7a47485c6d1bb1307f01fb93634/src/main/java/javafixes/concurrency/ReusableCountLatch.java">ReusableCountLatch.java</a>.
  *
  * <p>A synchronization aid that allows one or more threads to wait until a set of operations being
  * performed in other threads completes.

--- a/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
@@ -26,5 +26,10 @@ public final class StdoutTransport implements ITransport {
   }
 
   @Override
+  public void flush(long timeoutMillis) {
+    System.out.println("Flushing");
+  }
+
+  @Override
   public void close() {}
 }

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -19,7 +19,6 @@ import io.sentry.Session
 import io.sentry.dsnString
 import io.sentry.protocol.User
 import java.io.IOException
-import java.util.concurrent.ExecutorService
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -28,7 +27,7 @@ class AsyncHttpTransportTest {
     private class Fixture {
         var connection = mock<HttpConnection>()
         var transportGate = mock<ITransportGate>()
-        var executor = mock<ExecutorService>()
+        var executor = mock<QueuedThreadPoolExecutor>()
         var rateLimiter = mock<RateLimiter>()
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
@@ -253,6 +252,13 @@ class AsyncHttpTransportTest {
 
         // then
         verify(fixture.sentryOptions.envelopeDiskCache, never()).discard(any())
+    }
+
+    @Test
+    fun `flush waits for executor to finish tasks`() {
+        val sut = fixture.getSUT()
+        sut.flush(500)
+        verify(fixture.executor).waitTillIdle()
     }
 
     private fun createSession(): Session {

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -258,7 +258,7 @@ class AsyncHttpTransportTest {
     fun `flush waits for executor to finish tasks`() {
         val sut = fixture.getSUT()
         sut.flush(500)
-        verify(fixture.executor).waitTillIdle()
+        verify(fixture.executor).waitTillIdle(500)
     }
 
     private fun createSession(): Session {

--- a/sentry/src/test/java/io/sentry/transport/QueuedThreadPoolExecutorTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/QueuedThreadPoolExecutorTest.kt
@@ -138,4 +138,18 @@ class QueuedThreadPoolExecutorTest {
         val runnables = sut.shutdownNow()
         assertTrue(runnables.isEmpty())
     }
+
+    @Test
+    fun `waits until all tasks are finished`() {
+        val sut = fixture.getSut()
+        val finished = AtomicInteger()
+        for (i in 1..3) {
+            sut.submit {
+                Thread.sleep(500)
+                finished.incrementAndGet()
+            }
+        }
+        sut.waitTillIdle()
+        assertEquals(3, finished.get())
+    }
 }

--- a/sentry/src/test/java/io/sentry/transport/QueuedThreadPoolExecutorTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/QueuedThreadPoolExecutorTest.kt
@@ -149,7 +149,7 @@ class QueuedThreadPoolExecutorTest {
                 finished.incrementAndGet()
             }
         }
-        sut.waitTillIdle()
+        sut.waitTillIdle(1000)
         assertEquals(3, finished.get())
     }
 }

--- a/sentry/src/test/java/io/sentry/transport/ReusableCountLatchTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/ReusableCountLatchTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Tests originally copied from <a href="https://github.com/MatejTymes/JavaFixes/blob/master/src/test/java/javafixes/concurrency/ReusableCountLatchTest.java">ReusableCountLatchTest</a>.
+ * Tests originally copied from <a href="https://github.com/MatejTymes/JavaFixes/blob/37e74b9d0a29f7a47485c6d1bb1307f01fb93634/src/test/java/javafixes/concurrency/ReusableCountLatchTest.java">ReusableCountLatchTest</a>.
  */
 class ReusableCountLatchTest {
     @Test

--- a/sentry/src/test/java/io/sentry/transport/ReusableCountLatchTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/ReusableCountLatchTest.kt
@@ -1,0 +1,127 @@
+package io.sentry.transport
+
+import java.util.concurrent.Executors.newScheduledThreadPool
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests originally copied from <a href="https://github.com/MatejTymes/JavaFixes/blob/master/src/test/java/javafixes/concurrency/ReusableCountLatchTest.java">ReusableCountLatchTest</a>.
+ */
+class ReusableCountLatchTest {
+    @Test
+    fun `should reflect initial value`() {
+        val positiveCount = 10
+        assertEquals(positiveCount, ReusableCountLatch(positiveCount).count)
+        assertEquals(0, ReusableCountLatch().count)
+    }
+
+    @Test
+    fun `should fail on negative initial value`() {
+        assertFailsWith(IllegalArgumentException::class) {
+            ReusableCountLatch(-10)
+        }
+    }
+
+    @Test
+    fun `should return current count`() {
+        val latch = ReusableCountLatch(0)
+        var expectedCount = 0
+        for (iteration in 0..9999) {
+            if (Random.nextBoolean()) {
+                latch.increment()
+                expectedCount++
+            } else {
+                latch.decrement()
+                if (expectedCount > 0) {
+                    expectedCount--
+                }
+            }
+            assertEquals(expectedCount, latch.count)
+        }
+    }
+
+    @Test(timeout = 500L)
+    fun `should not block if zero`() {
+        val latch = ReusableCountLatch(2)
+        latch.decrement()
+        latch.decrement()
+
+        // When
+        val startTime = System.currentTimeMillis()
+        latch.waitTillZero()
+        val duration = System.currentTimeMillis() - startTime
+
+        // Then
+        assertTrue(duration < 10L)
+    }
+
+    @Test(timeout = 500L)
+    fun `should block if not zero`() {
+        val latch = ReusableCountLatch(2)
+        latch.decrement()
+
+        // When
+        val startTime = System.currentTimeMillis()
+        val isZero = latch.waitTillZero(200, TimeUnit.MILLISECONDS)
+        val duration = System.currentTimeMillis() - startTime
+
+        // Then
+        assertTrue(duration >= 200L)
+        assertFalse(isZero)
+    }
+
+    @Test(timeout = 2000L)
+    fun `should block till zero`() {
+        val executor: ScheduledExecutorService = newScheduledThreadPool(2)
+        try {
+            val latch = ReusableCountLatch()
+            latch.increment()
+            latch.increment()
+            executor.schedule({ latch.decrement() }, 200L, TimeUnit.MILLISECONDS)
+            executor.schedule({ latch.decrement() }, 600L, TimeUnit.MILLISECONDS)
+            val startTime = System.currentTimeMillis()
+            latch.waitTillZero()
+            val duration = System.currentTimeMillis() - startTime
+            assertTrue(duration >= 550L)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `should be reusable`() {
+        val latch = ReusableCountLatch()
+        latch.increment()
+        var startTime = System.currentTimeMillis()
+        var isZero = latch.waitTillZero(150, TimeUnit.MILLISECONDS)
+        var duration = System.currentTimeMillis() - startTime
+        assertFalse(isZero)
+        assertTrue(duration >= 150L)
+        latch.decrement()
+        startTime = System.currentTimeMillis()
+        isZero = latch.waitTillZero(150, TimeUnit.MILLISECONDS)
+        duration = System.currentTimeMillis() - startTime
+        assertTrue(isZero)
+        assertTrue(duration < 10L)
+        latch.increment()
+        latch.increment()
+        startTime = System.currentTimeMillis()
+        isZero = latch.waitTillZero(150, TimeUnit.MILLISECONDS)
+        duration = System.currentTimeMillis() - startTime
+        assertFalse(isZero)
+        assertTrue(duration >= 150L)
+        latch.decrement()
+        latch.decrement()
+        startTime = System.currentTimeMillis()
+        isZero = latch.waitTillZero(150, TimeUnit.MILLISECONDS)
+        duration = System.currentTimeMillis() - startTime
+        assertTrue(isZero)
+        assertTrue(duration < 10L)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add ability to flush events synchronously.

Under the hood, used (copied) https://github.com/MatejTymes/JavaFixes/blob/master/src/main/java/javafixes/concurrency/ReusableCountLatch.java


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #916.

Gives user an option to use Sentry in serverless scenarios where events must be flushed before lambda execution is finished.


## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

The breaking change is: `AsyncHttpTransport` takes now `QueuedThreadExecutor` instead of any `ExecutorService` in a constructor.