### PR TITLE
Fix: Make sure scope is popped when processing request results in exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 * Feat: Add support for async methods in Spring MVC (#1652)
 * Feat: Add secondary constructor taking IHub to SentryOkHttpInterceptor (#1657)
 * Feat: Merge external map properties (#1656)
-* Fix: Make sure scope is popped when processing request results in exception #1665
-
+* Fix: Make sure scope is popped when processing request results in exception (#1665)
 
 ## 5.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Feat: Add support for async methods in Spring MVC (#1652)
 * Feat: Add secondary constructor taking IHub to SentryOkHttpInterceptor (#1657)
 * Feat: Merge external map properties (#1656)
+* Fix: Make sure scope is popped when processing request results in exception #1665
+
 
 ## 5.1.0
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
@@ -53,31 +53,37 @@ public class SentrySpringFilter extends OncePerRequestFilter {
       hub.pushScope();
       try {
         hub.addBreadcrumb(Breadcrumb.http(request.getRequestURI(), request.getMethod()));
-        hub.configureScope(
-            scope -> {
-              // set basic request information on the scope
-              scope.setRequest(requestResolver.resolveSentryRequest(request));
-              // transaction name is known at the later stage of request processing, thus it cannot
-              // be set on the scope
-              scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(request));
-              // only if request caches body, add an event processor that sets body on the event
-              // body is not on the scope, to avoid using memory when no event is triggered during
-              // request processing
-              if (request instanceof CachedBodyHttpServletRequest) {
-                scope.addEventProcessor(
-                    new RequestBodyExtractingEventProcessor(request, hub.getOptions()));
-              }
-            });
-      } catch (Exception e) {
-        hub.getOptions()
-            .getLogger()
-            .log(SentryLevel.ERROR, "Failed to set scope for HTTP request", e);
-      } finally {
+        configureScope(request);
         filterChain.doFilter(request, response);
+      } finally {
         hub.popScope();
       }
     } else {
       filterChain.doFilter(servletRequest, response);
+    }
+  }
+
+  private void configureScope(HttpServletRequest request) {
+    try {
+      hub.configureScope(
+          scope -> {
+            // set basic request information on the scope
+            scope.setRequest(requestResolver.resolveSentryRequest(request));
+            // transaction name is known at the later stage of request processing, thus it cannot
+            // be set on the scope
+            scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(request));
+            // only if request caches body, add an event processor that sets body on the event
+            // body is not on the scope, to avoid using memory when no event is triggered during
+            // request processing
+            if (request instanceof CachedBodyHttpServletRequest) {
+              scope.addEventProcessor(
+                  new RequestBodyExtractingEventProcessor(request, hub.getOptions()));
+            }
+          });
+    } catch (Exception e) {
+      hub.getOptions()
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to set scope for HTTP request", e);
     }
   }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import org.assertj.core.api.Assertions
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletRequest
@@ -81,6 +82,19 @@ class SentrySpringFilterTest {
         listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
         verify(fixture.hub).popScope()
+    }
+
+    @Test
+    fun `pops scope when chain throws`() {
+        val listener = fixture.getSut()
+        whenever(fixture.chain.doFilter(any(), any())).thenThrow(RuntimeException())
+
+        try {
+            listener.doFilter(fixture.request, fixture.response, fixture.chain)
+            fail()
+        } catch (e: Exception) {
+            verify(fixture.hub).popScope()
+        }
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix: Make sure scope is popped when processing request results in exception

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In case of error, the scope has not been popped.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes