### PR TITLE
Update gson to 2.8.9 for CWE-502

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -45,7 +45,7 @@ object Config {
         val okhttpBom = "com.squareup.okhttp3:okhttp-bom:$okHttpVersion"
         val okhttp = "com.squareup.okhttp3:okhttp"
         // only bump gson if https://github.com/google/gson/issues/1597 is fixed
-        private val gsonVersion = "2.8.5"
+        private val gsonVersion = "2.8.9"
         val gsonDep = "com.google.code.gson:gson"
         val gson = "$gsonDep:$gsonVersion"
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.7"


### PR DESCRIPTION
## :scroll: Description
CWE-502 is a CVSS 7.7 scored vulnerability in the gson library that was fixed in gson 2.8.9.

## :bulb: Motivation and Context
Some users of the Sentry library are subject to security gates that will fail on the presence of this vuln. Instead of just making one-off changes, I am contributing back ❤️ 

## :green_heart: How did you test it?
Tested it on a local project and confirmed that Sentry event submission did not suffer any new failures.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ x] I updated the docs if needed
- [ x] No breaking changes


## :crystal_ball: Next steps
