### PR TITLE
Allow inheritance of SentryHandler class in sentry-jul package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Feat: Add option to ignore exceptions by type (#1352)
 * Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
+* Enhancement: Allow inheritance of SentryHandler class in sentry-jul package(#1367)
 
 # 4.4.0-alpha.1
 

--- a/sentry-jul/api/sentry-jul.api
+++ b/sentry-jul/api/sentry-jul.api
@@ -3,7 +3,7 @@ public final class io/sentry/jul/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
-public final class io/sentry/jul/SentryHandler : java/util/logging/Handler {
+public class io/sentry/jul/SentryHandler : java/util/logging/Handler {
 	public static final field THREAD_ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/SentryOptions;)V

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -1,5 +1,6 @@
 package io.sentry.jul;
 
+import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
@@ -25,7 +26,8 @@ import org.jetbrains.annotations.TestOnly;
 import org.slf4j.MDC;
 
 /** Logging handler in charge of sending the java.util.logging records to a Sentry server. */
-public final class SentryHandler extends Handler {
+@Open
+public class SentryHandler extends Handler {
   /** Name of the {@link SentryEvent} extra property containing the Thread id. */
   public static final String THREAD_ID = "thread_id";
   /**


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Removing final keyword on sentry-jul SentryHandler class to allow inheritance for the creation of custom log handlers based on SentryHandler. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows extension of SentryHandler to create custom LogHandlers that can be deployed to EE application servers like Glassfish/Payara.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1360 

## :green_heart: How did you test it?
Ran local tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ x] No breaking changes


## :crystal_ball: Next steps
