### PR TITLE
Fix setting transaction name on events sent after transaction is over.

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -127,7 +127,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -165,7 +165,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -218,7 +218,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setFingerprint (Ljava/util/List;)V
 	public abstract fun setLevel (Lio/sentry/SentryLevel;)V
-	public abstract fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
+	public abstract fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;Ljava/lang/String;)V
 	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setTransaction (Ljava/lang/String;)V
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
@@ -368,7 +368,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -1873,10 +1873,8 @@ public final class io/sentry/util/Objects {
 
 public final class io/sentry/util/Pair {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
-	public fun equals (Ljava/lang/Object;)Z
 	public fun getFirst ()Ljava/lang/Object;
 	public fun getSecond ()Ljava/lang/Object;
-	public fun hashCode ()I
 }
 
 public final class io/sentry/util/StringUtils {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -127,7 +127,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -165,7 +165,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -218,7 +218,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setFingerprint (Ljava/util/List;)V
 	public abstract fun setLevel (Lio/sentry/SentryLevel;)V
-	public abstract fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;)V
+	public abstract fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
 	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setTransaction (Ljava/lang/String;)V
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
@@ -368,7 +368,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
-	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/ISpan;)V
+	public fun setSpanContext (Ljava/lang/Throwable;Lio/sentry/util/Pair;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
@@ -1869,6 +1869,14 @@ public final class io/sentry/util/LogUtils {
 
 public final class io/sentry/util/Objects {
 	public static fun requireNonNull (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+}
+
+public final class io/sentry/util/Pair {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFirst ()Ljava/lang/Object;
+	public fun getSecond ()Ljava/lang/Object;
+	public fun hashCode ()I
 }
 
 public final class io/sentry/util/StringUtils {

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -7,6 +7,7 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
+import io.sentry.util.Pair;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
@@ -22,7 +23,7 @@ public final class Hub implements IHub {
   private volatile boolean isEnabled;
   private final @NotNull Stack stack;
   private final @NotNull TracesSampler tracesSampler;
-  private final @NotNull Map<Throwable, ISpan> throwableToSpan =
+  private final @NotNull Map<Throwable, Pair<ISpan, String>> throwableToSpan =
       Collections.synchronizedMap(new WeakHashMap<>());
 
   public Hub(final @NotNull SentryOptions options) {
@@ -174,10 +175,13 @@ public final class Hub implements IHub {
 
   private void assignTraceContext(final @NotNull SentryEvent event) {
     if (event.getThrowable() != null) {
-      final ISpan span = throwableToSpan.get(event.getThrowable());
-      if (span != null) {
+      final Pair<ISpan, String> pair = throwableToSpan.get(event.getThrowable());
+      if (pair != null) {
         if (event.getContexts().getTrace() == null) {
-          event.getContexts().setTrace(span.getSpanContext());
+          event.getContexts().setTrace(pair.getFirst().getSpanContext());
+        }
+        if (event.getTransaction() == null) {
+          event.setTransaction(pair.getSecond());
         }
       }
     }
@@ -632,7 +636,8 @@ public final class Hub implements IHub {
 
   @Override
   @ApiStatus.Internal
-  public void setSpanContext(final @NotNull Throwable throwable, final @NotNull ISpan span) {
+  public void setSpanContext(
+      final @NotNull Throwable throwable, final @NotNull Pair<ISpan, String> span) {
     Objects.requireNonNull(throwable, "throwable is required");
     Objects.requireNonNull(span, "span is required");
     // the most inner span should be assigned to a throwable
@@ -644,9 +649,9 @@ public final class Hub implements IHub {
   @Nullable
   SpanContext getSpanContext(final @NotNull Throwable throwable) {
     Objects.requireNonNull(throwable, "throwable is required");
-    final ISpan span = this.throwableToSpan.get(throwable);
+    final Pair<ISpan, String> span = this.throwableToSpan.get(throwable);
     if (span != null) {
-      return span.getSpanContext();
+      return span.getFirst().getSpanContext();
     }
     return null;
   }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -637,12 +637,15 @@ public final class Hub implements IHub {
   @Override
   @ApiStatus.Internal
   public void setSpanContext(
-      final @NotNull Throwable throwable, final @NotNull Pair<ISpan, String> span) {
+      final @NotNull Throwable throwable,
+      final @NotNull ISpan span,
+      final @NotNull String transactionName) {
     Objects.requireNonNull(throwable, "throwable is required");
     Objects.requireNonNull(span, "span is required");
+    Objects.requireNonNull(transactionName, "transactionName is required");
     // the most inner span should be assigned to a throwable
     if (!throwableToSpan.containsKey(throwable)) {
-      this.throwableToSpan.put(throwable, span);
+      this.throwableToSpan.put(throwable, new Pair<>(span, transactionName));
     }
   }
 

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -3,7 +3,6 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
-import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -179,8 +178,11 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void setSpanContext(final @NotNull Throwable t, final @NotNull Pair<ISpan, String> sc) {
-    Sentry.getCurrentHub().setSpanContext(t, sc);
+  public void setSpanContext(
+      final @NotNull Throwable t,
+      final @NotNull ISpan span,
+      final @NotNull String transactionName) {
+    Sentry.getCurrentHub().setSpanContext(t, span, transactionName);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -179,10 +179,10 @@ public final class HubAdapter implements IHub {
 
   @Override
   public void setSpanContext(
-      final @NotNull Throwable t,
+      final @NotNull Throwable throwable,
       final @NotNull ISpan span,
       final @NotNull String transactionName) {
-    Sentry.getCurrentHub().setSpanContext(t, span, transactionName);
+    Sentry.getCurrentHub().setSpanContext(throwable, span, transactionName);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -178,7 +179,7 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void setSpanContext(final @NotNull Throwable t, final @NotNull ISpan sc) {
+  public void setSpanContext(final @NotNull Throwable t, final @NotNull Pair<ISpan, String> sc) {
     Sentry.getCurrentHub().setSpanContext(t, sc);
   }
 

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -410,7 +410,7 @@ public interface IHub {
    * @param transactionName the transaction name
    */
   @ApiStatus.Internal
-  void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span, String transactionName);
+  void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span, @NotNull String transactionName);
 
   /**
    * Gets the current active transaction or span.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -402,14 +403,14 @@ public interface IHub {
   SentryTraceHeader traceHeaders();
 
   /**
-   * Associates {@link ISpan} with the {@link Throwable}. Used to determine in which trace the
-   * exception has been thrown in framework integrations.
+   * Associates {@link ISpan} and the transaction name with the {@link Throwable}. Used to determine
+   * in which trace the exception has been thrown in framework integrations.
    *
    * @param throwable the throwable
-   * @param span the span context
+   * @param span a pair of span context and transaction name
    */
   @ApiStatus.Internal
-  void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span);
+  void setSpanContext(@NotNull Throwable throwable, @NotNull Pair<ISpan, String> span);
 
   /**
    * Gets the current active transaction or span.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -3,7 +3,6 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
-import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -407,10 +406,11 @@ public interface IHub {
    * in which trace the exception has been thrown in framework integrations.
    *
    * @param throwable the throwable
-   * @param span a pair of span context and transaction name
+   * @param span the span context
+   * @param transactionName the transaction name
    */
   @ApiStatus.Internal
-  void setSpanContext(@NotNull Throwable throwable, @NotNull Pair<ISpan, String> span);
+  void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span, String transactionName);
 
   /**
    * Gets the current active transaction or span.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -410,7 +410,8 @@ public interface IHub {
    * @param transactionName the transaction name
    */
   @ApiStatus.Internal
-  void setSpanContext(@NotNull Throwable throwable, @NotNull ISpan span, @NotNull String transactionName);
+  void setSpanContext(
+      @NotNull Throwable throwable, @NotNull ISpan span, @NotNull String transactionName);
 
   /**
    * Gets the current active transaction or span.

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -3,7 +3,6 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
-import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -141,7 +140,9 @@ public final class NoOpHub implements IHub {
 
   @Override
   public void setSpanContext(
-      final @NotNull Throwable throwable, final @NotNull Pair<ISpan, String> spanContext) {}
+      final @NotNull Throwable throwable,
+      final @NotNull ISpan spanContext,
+      final @NotNull String transactionName) {}
 
   @Override
   public @Nullable ISpan getSpan() {

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.util.Pair;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -140,7 +141,7 @@ public final class NoOpHub implements IHub {
 
   @Override
   public void setSpanContext(
-      final @NotNull Throwable throwable, final @NotNull ISpan spanContext) {}
+      final @NotNull Throwable throwable, final @NotNull Pair<ISpan, String> spanContext) {}
 
   @Override
   public @Nullable ISpan getSpan() {

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -2,7 +2,6 @@ package io.sentry;
 
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
-import io.sentry.util.Pair;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -95,7 +94,7 @@ public final class Span implements ISpan {
     this.context.setStatus(status);
     timestamp = DateUtils.getCurrentDateTime();
     if (throwable != null) {
-      hub.setSpanContext(throwable, new Pair<>(this, this.transaction.getName()));
+      hub.setSpanContext(throwable, this, this.transaction.getName());
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
+import io.sentry.util.Pair;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -94,7 +95,7 @@ public final class Span implements ISpan {
     this.context.setStatus(status);
     timestamp = DateUtils.getCurrentDateTime();
     if (throwable != null) {
-      hub.setSpanContext(throwable, this);
+      hub.setSpanContext(throwable, new Pair<>(this, this.transaction.getName()));
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/Pair.java
+++ b/sentry/src/main/java/io/sentry/util/Pair.java
@@ -20,22 +20,4 @@ public final class Pair<A, B> {
   public @Nullable B getSecond() {
     return second;
   }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    Pair<?, ?> pair = (Pair<?, ?>) o;
-
-    if (first != null ? !first.equals(pair.first) : pair.first != null) return false;
-    return second != null ? second.equals(pair.second) : pair.second == null;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = first != null ? first.hashCode() : 0;
-    result = 31 * result + (second != null ? second.hashCode() : 0);
-    return result;
-  }
 }

--- a/sentry/src/main/java/io/sentry/util/Pair.java
+++ b/sentry/src/main/java/io/sentry/util/Pair.java
@@ -1,7 +1,9 @@
 package io.sentry.util;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+@ApiStatus.Internal
 public final class Pair<A, B> {
   private final @Nullable A first;
   private final @Nullable B second;

--- a/sentry/src/main/java/io/sentry/util/Pair.java
+++ b/sentry/src/main/java/io/sentry/util/Pair.java
@@ -1,0 +1,39 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.Nullable;
+
+public final class Pair<A, B> {
+  private final @Nullable A first;
+  private final @Nullable B second;
+
+  public Pair(final @Nullable A first, final @Nullable B second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  public @Nullable A getFirst() {
+    return first;
+  }
+
+  public @Nullable B getSecond() {
+    return second;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Pair<?, ?> pair = (Pair<?, ?>) o;
+
+    if (first != null ? !first.equals(pair.first) : pair.first != null) return false;
+    return second != null ? second.equals(pair.second) : pair.second == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = first != null ? first.hashCode() : 0;
+    result = 31 * result + (second != null ? second.hashCode() : 0);
+    return result;
+  }
+}

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -314,7 +314,7 @@ class HubTest {
         val exception = RuntimeException()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
+        sut.setSpanContext(exception, span, "tx-name")
 
         val event = SentryEvent(exception)
 
@@ -330,7 +330,7 @@ class HubTest {
         val exception = RuntimeException()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
+        sut.setSpanContext(exception, span, "tx-name")
 
         val event = SentryEvent(exception)
         val originalSpanContext = SpanContext("op")
@@ -435,7 +435,7 @@ class HubTest {
         val throwable = Throwable()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(throwable, io.sentry.util.Pair(span, "tx-name"))
+        sut.setSpanContext(throwable, span, "tx-name")
 
         sut.captureException(throwable)
         verify(mockClient).captureEvent(check {
@@ -449,7 +449,7 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(Throwable(), io.sentry.util.Pair(span, "tx-name"))
+        sut.setSpanContext(Throwable(), span, "tx-name")
 
         sut.captureException(Throwable())
         verify(mockClient).captureEvent(check {
@@ -1171,7 +1171,7 @@ class HubTest {
         val span = transaction.startChild("op")
         val exception = RuntimeException()
 
-        hub.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
+        hub.setSpanContext(exception, span, "tx-name")
         hub.captureEvent(SentryEvent(exception))
 
         verify(mockClient).captureEvent(check {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -314,7 +314,7 @@ class HubTest {
         val exception = RuntimeException()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(exception, span)
+        sut.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
 
         val event = SentryEvent(exception)
 
@@ -330,7 +330,7 @@ class HubTest {
         val exception = RuntimeException()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(exception, span)
+        sut.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
 
         val event = SentryEvent(exception)
         val originalSpanContext = SpanContext("op")
@@ -435,11 +435,12 @@ class HubTest {
         val throwable = Throwable()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(throwable, span)
+        sut.setSpanContext(throwable, io.sentry.util.Pair(span, "tx-name"))
 
         sut.captureException(throwable)
         verify(mockClient).captureEvent(check {
             assertEquals(span.spanContext, it.contexts.trace)
+            assertEquals("tx-name", it.transaction)
         }, any(), anyOrNull())
     }
 
@@ -448,7 +449,7 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
         val span = mock<Span>()
         whenever(span.spanContext).thenReturn(SpanContext("op"))
-        sut.setSpanContext(Throwable(), span)
+        sut.setSpanContext(Throwable(), io.sentry.util.Pair(span, "tx-name"))
 
         sut.captureException(Throwable())
         verify(mockClient).captureEvent(check {
@@ -1170,7 +1171,7 @@ class HubTest {
         val span = transaction.startChild("op")
         val exception = RuntimeException()
 
-        hub.setSpanContext(exception, span)
+        hub.setSpanContext(exception, io.sentry.util.Pair(span, "tx-name"))
         hub.captureEvent(SentryEvent(exception))
 
         verify(mockClient).captureEvent(check {

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -85,5 +85,5 @@ class NoOpHubTest {
     }
 
     @Test
-    fun `setSpanContext doesnt throw`() = sut.setSpanContext(RuntimeException(), mock())
+    fun `setSpanContext doesnt throw`() = sut.setSpanContext(RuntimeException(), mock(), "")
 }

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.protocol.App
 import io.sentry.protocol.Request
+import io.sentry.util.Pair
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -122,7 +123,7 @@ class SentryTracerTest {
         val ex = RuntimeException()
         tracer.throwable = ex
         tracer.finish()
-        verify(fixture.hub).setSpanContext(ex, tracer.root)
+        verify(fixture.hub).setSpanContext(ex, Pair(tracer.root, "name"))
     }
 
     @Test
@@ -284,7 +285,7 @@ class SentryTracerTest {
         transaction.finish(SpanStatus.UNKNOWN_ERROR)
 
         // call only once
-        verify(fixture.hub).setSpanContext(ex, transaction.root)
+        verify(fixture.hub).setSpanContext(ex, Pair(transaction.root, "name"))
         verify(fixture.hub).captureTransaction(check {
             assertEquals(transaction.root.spanContext, it.contexts.trace)
         })

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.protocol.App
 import io.sentry.protocol.Request
-import io.sentry.util.Pair
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -123,7 +122,7 @@ class SentryTracerTest {
         val ex = RuntimeException()
         tracer.throwable = ex
         tracer.finish()
-        verify(fixture.hub).setSpanContext(ex, Pair(tracer.root, "name"))
+        verify(fixture.hub).setSpanContext(ex, tracer.root, "name")
     }
 
     @Test
@@ -285,7 +284,7 @@ class SentryTracerTest {
         transaction.finish(SpanStatus.UNKNOWN_ERROR)
 
         // call only once
-        verify(fixture.hub).setSpanContext(ex, Pair(transaction.root, "name"))
+        verify(fixture.hub).setSpanContext(ex, transaction.root, "name")
         verify(fixture.hub).captureTransaction(check {
             assertEquals(transaction.root.spanContext, it.contexts.trace)
         })

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.protocol.SentryId
-import io.sentry.util.Pair
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -124,7 +123,7 @@ class SpanTest {
         span.throwable = ex
         span.finish()
 
-        verify(fixture.hub).setSpanContext(ex, Pair(span, "name"))
+        verify(fixture.hub).setSpanContext(ex, span, "name")
     }
 
     @Test
@@ -139,7 +138,7 @@ class SpanTest {
         span.finish(SpanStatus.UNKNOWN_ERROR)
 
         // call only once
-        verify(fixture.hub).setSpanContext(any(), any())
+        verify(fixture.hub).setSpanContext(any(), any(), any())
         assertEquals(SpanStatus.OK, span.status)
         assertEquals(timestamp, span.timestamp)
     }

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.protocol.SentryId
+import io.sentry.util.Pair
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -123,7 +124,7 @@ class SpanTest {
         span.throwable = ex
         span.finish()
 
-        verify(fixture.hub).setSpanContext(ex, span)
+        verify(fixture.hub).setSpanContext(ex, Pair(span, "name"))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix setting transaction name on events sent after transaction is over.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Events that got triggered after span/transaction is over, but are connected with a span, must have also `transaction` field set, so that they are searchable in the UI by transaction name.

Also, without `transaction` field set, the red error box is not shown on the transaction details page (like below)
![image](https://user-images.githubusercontent.com/1357927/115529564-4d8e5d80-a293-11eb-91ec-add8a5063e58.png)

This topic has been discussed on Discord: https://discord.com/channels/621778831602221064/777210445442187274/834151506620973058


## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes