### PR TITLE
Enha: Add "io.sentry.mobile." as an exception when detecting own stack frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # vNext
 
+* Enha: Add "io.sentry.mobile." as an exception when detecting own stack frames
+
 # 4.2.0
 
 * Fix: Remove experimental annotation for Attachment #1257

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # vNext
 
-* Enha: Add "io.sentry.mobile." as an exception when detecting own stack frames
 
 # 4.2.0
 

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -39,7 +39,9 @@ final class SentryStackTraceFactory {
 
           // we don't want to add our own frames
           final String className = item.getClassName();
-          if (className.startsWith("io.sentry.") && !className.startsWith("io.sentry.samples.")) {
+          if (className.startsWith("io.sentry.")
+              && !className.startsWith("io.sentry.samples.")
+              && !className.startsWith("io.sentry.mobile.")) {
             continue;
           }
 

--- a/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
@@ -165,6 +165,17 @@ class SentryStackTraceFactoryTest {
         })
     }
 
+    @Test
+    fun `when getStackFrames is called, does not remove sentry mobile classes`() {
+        var stacktrace = Thread.currentThread().stackTrace
+        val sentryElement = StackTraceElement("io.sentry.mobile.element", "test", "test.java", 1)
+        stacktrace = stacktrace.plusElement(sentryElement)
+
+        assertNotNull(sut.getStackFrames(stacktrace)!!.find {
+            it.module.startsWith("io.sentry")
+        })
+    }
+
     private fun generateStackTrace(className: String?) =
         StackTraceElement(className, "method", "fileName", 10)
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add `io.sentry.mobile.` as an exception when detecting own stack frames

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With this change, we cant use `io.sentry` as prefix in the packages for the sentry mobile app so that frames are marked correctly with `inApp=true`.

See https://github.com/getsentry/sentry-mobile/issues/117 for more information.

## :green_heart: How did you test it?

Added a unit test and ran the tests.

- Had issues with OpenJDK 15  though, as the tests would not run.  Had to apply fix from https://github.com/gradle/gradle/issues/15038#issuecomment-754172184 locally for them to run.

```
repositories {
    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
}
jacoco {
    toolVersion = "0.8.7-SNAPSHOT"
}
```

- Some unrelated tests seem to be failing on main.

```
io.sentry.config.EnvironmentVariablePropertiesProviderTest > when system property is set resolves property replacing dashes with underscores FAILED
io.sentry.config.EnvironmentVariablePropertiesProviderTest > when system property is set resolves property replacing dots with underscores FAILED
io.sentry.config.EnvironmentVariablePropertiesProviderTest > resolves map properties FAILED
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
