### PR TITLE
Fix: Interrupt the thread in QueuedThreadPoolExecutor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Enchancement: Integration interface better compatibility with Kotlin null-safety
 * Enchancement: Simplify Sentry configuration in Spring integration (#1259)
 * Enchancement: Optimize SentryTracingFilter when hub is disabled.
+* Fix: Interrupt the thread in QueuedThreadPoolExecutor (#1276)
 
 Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -80,6 +80,7 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
       unfinishedTasksCount.waitTillZero(timeoutMillis, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       logger.log(SentryLevel.ERROR, "Failed to wait till idle", e);
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Interrupt the thread in QueuedThreadPoolExecutor.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When wait till idle is interrupted, it should interrupt also the parent thread.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes