### PR TITLE
Fix: Move tags from transaction.contexts.trace.tags to transaction.tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Feat: Add tracestate HTTP header support (#1683)
 * Feat: Include unfinished spans in transaction (#1699)
+* Fix: Move tags from transaction.contexts.trace.tags to transaction.tags (#1700)
 
 Breaking changes:
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1077,6 +1077,7 @@ public class io/sentry/SpanContext {
 	protected field status Lio/sentry/SpanStatus;
 	protected field tags Ljava/util/Map;
 	public fun <init> (Lio/sentry/SpanContext;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/sentry/SpanStatus;)V
 	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Ljava/lang/String;Lio/sentry/SpanId;Ljava/lang/Boolean;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;)V

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -6,6 +6,7 @@ import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -60,11 +61,25 @@ public class SpanContext {
       final @NotNull String operation,
       final @Nullable SpanId parentSpanId,
       final @Nullable Boolean sampled) {
+    this(traceId, spanId, parentSpanId, operation, null, sampled, null);
+  }
+
+  @ApiStatus.Internal
+  public SpanContext(
+      final @NotNull SentryId traceId,
+      final @NotNull SpanId spanId,
+      final @Nullable SpanId parentSpanId,
+      final @NotNull String operation,
+      final @Nullable String description,
+      final @Nullable Boolean sampled,
+      final @Nullable SpanStatus status) {
     this.traceId = Objects.requireNonNull(traceId, "traceId is required");
     this.spanId = Objects.requireNonNull(spanId, "spanId is required");
     this.op = Objects.requireNonNull(operation, "operation is required");
     this.parentSpanId = parentSpanId;
     this.sampled = sampled;
+    this.description = description;
+    this.status = status;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -524,6 +524,7 @@ class GsonSerializerTest {
         assertNotNull(element["start_timestamp"].asString)
         assertNotNull(element["event_id"].asString)
         assertNotNull(element["spans"].asJsonArray)
+        assertEquals("myValue", element["tags"].asJsonObject["myTag"].asString)
 
         val jsonSpan = element["spans"].asJsonArray[0].asJsonObject
         assertNotNull(jsonSpan["trace_id"])
@@ -540,7 +541,6 @@ class GsonSerializerTest {
         assertEquals("http", jsonTrace["op"].asString)
         assertEquals("some request", jsonTrace["description"].asString)
         assertEquals("ok", jsonTrace["status"].asString)
-        assertEquals("myValue", jsonTrace["tags"].asJsonObject["myTag"].asString)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argWhere
+import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
@@ -19,6 +20,7 @@ import java.nio.file.Paths
 import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -108,9 +110,11 @@ class OutboxSenderTest {
         assertTrue(File(path).exists())
         sut.processEnvelopeFile(path, mock<Retryable>())
 
-        verify(fixture.hub).captureTransaction(eq(expected), any(), any())
+        verify(fixture.hub).captureTransaction(check {
+            assertEquals(expected, it)
+            assertTrue(it.isSampled)
+        }, any(), any())
         assertFalse(File(path).exists())
-        assertTrue(transactionContext.sampled ?: false)
 
         // Additionally make sure we have no errors logged
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any(), any<Any>())

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -328,8 +328,8 @@ class SentryTracerTest {
         transaction.finish(SpanStatus.UNKNOWN_ERROR)
 
         // call only once
-        verify(fixture.hub, times(1)).setSpanContext(ex, transaction.root, "name")
-        verify(fixture.hub, times(1)).captureTransaction(check {
+        verify(fixture.hub).setSpanContext(ex, transaction.root, "name")
+        verify(fixture.hub).captureTransaction(check {
             assertNotNull(it.contexts.trace) {
                 assertEquals(SpanStatus.OK, it.status)
             }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Move tags from `transaction.contexts.trace.tags` to `transaction.tags`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1693

The implementation could be cleaner - like introducing a dedicated `TraceContext` object, but this would mean we introduce a breaking change - something to keep in mind for 6.0.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes