### PR TITLE
Fix: Append all threads if Hint is Cached but attachThreads is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix: Do not append threads that come from the EnvelopeFileObserver (#1501)
 * Ref: Deprecate cacheDirSize and add maxCacheItems (#1499)
+* Fix: Append all threads if Hint is Cached but attachThreads is enabled (#1503)
 
 # 5.0.0-beta.6
 

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -187,7 +187,7 @@ public final class MainEventProcessor implements EventProcessor {
   }
 
   private void setThreads(final @NotNull SentryEvent event, final @Nullable Object hint) {
-    if (event.getThreads() == null && !isCachedHint(hint)) {
+    if (event.getThreads() == null) {
       // collecting threadIds that came from the exception mechanism, so we can mark threads as
       // crashed properly
       List<Long> mechanismThreadIds = null;
@@ -208,7 +208,8 @@ public final class MainEventProcessor implements EventProcessor {
       if (options.isAttachThreads()) {
         event.setThreads(sentryThreadFactory.getCurrentThreads(mechanismThreadIds));
       } else if (options.isAttachStacktrace()
-          && (eventExceptions == null || eventExceptions.isEmpty())) {
+          && (eventExceptions == null || eventExceptions.isEmpty())
+          && !isCachedHint(hint)) {
         // when attachStacktrace is enabled, we attach only the current thread and its stack traces,
         // if there are no exceptions, exceptions have its own stack traces.
         event.setThreads(sentryThreadFactory.getCurrentThread());
@@ -218,7 +219,7 @@ public final class MainEventProcessor implements EventProcessor {
 
   /**
    * If the event has a Cached Hint, it means that it came from the EnvelopeFileObserver. We don't
-   * want to append this thread to the event.
+   * want to append the current thread to the event.
    *
    * @param hint the Hint
    * @return true if Cached or false otherwise

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -162,8 +162,9 @@ class MainEventProcessorTest {
         assertEquals("environment", event.environment)
         assertEquals("dist", event.dist)
         assertEquals("server", event.serverName)
-        // threads are special case if its a Cached hint
-        assertNull(event.threads)
+        assertNotNull(event.threads) {
+            assertTrue(it.first { t -> t.id == crashedThread.id }.isCrashed == true)
+        }
     }
 
     @Test
@@ -394,8 +395,8 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `when event has Cached hint, threads should not be set`() {
-        val sut = fixture.getSut()
+    fun `when event has Cached hint, current thread should not be set`() {
+        val sut = fixture.getSut(attachThreads = false)
 
         var event = SentryEvent()
         event = sut.process(event, CustomCachedApplyScopeDataHint())


### PR DESCRIPTION
## :scroll: Description
Fix: Append all threads if Hint is Cached but attachThreads is enabled


## :bulb: Motivation and Context
Ammend to #1501


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
