### PR TITLE
Ref: Deprecate SentryBaseEvent#getOriginThrowable and add SentryBaseEvent#getThrowableMechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Ref: Deprecate SentryBaseEvent#getOriginThrowable and add SentryBaseEvent#getThrowableMechanism
+
 # 5.0.0-beta.6
 
 * Feat: Add secondary constructor to SentryOkHttpInterceptor (#1491)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Ref: Deprecate SentryBaseEvent#getOriginThrowable and add SentryBaseEvent#getThrowableMechanism
+* Ref: Deprecate SentryBaseEvent#getOriginThrowable and add SentryBaseEvent#getThrowableMechanism (#1502)
 
 # 5.0.0-beta.6
 

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -23,7 +23,7 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
   public @Nullable SentryEvent process(
       final @NotNull SentryEvent event, final @Nullable Object hint) {
     if (options.isEnableDeduplication()) {
-      final Throwable throwable = event.getOriginThrowable();
+      final Throwable throwable = event.getThrowable();
       if (throwable != null) {
         if (capturedObjects.containsKey(throwable)
             || containsAnyKey(capturedObjects, allCauses(throwable))) {

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -179,7 +179,7 @@ public final class MainEventProcessor implements EventProcessor {
   }
 
   private void setExceptions(final @NotNull SentryEvent event) {
-    final Throwable throwable = event.getThrowable();
+    final Throwable throwable = event.getThrowableMechanism();
     if (throwable != null) {
       event.setExceptions(sentryExceptionFactory.getSentryExceptions(throwable));
     }

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -168,7 +168,6 @@ public abstract class SentryBaseEvent {
    * ExceptionMechanismException}, returns unwrapped throwable.
    *
    * @deprecated use {{@link SentryBaseEvent#getThrowable()} }
-   *
    * @return the Throwable or null
    */
   @Deprecated
@@ -178,11 +177,13 @@ public abstract class SentryBaseEvent {
   }
 
   /**
-   * Returns the captured Throwable or null.
-   * It may be wrapped in a {@link ExceptionMechanismException}.
+   * Returns the captured Throwable or null. It may be wrapped in a {@link
+   * ExceptionMechanismException}.
+   *
    * @return the Throwable or null
    */
-  @Nullable Throwable getThrowableMechanism() {
+  @Nullable
+  Throwable getThrowableMechanism() {
     return throwable;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -149,27 +149,41 @@ public abstract class SentryBaseEvent {
   }
 
   /**
-   * Returns the captured Throwable or null
-   *
-   * @return the Throwable or null
-   */
-  public @Nullable Throwable getThrowable() {
-    return throwable;
-  }
-
-  /**
    * Returns the captured Throwable or null. If a throwable is wrapped in {@link
    * ExceptionMechanismException}, returns unwrapped throwable.
    *
    * @return the Throwable or null
    */
-  public @Nullable Throwable getOriginThrowable() {
+  public @Nullable Throwable getThrowable() {
     final Throwable ex = throwable;
     if (ex instanceof ExceptionMechanismException) {
       return ((ExceptionMechanismException) ex).getThrowable();
     } else {
       return ex;
     }
+  }
+
+  /**
+   * Returns the captured Throwable or null. If a throwable is wrapped in {@link
+   * ExceptionMechanismException}, returns unwrapped throwable.
+   *
+   * @deprecated use {{@link SentryBaseEvent#getThrowable()} }
+   *
+   * @return the Throwable or null
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public @Nullable Throwable getOriginThrowable() {
+    return getThrowable();
+  }
+
+  /**
+   * Returns the captured Throwable or null.
+   * It may be wrapped in a {@link ExceptionMechanismException}.
+   * @return the Throwable or null
+   */
+  @Nullable Throwable getThrowableMechanism() {
+    return throwable;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -105,14 +105,14 @@ public final class SentryClient implements ISentryClient {
     }
 
     if (event != null) {
-      if (event.getOriginThrowable() != null
-          && options.containsIgnoredExceptionForType(event.getOriginThrowable())) {
+      if (event.getThrowable() != null
+          && options.containsIgnoredExceptionForType(event.getThrowable())) {
         options
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
                 "Event was dropped as the exception %s is ignored",
-                event.getOriginThrowable().getClass());
+                event.getThrowable().getClass());
         return SentryId.EMPTY_ID;
       }
       event = executeBeforeSend(event, hint);

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -79,19 +79,37 @@ class SentryEventTest {
     }
 
     @Test
-    fun `when throwable is a ExceptionMechanismException, getOriginThrowable unwraps original throwable`() {
+    fun `when throwable is a ExceptionMechanismException, getThrowable unwraps original throwable`() {
         val event = SentryEvent()
         val ex = RuntimeException()
         event.throwable = ExceptionMechanismException(Mechanism(), ex, Thread.currentThread())
-        assertEquals(ex, event.originThrowable)
+        assertEquals(ex, event.getThrowable())
     }
 
     @Test
-    fun `when throwable is not a ExceptionMechanismException, getOriginThrowable returns throwable`() {
+    fun `when throwable is not a ExceptionMechanismException, getThrowable returns throwable`() {
         val event = SentryEvent()
         val ex = RuntimeException()
         event.throwable = ex
-        assertEquals(ex, event.originThrowable)
+        assertEquals(ex, event.getThrowable())
+    }
+
+    @Test
+    fun `when throwable is a ExceptionMechanismException, getThrowableMechanism returns the wrapped throwable`() {
+        val event = SentryEvent()
+        val ex = RuntimeException()
+        val exceptionMechanism = ExceptionMechanismException(Mechanism(), ex, Thread.currentThread())
+        event.throwable = exceptionMechanism
+        assertEquals(exceptionMechanism, event.throwableMechanism)
+    }
+
+    @Test
+    fun `when getOriginThrowable is called, fallback to getThrowable`() {
+        val event = SentryEvent()
+        val ex = RuntimeException()
+        val exceptionMechanism = ExceptionMechanismException(Mechanism(), ex, Thread.currentThread())
+        event.throwable = exceptionMechanism
+        assertEquals(event.getThrowable(), event.originThrowable)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Ref: Deprecate SentryBaseEvent#getOriginThrowable and add SentryBaseEvent#getThrowableMechanism


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-java/issues/1301


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
