### PR TITLE
Bump: sentry-native to 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix: set scope on transaction (#1409)
 * Fix: Apply user from the scope to transaction (#1424)
 * Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
+* Bump: sentry-native to 0.4.9
 
 # 4.4.0-alpha.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Fix: set scope on transaction (#1409)
 * Fix: Apply user from the scope to transaction (#1424)
 * Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
-* Bump: sentry-native to 0.4.9
+* Bump: sentry-native to 0.4.9 (#1431)
 
 # 4.4.0-alpha.2
 

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -398,5 +398,5 @@ Java_io_sentry_android_ndk_NativeModuleListLoader_nativeLoadModuleList(JNIEnv *e
 
 JNIEXPORT void JNICALL
 Java_io_sentry_android_ndk_SentryNdk_shutdown(JNIEnv *env, jclass cls) {
-    sentry_shutdown();
+    sentry_close();
 }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -21,8 +21,6 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
-        android:allowNativeHeapPointerTagging="false"
-        android:extractNativeLibs="true"
         tools:ignore="GoogleAppIndexingWarning, UnusedAttribute">
 
         <activity android:name=".MainActivity">


### PR DESCRIPTION
## :scroll: Description
Bump: sentry-native to 0.4.9


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-native/releases/tag/0.4.9


## :green_heart: How did you test it?
locally and running tests on device farm

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
migration page for removing `extractNativeLibs`