### PR TITLE
Bump: Gradle to 7.0 and plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,9 +94,6 @@ subprojects {
             configure<MavenPublishPluginExtension> {
                 val sign = Config.BuildPlugins.shouldSignArtifacts(project.version.toString())
                 releaseSigningEnabled = sign
-                nexus {
-                    stagingProfile = Config.Sentry.group
-                }
             }
 
             // signing info and maven central info go to:
@@ -108,8 +105,8 @@ subprojects {
             // signing.secretKeyRingFile=file path
 
             // maven central info:
-            // mavenCentralRepositoryUsername=user name
-            // mavenCentralRepositoryPassword=password
+            // mavenCentralUsername=user name
+            // mavenCentralPassword=password
         }
     }
 }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -18,9 +18,9 @@ object Config {
         val springDependencyManagement = "io.spring.dependency-management"
         val springDependencyManagementVersion = "1.0.11.RELEASE"
         val gretty = "org.gretty"
-        val grettyVersion = "3.0.3"
-        val gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.14.2"
-        val dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
+        val grettyVersion = "3.0.4"
+        val gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.15.1"
+        val dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:$kotlinVersion"
 
         fun shouldSignArtifacts(version: String): Boolean {
             return !(System.getenv("CI")?.toBoolean() ?: false) &&

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sentry-samples/sentry-samples-spring/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring/build.gradle.kts
@@ -7,7 +7,8 @@ plugins {
     kotlin("jvm")
     kotlin("plugin.spring") version Config.kotlinVersion
     id("war")
-    id(Config.BuildPlugins.gretty) version Config.BuildPlugins.grettyVersion
+    // https://github.com/gretty-gradle-plugin/gretty/issues/206
+    id(Config.BuildPlugins.gretty) version Config.BuildPlugins.grettyVersion apply false
 }
 
 group = "io.sentry.sample.spring"


### PR DESCRIPTION
## :scroll: Description
Bump: Gradle to 7.0 and plugins

_#skip-changelog_


## :bulb: Motivation and Context
Gradle 7 is less flaky when uploading artifacts to MC
See https://github.com/vanniktech/gradle-maven-publish-plugin/issues/232


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
