### PR TITLE
Add Request to the Scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix: Make the ANR Atomic flags immutable
 * Enchancement: Integration interface better compatibility with Kotlin null-safety
 * Enchancement: Simplify Sentry configuration in Spring integration (#1259)
+* Enchancement: Add Request to the Scope. #1270
 
 Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -436,6 +436,7 @@ public final class io/sentry/Scope : java/lang/Cloneable {
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
 	public fun getLevel ()Lio/sentry/SentryLevel;
+	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getSpan ()Lio/sentry/ISpan;
 	public fun getTransaction ()Lio/sentry/ITransaction;
 	public fun getTransactionName ()Ljava/lang/String;
@@ -450,6 +451,7 @@ public final class io/sentry/Scope : java/lang/Cloneable {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setRequest (Lio/sentry/protocol/Request;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Lio/sentry/ITransaction;)V
 	public fun setTransaction (Ljava/lang/String;)V
@@ -1463,9 +1465,11 @@ public final class io/sentry/protocol/OperatingSystem : io/sentry/IUnknownProper
 	public fun setVersion (Ljava/lang/String;)V
 }
 
-public final class io/sentry/protocol/Request : io/sentry/IUnknownPropertiesConsumer {
+public final class io/sentry/protocol/Request : io/sentry/IUnknownPropertiesConsumer, java/lang/Cloneable {
 	public fun <init> ()V
 	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public fun clone ()Lio/sentry/protocol/Request;
+	public synthetic fun clone ()Ljava/lang/Object;
 	public fun getCookies ()Ljava/lang/String;
 	public fun getData ()Ljava/lang/Object;
 	public fun getEnvs ()Ljava/util/Map;

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -309,6 +309,7 @@ public final class Scope implements Cloneable {
     level = null;
     transaction = null;
     user = null;
+    request = null;
     fingerprint.clear();
     breadcrumbs.clear();
     tags.clear();
@@ -510,6 +511,9 @@ public final class Scope implements Cloneable {
 
     final User userRef = user;
     clone.user = userRef != null ? userRef.clone() : null;
+
+    final Request requestRef = request;
+    clone.request = requestRef != null ? requestRef.clone() : null;
 
     clone.fingerprint = new ArrayList<>(fingerprint);
     clone.eventProcessors = new CopyOnWriteArrayList<>(eventProcessors);

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import io.sentry.protocol.Contexts;
+import io.sentry.protocol.Request;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
@@ -28,6 +29,9 @@ public final class Scope implements Cloneable {
 
   /** Scope's user */
   private @Nullable User user;
+
+  /** Scope's request */
+  private @Nullable Request request;
 
   /** Scope's fingerprint */
   private @NotNull List<String> fingerprint = new ArrayList<>();
@@ -161,6 +165,24 @@ public final class Scope implements Cloneable {
         observer.setUser(user);
       }
     }
+  }
+
+  /**
+   * Returns the Scope's request
+   *
+   * @return the request
+   */
+  public @Nullable Request getRequest() {
+    return request;
+  }
+
+  /**
+   * Sets the Scope's request
+   *
+   * @param request the request
+   */
+  public void setRequest(final @Nullable Request request) {
+    this.request = request;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -421,6 +421,9 @@ public final class SentryClient implements ISentryClient {
       if (event.getUser() == null) {
         event.setUser(scope.getUser());
       }
+      if (event.getRequest() == null) {
+        event.setRequest(scope.getRequest());
+      }
       if (event.getFingerprints() == null) {
         event.setFingerprints(scope.getFingerprint());
       }

--- a/sentry/src/main/java/io/sentry/protocol/Request.java
+++ b/sentry/src/main/java/io/sentry/protocol/Request.java
@@ -1,8 +1,12 @@
 package io.sentry.protocol;
 
 import io.sentry.IUnknownPropertiesConsumer;
+import io.sentry.util.CollectionUtils;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Http request information.
@@ -40,7 +44,7 @@ import org.jetbrains.annotations.ApiStatus;
  * csrftoken=u32t4o3tb3gg43; _gat=1;", "headers": { "content-type": "text/html" }, "env": {
  * "REMOTE_ADDR": "192.168.0.1" } } } ```
  */
-public final class Request implements IUnknownPropertiesConsumer {
+public final class Request implements Cloneable, IUnknownPropertiesConsumer {
   /**
    * The URL of the request if available.
    *
@@ -159,9 +163,38 @@ public final class Request implements IUnknownPropertiesConsumer {
     this.other = other;
   }
 
+  /**
+   * the Request's unknown fields
+   *
+   * @return the unknown map
+   */
+  @TestOnly
+  @Nullable
+  Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
   @ApiStatus.Internal
   @Override
   public void acceptUnknownProperties(Map<String, Object> unknown) {
     this.unknown = unknown;
+  }
+
+  /**
+   * Clones an User aka deep copy
+   *
+   * @return the cloned User
+   * @throws CloneNotSupportedException if the User is not cloneable
+   */
+  @Override
+  public @NotNull Request clone() throws CloneNotSupportedException {
+    final Request clone = (Request) super.clone();
+
+    clone.headers = CollectionUtils.shallowCopy(headers);
+    clone.env = CollectionUtils.shallowCopy(env);
+    clone.other = CollectionUtils.shallowCopy(other);
+    clone.unknown = CollectionUtils.shallowCopy(unknown);
+
+    return clone;
   }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -262,6 +262,9 @@ class SentryClientTest {
         assertEquals("fp", event.fingerprints[0])
         assertEquals("id", event.user.id)
         assertEquals(SentryLevel.FATAL, event.level)
+        assertNotNull(event.request) {
+            assertEquals("post", it.method)
+        }
     }
 
     @Test
@@ -854,6 +857,9 @@ class SentryClientTest {
             level = SentryLevel.FATAL
             user = User().apply {
                 id = "id"
+            }
+            request = Request().apply {
+                method = "post"
             }
         }
     }

--- a/sentry/src/test/java/io/sentry/protocol/RequestTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/RequestTest.kt
@@ -1,0 +1,81 @@
+package io.sentry.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+
+class RequestTest {
+    @Test
+    fun `cloning request wont have the same references`() {
+        val request = createRequest()
+        val clone = request.clone()
+
+        assertNotNull(clone)
+        assertNotSame(request, clone)
+
+        assertNotSame(request.others, clone.others)
+
+        assertNotSame(request.unknown, clone.unknown)
+    }
+
+    @Test
+    fun `cloning request will have the same values`() {
+        val request = createRequest()
+        val clone = request.clone()
+
+        assertEquals("get", clone.method)
+        assertEquals("http://localhost:8080", clone.url)
+        assertEquals("?foo=bar", clone.queryString)
+        assertEquals("envs", clone.envs!!["envs"])
+        assertEquals("others", clone.others!!["others"])
+        assertEquals("unknown", clone.unknown!!["unknown"])
+    }
+
+    @Test
+    fun `cloning request and changing the original values wont change the clone values`() {
+        val request = createRequest()
+        val clone = request.clone()
+
+        request.method = "post"
+        request.url = "http://another-host:8081/"
+        request.queryString = "?xxx=yyy"
+        request.envs!!["envs"] = "newEnvs"
+        request.others!!["others"] = "newOthers"
+        request.others!!["anotherOne"] = "anotherOne"
+        val newUnknown = mapOf(Pair("unknown", "newUnknown"), Pair("otherUnknown", "otherUnknown"))
+        request.acceptUnknownProperties(newUnknown)
+
+        assertEquals("get", clone.method)
+        assertEquals("http://localhost:8080", clone.url)
+        assertEquals("?foo=bar", clone.queryString)
+        assertEquals("envs", clone.envs!!["envs"])
+        assertEquals(1, clone.envs!!.size)
+        assertEquals("others", clone.others!!["others"])
+        assertEquals(1, clone.others!!.size)
+        assertEquals("unknown", clone.unknown!!["unknown"])
+        assertEquals(1, clone.unknown!!.size)
+    }
+
+    @Test
+    fun `setting null others do not crash`() {
+        val request = createRequest()
+        request.others = null
+
+        assertNull(request.others)
+    }
+
+    private fun createRequest(): Request {
+        return Request().apply {
+            method = "get"
+            url = "http://localhost:8080"
+            queryString = "?foo=bar"
+            envs = mutableMapOf(Pair("envs", "envs"))
+            val others = mutableMapOf(Pair("others", "others"))
+            setOthers(others)
+            val unknown = mapOf(Pair("unknown", "unknown"))
+            acceptUnknownProperties(unknown)
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add Request to the Scope.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We need to have a simple way to pass scope to another thread - including the request. Sample scenario:

HTTP request coming to a server application, this application executes a task on the thread from the pool, Sentry event is sent from this thread. There should be an easy way to pass the HTTP request context to this event.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

Refactor Spring and Servlet integrations to set the request on the scope instead of attaching event processor.