### PR TITLE
Feat: Add secondary constructor to `SentryInstrumentation`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Feat: Refactor OkHttp and Apollo to Kotlin functional interfaces (#1797)
+* Feat: Add secondary constructor to SentryInstrumentation (#1804)
 
 ## 5.4.0
 

--- a/sentry-graphql/api/sentry-graphql.api
+++ b/sentry-graphql/api/sentry-graphql.api
@@ -8,6 +8,7 @@ public final class io/sentry/graphql/SentryInstrumentation : graphql/execution/i
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IHub;)V
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;)V
+	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;)V
 	public fun beginExecution (Lgraphql/execution/instrumentation/parameters/InstrumentationExecutionParameters;)Lgraphql/execution/instrumentation/InstrumentationContext;
 	public fun createState ()Lgraphql/execution/instrumentation/InstrumentationState;
 	public fun instrumentDataFetcher (Lgraphql/schema/DataFetcher;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Lgraphql/schema/DataFetcher;

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
@@ -30,6 +30,10 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
     this.beforeSpan = beforeSpan;
   }
 
+  public SentryInstrumentation(final @Nullable BeforeSpanCallback beforeSpan) {
+    this(HubAdapter.getInstance(), beforeSpan);
+  }
+
   public SentryInstrumentation(final @NotNull IHub hub) {
     this(hub, null);
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Feat: Add secondary constructor to `SentryInstrumentation`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It wasn't possible to pass `BeforeSpanCallback` without passing the `Hub`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
