### PR TITLE
Fix: Do not throw IAE when tracing header contain invalid trace id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Do not throw IAE when tracing header contain invalid trace id (#1605)
+
 ## 5.1.0-beta.4
 
 * Update sentry-native to 0.4.11 (#1591)

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -109,7 +109,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       } catch (InvalidSentryTraceHeaderException e) {
         hub.getOptions()
             .getLogger()
-            .log(SentryLevel.DEBUG, "Failed to parse Sentry trace header: %s", e.getMessage());
+            .log(SentryLevel.DEBUG, e, "Failed to parse Sentry trace header: %s", e.getMessage());
       }
     }
     return hub.startTransaction(name, "http.server", customSamplingContext, true);

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1283,6 +1283,7 @@ public final class io/sentry/exception/ExceptionMechanismException : java/lang/R
 
 public final class io/sentry/exception/InvalidSentryTraceHeaderException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun getSentryTraceHeader ()Ljava/lang/String;
 }
 

--- a/sentry/src/main/java/io/sentry/SentryTraceHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryTraceHeader.java
@@ -31,8 +31,12 @@ public final class SentryTraceHeader {
     } else {
       this.sampled = null;
     }
-    this.traceId = new SentryId(parts[0]);
-    this.spanId = new SpanId(parts[1]);
+    try {
+      this.traceId = new SentryId(parts[0]);
+      this.spanId = new SpanId(parts[1]);
+    } catch (Exception e) {
+      throw new InvalidSentryTraceHeaderException(value, e);
+    }
   }
 
   public @NotNull String getName() {

--- a/sentry/src/main/java/io/sentry/exception/InvalidSentryTraceHeaderException.java
+++ b/sentry/src/main/java/io/sentry/exception/InvalidSentryTraceHeaderException.java
@@ -2,6 +2,7 @@ package io.sentry.exception;
 
 import io.sentry.SentryTraceHeader;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Thrown when {@link SentryTraceHeader} fails to create because of the invalid value of the
@@ -12,7 +13,12 @@ public final class InvalidSentryTraceHeaderException extends Exception {
   private final @NotNull String sentryTraceHeader;
 
   public InvalidSentryTraceHeaderException(final @NotNull String sentryTraceHeader) {
-    super("sentry-trace header does not conform to expected format: " + sentryTraceHeader);
+    this(sentryTraceHeader, null);
+  }
+
+  public InvalidSentryTraceHeaderException(
+      final @NotNull String sentryTraceHeader, final @Nullable Throwable cause) {
+    super("sentry-trace header does not conform to expected format: " + sentryTraceHeader, cause);
     this.sentryTraceHeader = sentryTraceHeader;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryTraceHeaderTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTraceHeaderTest.kt
@@ -69,4 +69,9 @@ class SentryTraceHeaderTest {
         val header = SentryTraceHeader("$sentryId-$spanId-0")
         assertEquals("$sentryId-$spanId-0", header.value)
     }
+
+    @Test
+    fun `throws InvalidSentryTraceHeaderException when traceId has invalid value`() {
+        assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("xxx-${SpanId()}-0") }
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: Do not throw IAE when tracing header contain invalid trace id.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1604

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes