### PR TITLE
Fix: use connection and read timeouts in ApacheHttpClient based transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: use connection and read timeouts in ApacheHttpClient based transport (#1397)
+
 # 4.4.0-alpha.2
 
 * Feat: Add option to ignore exceptions by type (#1352)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512m -XX:MaxMetaspaceSize=1536m -XX:+H
 android.useAndroidX=true
 
 # Release information
-buildVersionCode=20059
+buildVersionCode=20060
 # -SNAPSHOT avoids signing
-versionName=4.4.0-alpha.2-SNAPSHOT
+versionName=4.4.0-alpha.3-SNAPSHOT
 
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -11,10 +11,8 @@ import org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient
 class ApacheHttpClientTransportFactoryTest {
 
     class Fixture {
-        fun getSut(options: SentryOptions = SentryOptions()): ApacheHttpClientTransport {
-            val factory = ApacheHttpClientTransportFactory()
-            return factory.create(options, mock()) as ApacheHttpClientTransport
-        }
+        fun getSut(options: SentryOptions = SentryOptions()) =
+            ApacheHttpClientTransportFactory().create(options, mock()) as ApacheHttpClientTransport
     }
 
     private val fixture = Fixture()

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -10,21 +10,26 @@ import org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient
 
 class ApacheHttpClientTransportFactoryTest {
 
+    class Fixture {
+        fun getSut(options: SentryOptions = SentryOptions()): ApacheHttpClientTransport {
+            val factory = ApacheHttpClientTransportFactory()
+            return factory.create(options, mock()) as ApacheHttpClientTransport
+        }
+    }
+
+    private val fixture = Fixture()
+
     @Test
     fun `creates ApacheHttpClientTransport`() {
-        val factory = ApacheHttpClientTransportFactory()
-        val transport = factory.create(SentryOptions(), mock())
-        assertNotNull(transport)
+        assertNotNull(fixture.getSut())
     }
 
     @Test
     fun `options timeouts are applied to http client`() {
-        val factory = ApacheHttpClientTransportFactory()
-        val options = SentryOptions().apply {
+        val transport = fixture.getSut(SentryOptions().apply {
             this.connectionTimeoutMillis = 1500
             this.readTimeoutMillis = 2500
-        }
-        val transport = factory.create(options, mock()) as ApacheHttpClientTransport
+        })
         val requestConfig = transport.getClient().getRequestConfig()
         assertEquals(1500, requestConfig.connectTimeout.toMilliseconds())
         assertEquals(1500, requestConfig.connectionRequestTimeout.toMilliseconds())

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -1,7 +1,9 @@
 package io.sentry.transport.apache
 
 import com.nhaarman.mockitokotlin2.mock
-import io.sentry.RequestDetails
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import io.sentry.SentryOptions
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -11,13 +13,16 @@ class ApacheHttpClientTransportFactoryTest {
     @Test
     fun `creates ApacheHttpClientTransport`() {
         val factory = ApacheHttpClientTransportFactory()
-        val options = SentryOptions().apply {
-            setLogger(mock())
-            setSerializer(mock())
-        }
-        val requestDetails = mock<RequestDetails>()
-
-        val transport = factory.create(options, requestDetails)
+        val transport = factory.create(SentryOptions(), mock())
         assertNotNull(transport)
+    }
+
+    @Test
+    fun `options timeouts are used when creating ApacheHttpClientTransport`() {
+        val factory = ApacheHttpClientTransportFactory()
+        val options = spy(SentryOptions())
+        factory.create(options, mock())
+        verify(options, times(2)).connectionTimeoutMillis
+        verify(options).readTimeoutMillis
     }
 }

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -18,7 +18,7 @@ class ApacheHttpClientTransportFactoryTest {
     }
 
     @Test
-    fun `options timeouts are used when creating ApacheHttpClientTransport`() {
+    fun `options timeouts are applied to http client`() {
         val factory = ApacheHttpClientTransportFactory()
         val options = SentryOptions().apply {
             this.connectionTimeoutMillis = 1500

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -1,12 +1,12 @@
 package io.sentry.transport.apache
 
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.spy
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
 import io.sentry.SentryOptions
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.apache.hc.client5.http.config.RequestConfig
+import org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient
 
 class ApacheHttpClientTransportFactoryTest {
 
@@ -20,9 +20,26 @@ class ApacheHttpClientTransportFactoryTest {
     @Test
     fun `options timeouts are used when creating ApacheHttpClientTransport`() {
         val factory = ApacheHttpClientTransportFactory()
-        val options = spy(SentryOptions())
-        factory.create(options, mock())
-        verify(options, times(2)).connectionTimeoutMillis
-        verify(options).readTimeoutMillis
+        val options = SentryOptions().apply {
+            this.connectionTimeoutMillis = 1500
+            this.readTimeoutMillis = 2500
+        }
+        val transport = factory.create(options, mock()) as ApacheHttpClientTransport
+        val requestConfig = transport.getClient().getRequestConfig()
+        assertEquals(1500, requestConfig.connectTimeout.toMilliseconds())
+        assertEquals(1500, requestConfig.connectionRequestTimeout.toMilliseconds())
+        assertEquals(2500, requestConfig.responseTimeout.toMilliseconds())
     }
+
+    private fun ApacheHttpClientTransport.getClient(): InternalHttpAsyncClient = this.getProperty("httpclient")
+    private fun InternalHttpAsyncClient.getRequestConfig(): RequestConfig = this.getProperty("defaultConfig")
+
+    private inline fun <reified T> Any.getProperty(name: String): T =
+        try {
+            this::class.java.getDeclaredField(name)
+        } catch (_: NoSuchFieldException) {
+            this::class.java.superclass.getDeclaredField(name)
+        }.apply {
+            this.isAccessible = true
+        }.get(this) as T
 }

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportFactoryTest.kt
@@ -2,6 +2,7 @@ package io.sentry.transport.apache
 
 import com.nhaarman.mockitokotlin2.mock
 import io.sentry.SentryOptions
+import io.sentry.test.getProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -36,13 +37,4 @@ class ApacheHttpClientTransportFactoryTest {
 
     private fun ApacheHttpClientTransport.getClient(): InternalHttpAsyncClient = this.getProperty("httpclient")
     private fun InternalHttpAsyncClient.getRequestConfig(): RequestConfig = this.getProperty("defaultConfig")
-
-    private inline fun <reified T> Any.getProperty(name: String): T =
-        try {
-            this::class.java.getDeclaredField(name)
-        } catch (_: NoSuchFieldException) {
-            this::class.java.superclass.getDeclaredField(name)
-        }.apply {
-            this.isAccessible = true
-        }.get(this) as T
 }

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/reflection.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/reflection.kt
@@ -10,3 +10,12 @@ inline fun <reified T : Any> T.callMethod(name: String, parameterTypes: Class<*>
     T::class.java.getDeclaredMethod(name, parameterTypes)
             .invoke(this, value)
 }
+
+inline fun <reified T> Any.getProperty(name: String): T =
+    try {
+        this::class.java.getDeclaredField(name)
+    } catch (_: NoSuchFieldException) {
+        this::class.java.superclass.getDeclaredField(name)
+    }.apply {
+        this.isAccessible = true
+    }.get(this) as T


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: use connection and read timeouts in ApacheHttpClient based transport

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `ApacheHttpClientTransport` was used, timeouts were not respected.

## :green_heart: How did you test it?

Console sample and slowing down connections with ToxiProxy connected to Sentry relay running locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes