### PR TITLE
feat: Add clearAttachments to Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix: Handling missing Spring Security on classpath on Java 8 (#1552)
 * Feat: Support transaction waiting for children to finish. (#1535) 
 * Feat: Capture logged marker in log4j2 and logback appenders (#1551)
+* Feat: Allow clearing of attachments in the scope (#1517)
 * Fix: Use a different method to get strings from JNI, and avoid excessive Stack Space usage. (#1214)
 * Fix: Add data field to SentrySpan (#1555)
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix: Handling missing Spring Security on classpath on Java 8 (#1552)
 * Feat: Support transaction waiting for children to finish. (#1535) 
 * Feat: Capture logged marker in log4j2 and logback appenders (#1551)
-* Feat: Allow clearing of attachments in the scope (#1517)
+* Feat: Allow clearing of attachments in the scope (#1562)
 * Fix: Use a different method to get strings from JNI, and avoid excessive Stack Space usage. (#1214)
 * Fix: Add data field to SentrySpan (#1555)
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -554,9 +554,7 @@ public final class Scope {
     attachments.add(attachment);
   }
 
-  /**
-   * Clear all attachments.
-   */
+  /** Clear all attachments. */
   public void clearAttachments() {
     attachments.clear();
   }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -379,12 +379,12 @@ public final class Scope {
     user = null;
     request = null;
     fingerprint.clear();
-    breadcrumbs.clear();
+    clearBreadcrumbs();
     tags.clear();
     extra.clear();
     eventProcessors.clear();
     clearTransaction();
-    attachments.clear();
+    clearAttachments();
   }
 
   /**
@@ -552,6 +552,13 @@ public final class Scope {
    */
   public void addAttachment(final @NotNull Attachment attachment) {
     attachments.add(attachment);
+  }
+
+  /**
+   * Clear all attachments.
+   */
+  public void clearAttachments() {
+    attachments.clear();
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -765,6 +765,17 @@ class ScopeTest {
     }
 
     @Test
+    fun `clearAttachments clears all attachments`() {
+        val scope = Scope(SentryOptions())
+        scope.addAttachment(Attachment(""))
+        scope.addAttachment(Attachment(""))
+
+        assertEquals(2, scope.attachments.count())
+        scope.clearAttachments()
+        assertEquals(0, scope.attachments.count())
+    }
+
+    @Test
     fun `setting null fingerprint do not overwrite current value`() {
         val scope = Scope(SentryOptions())
         // sanity check


### PR DESCRIPTION
## :scroll: Description
We want to expose a method to clear the attachments on the scope.


## :bulb: Motivation and Context
getsentry/sentry-java#1517


## :green_heart: How did you test it?
I added a test to ScopeTest to verify that the `clearAttachments` method really clears all attachments.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
