### PR TITLE
Fix: Add missing proguard rules

### DIFF
--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -34,4 +34,8 @@
 # R8: Attribute Signature requires InnerClasses attribute. Check -keepattributes directive.
 -keepattributes InnerClasses
 
+# To ensure that stack traces is unambiguous
+# https://developer.android.com/studio/build/shrink-code#decode-stack-trace
+-keepattributes LineNumberTable,SourceFile
+
 ##---------------End: proguard configuration for Gson  ----------

--- a/sentry-android-ndk/proguard-rules.pro
+++ b/sentry-android-ndk/proguard-rules.pro
@@ -7,4 +7,11 @@
     native <methods>;
 }
 
+# don't warn jetbrains annotations
+-dontwarn org.jetbrains.annotations.**
+
+# To ensure that stack traces is unambiguous
+# https://developer.android.com/studio/build/shrink-code#decode-stack-trace
+-keepattributes LineNumberTable,SourceFile
+
 ##---------------End: proguard configuration for NDK  ----------

--- a/sentry-android-timber/proguard-rules.pro
+++ b/sentry-android-timber/proguard-rules.pro
@@ -2,4 +2,8 @@
 
 -keep class io.sentry.android.timber.** { *; }
 
+# To ensure that stack traces is unambiguous
+# https://developer.android.com/studio/build/shrink-code#decode-stack-trace
+-keepattributes LineNumberTable,SourceFile
+
 ##---------------End: proguard configuration for Timber  ----------


### PR DESCRIPTION
## :scroll: Description
Fix: Add missing proguard rules


## :bulb: Motivation and Context
rules are per module, so some of them need to be placed in all of our android modules.
missing 2 important rules that keep our stack traces unambiguous


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
