### PR TITLE
fix(craft): Add empty `Unreleased` entry to the changelog after release

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eux
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+# Add a new unreleased entry in the changelog
+sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md


### PR DESCRIPTION
After updating the changelog entry policy to `auto` (see https://github.com/getsentry/sentry-java/pull/1520), Craft renames the `Unreleased` entry to the actual version being released. This PR adds the `post-release.sh` script, run after Craft has finished the release (see [docs](https://github.com/getsentry/craft#post-release-command)), creates a new empty entry in the changelog, for future commits.

_#skip-changelog_