### PR TITLE
Fix: Cloning Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Feat: Add breadcrumb in Spring RestTemplate integration (#1481)
+* Fix: Cloning Stack (#1483)
 
 # 5.0.0-beta.4
 

--- a/sentry/src/main/java/io/sentry/Stack.java
+++ b/sentry/src/main/java/io/sentry/Stack.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.util.Objects;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingDeque;
 import org.jetbrains.annotations.NotNull;
 
@@ -60,9 +61,14 @@ final class Stack {
   }
 
   public Stack(final @NotNull Stack stack) {
-    this(stack.logger, stack.items.getFirst());
-    for (final StackItem item : stack.items) {
-      push(new StackItem(item));
+    this(stack.logger, new StackItem(stack.items.getFirst()));
+    final Iterator<StackItem> iterator = stack.items.iterator();
+    // skip first item (root item)
+    if (iterator.hasNext()) {
+      iterator.next();
+    }
+    while (iterator.hasNext()) {
+      push(new StackItem(iterator.next()));
     }
   }
 

--- a/sentry/src/test/java/io/sentry/StackTest.kt
+++ b/sentry/src/test/java/io/sentry/StackTest.kt
@@ -61,12 +61,21 @@ class StackTest {
     @Test
     fun `cloning stack clones stack items`() {
         val stack = fixture.getSut()
+        stack.push(StackItem(fixture.options, fixture.client, fixture.scope))
         val clone = Stack(stack)
 
-        val stackRootItem = stack.peek()
-        val cloneRootItem = clone.peek()
-        assertNotEquals(stackRootItem, cloneRootItem)
-        assertNotEquals(stackRootItem.scope, cloneRootItem.scope)
-        assertEquals(stackRootItem.client, cloneRootItem.client)
+        assertEquals(stack.size(), clone.size())
+        // assert first stack item
+        assertStackItems(stack.peek(), clone.peek())
+        stack.pop()
+        clone.pop()
+        // assert root item
+        assertStackItems(stack.peek(), clone.peek())
+    }
+
+    private fun assertStackItems(item1: StackItem, item2: StackItem) {
+        assertNotEquals(item1, item2)
+        assertNotEquals(item1.scope, item2.scope)
+        assertEquals(item1.client, item2.client)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: Cloning Stack

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The root item was added twice, first as exactly the same reference, second as a cloned item.

This fix ensures that root item is added only once as a clone.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes