### PR TITLE
fix: Properly bootstrap ndk

### DIFF
--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -113,13 +113,3 @@ dependencies {
 
     testImplementation(Config.TestLibs.mockitoKotlin)
 }
-
-val initNative = tasks.register<Exec>("initNative") {
-    logger.log(LogLevel.LIFECYCLE, "Initializing git submodules")
-    commandLine("git", "submodule", "update", "--init", "--recursive")
-    outputs.dir("${project.projectDir}/$sentryNativeSrc")
-}
-
-tasks.named("preBuild") {
-    dependsOn(initNative)
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,3 +32,12 @@ include(
     "sentry-samples:sentry-samples-spring",
     "sentry-samples:sentry-samples-spring-boot",
     "sentry-samples:sentry-samples-spring-boot-webflux")
+
+gradle.beforeProject {
+    if (project.name == "sentry-android-ndk" || project.name == "sentry-samples-android") {
+        exec {
+            logger.log(LogLevel.LIFECYCLE, "Initializing git submodules")
+            commandLine("git", "submodule", "update", "--init", "--recursive")
+        }
+    }
+}


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
The previous way of bootstrapping the native submodule didn't really work for me (the `sentry-native` folder was always empty after a gradle sync, hence `cmake` couldn't succeed)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
* `rm -rf sentry-java`
* `git clone git@github.com:getsentry/sentry-java.git`
* `idea sentry-java`
* Do a gradle sync -> shouldn't fail

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
