### PR TITLE
Optimize DuplicateEventDetectionEventProcessor performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
+* Ref: Optimize DuplicateEventDetectionEventProcessor performance.
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
-* Ref: Optimize DuplicateEventDetectionEventProcessor performance.
+* Ref: Optimize DuplicateEventDetectionEventProcessor performance (#1247).
 
 # 4.1.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -71,6 +71,7 @@ public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {
 
 public final class io/sentry/DuplicateEventDetectionEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun <init> (Lio/sentry/SentryOptions;I)V
 	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -71,7 +71,6 @@ public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {
 
 public final class io/sentry/DuplicateEventDetectionEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
-	public fun <init> (Lio/sentry/SentryOptions;I)V
 	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -750,6 +750,7 @@ public class io/sentry/SentryOptions {
 	public fun isAttachStacktrace ()Z
 	public fun isAttachThreads ()Z
 	public fun isDebug ()Z
+	public fun isEnableDeduplication ()Z
 	public fun isEnableExternalConfiguration ()Z
 	public fun isEnableNdk ()Z
 	public fun isEnableScopeSync ()Z
@@ -769,6 +770,7 @@ public class io/sentry/SentryOptions {
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDistinctId (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
+	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnableExternalConfiguration (Z)V
 	public fun setEnableNdk (Z)V
 	public fun setEnableScopeSync (Z)V

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -37,6 +37,8 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
           capturedObjects.put(throwable, null);
         }
       }
+    } else {
+      options.getLogger().log(SentryLevel.DEBUG, "Event deduplication is disabled.");
     }
     return event;
   }

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -4,15 +4,14 @@ import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ConcurrentLinkedDeque;
-
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 /** Deduplicates events containing throwable that has been already processed. */
 public final class DuplicateEventDetectionEventProcessor implements EventProcessor {
-  private final ConcurrentLinkedDeque<Throwable> capturedObjects = new ConcurrentLinkedDeque<>();
+  private final ConcurrentLinkedQueue<Throwable> capturedObjects = new ConcurrentLinkedQueue<>();
   private final SentryOptions options;
   private final int bufferSize;
 
@@ -20,7 +19,8 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
     this(options, 100);
   }
 
-  public DuplicateEventDetectionEventProcessor(final @NotNull SentryOptions options, int bufferSize) {
+  public DuplicateEventDetectionEventProcessor(
+      final @NotNull SentryOptions options, int bufferSize) {
     this.options = Objects.requireNonNull(options, "options are required");
     this.bufferSize = bufferSize;
   }
@@ -54,7 +54,7 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
   }
 
   private static <T> boolean containsAnyKey(
-    final @NotNull Collection<T> map, final @NotNull List<T> list) {
+      final @NotNull Collection<T> map, final @NotNull List<T> list) {
     for (T entry : list) {
       if (map.contains(entry)) {
         return true;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -255,6 +255,13 @@ public class SentryOptions {
   private long maxAttachmentSize = 20 * 1024 * 1024;
 
   /**
+   * Enables event deduplication with {@link DuplicateEventDetectionEventProcessor}. Event
+   * deduplication prevents from receiving the same exception multiple times when there is more than
+   * one framework active that captures errors, for example Logback and Spring Boot.
+   */
+  private Boolean enableDeduplication = true;
+
+  /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
    * @param propertiesProvider the properties provider
@@ -271,6 +278,7 @@ public class SentryOptions {
         propertiesProvider.getBooleanProperty("uncaught.handler.enabled"));
     options.setTracesSampleRate(propertiesProvider.getDoubleProperty("traces-sample-rate"));
     options.setDebug(propertiesProvider.getBooleanProperty("debug"));
+    options.setEnableDeduplication(propertiesProvider.getBooleanProperty("enable-deduplication"));
     final Map<String, String> tags = propertiesProvider.getMap("tags");
     for (final Map.Entry<String, String> tag : tags.entrySet()) {
       options.setTag(tag.getKey(), tag.getValue());
@@ -1224,6 +1232,33 @@ public class SentryOptions {
     this.maxAttachmentSize = maxAttachmentSize;
   }
 
+  /**
+   * Returns if event deduplication is turned on.
+   *
+   * @return if event deduplication is turned on.
+   */
+  public boolean isEnableDeduplication() {
+    return Boolean.TRUE.equals(enableDeduplication);
+  }
+
+  /**
+   * Returns if event deduplication is turned on or of or {@code null} if not specified.
+   *
+   * @return if event deduplication is turned on or of or {@code null} if not specified.
+   */
+  private @Nullable Boolean getEnableDeduplication() {
+    return enableDeduplication;
+  }
+
+  /**
+   * Enables or disables event deduplication.
+   *
+   * @param enableDeduplication true if enabled false otherwise
+   */
+  public void setEnableDeduplication(final @Nullable Boolean enableDeduplication) {
+    this.enableDeduplication = enableDeduplication;
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -1317,6 +1352,9 @@ public class SentryOptions {
     }
     if (options.getDebug() != null) {
       setDebug(options.getDebug());
+    }
+    if (options.getEnableDeduplication() != null) {
+      setEnableDeduplication(options.getEnableDeduplication());
     }
     final Map<String, String> tags = new HashMap<>(options.getTags());
     for (final Map.Entry<String, String> tag : tags.entrySet()) {

--- a/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
@@ -4,24 +4,19 @@ import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.Mechanism
 import java.lang.RuntimeException
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class DuplicateEventDetectionEventProcessorTest {
 
     class Fixture {
-        fun getSut(bufferSize: Int? = null, enableDeduplication: Boolean? = null): DuplicateEventDetectionEventProcessor {
+        fun getSut(enableDeduplication: Boolean? = null): DuplicateEventDetectionEventProcessor {
             val options = SentryOptions().apply {
                 if (enableDeduplication != null) {
                     this.setEnableDeduplication(enableDeduplication)
                 }
             }
-            return if (bufferSize != null) {
-                DuplicateEventDetectionEventProcessor(options, bufferSize)
-            } else {
-                DuplicateEventDetectionEventProcessor(options)
-            }
+            return DuplicateEventDetectionEventProcessor(options)
         }
     }
 
@@ -88,16 +83,6 @@ class DuplicateEventDetectionEventProcessorTest {
         val result = processor.process(SentryEvent(RuntimeException(RuntimeException(event.throwable))), null)
 
         assertNull(result)
-    }
-
-    @Test
-    fun `does not keep in memory more items than the buffer size`() {
-        val processor = fixture.getSut(50)
-        for (i in 1..100) {
-            val event = SentryEvent(RuntimeException())
-            processor.process(event, null)
-        }
-        assertEquals(50, processor.size())
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
@@ -11,11 +11,16 @@ import kotlin.test.assertNull
 class DuplicateEventDetectionEventProcessorTest {
 
     class Fixture {
-        fun getSut(bufferSize: Int? = null): DuplicateEventDetectionEventProcessor {
+        fun getSut(bufferSize: Int? = null, enableDeduplication: Boolean? = null): DuplicateEventDetectionEventProcessor {
+            val options = SentryOptions().apply {
+                if (enableDeduplication != null) {
+                    this.setEnableDeduplication(enableDeduplication)
+                }
+            }
             return if (bufferSize != null) {
-                DuplicateEventDetectionEventProcessor(SentryOptions(), bufferSize)
+                DuplicateEventDetectionEventProcessor(options, bufferSize)
             } else {
-                DuplicateEventDetectionEventProcessor(SentryOptions())
+                DuplicateEventDetectionEventProcessor(options)
             }
         }
     }
@@ -93,5 +98,13 @@ class DuplicateEventDetectionEventProcessorTest {
             processor.process(event, null)
         }
         assertEquals(50, processor.size())
+    }
+
+    @Test
+    fun `does not deduplicate is deduplication is disabled`() {
+        val processor = fixture.getSut(enableDeduplication = false)
+        val event = SentryEvent(RuntimeException())
+        assertNotNull(processor.process(event, null))
+        assertNotNull(processor.process(event, null))
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -437,6 +437,24 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `creates options with enableDeduplication using external properties`() {
+        // create a sentry.properties file in temporary folder
+        val temporaryFolder = TemporaryFolder()
+        temporaryFolder.create()
+        val file = temporaryFolder.newFile("sentry.properties")
+        file.appendText("enable-deduplication=true")
+        // set location of the sentry.properties file
+        System.setProperty("sentry.properties.file", file.absolutePath)
+
+        try {
+            val options = SentryOptions.from(PropertiesProviderFactory.create())
+            assertTrue(options.isEnableDeduplication)
+        } finally {
+            temporaryFolder.delete()
+        }
+    }
+
+    @Test
     fun `when options are initialized, maxAttachmentSize is 20`() {
         assertEquals(20 * 1024 * 1024, SentryOptions().maxAttachmentSize)
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Optimize potential `DuplicateEventDetectionEventProcessor` performance issue by changing how objects are stored from `WeakHashMap` to `ConcurrentLinkedQueue`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using WeakHashMap to store objects opens up a possibility that the map will grow to thousands of entries and causes performance loss when searching for stored exception. This may happen either if outside of the SDK code references to exceptions are kept or if GC does not run for long time.

Changing the implementation to `ConcurrentLinkedQueue` gives the event processor control over how many exceptions are stored in the memory.


## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes