### PR TITLE
Fix: Make the ANR Atomic flags immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix: Disable Gson HTML escaping
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Ref: Simplify RestTemplate instrumentation (#1246)
-* Fix: Make the ANR AtomicLong final 
+* Fix: Make the ANR Atomic flags immutable
 
 # 4.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix: Disable Gson HTML escaping
 * Enchancement: Support @SentrySpan and @SentryTransaction on classes and interfaces. (#1243)
 * Ref: Simplify RestTemplate instrumentation (#1246)
+* Fix: Make the ANR AtomicLong final 
 
 # 4.1.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -24,15 +24,15 @@ final class ANRWatchDog extends Thread {
   private final IHandler uiHandler;
   private final long timeoutIntervalMillis;
   private final @NotNull ILogger logger;
-  private AtomicLong tick = new AtomicLong(0);
-  private AtomicBoolean reported = new AtomicBoolean(false);
+  private final AtomicLong tick = new AtomicLong(0);
+  private final AtomicBoolean reported = new AtomicBoolean(false);
 
   private final @NotNull Context context;
 
   @SuppressWarnings("UnnecessaryLambda")
   private final Runnable ticker =
       () -> {
-        tick = new AtomicLong(0);
+        tick.set(0);
         reported.set(false);
       };
 


### PR DESCRIPTION
## :scroll: Description
Fix: Make the ANR Atomic flags immutable


## :bulb: Motivation and Context
https://stackoverflow.com/questions/66095728/sentry-android-anr-could-there-be-a-false-alarm/66097964?noredirect=1#comment116884716_66097964


## :green_heart: How did you test it?
could not reproduce the issue not being final, but the behavior is still the same.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
