### PR TITLE
Expose SentryOptions

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -559,6 +559,7 @@ public final class io/sentry/Sentry {
 	public static fun endSession ()V
 	public static fun flush (J)V
 	public static fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public static fun getOptions ()Lio/sentry/SentryOptions;
 	public static fun getSpan ()Lio/sentry/ISpan;
 	public static fun init ()V
 	public static fun init (Lio/sentry/OptionsContainer;Lio/sentry/Sentry$OptionsConfiguration;)V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -665,6 +665,15 @@ public final class Sentry {
   }
 
   /**
+   * Gets the SentryOptions attached to current scope.
+   *
+   * @return the options attached to current scope.
+   */
+  public static @NotNull SentryOptions getOptions() {
+    return getCurrentHub().getOptions();
+  }
+
+  /**
    * Configuration options callback
    *
    * @param <T> a class that extends SentryOptions or SentryOptions itself.

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -174,4 +174,15 @@ class SentryTest {
         assertFalse(tempFile.exists())
         return tempFile.absolutePath
     }
+
+    @Test
+    fun `getOptions exposes the options used on initialization`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.setTag("x", "x")
+        }
+
+        val options = Sentry.getOptions()
+        assertEquals(setOf("x"), options.tags.keys)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
Almost all methods of IHub are exposed on Sentry class, except by `getOptions`. This PR exposes that method.

## :bulb: Motivation and Context
If you have set `enableExternalConfiguration` when initializing with `Sentry.init()`, there is no public way to access `inAppInclude` list... Exposing the SentryOptions for the current context, all options resolved from system/environment/properties may be accessible by `Sentry.getOptions`. 


## :green_heart: How did you test it?
By checking if a custom option is accessible when calling the newly introduced method.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
