### PR TITLE
Fix: Do not drop Contexts key if Collection, Array or Char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: Do not drop Contexts key if Collection, Array or Char
+* Fix: Do not drop Contexts key if Collection, Array or Char (#1680)
 
 ## 5.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Do not drop Contexts key if Collection, Array or Char
+
 ## 5.1.1
 
 * Fix: Remove onActivityPreCreated call in favor of onActivityCreated (#1661)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -501,9 +501,12 @@ public final class io/sentry/Scope {
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun setContexts (Ljava/lang/String;Ljava/lang/Character;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setContexts (Ljava/lang/String;Ljava/util/Collection;)V
+	public fun setContexts (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -6,6 +6,7 @@ import io.sentry.protocol.User;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -521,6 +522,42 @@ public final class Scope {
    */
   public void setContexts(final @NotNull String key, final @NotNull Number value) {
     final Map<String, Number> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull Collection<?> value) {
+    final Map<String, Collection<?>> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull Object[] value) {
+    final Map<String, Object[]> map = new HashMap<>();
+    map.put("value", value);
+    setContexts(key, map);
+  }
+
+  /**
+   * Sets the Scope's contexts
+   *
+   * @param key the context key
+   * @param value the context value
+   */
+  public void setContexts(final @NotNull String key, final @NotNull Character value) {
+    final Map<String, Character> map = new HashMap<>();
     map.put("value", value);
     setContexts(key, map);
   }


### PR DESCRIPTION
## :scroll: Description
Fix: Do not drop Contexts key if Collection, Array or Char


## :bulb: Motivation and Context
```
Sentry.configureScope(scope -> {
  scope.setContexts("inventory", new String[] {"big potion", "small potion"});
});
```

would be dropped because it'd fall to `setContexts(String, Object)` but reflection would make an array instead of an object and array as a value, hence adding convenient method for the missing Java Data types

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
