### PR TITLE
feat(craft): Add `symbol-collector` target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,21 @@
 minVersion: 0.25.0
 changelogPolicy: auto
 targets:
+  - name: symbol-collector
+    includeNames: /libsentry(-android)?\.so/
+    batchType: android
+    bundleIdPrefix: android-ndk-
+  - name: maven
+    includeNames: /^sentry.*$/
+    gradleCliPath: ./gradlew
+    mavenCliPath: scripts/mvnw
+    mavenSettingsPath: scripts/settings.xml
+    mavenRepoId: ossrh
+    mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
+    android:
+      distDirRegex: /^sentry-android-.*$/
+      fileReplaceeRegex: /\d\.\d\.\d(-\w+(\.\d)?)?(-SNAPSHOT)?/
+      fileReplacerStr: release.aar
   - name: github
     excludeNames: /^libsentry.*\.so$/
   - name: registry
@@ -20,14 +35,3 @@ targets:
       maven:io.sentry:sentry-android-okhttp:
       maven:io.sentry:sentry-kotlin-extensions:
       maven:io:sentry:sentry-android-fragment:
-  - name: maven
-    includeNames: /^sentry.*$/
-    gradleCliPath: ./gradlew
-    mavenCliPath: scripts/mvnw
-    mavenSettingsPath: scripts/settings.xml
-    mavenRepoId: ossrh
-    mavenRepoUrl: https://oss.sonatype.org/service/local/staging/deploy/maven2/
-    android:
-      distDirRegex: /^sentry-android-.*$/
-      fileReplaceeRegex: /\d\.\d\.\d(-\w+(\.\d)?)?(-SNAPSHOT)?/
-      fileReplacerStr: release.aar


### PR DESCRIPTION
This PR adds the `symbol-collector` target to support https://github.com/getsentry/craft/pull/266. It also changes the target order, so that:

- `symbol-collector` runs before `maven`, since the former is reentrant and the latter isn't.
- `github` and `registry` targets go after `symbol-collector` and `maven`, since the first two should only be run once the actual release has been made.

_#skip-changelog_