### PR TITLE
Fix: Initialize Sentry in Logback appender when DSN is not set in XML config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # vNext
 
 * Fix: Fix setting in-app-includes from external properties (#1291)
+* Fix: Initialize Sentry in Logback appender when DSN is not set in XML config (#1296)
 
 
 # 4.2.0

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -35,7 +35,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
   @Override
   public void start() {
     if (!Sentry.isEnabled()) {
-      if (options.getDsn() != null && !options.getDsn().endsWith("_IS_UNDEFINED")) {
+      if (options.getDsn() == null || !options.getDsn().endsWith("_IS_UNDEFINED")) {
         options.setEnableExternalConfiguration(true);
         options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
         options.setSdkVersion(createSdkVersion(options));

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -308,10 +308,19 @@ class SentryAppenderTest {
     }
 
     @Test
-    fun `does not initialize Sentry when environment variable with DSN is not set`() {
+    fun `does not initialize Sentry when environment variable with DSN is passed through environment variable that is not set`() {
         // environment variables referenced in the logback.xml that are not set in the OS, have value "ENV_NAME_IS_UNDEFINED"
         fixture = Fixture(dsn = "DSN_IS_UNDEFINED", minimumEventLevel = Level.DEBUG)
 
         assertTrue(fixture.loggerContext.statusManager.copyOfStatusList.none { it.level == Status.WARN })
+    }
+
+    @Test
+    fun `does initialize Sentry when DSN is not set`() {
+        System.setProperty("sentry.dsn", "http://key@localhost/proj")
+        fixture = Fixture(dsn = null, minimumEventLevel = Level.DEBUG)
+
+        assertTrue(Sentry.isEnabled())
+        System.clearProperty("sentry.dsn")
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Initialize Sentry in Logback appender when DSN is not set in XML config

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1295

With the recent change, when DSN is set using external properties, Sentry would fail to initialize.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
