### PR TITLE
Feat: Add `tracestate` HTTP header support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feat: Add tracestate HTTP header support (#1683)
+
 ## 5.1.2
 
 * Fix: Servlet 3.1 compatibility issue (#1681)

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -8,6 +8,7 @@ import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.util.Objects;
 import java.util.Locale;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,6 +50,8 @@ final class ManifestMetadataReader {
   static final String TRACES_ACTIVITY_ENABLE = "io.sentry.traces.activity.enable";
   static final String TRACES_ACTIVITY_AUTO_FINISH_ENABLE =
       "io.sentry.traces.activity.auto-finish.enable";
+
+  @ApiStatus.Experimental static final String TRACE_SAMPLING = "io.sentry.traces.trace-sampling";
 
   static final String ATTACH_THREADS = "io.sentry.attach-threads";
 
@@ -183,6 +186,9 @@ final class ManifestMetadataReader {
             options.setTracesSampleRate(tracesSampleRate);
           }
         }
+
+        options.setTraceSampling(
+            readBool(metadata, logger, TRACE_SAMPLING, options.isTraceSampling()));
 
         options.setEnableAutoActivityLifecycleTracing(
             readBool(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -34,7 +34,9 @@ class ActivityLifecycleIntegrationTest {
     private class Fixture {
         val application = mock<Application>()
         val hub = mock<Hub>()
-        val options = SentryAndroidOptions()
+        val options = SentryAndroidOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+        }
         val bundle = mock<Bundle>()
         val context = TransactionContext("name", "op")
         val activityFramesTracker = mock<ActivityFramesTracker>()
@@ -343,7 +345,7 @@ class ActivityLifecycleIntegrationTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertEquals(SpanStatus.OK, it.status)
-        })
+        }, any())
     }
 
     @Test
@@ -361,7 +363,7 @@ class ActivityLifecycleIntegrationTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertEquals(SpanStatus.UNKNOWN_ERROR, it.status)
-        })
+        }, any())
     }
 
     @Test
@@ -375,7 +377,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
         sut.onActivityPostResumed(activity)
 
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
     }
 
     @Test
@@ -386,7 +388,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityPostResumed(activity)
 
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
     }
 
     @Test
@@ -399,7 +401,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
         sut.onActivityDestroyed(activity)
 
-        verify(fixture.hub).captureTransaction(any())
+        verify(fixture.hub).captureTransaction(any(), any())
     }
 
     @Test
@@ -436,7 +438,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(mock(), mock())
 
         sut.onActivityCreated(mock(), fixture.bundle)
-        verify(fixture.hub).captureTransaction(any())
+        verify(fixture.hub).captureTransaction(any(), any())
     }
 
     @Test
@@ -449,7 +451,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, mock())
         sut.onActivityResumed(activity)
 
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
     }
 
     @Test
@@ -476,7 +478,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, mock())
         sut.onActivityResumed(activity)
 
-        verify(fixture.hub).captureTransaction(any())
+        verify(fixture.hub).captureTransaction(any(), any())
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -345,7 +345,7 @@ class ActivityLifecycleIntegrationTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertEquals(SpanStatus.OK, it.status)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -363,7 +363,7 @@ class ActivityLifecycleIntegrationTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertEquals(SpanStatus.UNKNOWN_ERROR, it.status)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -377,7 +377,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
         sut.onActivityPostResumed(activity)
 
-        verify(fixture.hub, never()).captureTransaction(any(), any())
+        verify(fixture.hub, never()).captureTransaction(any(), anyOrNull())
     }
 
     @Test
@@ -388,7 +388,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityPostResumed(activity)
 
-        verify(fixture.hub, never()).captureTransaction(any(), any())
+        verify(fixture.hub, never()).captureTransaction(any(), anyOrNull())
     }
 
     @Test
@@ -401,7 +401,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
         sut.onActivityDestroyed(activity)
 
-        verify(fixture.hub).captureTransaction(any(), any())
+        verify(fixture.hub).captureTransaction(any(), anyOrNull())
     }
 
     @Test
@@ -438,7 +438,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(mock(), mock())
 
         sut.onActivityCreated(mock(), fixture.bundle)
-        verify(fixture.hub).captureTransaction(any(), any())
+        verify(fixture.hub).captureTransaction(any(), anyOrNull())
     }
 
     @Test
@@ -478,7 +478,7 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, mock())
         sut.onActivityResumed(activity)
 
-        verify(fixture.hub).captureTransaction(any(), any())
+        verify(fixture.hub).captureTransaction(any(), anyOrNull())
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -663,4 +663,29 @@ class ManifestMetadataReaderTest {
         // Assert
         assertTrue(fixture.options.isEnableActivityLifecycleTracingAutoFinish)
     }
