### PR TITLE
Fix Servlet 3.1 compatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Servlet 3.1 compatibility issue (#1681)
+
 ## 5.1.1
 
 * Fix: Remove onActivityPreCreated call in favor of onActivityCreated (#1661)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -73,7 +73,7 @@ object Config {
         val springSecurityConfig = "org.springframework.security:spring-security-config"
         val springAop = "org.springframework:spring-aop"
         val aspectj = "org.aspectj:aspectjweaver"
-        val servletApi = "javax.servlet:javax.servlet-api"
+        val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
 
         val apacheHttpClient = "org.apache.httpcomponents.client5:httpclient5:5.0.4"
 

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -68,9 +68,9 @@ public final class io/sentry/spring/SentryTaskDecorator : org/springframework/co
 	public fun decorate (Ljava/lang/Runnable;)Ljava/lang/Runnable;
 }
 
-public class io/sentry/spring/SentryUserFilter : javax/servlet/Filter {
+public class io/sentry/spring/SentryUserFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
-	public fun doFilter (Ljavax/servlet/ServletRequest;Ljavax/servlet/ServletResponse;Ljavax/servlet/FilterChain;)V
+	protected fun doFilterInternal (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljavax/servlet/FilterChain;)V
 	public fun getSentryUserProviders ()Ljava/util/List;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -11,21 +11,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Sets the {@link User} on the {@link Scope} with information retrieved from {@link
  * SentryUserProvider}s.
  */
 @Open
-public class SentryUserFilter implements Filter {
+public class SentryUserFilter extends OncePerRequestFilter {
   private final @NotNull IHub hub;
   private final @NotNull List<SentryUserProvider> sentryUserProviders;
 
@@ -37,11 +37,11 @@ public class SentryUserFilter implements Filter {
   }
 
   @Override
-  public void doFilter(
-      final @NotNull ServletRequest request,
-      final @NotNull ServletResponse response,
+  protected void doFilterInternal(
+      final @NotNull HttpServletRequest request,
+      final @NotNull HttpServletResponse response,
       final @NotNull FilterChain chain)
-      throws IOException, ServletException {
+      throws ServletException, IOException {
     final User user = new User();
     for (final SentryUserProvider provider : sentryUserProviders) {
       apply(user, provider.provideUser());


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add explicit support for Servlet API 3.1 (used by Tomcat 8.5), fix classes that previously relied on default `javax.servlet.Filter` methods introduced in Servlet 4.0 specs. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1677

## :green_heart: How did you test it?

Built a sample war file, deployed to Tomcat 8.5.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes