### PR TITLE
change put() to putIfAbsent()

### DIFF
--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -247,7 +247,7 @@ public final class RateLimiter {
 
     // only overwrite its previous date if the limit is even longer
     if (oldDate == null || date.after(oldDate)) {
-      sentryRetryAfterLimit.put(dataCategory, date);
+      sentryRetryAfterLimit.putIfAbsent(dataCategory, date);
     }
   }
 


### PR DESCRIPTION
- Problem

You are using a ConcurrentHashMap, but your usage of get() and put() may not be thread-safe at lines: 246, 249, and 250. Two threads can perform this same check at the same time and one thread can overwrite the value written by the other thread.

- Fix

Consider replacing put() with putIfAbsent() to help prevent accidental overwriting. putIfAbsent() puts the value only if the ConcurrentHashMap does not contain the key and therefore avoids overwriting the value written there by the other thread's putIfAbsent().

- More info

putIfAbsent() returns null if the value did not exist and returns the value in the map if one already exists.