### PR TITLE
fix(release): Add missing var to post-release script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,9 +7,6 @@ cd $SCRIPT_DIR/..
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
-echo $OLD_VERSION
-echo $NEW_VERSION
-
 GRADLE_FILEPATH="gradle.properties"
 
 # Replace `versionName` with the given version

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -7,6 +7,8 @@ cd $SCRIPT_DIR/..
 OLD_VERSION="${1}"
 NEW_VERSION="${2}"
 
+GRADLE_FILEPATH="gradle.properties"
+
 # Add a new unreleased entry in the changelog
 sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 


### PR DESCRIPTION
Adds a missing and required variable to `scripts/post-release.sh`, run by Craft after a release.

_#skip-changelog_