### PR TITLE
Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name
+* Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
 
 # 5.0.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name
+
 # 5.0.0-beta.1
 
 * Fix: Activity tracing auto instrumentation for Android API < 29 (#1402)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -125,6 +125,7 @@ object Config {
     object Sentry {
         val SENTRY_JAVA_SDK_NAME = "sentry.java"
         val SENTRY_ANDROID_SDK_NAME = "$SENTRY_JAVA_SDK_NAME.android"
+        val SENTRY_TIMBER_SDK_NAME = "$SENTRY_ANDROID_SDK_NAME.timber"
         val SENTRY_LOGBACK_SDK_NAME = "$SENTRY_JAVA_SDK_NAME.logback"
         val SENTRY_JUL_SDK_NAME = "$SENTRY_JAVA_SDK_NAME.jul"
         val SENTRY_LOG4J2_SDK_NAME = "$SENTRY_JAVA_SDK_NAME.log4j2"

--- a/sentry-android-timber/api/sentry-android-timber.api
+++ b/sentry-android-timber/api/sentry-android-timber.api
@@ -2,6 +2,7 @@ public final class io/sentry/android/timber/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field SENTRY_TIMBER_SDK_NAME Ljava/lang/String;
 	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V
 }

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -25,6 +25,7 @@ android {
 
         // for AGP 4.1
         buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
+        buildConfigField("String", "SENTRY_TIMBER_SDK_NAME", "\"${Config.Sentry.SENTRY_TIMBER_SDK_NAME}\"")
     }
 
     buildTypes {

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
@@ -5,6 +5,8 @@ import io.sentry.ILogger
 import io.sentry.Integration
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
+import io.sentry.android.timber.BuildConfig.SENTRY_TIMBER_SDK_NAME
+import io.sentry.android.timber.BuildConfig.VERSION_NAME
 import io.sentry.protocol.SdkVersion
 import java.io.Closeable
 import timber.log.Timber
@@ -20,7 +22,7 @@ class SentryTimberIntegration(
     private lateinit var logger: ILogger
 
     override fun register(hub: IHub, options: SentryOptions) {
-        addPackage(options.sdkVersion)
+        createSdkVersion(options)
         logger = options.logger
 
         tree = SentryTimberTree(hub, minEventLevel, minBreadcrumbLevel)
@@ -39,7 +41,15 @@ class SentryTimberIntegration(
         }
     }
 
-    private fun addPackage(sdkVersion: SdkVersion?) {
-        sdkVersion?.addPackage("maven:io.sentry:sentry-android-timber", BuildConfig.VERSION_NAME)
+    private fun createSdkVersion(options: SentryOptions): SdkVersion {
+        var sdkVersion = options.sdkVersion
+
+        val name = SENTRY_TIMBER_SDK_NAME
+        val version = VERSION_NAME
+        sdkVersion = SdkVersion.updateSdkVersion(sdkVersion, name, version)
+
+        sdkVersion.addPackage("maven:io.sentry:sentry-android-timber", VERSION_NAME)
+
+        return sdkVersion
     }
 }

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
@@ -18,7 +18,7 @@ class SentryTimberIntegrationTest {
     private class Fixture {
         val hub = mock<IHub>()
         val options = SentryOptions().apply {
-            sdkVersion = SdkVersion()
+            sdkVersion = SdkVersion("test", "1.2.3")
         }
 
         fun getSut(
@@ -95,5 +95,16 @@ class SentryTimberIntegrationTest {
             it.name == "maven:io.sentry:sentry-android-timber"
             it.version == BuildConfig.VERSION_NAME
         })
+    }
+
+    @Test
+    fun `Integration sets SDK name and version to options`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+
+        val sdkVersion = fixture.options.sdkVersion!!
+
+        assertEquals(sdkVersion.name, "sentry.java.android.timber")
+        assertEquals(sdkVersion.version, BuildConfig.VERSION_NAME)
     }
 }


### PR DESCRIPTION
## :scroll: Description
Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name


## :bulb: Motivation and Context
fixes #1175


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
