### PR TITLE
Add secondary constructor taking `IHub` to `SentryOkHttpInterceptor`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feat: Add secondary constructor taking IHub to SentryOkHttpInterceptor (#1657)
+
 ## 5.1.0
 
 * Feat: Spring WebClient integration (#1621)

--- a/sentry-android-okhttp/api/sentry-android-okhttp.api
+++ b/sentry-android-okhttp/api/sentry-android-okhttp.api
@@ -8,6 +8,7 @@ public final class io/sentry/android/okhttp/BuildConfig {
 
 public final class io/sentry/android/okhttp/SentryOkHttpInterceptor : okhttp3/Interceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;)V
 	public synthetic fun <init> (Lio/sentry/IHub;Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/sentry/android/okhttp/SentryOkHttpInterceptor$BeforeSpanCallback;)V

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -15,6 +15,7 @@ class SentryOkHttpInterceptor(
     private val beforeSpan: BeforeSpanCallback? = null
 ) : Interceptor {
 
+    constructor(hub: IHub) : this(hub, null)
     constructor(beforeSpan: BeforeSpanCallback) : this(HubAdapter.getInstance(), beforeSpan)
 
     override fun intercept(chain: Interceptor.Chain): Response {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add secondary constructor taking `IHub` to `SentryOkHttpInterceptor`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For the sake of improving Java compatiblity when users want to set only `IHub` and skip `BeforeSendCallback`.
Fixes #1526


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes