### PR TITLE
Debug log serializable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.x.x
 
 * Ref: Bind external properties to a dedicated class. (#1750)
+* Ref: Debug log serializable objects (#1795)
 
 Breaking changes:
 

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -191,7 +191,7 @@ public final class JsonSerializer implements ISerializer {
 
   // Helper
 
-  private @NotNull String serializeToString(Object object, Boolean pretty) throws IOException {
+  private @NotNull String serializeToString(Object object, boolean pretty) throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonObjectWriter jsonObjectWriter = new JsonObjectWriter(stringWriter, options.getMaxDepth());
     if (pretty) {

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -138,13 +138,11 @@ public final class JsonSerializer implements ISerializer {
     Objects.requireNonNull(writer, "The Writer object is required.");
 
     if (options.getLogger().isEnabled(SentryLevel.DEBUG)) {
-      options.getLogger().log(SentryLevel.DEBUG, "Serializing object: %s", entity);
+      String serialized = serializeToString(entity, true);
+      options.getLogger().log(SentryLevel.DEBUG, "Serializing object: %s", serialized);
     }
-
-    if (entity instanceof JsonSerializable) {
-      JsonObjectWriter jsonObjectWriter = new JsonObjectWriter(writer, options.getMaxDepth());
-      ((JsonSerializable) entity).serialize(jsonObjectWriter, options.getLogger());
-    }
+    JsonObjectWriter jsonObjectWriter = new JsonObjectWriter(writer, options.getMaxDepth());
+    jsonObjectWriter.value(options.getLogger(), entity);
     writer.flush();
   }
 
@@ -188,9 +186,18 @@ public final class JsonSerializer implements ISerializer {
 
   @Override
   public @NotNull String serialize(@NotNull Map<String, Object> data) throws Exception {
+    return serializeToString(data, false);
+  }
+
+  // Helper
+
+  private @NotNull String serializeToString(Object object, Boolean pretty) throws IOException {
     StringWriter stringWriter = new StringWriter();
     JsonObjectWriter jsonObjectWriter = new JsonObjectWriter(stringWriter, options.getMaxDepth());
-    jsonObjectWriter.value(options.getLogger(), data);
+    if (pretty) {
+      jsonObjectWriter.setIndent("\t");
+    }
+    jsonObjectWriter.value(options.getLogger(), object);
     return stringWriter.toString();
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Log serialisable objects (with pretty printing)
- Serialize any object, not just `JsonSerializable`

Closes #1792

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This functionality was lost when replacing GSON.

## :green_heart: How did you test it?

- Checked wether serialized object was logged correctly.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
