### PR TITLE
docs: Fix code doc for toTraceHeader

### DIFF
--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -32,7 +32,7 @@ public interface ISpan {
   ISpan startChild(@NotNull String operation, @Nullable String description);
 
   /**
-   * Returns a string that could be sent as a sentry-trace header.
+   * Returns the trace information that could be sent as a sentry-trace header.
    *
    * @return SentryTraceHeader.
    */


### PR DESCRIPTION

## :scroll: Description
The code comment for toTraceHeader was not accurate.
This is fixed now.

#skip-changelog


## :bulb: Motivation and Context
We noticed that in a PR for sentry-cocoa: https://github.com/getsentry/sentry-cocoa/pull/1213#discussion_r668664485


## :green_heart: How did you test it?
CI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
