### PR TITLE
Fix: set scope on transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix: use connection and read timeouts in ApacheHttpClient based transport (#1397)
 * Ref: Refactor converting HttpServletRequest to Sentry Request in Spring integration (#1387)
 * Fix: handle network errors in SentrySpanClientHttpRequestInterceptor (#1407)
+* Fix: set scope on transaction (#1409)
 
 # 4.4.0-alpha.2
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: set scope on transaction

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Until now, only request has been set from the scope on transaction.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

I believe applying scope deserves a refactoring. We can add a method on `SentryBaseEvent#applyScope(scope)` which will get overwritten in `SentryTransaction` and `SentryEvent`.