### PR TITLE
Accept only non null value maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Feat: Add option to ignore exceptions by type (#1352)
 * Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
+* Fix: Accept only non null value maps (#1368)
 
 # 4.4.0-alpha.1
 
@@ -16,7 +17,6 @@
 * Fix: set "java" platform to transactions #1332
 * Feat: Add OkHttp client application interceptor (#1330)
 * Fix: Allow disabling tracing through SentryOptions (#1337)
-* Fix: Accept only non null value maps (#1366)
 
 # 4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix: set "java" platform to transactions #1332
 * Feat: Add OkHttp client application interceptor (#1330)
 * Fix: Allow disabling tracing through SentryOptions (#1337)
+* Fix: Accept only non null value maps (#1366)
 
 # 4.3.0
 

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -23,7 +23,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
   private @Nullable String type;
 
   /** Data associated with this breadcrumb. */
-  private @NotNull Map<String, Object> data = new ConcurrentHashMap<>();
+  private @NotNull Map<String, @NotNull Object> data = new ConcurrentHashMap<>();
 
   /** Dotted strings that indicate what the crumb is or where it comes from. */
   private @Nullable String category;
@@ -222,7 +222,7 @@ public final class Breadcrumb implements Cloneable, IUnknownPropertiesConsumer {
    */
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(@Nullable Map<String, Object> unknown) {
+  public void acceptUnknownProperties(@Nullable Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -41,10 +41,10 @@ public final class Scope implements Cloneable {
   private @NotNull Queue<Breadcrumb> breadcrumbs;
 
   /** Scope's tags */
-  private @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
+  private @NotNull Map<String, @NotNull String> tags = new ConcurrentHashMap<>();
 
   /** Scope's extras */
-  private @NotNull Map<String, Object> extra = new ConcurrentHashMap<>();
+  private @NotNull Map<String, @NotNull Object> extra = new ConcurrentHashMap<>();
 
   /** Scope's event processor list */
   private @NotNull List<EventProcessor> eventProcessors = new CopyOnWriteArrayList<>();
@@ -537,7 +537,7 @@ public final class Scope implements Cloneable {
 
     final Map<String, String> tagsRef = tags;
 
-    final Map<String, String> tagsClone = new ConcurrentHashMap<>();
+    final Map<String, @NotNull String> tagsClone = new ConcurrentHashMap<>();
 
     for (Map.Entry<String, String> item : tagsRef.entrySet()) {
       if (item != null) {
@@ -549,7 +549,7 @@ public final class Scope implements Cloneable {
 
     final Map<String, Object> extraRef = extra;
 
-    Map<String, Object> extraClone = new ConcurrentHashMap<>();
+    Map<String, @NotNull Object> extraClone = new ConcurrentHashMap<>();
 
     for (Map.Entry<String, Object> item : extraRef.entrySet()) {
       if (item != null) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -256,7 +256,7 @@ public class SentryOptions {
   private boolean enableExternalConfiguration;
 
   /** Tags applied to every event and transaction */
-  private final @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
+  private final @NotNull Map<String, @NotNull String> tags = new ConcurrentHashMap<>();
 
   /** max attachment size in bytes. */
   private long maxAttachmentSize = 20 * 1024 * 1024;

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -39,7 +39,7 @@ public class SpanContext implements Cloneable {
   protected @Nullable SpanStatus status;
 
   /** A map or list of tags for this event. Each tag must be less than 200 characters. */
-  protected @NotNull Map<String, String> tags = new ConcurrentHashMap<>();
+  protected @NotNull Map<String, @NotNull String> tags = new ConcurrentHashMap<>();
 
   public SpanContext(final @NotNull String operation, final @Nullable Boolean sampled) {
     this(new SentryId(), new SpanId(), operation, null, sampled);

--- a/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/EnvironmentVariablePropertiesProvider.java
@@ -33,12 +33,14 @@ final class EnvironmentVariablePropertiesProvider implements PropertiesProvider 
   public @NotNull Map<String, String> getMap(final @NotNull String property) {
     final String prefix = propertyToEnvironmentVariableName(property) + "_";
 
-    final Map<String, String> result = new ConcurrentHashMap<>();
+    final Map<String, @NotNull String> result = new ConcurrentHashMap<>();
     for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
       final String key = entry.getKey();
       if (key.startsWith(prefix)) {
         final String value = StringUtils.removeSurrounding(entry.getValue(), "\"");
-        result.put(key.substring(prefix.length()).toLowerCase(Locale.ROOT), value);
+        if (value != null) {
+          result.put(key.substring(prefix.length()).toLowerCase(Locale.ROOT), value);
+        }
       }
     }
     return result;

--- a/sentry/src/main/java/io/sentry/protocol/App.java
+++ b/sentry/src/main/java/io/sentry/protocol/App.java
@@ -32,7 +32,7 @@ public final class App implements IUnknownPropertiesConsumer, Cloneable {
   private String appBuild;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getAppIdentifier() {
     return appIdentifier;
@@ -99,7 +99,7 @@ public final class App implements IUnknownPropertiesConsumer, Cloneable {
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/Browser.java
+++ b/sentry/src/main/java/io/sentry/protocol/Browser.java
@@ -16,7 +16,7 @@ public final class Browser implements IUnknownPropertiesConsumer, Cloneable {
   private String version;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getName() {
     return name;
@@ -41,7 +41,7 @@ public final class Browser implements IUnknownPropertiesConsumer, Cloneable {
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -99,7 +99,7 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
   private Float batteryTemperature;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getName() {
     return name;
@@ -350,7 +350,7 @@ public final class Device implements IUnknownPropertiesConsumer, Cloneable {
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/Gpu.java
+++ b/sentry/src/main/java/io/sentry/protocol/Gpu.java
@@ -35,7 +35,7 @@ public final class Gpu implements IUnknownPropertiesConsumer, Cloneable {
   private String npotSupport;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getName() {
     return name;
@@ -116,7 +116,7 @@ public final class Gpu implements IUnknownPropertiesConsumer, Cloneable {
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
+++ b/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
@@ -35,7 +35,7 @@ public final class OperatingSystem implements IUnknownPropertiesConsumer, Clonea
   private Boolean rooted;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getName() {
     return name;
@@ -92,7 +92,7 @@ public final class OperatingSystem implements IUnknownPropertiesConsumer, Clonea
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
@@ -25,7 +25,7 @@ public final class SentryRuntime implements IUnknownPropertiesConsumer, Cloneabl
   private String rawDescription;
 
   @SuppressWarnings("unused")
-  private Map<String, Object> unknown;
+  private Map<String, @NotNull Object> unknown;
 
   public String getName() {
     return name;
@@ -58,7 +58,7 @@ public final class SentryRuntime implements IUnknownPropertiesConsumer, Cloneabl
 
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(Map<String, Object> unknown) {
+  public void acceptUnknownProperties(Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -33,10 +33,10 @@ public final class User implements Cloneable, IUnknownPropertiesConsumer {
    * Additional arbitrary fields, as stored in the database (and sometimes as sent by clients). All
    * data from `self.other` should end up here after store normalization.
    */
-  private @Nullable Map<String, String> other;
+  private @Nullable Map<String, @NotNull String> other;
 
   /** unknown fields, only internal usage. */
-  private @Nullable Map<String, Object> unknown;
+  private @Nullable Map<String, @NotNull Object> unknown;
 
   /**
    * Gets the e-mail address of the user.
@@ -115,7 +115,7 @@ public final class User implements Cloneable, IUnknownPropertiesConsumer {
    *
    * @return the other user data.
    */
-  public @Nullable Map<String, String> getOthers() {
+  public @Nullable Map<String, @NotNull String> getOthers() {
     return other;
   }
 
@@ -124,7 +124,7 @@ public final class User implements Cloneable, IUnknownPropertiesConsumer {
    *
    * @param other the other user related data..
    */
-  public void setOthers(final @Nullable Map<String, String> other) {
+  public void setOthers(final @Nullable Map<String, @NotNull String> other) {
     if (other != null) {
       this.other = new ConcurrentHashMap<>(other);
     } else {
@@ -139,7 +139,7 @@ public final class User implements Cloneable, IUnknownPropertiesConsumer {
    */
   @ApiStatus.Internal
   @Override
-  public void acceptUnknownProperties(final @NotNull Map<String, Object> unknown) {
+  public void acceptUnknownProperties(final @NotNull Map<String, @NotNull Object> unknown) {
     this.unknown = new ConcurrentHashMap<>(unknown);
   }
 
@@ -150,7 +150,7 @@ public final class User implements Cloneable, IUnknownPropertiesConsumer {
    */
   @TestOnly
   @Nullable
-  Map<String, Object> getUnknown() {
+  Map<String, @NotNull Object> getUnknown() {
     return unknown;
   }
 

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -45,7 +45,8 @@ public final class RateLimiter {
 
   private final @NotNull ICurrentDateProvider currentDateProvider;
   private final @NotNull ILogger logger;
-  private final @NotNull Map<DataCategory, Date> sentryRetryAfterLimit = new ConcurrentHashMap<>();
+  private final @NotNull Map<DataCategory, @NotNull Date> sentryRetryAfterLimit =
+      new ConcurrentHashMap<>();
 
   public RateLimiter(
       final @NotNull ICurrentDateProvider currentDateProvider, final @NotNull ILogger logger) {

--- a/sentry/src/main/java/io/sentry/util/CollectionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CollectionUtils.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Util class for Collections */
@@ -37,7 +38,7 @@ public final class CollectionUtils {
    * @param <V> the type of map values
    * @return the shallow copy of map
    */
-  public static <K, V> @Nullable Map<K, V> shallowCopy(@Nullable Map<K, V> map) {
+  public static <K, V> @Nullable Map<K, @NotNull V> shallowCopy(@Nullable Map<K, @NotNull V> map) {
     if (map != null) {
       return new ConcurrentHashMap<>(map);
     } else {


### PR DESCRIPTION
Resolves: #1366 

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds `org.jetbrains.annotations.NotNull` annotation for a places, where SDK could receive a `Map` from a client, which has a `nullable` type for `value` generic parameter.

I've also added this annotation to internal API methods and some fields to which `ConcurrentHashMap` is assigned.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ConcurrentHashMap` can't have a `null` for any of it's entries value, [otherwise `NullPointerException` is thrown](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/ConcurrentHashMap.java#l1011). By adding this `NotNull` annotation we:
- raise awareness of this issue for Java clients
- have a build-time check for Kotlin clients:
![image](https://user-images.githubusercontent.com/5845095/113033799-b5202400-9191-11eb-8789-68aef0c76372.png)



## :green_heart: How did you test it?

Unfortunately, I don't know how to test it, I'm open to any suggestions.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
