### PR TITLE
Fix: SentryTransaction#finish should not clear another transaction from the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Enchancement: Integration interface better compatibility with Kotlin null-safety
 * Enchancement: Simplify Sentry configuration in Spring integration (#1259)
 * Enchancement: Optimize SentryTracingFilter when hub is disabled.
+* Fix: SentryTransaction#finish should not clear another transaction from the scope (#1278)
 
 Breaking Changes:
 * Enchancement: SentryExceptionResolver should not send handled errors by default (#1248).

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -556,7 +556,10 @@ public final class Hub implements IHub {
                   e);
         } finally {
           if (item != null) {
-            item.getScope().clearTransaction();
+            final Scope scope = item.getScope();
+            if (scope.getTransaction() == transaction) {
+              scope.clearTransaction();
+            }
           }
         }
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

SentryTransaction#finish should not clear another transaction from the scope


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1269

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes