### PR TITLE
Fix: Apply user from the scope to transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix: set correct transaction status for unhandled exceptions in SentryTracingFilter (#1406)
 * Fix: handle network errors in SentrySpanClientHttpRequestInterceptor (#1407)
 * Fix: set scope on transaction (#1409)
+* Fix: Apply user from the scope to transaction (#1424)
 
 # 4.4.0-alpha.2
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -213,8 +213,9 @@ class DefaultAndroidEventProcessorTest {
             setUser(user)
         }
         event = sut.process(event, null)
-        assertNotNull(event.user)
-        assertNotNull(event.user.id)
+        assertNotNull(event.user) {
+            assertNotNull(it.id)
+        }
     }
 
     @Test

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -84,8 +84,8 @@ class SentrySpringIntegrationTest {
                 assertThat(event.request).isNotNull()
                 assertThat(event.request!!.url).isEqualTo("http://localhost:$port/hello")
                 assertThat(event.user).isNotNull()
-                assertThat(event.user.username).isEqualTo("user")
-                assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")
+                assertThat(event.user!!.username).isEqualTo("user")
+                assertThat(event.user!!.ipAddress).isEqualTo("169.128.0.1")
             }, anyOrNull())
         }
     }
@@ -101,7 +101,8 @@ class SentrySpringIntegrationTest {
 
         await.untilAsserted {
             verify(transport).send(checkEvent { event ->
-                assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")
+                assertThat(event.user).isNotNull()
+                assertThat(event.user!!.ipAddress).isEqualTo("169.128.0.1")
             }, anyOrNull())
         }
     }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringIntegrationTest.kt
@@ -75,8 +75,8 @@ class SentrySpringIntegrationTest {
                 assertThat(event.request).isNotNull()
                 assertThat(event.request!!.url).isEqualTo("http://localhost:$port/hello")
                 assertThat(event.user).isNotNull()
-                assertThat(event.user.username).isEqualTo("user")
-                assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")
+                assertThat(event.user!!.username).isEqualTo("user")
+                assertThat(event.user!!.ipAddress).isEqualTo("169.128.0.1")
             }, anyOrNull())
         }
     }
@@ -92,7 +92,8 @@ class SentrySpringIntegrationTest {
 
         await.untilAsserted {
             verify(transport).send(checkEvent { event ->
-                assertThat(event.user.ipAddress).isEqualTo("169.128.0.1")
+                assertThat(event.user).isNotNull()
+                assertThat(event.user!!.ipAddress).isEqualTo("169.128.0.1")
             }, anyOrNull())
         }
     }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorIntegrationTest.kt
@@ -39,7 +39,7 @@ class SentryUserProviderEventProcessorIntegrationTest {
                 await.untilAsserted {
                     verify(transport).send(checkEvent { event: SentryEvent ->
                         assertThat(event.user).isNotNull
-                        assertThat(event.user.username).isEqualTo("john.smith")
+                        assertThat(event.user!!.username).isEqualTo("john.smith")
                     }, anyOrNull())
                 }
             }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorTest.kt
@@ -37,12 +37,13 @@ class SentryUserProviderEventProcessorTest {
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNotNull(result.user)
-        assertEquals("john.doe", result.user.username)
-        assertEquals("user-id", result.user.id)
-        assertEquals("192.168.0.1", result.user.ipAddress)
-        assertEquals("john.doe@example.com", result.user.email)
-        assertEquals(mapOf("key" to "value"), result.user.others)
+        assertNotNull(result.user) {
+            assertEquals("john.doe", it.username)
+            assertEquals("user-id", it.id)
+            assertEquals("192.168.0.1", it.ipAddress)
+            assertEquals("john.doe@example.com", it.email)
+            assertEquals(mapOf("key" to "value"), it.others)
+        }
     }
 
     @Test
@@ -62,12 +63,13 @@ class SentryUserProviderEventProcessorTest {
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNotNull(result.user)
-        assertEquals("john.doe", result.user.username)
-        assertEquals("user-id", result.user.id)
-        assertEquals("192.168.0.1", result.user.ipAddress)
-        assertEquals("john.doe@example.com", result.user.email)
-        assertEquals(mapOf("key" to "value"), result.user.others)
+        assertNotNull(result.user) {
+            assertEquals("john.doe", it.username)
+            assertEquals("user-id", it.id)
+            assertEquals("192.168.0.1", it.ipAddress)
+            assertEquals("john.doe@example.com", it.email)
+            assertEquals(mapOf("key" to "value"), it.others)
+        }
     }
 
     @Test
@@ -78,22 +80,24 @@ class SentryUserProviderEventProcessorTest {
         }
 
         val event = SentryEvent()
