### PR TITLE
Simplify configuring Logback integration when environment variable with the DSN is not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fix: Make the ANR Atomic flags immutable
 * Enchancement: Integration interface better compatibility with Kotlin null-safety
 * Enchancement: Simplify Sentry configuration in Spring integration (#1259)
+* Enchancement: Simplify configuring Logback integration when environment variable with the DSN is not set (#1271)
+
 
 Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -48,7 +48,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
       } else {
         options
             .getLogger()
-            .log(SentryLevel.DEBUG, "DSN is null. SentryLogbackAppender is not being initialized");
+            .log(SentryLevel.WARNING, "DSN is null. SentryAppender is not being initialized");
       }
     }
     super.start();

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -35,14 +35,20 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   @Override
   public void start() {
     if (!Sentry.isEnabled()) {
-      options.setEnableExternalConfiguration(true);
-      options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
-      options.setSdkVersion(createSdkVersion(options));
-      Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
-      try {
-        Sentry.init(options);
-      } catch (IllegalArgumentException e) {
-        addWarn("Failed to init Sentry during appender initialization: " + e.getMessage());
+      if (options.getDsn() != null && !options.getDsn().endsWith("_IS_UNDEFINED")) {
+        options.setEnableExternalConfiguration(true);
+        options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
+        options.setSdkVersion(createSdkVersion(options));
+        Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
+        try {
+          Sentry.init(options);
+        } catch (IllegalArgumentException e) {
+          addWarn("Failed to init Sentry during appender initialization: " + e.getMessage());
+        }
+      } else {
+        options
+            .getLogger()
+            .log(SentryLevel.DEBUG, "DSN is null. SentryLogbackAppender is not being initialized");
       }
     }
     super.start();

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -308,7 +308,8 @@ class SentryAppenderTest {
     }
 
     @Test
-    fun `does not initialize Sentry when DSN is null`() {
+    fun `does not initialize Sentry when environment variable with DSN is not set`() {
+        // environment variables referenced in the logback.xml that are not set in the OS, have value "ENV_NAME_IS_UNDEFINED"
         fixture = Fixture(dsn = "DSN_IS_UNDEFINED", minimumEventLevel = Level.DEBUG)
 
         assertTrue(fixture.loggerContext.statusManager.copyOfStatusList.none { it.level == Status.WARN })

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -10,7 +10,7 @@
     <options>
       <debug>true</debug>
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
-      <dsn>${SENTRY_XXX}</dsn>
+      <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -8,8 +8,9 @@
 
   <appender name="sentry" class="io.sentry.logback.SentryAppender">
     <options>
+      <debug>true</debug>
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
-      <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
+      <dsn>${SENTRY_XXX}</dsn>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Simplify configuring Logback integration when environment variable with the DSN is not set.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When an environment property that is referenced in logback.xml is not set, Logback sets its value to PROPERTY_NAME_IS_UNDEFINED (not a `null` like it could have been expected). This complicates setting up SentryLogback appender configuration where the integration should be disabled in environments that do not have this property.

Before this change, users had to do:

```xml
<options>
  <dsn>${PROPERTY:- }</dsn>
</options>
```

With this change:

```xml
<options>
  <dsn>${PROPERTY}</dsn>
</options>
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes