### PR TITLE
SentryExceptionResolver should not send handled errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
+
+Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).
+
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
+* Enchancement: SentryExceptionResolver should not send handled errors by default
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
-* Enchancement: SentryExceptionResolver should not send handled errors by default
+* Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).
 
 # 4.1.0
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -19,7 +19,7 @@ public class SentryProperties extends SentryOptions {
   private boolean enableTracing;
 
   /** Report all or only uncaught web exceptions. */
-  private int exceptionResolverOrder = Integer.MIN_VALUE;
+  private int exceptionResolverOrder = 1;
 
   /** Logging framework integration properties. */
   private @NotNull Logging logging = new Logging();

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -3,17 +3,17 @@ package io.sentry.spring.boot.it
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.IHub
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.spring.tracing.SentrySpan
 import io.sentry.test.checkEvent
 import io.sentry.transport.ITransport
 import java.lang.RuntimeException
-import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.Before
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.context.annotation.Bean
@@ -56,6 +57,9 @@ class SentrySpringIntegrationTest {
 
     @Autowired
     lateinit var transport: ITransport
+
+    @SpyBean
+    lateinit var hub: IHub
 
     @LocalServerPort
     lateinit var port: Integer
@@ -149,9 +153,7 @@ class SentrySpringIntegrationTest {
 
         restTemplate.getForEntity("http://localhost:$port/throws-handled", String::class.java)
 
-        await.during(Duration.ofSeconds(2)).untilAsserted {
-            verifyZeroInteractions(transport)
-        }
+        verify(hub, never()).captureEvent(any())
     }
 }
 

--- a/sentry-spring-boot-starter/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/sentry-spring-boot-starter/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/sentry-spring/src/main/java/io/sentry/spring/EnableSentry.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/EnableSentry.java
@@ -5,7 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.Ordered;
 
 /**
  * Enables Sentry error handling capabilities.
@@ -44,5 +43,5 @@ public @interface EnableSentry {
    *
    * @return the order to use for {@link SentryExceptionResolver}
    */
-  int exceptionResolverOrder() default Ordered.HIGHEST_PRECEDENCE;
+  int exceptionResolverOrder() default 1;
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
@@ -70,7 +70,7 @@ class EnableSentryTest {
         contextRunner.run {
             assertThat(it).hasSingleBean(SentryExceptionResolver::class.java)
             assertThat(it).getBean(SentryExceptionResolver::class.java)
-                .hasFieldOrPropertyWithValue("order", Integer.MIN_VALUE)
+                .hasFieldOrPropertyWithValue("order", 1)
         }
     }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
@@ -25,7 +25,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.Ordered
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -140,7 +139,7 @@ class SentrySpringIntegrationTest {
 }
 
 @SpringBootApplication
-@EnableSentry(dsn = "http://key@localhost/proj", sendDefaultPii = true, exceptionResolverOrder = Ordered.LOWEST_PRECEDENCE)
+@EnableSentry(dsn = "http://key@localhost/proj", sendDefaultPii = true)
 open class App {
 
     private val transport = mock<ITransport>()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Change the default SentryExceptionResolver behavior to not send errors handled with Spring exception handlers.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I believe current default behavior of `SentryExceptionResolver` is surprising for users - even if they define an exception handler for an exception - to handle it gracefully - it's still being sent to Sentry as an error. This PR changes the default behavior (that can still be overwritten through setting `exception-resolver-order`) to send only unhandled exceptions.

## :green_heart: How did you test it?

Integration tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps

While it does not break the compilation process, it is a breaking change from the behavior point of view.