### PR TITLE
Simplify RestTemplate instrumentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Enchancement: Improve EventProcessor nullability annotations (#1229).
 * Fix: Disable Gson HTML escaping
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
+* Ref: Simplify RestTemplate instrumentation (#1246)
 
 # 4.1.0
 

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.util.UriTemplateHandler;
 
 @Configuration
 @EnableAspectJAutoProxy(proxyTargetClass = true)
@@ -29,9 +28,6 @@ public class WebConfig {
     RestTemplate restTemplate = new RestTemplate();
     SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
         new SentrySpanClientHttpRequestInterceptor(hub);
-    UriTemplateHandler templateHandler = restTemplate.getUriTemplateHandler();
-    restTemplate.setUriTemplateHandler(
-        sentryRestTemplateInterceptor.createUriTemplateHandler(templateHandler));
     restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
     return restTemplate;
   }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentrySpanRestTemplateCustomizer.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentrySpanRestTemplateCustomizer.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriTemplateHandler;
 
 @Open
 class SentrySpanRestTemplateCustomizer implements RestTemplateCustomizer {
@@ -21,9 +20,6 @@ class SentrySpanRestTemplateCustomizer implements RestTemplateCustomizer {
 
   @Override
   public void customize(final @NotNull RestTemplate restTemplate) {
-    UriTemplateHandler templateHandler = restTemplate.getUriTemplateHandler();
-    templateHandler = this.interceptor.createUriTemplateHandler(templateHandler);
-    restTemplate.setUriTemplateHandler(templateHandler);
     final List<ClientHttpRequestInterceptor> existingInterceptors = restTemplate.getInterceptors();
     if (!existingInterceptors.contains(this.interceptor)) {
       final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -63,7 +63,7 @@ class SentrySpanRestTemplateCustomizerTest {
         assertThat(fixture.transaction.spans).hasSize(1)
         val span = fixture.transaction.spans.first()
         assertThat(span.operation).isEqualTo("http.client")
-        assertThat(span.description).isEqualTo("GET /test/{id}")
+        assertThat(span.description).isEqualTo("GET /test/123")
         assertThat(span.status).isEqualTo(SpanStatus.OK)
         fixture.mockServer.verify()
     }
@@ -76,7 +76,7 @@ class SentrySpanRestTemplateCustomizerTest {
         assertThat(fixture.transaction.spans).hasSize(1)
         val span = fixture.transaction.spans.first()
         assertThat(span.operation).isEqualTo("http.client")
-        assertThat(span.description).isEqualTo("GET /test/{id}")
+        assertThat(span.description).isEqualTo("GET /test/123")
         assertThat(span.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
         fixture.mockServer.verify()
     }
@@ -98,14 +98,5 @@ class SentrySpanRestTemplateCustomizerTest {
         assertThat(restTemplate.interceptors).hasSize(1)
         fixture.customizer.customize(restTemplate)
         assertThat(restTemplate.interceptors).hasSize(1)
-    }
-
-    @Test
-    fun `normalizes URI to contain leading slash`() {
-        val result = fixture.getSut(isTransactionActive = true).getForObject("test/{id}", String::class.java, 123)
-
-        assertThat(result).isEqualTo("OK")
-        assertThat(fixture.transaction.spans.first().description).isEqualTo("GET /test/{id}")
-        fixture.mockServer.verify()
     }
 }

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -90,7 +90,6 @@ public class io/sentry/spring/tracing/SentrySpanAdvice : org/aopalliance/interce
 
 public class io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor : org/springframework/http/client/ClientHttpRequestInterceptor {
 	public fun <init> (Lio/sentry/IHub;)V
-	public fun createUriTemplateHandler (Lorg/springframework/web/util/UriTemplateHandler;)Lorg/springframework/web/util/UriTemplateHandler;
 	public fun intercept (Lorg/springframework/http/HttpRequest;[BLorg/springframework/http/client/ClientHttpRequestExecution;)Lorg/springframework/http/client/ClientHttpResponse;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -7,23 +7,14 @@ import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.springframework.core.NamedThreadLocal;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.web.util.UriTemplateHandler;
 
 @Open
 public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-  private static final @NotNull ThreadLocal<Deque<String>> urlTemplate =
-      new UrlTemplateThreadLocal();
   private final @NotNull IHub hub;
 
   public SentrySpanClientHttpRequestInterceptor(final @NotNull IHub hub) {
@@ -42,8 +33,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
     }
 
     final ISpan span = activeSpan.startChild("http.client");
-    span.setDescription(
-        request.getMethodValue() + " " + ensureLeadingSlash(urlTemplate.get().poll()));
+    span.setDescription(request.getMethodValue() + " " + request.getURI());
 
     final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
     request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
@@ -53,43 +43,6 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       return response;
     } finally {
       span.finish();
-      if (urlTemplate.get().isEmpty()) {
-        urlTemplate.remove();
-      }
-    }
-  }
-
-  public @NotNull UriTemplateHandler createUriTemplateHandler(
-      final @NotNull UriTemplateHandler delegate) {
-    return new UriTemplateHandler() {
-
-      @Override
-      public URI expand(String url, Map<String, ?> arguments) {
-        urlTemplate.get().push(url);
-        return delegate.expand(url, arguments);
-      }
-
-      @Override
-      public URI expand(String url, Object... arguments) {
-        urlTemplate.get().push(url);
-        return delegate.expand(url, arguments);
-      }
-    };
-  }
-
-  private static @NotNull String ensureLeadingSlash(final @Nullable String url) {
-    return (url == null || url.startsWith("/")) ? url : "/" + url;
-  }
-
-  private static final class UrlTemplateThreadLocal extends NamedThreadLocal<Deque<String>> {
-
-    private UrlTemplateThreadLocal() {
-      super("Rest Template URL Template");
-    }
-
-    @Override
-    protected Deque<String> initialValue() {
-      return new ArrayDeque<>();
     }
   }
 }


### PR DESCRIPTION



## :scroll: Description
<!--- Describe your changes in detail -->
Instead of passing templated URL to span description, pass real URL against which request is executed. It adds more details about request to executed Span and simplifies RestTemplate instrumentation configuration in non-boot usage.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1240.

## :green_heart: How did you test it?

Unit & Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

Update reference docs.
