### PR TITLE
Fix: Script to deploy to MC via mvn CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 .project
 .settings/
 bin/
+distributions/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 # 5.0.0-beta.2
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 5.0.0-beta.2
 
 * Fix: sentry-android-timber package sets sentry.java.android.timber as SDK name (#1456)
 * Fix: When AppLifecycleIntegration is closed, it should remove observer using UI thread (#1459)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ dryRelease:
 # remember to remove the -SNAPSHOT suffix from the version
 # promotes the release to maven central
 doRelease:
-	./gradlew publish --no-daemon
+	cd scripts
+	kotlinc -script release.kts -- -d ../distributions | sh
+	cd ..
 	./gradlew closeAndReleaseRepository
 
 # clean, build, deploy and promote to maven central

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,25 +66,41 @@ subprojects {
     if (!this.name.contains("sample") && this.name != "sentry-test-support") {
         apply<DistributionPlugin>()
 
+        val sep = File.separator
+
         configure<DistributionContainer> {
             this.getByName("main").contents {
                 // non android modules
-                from("build/libs")
-                from("build/publications/maven")
+                from("build${sep}libs")
+                from("build${sep}publications${sep}maven")
                 // android modules
-                from("build/outputs/aar")
-                from("build/publications/release")
+                from("build${sep}outputs${sep}aar")
+                from("build${sep}publications${sep}release")
             }
         }
+
+        val rootDir = this.project.rootProject.projectDir
+        val distDir = File("${rootDir}${sep}distributions")
+
+        // create dir if it does not exist
+        distDir.mkdirs()
+
         tasks.named("distZip").configure {
             this.dependsOn("publishToMavenLocal")
             this.doLast {
-                val distributionFilePath = "${this.project.buildDir}/distributions/${this.project.name}-${this.project.version}.zip"
+                val distributionFilePath = "${this.project.buildDir}${sep}distributions${sep}${this.project.name}-${this.project.version}.zip"
                 val file = File(distributionFilePath)
                 if (!file.exists()) throw IllegalStateException("Distribution file: $distributionFilePath does not exist")
                 if (file.length() == 0L) throw IllegalStateException("Distribution file: $distributionFilePath is empty")
+
+                val newFile = File("${distDir}${sep}${file.name}")
+                file.copyTo(newFile, overwrite = true)
+
+                UnzipUtils.unzip(newFile, distDir.path)
+                newFile.delete()
             }
         }
+
         afterEvaluate {
             apply<MavenPublishPlugin>()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,17 +105,13 @@ subprojects {
             apply<MavenPublishPlugin>()
 
             configure<MavenPublishPluginExtension> {
-                val sign = Config.BuildPlugins.shouldSignArtifacts(project.version.toString())
-                releaseSigningEnabled = sign
+                // signing is done when uploading files to MC
+                // via gpg:sign-and-deploy-file (release.kts)
+                releaseSigningEnabled = false
             }
 
-            // signing info and maven central info go to:
+            // maven central info go to:
             // ~/.gradle/gradle.properties
-
-            // signing info:
-            // signing.keyId=id
-            // signing.password=password
-            // signing.secretKeyRingFile=file path
 
             // maven central info:
             // mavenCentralUsername=user name

--- a/buildSrc/src/main/java/UnzipUtils.kt
+++ b/buildSrc/src/main/java/UnzipUtils.kt
@@ -35,9 +35,7 @@ object UnzipUtils {
                         val dir = File(filePath)
                         dir.mkdir()
                     }
-
                 }
-
             }
         }
     }

--- a/buildSrc/src/main/java/UnzipUtils.kt
+++ b/buildSrc/src/main/java/UnzipUtils.kt
@@ -1,0 +1,66 @@
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.zip.ZipFile
+
+/**
+ * UnzipUtils class extracts files and sub-directories of a standard zip file to
+ * a destination directory.
+ *
+ */
+object UnzipUtils {
+    /**
+     * @param zipFilePath
+     * @param destDirectory
+     * @throws IOException
+     */
+    @Throws(IOException::class)
+    fun unzip(zipFilePath: File, destDirectory: String) {
+        val destDir = File(destDirectory)
+        if (!destDir.exists()) {
+            destDir.mkdir()
+        }
+        ZipFile(zipFilePath).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                zip.getInputStream(entry).use { input ->
+                    val filePath = destDirectory + File.separator + entry.name
+
+                    if (!entry.isDirectory) {
+                        // if the entry is a file, extracts it
+                        extractFile(input, filePath)
+                    } else {
+                        // if the entry is a directory, make the directory
+                        val dir = File(filePath)
+                        dir.mkdir()
+                    }
+
+                }
+
+            }
+        }
+    }
+
+    /**
+     * Extracts a zip entry (file entry)
+     * @param inputStream
+     * @param destFilePath
+     * @throws IOException
+     */
+    @Throws(IOException::class)
+    private fun extractFile(inputStream: InputStream, destFilePath: String) {
+        val bos = BufferedOutputStream(FileOutputStream(destFilePath))
+        val bytesIn = ByteArray(BUFFER_SIZE)
+        var read: Int
+        while (inputStream.read(bytesIn).also { read = it } != -1) {
+            bos.write(bytesIn, 0, read)
+        }
+        bos.close()
+    }
+
+    /**
+     * Size of the buffer to read/write data
+     */
+    private const val BUFFER_SIZE = 4096
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ android.useAndroidX=true
 # Release information
 buildVersionCode=20061
 # -SNAPSHOT avoids signing
-versionName=5.0.0-beta.2-SNAPSHOT
+versionName=5.0.0-beta.2
 
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,9 +5,9 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512m -XX:MaxMetaspaceSize=1536m -XX:+H
 android.useAndroidX=true
 
 # Release information
-buildVersionCode=20061
+buildVersionCode=20062
 # -SNAPSHOT avoids signing
-versionName=5.0.0-beta.2
+versionName=5.0.0-beta.3-SNAPSHOT
 
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false

--- a/scripts/release.kts
+++ b/scripts/release.kts
@@ -1,10 +1,10 @@
 /**
- * Outputs the bash script that uploads packages to Bintray.
+ * Outputs the bash script that uploads packages to MavenCentral.
  *
  * This script assumes that all distrbution packages have been downloaded and unzipped in one directory.
- * For example, all packages are in the "dist" directory:
+ * For example, all packages are in the "distributions" directory:
  *
- * dist
+ * distributions
  *  ├── sentry-3.1.2-SNAPSHOT
  *  ├── sentry-android-3.1.2-SNAPSHOT
  *  ├── sentry-android-core-3.1.2-SNAPSHOT
@@ -16,10 +16,10 @@
  *  ├── sentry-spring-3.1.2-SNAPSHOT
  *  └── sentry-spring-boot-starter-3.1.2-SNAPSHOT
  *
- * To execute the script two environment variables that are used by Maven have to be present: BINTRAY_USERNAME, BINTRAY_API_KEY
+ * To execute the script two environment variables that are used by Maven have to be present: OSSRH_USERNAME, OSSRH_PASSWORD
  *
- * Example usage (assuming that the script is executed from the `<project-root>/scripts` directory and the distribution files are in `<project-root>/dist`):
- * $ kotlinc -script release.kts -- -d ../dist | sh
+ * Example usage (assuming that the script is executed from the `<project-root>/scripts` directory and the distribution files are in `<project-root>/distributions`):
+ * $ kotlinc -script release.kts -- -d ../distributions | sh
  *
  */
 import java.io.File
@@ -30,14 +30,14 @@ import java.io.File
 val path = argOrDefault("d", ".")
 
 /**
- * Path to Maven settings.xml containing bintray username and api key.
+ * Path to Maven settings.xml containing MavenCentral username and api key.
  */
 val settingsPath = argOrDefault("s", "./settings.xml")
 
 /**
  * Maven repository URL.
  */
-val repositoryUrl = argOrDefault("repositoryUrl", "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+val repositoryUrl = argOrDefault("repositoryUrl", "https://oss.sonatype.org/service/local/staging/deploy/maven2/")
 
 /**
  * Maven server id in the settings.xml file.


### PR DESCRIPTION
## :scroll: Description
Fix: Script to deploy to MC via mvn CLI

_#skip-changelog_


## :bulb: Motivation and Context
publishing the artifacts via Gradle is too flaky, we're publishing via the maven CLI now.
https://github.com/gradle/gradle/issues/17082


## :green_heart: How did you test it?
publishing https://github.com/getsentry/sentry-java/releases/tag/5.0.0-beta.2

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
work on Craft