### PR TITLE
fix: Remove experimental annotation for Attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # vNext
 
+* Fix: Remove experimental annotation for Attachment #1257
 * Fix: Mark stacktrace as snapshot if captured at arbitrary moment #1231
 * Enchancement: Improve EventProcessor nullability annotations (#1229).
 * Bump: sentry-native to 0.4.7

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -1,12 +1,10 @@
 package io.sentry;
 
 import java.io.File;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** You can use an attachment to store additional files alongside an event or transaction. */
-@ApiStatus.Experimental
 public final class Attachment {
 
   private @Nullable byte[] bytes;

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -459,7 +458,6 @@ public final class Scope implements Cloneable {
    *
    * @param attachment The attachment to add to the Scope's list of attachments.
    */
-  @ApiStatus.Experimental
   public void addAttachment(final @NotNull Attachment attachment) {
     attachments.add(attachment);
   }


### PR DESCRIPTION




## :scroll: Description
The API is stable and not experimental anymore. We can remove the annotation.


## :bulb: Motivation and Context
Fixes GH-1255


## :green_heart: How did you test it?
CI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
