### PR TITLE
Fix: ActivityFramesTracker does not throw if Activity has no observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Feat: Add `graphql-java` instrumentation (#1777)
-* Fix: ActivityFramesTracker does not throw if Activity has no observers (#)
+* Fix: ActivityFramesTracker does not throw if Activity has no observers (#1799)
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Feat: Add `graphql-java` instrumentation (#1777)
+* Fix: ActivityFramesTracker does not throw if Activity has no observers (#)
 
 ## 5.3.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -67,9 +67,11 @@ final class ActivityFramesTracker {
     SparseIntArray[] framesRates = null;
     try {
       framesRates = frameMetricsAggregator.remove(activity);
-    } catch (IllegalArgumentException ignored) {
-      // it throws when attempt to remove OnFrameMetricsAvailableListener that was never added.
-      // there's no contains method
+    } catch (Exception ignored) {
+      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener that was never added.
+      // there's no contains method.
+      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and there was no
+      // Observers, See https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
     }
 
     if (framesRates != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -68,10 +68,13 @@ final class ActivityFramesTracker {
     try {
       framesRates = frameMetricsAggregator.remove(activity);
     } catch (Exception ignored) {
-      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener that was never added.
+      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
+      // that was never added.
       // there's no contains method.
-      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and there was no
-      // Observers, See https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
+      // there was no
+      // Observers, See
+      // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
     }
 
     if (framesRates != null) {


### PR DESCRIPTION
## :scroll: Description
Fix: ActivityFramesTracker does not throw if Activity has no observers


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1798


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
