### PR TITLE
Log dropped items size in RateLimiter only after all items are added to list

### DIFF
--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -69,13 +69,11 @@ public final class RateLimiter {
         }
         dropItems.add(item);
       }
-      if (dropItems != null) {
-        logger.log(
-            SentryLevel.INFO, "%d items will be dropped due rate limiting.", dropItems.size());
-      }
     }
 
     if (dropItems != null) {
+      logger.log(SentryLevel.INFO, "%d items will be dropped due rate limiting.", dropItems.size());
+
       //       Need a new envelope
       List<SentryEnvelopeItem> toSend = new ArrayList<>();
       for (SentryEnvelopeItem item : envelope.getItems()) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Currently, The debug logs for dropped item size is printed each time a dropped item is added to the list from SentryEnvelop in RateLimiter class.
Updated this to log the dropped item size only after we have the complete list of dropped items to avoid unnecessary logs.

## :bulb: Motivation and Context
https://github.com/getsentry/sentry-java/issues/1316


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
