### PR TITLE
Fix: Run event processors and enrich transactions with contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix: Do not set free memory and is low memory fields when it's a NDK hard crash (#1399)
 * Fix: Apply user from the scope to transaction (#1424)
 * Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
+* Fix: Run event processors and enrich transactions with contexts (#1430)
 
 # 4.4.0-alpha.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix: set correct transaction status for unhandled exceptions in SentryTracingFilter (#1406)
 * Fix: handle network errors in SentrySpanClientHttpRequestInterceptor (#1407)
 * Fix: set scope on transaction (#1409)
+* Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
 
 # 4.4.0-alpha.2
 

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ checkFormat:
 # Spotless format's code
 format:
 	./gradlew spotlessApply
+
+# Binary compatibility validator
+api:
+	./gradlew apiDump

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -94,4 +94,5 @@ dependencies {
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.awaitility)
+    testImplementation(project(":sentry-test-support"))
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -157,9 +157,11 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setCommons(
-      final @NotNull SentryBaseEvent event, final boolean doIO, final boolean applyScopeData) {
+      final @NotNull SentryBaseEvent event,
+      final boolean errorEvent,
+      final boolean applyScopeData) {
     mergeUser(event);
-    setDevice(event, doIO, applyScopeData);
+    setDevice(event, errorEvent, applyScopeData);
     mergeOS(event);
     setSideLoadedInfo(event);
   }
@@ -188,9 +190,11 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setDevice(
-      final @NotNull SentryBaseEvent event, final boolean doIO, final boolean applyScopeData) {
+      final @NotNull SentryBaseEvent event,
+      final boolean errorEvent,
+      final boolean applyScopeData) {
     if (event.getContexts().getDevice() == null) {
-      event.getContexts().setDevice(getDevice(doIO, applyScopeData));
+      event.getContexts().setDevice(getDevice(errorEvent, applyScopeData));
     }
   }
 
@@ -337,7 +341,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   // we can get some inspiration here
   // https://github.com/flutter/plugins/blob/master/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
-  private @NotNull Device getDevice(final boolean doIO, final boolean applyScopeData) {
+  private @NotNull Device getDevice(final boolean errorEvent, final boolean applyScopeData) {
     // TODO: missing usable memory
 
     Device device = new Device();
@@ -350,7 +354,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     setArchitectures(device);
 
     // setting such values require IO hence we don't run for transactions
-    if (doIO) {
+    if (errorEvent) {
       setDeviceIO(device, applyScopeData);
     }
 
@@ -1012,7 +1016,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   @Override
-  public @Nullable SentryTransaction process(
+  public @NotNull SentryTransaction process(
       final @NotNull SentryTransaction transaction, final @Nullable Object hint) {
     final boolean applyScopeData = shouldApplyScopeData(transaction, hint);
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -351,7 +351,7 @@ class DefaultAndroidEventProcessorTest {
     }
 
     @Test
-    fun `Transaction sets device's context`() {
+    fun `Device's context is set on transactions`() {
         val sut = fixture.getSut(context)
 
         assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {
@@ -360,7 +360,7 @@ class DefaultAndroidEventProcessorTest {
     }
 
     @Test
-    fun `Transaction sets device's OS`() {
+    fun `Device's OS is set on transactions`() {
         val sut = fixture.getSut(context)
 
         assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -193,6 +193,7 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
     jmethodID environment_mid = (*env)->GetMethodID(env, options_cls, "getEnvironment",
                                                     "()Ljava/lang/String;");
     jmethodID dist_mid = (*env)->GetMethodID(env, options_cls, "getDist", "()Ljava/lang/String;");
+    jmethodID max_crumbs_mid = (*env)->GetMethodID(env, options_cls, "getMaxBreadcrumbs", "()I");
 
     jstring outbox_path_j = (jstring) (*env)->CallObjectMethod(env, sentry_sdk_options,
                                                                outbox_path_mid);
@@ -202,6 +203,7 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
     jstring environment = (jstring) (*env)->CallObjectMethod(env, sentry_sdk_options,
                                                              environment_mid);
     jstring dist = (jstring) (*env)->CallObjectMethod(env, sentry_sdk_options, dist_mid);
+    jint max_crumbs = (jint) (*env)->CallIntMethod(env, sentry_sdk_options, max_crumbs_mid);
 
     ENSURE(outbox_path_j);
     const char *outbox_path_str = (*env)->GetStringUTFChars(env, outbox_path_j, 0);
@@ -229,6 +231,8 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
 
     sentry_options_set_transport(options, transport);
     sentry_options_set_debug(options, debug);
+    sentry_options_set_max_breadcrumbs(options, max_crumbs);
+
     const char *dsn_str = (*env)->GetStringUTFChars(env, dsn, 0);
     sentry_options_set_dsn(options, dsn_str);
     (*env)->ReleaseStringUTFChars(env, dsn, dsn_str);

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -1,5 +1,6 @@
 package io.sentry.samples.console;
 
+import com.sun.istack.internal.NotNull;
 import io.sentry.Breadcrumb;
 import io.sentry.EventProcessor;
 import io.sentry.ISpan;
@@ -166,7 +167,7 @@ public class Main {
 
   private static class SomeEventProcessor implements EventProcessor {
     @Override
-    public SentryEvent process(SentryEvent event, Object hint) {
+    public @NotNull SentryEvent process(SentryEvent event, Object hint) {
       // Here you can modify the event as you need
       if (event.getLevel() != null && event.getLevel().ordinal() > SentryLevel.INFO.ordinal()) {
         event.addBreadcrumb(new Breadcrumb("Processed by " + SomeEventProcessor.class));

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -1,6 +1,5 @@
 package io.sentry.samples.console;
 
-import com.sun.istack.internal.NotNull;
 import io.sentry.Breadcrumb;
 import io.sentry.EventProcessor;
 import io.sentry.ISpan;
@@ -167,7 +166,7 @@ public class Main {
 
   private static class SomeEventProcessor implements EventProcessor {
     @Override
-    public @NotNull SentryEvent process(SentryEvent event, Object hint) {
+    public SentryEvent process(SentryEvent event, Object hint) {
       // Here you can modify the event as you need
       if (event.getLevel() != null && event.getLevel().ordinal() > SentryLevel.INFO.ordinal()) {
         event.addBreadcrumb(new Breadcrumb("Processed by " + SomeEventProcessor.class));

--- a/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
@@ -26,7 +26,7 @@ public class CustomEventProcessor implements EventProcessor {
   }
 
   @Override
-  public SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint) {
+  public @NotNull SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint) {
     final SentryRuntime runtime = new SentryRuntime();
     runtime.setVersion(javaVersion);
     runtime.setName(javaVendor);

--- a/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.samples.spring.boot;
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
 import io.sentry.protocol.SentryRuntime;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +26,7 @@ public class CustomEventProcessor implements EventProcessor {
   }
 
   @Override
-  public SentryEvent process(SentryEvent event, @Nullable Object hint) {
+  public SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint) {
     final SentryRuntime runtime = new SentryRuntime();
     runtime.setVersion(javaVersion);
     runtime.setName(javaVendor);

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -62,6 +62,7 @@ public final class io/sentry/spring/SentryUserProviderEventProcessor : io/sentry
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/spring/SentryUserProvider;)V
 	public fun getSentryUserProvider ()Lio/sentry/spring/SentryUserProvider;
 	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public class io/sentry/spring/SentryWebConfiguration {

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+// TODO: check if I need to support process(SentryTransaction) here
 public final class SentryUserProviderEventProcessor implements EventProcessor {
   private final @NotNull SentryOptions options;
   private final @NotNull SentryUserProvider sentryUserProvider;

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserProviderEventProcessorTest.kt
@@ -208,11 +208,13 @@ class SentryUserProviderEventProcessorTest {
     }
 
     @Test
-    fun `Transaction sets the user`() {
+    fun `User is set on transaction`() {
         val processor = fixture.getSut(isSendDefaultPii = true) {
             User()
         }
 
-        assertNotNull(processor.process(SentryTransaction(fixture.sentryTracer), null))
+        val result = processor.process(SentryTransaction(fixture.sentryTracer), null)
+
+        assertNotNull(result.user)
     }
 }

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -2,3 +2,7 @@ public final class io/sentry/test/AssertionsKt {
 	public static final fun checkEvent (Lkotlin/jvm/functions/Function1;)Lio/sentry/SentryEnvelope;
 }
 
+public final class io/sentry/test/ReflectionKt {
+	public static final fun getCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+}
+

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/reflection.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/reflection.kt
@@ -1,5 +1,7 @@
 package io.sentry.test
 
+import java.lang.reflect.Constructor
+
 inline fun <reified T : Any> T.injectForField(name: String, value: Any?) {
     T::class.java.getDeclaredField(name)
         .apply { isAccessible = true }
@@ -19,3 +21,8 @@ inline fun <reified T> Any.getProperty(name: String): T =
     }.apply {
         this.isAccessible = true
     }.get(this) as T
+
+fun String.getCtor(ctorTypes: Array<Class<*>>): Constructor<*> {
+    val clazz = Class.forName(this)
+    return clazz.getConstructor(*ctorTypes)
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -88,6 +88,7 @@ public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
 
 public abstract interface class io/sentry/EventProcessor {
 	public abstract fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public final class io/sentry/GsonSerializer : io/sentry/ISerializer {
@@ -331,8 +332,8 @@ public final class io/sentry/IpAddressUtils {
 }
 
 public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor {
-	public static final field DEFAULT_IP_ADDRESS Ljava/lang/String;
 	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
@@ -601,25 +602,37 @@ public abstract class io/sentry/SentryBaseEvent {
 	protected field throwable Ljava/lang/Throwable;
 	protected fun <init> ()V
 	protected fun <init> (Lio/sentry/protocol/SentryId;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
+	public fun addBreadcrumb (Ljava/lang/String;)V
+	public fun getBreadcrumbs ()Ljava/util/List;
 	public fun getContexts ()Lio/sentry/protocol/Contexts;
+	public fun getDist ()Ljava/lang/String;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
+	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getOriginThrowable ()Ljava/lang/Throwable;
 	public fun getPlatform ()Ljava/lang/String;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getSdk ()Lio/sentry/protocol/SdkVersion;
+	public fun getServerName ()Ljava/lang/String;
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getTags ()Ljava/util/Map;
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun getUser ()Lio/sentry/protocol/User;
+	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
+	public fun setBreadcrumbs (Ljava/util/List;)V
+	public fun setDist (Ljava/lang/String;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setEventId (Lio/sentry/protocol/SentryId;)V
+	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setExtras (Ljava/util/Map;)V
 	public fun setPlatform (Ljava/lang/String;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setRequest (Lio/sentry/protocol/Request;)V
 	public fun setSdk (Lio/sentry/protocol/SdkVersion;)V
+	public fun setServerName (Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTags (Ljava/util/Map;)V
 	public fun setThrowable (Ljava/lang/Throwable;)V
@@ -694,40 +707,28 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun <init> (Ljava/lang/Throwable;)V
 	public fun <init> (Ljava/util/Date;)V
 	public fun acceptUnknownProperties (Ljava/util/Map;)V
-	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
-	public fun addBreadcrumb (Ljava/lang/String;)V
-	public fun getBreadcrumbs ()Ljava/util/List;
 	public fun getDebugMeta ()Lio/sentry/protocol/DebugMeta;
-	public fun getDist ()Ljava/lang/String;
 	public fun getExceptions ()Ljava/util/List;
-	public fun getExtra (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getFingerprints ()Ljava/util/List;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getLogger ()Ljava/lang/String;
 	public fun getMessage ()Lio/sentry/protocol/Message;
 	public fun getModule (Ljava/lang/String;)Ljava/lang/String;
-	public fun getServerName ()Ljava/lang/String;
 	public fun getThreads ()Ljava/util/List;
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun getTransaction ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun isCrashed ()Z
 	public fun isErrored ()Z
-	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeModule (Ljava/lang/String;)V
-	public fun setBreadcrumbs (Ljava/util/List;)V
 	public fun setDebugMeta (Lio/sentry/protocol/DebugMeta;)V
-	public fun setDist (Ljava/lang/String;)V
 	public fun setExceptions (Ljava/util/List;)V
-	public fun setExtra (Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setExtras (Ljava/util/Map;)V
 	public fun setFingerprints (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
 	public fun setLogger (Ljava/lang/String;)V
 	public fun setMessage (Lio/sentry/protocol/Message;)V
 	public fun setModule (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setModules (Ljava/util/Map;)V
-	public fun setServerName (Ljava/lang/String;)V
 	public fun setThreads (Ljava/util/List;)V
 	public fun setTransaction (Ljava/lang/String;)V
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -87,7 +87,7 @@ public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
 }
 
 public abstract interface class io/sentry/EventProcessor {
-	public abstract fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryTransaction;
 }
 

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -20,7 +20,8 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
   }
 
   @Override
-  public SentryEvent process(final @NotNull SentryEvent event, final @Nullable Object hint) {
+  public @Nullable SentryEvent process(
+      final @NotNull SentryEvent event, final @Nullable Object hint) {
     if (options.isEnableDeduplication()) {
       final Throwable throwable = event.getOriginThrowable();
       if (throwable != null) {

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -6,7 +6,9 @@ import org.jetbrains.annotations.Nullable;
 
 public interface EventProcessor {
   @Nullable
-  SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint);
+  default SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint) {
+    return event;
+  }
 
   @Nullable
   default SentryTransaction process(@NotNull SentryTransaction transaction, @Nullable Object hint) {

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -1,9 +1,15 @@
 package io.sentry;
 
+import io.sentry.protocol.SentryTransaction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface EventProcessor {
   @Nullable
   SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint);
+
+  @Nullable
+  default SentryTransaction process(@NotNull SentryTransaction transaction, @Nullable Object hint) {
+    return transaction;
+  }
 }

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -4,12 +4,30 @@ import io.sentry.protocol.SentryTransaction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * An Event Processor that may mutate or drop an event. Runs for SentryEvent or SentryTransaction
+ */
 public interface EventProcessor {
+
+  /**
+   * May mutate or drop a SentryEvent
+   *
+   * @param event the SentryEvent
+   * @param hint the Hint
+   * @return the event itself, a mutated SentryEvent or null
+   */
   @Nullable
   default SentryEvent process(@NotNull SentryEvent event, @Nullable Object hint) {
     return event;
   }
 
+  /**
+   * May mutate or drop a SentryTransaction
+   *
+   * @param transaction the SentryTransaction
+   * @param hint the Hint
+   * @return the event itself, a mutated SentryTransaction or null
+   */
   @Nullable
   default SentryTransaction process(@NotNull SentryTransaction transaction, @Nullable Object hint) {
     return transaction;

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -97,7 +97,7 @@ public final class MainEventProcessor implements EventProcessor {
   }
 
   @Override
-  public @Nullable SentryTransaction process(
+  public @NotNull SentryTransaction process(
       final @NotNull SentryTransaction transaction, final @Nullable Object hint) {
     setCommons(transaction);
 

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -6,7 +6,9 @@ import io.sentry.protocol.Request;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -98,6 +100,16 @@ public abstract class SentryBaseEvent {
    * code of an Android build.
    */
   private String dist;
+
+  /** List of breadcrumbs recorded before this event. */
+  private List<Breadcrumb> breadcrumbs;
+
+  /**
+   * Arbitrary extra information set by the user.
+   *
+   * <p>```json { "extra": { "my_key": 1, "some_other_value": "foo bar" } }```
+   */
+  private Map<String, Object> extra;
 
   protected SentryBaseEvent(final @NotNull SentryId eventId) {
     this.eventId = eventId;
@@ -243,5 +255,52 @@ public abstract class SentryBaseEvent {
 
   public void setUser(final @Nullable User user) {
     this.user = user;
+  }
+
+  public List<Breadcrumb> getBreadcrumbs() {
+    return breadcrumbs;
+  }
+
+  public void setBreadcrumbs(List<Breadcrumb> breadcrumbs) {
+    this.breadcrumbs = breadcrumbs;
+  }
+
+  public void addBreadcrumb(Breadcrumb breadcrumb) {
+    if (breadcrumbs == null) {
+      breadcrumbs = new ArrayList<>();
+    }
+    breadcrumbs.add(breadcrumb);
+  }
+
+  Map<String, Object> getExtras() {
+    return extra;
+  }
+
+  public void setExtras(Map<String, Object> extra) {
+    this.extra = extra;
+  }
+
+  public void setExtra(String key, Object value) {
+    if (extra == null) {
+      extra = new HashMap<>();
+    }
+    extra.put(key, value);
+  }
+
+  public void removeExtra(@NotNull String key) {
+    if (extra != null) {
+      extra.remove(key);
+    }
+  }
+
+  public @Nullable Object getExtra(final @NotNull String key) {
+    if (extra != null) {
+      return extra.get(key);
+    }
+    return null;
+  }
+
+  public void addBreadcrumb(final @Nullable String message) {
+    this.addBreadcrumb(new Breadcrumb(message));
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -77,6 +77,24 @@ public abstract class SentryBaseEvent {
   /** The captured Throwable */
   protected transient @Nullable Throwable throwable;
 
+  /**
+   * Server or device name the event was generated on.
+   *
+   * <p>This is supposed to be a hostname.
+   */
+  private String serverName;
+
+  /**
+   * Program's distribution identifier.
+   *
+   * <p>The distribution of the application.
+   *
+   * <p>Distributions are used to disambiguate build or deployment variants of the same release of
+   * an application. For example, the dist can be the build number of an XCode build or the version
+   * code of an Android build.
+   */
+  private String dist;
+
   protected SentryBaseEvent(final @NotNull SentryId eventId) {
     this.eventId = eventId;
   }
@@ -197,5 +215,21 @@ public abstract class SentryBaseEvent {
 
   public void setPlatform(final @Nullable String platform) {
     this.platform = platform;
+  }
+
+  public String getServerName() {
+    return serverName;
+  }
+
+  public void setServerName(String serverName) {
+    this.serverName = serverName;
+  }
+
+  public String getDist() {
+    return dist;
+  }
+
+  public void setDist(String dist) {
+    this.dist = dist;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -81,6 +81,7 @@ public final class SentryClient implements ISentryClient {
 
       if (event == null) {
         options.getLogger().log(SentryLevel.DEBUG, "Event was dropped by applyScope");
+        return SentryId.EMPTY_ID;
       }
     }
 
@@ -103,8 +104,6 @@ public final class SentryClient implements ISentryClient {
       }
     }
 
-    SentryId sentryId = SentryId.EMPTY_ID;
-
     if (event != null) {
       if (event.getOriginThrowable() != null
           && options.containsIgnoredExceptionForType(event.getOriginThrowable())) {
@@ -114,7 +113,7 @@ public final class SentryClient implements ISentryClient {
                 SentryLevel.DEBUG,
                 "Event was dropped as the exception %s is ignored",
                 event.getOriginThrowable().getClass());
-        return sentryId;
+        return SentryId.EMPTY_ID;
       }
       event = executeBeforeSend(event, hint);
 
@@ -123,7 +122,8 @@ public final class SentryClient implements ISentryClient {
       }
     }
 
-    if (event != null) {
+    SentryId sentryId = SentryId.EMPTY_ID;
+    if (event != null && event.getEventId() != null) {
       sentryId = event.getEventId();
     }
 
@@ -402,7 +402,10 @@ public final class SentryClient implements ISentryClient {
         .getLogger()
         .log(SentryLevel.DEBUG, "Capturing transaction: %s", transaction.getEventId());
 
-    SentryId sentryId = transaction.getEventId();
+    SentryId sentryId = SentryId.EMPTY_ID;
+    if (transaction.getEventId() != null) {
+      sentryId = transaction.getEventId();
+    }
 
     if (shouldApplyScopeData(transaction, hint)) {
       transaction = applyScope(transaction, scope);

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import io.sentry.protocol.*;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -64,18 +63,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
    * <p>```json { "fingerprint": ["myrpc", "POST", "/foo.bar"] }
    */
   private List<String> fingerprint;
-
-  // TODO: should breadcrumbs be part of a transaction?
-  /** List of breadcrumbs recorded before this event. */
-  private List<Breadcrumb> breadcrumbs;
-
-  // TODO: should extras be part of a transaction?
-  /**
-   * Arbitrary extra information set by the user.
-   *
-   * <p>```json { "extra": { "my_key": 1, "some_other_value": "foo bar" } }```
-   */
-  private Map<String, Object> extra;
 
   private Map<String, Object> unknown;
   /**
@@ -181,53 +168,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void setFingerprints(List<String> fingerprint) {
     this.fingerprint = fingerprint;
-  }
-
-  public List<Breadcrumb> getBreadcrumbs() {
-    return breadcrumbs;
-  }
-
-  public void setBreadcrumbs(List<Breadcrumb> breadcrumbs) {
-    this.breadcrumbs = breadcrumbs;
-  }
-
-  public void addBreadcrumb(Breadcrumb breadcrumb) {
-    if (breadcrumbs == null) {
-      breadcrumbs = new ArrayList<>();
-    }
-    breadcrumbs.add(breadcrumb);
-  }
-
-  public void addBreadcrumb(final @Nullable String message) {
-    this.addBreadcrumb(new Breadcrumb(message));
-  }
-
-  Map<String, Object> getExtras() {
-    return extra;
-  }
-
-  public void setExtras(Map<String, Object> extra) {
-    this.extra = extra;
-  }
-
-  public void setExtra(String key, Object value) {
-    if (extra == null) {
-      extra = new HashMap<>();
-    }
-    extra.put(key, value);
-  }
-
-  public void removeExtra(@NotNull String key) {
-    if (extra != null) {
-      extra.remove(key);
-    }
-  }
-
-  public @Nullable Object getExtra(final @NotNull String key) {
-    if (extra != null) {
-      return extra.get(key);
-    }
-    return null;
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -31,23 +31,7 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
   private final Date timestamp;
 
   private Message message;
-  /**
-   * Server or device name the event was generated on.
-   *
-   * <p>This is supposed to be a hostname.
-   */
-  private String serverName;
 
-  /**
-   * Program's distribution identifier.
-   *
-   * <p>The distribution of the application.
-   *
-   * <p>Distributions are used to disambiguate build or deployment variants of the same release of
-   * an application. For example, the dist can be the build number of an XCode build or the version
-   * code of an Android build.
-   */
-  private String dist;
   /** Logger that created the event. */
   private String logger;
   /** Threads that were active when the event occurred. */
@@ -144,22 +128,6 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
 
   public void setMessage(Message message) {
     this.message = message;
-  }
-
-  public String getServerName() {
-    return serverName;
-  }
-
-  public void setServerName(String serverName) {
-    this.serverName = serverName;
-  }
-
-  public String getDist() {
-    return dist;
-  }
-
-  public void setDist(String dist) {
-    this.dist = dist;
   }
 
   public String getLogger() {

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -64,9 +64,12 @@ public final class SentryEvent extends SentryBaseEvent implements IUnknownProper
    * <p>```json { "fingerprint": ["myrpc", "POST", "/foo.bar"] }
    */
   private List<String> fingerprint;
+
+  // TODO: should breadcrumbs be part of a transaction?
   /** List of breadcrumbs recorded before this event. */
   private List<Breadcrumb> breadcrumbs;
 
+  // TODO: should extras be part of a transaction?
   /**
    * Arbitrary extra information set by the user.
    *

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -342,7 +342,7 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `Transaction sets server name`() {
+    fun `Server name is set on transaction`() {
         val processor = fixture.getSut(serverName = "optionsHost")
 
         var transaction = SentryTransaction(fixture.sentryTracer)
@@ -352,7 +352,7 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `Transaction sets dist`() {
+    fun `Dist is set on transaction`() {
         val processor = fixture.getSut()
 
         var transaction = SentryTransaction(fixture.sentryTracer)
@@ -362,7 +362,7 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `Transaction merges user`() {
+    fun `User is merged on transaction`() {
         val processor = fixture.getSut(sendDefaultPii = true)
 
         var transaction = SentryTransaction(fixture.sentryTracer)

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -26,10 +26,7 @@ class MainEventProcessorTest {
             dsn = dsnString
             release = "release"
             dist = "dist"
-            sdkVersion = SdkVersion().apply {
-                name = "test"
-                version = "1.2.3"
-            }
+            sdkVersion = SdkVersion("test", "1.2.3")
         }
         val getLocalhost = mock<InetAddress>()
 

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.hints.ApplyScopeData
 import io.sentry.hints.Cached
 import io.sentry.protocol.SdkVersion
+import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import java.lang.RuntimeException
 import java.net.InetAddress
@@ -29,6 +30,7 @@ class MainEventProcessorTest {
             sdkVersion = SdkVersion("test", "1.2.3")
         }
         val getLocalhost = mock<InetAddress>()
+        val sentryTracer = SentryTracer(TransactionContext("", ""), mock())
 
         fun getSut(attachThreads: Boolean = true, attachStackTrace: Boolean = true, environment: String? = "environment", tags: Map<String, String> = emptyMap(), sendDefaultPii: Boolean? = null, serverName: String? = "server", host: String? = null, resolveHostDelay: Long? = null, hostnameCacheDuration: Long = 10): MainEventProcessor {
             sentryOptions.isAttachThreads = attachThreads
@@ -337,6 +339,36 @@ class MainEventProcessorTest {
         val event = SentryEvent()
         processor.process(event, null)
         assertEquals("optionsHost", event.serverName)
+    }
+
+    @Test
+    fun `Transaction sets server name`() {
+        val processor = fixture.getSut(serverName = "optionsHost")
+
+        var transaction = SentryTransaction(fixture.sentryTracer)
+        transaction = processor.process(transaction, null)
+
+        assertEquals("optionsHost", transaction.serverName)
+    }
+
+    @Test
+    fun `Transaction sets dist`() {
+        val processor = fixture.getSut()
+
+        var transaction = SentryTransaction(fixture.sentryTracer)
+        transaction = processor.process(transaction, null)
+
+        assertEquals("dist", transaction.dist)
+    }
+
+    @Test
+    fun `Transaction merges user`() {
+        val processor = fixture.getSut(sendDefaultPii = true)
+
+        var transaction = SentryTransaction(fixture.sentryTracer)
+        transaction = processor.process(transaction, null)
+
+        assertNotNull(transaction.user)
     }
 
     private fun generateCrashedEvent(crashedThread: Thread = Thread.currentThread()) = SentryEvent().apply {

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -221,7 +221,7 @@ class ScopeTest {
         scope.addBreadcrumb(Breadcrumb())
         scope.setTag("some", "tag")
         scope.setExtra("some", "extra")
-        scope.addEventProcessor { event, _ -> event }
+        scope.addEventProcessor(eventProcessor())
         scope.addAttachment(Attachment("path"))
 
         scope.clear()
@@ -749,6 +749,14 @@ class ScopeTest {
 
         scope.withTransaction {
             assertNull(it)
+        }
+    }
+
+    private fun eventProcessor(): EventProcessor {
+        return object : EventProcessor {
+            override fun process(event: SentryEvent, hint: Any?): SentryEvent? {
+                return event
+            }
         }
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -56,10 +56,7 @@ class SentryClientTest {
 
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
-            sdkVersion = SdkVersion().apply {
-                name = "test"
-                version = "1.2.3"
-            }
+            sdkVersion = SdkVersion("test", "1.2.3")
             setDebug(true)
             setDiagnosticLevel(SentryLevel.DEBUG)
             setSerializer(GsonSerializer(this))
@@ -544,7 +541,7 @@ class SentryClientTest {
         val event = SentryEvent()
         val scope = createScope()
         val processor = mock<EventProcessor>()
-        whenever(processor.process(any(), anyOrNull())).thenReturn(event)
+        whenever(processor.process(any<SentryEvent>(), anyOrNull())).thenReturn(event)
         scope.addEventProcessor(processor)
 
         val sut = fixture.getSut()

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -774,7 +774,7 @@ class SentryClientTest {
 
     @Test
     fun `exception thrown by an event processor is handled gracefully`() {
-        fixture.sentryOptions.addEventProcessor { _, _ -> throw RuntimeException() }
+        fixture.sentryOptions.addEventProcessor(eventProcessorThrows())
         val sut = fixture.getSut()
         sut.captureEvent(SentryEvent())
     }
@@ -1100,5 +1100,13 @@ class SentryClientTest {
 
     internal class DiskFlushNotificationHint : DiskFlushNotification {
         override fun markFlushed() {}
+    }
+
+    private fun eventProcessorThrows(): EventProcessor {
+        return object : EventProcessor {
+            override fun process(event: SentryEvent, hint: Any?): SentryEvent? {
+                throw RuntimeException()
+            }
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Description
Fix: Run event processors and enrich transactions with contexts


## :bulb: Motivation and Context
Event processors were not run for transactions, so contexts were missing.
Some contexts are heavy for Android, hence there's a flag to not do IO nor IPC if it's a transaction.
Spring User is also run, hence transactions for the Spring integration will contain the user info.
Some fields from Event were moved to BaseEvent so transactions contain more data like breadcrumbs, extra, etc...

## :green_heart: How did you test it?
running and unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
