### PR TITLE
Fix: Use logger set on SentryOptions in GsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix: Initialize Sentry in Logback appender when DSN is not set in XML config (#1296)
 * Fix: Fix JUL integration SDK name (#1293)
 * Feat: Activity tracing auto instrumentation
+* Fix: Use logger set on SentryOptions in GsonSerializer (#1308)
 
 # 4.2.0
 

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/assertions.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/assertions.kt
@@ -2,7 +2,6 @@ package io.sentry.test
 
 import com.nhaarman.mockitokotlin2.check
 import io.sentry.GsonSerializer
-import io.sentry.NoOpLogger
 import io.sentry.SentryEnvelope
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
@@ -12,7 +11,7 @@ import io.sentry.SentryOptions
  */
 inline fun checkEvent(noinline predicate: (SentryEvent) -> Unit): SentryEnvelope {
     val options = SentryOptions().apply {
-        setSerializer(GsonSerializer(NoOpLogger.getInstance(), envelopeReader))
+        setSerializer(GsonSerializer(SentryOptions(), envelopeReader))
     }
     return check {
         val event = it.items.first().getEvent(options.serializer)!!

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -90,7 +90,7 @@ public abstract interface class io/sentry/EventProcessor {
 }
 
 public final class io/sentry/GsonSerializer : io/sentry/ISerializer {
-	public fun <init> (Lio/sentry/ILogger;Lio/sentry/IEnvelopeReader;)V
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/IEnvelopeReader;)V
 	public fun deserialize (Ljava/io/Reader;Ljava/lang/Class;)Ljava/lang/Object;
 	public fun deserializeEnvelope (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
 	public fun serialize (Lio/sentry/SentryEnvelope;Ljava/io/OutputStream;)V
@@ -906,7 +906,7 @@ public final class io/sentry/Session$State : java/lang/Enum {
 }
 
 public final class io/sentry/SessionAdapter : com/google/gson/TypeAdapter {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun read (Lcom/google/gson/stream/JsonReader;)Lio/sentry/Session;
 	public synthetic fun read (Lcom/google/gson/stream/JsonReader;)Ljava/lang/Object;
 	public fun write (Lcom/google/gson/stream/JsonWriter;Lio/sentry/Session;)V
@@ -1036,25 +1036,25 @@ public final class io/sentry/adapters/CollectionAdapter : com/google/gson/JsonSe
 }
 
 public final class io/sentry/adapters/ContextsDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/Contexts;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/ContextsSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/protocol/Contexts;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/DateDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/util/Date;
 }
 
 public final class io/sentry/adapters/DateSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public fun serialize (Ljava/util/Date;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
@@ -1066,73 +1066,73 @@ public final class io/sentry/adapters/MapAdapter : com/google/gson/JsonSerialize
 }
 
 public final class io/sentry/adapters/OrientationDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/Device$DeviceOrientation;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/OrientationSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/protocol/Device$DeviceOrientation;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/SentryIdDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/protocol/SentryId;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/SentryIdSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/protocol/SentryId;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/SentryLevelDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SentryLevel;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/SentryLevelSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/SentryLevel;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/SpanIdDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SpanId;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/SpanIdSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/SpanId;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/SpanStatusDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lio/sentry/SpanStatus;
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 }
 
 public final class io/sentry/adapters/SpanStatusSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun serialize (Lio/sentry/SpanStatus;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }
 
 public final class io/sentry/adapters/TimeZoneDeserializerAdapter : com/google/gson/JsonDeserializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public synthetic fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 	public fun deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/util/TimeZone;
 }
 
 public final class io/sentry/adapters/TimeZoneSerializerAdapter : com/google/gson/JsonSerializer {
-	public fun <init> (Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public synthetic fun serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 	public fun serialize (Ljava/util/TimeZone;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 }

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -48,8 +48,8 @@ public final class GsonSerializer implements ISerializer {
   @SuppressWarnings("CharsetObjectCanBeUsed")
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  /** the ILogger interface */
-  private final @NotNull ILogger logger;
+  /** the SentryOptions */
+  private final @NotNull SentryOptions options;
 
   /** the Gson instance */
   private final @NotNull Gson gson;
@@ -60,12 +60,12 @@ public final class GsonSerializer implements ISerializer {
   /**
    * AndroidSerializer ctor
    *
-   * @param logger the ILogger interface
+   * @param options the SentryOptions object
    * @param envelopeReader the IEnvelopeReader interface
    */
   public GsonSerializer(
-      final @NotNull ILogger logger, final @NotNull IEnvelopeReader envelopeReader) {
-    this.logger = Objects.requireNonNull(logger, "The ILogger object is required.");
+      final @NotNull SentryOptions options, final @NotNull IEnvelopeReader envelopeReader) {
+    this.options = Objects.requireNonNull(options, "The SentryOptions object is required.");
     this.envelopeReader =
         Objects.requireNonNull(envelopeReader, "The IEnvelopeReader object is required.");
 
@@ -80,28 +80,28 @@ public final class GsonSerializer implements ISerializer {
   private @NotNull Gson provideGson() {
     return new GsonBuilder()
         .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-        .registerTypeAdapter(SentryId.class, new SentryIdSerializerAdapter(logger))
-        .registerTypeAdapter(SentryId.class, new SentryIdDeserializerAdapter(logger))
-        .registerTypeAdapter(Date.class, new DateSerializerAdapter(logger))
-        .registerTypeAdapter(Date.class, new DateDeserializerAdapter(logger))
-        .registerTypeAdapter(TimeZone.class, new TimeZoneSerializerAdapter(logger))
-        .registerTypeAdapter(TimeZone.class, new TimeZoneDeserializerAdapter(logger))
+        .registerTypeAdapter(SentryId.class, new SentryIdSerializerAdapter(options))
+        .registerTypeAdapter(SentryId.class, new SentryIdDeserializerAdapter(options))
+        .registerTypeAdapter(Date.class, new DateSerializerAdapter(options))
+        .registerTypeAdapter(Date.class, new DateDeserializerAdapter(options))
+        .registerTypeAdapter(TimeZone.class, new TimeZoneSerializerAdapter(options))
+        .registerTypeAdapter(TimeZone.class, new TimeZoneDeserializerAdapter(options))
         .registerTypeAdapter(
-            Device.DeviceOrientation.class, new OrientationSerializerAdapter(logger))
+            Device.DeviceOrientation.class, new OrientationSerializerAdapter(options))
         .registerTypeAdapter(
-            Device.DeviceOrientation.class, new OrientationDeserializerAdapter(logger))
-        .registerTypeAdapter(SentryLevel.class, new SentryLevelSerializerAdapter(logger))
-        .registerTypeAdapter(SentryLevel.class, new SentryLevelDeserializerAdapter(logger))
-        .registerTypeAdapter(Contexts.class, new ContextsDeserializerAdapter(logger))
-        .registerTypeAdapter(Contexts.class, new ContextsSerializerAdapter(logger))
+            Device.DeviceOrientation.class, new OrientationDeserializerAdapter(options))
+        .registerTypeAdapter(SentryLevel.class, new SentryLevelSerializerAdapter(options))
+        .registerTypeAdapter(SentryLevel.class, new SentryLevelDeserializerAdapter(options))
+        .registerTypeAdapter(Contexts.class, new ContextsDeserializerAdapter(options))
+        .registerTypeAdapter(Contexts.class, new ContextsSerializerAdapter(options))
         .registerTypeAdapterFactory(UnknownPropertiesTypeAdapterFactory.get())
         .registerTypeAdapter(SentryEnvelopeHeader.class, new SentryEnvelopeHeaderAdapter())
         .registerTypeAdapter(SentryEnvelopeItemHeader.class, new SentryEnvelopeItemHeaderAdapter())
-        .registerTypeAdapter(Session.class, new SessionAdapter(logger))
-        .registerTypeAdapter(SpanId.class, new SpanIdDeserializerAdapter(logger))
-        .registerTypeAdapter(SpanId.class, new SpanIdSerializerAdapter(logger))
-        .registerTypeAdapter(SpanStatus.class, new SpanStatusDeserializerAdapter(logger))
-        .registerTypeAdapter(SpanStatus.class, new SpanStatusSerializerAdapter(logger))
+        .registerTypeAdapter(Session.class, new SessionAdapter(options))
+        .registerTypeAdapter(SpanId.class, new SpanIdDeserializerAdapter(options))
+        .registerTypeAdapter(SpanId.class, new SpanIdSerializerAdapter(options))
+        .registerTypeAdapter(SpanStatus.class, new SpanStatusDeserializerAdapter(options))
+        .registerTypeAdapter(SpanStatus.class, new SpanStatusSerializerAdapter(options))
         .registerTypeHierarchyAdapter(Collection.class, new CollectionAdapter())
         .registerTypeHierarchyAdapter(Map.class, new MapAdapter())
         .disableHtmlEscaping()
@@ -135,7 +135,7 @@ public final class GsonSerializer implements ISerializer {
     try {
       return envelopeReader.read(inputStream);
     } catch (IOException e) {
-      logger.log(SentryLevel.ERROR, "Error deserializing envelope.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error deserializing envelope.", e);
       return null;
     }
   }
@@ -146,8 +146,8 @@ public final class GsonSerializer implements ISerializer {
     Objects.requireNonNull(entity, "The entity is required.");
     Objects.requireNonNull(writer, "The Writer object is required.");
 
-    if (logger.isEnabled(SentryLevel.DEBUG)) {
-      logger.log(SentryLevel.DEBUG, "Serializing object: %s", gson.toJson(entity));
+    if (options.getLogger().isEnabled(SentryLevel.DEBUG)) {
+      options.getLogger().log(SentryLevel.DEBUG, "Serializing object: %s", gson.toJson(entity));
     }
     gson.toJson(entity, entity.getClass(), writer);
 
@@ -187,7 +187,9 @@ public final class GsonSerializer implements ISerializer {
 
           writer.write("\n");
         } catch (Exception exception) {
-          logger.log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);
+          options
+              .getLogger()
+              .log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);
         }
       }
       writer.flush();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -81,7 +81,7 @@ public class SentryOptions {
   private @NotNull IEnvelopeReader envelopeReader = new EnvelopeReader();
 
   /** Serializer interface to serialize/deserialize json events */
-  private @NotNull ISerializer serializer = new GsonSerializer(logger, envelopeReader);
+  private @NotNull ISerializer serializer = new GsonSerializer(this, envelopeReader);
 
   /**
    * Sentry client name used for the HTTP authHeader and userAgent eg

--- a/sentry/src/main/java/io/sentry/SessionAdapter.java
+++ b/sentry/src/main/java/io/sentry/SessionAdapter.java
@@ -17,10 +17,10 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SessionAdapter extends TypeAdapter<Session> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SessionAdapter(final @NotNull ILogger logger) {
-    this.logger = Objects.requireNonNull(logger, "The Logger is required.");
+  public SessionAdapter(final @NotNull SentryOptions options) {
+    this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
   }
 
   @Override
@@ -137,7 +137,7 @@ public final class SessionAdapter extends TypeAdapter<Session> {
             sidStr = reader.nextString();
             sid = UUID.fromString(sidStr);
           } catch (IllegalArgumentException e) {
-            logger.log(SentryLevel.ERROR, "%s sid is not valid.", sidStr);
+            options.getLogger().log(SentryLevel.ERROR, "%s sid is not valid.", sidStr);
           }
           break;
         case "did":
@@ -155,7 +155,7 @@ public final class SessionAdapter extends TypeAdapter<Session> {
             statusStr = StringUtils.capitalize(reader.nextString());
             status = Session.State.valueOf(statusStr);
           } catch (IllegalArgumentException e) {
-            logger.log(SentryLevel.ERROR, "%s status is not valid.", statusStr);
+            options.getLogger().log(SentryLevel.ERROR, "%s status is not valid.", statusStr);
           }
           break;
         case "errors":
@@ -204,7 +204,9 @@ public final class SessionAdapter extends TypeAdapter<Session> {
     reader.endObject();
 
     if (status == null || started == null || release == null || release.isEmpty()) {
-      logger.log(SentryLevel.ERROR, "Session is gonna be dropped due to invalid fields.");
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Session is gonna be dropped due to invalid fields.");
       return null;
     }
 
@@ -229,7 +231,7 @@ public final class SessionAdapter extends TypeAdapter<Session> {
     try {
       return DateUtils.getDateTime(timestamp);
     } catch (IllegalArgumentException e) {
-      logger.log(SentryLevel.ERROR, e, "Error converting session (%s) field.", field);
+      options.getLogger().log(SentryLevel.ERROR, e, "Error converting session (%s) field.", field);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/ContextsDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/ContextsDeserializerAdapter.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.SpanContext;
 import io.sentry.protocol.App;
 import io.sentry.protocol.Browser;
@@ -23,10 +23,10 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class ContextsDeserializerAdapter implements JsonDeserializer<Contexts> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public ContextsDeserializerAdapter(@NotNull final ILogger logger) {
-    this.logger = logger;
+  public ContextsDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -89,7 +89,9 @@ public final class ContextsDeserializerAdapter implements JsonDeserializer<Conte
                     final Object object = context.deserialize(element, Object.class);
                     contexts.put(key, object);
                   } catch (JsonParseException e) {
-                    logger.log(SentryLevel.ERROR, e, "Error when deserializing the %s key.", key);
+                    options
+                        .getLogger()
+                        .log(SentryLevel.ERROR, e, "Error when deserializing the %s key.", key);
                   }
                 }
                 break;
@@ -99,7 +101,7 @@ public final class ContextsDeserializerAdapter implements JsonDeserializer<Conte
         return contexts;
       }
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing Contexts", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing Contexts", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/ContextsSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/ContextsSerializerAdapter.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Contexts;
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -16,10 +16,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class ContextsSerializerAdapter implements JsonSerializer<Contexts> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public ContextsSerializerAdapter(@NotNull final ILogger logger) {
-    this.logger = logger;
+  public ContextsSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -36,7 +36,7 @@ public final class ContextsSerializerAdapter implements JsonSerializer<Contexts>
           object.add(entry.getKey(), element);
         }
       } catch (JsonParseException e) {
-        logger.log(SentryLevel.ERROR, "%s context key isn't serializable.");
+        options.getLogger().log(SentryLevel.ERROR, "%s context key isn't serializable.");
       }
     }
     return object;

--- a/sentry/src/main/java/io/sentry/adapters/DateDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/DateDeserializerAdapter.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import io.sentry.DateUtils;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.Date;
 import org.jetbrains.annotations.ApiStatus;
@@ -15,10 +15,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public DateDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public DateDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -27,15 +27,19 @@ public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
     try {
       return json == null ? null : DateUtils.getDateTime(json.getAsString());
     } catch (Exception e) {
-      logger.log(
-          SentryLevel.DEBUG,
-          "Error when deserializing UTC timestamp format, it might be millis timestamp format.",
-          e);
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Error when deserializing UTC timestamp format, it might be millis timestamp format.",
+              e);
     }
     try {
       return DateUtils.getDateTimeWithMillisPrecision(json.getAsString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing millis timestamp format.", e);
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Error when deserializing millis timestamp format.", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/DateSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/DateSerializerAdapter.java
@@ -5,8 +5,8 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import io.sentry.DateUtils;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.Date;
 import org.jetbrains.annotations.ApiStatus;
@@ -15,10 +15,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class DateSerializerAdapter implements JsonSerializer<Date> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public DateSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public DateSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class DateSerializerAdapter implements JsonSerializer<Date> {
     try {
       return src == null ? null : new JsonPrimitive(DateUtils.getTimestamp(src));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing Date", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing Date", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/OrientationDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/OrientationDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Device;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -16,10 +16,10 @@ import org.jetbrains.annotations.NotNull;
 public final class OrientationDeserializerAdapter
     implements JsonDeserializer<Device.DeviceOrientation> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public OrientationDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public OrientationDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -31,7 +31,7 @@ public final class OrientationDeserializerAdapter
           ? null
           : Device.DeviceOrientation.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing DeviceOrientation", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing DeviceOrientation", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/OrientationSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/OrientationSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.Device;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -16,10 +16,10 @@ import org.jetbrains.annotations.NotNull;
 public final class OrientationSerializerAdapter
     implements JsonSerializer<Device.DeviceOrientation> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public OrientationSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public OrientationSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -28,7 +28,7 @@ public final class OrientationSerializerAdapter
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing DeviceOrientation", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing DeviceOrientation", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SentryIdDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryIdDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.SentryId;
 import java.lang.reflect.Type;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SentryIdDeserializerAdapter implements JsonDeserializer<SentryId> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SentryIdDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SentryIdDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class SentryIdDeserializerAdapter implements JsonDeserializer<Sentr
     try {
       return json == null ? null : new SentryId(json.getAsString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing SentryId", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SentryId", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SentryIdSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryIdSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.protocol.SentryId;
 import java.lang.reflect.Type;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SentryIdSerializerAdapter implements JsonSerializer<SentryId> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SentryIdSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SentryIdSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -25,7 +25,7 @@ public final class SentryIdSerializerAdapter implements JsonSerializer<SentryId>
     try {
       return src == null ? null : new JsonPrimitive(src.toString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing SentryId", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing SentryId", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SentryLevelDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryLevelDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SentryLevelDeserializerAdapter implements JsonDeserializer<SentryLevel> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SentryLevelDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SentryLevelDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class SentryLevelDeserializerAdapter implements JsonDeserializer<Se
     try {
       return json == null ? null : SentryLevel.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing SentryLevel", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SentryLevel", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SentryLevelSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryLevelSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SentryLevelSerializerAdapter implements JsonSerializer<SentryLevel> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SentryLevelSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SentryLevelSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -25,7 +25,7 @@ public final class SentryLevelSerializerAdapter implements JsonSerializer<Sentry
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing SentryLevel", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing SentryLevel", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SpanIdDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanIdDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.SpanId;
 import java.lang.reflect.Type;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SpanIdDeserializerAdapter implements JsonDeserializer<SpanId> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SpanIdDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SpanIdDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class SpanIdDeserializerAdapter implements JsonDeserializer<SpanId>
     try {
       return json == null ? null : new SpanId(json.getAsString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing SpanId", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SpanId", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SpanIdSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanIdSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.SpanId;
 import java.lang.reflect.Type;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SpanIdSerializerAdapter implements JsonSerializer<SpanId> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SpanIdSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SpanIdSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -25,7 +25,7 @@ public final class SpanIdSerializerAdapter implements JsonSerializer<SpanId> {
     try {
       return src == null ? null : new JsonPrimitive(src.toString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing SpanId", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing SpanId", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SpanStatusDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanStatusDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -15,10 +15,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SpanStatusDeserializerAdapter implements JsonDeserializer<SpanStatus> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SpanStatusDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SpanStatusDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -27,7 +27,7 @@ public final class SpanStatusDeserializerAdapter implements JsonDeserializer<Spa
     try {
       return json == null ? null : SpanStatus.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing SpanStatus", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SpanStatus", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/SpanStatusSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanStatusSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -15,10 +15,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class SpanStatusSerializerAdapter implements JsonSerializer<SpanStatus> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public SpanStatusSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public SpanStatusSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class SpanStatusSerializerAdapter implements JsonSerializer<SpanSta
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing SpanStatus", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing SpanStatus", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/TimeZoneDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TimeZoneDeserializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.TimeZone;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class TimeZoneDeserializerAdapter implements JsonDeserializer<TimeZone> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public TimeZoneDeserializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public TimeZoneDeserializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -26,7 +26,7 @@ public final class TimeZoneDeserializerAdapter implements JsonDeserializer<TimeZ
     try {
       return json == null ? null : TimeZone.getTimeZone(json.getAsString());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when deserializing TimeZone", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when deserializing TimeZone", e);
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/adapters/TimeZoneSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TimeZoneSerializerAdapter.java
@@ -4,8 +4,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
 import java.lang.reflect.Type;
 import java.util.TimeZone;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,10 +14,10 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class TimeZoneSerializerAdapter implements JsonSerializer<TimeZone> {
 
-  private final @NotNull ILogger logger;
+  private final @NotNull SentryOptions options;
 
-  public TimeZoneSerializerAdapter(final @NotNull ILogger logger) {
-    this.logger = logger;
+  public TimeZoneSerializerAdapter(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   @Override
@@ -25,7 +25,7 @@ public final class TimeZoneSerializerAdapter implements JsonSerializer<TimeZone>
     try {
       return src == null ? null : new JsonPrimitive(src.getID());
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error when serializing TimeZone", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error when serializing TimeZone", e);
     }
     return null;
   }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -59,7 +59,7 @@ class SentryClientTest {
             }
             setDebug(true)
             setDiagnosticLevel(SentryLevel.DEBUG)
-            setSerializer(GsonSerializer(mock(), envelopeReader))
+            setSerializer(GsonSerializer(this, envelopeReader))
             setLogger(mock())
             maxAttachmentSize = this@Fixture.maxAttachmentSize
             setTransportFactory(factory)

--- a/sentry/src/test/java/io/sentry/SessionAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/SessionAdapterTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNull
 
 class SessionAdapterTest {
 
-    private val serializer = GsonSerializer(mock(), EnvelopeReader())
+    private val serializer = GsonSerializer(SentryOptions().apply { setLogger(mock()) }, EnvelopeReader())
 
     @Test
     fun `null timestamp does not serialize `() {

--- a/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
@@ -97,7 +97,7 @@ class CacheStrategyTest {
     @Test
     fun `move init flag if state is ok`() {
         val options = SentryOptions().apply {
-            setSerializer(GsonSerializer(mock(), envelopeReader))
+            setSerializer(GsonSerializer(this, envelopeReader))
         }
         val sut = fixture.getSUT(3, options)
 
@@ -177,7 +177,7 @@ class CacheStrategyTest {
 
     private fun getOptionsWithRealSerializer(): SentryOptions {
         return SentryOptions().apply {
-            setSerializer(GsonSerializer(mock(), envelopeReader))
+            setSerializer(GsonSerializer(this, envelopeReader))
         }
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use logger set on SentryOptions in GsonSerializer.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1308

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

The breaking change is that `GsonSerializer` does not take a `ILogger` as a constructor parameter but `SentryOptions` instead.