### PR TITLE
Feat: Sentry closes Android NDK and ShutdownHook integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Feat: Add option to ignore exceptions by type (#1352)
+* Feat: Sentry closes Android NDK and ShutdownHook integrations
 
 # 4.4.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Feat: Add option to ignore exceptions by type (#1352)
-* Feat: Sentry closes Android NDK and ShutdownHook integrations
+* Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
 
 # 4.4.0-alpha.1
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -66,9 +66,10 @@ public abstract interface class io/sentry/android/core/IDebugImagesLoader {
 	public abstract fun loadDebugImages ()Ljava/util/List;
 }
 
-public final class io/sentry/android/core/NdkIntegration : io/sentry/Integration {
+public final class io/sentry/android/core/NdkIntegration : io/sentry/Integration, java/io/Closeable {
 	public static final field SENTRY_NDK_CLASS_NAME Ljava/lang/String;
 	public fun <init> (Ljava/lang/Class;)V
+	public fun close ()V
 	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -79,6 +79,8 @@ public final class NdkIntegration implements Integration, Closeable {
       try {
         final Method method = sentryNdkClass.getMethod("close");
         method.invoke(null, new Object[0]);
+
+        options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration removed.");
       } catch (NoSuchMethodException e) {
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -75,7 +75,7 @@ public final class NdkIntegration implements Integration, Closeable {
 
   @Override
   public void close() throws IOException {
-    if (sentryNdkClass != null && options.isEnableNdk()) {
+    if (options != null && options.isEnableNdk() && sentryNdkClass != null) {
       try {
         final Method method = sentryNdkClass.getMethod("close");
         method.invoke(null, new Object[0]);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -5,17 +5,21 @@ import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.util.Objects;
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 /** Enables the NDK error reporting for Android */
-public final class NdkIntegration implements Integration {
+public final class NdkIntegration implements Integration, Closeable {
 
   public static final String SENTRY_NDK_CLASS_NAME = "io.sentry.android.ndk.SentryNdk";
 
   private final @Nullable Class<?> sentryNdkClass;
+
+  private @NotNull SentryAndroidOptions options;
 
   public NdkIntegration(final @Nullable Class<?> sentryNdkClass) {
     this.sentryNdkClass = sentryNdkClass;
@@ -24,44 +28,42 @@ public final class NdkIntegration implements Integration {
   @Override
   public final void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
     Objects.requireNonNull(hub, "Hub is required");
-    final SentryAndroidOptions androidOptions =
+    this.options =
         Objects.requireNonNull(
             (options instanceof SentryAndroidOptions) ? (SentryAndroidOptions) options : null,
             "SentryAndroidOptions is required");
 
-    final boolean enabled = androidOptions.isEnableNdk();
-    androidOptions.getLogger().log(SentryLevel.DEBUG, "NdkIntegration enabled: %s", enabled);
+    final boolean enabled = this.options.isEnableNdk();
+    this.options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration enabled: %s", enabled);
 
     // Note: `hub` isn't used here because the NDK integration writes files to disk which are picked
     // up by another integration (EnvelopeFileObserverIntegration).
     if (enabled && sentryNdkClass != null) {
-      final String cachedDir = androidOptions.getCacheDirPath();
+      final String cachedDir = this.options.getCacheDirPath();
       if (cachedDir == null || cachedDir.isEmpty()) {
-        androidOptions
-            .getLogger()
-            .log(SentryLevel.ERROR, "No cache dir path is defined in options.");
-        androidOptions.setEnableNdk(false);
+        this.options.getLogger().log(SentryLevel.ERROR, "No cache dir path is defined in options.");
+        this.options.setEnableNdk(false);
         return;
       }
 
       try {
         final Method method = sentryNdkClass.getMethod("init", SentryAndroidOptions.class);
         final Object[] args = new Object[1];
-        args[0] = androidOptions;
+        args[0] = this.options;
         method.invoke(null, args);
 
-        androidOptions.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
+        this.options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
       } catch (NoSuchMethodException e) {
-        androidOptions.setEnableNdk(false);
-        androidOptions
+        this.options.setEnableNdk(false);
+        this.options
             .getLogger()
             .log(SentryLevel.ERROR, "Failed to invoke the SentryNdk.init method.", e);
       } catch (Throwable e) {
-        androidOptions.setEnableNdk(false);
-        androidOptions.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
+        this.options.setEnableNdk(false);
+        this.options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
       }
     } else {
-      androidOptions.setEnableNdk(false);
+      this.options.setEnableNdk(false);
     }
   }
 
@@ -69,5 +71,23 @@ public final class NdkIntegration implements Integration {
   @Nullable
   Class<?> getSentryNdkClass() {
     return sentryNdkClass;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (sentryNdkClass != null && options.isEnableNdk()) {
+      try {
+        final Method method = sentryNdkClass.getMethod("close");
+        method.invoke(null, new Object[0]);
+      } catch (NoSuchMethodException e) {
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Failed to invoke the SentryNdk.close method.", e);
+      } catch (Throwable e) {
+        options.getLogger().log(SentryLevel.ERROR, "Failed to close SentryNdk.", e);
+      } finally {
+        this.options.setEnableNdk(false);
+      }
+    }
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryNdk.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryNdk.kt
@@ -5,5 +5,9 @@ class SentryNdk {
         @JvmStatic
         fun init(options: SentryAndroidOptions) {
         }
+
+        @JvmStatic
+        fun close() {
+        }
     }
 }

--- a/sentry-android-ndk/api/sentry-android-ndk.api
+++ b/sentry-android-ndk/api/sentry-android-ndk.api
@@ -17,6 +17,7 @@ public final class io/sentry/android/ndk/NdkScopeObserver : io/sentry/IScopeObse
 }
 
 public final class io/sentry/android/ndk/SentryNdk {
+	public static fun close ()V
 	public static fun init (Lio/sentry/android/core/SentryAndroidOptions;)V
 }
 

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -22,11 +22,23 @@ public final class SentryNdk {
 
   private static native void initSentryNative(@NotNull final SentryAndroidOptions options);
 
+  private static native void shutdown();
+
+  /**
+   * Init the NDK integration
+   *
+   * @param options the SentryAndroidOptions
+   */
   public static void init(@NotNull final SentryAndroidOptions options) {
     SentryNdkUtil.addPackage(options.getSdkVersion());
     initSentryNative(options);
     options.addScopeObserver(new NdkScopeObserver(options));
 
     options.setDebugImagesLoader(new DebugImagesLoader(options, new NativeModuleListLoader()));
+  }
+
+  /** Closes the NDK integration */
+  public static void close() {
+    shutdown();
   }
 }

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -391,3 +391,8 @@ Java_io_sentry_android_ndk_NativeModuleListLoader_nativeLoadModuleList(JNIEnv *e
 
     return image_list;
 }
+
+JNIEXPORT void JNICALL
+Java_io_sentry_android_ndk_SentryNdk_shutdown(JNIEnv *env, jclass cls) {
+    sentry_shutdown();
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -936,9 +936,10 @@ public final class io/sentry/SessionAdapter : com/google/gson/TypeAdapter {
 	public synthetic fun write (Lcom/google/gson/stream/JsonWriter;Ljava/lang/Object;)V
 }
 
-public final class io/sentry/ShutdownHookIntegration : io/sentry/Integration {
+public final class io/sentry/ShutdownHookIntegration : io/sentry/Integration, java/io/Closeable {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Runtime;)V
+	public fun close ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 }
 

--- a/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
+++ b/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
@@ -5,6 +5,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /** Registers hook that closes {@link Hub} when main thread shuts down. */
 public final class ShutdownHookIntegration implements Integration, Closeable {
@@ -33,5 +34,11 @@ public final class ShutdownHookIntegration implements Integration, Closeable {
   @Override
   public void close() throws IOException {
     runtime.removeShutdownHook(thread);
+  }
+
+  @VisibleForTesting
+  @NotNull
+  Thread getHook() {
+    return thread;
   }
 }

--- a/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
+++ b/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
@@ -33,7 +33,9 @@ public final class ShutdownHookIntegration implements Integration, Closeable {
 
   @Override
   public void close() throws IOException {
-    runtime.removeShutdownHook(thread);
+    if (thread != null) {
+      runtime.removeShutdownHook(thread);
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## :scroll: Description
Feat: Sentry closes Android NDK and ShutdownHook integrations


## :bulb: Motivation and Context
#1225


## :green_heart: How did you test it?
running it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
