### PR TITLE
Fix: Handle exception if Context.registerReceiver throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Handle exception if Context.registerReceiver throws (#)
+
 ## 5.2.0
 
 * Feat: Allow setting proguard via Options and/or external resources (#1728)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: Handle exception if Context.registerReceiver throws (#)
+* Fix: Handle exception if Context.registerReceiver throws (#1747)
 
 ## 5.2.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -95,8 +95,18 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       for (String item : actions) {
         filter.addAction(item);
       }
-      context.registerReceiver(receiver, filter);
-      options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
+      try {
+        // registerReceiver can throw SecurityException but it's not documented in the official docs
+        context.registerReceiver(receiver, filter);
+        this.options
+            .getLogger()
+            .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
+      } catch (Exception e) {
+        this.options.setEnableSystemEventBreadcrumbs(false);
+        this.options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Failed to initialize SystemEventsBreadcrumbsIntegration.", e);
+      }
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -7,11 +7,13 @@ import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.SentryLevel
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -19,8 +21,13 @@ class SystemEventsBreadcrumbsIntegrationTest {
 
     private class Fixture {
         val context = mock<Context>()
+        var options = SentryAndroidOptions()
+        val hub = mock<IHub>()
 
-        fun getSut(): SystemEventsBreadcrumbsIntegration {
+        fun getSut(enableSystemEventBreadcrumbs: Boolean = true): SystemEventsBreadcrumbsIntegration {
+            options = SentryAndroidOptions().apply {
+                isEnableSystemEventBreadcrumbs = enableSystemEventBreadcrumbs
+            }
             return SystemEventsBreadcrumbsIntegration(context)
         }
     }
@@ -30,21 +37,19 @@ class SystemEventsBreadcrumbsIntegrationTest {
     @Test
     fun `When system events breadcrumb is enabled, it registers callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
-        val hub = mock<IHub>()
-        sut.register(hub, options)
+
+        sut.register(fixture.hub, fixture.options)
+
         verify(fixture.context).registerReceiver(any(), any())
         assertNotNull(sut.receiver)
     }
 
     @Test
     fun `When system events breadcrumb is disabled, it doesn't register callback`() {
-        val sut = fixture.getSut()
-        val options = SentryAndroidOptions().apply {
-            isEnableSystemEventBreadcrumbs = false
-        }
-        val hub = mock<IHub>()
-        sut.register(hub, options)
+        val sut = fixture.getSut(enableSystemEventBreadcrumbs = false)
+
+        sut.register(fixture.hub, fixture.options)
+
         verify(fixture.context, never()).registerReceiver(any(), any())
         assertNull(sut.receiver)
     }
@@ -52,10 +57,10 @@ class SystemEventsBreadcrumbsIntegrationTest {
     @Test
     fun `When ActivityBreadcrumbsIntegration is closed, it should unregister the callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
-        val hub = mock<IHub>()
-        sut.register(hub, options)
+
+        sut.register(fixture.hub, fixture.options)
         sut.close()
+
         verify(fixture.context).unregisterReceiver(any())
         assertNull(sut.receiver)
     }
@@ -63,19 +68,28 @@ class SystemEventsBreadcrumbsIntegrationTest {
     @Test
     fun `When broadcast received, added breadcrumb with type and category`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
-        val hub = mock<IHub>()
-        sut.register(hub, options)
+
+        sut.register(fixture.hub, fixture.options)
         val intent = Intent().apply {
             action = Intent.ACTION_TIME_CHANGED
         }
         sut.receiver!!.onReceive(any(), intent)
 
-        verify(hub).addBreadcrumb(check<Breadcrumb> {
+        verify(fixture.hub).addBreadcrumb(check<Breadcrumb> {
             assertEquals("device.event", it.category)
             assertEquals("system", it.type)
             assertEquals(SentryLevel.INFO, it.level)
             // cant assert data, its not a public API
         })
+    }
+
+    @Test
+    fun `Do not crash if registerReceiver throws exception`() {
+        val sut = fixture.getSut()
+        whenever(fixture.context.registerReceiver(any(), any())).thenThrow(SecurityException())
+
+        sut.register(fixture.hub, fixture.options)
+
+        assertFalse(fixture.options.isEnableSystemEventBreadcrumbs)
     }
 }


### PR DESCRIPTION
## :scroll: Description
Fix: Handle exception if Context.registerReceiver throws


## :bulb: Motivation and Context
Caused by: java.lang.SecurityException: 
  at android.os.Parcel.createExceptionOrNull (Parcel.java:2385)
  at android.os.Parcel.createException (Parcel.java:2369)
  at android.os.Parcel.readException (Parcel.java:2352)
  at android.os.Parcel.readException (Parcel.java:2294)
  at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature (IActivityManager.java:6381)
  at android.app.ContextImpl.registerReceiverInternal (ContextImpl.java:1696)
  at android.app.ContextImpl.registerReceiver (ContextImpl.java:1650)
  at android.app.ContextImpl.registerReceiver (ContextImpl.java:1638)
  at android.content.ContextWrapper.registerReceiver (ContextWrapper.java:686)
  at io.sentry.android.core.SystemEventsBreadcrumbsIntegration.register (SystemEventsBreadcrumbsIntegration.java:98)
  at io.sentry.Sentry.init (Sentry.java:181)
  at io.sentry.Sentry.init (Sentry.java:110)
  at io.sentry.android.core.SentryAndroid.init (SentryAndroid.java:59)
  at io.sentry.android.core.SentryAndroid.init (SentryAndroid.java:44)
  at com.png.sportsbook.app.App.onCreate (App.kt:73)
  at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1192)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:7535)
  at android.app.ActivityThread.access$1500 (ActivityThread.java:301)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2158)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:246)
  at android.app.ActivityThread.main (ActivityThread.java:8595)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:602)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1130)


## :green_heart: How did you test it?
unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
