### PR TITLE
Fix: set user on transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
 * Fix: Run event processors and enrich transactions with contexts (#1430)
 * Bump: sentry-native to 0.4.9 (#1431)
-* Fix: Set user on transaction (#1443)
+* Fix: Set user on transaction in Spring & Spring Boot integrations (#1443)
 
 # 4.4.0-alpha.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix: Pass maxBreadcrumbs config. to sentry-native (#1425)
 * Fix: Run event processors and enrich transactions with contexts (#1430)
 * Bump: sentry-native to 0.4.9 (#1431)
+* Fix: Set user on transaction (#1443)
 
 # 4.4.0-alpha.2
 

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
@@ -1,8 +1,20 @@
 package io.sentry.samples.spring;
 
+import io.sentry.IHub;
+import io.sentry.spring.SentryUserFilter;
+import io.sentry.spring.SentryUserProvider;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import(SentryConfig.class)
-public class AppConfig {}
+public class AppConfig {
+
+  @Bean
+  SentryUserFilter sentryUserFilter(
+      final IHub hub, final List<SentryUserProvider> sentryUserProviders) {
+    return new SentryUserFilter(hub, sentryUserProviders);
+  }
+}

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppInitializer.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppInitializer.java
@@ -3,6 +3,7 @@ package io.sentry.samples.spring;
 import io.sentry.spring.tracing.SentryTracingFilter;
 import javax.servlet.Filter;
 import org.springframework.web.filter.DelegatingFilterProxy;
+import org.springframework.web.filter.RequestContextFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
 public class AppInitializer extends AbstractAnnotationConfigDispatcherServletInitializer {
@@ -30,6 +31,15 @@ public class AppInitializer extends AbstractAnnotationConfigDispatcherServletIni
     // filter required by Spring Security
     DelegatingFilterProxy springSecurityFilterChain = new DelegatingFilterProxy();
     springSecurityFilterChain.setTargetBeanName("springSecurityFilterChain");
-    return new Filter[] {sentryTracingFilter, springSecurityFilterChain};
+    // sets request on RequestContextHolder
+    RequestContextFilter requestContextFilter = new RequestContextFilter();
+
+    // sets Sentry user on the scope
+    DelegatingFilterProxy sentryUserFilterProxy = new DelegatingFilterProxy();
+    sentryUserFilterProxy.setTargetBeanName("sentryUserFilter");
+
+    return new Filter[] {
+      sentryTracingFilter, springSecurityFilterChain, requestContextFilter, sentryUserFilterProxy
+    };
   }
 }

--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -22,12 +22,14 @@ public class io/sentry/spring/boot/SentryProperties : io/sentry/SentryOptions {
 	public fun <init> ()V
 	public fun getExceptionResolverOrder ()I
 	public fun getLogging ()Lio/sentry/spring/boot/SentryProperties$Logging;
+	public fun getUserFilterOrder ()Ljava/lang/Integer;
 	public fun isEnableTracing ()Z
 	public fun isUseGitCommitIdAsRelease ()Z
 	public fun setEnableTracing (Z)V
 	public fun setExceptionResolverOrder (I)V
 	public fun setLogging (Lio/sentry/spring/boot/SentryProperties$Logging;)V
 	public fun setUseGitCommitIdAsRelease (Z)V
+	public fun setUserFilterOrder (Ljava/lang/Integer;)V
 }
 
 public class io/sentry/spring/boot/SentryProperties$Logging {

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     compileOnly(Config.Libs.springWeb)
     compileOnly(Config.Libs.servletApi)
     compileOnly(Config.Libs.springBootStarterAop)
+    compileOnly(Config.Libs.springBootStarterSecurity)
 
     annotationProcessor(Config.AnnotationProcessors.springBootAutoConfigure)
     annotationProcessor(Config.AnnotationProcessors.springBootConfiguration)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -12,9 +12,11 @@ import io.sentry.protocol.SdkVersion;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryRequestResolver;
 import io.sentry.spring.SentrySpringRequestListener;
+import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
 import io.sentry.spring.SentryUserProviderEventProcessor;
 import io.sentry.spring.SentryWebConfiguration;
+import io.sentry.spring.SpringSecuritySentryUserProvider;
 import io.sentry.spring.tracing.SentryAdviceConfiguration;
 import io.sentry.spring.tracing.SentrySpanPointcutConfiguration;
 import io.sentry.spring.tracing.SentryTracingFilter;
@@ -22,6 +24,8 @@ import io.sentry.spring.tracing.SentryTransactionPointcutConfiguration;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.apache.ApacheHttpClientTransportFactory;
 import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.ObjectProvider;
@@ -42,6 +46,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration(proxyBeanMethods = false)
@@ -124,6 +129,43 @@ public class SentryAutoConfiguration {
     @Import(SentryWebConfiguration.class)
     @Open
     static class SentryWebMvcConfiguration {
+
+      @Bean
+      @ConditionalOnClass(SecurityContextHolder.class)
+      @Order(1)
+      public @NotNull SpringSecuritySentryUserProvider springSecuritySentryUserProvider(
+          final @NotNull SentryOptions sentryOptions) {
+        return new SpringSecuritySentryUserProvider(sentryOptions);
+      }
+
+      /**
+       * Configures {@link SentryUserFilter}. By default it runs as the last filter in order to make
+       * sure that all potential authentication information is propagated to {@link
+       * HttpServletRequest#getUserPrincipal()}. If Spring Security is auto-configured, its order is
+       * set to run after Spring Security.
+       *
+       * @param hub the Sentry hub
+       * @param sentryProperties the Sentry properties
+       * @param sentryUserProvider the user provider
+       * @return {@link SentryUserFilter} registration bean
+       */
+      @Bean
+      @ConditionalOnBean(SentryUserProvider.class)
+      public @NotNull FilterRegistrationBean<SentryUserFilter> sentryUserFilter(
+          final @NotNull IHub hub,
+          final @NotNull SentryProperties sentryProperties,
+          final @NotNull List<SentryUserProvider> sentryUserProvider) {
+        final FilterRegistrationBean<SentryUserFilter> filter = new FilterRegistrationBean<>();
+        filter.setFilter(new SentryUserFilter(hub, sentryUserProvider));
+        filter.setOrder(resolveUserFilterOrder(sentryProperties));
+        return filter;
+      }
+
+      private @NotNull Integer resolveUserFilterOrder(
+          final @NotNull SentryProperties sentryProperties) {
+        return Optional.ofNullable(sentryProperties.getUserFilterOrder())
+            .orElse(Ordered.LOWEST_PRECEDENCE);
+      }
 
       @Bean
       public @NotNull SentryRequestResolver sentryRequestResolver(final @NotNull IHub hub) {

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -124,6 +124,14 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryWebMvcConfiguration {
 
+      /**
+       * Configures {@link SpringSecuritySentryUserProvider} only if Spring Security is on the
+       * classpath. Its order is set to be higher than {@link
+       * SentryWebConfiguration#httpServletRequestSentryUserProvider(SentryOptions)}
+       *
+       * @param sentryOptions the Sentry options
+       * @return {@link SpringSecuritySentryUserProvider}
+       */
       @Bean
       @ConditionalOnClass(SecurityContextHolder.class)
       @Order(1)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -14,7 +14,6 @@ import io.sentry.spring.SentryRequestResolver;
 import io.sentry.spring.SentrySpringRequestListener;
 import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
-import io.sentry.spring.SentryUserProviderEventProcessor;
 import io.sentry.spring.SentryWebConfiguration;
 import io.sentry.spring.SpringSecuritySentryUserProvider;
 import io.sentry.spring.tracing.SentryAdviceConfiguration;
@@ -71,7 +70,6 @@ public class SentryAutoConfiguration {
         final @NotNull List<EventProcessor> eventProcessors,
         final @NotNull List<Integration> integrations,
         final @NotNull ObjectProvider<ITransportGate> transportGate,
-        final @NotNull List<SentryUserProvider> sentryUserProviders,
         final @NotNull ObjectProvider<ITransportFactory> transportFactory,
         final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {
@@ -80,10 +78,6 @@ public class SentryAutoConfiguration {
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);
         eventProcessors.forEach(options::addEventProcessor);
         integrations.forEach(options::addIntegration);
-        sentryUserProviders.forEach(
-            sentryUserProvider ->
-                options.addEventProcessor(
-                    new SentryUserProviderEventProcessor(options, sentryUserProvider)));
         transportGate.ifAvailable(options::setTransportGate);
         transportFactory.ifAvailable(options::setTransportFactory);
         inAppPackagesResolver.resolveInAppIncludes().forEach(options::addInAppInclude);

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -26,6 +26,13 @@ public class SentryProperties extends SentryOptions {
   /** Report all or only uncaught web exceptions. */
   private int exceptionResolverOrder = 1;
 
+  /**
+   * Defines the {@link io.sentry.spring.SentryUserFilter} order. The default value is {@link
+   * org.springframework.core.Ordered.LOWEST_PRECEDENCE}, if Spring Security is auto-configured, its
+   * guaranteed to run after Spring Security filter chain.
+   */
+  private @Nullable Integer userFilterOrder;
+
   /** Logging framework integration properties. */
   private @NotNull Logging logging = new Logging();
 
@@ -67,7 +74,15 @@ public class SentryProperties extends SentryOptions {
     this.exceptionResolverOrder = exceptionResolverOrder;
   }
 
-  public Logging getLogging() {
+  public @Nullable Integer getUserFilterOrder() {
+    return userFilterOrder;
+  }
+
+  public void setUserFilterOrder(final @Nullable Integer userFilterOrder) {
+    this.userFilterOrder = userFilterOrder;
+  }
+
+  public @NotNull Logging getLogging() {
     return logging;
   }
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -320,12 +320,11 @@ class SentryAutoConfigurationTest {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true")
             .withConfiguration(UserConfigurations.of(SentryUserProviderConfiguration::class.java))
             .run {
-                val options = it.getBean("sentryUserFilter", FilterRegistrationBean::class.java).filter as SentryUserFilter
-                val userProviderEventProcessors = options.sentryUserProviders
-                assertEquals(3, userProviderEventProcessors.size)
-                assertTrue(userProviderEventProcessors[0] is HttpServletRequestSentryUserProvider)
-                assertTrue(userProviderEventProcessors[1] is SpringSecuritySentryUserProvider)
-                assertTrue(userProviderEventProcessors[2] is CustomSentryUserProvider)
+                val userProviders = it.getSentryUserProviders()
+                assertEquals(3, userProviders.size)
+                assertTrue(userProviders[0] is HttpServletRequestSentryUserProvider)
+                assertTrue(userProviders[1] is SpringSecuritySentryUserProvider)
+                assertTrue(userProviders[2] is CustomSentryUserProvider)
             }
     }
 
@@ -334,12 +333,11 @@ class SentryAutoConfigurationTest {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true")
             .withConfiguration(UserConfigurations.of(SentryHighestOrderUserProviderConfiguration::class.java))
             .run {
-                val options = it.getBean("sentryUserFilter", FilterRegistrationBean::class.java).filter as SentryUserFilter
-                val userProviderEventProcessors = options.sentryUserProviders
-                assertEquals(3, userProviderEventProcessors.size)
-                assertTrue(userProviderEventProcessors[0] is CustomSentryUserProvider)
-                assertTrue(userProviderEventProcessors[1] is HttpServletRequestSentryUserProvider)
-                assertTrue(userProviderEventProcessors[2] is SpringSecuritySentryUserProvider)
+                val userProviders = it.getSentryUserProviders()
+                assertEquals(3, userProviders.size)
+                assertTrue(userProviders[0] is CustomSentryUserProvider)
+                assertTrue(userProviders[1] is HttpServletRequestSentryUserProvider)
+                assertTrue(userProviders[2] is SpringSecuritySentryUserProvider)
             }
     }
 
@@ -755,5 +753,10 @@ class SentryAutoConfigurationTest {
         this.doesNotHaveBean("sentrySpanAdvice")
         this.doesNotHaveBean("sentrySpanAdvisor")
         return this
+    }
+
+    private fun ApplicationContext.getSentryUserProviders(): List<SentryUserProvider> {
+        val userFilter = this.getBean("sentryUserFilter", FilterRegistrationBean::class.java).filter as SentryUserFilter
+        return userFilter.sentryUserProviders
     }
 }

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -12,6 +12,7 @@ import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.spring.tracing.SentrySpan
 import io.sentry.test.checkEvent
+import io.sentry.test.checkTransaction
 import io.sentry.transport.ITransport
 import java.lang.RuntimeException
 import org.assertj.core.api.Assertions.assertThat
@@ -52,7 +53,7 @@ import org.springframework.web.bind.annotation.RestController
 @SpringBootTest(
     classes = [App::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = ["sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true", "sentry.enable-tracing=true"]
+    properties = ["sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true", "sentry.enable-tracing=true", "sentry.traces-sample-rate=1.0"]
 )
 class SentrySpringIntegrationTest {
 
@@ -164,6 +165,20 @@ class SentrySpringIntegrationTest {
         restTemplate.getForEntity("http://localhost:$port/throws-handled", String::class.java)
 
         verify(hub, never()).captureEvent(any())
+    }
+
+    @Test
+    fun `sets user on transaction`() {
+        val restTemplate = TestRestTemplate().withBasicAuth("user", "password")
+
+        restTemplate.getForEntity("http://localhost:$port/performance", String::class.java)
+
+        await.untilAsserted {
+            verify(transport).send(checkTransaction { transaction ->
+                assertThat(transaction.user).isNotNull()
+                assertThat(transaction.user!!.username).isEqualTo("user")
+            }, anyOrNull())
+        }
     }
 }
 

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -54,6 +54,12 @@ public class io/sentry/spring/SentrySpringServletContainerInitializer : javax/se
 	public fun onStartup (Ljava/util/Set;Ljavax/servlet/ServletContext;)V
 }
 
+public class io/sentry/spring/SentryUserFilter : javax/servlet/Filter {
+	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
+	public fun doFilter (Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;Ljavax/servlet/FilterChain;)V
+	public fun getSentryUserProviders ()Ljava/util/List;
+}
+
 public abstract interface class io/sentry/spring/SentryUserProvider {
 	public abstract fun provideUser ()Lio/sentry/protocol/User;
 }
@@ -68,6 +74,11 @@ public final class io/sentry/spring/SentryUserProviderEventProcessor : io/sentry
 public class io/sentry/spring/SentryWebConfiguration {
 	public fun <init> ()V
 	public fun httpServletRequestSentryUserProvider (Lio/sentry/SentryOptions;)Lio/sentry/spring/HttpServletRequestSentryUserProvider;
+}
+
+public final class io/sentry/spring/SpringSecuritySentryUserProvider : io/sentry/spring/SentryUserProvider {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun provideUser ()Lio/sentry/protocol/User;
 }
 
 public class io/sentry/spring/tracing/SentryAdviceConfiguration {

--- a/sentry-spring/build.gradle.kts
+++ b/sentry-spring/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     api(project(":sentry"))
     compileOnly(Config.Libs.springWeb)
     compileOnly(Config.Libs.springAop)
+    compileOnly(Config.Libs.springSecurityWeb)
     compileOnly(Config.Libs.aspectj)
     compileOnly(Config.Libs.servletApi)
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -20,7 +20,7 @@ public class SentryInitBeanPostProcessor implements BeanPostProcessor, Applicati
   private @Nullable ApplicationContext applicationContext;
 
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "deprecation"})
   public Object postProcessAfterInitialization(
       final @NotNull Object bean, @NotNull final String beanName) throws BeansException {
     if (bean instanceof SentryOptions) {

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -52,7 +52,7 @@ public class SentryUserFilter implements Filter {
         user.setIpAddress(null);
       }
     }
-    hub.configureScope(scope -> scope.setUser(user));
+    hub.setUser(user);
     chain.doFilter(request, response);
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -66,7 +66,7 @@ public class SentryUserFilter implements Filter {
         if (existingUser.getOthers() == null) {
           existingUser.setOthers(new ConcurrentHashMap<>());
         }
-        for (Map.Entry<String, String> entry : userFromProvider.getOthers().entrySet()) {
+        for (final Map.Entry<String, String> entry : userFromProvider.getOthers().entrySet()) {
           existingUser.getOthers().put(entry.getKey(), entry.getValue());
         }
       }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -1,0 +1,80 @@
+package io.sentry.spring;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.IHub;
+import io.sentry.IpAddressUtils;
+import io.sentry.Scope;
+import io.sentry.protocol.User;
+import io.sentry.util.Objects;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+/**
+ * Sets the {@link User} on the {@link Scope} with information retrieved from {@link
+ * SentryUserProvider}s.
+ */
+@Open
+public class SentryUserFilter implements Filter {
+  private final @NotNull IHub hub;
+  private final @NotNull List<SentryUserProvider> sentryUserProviders;
+
+  public SentryUserFilter(
+      final @NotNull IHub hub, final @NotNull List<SentryUserProvider> sentryUserProviders) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
+    this.sentryUserProviders =
+        Objects.requireNonNull(sentryUserProviders, "sentryUserProviders list is required");
+  }
+
+  @Override
+  public void doFilter(
+      final @NotNull ServletRequest request,
+      final @NotNull ServletResponse response,
+      final @NotNull FilterChain chain)
+      throws IOException, ServletException {
+    final User user = new User();
+    for (final SentryUserProvider provider : sentryUserProviders) {
+      apply(user, provider.provideUser());
+    }
+    if (hub.getOptions().isSendDefaultPii()) {
+      if (IpAddressUtils.isDefault(user.getIpAddress())) {
+        // unset {{auto}} as it would set the server's ip address as a user ip address
+        user.setIpAddress(null);
+      }
+    }
+    hub.configureScope(scope -> scope.setUser(user));
+    chain.doFilter(request, response);
+  }
+
+  private void apply(final @NotNull User existingUser, final @Nullable User user) {
+    if (user != null) {
+      Optional.ofNullable(user.getEmail()).ifPresent(existingUser::setEmail);
+      Optional.ofNullable(user.getId()).ifPresent(existingUser::setId);
+      Optional.ofNullable(user.getIpAddress()).ifPresent(existingUser::setIpAddress);
+      Optional.ofNullable(user.getUsername()).ifPresent(existingUser::setUsername);
+      if (user.getOthers() != null && !user.getOthers().isEmpty()) {
+        if (existingUser.getOthers() == null) {
+          existingUser.setOthers(new ConcurrentHashMap<>());
+        }
+        for (Map.Entry<String, String> entry : user.getOthers().entrySet()) {
+          existingUser.getOthers().put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public @NotNull List<SentryUserProvider> getSentryUserProviders() {
+    return sentryUserProviders;
+  }
+}

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -56,17 +56,17 @@ public class SentryUserFilter implements Filter {
     chain.doFilter(request, response);
   }
 
-  private void apply(final @NotNull User existingUser, final @Nullable User user) {
-    if (user != null) {
-      Optional.ofNullable(user.getEmail()).ifPresent(existingUser::setEmail);
-      Optional.ofNullable(user.getId()).ifPresent(existingUser::setId);
-      Optional.ofNullable(user.getIpAddress()).ifPresent(existingUser::setIpAddress);
-      Optional.ofNullable(user.getUsername()).ifPresent(existingUser::setUsername);
-      if (user.getOthers() != null && !user.getOthers().isEmpty()) {
+  private void apply(final @NotNull User existingUser, final @Nullable User userFromProvider) {
+    if (userFromProvider != null) {
+      Optional.ofNullable(userFromProvider.getEmail()).ifPresent(existingUser::setEmail);
+      Optional.ofNullable(userFromProvider.getId()).ifPresent(existingUser::setId);
+      Optional.ofNullable(userFromProvider.getIpAddress()).ifPresent(existingUser::setIpAddress);
+      Optional.ofNullable(userFromProvider.getUsername()).ifPresent(existingUser::setUsername);
+      if (userFromProvider.getOthers() != null && !userFromProvider.getOthers().isEmpty()) {
         if (existingUser.getOthers() == null) {
           existingUser.setOthers(new ConcurrentHashMap<>());
         }
-        for (Map.Entry<String, String> entry : user.getOthers().entrySet()) {
+        for (Map.Entry<String, String> entry : userFromProvider.getOthers().entrySet()) {
           existingUser.getOthers().put(entry.getKey(), entry.getValue());
         }
       }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
@@ -15,6 +15,10 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Deprecated: instead of using event processor for setting user on events and transactions, user
+ * should be set on the scope using {@link SentryUserFilter}.
+ */
 public final class SentryUserProviderEventProcessor implements EventProcessor {
   private final @NotNull SentryOptions options;
   private final @NotNull SentryUserProvider sentryUserProvider;

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserProviderEventProcessor.java
@@ -16,9 +16,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Deprecated: instead of using event processor for setting user on events and transactions, user
- * should be set on the scope using {@link SentryUserFilter}.
+ * @deprecated instead of using event processor for setting user on events and transactions, user
+ *     should be set on the scope using {@link SentryUserFilter}.
  */
+@Deprecated
 public final class SentryUserProviderEventProcessor implements EventProcessor {
   private final @NotNull SentryOptions options;
   private final @NotNull SentryUserProvider sentryUserProvider;

--- a/sentry-spring/src/main/java/io/sentry/spring/SpringSecuritySentryUserProvider.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SpringSecuritySentryUserProvider.java
@@ -1,0 +1,35 @@
+package io.sentry.spring;
+
+import io.sentry.SentryOptions;
+import io.sentry.protocol.User;
+import io.sentry.util.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Resolves user information from Spring Security {@link Authentication} obtained via {@link
+ * SecurityContextHolder}.
+ */
+public final class SpringSecuritySentryUserProvider implements SentryUserProvider {
+  private final @NotNull SentryOptions options;
+
+  public SpringSecuritySentryUserProvider(final @NotNull SentryOptions options) {
+    this.options = Objects.requireNonNull(options, "options is required");
+  }
+
+  @Override
+  public @Nullable User provideUser() {
+    if (options.isSendDefaultPii()) {
+      final SecurityContext context = SecurityContextHolder.getContext();
+      if (context != null && context.getAuthentication() != null) {
+        final User user = new User();
+        user.setUsername(context.getAuthentication().getName());
+        return user;
+      }
+    }
+    return null;
+  }
+}

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
@@ -1,17 +1,15 @@
 package io.sentry.spring
 
-import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.IHub
-import io.sentry.Scope
-import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
 import io.sentry.protocol.User
 import javax.servlet.FilterChain
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -22,14 +20,12 @@ class SentryUserFilterTest {
         val request = MockHttpServletRequest()
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
-        val options = SentryOptions()
-        val scope = Scope(options)
 
         fun getSut(isSendDefaultPii: Boolean = false, userProviders: List<SentryUserProvider>): SentryUserFilter {
-            val options = SentryOptions()
-            options.isSendDefaultPii = isSendDefaultPii
+            val options = SentryOptions().apply {
+                this.isSendDefaultPii = isSendDefaultPii
+            }
             whenever(hub.options).thenReturn(options)
-            whenever(hub.configureScope(any())).thenAnswer { (it.arguments[0] as ScopeCallback).run(scope) }
             return SentryUserFilter(hub, userProviders)
         }
     }
@@ -52,9 +48,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertEquals(sampleUser, it)
-        }
+        })
     }
 
     @Test
@@ -65,9 +61,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertEquals(sampleUser, it)
-        }
+        })
     }
 
     @Test
@@ -78,9 +74,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertEquals(sampleUser, it)
-        }
+        })
     }
 
     @Test
@@ -97,9 +93,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertEquals(mapOf("key" to "value", "new-key" to "new-value"), it.others)
-        }
+        })
     }
 
     @Test
@@ -112,9 +108,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertEquals("192.168.0.1", it.ipAddress)
-        }
+        })
     }
 
     @Test
@@ -127,9 +123,9 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        assertNotNull(fixture.scope.user) {
+        verify(fixture.hub).setUser(check {
             assertNull(it.ipAddress)
-        }
+        })
     }
 
     private fun assertEquals(user1: User, user2: User) {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
@@ -1,0 +1,142 @@
+package io.sentry.spring
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.IHub
+import io.sentry.Scope
+import io.sentry.ScopeCallback
+import io.sentry.SentryOptions
+import io.sentry.protocol.User
+import javax.servlet.FilterChain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class SentryUserFilterTest {
+    class Fixture {
+        val hub = mock<IHub>()
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val chain = mock<FilterChain>()
+        val options = SentryOptions()
+        val scope = Scope(options)
+
+        fun getSut(isSendDefaultPii: Boolean = false, userProviders: List<SentryUserProvider>): SentryUserFilter {
+            val options = SentryOptions()
+            options.isSendDefaultPii = isSendDefaultPii
+            whenever(hub.options).thenReturn(options)
+            whenever(hub.configureScope(any())).thenAnswer { (it.arguments[0] as ScopeCallback).run(scope) }
+            return SentryUserFilter(hub, userProviders)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    private val sampleUser = User().apply {
+        username = "john.doe"
+        id = "user-id"
+        ipAddress = "192.168.0.1"
+        email = "john.doe@example.com"
+        others = mapOf("key" to "value")
+    }
+
+    @Test
+    fun `sets provided user data on the scope`() {
+        val filter = fixture.getSut(userProviders = listOf(SentryUserProvider {
+            sampleUser
+        }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertEquals(sampleUser, it)
+        }
+    }
+
+    @Test
+    fun `when processor returns empty User, user data is not changed`() {
+        val filter = fixture.getSut(userProviders = listOf(SentryUserProvider {
+            sampleUser
+        }, SentryUserProvider { User() }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertEquals(sampleUser, it)
+        }
+    }
+
+    @Test
+    fun `when processor returns null, user data is not changed`() {
+        val filter = fixture.getSut(userProviders = listOf(SentryUserProvider {
+            sampleUser
+        }, SentryUserProvider { null }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertEquals(sampleUser, it)
+        }
+    }
+
+    @Test
+    fun `merges user#others with existing user#others set on SentryEvent`() {
+        val filter = fixture.getSut(userProviders = listOf(SentryUserProvider {
+            User().apply {
+                others = mapOf("key" to "value")
+            }
+        }, SentryUserProvider {
+            User().apply {
+                others = mapOf("new-key" to "new-value")
+            }
+        }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertEquals(mapOf("key" to "value", "new-key" to "new-value"), it.others)
+        }
+    }
+
+    @Test
+    fun `when isSendDefaultPii is true and user is set with custom ip address, user ip is unchanged`() {
+        val filter = fixture.getSut(isSendDefaultPii = true, userProviders = listOf(SentryUserProvider {
+            User().apply {
+                ipAddress = "192.168.0.1"
+            }
+        }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertEquals("192.168.0.1", it.ipAddress)
+        }
+    }
+
+    @Test
+    fun `when isSendDefaultPii is true and user is set with {{auto}} ip address, user ip is set to null`() {
+        val filter = fixture.getSut(isSendDefaultPii = true, userProviders = listOf(SentryUserProvider {
+            User().apply {
+                ipAddress = "{{auto}}"
+            }
+        }))
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        assertNotNull(fixture.scope.user) {
+            assertNull(it.ipAddress)
+        }
+    }
+
+    private fun assertEquals(user1: User, user2: User) {
+        assertEquals(user1.username, user2.username)
+        assertEquals(user1.id, user2.id)
+        assertEquals(user1.ipAddress, user2.ipAddress)
+        assertEquals(user1.email, user2.email)
+        assertEquals(user1.others, user2.others)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Set user on transaction.

User is set on the scope in Servlet filter - `SentryUserFilter`. This filter must run after Spring security (or any other filter verifying authentication details) so that `SentryUserProvider` implementations can access the currently logged in user data.

![Sentry request flow](https://user-images.githubusercontent.com/1357927/114510529-14247500-9c37-11eb-8967-2d24591cd318.png)

In Spring Boot integration, `SentryUserFilter` is set to run:

- by default runs as the last filter (lowest precedence)
- user can explicitly define the order

In Spring integration, filter bean must be created manually and a corresponding `DelegatingFilterProxy` servlet filter must be registered.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1335 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes