### PR TITLE
Feat: Add breadcrumb in Spring RestTemplate integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: Add breadcrumb in Spring RestTemplate integration (#1481)
+
 # 5.0.0-beta.4
 
 * Fix: Enrich Transactions with Context Data (#1469)

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -1,6 +1,7 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.Breadcrumb;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
@@ -8,6 +9,7 @@ import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -27,28 +29,44 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       @NotNull byte[] body,
       @NotNull ClientHttpRequestExecution execution)
       throws IOException {
-    final ISpan activeSpan = hub.getSpan();
-    if (activeSpan == null) {
-      return execution.execute(request, body);
-    }
-
-    final ISpan span = activeSpan.startChild("http.client");
-    span.setDescription(request.getMethodValue() + " " + request.getURI());
-
-    final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
-    request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+    Integer responseStatusCode = null;
     try {
-      final ClientHttpResponse response = execution.execute(request, body);
-      // handles both success and error responses
-      span.setStatus(SpanStatus.fromHttpStatusCode(response.getRawStatusCode()));
-      return response;
-    } catch (Exception e) {
-      // handles cases like connection errors
-      span.setThrowable(e);
-      span.setStatus(SpanStatus.INTERNAL_ERROR);
-      throw e;
+      final ISpan activeSpan = hub.getSpan();
+      if (activeSpan == null) {
+        return execution.execute(request, body);
+      }
+
+      final ISpan span = activeSpan.startChild("http.client");
+      span.setDescription(request.getMethodValue() + " " + request.getURI());
+
+      final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
+      request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+      try {
+        final ClientHttpResponse response = execution.execute(request, body);
+        // handles both success and error responses
+        span.setStatus(SpanStatus.fromHttpStatusCode(response.getRawStatusCode()));
+        responseStatusCode = response.getRawStatusCode();
+        return response;
+      } catch (Exception e) {
+        // handles cases like connection errors
+        span.setThrowable(e);
+        span.setStatus(SpanStatus.INTERNAL_ERROR);
+        throw e;
+      } finally {
+        span.finish();
+      }
     } finally {
-      span.finish();
+      addBreadcrumb(request, body, responseStatusCode);
     }
+  }
+
+  private void addBreadcrumb(
+      final @NotNull HttpRequest request,
+      final @NotNull byte[] body,
+      final @Nullable Integer responseStatusCode) {
+    final Breadcrumb breadcrumb =
+        Breadcrumb.http(request.getURI().toString(), request.getMethodValue(), responseStatusCode);
+    breadcrumb.setData("requestBodySize", body.length);
+    hub.addBreadcrumb(breadcrumb);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Feat: Add breadcrumb in Spring RestTemplate integration


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the process of alignment `OkHttp` integration with Spring `RestTemplate` integration I noticed that we do not add breadcrumb for http request going through `RestTemplate`. With this change, breadcrumb is added no matter if there is an active ongoing transaction.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes