### PR TITLE
Fix: Graceful Shutdown flushes event instead of Closing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: Graceful Shutdown flushes event instead of Closing SDK
+* Fix: Graceful Shutdown flushes event instead of Closing SDK (#1500)
 
 # 5.0.0-beta.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Graceful Shutdown flushes event instead of Closing SDK
+
 # 5.0.0-beta.6
 
 * Feat: Add secondary constructor to SentryOkHttpInterceptor (#1491)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -816,6 +816,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableNdk ()Z
 	public fun isEnableScopeSync ()Z
 	public fun isEnableSessionTracking ()Z
+	public fun isEnableShutdownHook ()Z
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isSendDefaultPii ()Z
 	public fun isTracingEnabled ()Z
@@ -838,6 +839,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableNdk (Z)V
 	public fun setEnableScopeSync (Z)V
 	public fun setEnableSessionTracking (Z)V
+	public fun setEnableShutdownHook (Z)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnvelopeDiskCache (Lio/sentry/cache/IEnvelopeCache;)V
 	public fun setEnvelopeReader (Lio/sentry/IEnvelopeReader;)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -271,6 +271,9 @@ public class SentryOptions {
   /** Maximum number of spans that can be atteched to single transaction. */
   private int maxSpans = 1000;
 
+  /** Registers hook that flushes {@link Hub} when main thread shuts down. */
+  private boolean enableShutdownHook = true;
+
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
@@ -1374,6 +1377,24 @@ public class SentryOptions {
   @ApiStatus.Experimental
   public void setMaxSpans(int maxSpans) {
     this.maxSpans = maxSpans;
+  }
+
+  /**
+   * True if ShutdownHookIntegration is enabled, false otherwise.
+   *
+   * @return true if enabled or false otherwise.
+   */
+  public boolean isEnableShutdownHook() {
+    return enableShutdownHook;
+  }
+
+  /**
+   * Enables or disable ShutdownHookIntegration.
+   *
+   * @param enableShutdownHook true if enabled or false otherwise.
+   */
+  public void setEnableShutdownHook(boolean enableShutdownHook) {
+    this.enableShutdownHook = enableShutdownHook;
   }
 
   /** The BeforeSend callback */


### PR DESCRIPTION
## :scroll: Description
Fix: Graceful Shutdown flushes event instead of Closing SDK


## :bulb: Motivation and Context
Fix #1458


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