+
+    @Test
+    fun `applyMetadata reads tracSampling to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.TRACE_SAMPLING to true)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertTrue(fixture.options.isTraceSampling)
+    }
+
+    @Test
+    fun `applyMetadata reads traceSampling to options and keeps default`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertFalse(fixture.options.isTraceSampling)
+    }
 }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -31,9 +31,14 @@ class SentryOkHttpInterceptor(
 
         var code: Int? = null
         try {
+            val requestBuilder = request.newBuilder()
             span?.toSentryTrace()?.let {
-                request = request.newBuilder().addHeader(it.name, it.value).build()
+                requestBuilder.addHeader(it.name, it.value)
             }
+            hub.traceStateHeader()?.let {
+                requestBuilder.addHeader(it.name, it.value)
+            }
+            request = requestBuilder.build()
             response = chain.proceed(request)
             code = response.code
             span?.status = SpanStatus.fromHttpStatusCode(code)

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -35,7 +35,7 @@ class SentryOkHttpInterceptor(
             span?.toSentryTrace()?.let {
                 requestBuilder.addHeader(it.name, it.value)
             }
-            hub.traceStateHeader()?.let {
+            span?.toTraceStateHeader()?.let {
                 requestBuilder.addHeader(it.name, it.value)
             }
             request = requestBuilder.build()

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -43,6 +43,7 @@ class SentryOkHttpInterceptorTest {
         init {
             whenever(hub.options).thenReturn(SentryOptions().apply {
                 dsn = "https://key@sentry.io/proj"
+                isTraceSampling = true
             })
         }
 

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -12,6 +12,7 @@ import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
+import io.sentry.TraceStateHeader
 import io.sentry.TransactionContext
 import java.io.IOException
 import kotlin.test.Test
@@ -75,11 +76,12 @@ class SentryOkHttpInterceptorTest {
                     .toMediaType())).url(fixture.server.url("/hello")).build() }
 
     @Test
-    fun `when there is an active span, adds sentry trace header to the request`() {
+    fun `when there is an active span, adds sentry trace headers to the request`() {
         val sut = fixture.getSut()
         sut.newCall(getRequest()).execute()
         val recorderRequest = fixture.server.takeRequest()
         assertNotNull(recorderRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
+        assertNotNull(recorderRequest.headers[TraceStateHeader.TRACE_STATE_HEADER])
     }
 
     @Test
@@ -88,6 +90,7 @@ class SentryOkHttpInterceptorTest {
         sut.newCall(getRequest()).execute()
         val recorderRequest = fixture.server.takeRequest()
         assertNull(recorderRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
+        assertNull(recorderRequest.headers[TraceStateHeader.TRACE_STATE_HEADER])
     }
 
     @Test

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -40,7 +40,9 @@ class SentryOkHttpInterceptorTest {
         val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
 
         init {
-            whenever(hub.options).thenReturn(SentryOptions())
+            whenever(hub.options).thenReturn(SentryOptions().apply {
+                dsn = "https://key@sentry.io/proj"
+            })
         }
 
         fun getSut(

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -37,7 +37,9 @@ class SentryTracingFilterTest {
         val transactionNameProvider = spy(TransactionNameProvider())
 
         init {
-            whenever(hub.options).thenReturn(SentryOptions())
+            whenever(hub.options).thenReturn(SentryOptions().apply {
+                dsn = "https://key@sentry.io/proj"
+            })
         }
 
         fun getSut(isEnabled: Boolean = true, status: Int = 200, sentryTraceHeader: String? = null): SentryTracingFilter {
@@ -72,7 +74,7 @@ class SentryTracingFilterTest {
             assertThat(it.transaction).isEqualTo("POST /product/{id}")
             assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.OK)
             assertThat(it.contexts.trace!!.operation).isEqualTo("http.server")
-        })
+        }, any())
     }
 
     @Test
@@ -83,7 +85,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        })
+        }, any())
     }
 
     @Test
@@ -94,7 +96,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.status).isNull()
-        })
+        }, any())
     }
 
     @Test
@@ -105,7 +107,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.parentSpanId).isNull()
-        })
+        }, any())
     }
 
     @Test
@@ -117,7 +119,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.parentSpanId).isEqualTo(parentSpanId)
-        })
+        }, any())
     }
 
     @Test
@@ -145,6 +147,6 @@ class SentryTracingFilterTest {
         }
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        })
+        }, any())
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.tracing
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -74,7 +75,7 @@ class SentryTracingFilterTest {
             assertThat(it.transaction).isEqualTo("POST /product/{id}")
             assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.OK)
             assertThat(it.contexts.trace!!.operation).isEqualTo("http.server")
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -85,7 +86,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -96,7 +97,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.status).isNull()
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -107,7 +108,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.parentSpanId).isNull()
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -119,7 +120,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.contexts.trace!!.parentSpanId).isEqualTo(parentSpanId)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -147,6 +148,6 @@ class SentryTracingFilterTest {
         }
         verify(fixture.hub).captureTransaction(check {
             assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        }, any())
+        }, anyOrNull())
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.tracing
 
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -58,7 +59,7 @@ class SentryTransactionAdviceTest {
             assertThat(it.transaction).isEqualTo("customName")
             assertThat(it.contexts.trace!!.operation).isEqualTo("bean")
             assertThat(it.status).isEqualTo(SpanStatus.OK)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -66,7 +67,7 @@ class SentryTransactionAdviceTest {
         assertThrows<RuntimeException> { sampleService.methodThrowingException() }
         verify(hub).captureTransaction(check {
             assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -75,7 +76,7 @@ class SentryTransactionAdviceTest {
         verify(hub).captureTransaction(check {
             assertThat(it.transaction).isEqualTo("SampleService.methodWithoutTransactionNameSet")
             assertThat(it.contexts.trace!!.operation).isEqualTo("op")
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -93,7 +94,7 @@ class SentryTransactionAdviceTest {
         verify(hub).captureTransaction(check {
             assertThat(it.transaction).isEqualTo("ClassAnnotatedSampleService.hello")
             assertThat(it.contexts.trace!!.operation).isEqualTo("op")
-        }, any())
+        }, anyOrNull())
     }
 
     @Test
@@ -102,7 +103,7 @@ class SentryTransactionAdviceTest {
         verify(hub).captureTransaction(check {
             assertThat(it.transaction).isEqualTo("ClassAnnotatedWithOperationSampleService.hello")
             assertThat(it.contexts.trace!!.operation).isEqualTo("my-op")
-        }, any())
+        }, anyOrNull())
     }
 
     @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -137,6 +137,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -178,6 +179,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -240,6 +242,7 @@ public abstract interface class io/sentry/IHub {
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public abstract fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public abstract fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -387,6 +390,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -606,6 +610,7 @@ public final class io/sentry/Sentry {
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public static fun traceHeaders ()Lio/sentry/SentryTraceHeader;
+	public static fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public static fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -680,8 +685,10 @@ public final class io/sentry/SentryEnvelopeHeader {
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/protocol/SentryId;)V
 	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;Lio/sentry/TraceState;)V
 	public fun getEventId ()Lio/sentry/protocol/SentryId;
 	public fun getSdkVersion ()Lio/sentry/protocol/SdkVersion;
+	public fun getTrace ()Lio/sentry/TraceState;
 }
 
 public final class io/sentry/SentryEnvelopeHeaderAdapter : com/google/gson/TypeAdapter {
@@ -1114,6 +1121,23 @@ public final class io/sentry/SystemOutLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/TraceState {
+	public fun <init> (Lio/sentry/protocol/SentryId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/sentry/TraceState$TraceStateUser;Ljava/lang/String;)V
+	public fun getEnvironment ()Ljava/lang/String;
+	public fun getPublicKey ()Ljava/lang/String;
+	public fun getRelease ()Ljava/lang/String;
+	public fun getTraceId ()Lio/sentry/protocol/SentryId;
+	public fun getTransaction ()Ljava/lang/String;
+	public fun getUser ()Lio/sentry/TraceState$TraceStateUser;
+}
+
+public final class io/sentry/TraceStateHeader {
+	public fun <init> (Ljava/lang/String;)V
+	public static fun fromTraceState (Lio/sentry/TraceState;Lio/sentry/ISerializer;Lio/sentry/ILogger;)Lio/sentry/TraceStateHeader;
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 }
 
 public final class io/sentry/TransactionContext : io/sentry/SpanContext {
@@ -1921,5 +1945,21 @@ public final class io/sentry/util/StringUtils {
 	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
 	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;
 	public static fun removeSurrounding (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public class io/sentry/vendor/Base64 {
+	public static final field CRLF I
+	public static final field DEFAULT I
+	public static final field NO_CLOSE I
+	public static final field NO_PADDING I
+	public static final field NO_WRAP I
+	public static final field URL_SAFE I
+	public static fun decode (Ljava/lang/String;I)[B
+	public static fun decode ([BI)[B
+	public static fun decode ([BIII)[B
+	public static fun encode ([BI)[B
+	public static fun encode ([BIII)[B
+	public static fun encodeToString ([BI)Ljava/lang/String;
+	public static fun encodeToString ([BIII)Ljava/lang/String;
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -275,6 +275,7 @@ public abstract interface class io/sentry/ISentryClient {
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
 	public abstract fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1140,6 +1140,7 @@ public final class io/sentry/TraceState {
 }
 
 public final class io/sentry/TraceStateHeader {
+	public static final field TRACE_STATE_HEADER Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
 	public static fun fromTraceState (Lio/sentry/TraceState;Lio/sentry/ISerializer;Lio/sentry/ILogger;)Lio/sentry/TraceStateHeader;
 	public fun getName ()Ljava/lang/String;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -853,6 +853,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableShutdownHook ()Z
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isSendDefaultPii ()Z
+	public fun isTraceSampling ()Z
 	public fun isTracingEnabled ()Z
 	public fun setAttachServerName (Z)V
 	public fun setAttachStacktrace (Z)V
@@ -900,6 +901,7 @@ public class io/sentry/SentryOptions {
 	public fun setShutdownTimeout (J)V
 	public fun setSslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTraceSampling (Z)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
 	public fun setTransportFactory (Lio/sentry/ITransportFactory;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -610,7 +610,6 @@ public final class io/sentry/Sentry {
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public static fun traceHeaders ()Lio/sentry/SentryTraceHeader;
-	public static fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public static fun withScope (Lio/sentry/ScopeCallback;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -108,7 +108,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -137,7 +137,6 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
-	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -148,7 +147,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -179,7 +178,6 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
-	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -205,8 +203,9 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun clearBreadcrumbs ()V
 	public abstract fun clone ()Lio/sentry/IHub;
@@ -242,7 +241,6 @@ public abstract interface class io/sentry/IHub {
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
 	public abstract fun traceHeaders ()Lio/sentry/SentryTraceHeader;
-	public abstract fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -277,8 +275,9 @@ public abstract interface class io/sentry/ISentryClient {
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
 	public abstract fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun close ()V
 	public abstract fun flush (J)V
@@ -312,6 +311,8 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public abstract fun startChild (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/sentry/ISpan;
 	public abstract fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+	public abstract fun toTraceStateHeader ()Lio/sentry/TraceStateHeader;
+	public abstract fun traceState ()Lio/sentry/TraceState;
 }
 
 public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
@@ -359,7 +360,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -390,7 +391,6 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;ZLjava/util/Date;ZLio/sentry/TransactionFinishedCallback;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
-	public fun traceStateHeader ()Lio/sentry/TraceStateHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
@@ -422,6 +422,8 @@ public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/sentry/ISpan;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+	public fun toTraceStateHeader ()Lio/sentry/TraceStateHeader;
+	public fun traceState ()Lio/sentry/TraceState;
 }
 
 public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
@@ -453,6 +455,8 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/sentry/ISpan;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+	public fun toTraceStateHeader ()Lio/sentry/TraceStateHeader;
+	public fun traceState ()Lio/sentry/TraceState;
 }
 
 public final class io/sentry/NoOpTransportFactory : io/sentry/ITransportFactory {
@@ -663,7 +667,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;Ljava/lang/Object;)V
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/lang/Object;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun close ()V
 	public fun flush (J)V
@@ -977,6 +981,8 @@ public final class io/sentry/SentryTracer : io/sentry/ITransaction {
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/sentry/ISpan;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+	public fun toTraceStateHeader ()Lio/sentry/TraceStateHeader;
+	public fun traceState ()Lio/sentry/TraceState;
 }
 
 public final class io/sentry/Session {
@@ -1054,6 +1060,8 @@ public final class io/sentry/Span : io/sentry/ISpan {
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startChild (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/sentry/ISpan;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
+	public fun toTraceStateHeader ()Lio/sentry/TraceStateHeader;
+	public fun traceState ()Lio/sentry/TraceState;
 }
 
 public class io/sentry/SpanContext {
@@ -1123,7 +1131,6 @@ public final class io/sentry/SystemOutLogger : io/sentry/ILogger {
 }
 
 public final class io/sentry/TraceState {
-	public fun <init> (Lio/sentry/protocol/SentryId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/sentry/TraceState$TraceStateUser;Ljava/lang/String;)V
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getPublicKey ()Ljava/lang/String;
 	public fun getRelease ()Ljava/lang/String;

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -88,4 +88,5 @@ tasks.withType<JavaCompile>() {
         check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
         option("NullAway:AnnotatedPackages", "io.sentry")
     }
+    options.errorprone.errorproneArgs.add("-XepExcludedPaths:.*/io/sentry/vendor/.*")
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -675,6 +675,18 @@ public final class Hub implements IHub {
   }
 
   @Override
+  public @Nullable TraceStateHeader traceStateHeader() {
+    final Scope scope = stack.peek().getScope();
+    final TraceState traceState = TraceState.create(scope, options);
+    if (traceState != null) {
+      return TraceStateHeader.fromTraceState(
+          traceState, options.getSerializer(), options.getLogger());
+    } else {
+      return null;
+    }
+  }
+
+  @Override
   public @Nullable ISpan getSpan() {
     ISpan span = null;
     if (!isEnabled()) {

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -531,7 +531,9 @@ public final class Hub implements IHub {
   @ApiStatus.Internal
   @Override
   public @NotNull SentryId captureTransaction(
-      final @NotNull SentryTransaction transaction, final @Nullable Object hint) {
+      final @NotNull SentryTransaction transaction,
+      final @Nullable TraceState traceState,
+      final @Nullable Object hint) {
     Objects.requireNonNull(transaction, "transaction is required");
 
     SentryId sentryId = SentryId.EMPTY_ID;
@@ -561,7 +563,8 @@ public final class Hub implements IHub {
         StackItem item = null;
         try {
           item = stack.peek();
-          sentryId = item.getClient().captureTransaction(transaction, item.getScope(), hint);
+          sentryId =
+              item.getClient().captureTransaction(transaction, traceState, item.getScope(), hint);
         } catch (Exception e) {
           options
               .getLogger()
@@ -672,27 +675,6 @@ public final class Hub implements IHub {
       }
     }
     return traceHeader;
-  }
-
-  @Override
-  public @Nullable TraceStateHeader traceStateHeader() {
-    TraceStateHeader header = null;
-    if (!isEnabled()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.WARNING,
-              "Instance is disabled and this 'traceStateHeader' call is a no-op.");
-    } else {
-      final Scope scope = stack.peek().getScope();
-      final TraceState traceState = TraceState.create(scope, options);
-      if (traceState != null) {
-        header =
-            TraceStateHeader.fromTraceState(
-                traceState, options.getSerializer(), options.getLogger());
-      }
-    }
-    return header;
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -676,14 +676,23 @@ public final class Hub implements IHub {
 
   @Override
   public @Nullable TraceStateHeader traceStateHeader() {
-    final Scope scope = stack.peek().getScope();
-    final TraceState traceState = TraceState.create(scope, options);
-    if (traceState != null) {
-      return TraceStateHeader.fromTraceState(
-          traceState, options.getSerializer(), options.getLogger());
+    TraceStateHeader header = null;
+    if (!isEnabled()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "Instance is disabled and this 'traceStateHeader' call is a no-op.");
     } else {
-      return null;
+      final Scope scope = stack.peek().getScope();
+      final TraceState traceState = TraceState.create(scope, options);
+      if (traceState != null) {
+        header =
+            TraceStateHeader.fromTraceState(
+                traceState, options.getSerializer(), options.getLogger());
+      }
     }
+    return header;
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -210,6 +210,11 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
+  public @Nullable TraceStateHeader traceStateHeader() {
+    return Sentry.traceStateHeader();
+  }
+
+  @Override
   public void setSpanContext(
       final @NotNull Throwable throwable,
       final @NotNull ISpan span,

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -158,8 +158,10 @@ public final class HubAdapter implements IHub {
 
   @Override
   public @NotNull SentryId captureTransaction(
-      @NotNull SentryTransaction transaction, @Nullable Object hint) {
-    return Sentry.getCurrentHub().captureTransaction(transaction, hint);
+      @NotNull SentryTransaction transaction,
+      @Nullable TraceState traceState,
+      @Nullable Object hint) {
+    return Sentry.getCurrentHub().captureTransaction(transaction, traceState, hint);
   }
 
   @Override
@@ -207,11 +209,6 @@ public final class HubAdapter implements IHub {
   @Override
   public @Nullable SentryTraceHeader traceHeaders() {
     return Sentry.traceHeaders();
-  }
-
-  @Override
-  public @Nullable TraceStateHeader traceStateHeader() {
-    return Sentry.getCurrentHub().traceStateHeader();
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -211,7 +211,7 @@ public final class HubAdapter implements IHub {
 
   @Override
   public @Nullable TraceStateHeader traceStateHeader() {
-    return Sentry.traceStateHeader();
+    return Sentry.getCurrentHub().traceStateHeader();
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -275,7 +275,17 @@ public interface IHub {
    */
   @ApiStatus.Internal
   @NotNull
-  SentryId captureTransaction(@NotNull SentryTransaction transaction, @Nullable Object hint);
+  SentryId captureTransaction(
+      @NotNull SentryTransaction transaction,
+      @Nullable TraceState traceState,
+      @Nullable Object hint);
+
+  @ApiStatus.Internal
+  @NotNull
+  default SentryId captureTransaction(
+      @NotNull SentryTransaction transaction, @Nullable Object hint) {
+    return captureTransaction(transaction, null, hint);
+  }
 
   /**
    * Captures the transaction and enqueues it for sending to Sentry server.
@@ -284,8 +294,9 @@ public interface IHub {
    * @return transaction's id
    */
   @ApiStatus.Internal
-  default @NotNull SentryId captureTransaction(@NotNull SentryTransaction transaction) {
-    return captureTransaction(transaction, null);
+  default @NotNull SentryId captureTransaction(
+      @NotNull SentryTransaction transaction, @Nullable TraceState traceState) {
+    return captureTransaction(transaction, traceState, null);
   }
 
   /**
@@ -444,9 +455,6 @@ public interface IHub {
    */
   @Nullable
   SentryTraceHeader traceHeaders();
-
-  @Nullable
-  TraceStateHeader traceStateHeader();
 
   /**
    * Associates {@link ISpan} and the transaction name with the {@link Throwable}. Used to determine

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -270,6 +270,7 @@ public interface IHub {
    * Captures the transaction and enqueues it for sending to Sentry server.
    *
    * @param transaction the transaction
+   * @param traceState the trace state
    * @param hint the hint
    * @return transaction's id
    */
@@ -291,6 +292,7 @@ public interface IHub {
    * Captures the transaction and enqueues it for sending to Sentry server.
    *
    * @param transaction the transaction
+   * @param traceState the trace state
    * @return transaction's id
    */
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -445,6 +445,9 @@ public interface IHub {
   @Nullable
   SentryTraceHeader traceHeaders();
 
+  @Nullable
+  TraceStateHeader traceStateHeader();
+
   /**
    * Associates {@link ISpan} and the transaction name with the {@link Throwable}. Used to determine
    * in which trace the exception has been thrown in framework integrations.

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -232,7 +232,7 @@ public interface ISentryClient {
    */
   @ApiStatus.Experimental
   default @NotNull SentryId captureTransaction(
-      @NotNull SentryTransaction transaction, @NotNull TraceState traceState) {
+      @NotNull SentryTransaction transaction, @Nullable TraceState traceState) {
     return captureTransaction(transaction, traceState, null, null);
   }
 

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -205,7 +206,17 @@ public interface ISentryClient {
     return captureTransaction(transaction, null, scope, hint);
   }
 
+  /**
+   * Captures a transaction.
+   *
+   * @param transaction the {@link ITransaction} to send
+   * @param traceState the trace state
+   * @param scope An optional scope to be applied to the event.
+   * @param hint SDK specific but provides high level information about the origin of the event
+   * @return The Id (SentryId object) of the event
+   */
   @NotNull
+  @ApiStatus.Experimental
   SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
@@ -216,10 +227,22 @@ public interface ISentryClient {
    * Captures a transaction without scope nor hint.
    *
    * @param transaction the {@link ITransaction} to send
+   * @param traceState the trace state
    * @return The Id (SentryId object) of the event
    */
+  @ApiStatus.Experimental
   default @NotNull SentryId captureTransaction(
       @NotNull SentryTransaction transaction, @NotNull TraceState traceState) {
     return captureTransaction(transaction, traceState, null, null);
+  }
+
+  /**
+   * Captures a transaction without scope nor hint.
+   *
+   * @param transaction the {@link ITransaction} to send
+   * @return The Id (SentryId object) of the event
+   */
+  default @NotNull SentryId captureTransaction(@NotNull SentryTransaction transaction) {
+    return captureTransaction(transaction, null, null, null);
   }
 }

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -200,8 +200,17 @@ public interface ISentryClient {
    * @return The Id (SentryId object) of the event
    */
   @NotNull
+  default SentryId captureTransaction(
+      @NotNull SentryTransaction transaction, @Nullable Scope scope, @Nullable Object hint) {
+    return captureTransaction(transaction, null, scope, hint);
+  }
+
+  @NotNull
   SentryId captureTransaction(
-      @NotNull SentryTransaction transaction, @Nullable Scope scope, @Nullable Object hint);
+      @NotNull SentryTransaction transaction,
+      @Nullable TraceState traceState,
+      @Nullable Scope scope,
+      @Nullable Object hint);
 
   /**
    * Captures a transaction without scope nor hint.
@@ -209,7 +218,8 @@ public interface ISentryClient {
    * @param transaction the {@link ITransaction} to send
    * @return The Id (SentryId object) of the event
    */
-  default @NotNull SentryId captureTransaction(@NotNull SentryTransaction transaction) {
-    return captureTransaction(transaction, null, null);
+  default @NotNull SentryId captureTransaction(
+      @NotNull SentryTransaction transaction, @NotNull TraceState traceState) {
+    return captureTransaction(transaction, traceState, null, null);
   }
 }

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -39,9 +39,20 @@ public interface ISpan {
   @NotNull
   SentryTraceHeader toSentryTrace();
 
+  /**
+   * Returns the trace state information. @see <a
+   * href="https://develop.sentry.dev/sdk/trace-context/">Trace Context</a>.
+   *
+   * @return a trace state
+   */
   @NotNull
   TraceState traceState();
 
+  /**
+   * Returns the trace state that can be sent as a "tracestate" header.
+   *
+   * @return TraceStateHeader
+   */
   @NotNull
   TraceStateHeader toTraceStateHeader();
 

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -39,6 +39,12 @@ public interface ISpan {
   @NotNull
   SentryTraceHeader toSentryTrace();
 
+  @NotNull
+  TraceState traceState();
+
+  @NotNull
+  TraceStateHeader toTraceStateHeader();
+
   /** Sets span timestamp marking this span as finished. */
   void finish();
 

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -43,18 +43,19 @@ public interface ISpan {
    * Returns the trace state information. @see <a
    * href="https://develop.sentry.dev/sdk/trace-context/">Trace Context</a>.
    *
-   * @return a trace state
+   * @return a trace state or {@code null} if {@link SentryOptions#isTraceSampling()} is disabled.
    */
-  @NotNull
+  @Nullable
   @ApiStatus.Experimental
   TraceState traceState();
 
   /**
    * Returns the trace state that can be sent as a "tracestate" header.
    *
-   * @return TraceStateHeader
+   * @return TraceStateHeader or {@code null} if {@link SentryOptions#isTraceSampling()} is
+   *     disabled.
    */
-  @NotNull
+  @Nullable
   @ApiStatus.Experimental
   TraceStateHeader toTraceStateHeader();
 

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -46,6 +46,7 @@ public interface ISpan {
    * @return a trace state
    */
   @NotNull
+  @ApiStatus.Experimental
   TraceState traceState();
 
   /**
@@ -54,6 +55,7 @@ public interface ISpan {
    * @return TraceStateHeader
    */
   @NotNull
+  @ApiStatus.Experimental
   TraceStateHeader toTraceStateHeader();
 
   /** Sets span timestamp marking this span as finished. */

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -118,7 +118,9 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @NotNull SentryId captureTransaction(
-      final @NotNull SentryTransaction transaction, final @Nullable Object hint) {
+      final @NotNull SentryTransaction transaction,
+      final @Nullable TraceState traceState,
+      final @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 
@@ -158,11 +160,6 @@ public final class NoOpHub implements IHub {
   @Override
   public @NotNull SentryTraceHeader traceHeaders() {
     return new SentryTraceHeader(SentryId.EMPTY_ID, SpanId.EMPTY_ID, true);
-  }
-
-  @Override
-  public @Nullable TraceStateHeader traceStateHeader() {
-    return null;
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -161,6 +161,11 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
+  public @Nullable TraceStateHeader traceStateHeader() {
+    return null;
+  }
+
+  @Override
   public void setSpanContext(
       final @NotNull Throwable throwable,
       final @NotNull ISpan spanContext,

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -45,7 +45,10 @@ final class NoOpSentryClient implements ISentryClient {
 
   @Override
   public @NotNull SentryId captureTransaction(
-      @NotNull SentryTransaction transaction, @Nullable Scope scope, @Nullable Object hint) {
+      @NotNull SentryTransaction transaction,
+      @Nullable TraceState traceState,
+      @Nullable Scope scope,
+      @Nullable Object hint) {
     return SentryId.EMPTY_ID;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpSpan.java
+++ b/sentry/src/main/java/io/sentry/NoOpSpan.java
@@ -38,6 +38,16 @@ public final class NoOpSpan implements ISpan {
   }
 
   @Override
+  public @NotNull TraceState traceState() {
+    return new TraceState(SentryId.EMPTY_ID, "");
+  }
+
+  @Override
+  public @NotNull TraceStateHeader toTraceStateHeader() {
+    return new TraceStateHeader("");
+  }
+
+  @Override
   public void finish() {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -100,6 +100,16 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
+  public @NotNull TraceState traceState() {
+    return new TraceState(SentryId.EMPTY_ID, "");
+  }
+
+  @Override
+  public @NotNull TraceStateHeader toTraceStateHeader() {
+    return new TraceStateHeader("");
+  }
+
+  @Override
   public void finish() {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -163,7 +163,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
               // transient property.
               transaction.getContexts().getTrace().setSampled(true);
             }
-            hub.captureTransaction(transaction, hint);
+            hub.captureTransaction(transaction, envelope.getHeader().getTrace(), hint);
             logItemCaptured(currentItem);
 
             if (!waitFlush(hint)) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -699,10 +699,6 @@ public final class Sentry {
     return getCurrentHub().getSpan();
   }
 
-  public static @Nullable TraceStateHeader traceStateHeader() {
-    return getCurrentHub().traceStateHeader();
-  }
-
   /**
    * Configuration options callback
    *

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -699,6 +699,10 @@ public final class Sentry {
     return getCurrentHub().getSpan();
   }
 
+  public static @Nullable TraceStateHeader traceStateHeader() {
+    return getCurrentHub().traceStateHeader();
+  }
+
   /**
    * Configuration options callback
    *

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -128,9 +128,12 @@ public final class SentryClient implements ISentryClient {
     }
 
     try {
+      final TraceState traceState =
+          scope != null && scope.getTransaction() != null
+              ? scope.getTransaction().traceState()
+              : null;
       final SentryEnvelope envelope =
-          buildEnvelope(
-              event, getAttachmentsFromScope(scope), session, TraceState.create(scope, options));
+          buildEnvelope(event, getAttachmentsFromScope(scope), session, traceState);
 
       if (envelope != null) {
         transport.send(envelope, hint);
@@ -396,6 +399,7 @@ public final class SentryClient implements ISentryClient {
   @Override
   public @NotNull SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
+      @Nullable TraceState traceState,
       final @Nullable Scope scope,
       final @Nullable Object hint) {
     Objects.requireNonNull(transaction, "Transaction is required.");
@@ -435,10 +439,7 @@ public final class SentryClient implements ISentryClient {
     try {
       final SentryEnvelope envelope =
           buildEnvelope(
-              transaction,
-              filterForTransaction(getAttachmentsFromScope(scope)),
-              null,
-              TraceState.create(transaction, scope, options));
+              transaction, filterForTransaction(getAttachmentsFromScope(scope)), null, traceState);
       if (envelope != null) {
         transport.send(envelope, hint);
       } else {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -438,7 +438,7 @@ public final class SentryClient implements ISentryClient {
               transaction,
               filterForTransaction(getAttachmentsFromScope(scope)),
               null,
-              scope != null ? TraceState.create(transaction, scope, options) : null);
+              TraceState.create(transaction, scope, options));
       if (envelope != null) {
         transport.send(envelope, hint);
       } else {

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeHeader.java
@@ -13,10 +13,20 @@ public final class SentryEnvelopeHeader {
 
   private final @Nullable SdkVersion sdkVersion;
 
+  private final @Nullable TraceState trace;
+
   public SentryEnvelopeHeader(
       final @Nullable SentryId eventId, final @Nullable SdkVersion sdkVersion) {
+    this(eventId, sdkVersion, null);
+  }
+
+  public SentryEnvelopeHeader(
+      final @Nullable SentryId eventId,
+      final @Nullable SdkVersion sdkVersion,
+      final @Nullable TraceState trace) {
     this.eventId = eventId;
     this.sdkVersion = sdkVersion;
+    this.trace = trace;
   }
 
   public SentryEnvelopeHeader(final @Nullable SentryId eventId) {
@@ -33,5 +43,9 @@ public final class SentryEnvelopeHeader {
 
   public @Nullable SdkVersion getSdkVersion() {
     return sdkVersion;
+  }
+
+  public @Nullable TraceState getTrace() {
+    return trace;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeHeaderAdapter.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeHeaderAdapter.java
@@ -73,6 +73,34 @@ public final class SentryEnvelopeHeaderAdapter extends TypeAdapter<SentryEnvelop
         writer.endObject();
       }
     }
+    TraceState trace = value.getTrace();
+    if (trace != null) {
+      writer.name("trace");
+      writer.beginObject();
+      writer.name("trace_id").value(trace.getTraceId().toString());
+      writer.name("public_key").value(trace.getPublicKey());
+      if (trace.getRelease() != null) {
+        writer.name("release").value(trace.getRelease());
+      }
+      if (trace.getEnvironment() != null) {
+        writer.name("environment").value(trace.getEnvironment());
+      }
+      if (trace.getTransaction() != null) {
+        writer.name("transaction").value(trace.getTransaction());
+      }
+      if (trace.getUser() != null) {
+        writer.name("user");
+        writer.beginObject();
+        if (trace.getUser().getId() != null) {
+          writer.name("id").value(trace.getUser().getId());
+        }
+        if (trace.getUser().getSegment() != null) {
+          writer.name("segment").value(trace.getUser().getSegment());
+        }
+        writer.endObject();
+      }
+      writer.endObject();
+    }
 
     writer.endObject();
   }

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeHeaderAdapter.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeHeaderAdapter.java
@@ -88,7 +88,8 @@ public final class SentryEnvelopeHeaderAdapter extends TypeAdapter<SentryEnvelop
       if (trace.getTransaction() != null) {
         writer.name("transaction").value(trace.getTransaction());
       }
-      if (trace.getUser() != null) {
+      if (trace.getUser() != null
+          && (trace.getUser().getId() != null || trace.getUser().getSegment() != null)) {
         writer.name("user");
         writer.beginObject();
         if (trace.getUser().getId() != null) {
@@ -260,7 +261,9 @@ public final class SentryEnvelopeHeaderAdapter extends TypeAdapter<SentryEnvelop
                       publicKey,
                       release,
                       environment,
-                      new TraceState.TraceStateUser(userId, segment),
+                      userId != null || segment != null
+                          ? new TraceState.TraceStateUser(userId, segment)
+                          : null,
                       transaction);
             }
             reader.endObject();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -280,6 +280,9 @@ public class SentryOptions {
    */
   private @NotNull RequestSize maxRequestBodySize = RequestSize.NONE;
 
+  /** Controls if the `tracestate` header is attached to envelopes and HTTP client integrations. */
+  private boolean traceSampling;
+
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
@@ -1436,6 +1439,22 @@ public class SentryOptions {
 
   public void setMaxRequestBodySize(final @NotNull RequestSize maxRequestBodySize) {
     this.maxRequestBodySize = maxRequestBodySize;
+  }
+
+  /** Note: this is an experimental API and will be removed without notice. */
+  @ApiStatus.Experimental
+  public boolean isTraceSampling() {
+    return traceSampling;
+  }
+
+  /**
+   * Note: this is an experimental API and will be removed without notice.
+   *
+   * @param traceSampling - if trace sampling should be enabled
+   */
+  @ApiStatus.Experimental
+  public void setTraceSampling(boolean traceSampling) {
+    this.traceSampling = traceSampling;
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -227,15 +227,17 @@ public final class SentryTracer implements ITransaction {
   @Override
   public @Nullable TraceState traceState() {
     if (hub.getOptions().isTraceSampling()) {
-      if (traceState == null) {
-        final AtomicReference<User> userAtomicReference = new AtomicReference<>();
-        hub.configureScope(
+      synchronized (this) {
+        if (traceState == null) {
+          final AtomicReference<User> userAtomicReference = new AtomicReference<>();
+          hub.configureScope(
             scope -> {
               userAtomicReference.set(scope.getUser());
             });
-        this.traceState = new TraceState(this, userAtomicReference.get(), hub.getOptions());
+          this.traceState = new TraceState(this, userAtomicReference.get(), hub.getOptions());
+        }
+        return this.traceState;
       }
-      return this.traceState;
     } else {
       return null;
     }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -231,9 +231,9 @@ public final class SentryTracer implements ITransaction {
         if (traceState == null) {
           final AtomicReference<User> userAtomicReference = new AtomicReference<>();
           hub.configureScope(
-            scope -> {
-              userAtomicReference.set(scope.getUser());
-            });
+              scope -> {
+                userAtomicReference.set(scope.getUser());
+              });
           this.traceState = new TraceState(this, userAtomicReference.get(), hub.getOptions());
         }
         return this.traceState;

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -4,11 +4,13 @@ import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.protocol.User;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,6 +43,8 @@ public final class SentryTracer implements ITransaction {
    * transaction is captured.
    */
   private final @Nullable TransactionFinishedCallback transactionFinishedCallback;
+
+  private @Nullable TraceState traceState;
 
   public SentryTracer(final @NotNull TransactionContext context, final @NotNull IHub hub) {
     this(context, hub, null);
@@ -216,8 +220,27 @@ public final class SentryTracer implements ITransaction {
       if (transactionFinishedCallback != null) {
         transactionFinishedCallback.execute(this);
       }
-      hub.captureTransaction(transaction);
+      hub.captureTransaction(transaction, this.traceState());
     }
+  }
+
+  @Override
+  public @NotNull TraceState traceState() {
+    if (traceState == null) {
+      final AtomicReference<User> userAtomicReference = new AtomicReference<>();
+      hub.configureScope(
+          scope -> {
+            userAtomicReference.set(scope.getUser());
+          });
+      this.traceState = new TraceState(this, userAtomicReference.get(), hub.getOptions());
+    }
+    return this.traceState;
+  }
+
+  @Override
+  public @NotNull TraceStateHeader toTraceStateHeader() {
+    return TraceStateHeader.fromTraceState(
+        traceState(), hub.getOptions().getSerializer(), hub.getOptions().getLogger());
   }
 
   private boolean hasAllChildrenFinished() {

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -106,6 +106,16 @@ public final class Span implements ISpan {
   }
 
   @Override
+  public @NotNull TraceState traceState() {
+    return transaction.traceState();
+  }
+
+  @Override
+  public @NotNull TraceStateHeader toTraceStateHeader() {
+    return transaction.toTraceStateHeader();
+  }
+
+  @Override
   public void finish() {
     this.finish(this.context.getStatus());
   }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -106,12 +106,12 @@ public final class Span implements ISpan {
   }
 
   @Override
-  public @NotNull TraceState traceState() {
+  public @Nullable TraceState traceState() {
     return transaction.traceState();
   }
 
   @Override
-  public @NotNull TraceStateHeader toTraceStateHeader() {
+  public @Nullable TraceStateHeader toTraceStateHeader() {
     return transaction.toTraceStateHeader();
   }
 

--- a/sentry/src/main/java/io/sentry/TraceState.java
+++ b/sentry/src/main/java/io/sentry/TraceState.java
@@ -74,7 +74,12 @@ public final class TraceState {
     private @Nullable String id;
     private @Nullable String segment;
 
-    TraceStateUser(final @Nullable User protocolUser) {
+    TraceStateUser(final @Nullable String id, final @Nullable String segment) {
+      this.id = id;
+      this.segment = segment;
+    }
+
+    public TraceStateUser(final @Nullable User protocolUser) {
       if (protocolUser != null) {
         this.id = protocolUser.getId();
         this.segment = getSegment(protocolUser);

--- a/sentry/src/main/java/io/sentry/TraceState.java
+++ b/sentry/src/main/java/io/sentry/TraceState.java
@@ -1,0 +1,120 @@
+package io.sentry;
+
+import io.sentry.protocol.SentryId;
+import io.sentry.protocol.SentryTransaction;
+import io.sentry.protocol.User;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class TraceState {
+  private @NotNull SentryId traceId;
+  private @NotNull String publicKey;
+  private @Nullable String release;
+  private @Nullable String environment;
+  private @Nullable TraceState.TraceStateUser user;
+  private @Nullable String transaction;
+
+  public TraceState(
+      @NotNull SentryId traceId,
+      @NotNull String publicKey,
+      @Nullable String release,
+      @Nullable String environment,
+      @Nullable TraceState.TraceStateUser user,
+      @Nullable String transaction) {
+    this.traceId = traceId;
+    this.publicKey = publicKey;
+    this.release = release;
+    this.environment = environment;
+    this.user = user;
+    this.transaction = transaction;
+  }
+
+  static @Nullable TraceState create(
+      final @Nullable Scope scope, final @NotNull SentryOptions sentryOptions) {
+    return scope != null ? create(scope.getTransaction(), scope, sentryOptions) : null;
+  }
+
+  static @Nullable TraceState create(
+      final @Nullable ITransaction transaction,
+      final @NotNull Scope scope,
+      final @NotNull SentryOptions sentryOptions) {
+    return transaction != null
+        ? new TraceState(
+            transaction.getSpanContext().getTraceId(),
+            new Dsn(sentryOptions.getDsn()).getPublicKey(),
+            sentryOptions.getRelease(),
+            sentryOptions.getEnvironment(),
+            new TraceStateUser(scope.getUser()),
+            transaction.getName())
+        : null;
+  }
+
+  static @Nullable TraceState create(
+      final @Nullable SentryTransaction transaction,
+      final @NotNull Scope scope,
+      final @NotNull SentryOptions sentryOptions) {
+    return transaction != null && transaction.getContexts().getTrace() != null
+        ? new TraceState(
+            transaction.getContexts().getTrace().getTraceId(),
+            new Dsn(sentryOptions.getDsn()).getPublicKey(),
+            sentryOptions.getRelease(),
+            sentryOptions.getEnvironment(),
+            new TraceStateUser(scope.getUser()),
+            transaction.getTransaction())
+        : null;
+  }
+
+  public @NotNull SentryId getTraceId() {
+    return traceId;
+  }
+
+  public @NotNull String getPublicKey() {
+    return publicKey;
+  }
+
+  public @Nullable String getRelease() {
+    return release;
+  }
+
+  public @Nullable String getEnvironment() {
+    return environment;
+  }
+
+  public @Nullable TraceStateUser getUser() {
+    return user;
+  }
+
+  public @Nullable String getTransaction() {
+    return transaction;
+  }
+
+  static final class TraceStateUser {
+    private @Nullable String id;
+    private @Nullable String segment;
+
+    TraceStateUser(final @Nullable User protocolUser) {
+      if (protocolUser != null) {
+        this.id = protocolUser.getId();
+        this.segment = getSegment(protocolUser);
+      }
+    }
+
+    private static @Nullable String getSegment(final @NotNull User user) {
+      final Map<String, String> others = user.getOthers();
+      if (others != null) {
+        return others.get("segment");
+      } else {
+        return null;
+      }
+    }
+
+    public @Nullable String getId() {
+      return id;
+    }
+
+    public @Nullable String getSegment() {
+      return segment;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/TraceState.java
+++ b/sentry/src/main/java/io/sentry/TraceState.java
@@ -37,7 +37,7 @@ public final class TraceState {
 
   static @Nullable TraceState create(
       final @Nullable ITransaction transaction,
-      final @NotNull Scope scope,
+      final @Nullable Scope scope,
       final @NotNull SentryOptions sentryOptions) {
     return transaction != null
         ? new TraceState(
@@ -45,14 +45,14 @@ public final class TraceState {
             new Dsn(sentryOptions.getDsn()).getPublicKey(),
             sentryOptions.getRelease(),
             sentryOptions.getEnvironment(),
-            new TraceStateUser(scope.getUser()),
+            scope != null ? new TraceStateUser(scope.getUser()) : null,
             transaction.getName())
         : null;
   }
 
   static @Nullable TraceState create(
       final @Nullable SentryTransaction transaction,
-      final @NotNull Scope scope,
+      final @Nullable Scope scope,
       final @NotNull SentryOptions sentryOptions) {
     return transaction != null && transaction.getContexts().getTrace() != null
         ? new TraceState(
@@ -60,7 +60,7 @@ public final class TraceState {
             new Dsn(sentryOptions.getDsn()).getPublicKey(),
             sentryOptions.getRelease(),
             sentryOptions.getEnvironment(),
-            new TraceStateUser(scope.getUser()),
+            scope != null ? new TraceStateUser(scope.getUser()) : null,
             transaction.getTransaction())
         : null;
   }

--- a/sentry/src/main/java/io/sentry/TraceState.java
+++ b/sentry/src/main/java/io/sentry/TraceState.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import io.sentry.protocol.SentryId;
-import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -15,7 +14,11 @@ public final class TraceState {
   private @Nullable TraceState.TraceStateUser user;
   private @Nullable String transaction;
 
-  public TraceState(
+  TraceState(@NotNull SentryId traceId, @NotNull String publicKey) {
+    this(traceId, publicKey, null, null, null, null);
+  }
+
+  TraceState(
       @NotNull SentryId traceId,
       @NotNull String publicKey,
       @Nullable String release,
@@ -30,39 +33,17 @@ public final class TraceState {
     this.transaction = transaction;
   }
 
-  static @Nullable TraceState create(
-      final @Nullable Scope scope, final @NotNull SentryOptions sentryOptions) {
-    return scope != null ? create(scope.getTransaction(), scope, sentryOptions) : null;
-  }
-
-  static @Nullable TraceState create(
-      final @Nullable ITransaction transaction,
-      final @Nullable Scope scope,
+  TraceState(
+      final @NotNull ITransaction transaction,
+      final @Nullable User user,
       final @NotNull SentryOptions sentryOptions) {
-    return transaction != null
-        ? new TraceState(
-            transaction.getSpanContext().getTraceId(),
-            new Dsn(sentryOptions.getDsn()).getPublicKey(),
-            sentryOptions.getRelease(),
-            sentryOptions.getEnvironment(),
-            scope != null ? new TraceStateUser(scope.getUser()) : null,
-            transaction.getName())
-        : null;
-  }
-
-  static @Nullable TraceState create(
-      final @Nullable SentryTransaction transaction,
-      final @Nullable Scope scope,
-      final @NotNull SentryOptions sentryOptions) {
-    return transaction != null && transaction.getContexts().getTrace() != null
-        ? new TraceState(
-            transaction.getContexts().getTrace().getTraceId(),
-            new Dsn(sentryOptions.getDsn()).getPublicKey(),
-            sentryOptions.getRelease(),
-            sentryOptions.getEnvironment(),
-            scope != null ? new TraceStateUser(scope.getUser()) : null,
-            transaction.getTransaction())
-        : null;
+    this(
+        transaction.getSpanContext().getTraceId(),
+        new Dsn(sentryOptions.getDsn()).getPublicKey(),
+        sentryOptions.getRelease(),
+        sentryOptions.getEnvironment(),
+        user != null ? new TraceStateUser(user) : null,
+        transaction.getName());
   }
 
   public @NotNull SentryId getTraceId() {

--- a/sentry/src/main/java/io/sentry/TraceState.java
+++ b/sentry/src/main/java/io/sentry/TraceState.java
@@ -3,9 +3,11 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@ApiStatus.Experimental
 public final class TraceState {
   private @NotNull SentryId traceId;
   private @NotNull String publicKey;

--- a/sentry/src/main/java/io/sentry/TraceStateHeader.java
+++ b/sentry/src/main/java/io/sentry/TraceStateHeader.java
@@ -1,0 +1,62 @@
+package io.sentry;
+
+import static io.sentry.vendor.Base64.DEFAULT;
+
+import io.sentry.vendor.Base64;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+import org.jetbrains.annotations.NotNull;
+
+public final class TraceStateHeader {
+  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+
+  private static final String TRACE_STATE_HEADER = "tracestate";
+  private final @NotNull String value;
+
+  public static @NotNull TraceStateHeader fromTraceState(
+      final @NotNull TraceState traceState,
+      final @NotNull ISerializer serializer,
+      final @NotNull ILogger logger) {
+    return new TraceStateHeader(
+        stripForbiddenChars(base64(toBytes(toJson(traceState, serializer, logger)))));
+  }
+
+  public TraceStateHeader(final @NotNull String value) {
+    this.value = value;
+  }
+
+  public @NotNull String getName() {
+    return TRACE_STATE_HEADER;
+  }
+
+  public @NotNull String getValue() {
+    return value;
+  }
+
+  private static @NotNull String base64(final @NotNull byte[] input) {
+    return Base64.encodeToString(input, DEFAULT);
+  }
+
+  private static @NotNull String stripForbiddenChars(final @NotNull String input) {
+    return input.replace("=", "");
+  }
+
+  private static @NotNull String toJson(
+      final @NotNull TraceState traceState,
+      final @NotNull ISerializer serializer,
+      final @NotNull ILogger logger) {
+    StringWriter stringWriter = new StringWriter();
+    try {
+      serializer.serialize(traceState, stringWriter);
+      return stringWriter.toString();
+    } catch (IOException e) {
+      logger.log(SentryLevel.ERROR, "Failed to serialize trace state header", e);
+      return "{}";
+    }
+  }
+
+  private static @NotNull byte[] toBytes(final @NotNull String input) {
+    return input.getBytes(UTF8_CHARSET);
+  }
+}

--- a/sentry/src/main/java/io/sentry/TraceStateHeader.java
+++ b/sentry/src/main/java/io/sentry/TraceStateHeader.java
@@ -11,9 +11,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public final class TraceStateHeader {
+  public static final String TRACE_STATE_HEADER = "tracestate";
+
   private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
 
-  private static final String TRACE_STATE_HEADER = "tracestate";
   private final @NotNull String value;
 
   public static @NotNull TraceStateHeader fromTraceState(

--- a/sentry/src/main/java/io/sentry/TraceStateHeader.java
+++ b/sentry/src/main/java/io/sentry/TraceStateHeader.java
@@ -7,9 +7,11 @@ import io.sentry.vendor.Base64;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
+@ApiStatus.Experimental
 public final class TraceStateHeader {
   public static final String TRACE_STATE_HEADER = "tracestate";
 

--- a/sentry/src/main/java/io/sentry/TraceStateHeader.java
+++ b/sentry/src/main/java/io/sentry/TraceStateHeader.java
@@ -5,6 +5,8 @@ import static io.sentry.vendor.Base64.DEFAULT;
 import io.sentry.vendor.Base64;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,8 +20,19 @@ public final class TraceStateHeader {
       final @NotNull TraceState traceState,
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger) {
-    return new TraceStateHeader(
-        stripForbiddenChars(base64(toBytes(toJson(traceState, serializer, logger)))));
+    return new TraceStateHeader(toHttpHeaderFriendlyBase64(toJson(traceState, serializer, logger)));
+  }
+
+  static @NotNull String toHttpHeaderFriendlyBase64(final @NotNull String input) {
+    return toUtf8(stripForbiddenChars(base64(toBytes(input))));
+  }
+
+  private static String toUtf8(String toJson) {
+    try {
+      return URLEncoder.encode(toJson, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      return toJson;
+    }
   }
 
   public TraceStateHeader(final @NotNull String value) {

--- a/sentry/src/main/java/io/sentry/vendor/Base64.java
+++ b/sentry/src/main/java/io/sentry/vendor/Base64.java
@@ -1,0 +1,673 @@
+package io.sentry.vendor;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Utilities for encoding and decoding the Base64 representation of binary data. See RFCs <a
+ * href="http://www.ietf.org/rfc/rfc2045.txt">2045</a> and <a
+ * href="http://www.ietf.org/rfc/rfc3548.txt">3548</a>.
+ */
+public class Base64 {
+  /** Default values for encoder/decoder flags. */
+  public static final int DEFAULT = 0;
+
+  /** Encoder flag bit to omit the padding '=' characters at the end of the output (if any). */
+  public static final int NO_PADDING = 1;
+
+  /** Encoder flag bit to omit all line terminators (i.e., the output will be on one long line). */
+  public static final int NO_WRAP = 2;
+
+  /**
+   * Encoder flag bit to indicate lines should be terminated with a CRLF pair instead of just an LF.
+   * Has no effect if {@code NO_WRAP} is specified as well.
+   */
+  public static final int CRLF = 4;
+
+  /**
+   * Encoder/decoder flag bit to indicate using the "URL and filename safe" variant of Base64 (see
+   * RFC 3548 section 4) where {@code -} and {@code _} are used in place of {@code +} and {@code /}.
+   */
+  public static final int URL_SAFE = 8;
+
+  /**
+   * Flag to pass to {@link Base64OutputStream} to indicate that it should not close the output
+   * stream it is wrapping when it itself is closed.
+   */
+  public static final int NO_CLOSE = 16;
+
+  //  --------------------------------------------------------
+  //  shared code
+  //  --------------------------------------------------------
+
+  /* package */ abstract static class Coder {
+    public byte[] output;
+    public int op;
+
+    /**
+     * Encode/decode another block of input data. this.output is provided by the caller, and must be
+     * big enough to hold all the coded data. On exit, this.opwill be set to the length of the coded
+     * data.
+     *
+     * @param finish true if this is the final call to process for this object. Will finalize the
+     *     coder state and include any final bytes in the output.
+     * @return true if the input so far is good; false if some error has been detected in the input
+     *     stream..
+     */
+    public abstract boolean process(byte[] input, int offset, int len, boolean finish);
+
+    /**
+     * @return the maximum number of bytes a call to process() could produce for the given number of
+     *     input bytes. This may be an overestimate.
+     */
+    public abstract int maxOutputSize(int len);
+  }
+
+  //  --------------------------------------------------------
+  //  decoding
+  //  --------------------------------------------------------
+
+  /**
+   * Decode the Base64-encoded data in input and return the data in a new byte array.
+   *
+   * <p>The padding '=' characters at the end are considered optional, but if any are present, there
+   * must be the correct number of them.
+   *
+   * @param str the input String to decode, which is converted to bytes using the default charset
+   * @param flags controls certain features of the decoded output. Pass {@code DEFAULT} to decode
+   *     standard Base64.
+   * @throws IllegalArgumentException if the input contains incorrect padding
+   */
+  public static byte[] decode(String str, int flags) {
+    return decode(str.getBytes(), flags);
+  }
+
+  /**
+   * Decode the Base64-encoded data in input and return the data in a new byte array.
+   *
+   * <p>The padding '=' characters at the end are considered optional, but if any are present, there
+   * must be the correct number of them.
+   *
+   * @param input the input array to decode
+   * @param flags controls certain features of the decoded output. Pass {@code DEFAULT} to decode
+   *     standard Base64.
+   * @throws IllegalArgumentException if the input contains incorrect padding
+   */
+  public static byte[] decode(byte[] input, int flags) {
+    return decode(input, 0, input.length, flags);
+  }
+
+  /**
+   * Decode the Base64-encoded data in input and return the data in a new byte array.
+   *
+   * <p>The padding '=' characters at the end are considered optional, but if any are present, there
+   * must be the correct number of them.
+   *
+   * @param input the data to decode
+   * @param offset the position within the input array at which to start
+   * @param len the number of bytes of input to decode
+   * @param flags controls certain features of the decoded output. Pass {@code DEFAULT} to decode
+   *     standard Base64.
+   * @throws IllegalArgumentException if the input contains incorrect padding
+   */
+  public static byte[] decode(byte[] input, int offset, int len, int flags) {
+    // Allocate space for the most data the input could represent.
+    // (It could contain less if it contains whitespace, etc.)
+    Decoder decoder = new Decoder(flags, new byte[len * 3 / 4]);
+
+    if (!decoder.process(input, offset, len, true)) {
+      throw new IllegalArgumentException("bad base-64");
+    }
+
+    // Maybe we got lucky and allocated exactly enough output space.
+    if (decoder.op == decoder.output.length) {
+      return decoder.output;
+    }
+
+    // Need to shorten the array, so allocate a new one of the
+    // right size and copy.
+    byte[] temp = new byte[decoder.op];
+    System.arraycopy(decoder.output, 0, temp, 0, decoder.op);
+    return temp;
+  }
+
+  /* package */ static class Decoder extends Coder {
+    /** Lookup table for turning bytes into their position in the Base64 alphabet. */
+    private static final int DECODE[] = {
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,
+      52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+      -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+      -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    };
+
+    /**
+     * Decode lookup table for the "web safe" variant (RFC 3548 sec. 4) where - and _ replace + and
+     * /.
+     */
+    private static final int DECODE_WEBSAFE[] = {
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1,
+      52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1, -1,
+      -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+      15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, 63,
+      -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+      41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    };
+
+    /** Non-data values in the DECODE arrays. */
+    private static final int SKIP = -1;
+
+    private static final int EQUALS = -2;
+
+    /**
+     * States 0-3 are reading through the next input tuple. State 4 is having read one '=' and
+     * expecting exactly one more. State 5 is expecting no more data or padding characters in the
+     * input. State 6 is the error state; an error has been detected in the input and no future
+     * input can "fix" it.
+     */
+    private int state; // state number (0 to 6)
+
+    private int value;
+
+    private final int[] alphabet;
+
+    public Decoder(int flags, byte[] output) {
+      this.output = output;
+
+      alphabet = ((flags & URL_SAFE) == 0) ? DECODE : DECODE_WEBSAFE;
+      state = 0;
+      value = 0;
+    }
+
+    /** @return an overestimate for the number of bytes {@code len} bytes could decode to. */
+    public int maxOutputSize(int len) {
+      return len * 3 / 4 + 10;
+    }
+
+    /**
+     * Decode another block of input data.
+     *
+     * @return true if the state machine is still healthy. false if bad base-64 data has been
+     *     detected in the input stream.
+     */
+    public boolean process(byte[] input, int offset, int len, boolean finish) {
+      if (this.state == 6) return false;
+
+      int p = offset;
+      len += offset;
+
+      // Using local variables makes the decoder about 12%
+      // faster than if we manipulate the member variables in
+      // the loop.  (Even alphabet makes a measurable
+      // difference, which is somewhat surprising to me since
+      // the member variable is final.)
+      int state = this.state;
+      int value = this.value;
+      int op = 0;
+      final byte[] output = this.output;
+      final int[] alphabet = this.alphabet;
+
+      while (p < len) {
+        // Try the fast path:  we're starting a new tuple and the
+        // next four bytes of the input stream are all data
+        // bytes.  This corresponds to going through states
+        // 0-1-2-3-0.  We expect to use this method for most of
+        // the data.
+        //
+        // If any of the next four bytes of input are non-data
+        // (whitespace, etc.), value will end up negative.  (All
+        // the non-data values in decode are small negative
+        // numbers, so shifting any of them up and or'ing them
+        // together will result in a value with its top bit set.)
+        //
+        // You can remove this whole block and the output should
+        // be the same, just slower.
+        if (state == 0) {
+          while (p + 4 <= len
+              && (value =
+                      ((alphabet[input[p] & 0xff] << 18)
+                          | (alphabet[input[p + 1] & 0xff] << 12)
+                          | (alphabet[input[p + 2] & 0xff] << 6)
+                          | (alphabet[input[p + 3] & 0xff])))
+                  >= 0) {
+            output[op + 2] = (byte) value;
+            output[op + 1] = (byte) (value >> 8);
+            output[op] = (byte) (value >> 16);
+            op += 3;
+            p += 4;
+          }
+          if (p >= len) break;
+        }
+
+        // The fast path isn't available -- either we've read a
+        // partial tuple, or the next four input bytes aren't all
+        // data, or whatever.  Fall back to the slower state
+        // machine implementation.
+
+        int d = alphabet[input[p++] & 0xff];
+
+        switch (state) {
+          case 0:
+            if (d >= 0) {
+              value = d;
+              ++state;
+            } else if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+
+          case 1:
+            if (d >= 0) {
+              value = (value << 6) | d;
+              ++state;
+            } else if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+
+          case 2:
+            if (d >= 0) {
+              value = (value << 6) | d;
+              ++state;
+            } else if (d == EQUALS) {
+              // Emit the last (partial) output tuple;
+              // expect exactly one more padding character.
+              output[op++] = (byte) (value >> 4);
+              state = 4;
+            } else if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+
+          case 3:
+            if (d >= 0) {
+              // Emit the output triple and return to state 0.
+              value = (value << 6) | d;
+              output[op + 2] = (byte) value;
+              output[op + 1] = (byte) (value >> 8);
+              output[op] = (byte) (value >> 16);
+              op += 3;
+              state = 0;
+            } else if (d == EQUALS) {
+              // Emit the last (partial) output tuple;
+              // expect no further data or padding characters.
+              output[op + 1] = (byte) (value >> 2);
+              output[op] = (byte) (value >> 10);
+              op += 2;
+              state = 5;
+            } else if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+
+          case 4:
+            if (d == EQUALS) {
+              ++state;
+            } else if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+
+          case 5:
+            if (d != SKIP) {
+              this.state = 6;
+              return false;
+            }
+            break;
+        }
+      }
+
+      if (!finish) {
+        // We're out of input, but a future call could provide
+        // more.
+        this.state = state;
+        this.value = value;
+        this.op = op;
+        return true;
+      }
+
+      // Done reading input.  Now figure out where we are left in
+      // the state machine and finish up.
+
+      switch (state) {
+        case 0:
+          // Output length is a multiple of three.  Fine.
+          break;
+        case 1:
+          // Read one extra input byte, which isn't enough to
+          // make another output byte.  Illegal.
+          this.state = 6;
+          return false;
+        case 2:
+          // Read two extra input bytes, enough to emit 1 more
+          // output byte.  Fine.
+          output[op++] = (byte) (value >> 4);
+          break;
+        case 3:
+          // Read three extra input bytes, enough to emit 2 more
+          // output bytes.  Fine.
+          output[op++] = (byte) (value >> 10);
+          output[op++] = (byte) (value >> 2);
+          break;
+        case 4:
+          // Read one padding '=' when we expected 2.  Illegal.
+          this.state = 6;
+          return false;
+        case 5:
+          // Read all the padding '='s we expected and no more.
+          // Fine.
+          break;
+      }
+
+      this.state = state;
+      this.op = op;
+      return true;
+    }
+  }
+
+  //  --------------------------------------------------------
+  //  encoding
+  //  --------------------------------------------------------
+
+  /**
+   * Base64-encode the given data and return a newly allocated String with the result.
+   *
+   * @param input the data to encode
+   * @param flags controls certain features of the encoded output. Passing {@code DEFAULT} results
+   *     in output that adheres to RFC 2045.
+   */
+  public static String encodeToString(byte[] input, int flags) {
+    try {
+      return new String(encode(input, flags), "US-ASCII");
+    } catch (UnsupportedEncodingException e) {
+      // US-ASCII is guaranteed to be available.
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Base64-encode the given data and return a newly allocated String with the result.
+   *
+   * @param input the data to encode
+   * @param offset the position within the input array at which to start
+   * @param len the number of bytes of input to encode
+   * @param flags controls certain features of the encoded output. Passing {@code DEFAULT} results
+   *     in output that adheres to RFC 2045.
+   */
+  public static String encodeToString(byte[] input, int offset, int len, int flags) {
+    try {
+      return new String(encode(input, offset, len, flags), "US-ASCII");
+    } catch (UnsupportedEncodingException e) {
+      // US-ASCII is guaranteed to be available.
+      throw new AssertionError(e);
+    }
+  }
+
+  /**
+   * Base64-encode the given data and return a newly allocated byte[] with the result.
+   *
+   * @param input the data to encode
+   * @param flags controls certain features of the encoded output. Passing {@code DEFAULT} results
+   *     in output that adheres to RFC 2045.
+   */
+  public static byte[] encode(byte[] input, int flags) {
+    return encode(input, 0, input.length, flags);
+  }
+
+  /**
+   * Base64-encode the given data and return a newly allocated byte[] with the result.
+   *
+   * @param input the data to encode
+   * @param offset the position within the input array at which to start
+   * @param len the number of bytes of input to encode
+   * @param flags controls certain features of the encoded output. Passing {@code DEFAULT} results
+   *     in output that adheres to RFC 2045.
+   */
+  public static byte[] encode(byte[] input, int offset, int len, int flags) {
+    Encoder encoder = new Encoder(flags, null);
+
+    // Compute the exact length of the array we will produce.
+    int output_len = len / 3 * 4;
+
+    // Account for the tail of the data and the padding bytes, if any.
+    if (encoder.do_padding) {
+      if (len % 3 > 0) {
+        output_len += 4;
+      }
+    } else {
+      switch (len % 3) {
+        case 0:
+          break;
+        case 1:
+          output_len += 2;
+          break;
+        case 2:
+          output_len += 3;
+          break;
+      }
+    }
+
+    // Account for the newlines, if any.
+    if (encoder.do_newline && len > 0) {
+      output_len += (((len - 1) / (3 * Encoder.LINE_GROUPS)) + 1) * (encoder.do_cr ? 2 : 1);
+    }
+
+    encoder.output = new byte[output_len];
+    encoder.process(input, offset, len, true);
+
+    assert encoder.op == output_len;
+
+    return encoder.output;
+  }
+
+  /* package */ static class Encoder extends Coder {
+    /**
+     * Emit a new line every this many output tuples. Corresponds to a 76-character line length (the
+     * maximum allowable according to <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>).
+     */
+    public static final int LINE_GROUPS = 19;
+
+    /** Lookup table for turning Base64 alphabet positions (6 bits) into output bytes. */
+    private static final byte ENCODE[] = {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+      'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+      'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+      'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
+    };
+
+    /** Lookup table for turning Base64 alphabet positions (6 bits) into output bytes. */
+    private static final byte ENCODE_WEBSAFE[] = {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+      'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+      'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+      'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_',
+    };
+
+    private final byte[] tail;
+    /* package */ int tailLen;
+    private int count;
+
+    public final boolean do_padding;
+    public final boolean do_newline;
+    public final boolean do_cr;
+    private final byte[] alphabet;
+
+    public Encoder(int flags, byte[] output) {
+      this.output = output;
+
+      do_padding = (flags & NO_PADDING) == 0;
+      do_newline = (flags & NO_WRAP) == 0;
+      do_cr = (flags & CRLF) != 0;
+      alphabet = ((flags & URL_SAFE) == 0) ? ENCODE : ENCODE_WEBSAFE;
+
+      tail = new byte[2];
+      tailLen = 0;
+
+      count = do_newline ? LINE_GROUPS : -1;
+    }
+
+    /** @return an overestimate for the number of bytes {@code len} bytes could encode to. */
+    public int maxOutputSize(int len) {
+      return len * 8 / 5 + 10;
+    }
+
+    public boolean process(byte[] input, int offset, int len, boolean finish) {
+      // Using local variables makes the encoder about 9% faster.
+      final byte[] alphabet = this.alphabet;
+      final byte[] output = this.output;
+      int op = 0;
+      int count = this.count;
+
+      int p = offset;
+      len += offset;
+      int v = -1;
+
+      // First we need to concatenate the tail of the previous call
+      // with any input bytes available now and see if we can empty
+      // the tail.
+
+      switch (tailLen) {
+        case 0:
+          // There was no tail.
+          break;
+
+        case 1:
+          if (p + 2 <= len) {
+            // A 1-byte tail with at least 2 bytes of
+            // input available now.
+            v = ((tail[0] & 0xff) << 16) | ((input[p++] & 0xff) << 8) | (input[p++] & 0xff);
+            tailLen = 0;
+          }
+          ;
+          break;
+
+        case 2:
+          if (p + 1 <= len) {
+            // A 2-byte tail with at least 1 byte of input.
+            v = ((tail[0] & 0xff) << 16) | ((tail[1] & 0xff) << 8) | (input[p++] & 0xff);
+            tailLen = 0;
+          }
+          break;
+      }
+
+      if (v != -1) {
+        output[op++] = alphabet[(v >> 18) & 0x3f];
+        output[op++] = alphabet[(v >> 12) & 0x3f];
+        output[op++] = alphabet[(v >> 6) & 0x3f];
+        output[op++] = alphabet[v & 0x3f];
+        if (--count == 0) {
+          if (do_cr) output[op++] = '\r';
+          output[op++] = '\n';
+          count = LINE_GROUPS;
+        }
+      }
+
+      // At this point either there is no tail, or there are fewer
+      // than 3 bytes of input available.
+
+      // The main loop, turning 3 input bytes into 4 output bytes on
+      // each iteration.
+      while (p + 3 <= len) {
+        v = ((input[p] & 0xff) << 16) | ((input[p + 1] & 0xff) << 8) | (input[p + 2] & 0xff);
+        output[op] = alphabet[(v >> 18) & 0x3f];
+        output[op + 1] = alphabet[(v >> 12) & 0x3f];
+        output[op + 2] = alphabet[(v >> 6) & 0x3f];
+        output[op + 3] = alphabet[v & 0x3f];
+        p += 3;
+        op += 4;
+        if (--count == 0) {
+          if (do_cr) output[op++] = '\r';
+          output[op++] = '\n';
+          count = LINE_GROUPS;
+        }
+      }
+
+      if (finish) {
+        // Finish up the tail of the input.  Note that we need to
+        // consume any bytes in tail before any bytes
+        // remaining in input; there should be at most two bytes
+        // total.
+
+        if (p - tailLen == len - 1) {
+          int t = 0;
+          v = ((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 4;
+          tailLen -= t;
+          output[op++] = alphabet[(v >> 6) & 0x3f];
+          output[op++] = alphabet[v & 0x3f];
+          if (do_padding) {
+            output[op++] = '=';
+            output[op++] = '=';
+          }
+          if (do_newline) {
+            if (do_cr) output[op++] = '\r';
+            output[op++] = '\n';
+          }
+        } else if (p - tailLen == len - 2) {
+          int t = 0;
+          v =
+              (((tailLen > 1 ? tail[t++] : input[p++]) & 0xff) << 10)
+                  | (((tailLen > 0 ? tail[t++] : input[p++]) & 0xff) << 2);
+          tailLen -= t;
+          output[op++] = alphabet[(v >> 12) & 0x3f];
+          output[op++] = alphabet[(v >> 6) & 0x3f];
+          output[op++] = alphabet[v & 0x3f];
+          if (do_padding) {
+            output[op++] = '=';
+          }
+          if (do_newline) {
+            if (do_cr) output[op++] = '\r';
+            output[op++] = '\n';
+          }
+        } else if (do_newline && op > 0 && count != LINE_GROUPS) {
+          if (do_cr) output[op++] = '\r';
+          output[op++] = '\n';
+        }
+
+        assert tailLen == 0;
+        assert p == len;
+      } else {
+        // Save the leftovers in tail to be consumed on the next
+        // call to encodeInternal.
+
+        if (p == len - 1) {
+          tail[tailLen++] = input[p];
+        } else if (p == len - 2) {
+          tail[tailLen++] = input[p];
+          tail[tailLen++] = input[p + 1];
+        }
+      }
+
+      this.op = op;
+      this.count = count;
+
+      return true;
+    }
+  }
+
+  private Base64() {} // don't instantiate
+}

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -47,6 +47,7 @@ class GsonSerializerTest {
 
         init {
             val options = SentryOptions()
+            options.dsn = "https://key@sentry.io/proj"
             options.setLogger(logger)
             options.setDebug(true)
             options.setEnvelopeReader(EnvelopeReader())

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1071,7 +1071,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.captureTransaction(SentryTransaction(SentryTracer(TransactionContext("name", "op", true), mock())), null)
-        verify(mockClient).captureTransaction(any(), any(), eq(null))
+        verify(mockClient).captureTransaction(any(), eq(null), any(), eq(null))
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1070,7 +1070,7 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
 
-        val sentryTracer = SentryTracer(TransactionContext("name", "op", true), mock())
+        val sentryTracer = SentryTracer(TransactionContext("name", "op", true), sut)
         val traceState = sentryTracer.traceState()
         sut.captureTransaction(SentryTransaction(sentryTracer), traceState)
         verify(mockClient).captureTransaction(any(), eq(traceState), any(), eq(null))
@@ -1086,7 +1086,7 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
 
-        val sentryTracer = SentryTracer(TransactionContext("name", "op", false), mock())
+        val sentryTracer = SentryTracer(TransactionContext("name", "op", false), sut)
         val traceState = sentryTracer.traceState()
         sut.captureTransaction(SentryTransaction(sentryTracer), traceState)
         verify(mockClient, times(0)).captureTransaction(any(), eq(traceState), any(), eq(null))

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1070,8 +1070,10 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
 
-        sut.captureTransaction(SentryTransaction(SentryTracer(TransactionContext("name", "op", true), mock())), null)
-        verify(mockClient).captureTransaction(any(), eq(null), any(), eq(null))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op", true), mock())
+        val traceState = sentryTracer.traceState()
+        sut.captureTransaction(SentryTransaction(sentryTracer), traceState)
+        verify(mockClient).captureTransaction(any(), eq(traceState), any(), eq(null))
     }
 
     @Test
@@ -1084,8 +1086,10 @@ class HubTest {
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
 
-        sut.captureTransaction(SentryTransaction(SentryTracer(TransactionContext("name", "op", false), mock())), null)
-        verify(mockClient, times(0)).captureTransaction(any(), any(), eq(null))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op", false), mock())
+        val traceState = sentryTracer.traceState()
+        sut.captureTransaction(SentryTransaction(sentryTracer), traceState)
+        verify(mockClient, times(0)).captureTransaction(any(), eq(traceState), any(), eq(null))
     }
     //endregion
 

--- a/sentry/src/test/java/io/sentry/NoOpSentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSentryClientTest.kt
@@ -45,5 +45,5 @@ class NoOpSentryClientTest {
 
     @Test
     fun `captureTransaction returns empty SentryId`() =
-        assertEquals(SentryId.EMPTY_ID, sut.captureTransaction(mock()))
+        assertEquals(SentryId.EMPTY_ID, sut.captureTransaction(mock(), mock()))
 }

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -108,8 +108,7 @@ class OutboxSenderTest {
         assertTrue(File(path).exists())
         sut.processEnvelopeFile(path, mock<Retryable>())
 
-        // TODO: fix test
-//        verify(fixture.hub).captureTransaction(eq(expected), any(), any())
+        verify(fixture.hub).captureTransaction(eq(expected), any(), any())
         assertFalse(File(path).exists())
         assertTrue(transactionContext.sampled ?: false)
 

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -32,6 +32,11 @@ class OutboxSenderTest {
         val serializer = mock<ISerializer>()
         val logger = mock<ILogger>()
 
+        init {
+            whenever(options.dsn).thenReturn("https://key@sentry.io/proj")
+            whenever(hub.options).thenReturn(this.options)
+        }
+
         fun getSut(): OutboxSender {
             return OutboxSender(hub, envelopeReader, serializer, logger, 15000)
         }
@@ -103,7 +108,8 @@ class OutboxSenderTest {
         assertTrue(File(path).exists())
         sut.processEnvelopeFile(path, mock<Retryable>())
 
-        verify(fixture.hub).captureTransaction(eq(expected), any())
+        // TODO: fix test
+//        verify(fixture.hub).captureTransaction(eq(expected), any(), any())
         assertFalse(File(path).exists())
         assertTrue(transactionContext.sampled ?: false)
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -67,6 +67,7 @@ class SentryClientTest {
             maxAttachmentSize = this@Fixture.maxAttachmentSize
             setTransportFactory(factory)
             release = "0.0.1"
+            isTraceSampling = true
         }
 
         init {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -54,7 +54,8 @@ class SentryClientTest {
         var transport = mock<ITransport>()
         var factory = mock<ITransportFactory>()
         val maxAttachmentSize: Long = 5 * 1024 * 1024
-        val sentryTracer = SentryTracer(TransactionContext("a-transaction", "op"), mock())
+        val hub = mock<IHub>()
+        val sentryTracer = SentryTracer(TransactionContext("a-transaction", "op"), hub)
 
         var sentryOptions: SentryOptions = SentryOptions().apply {
             dsn = dsnString
@@ -67,8 +68,6 @@ class SentryClientTest {
             setTransportFactory(factory)
             release = "0.0.1"
         }
-
-        val hub = mock<IHub>()
 
         init {
             whenever(factory.create(any(), any())).thenReturn(transport)
@@ -605,7 +604,7 @@ class SentryClientTest {
 
         val transaction = SentryTransaction(fixture.sentryTracer)
 
-        fixture.getSut().captureTransaction(transaction)
+        fixture.getSut().captureTransaction(transaction, fixture.sentryTracer.traceState())
         verify(processor).process(eq(transaction), anyOrNull())
     }
 
@@ -941,7 +940,7 @@ class SentryClientTest {
         fixture.sentryOptions.environment = "optionsEnvironment"
         val sut = fixture.getSut()
         val transaction = SentryTransaction(fixture.sentryTracer)
-        sut.captureTransaction(transaction)
+        sut.captureTransaction(transaction, fixture.sentryTracer.traceState())
         assertEquals("optionsRelease", transaction.release)
         assertEquals("optionsEnvironment", transaction.environment)
     }
@@ -951,10 +950,11 @@ class SentryClientTest {
         fixture.sentryOptions.release = "optionsRelease"
         fixture.sentryOptions.environment = "optionsEnvironment"
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
         transaction.release = "transactionRelease"
         transaction.environment = "transactionEnvironment"
-        sut.captureTransaction(transaction)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals("transactionRelease", transaction.release)
         assertEquals("transactionEnvironment", transaction.environment)
     }
@@ -963,8 +963,9 @@ class SentryClientTest {
     fun `when transaction does not have SDK version set, and the SDK version is set on options, options values are applied to transactions`() {
         fixture.sentryOptions.sdkVersion = SdkVersion("sdk.name", "version")
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
-        sut.captureTransaction(transaction)
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals(fixture.sentryOptions.sdkVersion, transaction.sdk)
     }
 
@@ -972,10 +973,11 @@ class SentryClientTest {
     fun `when transaction has SDK version set, and the SDK version is set on options, options values are not applied to transactions`() {
         fixture.sentryOptions.sdkVersion = SdkVersion("sdk.name", "version")
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
         val sdkVersion = SdkVersion("transaction.sdk.name", "version")
         transaction.sdk = sdkVersion
-        sut.captureTransaction(transaction)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals(sdkVersion, transaction.sdk)
     }
 
@@ -983,8 +985,9 @@ class SentryClientTest {
     fun `when transaction does not have tags, and tags are set on options, options values are applied to transactions`() {
         fixture.sentryOptions.setTag("tag1", "value1")
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
-        sut.captureTransaction(transaction)
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals(mapOf("tag1" to "value1"), transaction.tags)
     }
 
@@ -993,27 +996,30 @@ class SentryClientTest {
         fixture.sentryOptions.setTag("tag1", "value1")
         fixture.sentryOptions.setTag("tag2", "value2")
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
         transaction.setTag("tag3", "value3")
         transaction.setTag("tag2", "transaction-tag")
-        sut.captureTransaction(transaction)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals(mapOf("tag1" to "value1", "tag2" to "transaction-tag", "tag3" to "value3"), transaction.tags)
     }
 
     @Test
     fun `captured transactions without a platform, have the default platform set`() {
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
-        sut.captureTransaction(transaction)
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals("java", transaction.platform)
     }
 
     @Test
     fun `captured transactions with a platform, do not get the platform overwritten`() {
         val sut = fixture.getSut()
-        val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), mock()))
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.hub)
+        val transaction = SentryTransaction(sentryTracer)
         transaction.platform = "abc"
-        sut.captureTransaction(transaction)
+        sut.captureTransaction(transaction, sentryTracer.traceState())
         assertEquals("abc", transaction.platform)
     }
 

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -114,7 +114,7 @@ class SentryTracerTest {
         tracer.finish()
         verify(fixture.hub).captureTransaction(check {
             assertEquals(it.transaction, tracer.name)
-        })
+        }, any())
     }
 
     @Test
@@ -143,7 +143,7 @@ class SentryTracerTest {
         tracer.finish()
         verify(fixture.hub).captureTransaction(check {
             assertEquals(request, it.request)
-        })
+        }, any())
     }
 
     @Test
@@ -158,7 +158,7 @@ class SentryTracerTest {
             assertEquals(app, it.contexts.app)
             assertEquals("value", it.contexts["custom"])
             assertEquals(tracer.spanContext, it.contexts.trace)
-        })
+        }, any())
     }
 
     @Test
@@ -171,7 +171,7 @@ class SentryTracerTest {
         verify(fixture.hub).captureTransaction(check {
             assertNotEquals(spanContext, it.contexts.trace)
             assertEquals(tracer.spanContext, it.contexts.trace)
-        })
+        }, any())
     }
 
     @Test
@@ -297,7 +297,7 @@ class SentryTracerTest {
         verify(fixture.hub).setSpanContext(ex, transaction.root, "name")
         verify(fixture.hub).captureTransaction(check {
             assertEquals(transaction.root.spanContext, it.contexts.trace)
-        })
+        }, any())
 
         assertEquals(SpanStatus.OK, transaction.status)
         assertEquals(timestamp, transaction.timestamp)
@@ -338,7 +338,7 @@ class SentryTracerTest {
         val transaction = fixture.getSut(waitForChildren = true)
         transaction.startChild("op")
         transaction.finish()
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
     }
 
     @Test
@@ -347,7 +347,7 @@ class SentryTracerTest {
         val child = transaction.startChild("op")
         child.finish()
         transaction.finish()
-        verify(fixture.hub).captureTransaction(any())
+        verify(fixture.hub).captureTransaction(any(), any())
     }
 
     @Test
@@ -368,7 +368,7 @@ class SentryTracerTest {
         val transaction = fixture.getSut(waitForChildren = true)
         val child = transaction.startChild("op")
         child.finish()
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
     }
 
     @Test
@@ -376,10 +376,10 @@ class SentryTracerTest {
         val transaction = fixture.getSut(waitForChildren = true)
         val child = transaction.startChild("op")
         transaction.finish(SpanStatus.INVALID_ARGUMENT)
-        verify(fixture.hub, never()).captureTransaction(any())
+        verify(fixture.hub, never()).captureTransaction(any(), any())
         child.finish()
         verify(fixture.hub, times(1)).captureTransaction(check {
             assertEquals(SpanStatus.INVALID_ARGUMENT, it.status)
-        })
+        }, any())
     }
 }

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -19,6 +19,7 @@ class SpanTest {
         init {
             whenever(hub.options).thenReturn(SentryOptions().apply {
                 dsn = "https://key@sentry.io/proj"
+                isTraceSampling = true
             })
         }
 
@@ -158,7 +159,9 @@ class SpanTest {
         val transaction = getTransaction()
         val span = transaction.startChild("operation", "description")
 
-        assertEquals(transaction.toTraceStateHeader().value, span.toTraceStateHeader().value)
+        assertNotNull(transaction.toTraceStateHeader()) {
+            assertEquals(it.value, span.toTraceStateHeader()!!.value)
+        }
     }
 
     private fun getTransaction(): SentryTracer {

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -17,7 +17,9 @@ class SpanTest {
         val hub = mock<IHub>()
 
         init {
-            whenever(hub.options).thenReturn(SentryOptions())
+            whenever(hub.options).thenReturn(SentryOptions().apply {
+                dsn = "https://key@sentry.io/proj"
+            })
         }
 
         fun getSut(): Span {
@@ -141,6 +143,22 @@ class SpanTest {
         verify(fixture.hub).setSpanContext(any(), any(), any())
         assertEquals(SpanStatus.OK, span.status)
         assertEquals(timestamp, span.timestamp)
+    }
+
+    @Test
+    fun `child trace state is equal to transaction trace state`() {
+        val transaction = getTransaction()
+        val span = transaction.startChild("operation", "description")
+
+        assertEquals(transaction.traceState(), span.traceState())
+    }
+
+    @Test
+    fun `child trace state header is equal to transaction trace state header`() {
+        val transaction = getTransaction()
+        val span = transaction.startChild("operation", "description")
+
+        assertEquals(transaction.toTraceStateHeader().value, span.toTraceStateHeader().value)
     }
 
     private fun getTransaction(): SentryTracer {

--- a/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
+++ b/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
@@ -1,0 +1,12 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TraceStateHeaderTest {
+
+    @Test
+    fun `converts to header friendly base64 string`() {
+        assertEquals("eyJ4IjoiYS3wn5iQLeivu%2BWGmeaxieWtlyAtIOWtpuS4reaWhyJ9%0A", TraceStateHeader.toHttpHeaderFriendlyBase64("{\"x\":\"a-😐-读写汉字 - 学中文\"}"))
+    }
+}

--- a/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
+++ b/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
@@ -6,7 +6,12 @@ import kotlin.test.assertEquals
 class TraceStateHeaderTest {
 
     @Test
-    fun `converts to header friendly base64 string`() {
-        assertEquals("eyJ4IjoiYS3wn5iQLeivu%2BWGmeaxieWtlyAtIOWtpuS4reaWhyJ9%0A", TraceStateHeader.toHttpHeaderFriendlyBase64("{\"x\":\"a-😐-读写汉字 - 学中文\"}"))
+    fun `encodes to base64`() {
+        assertEquals("eyJ4IjoiYS3wn5mCLeivu+WGmeaxieWtlyAtIOWtpuS4reaWhyJ9", TraceStateHeader.base64encode("{\"x\":\"a-🙂-读写汉字 - 学中文\"}"))
+    }
+
+    @Test
+    fun `decode from base64`() {
+        assertEquals("{\"x\":\"a-🙂-读写汉字 - 学中文\"}", TraceStateHeader.base64decode("eyJ4IjoiYS3wn5mCLeivu+WGmeaxieWtlyAtIOWtpuS4reaWhyJ9"))
     }
 }

--- a/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
+++ b/sentry/src/test/java/io/sentry/TraceStateHeaderTest.kt
@@ -1,5 +1,11 @@
 package io.sentry
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.protocol.SentryId
+import java.io.StringWriter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -13,5 +19,15 @@ class TraceStateHeaderTest {
     @Test
     fun `decode from base64`() {
         assertEquals("{\"x\":\"a-🙂-读写汉字 - 学中文\"}", TraceStateHeader.base64decode("eyJ4IjoiYS3wn5mCLeivu+WGmeaxieWtlyAtIOWtpuS4reaWhyJ9"))
+    }
+
+    @Test
+    fun `creates header from the trace state`() {
+        val traceState = TraceState(SentryId("3367f5196c494acaae85bbbd535379ac"), "key", "env", "release", TraceState.TraceStateUser("id", "segment"), "transaction name")
+        val serializer = mock<ISerializer>()
+        whenever(serializer.serialize(eq(traceState), any())).thenAnswer { (it.arguments[1] as StringWriter).write("""{"trace_id":"3367f5196c494acaae85bbbd535379ac"}""") }
+        val header = TraceStateHeader.fromTraceState(traceState, serializer, mock())
+        assertEquals("eyJ0cmFjZV9pZCI6IjMzNjdmNTE5NmM0OTRhY2FhZTg1YmJiZDUzNTM3OWFjIn0", header.value)
+        assertEquals("tracestate", header.name)
     }
 }

--- a/sentry/src/test/resources/envelope-transaction.txt
+++ b/sentry/src/test/resources/envelope-transaction.txt
@@ -1,3 +1,3 @@
-{"event_id":"3367f5196c494acaae85bbbd535379ac"}
+{"event_id":"3367f5196c494acaae85bbbd535379ac","trace":{"trace_id":"b156a475de54423d9c1571df97ec7eb6","public_key":"key"}}
 {"type":"transaction","length":640,"content_type":"application/json"}
 {"transaction":"a-transaction","type":"transaction","start_timestamp":"2020-10-23T10:24:01.791Z","timestamp":"2020-10-23T10:24:02.791Z","event_id":"3367f5196c494acaae85bbbd535379ac","contexts":{"trace":{"trace_id":"b156a475de54423d9c1571df97ec7eb6","span_id":"0a53026963414893","op":"http","status":"ok"},"custom":{"some-key":"some-value"}},"spans":[{"start_timestamp":"2021-03-05T08:51:12.838Z","timestamp":"2021-03-05T08:51:12.949Z","trace_id":"2b099185293344a5bfdd7ad89ebf9416","span_id":"5b95c29a5ded4281","parent_span_id":"a3b2d1d58b344b07","op":"PersonService.create","description":"desc","status":"aborted","tags":{"name":"value"}}]}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add experimental `tracestate` HTTP header support defined in https://develop.sentry.dev/sdk/performance/trace-context/#client-options.

Trace context is added to each envelope containing transaction or an event.

In addition to that, `SentryOkHttpInterceptor` attaches a new `tracestate` header to all outgoing requests.

By default this feature is off and is controller by a `traceSampling` flag on `SentryOptions`. All new API classes or methods are marked as `@Experimental`.

## :green_heart: How did you test it?

Unit & Integration tests. Sending events to `sentry-java` project on in `sentry-sdks` and verifying if they appear.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes