### PR TITLE
Feat: Add static helpers for creating breadcrumbs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feat: Add option to filter which origins receive tracing headers (#1698)
 * Feat: Include unfinished spans in transaction (#1699)
 * Fix: Move tags from transaction.contexts.trace.tags to transaction.tags (#1700)
+* Feat: Add static helpers for creating breadcrumbs (#1702)
 
 Breaking changes:
 

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
 
         <!--    NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard-->
         <meta-data android:name="io.sentry.dsn" android:value="https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559" />
-        <meta-data android:name="io.sentry.tracing-origins" android:resource="@array/origins" />
 
         <!--    how to enable Sentry's debug mode-->
         <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
 
         <!--    NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard-->
         <meta-data android:name="io.sentry.dsn" android:value="https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559" />
+        <meta-data android:name="io.sentry.tracing-origins" android:resource="@array/origins" />
 
         <!--    how to enable Sentry's debug mode-->
         <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -24,6 +24,8 @@ public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/util/Date;)V
 	public fun acceptUnknownProperties (Ljava/util/Map;)V
+	public static fun debug (Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public static fun error (Ljava/lang/String;)Lio/sentry/Breadcrumb;
 	public fun getCategory ()Ljava/lang/String;
 	public fun getData ()Ljava/util/Map;
 	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
@@ -33,12 +35,18 @@ public final class io/sentry/Breadcrumb : io/sentry/IUnknownPropertiesConsumer {
 	public fun getType ()Ljava/lang/String;
 	public static fun http (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Breadcrumb;
 	public static fun http (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/sentry/Breadcrumb;
+	public static fun info (Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public static fun navigation (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public static fun query (Ljava/lang/String;)Lio/sentry/Breadcrumb;
 	public fun removeData (Ljava/lang/String;)V
 	public fun setCategory (Ljava/lang/String;)V
 	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
 	public fun setMessage (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
+	public static fun transaction (Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public static fun ui (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Breadcrumb;
+	public static fun user (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/Breadcrumb;
 }
 
 public final class io/sentry/BuildConfig {

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -90,6 +90,126 @@ public final class Breadcrumb implements IUnknownPropertiesConsumer {
     return breadcrumb;
   }
 
+  /**
+   * Creates navigation breadcrumb - a navigation event can be a URL change in a web application, or
+   * a UI transition in a mobile or desktop application, etc.
+   *
+   * @param from - the original application state / location
+   * @param to - the new application state / location
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb navigation(
+      final @NotNull String from, final @NotNull String to) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setCategory("navigation");
+    breadcrumb.setType("navigation");
+    breadcrumb.setData("from", from);
+    breadcrumb.setData("to", to);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates transaction breadcrumb - describing a tracing event.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb transaction(final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("default");
+    breadcrumb.setCategory("sentry.transaction");
+    breadcrumb.setMessage(message);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates debug breadcrumb - typically a log message. The data part is entirely undefined and as
+   * such, completely rendered as a key/value table.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb debug(final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("debug");
+    breadcrumb.setMessage(message);
+    breadcrumb.setLevel(SentryLevel.DEBUG);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates error breadcrumb.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb error(final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("error");
+    breadcrumb.setMessage(message);
+    breadcrumb.setLevel(SentryLevel.ERROR);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates info breadcrumb - information that helps identify the root cause of the issue or for
+   * whom the error occurred.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb info(final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("info");
+    breadcrumb.setMessage(message);
+    breadcrumb.setLevel(SentryLevel.INFO);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates query breadcrumb - representing a query that was made in your application.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb query(final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("query");
+    breadcrumb.setMessage(message);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates ui breadcrumb - a user interaction with your app's UI.
+   *
+   * @param category - the category, for example "click"
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb ui(
+      final @NotNull String category, final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("default");
+    breadcrumb.setCategory("ui." + category);
+    breadcrumb.setMessage(message);
+    return breadcrumb;
+  }
+
+  /**
+   * Creates user breadcrumb - a user interaction with your app's UI.
+   *
+   * @param message - the message
+   * @return the breadcrumb
+   */
+  public static @NotNull Breadcrumb user(
+      final @NotNull String category, final @NotNull String message) {
+    final Breadcrumb breadcrumb = new Breadcrumb();
+    breadcrumb.setType("user");
+    breadcrumb.setCategory(category);
+    breadcrumb.setMessage(message);
+    return breadcrumb;
+  }
+
   /** Breadcrumb ctor */
   public Breadcrumb() {
     this(DateUtils.getCurrentDateTime());

--- a/sentry/src/test/java/io/sentry/BreadcrumbTest.kt
+++ b/sentry/src/test/java/io/sentry/BreadcrumbTest.kt
@@ -129,4 +129,68 @@ class BreadcrumbTest {
         assertEquals("http", breadcrumb.category)
         assertFalse(breadcrumb.data.containsKey("status_code"))
     }
+
+    @Test
+    fun `creates navigation breadcrumb`() {
+        val breadcrumb = Breadcrumb.navigation("from", "to")
+        assertEquals("from", breadcrumb.data["from"])
+        assertEquals("to", breadcrumb.data["to"])
+        assertEquals("navigation", breadcrumb.type)
+        assertEquals("navigation", breadcrumb.category)
+    }
+
+    @Test
+    fun `creates transaction breadcrumb`() {
+        val breadcrumb = Breadcrumb.transaction("message")
+        assertEquals("default", breadcrumb.type)
+        assertEquals("sentry.transaction", breadcrumb.category)
+        assertEquals("message", breadcrumb.message)
+    }
+
+    @Test
+    fun `creates query breadcrumb`() {
+        val breadcrumb = Breadcrumb.query("message")
+        assertEquals("query", breadcrumb.type)
+        assertEquals("message", breadcrumb.message)
+    }
+
+    @Test
+    fun `creates ui breadcrumb`() {
+        val breadcrumb = Breadcrumb.ui("click", "message")
+        assertEquals("default", breadcrumb.type)
+        assertEquals("ui.click", breadcrumb.category)
+        assertEquals("message", breadcrumb.message)
+    }
+
+    @Test
+    fun `creates user breadcrumb`() {
+        val breadcrumb = Breadcrumb.user("click", "message")
+        assertEquals("user", breadcrumb.type)
+        assertEquals("message", breadcrumb.message)
+        assertEquals("click", breadcrumb.category)
+    }
+
+    @Test
+    fun `creates debug breadcrumb`() {
+        val breadcrumb = Breadcrumb.debug("message")
+        assertEquals("debug", breadcrumb.type)
+        assertEquals("message", breadcrumb.message)
+        assertEquals(SentryLevel.DEBUG, breadcrumb.level)
+    }
+
+    @Test
+    fun `creates info breadcrumb`() {
+        val breadcrumb = Breadcrumb.info("message")
+        assertEquals("info", breadcrumb.type)
+        assertEquals("message", breadcrumb.message)
+        assertEquals(SentryLevel.INFO, breadcrumb.level)
+    }
+
+    @Test
+    fun `creates error breadcrumb`() {
+        val breadcrumb = Breadcrumb.error("message")
+        assertEquals("error", breadcrumb.type)
+        assertEquals("message", breadcrumb.message)
+        assertEquals(SentryLevel.ERROR, breadcrumb.level)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add static helper methods for creating breadcrumbs, that render in special way in the UI.

Breadcrumbs created using these methods look following:

![image](https://user-images.githubusercontent.com/1357927/132393204-06e6b8f3-e826-4f92-a448-acb92a643421.png)

The question is if there is a value in having separate UI and User breadcrumb - as far as I can see they render the same way.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #361

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes