### PR TITLE
fix: Remove appStartMillis and appStartEndMillis getters and make getAppStartTime public instead

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -35,8 +35,7 @@ public final class io/sentry/android/core/AppLifecycleIntegration : io/sentry/In
 }
 
 public final class io/sentry/android/core/AppStartState {
-	public fun getAppStartEndMillis ()Ljava/lang/Long;
-	public fun getAppStartMillis ()Ljava/lang/Long;
+	public fun getAppStartTime ()Ljava/util/Date;
 	public static fun getInstance ()Lio/sentry/android/core/AppStartState;
 	public fun isColdStart ()Z
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
@@ -60,7 +60,7 @@ public final class AppStartState {
   }
 
   @Nullable
-  Date getAppStartTime() {
+  public Date getAppStartTime() {
     return appStartTime;
   }
 
@@ -71,13 +71,5 @@ public final class AppStartState {
     }
     this.appStartTime = appStartTime;
     this.appStartMillis = appStartMillis;
-  }
-
-  public @Nullable Long getAppStartMillis() {
-    return appStartMillis;
-  }
-
-  public @Nullable Long getAppStartEndMillis() {
-    return appStartEndMillis;
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
React Native will now only need `getAppStartTime` due to reduced api.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed due to misunderstanding that `appStartMillis` and `appStartEndMillis` are unix timestamps.

## :green_heart: How did you test it?
Have not built Android SDK before, relying on CI I guess.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
Make a release for RN