-        event.user = User()
-        event.user.username = "jane.smith"
-        event.user.id = "jane-smith"
-        event.user.ipAddress = "192.168.0.3"
-        event.user.email = "jane.smith@example.com"
-        event.user.others = mapOf("key" to "value")
+        event.user = User().apply {
+            username = "jane.smith"
+            id = "jane-smith"
+            ipAddress = "192.168.0.3"
+            email = "jane.smith@example.com"
+            others = mapOf("key" to "value")
+        }
 
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNotNull(result.user)
-        assertEquals("jane.smith", result.user.username)
-        assertEquals("jane-smith", result.user.id)
-        assertEquals("192.168.0.3", result.user.ipAddress)
-        assertEquals("jane.smith@example.com", result.user.email)
-        assertEquals(mapOf("key" to "value"), result.user.others)
+        assertNotNull(result.user) {
+            assertEquals("jane.smith", it.username)
+            assertEquals("jane-smith", it.id)
+            assertEquals("192.168.0.3", it.ipAddress)
+            assertEquals("jane.smith@example.com", it.email)
+            assertEquals(mapOf("key" to "value"), it.others)
+        }
     }
 
     @Test
@@ -103,22 +107,24 @@ class SentryUserProviderEventProcessorTest {
         }
 
         val event = SentryEvent()
-        event.user = User()
-        event.user.username = "jane.smith"
-        event.user.id = "jane-smith"
-        event.user.ipAddress = "192.168.0.3"
-        event.user.email = "jane.smith@example.com"
-        event.user.others = mapOf("key" to "value")
+        event.user = User().apply {
+            username = "jane.smith"
+            id = "jane-smith"
+            ipAddress = "192.168.0.3"
+            email = "jane.smith@example.com"
+            others = mapOf("key" to "value")
+        }
 
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNotNull(result.user)
-        assertEquals("jane.smith", result.user.username)
-        assertEquals("jane-smith", result.user.id)
-        assertEquals("192.168.0.3", result.user.ipAddress)
-        assertEquals("jane.smith@example.com", result.user.email)
-        assertEquals(mapOf("key" to "value"), result.user.others)
+        assertNotNull(result.user) {
+            assertEquals("jane.smith", it.username)
+            assertEquals("jane-smith", it.id)
+            assertEquals("192.168.0.3", it.ipAddress)
+            assertEquals("jane.smith@example.com", it.email)
+            assertEquals(mapOf("key" to "value"), it.others)
+        }
     }
 
     @Test
@@ -130,14 +136,16 @@ class SentryUserProviderEventProcessorTest {
         }
 
         val event = SentryEvent()
-        event.user = User()
-        event.user.others = mapOf("new-key" to "new-value")
+        event.user = User().apply {
+            others = mapOf("new-key" to "new-value")
+        }
 
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNotNull(result.user)
-        assertEquals(mapOf("key" to "value", "new-key" to "new-value"), result.user.others)
+        assertNotNull(result.user) {
+            assertEquals(mapOf("key" to "value", "new-key" to "new-value"), it.others)
+        }
     }
 
     @Test
@@ -169,7 +177,9 @@ class SentryUserProviderEventProcessorTest {
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertEquals(user.ipAddress, result.user.ipAddress)
+        assertNotNull(result.user) {
+            assertEquals(user.ipAddress, it.ipAddress)
+        }
     }
 
     @Test
