### PR TITLE
Fix: Make AtomicBooleans transitive as they are not serializable

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/SentryTransaction.java
@@ -33,7 +33,7 @@ public final class SentryTransaction extends SentryBaseEvent implements ITransac
 
   private final transient @NotNull SpanContext context;
 
-  private final @NotNull AtomicBoolean finished = new AtomicBoolean(false);
+  private final transient @NotNull AtomicBoolean finished = new AtomicBoolean(false);
 
   /** The {@code type} property is required in JSON payload sent to Sentry. */
   @SuppressWarnings("UnusedVariable")

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -25,7 +25,7 @@ public final class Span extends SpanContext implements ISpan {
 
   private final transient @NotNull IHub hub;
 
-  private final @NotNull AtomicBoolean finished = new AtomicBoolean(false);
+  private final transient @NotNull AtomicBoolean finished = new AtomicBoolean(false);
 
   Span(
       final @NotNull SentryId traceId,


### PR DESCRIPTION
## :scroll: Description
Fix: Make AtomicBooleans transitive as they are not serializable


## :bulb: Motivation and Context
Reflection would pass thru those fields but its not needed


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
