### PR TITLE
Add more convenient way to pass `BeforeSpanCallback` in OpenFeign integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Feat: Add more convenient way to pass BeforeSpanCallback in OpenFeign integration (#1637)
+
 ## Unreleased
 
 * Feat: Spring WebClient integration (#1621)

--- a/sentry-openfeign/api/sentry-openfeign.api
+++ b/sentry-openfeign/api/sentry-openfeign.api
@@ -1,6 +1,7 @@
 public final class io/sentry/openfeign/SentryCapability : feign/Capability {
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
+	public fun <init> (Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
 	public fun enrich (Lfeign/Client;)Lfeign/Client;
 }
 

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryCapability.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryCapability.java
@@ -19,6 +19,10 @@ public final class SentryCapability implements Capability {
     this.beforeSpan = beforeSpan;
   }
 
+  public SentryCapability(final @Nullable SentryFeignClient.BeforeSpanCallback beforeSpan) {
+    this(HubAdapter.getInstance(), beforeSpan);
+  }
+
   public SentryCapability() {
     this(HubAdapter.getInstance(), null);
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add more convenient way to pass `BeforeSpanCallback` in OpenFeign integration.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was no way to pass `BeforeSpanCallback` without passing also a `Hub`.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
