### PR TITLE
Update proguard keep rule for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Breaking changes:
 
-* Updated proguard keep rule for enums, which affects consumer application code (#1684)
+* Updated proguard keep rule for enums, which affects consumer application code (#1694)
 
 ## 5.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+* Updated proguard keep rule for enums, which affects consumer application code (#1684)
+
 ## 5.1.2
 
 * Fix: Servlet 3.1 compatibility issue (#1681)

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -12,7 +12,7 @@
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class io.sentry.** { *; }
--keepclassmembers enum * { *; }
+-keepclassmembers enum io.sentry.** { *; }
 -keep class io.sentry.android.core.** { *; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,


### PR DESCRIPTION
## :scroll: Description
Updated proguard rule to target library enums only.


## :bulb: Motivation and Context
This is a consumer proguard file, which means it is included into consumer application proguard config, and if we target `*`, it will apply to each class of consumer application too. This unreasonably prevents obfuscation of consumer application enums.

Fixes #1684


## :green_heart: How did you test it?
Didn't test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes

I think it's a breaking change because consumer application could accidentally rely on this rule, and removing it may break obfucated code.

## :crystal_ball: Next steps
