### PR TITLE
Fix flaky test: `ApacheHttpClientTransportTest`

### DIFF
--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -111,23 +111,20 @@ class ApacheHttpClientTransportTest {
 
     @Test
     fun `flush waits till all requests are finished`() {
-        for (i in 1..1000) {
-            val fixture = Fixture()
-            val sut = fixture.getSut()
-            whenever(fixture.client.execute(any(), any())).then {
-                CompletableFuture.runAsync {
-                    Thread.sleep(5)
-                    (it.arguments[1] as FutureCallback<SimpleHttpResponse>).completed(SimpleHttpResponse(200))
-                }
+        val sut = fixture.getSut()
+        whenever(fixture.client.execute(any(), any())).then {
+            CompletableFuture.runAsync {
+                Thread.sleep(5)
+                (it.arguments[1] as FutureCallback<SimpleHttpResponse>).completed(SimpleHttpResponse(200))
             }
-            sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
-            sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
-            sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
-
-            sut.flush(100)
-
-            verify(fixture.currentlyRunning, times(3)).decrement()
         }
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+        sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
+
+        sut.flush(100)
+
+        verify(fixture.currentlyRunning, times(3)).decrement()
     }
 
     @Test

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -124,7 +124,7 @@ class ApacheHttpClientTransportTest {
             sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
             sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
 
-            sut.flush(50)
+            sut.flush(100)
 
             verify(fixture.currentlyRunning, times(3)).decrement()
         }

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -112,7 +112,6 @@ class ApacheHttpClientTransportTest {
     @Test
     fun `flush waits till all requests are finished`() {
         for (i in 1..1000) {
-            println("Iteration $i")
             val fixture = Fixture()
             val sut = fixture.getSut()
             whenever(fixture.client.execute(any(), any())).then {
@@ -125,7 +124,7 @@ class ApacheHttpClientTransportTest {
             sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
             sut.send(SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null))
 
-            sut.flush(20)
+            sut.flush(50)
 
             verify(fixture.currentlyRunning, times(3)).decrement()
         }


### PR DESCRIPTION
## :scroll: Description

Fix flaky test in `ApacheHttpClientTransportTest` by increasing the flush timeout to 100ms.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Test was randomly failing when run with Github Actions.

Fixes: #1261 


## :green_heart: How did you test it?

Run 1000 iterations for the same test to make sure that test won't fail.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes