### PR TITLE
Feat: Add option to filter which origins receive tracing headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Feat: Add tracestate HTTP header support (#1683)
+* Feat: Add option to filter which origins receive tracing headers (#1698)
 
 Breaking changes:
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -7,6 +7,8 @@ import android.os.Bundle;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.util.Objects;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -52,6 +54,8 @@ final class ManifestMetadataReader {
       "io.sentry.traces.activity.auto-finish.enable";
 
   @ApiStatus.Experimental static final String TRACE_SAMPLING = "io.sentry.traces.trace-sampling";
+
+  static final String TRACING_ORIGINS = "io.sentry.traces.tracing-origins";
 
   static final String ATTACH_THREADS = "io.sentry.attach-threads";
 
@@ -203,7 +207,15 @@ final class ManifestMetadataReader {
                 logger,
                 TRACES_ACTIVITY_AUTO_FINISH_ENABLE,
                 options.isEnableActivityLifecycleTracingAutoFinish()));
+
+        final List<String> tracingOrigins = readList(metadata, logger, TRACING_ORIGINS);
+        if (tracingOrigins != null) {
+          for (final String tracingOrigin : tracingOrigins) {
+            options.addTracingOrigin(tracingOrigin);
+          }
+        }
       }
+
       options
           .getLogger()
           .log(SentryLevel.INFO, "Retrieving configuration from AndroidManifest.xml");
@@ -233,6 +245,17 @@ final class ManifestMetadataReader {
     final String value = metadata.getString(key, defaultValue);
     logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
     return value;
+  }
+
+  private static @Nullable List<String> readList(
+      final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
+    final String value = metadata.getString(key);
+    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    if (value != null) {
+      return Arrays.asList(value.split(",", -1));
+    } else {
+      return null;
+    }
   }
 
   private static @NotNull Double readDouble(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -665,7 +665,7 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata reads tracSampling to options`() {
+    fun `applyMetadata reads traceSampling to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.TRACE_SAMPLING to true)
         val context = fixture.getContext(metaData = bundle)
@@ -687,5 +687,31 @@ class ManifestMetadataReaderTest {
 
         // Assert
         assertFalse(fixture.options.isTraceSampling)
+    }
+
+    @Test
+    fun `applyMetadata reads tracingOrigins to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.TRACING_ORIGINS to """localhost,^(http|https)://api\..*$""")
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertEquals(listOf("localhost", """^(http|https)://api\..*$"""), fixture.options.tracingOrigins)
+    }
+
+    @Test
+    fun `applyMetadata reads tracingOrigins to options and keeps default`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        println(fixture.options.tracingOrigins)
+        assertTrue(fixture.options.tracingOrigins.isEmpty())
     }
 }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -33,7 +33,7 @@ class SentryOkHttpInterceptor(
         var code: Int? = null
         try {
             val requestBuilder = request.newBuilder()
-            if (span != null && TracingOrigins(hub.options.tracingOrigins).contain(request.url.toString())) {
+            if (span != null && TracingOrigins.contain(hub.options.tracingOrigins, request.url.toString())) {
                 span.toSentryTrace().let {
                     requestBuilder.addHeader(it.name, it.value)
                 }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -5,6 +5,7 @@ import io.sentry.HubAdapter
 import io.sentry.IHub
 import io.sentry.ISpan
 import io.sentry.SpanStatus
+import io.sentry.TracingOrigins
 import java.io.IOException
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -32,11 +33,13 @@ class SentryOkHttpInterceptor(
         var code: Int? = null
         try {
             val requestBuilder = request.newBuilder()
-            span?.toSentryTrace()?.let {
-                requestBuilder.addHeader(it.name, it.value)
-            }
-            span?.toTraceStateHeader()?.let {
-                requestBuilder.addHeader(it.name, it.value)
+            if (span != null && TracingOrigins(hub.options.tracingOrigins).contain(request.url.toString())) {
+                span.toSentryTrace().let {
+                    requestBuilder.addHeader(it.name, it.value)
+                }
+                span.toTraceStateHeader()?.let {
+                    requestBuilder.addHeader(it.name, it.value)
+                }
             }
             request = requestBuilder.build()
             response = chain.proceed(request)

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("MaxLineLength")
 package io.sentry.android.okhttp
 
 import com.nhaarman.mockitokotlin2.any
@@ -40,20 +41,25 @@ class SentryOkHttpInterceptorTest {
         val server = MockWebServer()
         val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
 
-        init {
-            whenever(hub.options).thenReturn(SentryOptions().apply {
-                dsn = "https://key@sentry.io/proj"
-                isTraceSampling = true
-            })
-        }
-
+        @SuppressWarnings("LongParameterList")
         fun getSut(
             isSpanActive: Boolean = true,
             httpStatusCode: Int = 201,
             responseBody: String = "success",
             socketPolicy: SocketPolicy = SocketPolicy.KEEP_OPEN,
-            beforeSpan: SentryOkHttpInterceptor.BeforeSpanCallback? = null
+            beforeSpan: SentryOkHttpInterceptor.BeforeSpanCallback? = null,
+            includeMockServerInTracingOrigins: Boolean = true
         ): OkHttpClient {
+            whenever(hub.options).thenReturn(SentryOptions().apply {
+                dsn = "https://key@sentry.io/proj"
+                isTraceSampling = true
+                tracingOrigins = if (includeMockServerInTracingOrigins) {
+                    listOf(server.hostName)
+                } else {
+                    listOf("other-api")
+                }
+            })
+
             if (isSpanActive) {
                 whenever(hub.span).thenReturn(sentryTracer)
             }
@@ -61,7 +67,7 @@ class SentryOkHttpInterceptorTest {
                     .setBody(responseBody)
                     .setSocketPolicy(socketPolicy)
                     .setResponseCode(httpStatusCode))
-            server.start()
+
             if (beforeSpan != null) {
                 interceptor = SentryOkHttpInterceptor(hub, beforeSpan)
             }
@@ -77,12 +83,21 @@ class SentryOkHttpInterceptorTest {
                     .toMediaType())).url(fixture.server.url("/hello")).build() }
 
     @Test
-    fun `when there is an active span, adds sentry trace headers to the request`() {
+    fun `when there is an active span and server is listed in tracing origins, adds sentry trace headers to the request`() {
         val sut = fixture.getSut()
         sut.newCall(getRequest()).execute()
         val recorderRequest = fixture.server.takeRequest()
         assertNotNull(recorderRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
         assertNotNull(recorderRequest.headers[TraceStateHeader.TRACE_STATE_HEADER])
+    }
+
+    @Test
+    fun `when there is an active span and server is not listed in tracing origins, does not add sentry trace headers to the request`() {
+        val sut = fixture.getSut(includeMockServerInTracingOrigins = false)
+        sut.newCall(Request.Builder().get().url(fixture.server.url("/hello")).build()).execute()
+        val recorderRequest = fixture.server.takeRequest()
+        assertNull(recorderRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
+        assertNull(recorderRequest.headers[TraceStateHeader.TRACE_STATE_HEADER])
     }
 
     @Test

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -53,10 +53,10 @@ class SentryOkHttpInterceptorTest {
             whenever(hub.options).thenReturn(SentryOptions().apply {
                 dsn = "https://key@sentry.io/proj"
                 isTraceSampling = true
-                tracingOrigins = if (includeMockServerInTracingOrigins) {
-                    listOf(server.hostName)
+                if (includeMockServerInTracingOrigins) {
+                    tracingOrigins.add(server.hostName)
                 } else {
-                    listOf("other-api")
+                    tracingOrigins.add("other-api")
                 }
             })
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -147,7 +147,8 @@ class SentryAutoConfigurationTest {
             "sentry.traces-sample-rate=0.3",
             "sentry.tags.tag1=tag1-value",
             "sentry.tags.tag2=tag2-value",
-            "sentry.ignored-exceptions-for-type=java.lang.RuntimeException,java.lang.IllegalStateException,io.sentry.Sentry"
+            "sentry.ignored-exceptions-for-type=java.lang.RuntimeException,java.lang.IllegalStateException,io.sentry.Sentry",
+            "sentry.tracing-origins=localhost,^(http|https)://api\\..*\$"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -175,6 +176,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.tracesSampleRate).isEqualTo(0.3)
             assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)
+            assertThat(options.tracingOrigins).containsOnly("localhost", "^(http|https)://api\\..*\$")
         }
     }
 

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -6,60 +6,51 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.Breadcrumb
 import io.sentry.IHub
-import io.sentry.Scope
 import io.sentry.SentryOptions
+import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
-import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.assertj.core.api.Assertions.assertThat
+import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.test.web.client.MockRestServiceServer
-import org.springframework.test.web.client.match.MockRestRequestMatchers
-import org.springframework.test.web.client.response.MockRestResponseCreators
 import org.springframework.web.client.RestTemplate
 
 class SentrySpanRestTemplateCustomizerTest {
     class Fixture {
         val sentryOptions = SentryOptions()
         val hub = mock<IHub>()
-        val restTemplate = RestTemplate()
-        var mockServer = MockRestServiceServer.createServer(restTemplate)
+        val restTemplate = RestTemplateBuilder().build()
+        var mockServer = MockWebServer()
         val transaction = SentryTracer(TransactionContext("aTransaction", "op", true), hub)
         internal val customizer = SentrySpanRestTemplateCustomizer(hub)
+        val url = mockServer.url("/test/123").toString()
 
         init {
             whenever(hub.options).thenReturn(sentryOptions)
         }
 
-        fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, throwIOException: Boolean = false): RestTemplate {
+        fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, socketPolicy: SocketPolicy = SocketPolicy.KEEP_OPEN, includeMockServerInTracingOrigins: Boolean = true): RestTemplate {
             customizer.customize(restTemplate)
 
-            if (isTransactionActive) {
-                val scope = Scope(sentryOptions)
-                scope.setTransaction(transaction)
-                whenever(hub.span).thenReturn(transaction)
-
-                val scenario = mockServer.expect(MockRestRequestMatchers.requestTo("/test/123"))
-                    .andExpect {
-                        // must have trace id from the parent transaction and must not contain spanId from the parent transaction
-                        assertThat(it.headers["sentry-trace"]!!.first()).startsWith(transaction.spanContext.traceId.toString())
-                            .endsWith("-1")
-                            .doesNotContain(transaction.spanContext.spanId.toString())
-                    }
-                if (throwIOException) {
-                    scenario.andRespond {
-                        throw IOException()
-                    }
-                } else {
-                    scenario.andRespond(MockRestResponseCreators.withStatus(status).body("OK").contentType(MediaType.APPLICATION_JSON))
-                }
+            sentryOptions.tracingOrigins = if (includeMockServerInTracingOrigins) {
+                listOf(mockServer.hostName)
             } else {
-                mockServer.expect(MockRestRequestMatchers.requestTo("/test/123"))
-                    .andRespond(MockRestResponseCreators.withStatus(status).body("OK").contentType(MediaType.APPLICATION_JSON))
+                listOf("other-api")
+            }
+
+            mockServer.enqueue(MockResponse()
+                .setBody("OK")
+                .setSocketPolicy(socketPolicy)
+                .setResponseCode(status.value()))
+
+            if (isTransactionActive) {
+                whenever(hub.span).thenReturn(transaction)
             }
 
             return restTemplate
@@ -70,52 +61,69 @@ class SentrySpanRestTemplateCustomizerTest {
 
     @Test
     fun `when transaction is active, creates span around RestTemplate HTTP call`() {
-        val result = fixture.getSut(isTransactionActive = true).getForObject("/test/{id}", String::class.java, 123)
+        val result = fixture.getSut(isTransactionActive = true).getForObject(fixture.url, String::class.java)
 
         assertThat(result).isEqualTo("OK")
         assertThat(fixture.transaction.spans).hasSize(1)
         val span = fixture.transaction.spans.first()
         assertThat(span.operation).isEqualTo("http.client")
-        assertThat(span.description).isEqualTo("GET /test/123")
+        assertThat(span.description).isEqualTo("GET ${fixture.url}")
         assertThat(span.status).isEqualTo(SpanStatus.OK)
-        fixture.mockServer.verify()
+
+        val recordedRequest = fixture.mockServer.takeRequest()
+        assertThat(recordedRequest.headers["sentry-trace"]!!).startsWith(fixture.transaction.spanContext.traceId.toString())
+            .endsWith("-1")
+            .doesNotContain(fixture.transaction.spanContext.spanId.toString())
+    }
+
+    @Test
+    fun `when transaction is active and server is not listed in tracing origins, does not add sentry trace header to the request`() {
+        fixture.getSut(isTransactionActive = true, includeMockServerInTracingOrigins = false)
+            .getForObject(fixture.url, String::class.java)
+        val recordedRequest = fixture.mockServer.takeRequest()
+        assertThat(recordedRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER]).isNull()
+    }
+
+    @Test
+    fun `when transaction is active and server is listed in tracing origins, adds sentry trace header to the request`() {
+        fixture.getSut(isTransactionActive = true, includeMockServerInTracingOrigins = true)
+            .getForObject(fixture.url, String::class.java)
+        val recordedRequest = fixture.mockServer.takeRequest()
+        assertThat(recordedRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER]).isNotNull()
     }
 
     @Test
     fun `when transaction is active and response code is not 2xx, creates span with error status around RestTemplate HTTP call`() {
         try {
-            fixture.getSut(isTransactionActive = true, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject("/test/{id}", String::class.java, 123)
+            fixture.getSut(isTransactionActive = true, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
         assertThat(fixture.transaction.spans).hasSize(1)
         val span = fixture.transaction.spans.first()
         assertThat(span.operation).isEqualTo("http.client")
-        assertThat(span.description).isEqualTo("GET /test/123")
+        assertThat(span.description).isEqualTo("GET ${fixture.url}")
         assertThat(span.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        fixture.mockServer.verify()
     }
 
     @Test
     fun `when transaction is active and throws IO exception, creates span with error status around RestTemplate HTTP call`() {
         try {
-            fixture.getSut(isTransactionActive = true, throwIOException = true).getForObject("/test/{id}", String::class.java, 123)
+            fixture.getSut(isTransactionActive = true, socketPolicy = SocketPolicy.DISCONNECT_AT_START).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
         assertThat(fixture.transaction.spans).hasSize(1)
         val span = fixture.transaction.spans.first()
         assertThat(span.operation).isEqualTo("http.client")
-        assertThat(span.description).isEqualTo("GET /test/123")
+        assertThat(span.description).isEqualTo("GET ${fixture.url}")
         assertThat(span.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
-        fixture.mockServer.verify()
     }
 
     @Test
     fun `when transaction is not active, does not create span around RestTemplate HTTP call`() {
-        val result = fixture.getSut(isTransactionActive = false).getForObject("/test/{id}", String::class.java, 123)
+        val result = fixture.getSut(isTransactionActive = false).getForObject(fixture.url, String::class.java)
 
         assertThat(result).isEqualTo("OK")
         assertThat(fixture.transaction.spans).isEmpty()
-        fixture.mockServer.verify()
     }
 
     @Test
@@ -130,10 +138,10 @@ class SentrySpanRestTemplateCustomizerTest {
 
     @Test
     fun `when transaction is active adds breadcrumb when http calls succeeds`() {
-        fixture.getSut(isTransactionActive = true).postForObject("/test/{id}", "content", String::class.java, 123)
+        fixture.getSut(isTransactionActive = true).postForObject(fixture.url, "content", String::class.java)
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("http", it.type)
-            assertEquals("/test/123", it.data["url"])
+            assertEquals(fixture.url, it.data["url"])
             assertEquals("POST", it.data["method"])
             assertEquals(7, it.data["request_body_size"])
         })
@@ -143,22 +151,22 @@ class SentrySpanRestTemplateCustomizerTest {
     @Test
     fun `when transaction is active adds breadcrumb when http calls results in exception`() {
         try {
-            fixture.getSut(isTransactionActive = true, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject("/test/{id}", String::class.java, 123)
+            fixture.getSut(isTransactionActive = true, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("http", it.type)
-            assertEquals("/test/123", it.data["url"])
+            assertEquals(fixture.url, it.data["url"])
             assertEquals("GET", it.data["method"])
         })
     }
 
     @Test
     fun `when transaction is not active adds breadcrumb when http calls succeeds`() {
-        fixture.getSut(isTransactionActive = false).postForObject("/test/{id}", "content", String::class.java, 123)
+        fixture.getSut(isTransactionActive = false).postForObject(fixture.url, "content", String::class.java)
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("http", it.type)
-            assertEquals("/test/123", it.data["url"])
+            assertEquals(fixture.url, it.data["url"])
             assertEquals("POST", it.data["method"])
             assertEquals(7, it.data["request_body_size"])
         })
@@ -168,12 +176,12 @@ class SentrySpanRestTemplateCustomizerTest {
     @Test
     fun `when transaction is not active adds breadcrumb when http calls results in exception`() {
         try {
-            fixture.getSut(isTransactionActive = false, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject("/test/{id}", String::class.java, 123)
+            fixture.getSut(isTransactionActive = false, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
         verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("http", it.type)
-            assertEquals("/test/123", it.data["url"])
+            assertEquals(fixture.url, it.data["url"])
             assertEquals("GET", it.data["method"])
         })
     }

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -38,10 +38,10 @@ class SentrySpanRestTemplateCustomizerTest {
         fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, socketPolicy: SocketPolicy = SocketPolicy.KEEP_OPEN, includeMockServerInTracingOrigins: Boolean = true): RestTemplate {
             customizer.customize(restTemplate)
 
-            sentryOptions.tracingOrigins = if (includeMockServerInTracingOrigins) {
-                listOf(mockServer.hostName)
+            if (includeMockServerInTracingOrigins) {
+                sentryOptions.tracingOrigins.add(mockServer.hostName)
             } else {
-                listOf("other-api")
+                sentryOptions.tracingOrigins.add("other-api")
             }
 
             mockServer.enqueue(MockResponse()

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanWebClientCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanWebClientCustomizerTest.kt
@@ -8,11 +8,14 @@ import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.Scope
 import io.sentry.SentryOptions
+import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -27,17 +30,21 @@ import org.springframework.web.reactive.function.client.WebClient
 
 class SentrySpanWebClientCustomizerTest {
     class Fixture {
-        val sentryOptions = SentryOptions()
+        lateinit var sentryOptions: SentryOptions
         val hub = mock<IHub>()
         var mockServer = MockWebServer()
         val transaction = SentryTracer(TransactionContext("aTransaction", "op", true), hub)
         private val customizer = SentrySpanWebClientCustomizer(hub)
 
-        init {
+        fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, throwIOException: Boolean = false, includeMockServerInTracingOrigins: Boolean = true): WebClient {
+            sentryOptions = SentryOptions().apply {
+                tracingOrigins = if (includeMockServerInTracingOrigins) {
+                    listOf(mockServer.hostName)
+                } else {
+                    listOf("other-api")
+                }
+            }
             whenever(hub.options).thenReturn(sentryOptions)
-        }
-
-        fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, throwIOException: Boolean = false): WebClient {
             val webClientBuilder = WebClient.builder()
             customizer.customize(webClientBuilder)
             val webClient = webClientBuilder.build()
@@ -51,16 +58,16 @@ class SentrySpanWebClientCustomizerTest {
             val dispatcher: Dispatcher = object : Dispatcher() {
                 @Throws(InterruptedException::class)
                 override fun dispatch(request: RecordedRequest): MockResponse {
-                    if (isTransactionActive) {
+                    if (isTransactionActive && includeMockServerInTracingOrigins) {
                         assertThat(request.headers["sentry-trace"]!!)
                             .startsWith(transaction.spanContext.traceId.toString())
                             .endsWith("-1")
                             .doesNotContain(transaction.spanContext.spanId.toString())
-                        if (throwIOException) {
-                            return MockResponse().setResponseCode(500)
+                        return if (throwIOException) {
+                            MockResponse().setResponseCode(500)
                                 .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                         } else {
-                            return MockResponse().setResponseCode(status.value()).setBody("OK")
+                            MockResponse().setResponseCode(status.value()).setBody("OK")
                                 .addHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                         }
                     } else {
@@ -101,6 +108,30 @@ class SentrySpanWebClientCustomizerTest {
         assertThat(span.operation).isEqualTo("http.client")
         assertThat(span.description).isEqualTo("GET $uri")
         assertThat(span.status).isEqualTo(SpanStatus.OK)
+    }
+
+    @Test
+    fun `when transaction is active and server is not listed in tracing origins, does not add sentry trace header to the request`() {
+        fixture.getSut(isTransactionActive = true, includeMockServerInTracingOrigins = false)
+            .get()
+            .uri(fixture.mockServer.url("/test/123").toUri())
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .block()
+        val recordedRequest = fixture.mockServer.takeRequest()
+        assertNull(recordedRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
+    }
+
+    @Test
+    fun `when transaction is active and server is listed in tracing origins, adds sentry trace header to the request`() {
+        fixture.getSut(isTransactionActive = true)
+            .get()
+            .uri(fixture.mockServer.url("/test/123").toUri())
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .block()
+        val recordedRequest = fixture.mockServer.takeRequest()
+        assertNotNull(recordedRequest.headers[SentryTraceHeader.SENTRY_TRACE_HEADER])
     }
 
     @Test

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanWebClientCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanWebClientCustomizerTest.kt
@@ -38,10 +38,10 @@ class SentrySpanWebClientCustomizerTest {
 
         fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, throwIOException: Boolean = false, includeMockServerInTracingOrigins: Boolean = true): WebClient {
             sentryOptions = SentryOptions().apply {
-                tracingOrigins = if (includeMockServerInTracingOrigins) {
-                    listOf(mockServer.hostName)
+                if (includeMockServerInTracingOrigins) {
+                    tracingOrigins.add(mockServer.hostName)
                 } else {
-                    listOf("other-api")
+                    tracingOrigins.add("other-api")
                 }
             }
             whenever(hub.options).thenReturn(sentryOptions)

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -42,7 +42,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
 
       final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
 
-      if (new TracingOrigins(hub.getOptions().getTracingOrigins()).contain(request.getURI())) {
+      if (TracingOrigins.contain(hub.getOptions().getTracingOrigins(), request.getURI())) {
         request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
       }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -6,6 +6,7 @@ import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
+import io.sentry.TracingOrigins;
 import io.sentry.util.Objects;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +41,11 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       span.setDescription(request.getMethodValue() + " " + request.getURI());
 
       final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
-      request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+
+      if (new TracingOrigins(hub.getOptions().getTracingOrigins()).contain(request.getURI())) {
+        request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+      }
+
       try {
         final ClientHttpResponse response = execution.execute(request, body);
         // handles both success and error responses

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
@@ -6,6 +6,7 @@ import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
+import io.sentry.TracingOrigins;
 import io.sentry.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,10 +38,13 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
 
     final SentryTraceHeader sentryTraceHeader = span.toSentryTrace();
 
-    final ClientRequest clientRequestWithSentryTraceHeader =
-        ClientRequest.from(request)
-            .header(sentryTraceHeader.getName(), sentryTraceHeader.getValue())
-            .build();
+    final ClientRequest.Builder requestBuilder = ClientRequest.from(request);
+
+    if (new TracingOrigins(hub.getOptions().getTracingOrigins()).contain(request.url())) {
+      requestBuilder.header(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+    }
+
+    final ClientRequest clientRequestWithSentryTraceHeader = requestBuilder.build();
 
     return next.exchange(clientRequestWithSentryTraceHeader)
         .flatMap(

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
@@ -40,7 +40,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
 
     final ClientRequest.Builder requestBuilder = ClientRequest.from(request);
 
-    if (new TracingOrigins(hub.getOptions().getTracingOrigins()).contain(request.url())) {
+    if (TracingOrigins.contain(hub.getOptions().getTracingOrigins(), request.url())) {
       requestBuilder.header(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1159,6 +1159,7 @@ public final class io/sentry/TracingOrigins {
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Ljava/lang/String;)V
 	public fun contain (Ljava/lang/String;)Z
+	public fun contain (Ljava/net/URI;)Z
 }
 
 public final class io/sentry/TransactionContext : io/sentry/SpanContext {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -795,6 +795,7 @@ public class io/sentry/SentryOptions {
 	public fun addInAppInclude (Ljava/lang/String;)V
 	public fun addIntegration (Lio/sentry/Integration;)V
 	public fun addScopeObserver (Lio/sentry/IScopeObserver;)V
+	public fun addTracingOrigin (Ljava/lang/String;)V
 	public static fun from (Lio/sentry/config/PropertiesProvider;Lio/sentry/ILogger;)Lio/sentry/SentryOptions;
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
@@ -905,7 +906,6 @@ public class io/sentry/SentryOptions {
 	public fun setTraceSampling (Z)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
-	public fun setTracingOrigins (Ljava/util/List;)V
 	public fun setTransportFactory (Lio/sentry/ITransportFactory;)V
 	public fun setTransportGate (Lio/sentry/transport/ITransportGate;)V
 }
@@ -1156,10 +1156,9 @@ public final class io/sentry/TraceStateHeader {
 }
 
 public final class io/sentry/TracingOrigins {
-	public fun <init> (Ljava/util/List;)V
-	public fun <init> ([Ljava/lang/String;)V
-	public fun contain (Ljava/lang/String;)Z
-	public fun contain (Ljava/net/URI;)Z
+	public fun <init> ()V
+	public static fun contain (Ljava/util/List;Ljava/lang/String;)Z
+	public static fun contain (Ljava/util/List;Ljava/net/URI;)Z
 }
 
 public final class io/sentry/TransactionContext : io/sentry/SpanContext {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -838,6 +838,7 @@ public class io/sentry/SentryOptions {
 	public fun getTags ()Ljava/util/Map;
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracesSampler ()Lio/sentry/SentryOptions$TracesSamplerCallback;
+	public fun getTracingOrigins ()Ljava/util/List;
 	public fun getTransportFactory ()Lio/sentry/ITransportFactory;
 	public fun getTransportGate ()Lio/sentry/transport/ITransportGate;
 	public fun isAttachServerName ()Z
@@ -904,6 +905,7 @@ public class io/sentry/SentryOptions {
 	public fun setTraceSampling (Z)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
+	public fun setTracingOrigins (Ljava/util/List;)V
 	public fun setTransportFactory (Lio/sentry/ITransportFactory;)V
 	public fun setTransportGate (Lio/sentry/transport/ITransportGate;)V
 }
@@ -1151,6 +1153,12 @@ public final class io/sentry/TraceStateHeader {
 	public static fun fromTraceState (Lio/sentry/TraceState;Lio/sentry/ISerializer;Lio/sentry/ILogger;)Lio/sentry/TraceStateHeader;
 	public fun getName ()Ljava/lang/String;
 	public fun getValue ()Ljava/lang/String;
+}
+
+public final class io/sentry/TracingOrigins {
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Ljava/lang/String;)V
+	public fun contain (Ljava/lang/String;)Z
 }
 
 public final class io/sentry/TransactionContext : io/sentry/SpanContext {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -284,6 +284,11 @@ public class SentryOptions {
   private boolean traceSampling;
 
   /**
+   * Contains a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+   */
+  private @NotNull List<String> tracingOrigins = new ArrayList<>();
+
+  /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
    *
    * @param propertiesProvider the properties provider
@@ -1455,6 +1460,24 @@ public class SentryOptions {
   @ApiStatus.Experimental
   public void setTraceSampling(boolean traceSampling) {
     this.traceSampling = traceSampling;
+  }
+
+  /**
+   * Returns a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+   *
+   * @return the list of origins
+   */
+  public @NotNull List<String> getTracingOrigins() {
+    return tracingOrigins;
+  }
+
+  /**
+   * Sets a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+   *
+   * @param tracingOrigins - the tracing origins
+   */
+  public void setTracingOrigins(final @NotNull List<String> tracingOrigins) {
+    this.tracingOrigins = tracingOrigins;
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -333,6 +333,9 @@ public class SentryOptions {
     for (final String inAppExclude : propertiesProvider.getList("in-app-excludes")) {
       options.addInAppExclude(inAppExclude);
     }
+    for (final String tracingOrigin : propertiesProvider.getList("tracing-origins")) {
+      options.addTracingOrigin(tracingOrigin);
+    }
     for (final String ignoredExceptionType :
         propertiesProvider.getList("ignored-exceptions-for-type")) {
       try {
@@ -1615,6 +1618,10 @@ public class SentryOptions {
     for (final Class<? extends Throwable> exceptionType :
         new HashSet<>(options.getIgnoredExceptionsForType())) {
       addIgnoredExceptionForType(exceptionType);
+    }
+    final List<String> tracingOrigins = new ArrayList<>(options.getTracingOrigins());
+    for (final String tracingOrigin : tracingOrigins) {
+      addTracingOrigin(tracingOrigin);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -286,7 +286,7 @@ public class SentryOptions {
   /**
    * Contains a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
    */
-  private @NotNull List<String> tracingOrigins = new ArrayList<>();
+  private final @NotNull List<String> tracingOrigins = new CopyOnWriteArrayList<>();
 
   /**
    * Creates {@link SentryOptions} from properties provided by a {@link PropertiesProvider}.
@@ -1472,12 +1472,12 @@ public class SentryOptions {
   }
 
   /**
-   * Sets a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+   * Adds an origin to which `sentry-trace` header should be sent in HTTP integrations.
    *
-   * @param tracingOrigins - the tracing origins
+   * @param tracingOrigin - the tracing origin
    */
-  public void setTracingOrigins(final @NotNull List<String> tracingOrigins) {
-    this.tracingOrigins = tracingOrigins;
+  public void addTracingOrigin(final @NotNull String tracingOrigin) {
+    this.tracingOrigins.add(tracingOrigin);
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/TracingOrigins.java
+++ b/sentry/src/main/java/io/sentry/TracingOrigins.java
@@ -1,25 +1,16 @@
 package io.sentry;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Contains a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+ * Checks if an URL matches the list of origins to which `sentry-trace` header should be sent in
+ * HTTP integrations.
  */
 public final class TracingOrigins {
-  private final @NotNull List<String> origins;
 
-  public TracingOrigins(final @NotNull List<String> origins) {
-    this.origins = origins;
-  }
-
-  public TracingOrigins(final @NotNull String... origins) {
-    this(Arrays.asList(origins));
-  }
-
-  public boolean contain(final @NotNull String url) {
+  public static boolean contain(final @NotNull List<String> origins, final @NotNull String url) {
     if (origins.isEmpty()) {
       return true;
     }
@@ -31,7 +22,7 @@ public final class TracingOrigins {
     return false;
   }
 
-  public boolean contain(final URI uri) {
-    return contain(uri.toString());
+  public static boolean contain(final @NotNull List<String> origins, final URI uri) {
+    return contain(origins, uri.toString());
   }
 }

--- a/sentry/src/main/java/io/sentry/TracingOrigins.java
+++ b/sentry/src/main/java/io/sentry/TracingOrigins.java
@@ -1,0 +1,32 @@
+package io.sentry;
+
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Contains a list of origins to which `sentry-trace` header should be sent in HTTP integrations.
+ */
+public final class TracingOrigins {
+  private final @NotNull List<String> origins;
+
+  public TracingOrigins(final @NotNull List<String> origins) {
+    this.origins = origins;
+  }
+
+  public TracingOrigins(final @NotNull String... origins) {
+    this(Arrays.asList(origins));
+  }
+
+  public boolean contain(final @NotNull String url) {
+    if (origins.isEmpty()) {
+      return true;
+    }
+    for (final String origin : origins) {
+      if (url.contains(origin) || url.matches(origin)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/sentry/src/main/java/io/sentry/TracingOrigins.java
+++ b/sentry/src/main/java/io/sentry/TracingOrigins.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -28,5 +29,9 @@ public final class TracingOrigins {
       }
     }
     return false;
+  }
+
+  public boolean contain(final URI uri) {
+    return contain(uri.toString());
   }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -201,6 +201,8 @@ class SentryOptionsTest {
         externalOptions.tracesSampleRate = 0.5
         externalOptions.addInAppInclude("com.app")
         externalOptions.addInAppExclude("io.off")
+        externalOptions.addTracingOrigin("localhost")
+        externalOptions.addTracingOrigin("api.foo.com")
         val options = SentryOptions()
 
         options.merge(externalOptions)
@@ -218,6 +220,7 @@ class SentryOptionsTest {
         assertEquals(0.5, options.tracesSampleRate)
         assertEquals(listOf("com.app"), options.inAppIncludes)
         assertEquals(listOf("io.off"), options.inAppExcludes)
+        assertEquals(listOf("localhost", "api.foo.com"), options.tracingOrigins)
     }
 
     @Test
@@ -352,6 +355,13 @@ class SentryOptionsTest {
     fun `creates options with maxRequestBodySize using external properties`() {
         withPropertiesFile("max-request-body-size=small") {
             assertEquals(SentryOptions.RequestSize.SMALL, it.maxRequestBodySize)
+        }
+    }
+
+    @Test
+    fun `creates options with tracing origins using external properties`() {
+        withPropertiesFile("""tracing-origins=localhost,^(http|https)://api\\..*$""") {
+            assertEquals(listOf("localhost", """^(http|https)://api\..*$"""), it.tracingOrigins)
         }
     }
 

--- a/sentry/src/test/java/io/sentry/TracingOriginsTest.kt
+++ b/sentry/src/test/java/io/sentry/TracingOriginsTest.kt
@@ -8,23 +8,22 @@ class TracingOriginsTest {
 
     @Test
     fun `origins contain the url when it contains one of the defined origins`() {
-        val tracingOrigins = TracingOrigins("localhost", "^(http|https)://api\\..*$")
-        assertTrue(tracingOrigins.contain("http://localhost:8080/foo"))
-        assertTrue(tracingOrigins.contain("http://xxx.localhost:8080/foo"))
+        val origins = listOf("localhost", "^(http|https)://api\\..*$")
+        assertTrue(TracingOrigins.contain(origins, "http://localhost:8080/foo"))
+        assertTrue(TracingOrigins.contain(origins, "http://xxx.localhost:8080/foo"))
     }
 
     @Test
     fun `origins contain the url when it matches regex`() {
-        val tracingOrigins = TracingOrigins("localhost", "^(http|https)://api\\..*$")
-        assertTrue(tracingOrigins.contain("http://api.foo.bar:8080/foo"))
-        assertTrue(tracingOrigins.contain("https://api.foo.bar:8080/foo"))
-        assertFalse(tracingOrigins.contain("ftp://api.foo.bar:8080/foo"))
-        assertTrue(tracingOrigins.contain("http://api.localhost:8080/foo"))
+        val origins = listOf("localhost", "^(http|https)://api\\..*$")
+        assertTrue(TracingOrigins.contain(origins, "http://api.foo.bar:8080/foo"))
+        assertTrue(TracingOrigins.contain(origins, "https://api.foo.bar:8080/foo"))
+        assertFalse(TracingOrigins.contain(origins, "ftp://api.foo.bar:8080/foo"))
+        assertTrue(TracingOrigins.contain(origins, "http://api.localhost:8080/foo"))
     }
 
     @Test
     fun `when no origins are defined, returns true for every url`() {
-        val tracingOrigins = TracingOrigins()
-        assertTrue(tracingOrigins.contain("http://some.api.com/"))
+        assertTrue(TracingOrigins.contain(emptyList(), "http://some.api.com/"))
     }
 }

--- a/sentry/src/test/java/io/sentry/TracingOriginsTest.kt
+++ b/sentry/src/test/java/io/sentry/TracingOriginsTest.kt
@@ -1,0 +1,30 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TracingOriginsTest {
+
+    @Test
+    fun `origins contain the url when it contains one of the defined origins`() {
+        val tracingOrigins = TracingOrigins("localhost", "^(http|https)://api\\..*$")
+        assertTrue(tracingOrigins.contain("http://localhost:8080/foo"))
+        assertTrue(tracingOrigins.contain("http://xxx.localhost:8080/foo"))
+    }
+
+    @Test
+    fun `origins contain the url when it matches regex`() {
+        val tracingOrigins = TracingOrigins("localhost", "^(http|https)://api\\..*$")
+        assertTrue(tracingOrigins.contain("http://api.foo.bar:8080/foo"))
+        assertTrue(tracingOrigins.contain("https://api.foo.bar:8080/foo"))
+        assertFalse(tracingOrigins.contain("ftp://api.foo.bar:8080/foo"))
+        assertTrue(tracingOrigins.contain("http://api.localhost:8080/foo"))
+    }
+
+    @Test
+    fun `when no origins are defined, returns true for every url`() {
+        val tracingOrigins = TracingOrigins()
+        assertTrue(tracingOrigins.contain("http://some.api.com/"))
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add `tracingOrigins` to `SentryOptions` and respect it in OkHttp, WebClient and RestTemplate integrations.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1697
Fixes #1585

## :green_heart: How did you test it?

Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes