### PR TITLE
remove zeus from ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,31 +66,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           name: sentry-java
-
-  release:
-    ## Only run on a release branch
-    if: github.event_name == 'push' && contains(github.ref, 'refs/heads/release')
-    needs: [build]
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download packages
-        uses: actions/download-artifact@v2
-        with:
-          name: artifacts
-          path: ./*/build/distributions/*.zip
-
-      - uses: actions/setup-node@v1
-
-      - name: Install Zeus
-        run: |
-          yarn global add @zeus-ci/cli
-          echo "::add-path::$(yarn global bin)"
-      - name: Upload to Zeus
-        env:
-          ZEUS_API_TOKEN: ${{ secrets.ZEUS_TOKEN }}
-          ZEUS_HOOK_BASE: ${{ secrets.ZEUS_HOOK_BASE }}
-        run: |
-          zeus job update -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA
-          zeus upload -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -t "application/zip+maven" *.zip
-          zeus job update --status=passed -b $GITHUB_RUN_ID -j $GITHUB_RUN_NUMBER -r $GITHUB_SHA


### PR DESCRIPTION
We don't use zeus anymore for releases

Craft expects a GitHub artifact named after the commit sha (which is already done on line 55)

#skip-changelog