### PR TITLE
Remove Settings.Secure.ANDROID_ID in favor of generated installationId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Breaking Changes:
 
-* Remove Settings.Secure.ANDROID_ID in favor of generated installationId 
+* Remove Settings.Secure.ANDROID_ID in favor of generated installationId (#1455)
 
 # 5.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+Breaking Changes:
+
+* Remove `Settings.Secure.ANDROID_ID` in favor of generated `installationId` 
+
 # 5.0.0-beta.1
 
 * Fix: Activity tracing auto instrumentation for Android API < 29 (#1402)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Breaking Changes:
 
-* Remove `Settings.Secure.ANDROID_ID` in favor of generated `installationId` 
+* Remove Settings.Secure.ANDROID_ID in favor of generated installationId 
 
 # 5.0.0-beta.1
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -892,7 +892,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return Installation.id(context);
     } catch (Exception e) {
-      logger.log(SentryLevel.ERROR, "Error getting androidId.", e);
+      logger.log(SentryLevel.ERROR, "Error getting installationId.", e);
     }
     return null;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -66,7 +66,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @TestOnly static final String PROGUARD_UUID = "proGuardUuids";
   @TestOnly static final String ROOTED = "rooted";
-  @TestOnly static final String ANDROID_ID = "androidId";
   @TestOnly static final String KERNEL_VERSION = "kernelVersion";
   @TestOnly static final String EMULATOR = "emulator";
   @TestOnly static final String SIDE_LOADED = "sideLoaded";
@@ -116,11 +115,6 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
 
     map.put(ROOTED, rootChecker.isDeviceRooted());
-
-    String androidId = getAndroidId();
-    if (androidId != null) {
-      map.put(ANDROID_ID, androidId);
-    }
 
     String kernelVersion = getKernelVersion();
     if (kernelVersion != null) {
@@ -896,38 +890,11 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   private @Nullable String getDeviceId() {
     try {
-      Object androidId = contextData.get().get(ANDROID_ID);
-
-      if (androidId != null) {
-        return (String) androidId;
-      }
+      return Installation.id(context);
     } catch (Exception e) {
       logger.log(SentryLevel.ERROR, "Error getting androidId.", e);
     }
     return null;
-  }
-
-  @SuppressWarnings("HardwareIds")
-  private @Nullable String getAndroidId() {
-    // Android 29 has changed and -> Avoid using hardware identifiers, find another way in the
-    // future
-    String androidId =
-        Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
-
-    //    https://android-developers.googleblog.com/2011/03/identifying-app-installations.html
-    if (androidId == null
-        || androidId.isEmpty()
-        || androidId.toLowerCase(Locale.ROOT).contentEquals("9774d56d682e549c")) {
-      try {
-        androidId = Installation.id(context);
-      } catch (RuntimeException e) {
-        logger.log(SentryLevel.ERROR, "Could not generate device Id.", e);
-
-        return null;
-      }
-    }
-
-    return androidId;
   }
 
   private @Nullable String[] getProguardUUIDs() {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
@@ -21,7 +21,8 @@ final class Installation {
   private Installation() {}
 
   /**
-   * Generates a random UUID and writes to a file to be used as an unique installationId.
+   * Generates a random UUID and writes to a file to be used as an unique installationId. Reads the
+   * installationId if already exists.
    *
    * @param context the Context
    * @return the generated installationId

--- a/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
@@ -15,13 +15,21 @@ final class Installation {
   @TestOnly static String deviceId = null;
 
   @TestOnly static final String INSTALLATION = "INSTALLATION";
+
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   private Installation() {}
 
+  /**
+   * Generates a random UUID and writes to a file to be used as an unique installationId.
+   *
+   * @param context the Context
+   * @return the generated installationId
+   * @throws RuntimeException if not possible to read nor to write to the file.
+   */
   public static synchronized String id(final @NotNull Context context) throws RuntimeException {
     if (deviceId == null) {
-      File installation = new File(context.getFilesDir(), INSTALLATION);
+      final File installation = new File(context.getFilesDir(), INSTALLATION);
       try {
         if (!installation.exists()) {
           deviceId = writeInstallationFile(installation);
@@ -37,8 +45,8 @@ final class Installation {
 
   @TestOnly
   static @NotNull String readInstallationFile(final @NotNull File installation) throws IOException {
-    try (RandomAccessFile f = new RandomAccessFile(installation, "r")) {
-      byte[] bytes = new byte[(int) f.length()];
+    try (final RandomAccessFile f = new RandomAccessFile(installation, "r")) {
+      final byte[] bytes = new byte[(int) f.length()];
       f.readFully(bytes);
       return new String(bytes, UTF_8);
     }
@@ -47,8 +55,8 @@ final class Installation {
   @TestOnly
   static @NotNull String writeInstallationFile(final @NotNull File installation)
       throws IOException {
-    try (OutputStream out = new FileOutputStream(installation)) {
-      String id = UUID.randomUUID().toString();
+    try (final OutputStream out = new FileOutputStream(installation)) {
+      final String id = UUID.randomUUID().toString();
       out.write(id.getBytes(UTF_8));
       out.flush();
       return id;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -16,7 +16,6 @@ import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
-import io.sentry.android.core.DefaultAndroidEventProcessor.ANDROID_ID
 import io.sentry.android.core.DefaultAndroidEventProcessor.EMULATOR
 import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
 import io.sentry.android.core.DefaultAndroidEventProcessor.PROGUARD_UUID
@@ -263,7 +262,6 @@ class DefaultAndroidEventProcessorTest {
         assertNotNull(contextData)
         assertEquals("test", (contextData[PROGUARD_UUID] as Array<*>)[0])
         assertNotNull(contextData[ROOTED])
-        assertNotNull(contextData[ANDROID_ID])
         assertNotNull(contextData[KERNEL_VERSION])
         assertNotNull(contextData[EMULATOR])
         assertNotNull(contextData[SIDE_LOADED])


### PR DESCRIPTION
## :scroll: Description
Remove Settings.Secure.ANDROID_ID in favor of generated installationId


## :bulb: Motivation and Context
https://docs.sentry.io/product/security/mobile-privacy/
Fixes #1446

## :green_heart: How did you test it?
running it, tests always exists for non null user id

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
