### PR TITLE
Feat: Add secondary constructor to SentryOkHttpInterceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Feat: Add secondary constructor to SentryOkHttpInterceptor (#1491)
+
 # 5.0.0-beta.5
 
 * Feat: OkHttp callback for Customising the Span (#1478)

--- a/sentry-android-okhttp/api/sentry-android-okhttp.api
+++ b/sentry-android-okhttp/api/sentry-android-okhttp.api
@@ -10,6 +10,7 @@ public final class io/sentry/android/okhttp/SentryOkHttpInterceptor : okhttp3/In
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;)V
 	public synthetic fun <init> (Lio/sentry/IHub;Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;)V
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 }
 

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -15,6 +15,8 @@ class SentryOkHttpInterceptor(
     private val beforeSpan: BeforeSpanCallback? = null
 ) : Interceptor {
 
+    constructor(beforeSpan: BeforeSpanCallback) : this(HubAdapter.getInstance(), beforeSpan)
+
     override fun intercept(chain: Interceptor.Chain): Response {
         var request = chain.request()
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add secondary constructor to SentryOkHttpInterceptor.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without secondary constructor it is inconvenient to pass `beforeSpan` in constructor without using named parameter or from Java.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes
