### PR TITLE
Fix: Avoid NPE when MDC contains null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 * Feat: Add option to ignore exceptions by type (#1352)
-* Fix: Fix NPE when MDC contains null values (#1364, #1385)
+* Fix: Fix NPE when MDC contains null values (#1364)
+* Fix: Avoid NPE when MDC contains null values(#1385)
 * Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
 * Enhancement: Allow inheritance of SentryHandler class in sentry-jul package(#1367)
 * Fix: Accept only non null value maps (#1368)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
 
 * Feat: Add option to ignore exceptions by type (#1352)
-* Fix: Fix NPE when MDC contains null values (#1364)
-* Fix: Avoid NPE when MDC contains null values(#1385)
+* Fix: Fix NPE when MDC contains null values (sentry-logback) (#1364)
+* Fix: Avoid NPE when MDC contains null values (sentry-jul) (#1385)
 * Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
 * Enhancement: Allow inheritance of SentryHandler class in sentry-jul package(#1367)
 * Fix: Accept only non null value maps (#1368)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Feat: Add option to ignore exceptions by type (#1352)
-* Fix: Fix NPE when MDC contains null values (#1364)
+* Fix: Fix NPE when MDC contains null values (#1364, #1385)
 * Feat: Sentry closes Android NDK and ShutdownHook integrations (#1358)
 * Enhancement: Allow inheritance of SentryHandler class in sentry-jul package(#1367)
 * Fix: Accept only non null value maps (#1368)

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -185,15 +185,15 @@ public class SentryHandler extends Handler {
     if (throwable != null) {
       event.setThrowable(throwable);
     }
-    final Map<String, String> mdcProperties = MDC.getMDCAdapter().getCopyOfContextMap();
-    if (mdcProperties != null && !mdcProperties.isEmpty()) {
-      event
-          .getContexts()
-          .put(
-              "MDC",
-              mdcProperties.entrySet().stream()
-                  .filter(it -> it.getValue() != null)
-                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    Map<String, String> mdcProperties = MDC.getMDCAdapter().getCopyOfContextMap();
+    if (mdcProperties != null) {
+      mdcProperties =
+          mdcProperties.entrySet().stream()
+              .filter(it -> it.getValue() != null)
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      if (!mdcProperties.isEmpty()) {
+        event.getContexts().put("MDC", mdcProperties);
+      }
     }
     event.setExtra(THREAD_ID, record.getThreadID());
     return event;

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -186,9 +186,13 @@ public class SentryHandler extends Handler {
     }
     final Map<String, String> mdcProperties = MDC.getMDCAdapter().getCopyOfContextMap();
     if (mdcProperties != null && !mdcProperties.isEmpty()) {
-      event.getContexts().put("MDC", mdcProperties.entrySet().stream()
-        .filter(it -> it.getValue() != null)
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+      event
+          .getContexts()
+          .put(
+              "MDC",
+              mdcProperties.entrySet().stream()
+                  .filter(it -> it.getValue() != null)
+                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
     event.setExtra(THREAD_ID, record.getThreadID());
     return event;

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -185,10 +185,11 @@ public class SentryHandler extends Handler {
     if (throwable != null) {
       event.setThrowable(throwable);
     }
-    final Map<String, String> mdcProperties =
-        CollectionUtils.shallowCopy(MDC.getMDCAdapter().getCopyOfContextMap());
+    final Map<String, String> mdcProperties = MDC.getMDCAdapter().getCopyOfContextMap();
     if (mdcProperties != null && !mdcProperties.isEmpty()) {
-      event.getContexts().put("MDC", mdcProperties);
+      event.getContexts().put("MDC", mdcProperties.entrySet().stream()
+        .filter(it -> it.getValue() != null)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
     event.setExtra(THREAD_ID, record.getThreadID());
     return event;

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -8,7 +8,6 @@ import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
-import io.sentry.util.CollectionUtils;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -19,6 +19,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -288,6 +288,19 @@ class SentryHandlerTest {
     }
 
     @Test
+    fun `ignore set tags with null values from MDC`() {
+        fixture = Fixture(minimumEventLevel = Level.WARNING)
+        MDC.put("key", null)
+        fixture.logger.warning("testing MDC tags")
+
+        await.untilAsserted {
+            verify(fixture.transport).send(checkEvent { event ->
+                assertFalse(event.contexts.containsKey("MDC"))
+            }, anyOrNull())
+        }
+    }
+
+    @Test
     fun `does not create MDC context when no MDC tags are set`() {
         fixture = Fixture(minimumEventLevel = Level.WARNING)
         fixture.logger.warning("testing without MDC tags")


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Avoid NPE when MDC contains null values
Follow up https://github.com/getsentry/sentry-java/pull/1364

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
