### PR TITLE
Simplify Sentry configuration in Spring integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Enchancement: Do not serialize empty collections and maps (#1245)
 * Ref: Simplify RestTemplate instrumentation (#1246)
 * Enchancement: Integration interface better compatibility with Kotlin null-safety
+* Enchancement: Simplify Sentry configuration in Spring integration (#1259)
 
 Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.spring;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.EventProcessor;
 import io.sentry.ITransportFactory;
+import io.sentry.Integration;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.SentryOptions.TracesSamplerCallback;
@@ -49,6 +50,10 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
             .getBeansOfType(EventProcessor.class)
             .values()
             .forEach(options::addEventProcessor);
+        applicationContext
+            .getBeansOfType(Integration.class)
+            .values()
+            .forEach(options::addIntegration);
         applicationContext
             .getBeanProvider(Sentry.OptionsConfiguration.class)
             .ifAvailable(optionsConfiguration -> optionsConfiguration.configure(options));

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -46,12 +46,12 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
             .getBeanProvider(SentryOptions.BeforeBreadcrumbCallback.class)
             .ifAvailable(options::setBeforeBreadcrumb);
         applicationContext
-            .getBeanProvider(Sentry.OptionsConfiguration.class)
-            .ifAvailable(optionsConfiguration -> optionsConfiguration.configure(options));
-        applicationContext
             .getBeansOfType(EventProcessor.class)
             .values()
             .forEach(options::addEventProcessor);
+        applicationContext
+            .getBeanProvider(Sentry.OptionsConfiguration.class)
+            .ifAvailable(optionsConfiguration -> optionsConfiguration.configure(options));
       }
       Sentry.init(options);
     }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.mock
 import io.sentry.EventProcessor
 import io.sentry.IHub
 import io.sentry.ITransportFactory
+import io.sentry.Integration
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import kotlin.test.Test
@@ -146,6 +147,17 @@ class EnableSentryTest {
             }
     }
 
+    @Test
+    fun `configures custom integrations`() {
+        ApplicationContextRunner().withConfiguration(UserConfigurations.of(AppConfigWithCustomIntegrations::class.java))
+            .run {
+                val firstIntegration = it.getBean("firstIntegration", Integration::class.java)
+                val secondIntegration = it.getBean("secondIntegration", Integration::class.java)
+                val options = it.getBean(SentryOptions::class.java)
+                assertThat(options.integrations).contains(firstIntegration, secondIntegration)
+            }
+    }
+
     @EnableSentry(dsn = "http://key@localhost/proj")
     class AppConfig
 
@@ -207,5 +219,15 @@ class EnableSentryTest {
 
         @Bean
         fun secondProcessor() = mock<EventProcessor>()
+    }
+
+    @EnableSentry(dsn = "http://key@localhost/proj")
+    class AppConfigWithCustomIntegrations {
+
+        @Bean
+        fun firstIntegration() = mock<Integration>()
+
+        @Bean
+        fun secondIntegration() = mock<Integration>()
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Auto-configures user provided callbacks and event processors on `SentryOptions` as well as `SentryConfiguration` bean.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently there is no straightforward way to configure callbacks and event processors on SentryOptions in Spring integration. With this change, there is a convenient way to set most common callbacks just as Spring beans and if something advanced needs to be configured users can define `SentryConfiguration` beans that post processes `SentryOptions` before `SentryInit` is called.

## :green_heart: How did you test it?

Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

Update reference docs.