### PR TITLE
Feat: add `continueFromHeader` methods to Sentry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: add continueFromHeader methods to Sentry (#1349)
+
 # 4.4.0-alpha.1
 
 * Bump: sentry-native to 0.4.8

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -516,6 +516,8 @@ public final class io/sentry/Sentry {
 	public static fun clearBreadcrumbs ()V
 	public static fun close ()V
 	public static fun configureScope (Lio/sentry/ScopeCallback;)V
+	public static fun continueFromHeader (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
+	public static fun continueFromHeader (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ISpan;
 	public static fun endSession ()V
 	public static fun flush (J)V
 	public static fun getLastEventId ()Lio/sentry/protocol/SentryId;

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.config.PropertiesProviderFactory;
+import io.sentry.exception.InvalidSentryTraceHeaderException;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import java.io.File;
@@ -665,6 +666,42 @@ public final class Sentry {
    */
   public static @Nullable ISpan getSpan() {
     return getCurrentHub().getSpan();
+  }
+
+  /**
+   * Starts a Transaction being a continuation of the span described in a `header` parameter.
+   * Started transaction is set on the scope.
+   *
+   * @param name the transaction name
+   * @param operation the operation
+   * @param header the string representing {@link SentryTraceHeader}
+   * @return created transaction
+   */
+  public static ISpan continueFromHeader(
+      final @NotNull String name, final @NotNull String operation, final @NotNull String header)
+      throws InvalidSentryTraceHeaderException {
+    return startTransaction(
+        TransactionContext.fromSentryTrace(name, operation, new SentryTraceHeader(header)));
+  }
+
+  /**
+   * Starts a Transaction being a continuation of the span described in a `header` parameter.
+   *
+   * @param name the transaction name
+   * @param operation the operation
+   * @param header the string representing {@link SentryTraceHeader}
+   * @param bindToScope if transaction should be bound to scope
+   * @return created transaction
+   */
+  public static ISpan continueFromHeader(
+      final @NotNull String name,
+      final @NotNull String operation,
+      final @NotNull String header,
+      boolean bindToScope)
+      throws InvalidSentryTraceHeaderException {
+    return startTransaction(
+        TransactionContext.fromSentryTrace(name, operation, new SentryTraceHeader(header)),
+        bindToScope);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -677,7 +677,7 @@ public final class Sentry {
    * @param header the string representing {@link SentryTraceHeader}
    * @return created transaction
    */
-  public static ISpan continueFromHeader(
+  public static @NotNull ISpan continueFromHeader(
       final @NotNull String name, final @NotNull String operation, final @NotNull String header)
       throws InvalidSentryTraceHeaderException {
     return startTransaction(
@@ -693,7 +693,7 @@ public final class Sentry {
    * @param bindToScope if transaction should be bound to scope
    * @return created transaction
    */
-  public static ISpan continueFromHeader(
+  public static @NotNull ISpan continueFromHeader(
       final @NotNull String name,
       final @NotNull String operation,
       final @NotNull String header,

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -13,9 +13,9 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.rules.TemporaryFolder
-import kotlin.test.assertNull
 
 class SentryTest {
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `continueFromHeader` methods to Sentry class.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1346

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes