### PR TITLE
Assign lastEventId only if event was queued for submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)
 * Feat: Set mechanism type in SentryExceptionResolver (#1556)
 * Ref: Prefer snake case for HTTP integration data keys (#1559)
+* Feat: Assign lastEventId only if event has been sent successfully ()
 
 ## 5.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)
 * Feat: Set mechanism type in SentryExceptionResolver (#1556)
 * Ref: Prefer snake case for HTTP integration data keys (#1559)
-* Feat: Assign lastEventId only if event was queued for submission (#1565)
+* Fix: Assign lastEventId only if event was queued for submission (#1565)
 
 ## 5.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)
 * Feat: Set mechanism type in SentryExceptionResolver (#1556)
 * Ref: Prefer snake case for HTTP integration data keys (#1559)
-* Feat: Assign lastEventId only if event has been sent successfully (#1565)
+* Feat: Assign lastEventId only if event was queued for submission (#1565)
 
 ## 5.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Fix: Clock drift issue when calling DateUtils#getDateTimeWithMillisPrecision (#1557)
 * Feat: Set mechanism type in SentryExceptionResolver (#1556)
 * Ref: Prefer snake case for HTTP integration data keys (#1559)
-* Feat: Assign lastEventId only if event has been sent successfully ()
+* Feat: Assign lastEventId only if event has been sent successfully (#1565)
 
 ## 5.1.0-beta.1
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -486,6 +486,7 @@ public final class io/sentry/Scope {
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/lang/Object;)V
 	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
 	public fun clear ()V
+	public fun clearAttachments ()V
 	public fun clearBreadcrumbs ()V
 	public fun clearTransaction ()V
 	public fun getContexts ()Lio/sentry/protocol/Contexts;

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -87,6 +87,7 @@ public final class Hub implements IHub {
         assignTraceContext(event);
         final StackItem item = stack.peek();
         sentryId = item.getClient().captureEvent(event, item.getScope(), hint);
+        this.lastEventId = sentryId;
       } catch (Exception e) {
         options
             .getLogger()
@@ -94,7 +95,6 @@ public final class Hub implements IHub {
                 SentryLevel.ERROR, "Error while capturing event with id: " + event.getEventId(), e);
       }
     }
-    this.lastEventId = sentryId;
     return sentryId;
   }
 

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -288,6 +288,19 @@ class HubTest {
     }
 
     @Test
+    fun `when captureEvent is called on disabled hub, lastEventId does not get overwritten`() {
+        val (sut, mockClient) = getEnabledHub()
+        whenever(mockClient.captureEvent(any(), any(), anyOrNull())).thenReturn(SentryId(UUID.randomUUID()))
+        val event = SentryEvent()
+        val hint = { }
+        sut.captureEvent(event, hint)
+        val lastEventId = sut.lastEventId
+        sut.close()
+        sut.captureEvent(event, hint)
+        assertEquals(lastEventId, sut.lastEventId)
+    }
+
+    @Test
     fun `when captureEvent is called and session tracking is disabled, it should not capture a session`() {
         val (sut, mockClient) = getEnabledHub()
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Assign lastEventId only if event has been sent successfully

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1414

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes