### PR TITLE
Fix: `SentryTransactionAdvice` should operate on the new scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Enhancement: Make NoOpHub public (#1379)
 * Fix: Do not bind transactions to scope by default. (#1376)
 * Fix: fix Hub thread safety (#1388)
+* Fix: SentryTransactionAdvice should operate on the new scope (#1389)
 
 # 4.4.0-alpha.1
 

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -56,11 +56,13 @@ public class SentryTransactionAdvice implements MethodInterceptor {
       } else {
         operation = "bean";
       }
+      hub.pushScope();
       final ITransaction transaction = hub.startTransaction(name, operation, true);
       try {
         return invocation.proceed();
       } finally {
         transaction.finish();
+        hub.popScope();
       }
     }
   }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -42,6 +43,7 @@ class SentryTransactionAdviceTest {
 
     @BeforeTest
     fun setup() {
+        reset(hub)
         whenever(hub.startTransaction(any<String>(), any(), eq(true))).thenAnswer { io.sentry.SentryTracer(TransactionContext(it.arguments[0] as String, it.arguments[1] as String), hub) }
     }
 
@@ -92,6 +94,18 @@ class SentryTransactionAdviceTest {
             assertThat(it.transaction).isEqualTo("ClassAnnotatedWithOperationSampleService.hello")
             assertThat(it.contexts.trace!!.operation).isEqualTo("my-op")
         })
+    }
+
+    @Test
+    fun `pushes the scope when advice starts`() {
+        classAnnotatedSampleService.hello()
+        verify(hub).pushScope()
+    }
+
+    @Test
+    fun `pops the scope when advice finishes`() {
+        classAnnotatedSampleService.hello()
+        verify(hub).popScope()
     }
 
     @Configuration


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: `SentryTransactionAdvice` should operate on the new scope.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`@SentryTransaction` is meant to be used for integrations that we do not support out of the box like messaging, scheduled jobs. These integrations work on thread pools, meaning if users modify the scope, without having push & pop scope changes would last also for further invocations happening on the same thread.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes