### PR TITLE
fix(craft): Increment versions in post-release

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -15,3 +15,6 @@ GRADLE_FILEPATH="gradle.properties"
 # Replace `versionName` with the given version
 VERSION_NAME_PATTERN="versionName"
 sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH
+
+# Don't bump `buildVersionCode` since it's bumped after doing the release.
+# See comments in `post-release.sh`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,12 +12,6 @@ echo $NEW_VERSION
 
 GRADLE_FILEPATH="gradle.properties"
 
-# Increment `buildVersionCode`
-VERSION_CODE_PATTERN="buildVersionCode"
-VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
-((VERSION_NUMBER++))
-sed -i "" -e "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH
-
 # Replace `versionName` with the given version
 VERSION_NAME_PATTERN="versionName"
 sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -15,6 +15,9 @@ sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 # fixed version until the next release it's made. For testing purposes, it's
 # interesting to have a different version name that doesn't match the
 # name of the version in production.
+# Note that the version must end with a number: `1.2.3-alpha` is a semantic
+# version but not compatible with this post-release script.
+# and `1.2.3-alpha.0` should be used instead.
 VERSION_NAME_PATTERN="versionName"
 version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
 version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -9,3 +9,9 @@ NEW_VERSION="${2}"
 
 # Add a new unreleased entry in the changelog
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
+
+# Increment `buildVersionCode`
+VERSION_CODE_PATTERN="buildVersionCode"
+VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
+((VERSION_NUMBER++))
+sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -11,9 +11,9 @@ NEW_VERSION="${2}"
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 
 # Increment `versionName` and make it a snapshot
-# Incrementing the version name before the release (`bump-version.sh`) sets the 
-# a fixed version until the next release it's made. For testing purposes, it's 
-# interesting to have a different version name that doesn't match with the
+# Incrementing the version name before the release (`bump-version.sh`) sets a
+# fixed version until the next release it's made. For testing purposes, it's
+# interesting to have a different version name that doesn't match the
 # name of the version in production.
 VERSION_NAME_PATTERN="versionName"
 version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -10,13 +10,11 @@ NEW_VERSION="${2}"
 # Add a new unreleased entry in the changelog
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 
-# Increment `buildVersionCode`
-VERSION_CODE_PATTERN="buildVersionCode"
-VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
-((VERSION_NUMBER++))
-sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH
-
 # Increment `versionName` and make it a snapshot
+# Incrementing the version name before the release (`bump-version.sh`) sets the 
+# a fixed version until the next release it's made. For testing purposes, it's 
+# interesting to have a different version name that doesn't match with the
+# name of the version in production.
 VERSION_NAME_PATTERN="versionName"
 version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
 version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"
@@ -25,3 +23,12 @@ version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep
 # since the version to be bumped is extracted using `+`.
 new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
 sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$new_version-SNAPSHOT/g" $GRADLE_FILEPATH
+
+# Increment `buildVersionCode`
+# After having incremented the version name (see comments above), the new version
+# still has the version code of the version in production. This must be
+# incremented to align with the new version.
+VERSION_CODE_PATTERN="buildVersionCode"
+VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
+((VERSION_NUMBER++))
+sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -15,3 +15,13 @@ VERSION_CODE_PATTERN="buildVersionCode"
 VERSION_NUMBER="$( awk "/$VERSION_CODE_PATTERN/" $GRADLE_FILEPATH | grep -o '[0-9]\+' )"
 ((VERSION_NUMBER++))
 sed -ie "s/$VERSION_CODE_PATTERN=.*$/$VERSION_CODE_PATTERN=$VERSION_NUMBER/g" $GRADLE_FILEPATH
+
+# Increment `versionName` and make it a snapshot
+VERSION_NAME_PATTERN="versionName"
+version="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9].*$' )" # from the first digit until the end
+version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep -o '[0-9]+$')"
+((version_digit_to_bump++))
+# Using `*` instead of `+` for compatibility. The result is the same,
+# since the version to be bumped is extracted using `+`.
+new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
+sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$new_version-SNAPSHOT/g" $GRADLE_FILEPATH


### PR DESCRIPTION
Incrementing the version name before the release sets a fixed version until the next release it's made. For testing purposes, it's interesting to have a different version name that doesn't match the name of the version in production (ending with `-SNAPSHOT`). Versions are incremented by increasing by one the last numeric value; for example, `1.2.3` will become `1.2.4`, and `1.2.5-beta.1` will become `1.2.5-beta.2`. The first version in these examples is the released version (the argument Craft takes). Note, however, that versions must end with a number: `1.2.3-alpha` is a semantic version but not compatible with this post-release script (doesn't end with a number), and `1.2.3-alpha.0` should be used instead.

Once incremented the version name, the version code has also to be incremented to not match with the version already in production, so this task has been moved from the prerelease to the post-release. The prerelease script (`bump-version.sh`) still replaces the version.

_#skip-changelog_

Closes https://github.com/getsentry/sentry-java/issues/1580.