### PR TITLE
Fix: Don't set lastEventId for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Don't set lastEventId for transactions (#1727)
+
 ## 5.2.0-beta.3
 
 * Fix: Check at runtime if AndroidX.Core is available (#1718)

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -146,7 +146,6 @@ public final class Hub implements IHub {
         options.getLogger().log(SentryLevel.ERROR, "Error while capturing envelope.", e);
       }
     }
-    this.lastEventId = sentryId;
     return sentryId;
   }
 
@@ -576,7 +575,6 @@ public final class Hub implements IHub {
         }
       }
     }
-    this.lastEventId = sentryId;
     return sentryId;
   }
 


### PR DESCRIPTION


## :scroll: Description
<!--- Describe your changes in detail -->
Fix: Don't set lastEventId for transactions

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1709

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes