### PR TITLE
Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
+* Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread
 
 Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
-* Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread
+* Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread (#1459)
 
 Breaking Changes:
 


### PR DESCRIPTION
## :scroll: Description
Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread


## :bulb: Motivation and Context
2021-05-04 16:20:05.210 27271-27444/xxx E/Sentry: Error while closing the Hub.
    java.lang.IllegalStateException: Method removeObserver must be called on the main thread
        at androidx.lifecycle.LifecycleRegistry.enforceMainThreadIfNeeded(LifecycleRegistry.java:317)
        at androidx.lifecycle.LifecycleRegistry.removeObserver(LifecycleRegistry.java:219)
        at io.sentry.android.core.AppLifecycleIntegration.close(AppLifecycleIntegration.java:94)
        at io.sentry.core.Hub.close(Hub.java:246)
        at io.sentry.core.Sentry.close(Sentry.java:216)
        at io.sentry.core.HubAdapter.close(HubAdapter.java:57)
        at io.sentry.core.ShutdownHookIntegration.lambda$register$0(ShutdownHookIntegration.java:25)
        at io.sentry.core.-$$Lambda$ShutdownHookIntegration$92gaGRLn-MU5DyRe0eDeeyrGh5g.run(Unknown Source:2)
        at java.lang.Thread.run(Thread.java:764)


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
