### PR TITLE
feat(release): Delegate version bumping to Craft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Add version bumping script for Craft (#1518)
-
 ## 5.0.1
 
 * Fix: Sources and Javadoc artifacts were mixed up (#1515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add version bumping script for Craft.
+
 ## 5.0.1
 
 * Fix: Sources and Javadoc artifacts were mixed up (#1515)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add version bumping script for Craft.
+* Add version bumping script for Craft (#1518)
 
 ## 5.0.1
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eux
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="$1"
+NEW_VERSION="$2"
+
+echo $OLD_VERSION
+echo $NEW_VERSION
+
+GRADLE_FILEPATH="gradle.properties"
+
+# Increment `buildVersionCode`
+VERSION_CODE_PATTERN="buildVersionCode"
+VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
+((VERSION_NUMBER++))
+sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH
+echo "buildVersionCode done"
+
+# Replace `versionName` with the given version
+VERSION_NAME_PATTERN="versionName"
+sed -ie "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH
+echo "versionName done"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -17,9 +17,7 @@ VERSION_CODE_PATTERN="buildVersionCode"
 VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
 ((VERSION_NUMBER++))
 sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH
-echo "buildVersionCode done"
 
 # Replace `versionName` with the given version
 VERSION_NAME_PATTERN="versionName"
 sed -ie "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH
-echo "versionName done"


### PR DESCRIPTION
At the moment, `buildVersionCode` and `versionName` have to be updated manually before doing a release. This PR adds a version bumping script, run by Craft on [`prepare`](https://github.com/getsentry/craft#pre-release-command).

- `buildVersionCode` will be incremented by 1.
- `versionName` will be the new version to prepare by Craft. For example, `craft prepare 6.0.0` will set `versionName=6.0.0`, and `craft prepare 6.1.0-alpha.1` will set `versionName=6.1.0-alpha.1`.

Note [Changelog Policies](6.1.0-alpha.1). Current policy is `simple`, so there must be an entry in the changelog with a matching version name for the new release passed to Craft; if not, the command will fail.

#skip-changelog