### PR TITLE
Capture markers in log4j2 and logback appenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feat: Capture logged marker in log4j2 and logback appenders  (#1551)
+
 ## 5.1.0-beta.1
 
 * Feat: Measure app start time (#1487)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Feat: Capture logged marker in log4j2 and logback appenders  (#1551)
+* Feat: Capture logged marker in log4j2 and logback appenders (#1551)
 
 ## 5.1.0-beta.1
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -155,6 +155,10 @@ public final class SentryAppender extends AbstractAppender {
       event.setExtra("thread_name", loggingEvent.getThreadName());
     }
 
+    if (loggingEvent.getMarker() != null) {
+      event.setExtra("marker", loggingEvent.getMarker().toString());
+    }
+
     final Map<String, String> contextData =
         CollectionUtils.filterMapEntries(
             loggingEvent.getContextData().toMap(), entry -> entry.getValue() != null);

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -91,6 +91,10 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
       event.setExtra("thread_name", loggingEvent.getThreadName());
     }
 
+    if (loggingEvent.getMarker() != null) {
+      event.setExtra("marker", loggingEvent.getMarker().toString());
+    }
+
     // remove keys with null values, there is no sense to send these keys to Sentry
     final Map<String, String> mdcProperties =
         CollectionUtils.filterMapEntries(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Collect markers from logger system in log4j2 and logback appenders.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds useful context to logged errors, some more discussion in #1547 


## :green_heart: How did you test it?
Running test suite for the relevant libraries. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
The change should probably be documented on these pages:
 - https://docs.sentry.io/platforms/java/guides/logback/usage/advanced-usage/
 - https://docs.sentry.io/platforms/java/guides/log4j2/advanced_usage/

Some inspiration could be had from this docs from the legacy sdk:
 - https://docs.sentry.io/platforms/java/guides/logback/legacy/logback/