@@ -186,6 +196,8 @@ class SentryUserProviderEventProcessorTest {
         val result = processor.process(event, null)
 
         assertNotNull(result)
-        assertNull(result.user.ipAddress)
+        assertNotNull(result.user) {
+            assertNull(it.ipAddress)
+        }
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -612,6 +612,7 @@ public abstract class io/sentry/SentryBaseEvent {
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getTags ()Ljava/util/Map;
 	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun getUser ()Lio/sentry/protocol/User;
 	public fun removeTag (Ljava/lang/String;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setEventId (Lio/sentry/protocol/SentryId;)V
@@ -622,6 +623,7 @@ public abstract class io/sentry/SentryBaseEvent {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTags (Ljava/util/Map;)V
 	public fun setThrowable (Ljava/lang/Throwable;)V
+	public fun setUser (Lio/sentry/protocol/User;)V
 }
 
 public final class io/sentry/SentryClient : io/sentry/ISentryClient {
@@ -709,7 +711,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun getTransaction ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
-	public fun getUser ()Lio/sentry/protocol/User;
 	public fun isCrashed ()Z
 	public fun isErrored ()Z
 	public fun removeExtra (Ljava/lang/String;)V
@@ -729,7 +730,6 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun setServerName (Ljava/lang/String;)V
 	public fun setThreads (Ljava/util/List;)V
 	public fun setTransaction (Ljava/lang/String;)V
-	public fun setUser (Lio/sentry/protocol/User;)V
 }
 
 public final class io/sentry/SentryItemType : java/lang/Enum {

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -5,6 +5,7 @@ import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
+import io.sentry.protocol.User;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
@@ -73,6 +74,9 @@ public abstract class SentryBaseEvent {
    * `ruby`
    */
   private @Nullable String platform;
+
+  /** Information about the user who triggered this event. */
+  private User user;
 
   /** The captured Throwable */
   protected transient @Nullable Throwable throwable;
@@ -197,5 +201,13 @@ public abstract class SentryBaseEvent {
 
   public void setPlatform(final @Nullable String platform) {
     this.platform = platform;
+  }
+
+  public @Nullable User getUser() {
+    return user;
+  }
+
+  public void setUser(final @Nullable User user) {
+    this.user = user;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -76,7 +76,7 @@ public abstract class SentryBaseEvent {
   private @Nullable String platform;
 
   /** Information about the user who triggered this event. */
-  private User user;
+  private @Nullable User user;
 
   /** The captured Throwable */
   protected transient @Nullable Throwable throwable;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -496,6 +496,9 @@ public final class SentryClient implements ISentryClient {
       if (sentryBaseEvent.getRequest() == null) {
         sentryBaseEvent.setRequest(scope.getRequest());
       }
+      if (sentryBaseEvent.getUser() == null) {
+        sentryBaseEvent.setUser(scope.getUser());
+      }
       if (sentryBaseEvent.getTags() == null) {
         sentryBaseEvent.setTags(new HashMap<>(scope.getTags()));
       } else {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -70,8 +70,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
    */
   private String transaction;
 
-  /** Information about the user who triggered this event. */
-  private User user;
   /**
    * Manual fingerprint override.
    *
@@ -204,14 +202,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void setTransaction(String transaction) {
     this.transaction = transaction;
-  }
-
-  public User getUser() {
-    return user;
-  }
-
-  public void setUser(User user) {
-    this.user = user;
   }
 
   public List<String> getFingerprints() {

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -215,19 +215,22 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(sendDefaultPii = true)
         val event = SentryEvent()
         sut.process(event, null)
-        assertNotNull(event.user)
-        assertEquals("{{auto}}", event.user.ipAddress)
+        assertNotNull(event.user) {
+            assertEquals("{{auto}}", it.ipAddress)
+        }
     }
 
     @Test
     fun `when event has ip address set and sendDefaultPii is set to true, keeps original ip address`() {
         val sut = fixture.getSut(sendDefaultPii = true)
         val event = SentryEvent()
-        event.user = User()
-        event.user.ipAddress = "192.168.0.1"
+        event.user = User().apply {
+            ipAddress = "192.168.0.1"
+        }
         sut.process(event, null)
-        assertNotNull(event.user)
-        assertEquals("192.168.0.1", event.user.ipAddress)
+        assertNotNull(event.user) {
+            assertEquals("192.168.0.1", it.ipAddress)
+        }
     }
 
     @Test
@@ -236,8 +239,9 @@ class MainEventProcessorTest {
         val event = SentryEvent()
         event.user = User()
         sut.process(event, null)
-        assertNotNull(event.user)
-        assertNull(event.user.ipAddress)
+        assertNotNull(event.user) {
+            assertNull(it.ipAddress)
+        }
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -266,7 +266,9 @@ class SentryClientTest {
         assertEquals("extra", event.extras["extra"])
         assertEquals("tags", event.tags["tags"])
         assertEquals("fp", event.fingerprints[0])
-        assertEquals("id", event.user.id)
+        assertNotNull(event.user) {
+            assertEquals("id", it.id)
+        }
         assertEquals(SentryLevel.FATAL, event.level)
         assertNotNull(event.request) {
             assertEquals("post", it.method)
@@ -324,7 +326,9 @@ class SentryClientTest {
 
         assertEquals("eventTransaction", event.transaction)
 
-        assertEquals("eventId", event.user.id)
+        assertNotNull(event.user) {
+            assertEquals("eventId", it.id)
+        }
 
         assertEquals(SentryLevel.FATAL, event.level)
     }
@@ -820,6 +824,19 @@ class SentryClientTest {
                 }
             }
         }, eq(null))
+    }
+
+    @Test
+    fun `when captureTransaction with scope, transaction should use user data`() {
+        val transaction = SentryTransaction(SentryTracer(TransactionContext("tx", "op"), mock()))
+        val scope = createScope()
+
+        val sut = fixture.getSut()
+
+        sut.captureTransaction(transaction, scope, null)
+        assertNotNull(transaction.user) {
+            assertEquals("id", it.id)
+        }
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Apply user from the scope to transaction.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1335 Note: this does not solve the issue of setting user on transaction in Spring/Spring Boot integrations.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

Adding nullability annotations to `user` makes it a breaking change for Kotlin users.

## :crystal_ball: Next steps

Fix setting user on transaction for Spring & Spring Boot.
