### PR TITLE
Fix: associate event with transaction when thrown exception is not a direct cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
 * Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread (#1459)
+* Fix: associate event with transaction when thrown exception is not a direct cause
 
 Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
 * Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread (#1459)
-* Fix: associate event with transaction when thrown exception is not a direct cause
+* Fix: associate event with transaction when thrown exception is not a direct cause (#1463)
 
 Breaking Changes:
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1862,6 +1862,11 @@ public final class io/sentry/util/CollectionUtils {
 	public static fun size (Ljava/lang/Iterable;)I
 }
 
+public final class io/sentry/util/ExceptionUtils {
+	public fun <init> ()V
+	public static fun findRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+}
+
 public final class io/sentry/util/LogUtils {
 	public fun <init> ()V
 	public static fun logIfNotFlushable (Lio/sentry/ILogger;Ljava/lang/Object;)V

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -6,6 +6,7 @@ import io.sentry.hints.SessionStartHint;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.util.ExceptionUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.Pair;
 import java.io.Closeable;
@@ -175,7 +176,8 @@ public final class Hub implements IHub {
 
   private void assignTraceContext(final @NotNull SentryEvent event) {
     if (event.getThrowable() != null) {
-      final Pair<ISpan, String> pair = throwableToSpan.get(event.getThrowable());
+      final Pair<ISpan, String> pair =
+          throwableToSpan.get(ExceptionUtils.findRootCause(event.getThrowable()));
       if (pair != null) {
         if (event.getContexts().getTrace() == null) {
           event.getContexts().setTrace(pair.getFirst().getSpanContext());

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -645,16 +645,19 @@ public final class Hub implements IHub {
     Objects.requireNonNull(throwable, "throwable is required");
     Objects.requireNonNull(span, "span is required");
     Objects.requireNonNull(transactionName, "transactionName is required");
+    // to match any cause, span context is always attached to the root cause of the exception
+    final Throwable rootCause = ExceptionUtils.findRootCause(throwable);
     // the most inner span should be assigned to a throwable
-    if (!throwableToSpan.containsKey(throwable)) {
-      throwableToSpan.put(throwable, new Pair<>(span, transactionName));
+    if (!throwableToSpan.containsKey(rootCause)) {
+      throwableToSpan.put(rootCause, new Pair<>(span, transactionName));
     }
   }
 
   @Nullable
   SpanContext getSpanContext(final @NotNull Throwable throwable) {
     Objects.requireNonNull(throwable, "throwable is required");
-    final Pair<ISpan, String> span = this.throwableToSpan.get(throwable);
+    final Throwable rootCause = ExceptionUtils.findRootCause(throwable);
+    final Pair<ISpan, String> span = this.throwableToSpan.get(rootCause);
     if (span != null) {
       return span.getFirst().getSpanContext();
     }

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -1,0 +1,23 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+public final class ExceptionUtils {
+
+  /**
+   * Returns exception root cause or the exception itself if there are no causes
+   *
+   * @param throwable - the throwable
+   * @return the root cause
+   */
+  public static @NotNull Throwable findRootCause(final @NotNull Throwable throwable) {
+    Objects.requireNonNull(throwable, "throwable cannot be null");
+    Throwable rootCause = throwable;
+    while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+      rootCause = rootCause.getCause();
+    }
+    return rootCause;
+  }
+}

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -341,6 +341,23 @@ class HubTest {
     }
 
     @Test
+    fun `when captureEvent is called and event has exception which non-root cause has been previously attached with span context, sets span context to the event`() {
+        val (sut, mockClient) = getEnabledHub()
+        val rootCause = RuntimeException()
+        val exceptionAssignedToSpan = RuntimeException(rootCause)
+        val span = mock<Span>()
+        whenever(span.spanContext).thenReturn(SpanContext("op"))
+        sut.setSpanContext(exceptionAssignedToSpan, span, "tx-name")
+
+        val event = SentryEvent(RuntimeException(exceptionAssignedToSpan))
+
+        val hint = { }
+        sut.captureEvent(event, hint)
+        assertEquals(span.spanContext, event.contexts.trace)
+        verify(mockClient).captureEvent(eq(event), any(), eq(hint))
+    }
+
+    @Test
     fun `when captureEvent is called and event has exception which has been previously attached with span context and trace context already set, does not set new span context to the event`() {
         val (sut, mockClient) = getEnabledHub()
         val exception = RuntimeException()

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -325,6 +325,22 @@ class HubTest {
     }
 
     @Test
+    fun `when captureEvent is called and event has exception which root cause has been previously attached with span context, sets span context to the event`() {
+        val (sut, mockClient) = getEnabledHub()
+        val rootCause = RuntimeException()
+        val span = mock<Span>()
+        whenever(span.spanContext).thenReturn(SpanContext("op"))
+        sut.setSpanContext(rootCause, span, "tx-name")
+
+        val event = SentryEvent(RuntimeException(rootCause))
+
+        val hint = { }
+        sut.captureEvent(event, hint)
+        assertEquals(span.spanContext, event.contexts.trace)
+        verify(mockClient).captureEvent(eq(event), any(), eq(hint))
+    }
+
+    @Test
     fun `when captureEvent is called and event has exception which has been previously attached with span context and trace context already set, does not set new span context to the event`() {
         val (sut, mockClient) = getEnabledHub()
         val exception = RuntimeException()

--- a/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/ExceptionUtilsTest.kt
@@ -1,0 +1,22 @@
+package io.sentry.util
+
+import java.lang.RuntimeException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExceptionUtilsTest {
+
+    @Test
+    fun `returns same exception when there is no cause`() {
+        val ex = RuntimeException()
+        assertEquals(ex, ExceptionUtils.findRootCause(ex))
+    }
+
+    @Test
+    fun `returns first cause when there are multiple causes`() {
+        val rootCause = RuntimeException()
+        val cause = RuntimeException(rootCause)
+        val ex = RuntimeException(cause)
+        assertEquals(rootCause, ExceptionUtils.findRootCause(ex))
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: associate event with transaction when thrown exception is not a direct cause

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1418

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes