### PR TITLE
Fix: Do not append threads that come from the EnvelopeFileObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Fix: Do not append threads that come from the EnvelopeFileObserver
+* Fix: Do not append threads that come from the EnvelopeFileObserver (#1501)
 
 # 5.0.0-beta.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Do not append threads that come from the EnvelopeFileObserver
+
 # 5.0.0-beta.6
 
 * Feat: Add secondary constructor to SentryOkHttpInterceptor (#1491)

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -156,15 +156,14 @@ class MainEventProcessorTest {
         val sut = fixture.getSut()
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
-        event = sut.process(event, mock<CustomCachedApplyScopeDataHint>())
+        event = sut.process(event, CustomCachedApplyScopeDataHint())
 
         assertEquals("release", event.release)
         assertEquals("environment", event.environment)
         assertEquals("dist", event.dist)
         assertEquals("server", event.serverName)
-        assertNotNull(event.threads) {
-            assertTrue(it.first { t -> t.id == crashedThread.id }.isCrashed == true)
-        }
+        // threads are special case if its a Cached hint
+        assertNull(event.threads)
     }
 
     @Test
@@ -392,6 +391,16 @@ class MainEventProcessorTest {
         transaction = processor.process(transaction, null)
 
         assertNotNull(transaction.user)
+    }
+
+    @Test
+    fun `when event has Cached hint, threads should not be set`() {
+        val sut = fixture.getSut()
+
+        var event = SentryEvent()
+        event = sut.process(event, CustomCachedApplyScopeDataHint())
+
+        assertNull(event.threads)
     }
 
     private fun generateCrashedEvent(crashedThread: Thread = Thread.currentThread()) = SentryEvent().apply {


### PR DESCRIPTION
## :scroll: Description
Fix: Do not append threads that come from the EnvelopeFileObserver


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-java/issues/1473


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
