### PR TITLE
feat: Make AppStartState methods public for Hybrid SDKs & add some getters

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
@@ -25,7 +25,7 @@ public final class AppStartState {
 
   private AppStartState() {}
 
-  static @NotNull AppStartState getInstance() {
+  public static @NotNull AppStartState getInstance() {
     return instance;
   }
 
@@ -42,7 +42,17 @@ public final class AppStartState {
   void setAppStartEnd(final long appStartEndMillis) {
     this.appStartEndMillis = appStartEndMillis;
   }
-
+  
+  @Nullable
+  public long getAppStartEnd() {
+    return appStartEndMillis
+  }
+  
+  @Nullable
+  public long getAppStart() {
+    return appStartMillis
+  }
+ 
   @Nullable
   synchronized Long getAppStartInterval() {
     if (appStartMillis == null || appStartEndMillis == null) {
@@ -51,7 +61,7 @@ public final class AppStartState {
     return appStartEndMillis - appStartMillis;
   }
 
-  boolean isColdStart() {
+  public boolean isColdStart() {
     return coldStart;
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Makes `getInstance` and `isColdStart` public on `AppStartState`

Adds `getAppStartEnd` and `getAppStart` getter methods to return the millis long values for Hybrid SDKs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The methods were package-private and RN was not able to access them in https://github.com/getsentry/sentry-react-native/pull/1696, also we would need to get the start and end timestamps.

## :green_heart: How did you test it?
Not tested as I never built the Java SDK before and don't know my way around yet.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

