### PR TITLE
Fix: Craft artifact provider

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: "0.13.2"
+minVersion: "0.18.0"
 github:
   owner: getsentry
   repo: sentry-java

--- a/.craft.yml
+++ b/.craft.yml
@@ -6,7 +6,7 @@ changelogPolicy: simple
 statusProvider:
   name: github
 artifactProvider:
-  name: github
+  name: none
 targets:
   - name: github
   - name: registry


### PR DESCRIPTION
Craft publish requires no artifact provider if we want only to publish to release-registry, command:

eg 4.2.0

> craft publish 4.2.0 --rev 4.2.0 --target registry