### PR TITLE
ref(release): Changelog policy to auto

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 minVersion: 0.23.1
-changelogPolicy: simple
+changelogPolicy: auto
 artifactProvider:
   name: none
 targets:


### PR DESCRIPTION
Setting Craft's [Changelog Policy](https://github.com/getsentry/craft#changelog-policies) from `simple` to `auto`. After this change, changelog entries can be added to `Unreleased` and Craft will take care of renaming that entry to the new version (while preparing).

#skip-changelog