### PR TITLE
Override all LyfecycleWatcher abstract methods to bypass Lifecycle issue

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
@@ -136,6 +136,27 @@ final class LifecycleWatcher implements DefaultLifecycleObserver {
     hub.addBreadcrumb(breadcrumb);
   }
 
+  // Override all abstract methods to pass Lifecycle issue
+  @Override
+  public void onCreate(final @NotNull LifecycleOwner owner) {
+
+  }
+
+  @Override
+  public void onResume(final @NotNull LifecycleOwner owner) {
+
+  }
+
+  @Override
+  public void onPause(final @NotNull LifecycleOwner owner) {
+
+  }
+
+  @Override
+  public void onDestroy(final @NotNull LifecycleOwner owner) {
+
+  }
+
   @TestOnly
   @NotNull
   AtomicBoolean isRunningSession() {


### PR DESCRIPTION
## :scroll: Description
Overrides all DefaultLifecycleObserver abstract methods in LyfecycleWatcher to bypass Lifecycle issue


## :bulb: Motivation and Context
Resolve DefaultLifecycleObserver Issue #1553

## :green_heart: 
Test project https://github.com/Blinkq/sentry_test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] No breaking changes
