### PR TITLE
Fix handling missing Spring Security on classpath on Java 8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+* Fix: Handling missing Spring Security on classpath on Java 8 (#1552)
+
 ## 5.1.0-beta.1
 
 * Feat: Measure app start time (#1487)
-* Feat: Automatic breadcrumbs logging for fragment lifecycle (#1522)
-* Fix: Handling missing Spring Security on classpath on Java 8 (#1552) 
+* Feat: Automatic breadcrumbs logging for fragment lifecycle (#1522) 
 
 ## 5.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## 5.1.0-beta.1
 
 * Feat: Measure app start time (#1487)
-* Feat: Automatic breadcrumbs logging for fragment lifecycle (#1522) 
+* Feat: Automatic breadcrumbs logging for fragment lifecycle (#1522)
+* Fix: Handling missing Spring Security on classpath on Java 8 (#1552) 
 
 ## 5.0.1
 

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -124,20 +124,24 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryWebMvcConfiguration {
 
-      /**
-       * Configures {@link SpringSecuritySentryUserProvider} only if Spring Security is on the
-       * classpath. Its order is set to be higher than {@link
-       * SentryWebConfiguration#httpServletRequestSentryUserProvider(SentryOptions)}
-       *
-       * @param sentryOptions the Sentry options
-       * @return {@link SpringSecuritySentryUserProvider}
-       */
-      @Bean
+      @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(SecurityContextHolder.class)
-      @Order(1)
-      public @NotNull SpringSecuritySentryUserProvider springSecuritySentryUserProvider(
-          final @NotNull SentryOptions sentryOptions) {
-        return new SpringSecuritySentryUserProvider(sentryOptions);
+      @Open
+      static class SentrySecurityConfiguration {
+        /**
+         * Configures {@link SpringSecuritySentryUserProvider} only if Spring Security is on the
+         * classpath. Its order is set to be higher than {@link
+         * SentryWebConfiguration#httpServletRequestSentryUserProvider(SentryOptions)}
+         *
+         * @param sentryOptions the Sentry options
+         * @return {@link SpringSecuritySentryUserProvider}
+         */
+        @Bean
+        @Order(1)
+        public @NotNull SpringSecuritySentryUserProvider springSecuritySentryUserProvider(
+            final @NotNull SentryOptions sentryOptions) {
+          return new SpringSecuritySentryUserProvider(sentryOptions);
+        }
       }
 
       /**


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix handling missing Spring Security on classpath on Java 8.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`@ConditionalOnClass` placed on methods ends up with an exception when used with Java 8. This behavior does not exist with Java 11+.

Fixes #1543
Fixes #1546

## :green_heart: How did you test it?

This bug is related with how classes are loaded, and the test with filtered class does not exactly reproduces the issue. To reproduce this issue we would need to add a separate Gradle module that has no Spring Security on the classpath. Not sure if it's worth it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes