### PR TITLE
Make NoOpHub public

### DIFF
--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-final class NoOpHub implements IHub {
+public final class NoOpHub implements IHub {
 
   private static final NoOpHub instance = new NoOpHub();
 


### PR DESCRIPTION
## :scroll: Description
Makes `NoOpHub` public.


## :bulb: Motivation and Context
This enables easier resource management in an Apache Beam use case that I have. In Beam, I must manage an IHub manually rather than using static methods in `Sentry`. Allowing end-users to create NoOpHub instances will provide the kind of flexibility needed for this kind of use case.

If there is currently a method by which I can create an instance of NoOpHub directly, please point it out and close this PR. Thanks!


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
