### PR TITLE
Merge external map properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feat: Merge external map properties ()
+
 ## 5.1.0
 
 * Feat: Spring WebClient integration (#1621)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Feat: Merge external map properties ()
+* Feat: Merge external map properties (#1656)
 
 ## 5.1.0
 

--- a/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
+++ b/sentry/src/main/java/io/sentry/config/CompositePropertiesProvider.java
@@ -31,12 +31,10 @@ final class CompositePropertiesProvider implements PropertiesProvider {
 
   @Override
   public @NotNull Map<String, String> getMap(final @NotNull String property) {
+    final Map<String, String> result = new ConcurrentHashMap<>();
     for (final PropertiesProvider provider : providers) {
-      final Map<String, String> result = provider.getMap(property);
-      if (!result.isEmpty()) {
-        return result;
-      }
+      result.putAll(provider.getMap(property));
     }
-    return new ConcurrentHashMap<>();
+    return result;
   }
 }

--- a/sentry/src/test/java/io/sentry/config/CompositePropertiesProviderTest.kt
+++ b/sentry/src/test/java/io/sentry/config/CompositePropertiesProviderTest.kt
@@ -31,4 +31,18 @@ class CompositePropertiesProviderTest {
         whenever(second.getProperty("property")).thenReturn(null)
         assertNull(provider.getProperty("property"))
     }
+
+    @Test
+    fun `combines map results from multiple providers into single map`() {
+        whenever(first.getMap("tags")).thenReturn(mapOf("first_tag" to "val1"))
+        whenever(second.getMap("tags")).thenReturn(mapOf("second_tag" to "val2"))
+        assertEquals(mapOf("first_tag" to "val1", "second_tag" to "val2"), provider.getMap("tags"))
+    }
+
+    @Test
+    fun `when multiple providers return same map entries, the last one takes the precedence`() {
+        whenever(first.getMap("tags")).thenReturn(mapOf("first_tag" to "val1", "conflicting_tag" to "val3"))
+        whenever(second.getMap("tags")).thenReturn(mapOf("second_tag" to "val2", "conflicting_tag" to "val4"))
+        assertEquals(mapOf("first_tag" to "val1", "second_tag" to "val2", "conflicting_tag" to "val4"), provider.getMap("tags"))
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Merge external map properties

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #874

Now tags can be set in multiple places: some in properties file, some in env variables. The resulting options will contain tags from all places.

## :green_heart: How did you test it?

Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

Not breaking in terms of compilation, but resulting tags can differ if they were set in different places (unlikely though).


## :crystal_ball: Next steps

The order of loading properties can (and probably should) be changed. Providers order by priority I think should be:

- system property
- properties files
- environment variables
