### PR TITLE
Make SentryAppender non-final for Log4j2 and Logback (#1602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Make SentryAppender non-final for Log4j2 and Logback (#1602) 
+* Make SentryAppender non-final for Log4j2 and Logback (#1603) 
 
 ## 5.1.0-beta.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Make SentryAppender non-final for Log4j2 and Logback (#1602) 
+
 ## 5.1.0-beta.4
 
 * Update sentry-native to 0.4.11 (#1591)

--- a/sentry-log4j2/api/sentry-log4j2.api
+++ b/sentry-log4j2/api/sentry-log4j2.api
@@ -3,10 +3,12 @@ public final class io/sentry/log4j2/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
-public final class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
+public class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
 	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/Boolean;Lio/sentry/ITransportFactory;Lio/sentry/IHub;)V
 	public fun append (Lorg/apache/logging/log4j/core/LogEvent;)V
 	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Ljava/lang/Boolean;Lorg/apache/logging/log4j/core/Filter;)Lio/sentry/log4j2/SentryAppender;
+	protected fun createBreadcrumb (Lorg/apache/logging/log4j/core/LogEvent;)Lio/sentry/Breadcrumb;
+	protected fun createEvent (Lorg/apache/logging/log4j/core/LogEvent;)Lio/sentry/SentryEvent;
 	public fun start ()V
 }
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -1,5 +1,6 @@
 package io.sentry.log4j2;
 
+import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.DateUtils;
 import io.sentry.HubAdapter;
@@ -33,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 
 /** Appender for Log4j2 in charge of sending the logged events to a Sentry server. */
 @Plugin(name = "Sentry", category = "Core", elementType = "appender", printObject = true)
+@Open
 public class SentryAppender extends AbstractAppender {
   private final @Nullable String dsn;
   private final @Nullable ITransportFactory transportFactory;

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 /** Appender for Log4j2 in charge of sending the logged events to a Sentry server. */
 @Plugin(name = "Sentry", category = "Core", elementType = "appender", printObject = true)
-public final class SentryAppender extends AbstractAppender {
+public class SentryAppender extends AbstractAppender {
   private final @Nullable String dsn;
   private final @Nullable ITransportFactory transportFactory;
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
@@ -136,7 +136,7 @@ public final class SentryAppender extends AbstractAppender {
    */
   // for the Android compatibility we must use old Java Date class
   @SuppressWarnings("JdkObsolete")
-  final @NotNull SentryEvent createEvent(final @NotNull LogEvent loggingEvent) {
+  protected @NotNull SentryEvent createEvent(final @NotNull LogEvent loggingEvent) {
     final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeMillis()));
     final Message message = new Message();
     message.setMessage(loggingEvent.getMessage().getFormat());
@@ -186,7 +186,7 @@ public final class SentryAppender extends AbstractAppender {
    * @param loggingEvent the log4j2 event
    * @return the sentry breadcrumb
    */
-  private @NotNull Breadcrumb createBreadcrumb(final @NotNull LogEvent loggingEvent) {
+  protected @NotNull Breadcrumb createBreadcrumb(final @NotNull LogEvent loggingEvent) {
     final Breadcrumb breadcrumb = new Breadcrumb();
     breadcrumb.setLevel(formatLevel(loggingEvent.getLevel()));
     breadcrumb.setCategory(loggingEvent.getLoggerName());

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -3,8 +3,12 @@ public final class io/sentry/logback/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
-public final class io/sentry/logback/SentryAppender : ch/qos/logback/core/UnsynchronizedAppenderBase {
+public class io/sentry/logback/SentryAppender : ch/qos/logback/core/UnsynchronizedAppenderBase {
 	public fun <init> ()V
+	protected fun append (Lch/qos/logback/classic/spi/ILoggingEvent;)V
+	protected synthetic fun append (Ljava/lang/Object;)V
+	protected fun createBreadcrumb (Lch/qos/logback/classic/spi/ILoggingEvent;)Lio/sentry/Breadcrumb;
+	protected fun createEvent (Lch/qos/logback/classic/spi/ILoggingEvent;)Lio/sentry/SentryEvent;
 	public fun getMinimumBreadcrumbLevel ()Lch/qos/logback/classic/Level;
 	public fun getMinimumEventLevel ()Lch/qos/logback/classic/Level;
 	public fun setMinimumBreadcrumbLevel (Lch/qos/logback/classic/Level;)V

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Appender for logback in charge of sending the logged events to a Sentry server. */
-public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @NotNull SentryOptions options = new SentryOptions();
   private @Nullable ITransportFactory transportFactory;
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
@@ -72,7 +72,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
    */
   // for the Android compatibility we must use old Java Date class
   @SuppressWarnings("JdkObsolete")
-  final @NotNull SentryEvent createEvent(@NotNull ILoggingEvent loggingEvent) {
+  protected @NotNull SentryEvent createEvent(@NotNull ILoggingEvent loggingEvent) {
     final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeStamp()));
     final Message message = new Message();
     message.setMessage(loggingEvent.getMessage());
@@ -123,7 +123,7 @@ public final class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEve
    * @param loggingEvent the logback event
    * @return the sentry breadcrumb
    */
-  private @NotNull Breadcrumb createBreadcrumb(final @NotNull ILoggingEvent loggingEvent) {
+  protected @NotNull Breadcrumb createBreadcrumb(final @NotNull ILoggingEvent loggingEvent) {
     final Breadcrumb breadcrumb = new Breadcrumb();
     breadcrumb.setLevel(formatLevel(loggingEvent.getLevel()));
     breadcrumb.setCategory(loggingEvent.getLoggerName());

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.DateUtils;
 import io.sentry.ITransportFactory;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Appender for logback in charge of sending the logged events to a Sentry server. */
+@Open
 public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @NotNull SentryOptions options = new SentryOptions();
   private @Nullable ITransportFactory transportFactory;


### PR DESCRIPTION
## :scroll: Description
Make SentryAppender non-final for Log4j2 and Logback


## :bulb: Motivation and Context
Users will be able to customize the appenders it if they need it. See #1602


## :green_heart: How did you test it?
Did a full build (I had to disable OutboxSenderTest class, `deserialize sample envelope with event and two attachments` test, SentryWebfluxIntegrationTest (due to an Error while closing the hub),  but I believe those are not related to to my changes at all.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [X] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
