### PR TITLE
catch throwable to suppress errors in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Feat: Refactor OkHttp and Apollo to Kotlin functional interfaces (#1797)
 * Feat: Add secondary constructor to SentryInstrumentation (#1804)
+* Ref: catch Throwable instead of Exception to suppress internal SDK errors (#1812)
 
 ## 5.4.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -67,7 +67,7 @@ final class ActivityFramesTracker {
     SparseIntArray[] framesRates = null;
     try {
       framesRates = frameMetricsAggregator.remove(activity);
-    } catch (Exception ignored) {
+    } catch (Throwable ignored) {
       // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
       // that was never added.
       // there's no contains method.

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -51,7 +51,7 @@ public final class AppComponentsBreadcrumbsIntegration
         options
             .getLogger()
             .log(SentryLevel.DEBUG, "AppComponentsBreadcrumbsIntegration installed.");
-      } catch (Exception e) {
+      } catch (Throwable e) {
         this.options.setEnableAppComponentBreadcrumbs(false);
         options.getLogger().log(SentryLevel.INFO, e, "ComponentCallbacks2 is not available.");
       }
@@ -63,8 +63,11 @@ public final class AppComponentsBreadcrumbsIntegration
     try {
       // if its a ContextImpl, unregisterComponentCallbacks can't be used
       context.unregisterComponentCallbacks(this);
-    } catch (Exception ignored) {
+    } catch (Throwable ignored) {
       // fine, might throw on older versions
+      if (options != null) {
+        options.getLogger().log(SentryLevel.DEBUG, ignored, "It was not possible to unregisterComponentCallbacks");
+      }
     }
 
     if (options != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -66,7 +66,9 @@ public final class AppComponentsBreadcrumbsIntegration
     } catch (Throwable ignored) {
       // fine, might throw on older versions
       if (options != null) {
-        options.getLogger().log(SentryLevel.DEBUG, ignored, "It was not possible to unregisterComponentCallbacks");
+        options
+            .getLogger()
+            .log(SentryLevel.DEBUG, ignored, "It was not possible to unregisterComponentCallbacks");
       }
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
@@ -21,7 +21,7 @@ final class ContextUtils {
   static PackageInfo getPackageInfo(final @NotNull Context context, final @NotNull ILogger logger) {
     try {
       return context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting package info.", e);
       return null;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -292,7 +292,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       if (emulator != null) {
         device.setSimulator((Boolean) emulator);
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting emulator.", e);
     }
 
@@ -419,7 +419,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       }
       logger.log(SentryLevel.INFO, "Error getting MemoryInfo.");
       return null;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
       return null;
     }
@@ -438,7 +438,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private @Nullable String getFamily() {
     try {
       return Build.MODEL.split(" ", -1)[0];
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting device family.", e);
       return null;
     }
@@ -461,7 +461,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       float percentMultiplier = 100.0f;
 
       return ((float) level / (float) scale) * percentMultiplier;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting device battery level.", e);
       return null;
     }
@@ -477,7 +477,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       int plugged = batteryIntent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
       return plugged == BatteryManager.BATTERY_PLUGGED_AC
           || plugged == BatteryManager.BATTERY_PLUGGED_USB;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting device charging state.", e);
       return null;
     }
@@ -489,7 +489,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       if (temperature != -1) {
         return ((float) temperature) / 10; // celsius
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting battery temperature.", e);
     }
     return null;
@@ -512,7 +512,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
             "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
         return null;
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting device orientation.", e);
     }
     return deviceOrientation;
@@ -542,7 +542,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           || Build.PRODUCT.contains("vbox86p")
           || Build.PRODUCT.contains("emulator")
           || Build.PRODUCT.contains("simulator");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(
           SentryLevel.ERROR, "Error checking whether application is running in an emulator.", e);
       return null;
@@ -559,7 +559,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long blockSize = getBlockSizeLong(stat);
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting total internal storage amount.", e);
       return null;
     }
@@ -614,7 +614,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long blockSize = getBlockSizeLong(stat);
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting unused internal storage amount.", e);
       return null;
     }
@@ -686,7 +686,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long blockSize = getBlockSizeLong(stat);
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting total external storage amount.", e);
       return null;
     }
@@ -710,7 +710,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long blockSize = getBlockSizeLong(stat);
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting unused external storage amount.", e);
       return null;
     }
@@ -724,7 +724,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private @Nullable DisplayMetrics getDisplayMetrics() {
     try {
       return context.getResources().getDisplayMetrics();
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting DisplayMetrics.", e);
       return null;
     }
@@ -746,7 +746,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       if (rooted != null) {
         os.setRooted((Boolean) rooted);
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting OperatingSystem.", e);
     }
 
@@ -802,7 +802,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       } else {
         return context.getString(stringId);
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting application name.", e);
     }
 
@@ -824,7 +824,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private @Nullable String getDeviceId() {
     try {
       return Installation.id(context);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting installationId.", e);
     }
     return null;
@@ -876,7 +876,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           event.setTag(entry.getKey(), entry.getValue());
         }
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting side loaded info.", e);
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -50,7 +50,7 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
       try {
         observer.startWatching();
         logger.log(SentryLevel.DEBUG, "EnvelopeFileObserverIntegration installed.");
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // it could throw eg NoSuchFileException or NullPointerException
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
@@ -38,7 +38,7 @@ final class Installation {
           return deviceId;
         }
         deviceId = readInstallationFile(installation);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         throw new RuntimeException(e);
       }
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -223,7 +223,7 @@ final class ManifestMetadataReader {
       options
           .getLogger()
           .log(SentryLevel.INFO, "Retrieving configuration from AndroidManifest.xml");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(
@@ -298,7 +298,7 @@ final class ManifestMetadataReader {
         autoInit = readBool(metadata, logger, AUTO_INIT, true);
       }
       logger.log(SentryLevel.INFO, "Retrieving auto-init from AndroidManifest.xml");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
     }
     return autoInit;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -53,7 +53,7 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
           telephonyManager.listen(listener, android.telephony.PhoneStateListener.LISTEN_CALL_STATE);
 
           options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
-        } catch (Exception e) {
+        } catch (Throwable e) {
           this.options
               .getLogger()
               .log(SentryLevel.INFO, e, "TelephonyManager is not available or ready to use.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -101,7 +101,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
         this.options
             .getLogger()
             .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
-      } catch (Exception e) {
+      } catch (Throwable e) {
         this.options.setEnableSystemEventBreadcrumbs(false);
         this.options
             .getLogger()
@@ -201,7 +201,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
             if (value != null) {
               newExtras.put(item, value.toString());
             }
-          } catch (Exception exception) {
+          } catch (Throwable exception) {
             logger.log(
                 SentryLevel.ERROR,
                 exception,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/util/RootChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/util/RootChecker.java
@@ -140,7 +140,7 @@ public final class RootChecker {
       }
     } catch (IOException e) {
       logger.log(SentryLevel.DEBUG, "SU isn't found on this Device.");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.DEBUG, "Error when trying to check if SU exists.", e);
     } finally {
       if (process != null) {

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/DebugImagesLoader.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/DebugImagesLoader.java
@@ -48,7 +48,7 @@ final class DebugImagesLoader implements IDebugImagesLoader {
                 .getLogger()
                 .log(SentryLevel.DEBUG, "Debug images loaded: %d", debugImages.size());
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           options.getLogger().log(SentryLevel.ERROR, e, "Failed to load debug images.");
         }
       }
@@ -64,7 +64,7 @@ final class DebugImagesLoader implements IDebugImagesLoader {
         moduleListLoader.clearModuleList();
 
         options.getLogger().log(SentryLevel.INFO, "Debug images cleared.");
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, e, "Failed to clear debug images.");
       }
       debugImages = null;

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/NdkScopeObserver.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/NdkScopeObserver.java
@@ -57,7 +57,7 @@ public final class NdkScopeObserver implements IScopeObserver {
         if (!dataRef.isEmpty()) {
           data = options.getSerializer().serialize(dataRef);
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, e, "Breadcrumb data is not serializable.");
       }
 

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -125,7 +125,7 @@ public final class ApacheHttpClientTransport implements ITransport {
                   currentlyRunning.decrement();
                 }
               });
-        } catch (Exception e) {
+        } catch (Throwable e) {
           options.getLogger().log(ERROR, "Error when sending envelope", e);
         }
       }

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
@@ -89,7 +89,7 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
             finish(span, environment, result);
           }
           return result;
-        } catch (Exception e) {
+        } catch (Throwable e) {
           span.setThrowable(e);
           span.setStatus(SpanStatus.INTERNAL_ERROR);
           finish(span, environment);

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -53,7 +53,7 @@ public final class SentryFeignClient implements Client {
         // handles both success and error responses
         span.setStatus(SpanStatus.fromHttpStatusCode(response.status()));
         return response;
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // handles cases like connection errors
         span.setThrowable(e);
         span.setStatus(SpanStatus.INTERNAL_ERROR);

--- a/sentry-samples/sentry-samples-jul/src/main/java/io/sentry/samples/jul/Main.java
+++ b/sentry-samples/sentry-samples-jul/src/main/java/io/sentry/samples/jul/Main.java
@@ -20,7 +20,7 @@ public class Main {
 
     try {
       throw new RuntimeException("Invalid productId=445");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOGGER.log(Level.SEVERE, "Something went wrong", e);
     }
   }

--- a/sentry-samples/sentry-samples-log4j2/src/main/java/io/sentry/samples/log4j2/Main.java
+++ b/sentry-samples/sentry-samples-log4j2/src/main/java/io/sentry/samples/log4j2/Main.java
@@ -23,7 +23,7 @@ public class Main {
 
     try {
       throw new RuntimeException("Invalid productId=445");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOGGER.error("Something went wrong", e);
     }
   }

--- a/sentry-samples/sentry-samples-logback/src/main/java/io/sentry/samples/logback/Main.java
+++ b/sentry-samples/sentry-samples-logback/src/main/java/io/sentry/samples/logback/Main.java
@@ -19,7 +19,7 @@ public class Main {
 
     try {
       throw new RuntimeException("Invalid productId=445");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOGGER.error("Something went wrong", e);
     }
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
@@ -80,7 +80,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
                   new RequestBodyExtractingEventProcessor(request, hub.getOptions()));
             }
           });
-    } catch (Exception e) {
+    } catch (Throwable e) {
       hub.getOptions()
           .getLogger()
           .log(SentryLevel.ERROR, "Failed to set scope for HTTP request", e);

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -52,7 +52,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
         span.setStatus(SpanStatus.fromHttpStatusCode(response.getRawStatusCode()));
         responseStatusCode = response.getRawStatusCode();
         return response;
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // handles cases like connection errors
         span.setThrowable(e);
         span.setStatus(SpanStatus.INTERNAL_ERROR);

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -67,7 +67,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       final ITransaction transaction = startTransaction(httpRequest, sentryTraceHeader);
       try {
         filterChain.doFilter(httpRequest, httpResponse);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // exceptions that are not handled by Spring
         transaction.setStatus(SpanStatus.INTERNAL_ERROR);
         throw e;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -63,7 +63,7 @@ public class SentryTransactionAdvice implements MethodInterceptor {
         final Object result = invocation.proceed();
         transaction.setStatus(SpanStatus.OK);
         return result;
-      } catch (Exception e) {
+      } catch (Throwable e) {
         transaction.setStatus(SpanStatus.INTERNAL_ERROR);
         transaction.setThrowable(e);
         throw e;

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -65,7 +65,7 @@ abstract class DirectoryProcessor {
         final SendCachedEnvelopeHint hint = new SendCachedEnvelopeHint(flushTimeoutMillis, logger);
         processFile(file, hint);
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, e, "Failed processing '%s'", directory.getAbsolutePath());
     }
   }

--- a/sentry/src/main/java/io/sentry/Dsn.java
+++ b/sentry/src/main/java/io/sentry/Dsn.java
@@ -83,7 +83,7 @@ final class Dsn {
               path + "api/" + projectId,
               null,
               null);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       throw new IllegalArgumentException(e);
     }
   }

--- a/sentry/src/main/java/io/sentry/EnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeSender.java
@@ -74,7 +74,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       logger.log(SentryLevel.ERROR, e, "File '%s' cannot be found.", file.getAbsolutePath());
     } catch (IOException e) {
       logger.log(SentryLevel.ERROR, e, "I/O on file '%s' failed.", file.getAbsolutePath());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(
           SentryLevel.ERROR, e, "Failed to capture cached envelope %s", file.getAbsolutePath());
       if (hint instanceof Retryable) {
@@ -122,7 +122,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
             file.getAbsolutePath(),
             errorMessageSuffix);
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       logger.log(
           SentryLevel.ERROR,
           e,

--- a/sentry/src/main/java/io/sentry/GsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/GsonSerializer.java
@@ -179,7 +179,7 @@ public final class GsonSerializer implements ISerializer {
           outputStream.write(data);
 
           writer.write("\n");
-        } catch (Exception exception) {
+        } catch (Throwable exception) {
           options
               .getLogger()
               .log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -88,7 +88,7 @@ public final class Hub implements IHub {
         final StackItem item = stack.peek();
         sentryId = item.getClient().captureEvent(event, item.getScope(), hint);
         this.lastEventId = sentryId;
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options
             .getLogger()
             .log(
@@ -114,7 +114,7 @@ public final class Hub implements IHub {
       try {
         final StackItem item = stack.peek();
         sentryId = item.getClient().captureMessage(message, level, item.getScope());
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error while capturing message: " + message, e);
       }
     }
@@ -142,7 +142,7 @@ public final class Hub implements IHub {
         if (capturedEnvelopeId != null) {
           sentryId = capturedEnvelopeId;
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error while capturing envelope.", e);
       }
     }
@@ -167,7 +167,7 @@ public final class Hub implements IHub {
         final SentryEvent event = new SentryEvent(throwable);
         assignTraceContext(event);
         sentryId = item.getClient().captureEvent(event, item.getScope(), hint);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options
             .getLogger()
             .log(
@@ -207,7 +207,7 @@ public final class Hub implements IHub {
       try {
         final StackItem item = stack.peek();
         item.getClient().captureUserFeedback(userFeedback);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options
             .getLogger()
             .log(
@@ -277,7 +277,7 @@ public final class Hub implements IHub {
         final StackItem item = stack.peek();
         // TODO: should we end session before closing client?
         item.getClient().close();
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error while closing the Hub.", e);
       }
       isEnabled = false;
@@ -467,7 +467,7 @@ public final class Hub implements IHub {
       pushScope();
       try {
         callback.run(stack.peek().getScope());
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error in the 'withScope' callback.", e);
       }
       popScope();
@@ -485,7 +485,7 @@ public final class Hub implements IHub {
     } else {
       try {
         callback.run(stack.peek().getScope());
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error in the 'configureScope' callback.", e);
       }
     }
@@ -518,7 +518,7 @@ public final class Hub implements IHub {
     } else {
       try {
         stack.peek().getClient().flush(timeoutMillis);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error in the 'client.flush'.", e);
       }
     }
@@ -570,7 +570,7 @@ public final class Hub implements IHub {
             item = stack.peek();
             sentryId =
                 item.getClient().captureTransaction(transaction, traceState, item.getScope(), hint);
-          } catch (Exception e) {
+          } catch (Throwable e) {
             options
                 .getLogger()
                 .log(

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -139,7 +139,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
               break;
             }
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           logger.log(ERROR, "Item failed to process.", e);
         }
       } else if (SentryItemType.Transaction.equals(item.getHeader().getType())) {
@@ -171,7 +171,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
               break;
             }
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           logger.log(ERROR, "Item failed to process.", e);
         }
       } else {

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -297,7 +297,7 @@ public final class Scope {
       final @Nullable Object hint) {
     try {
       breadcrumb = callback.execute(breadcrumb, hint);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -77,7 +77,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration implements Integra
               () -> {
                 try {
                   sender.send();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                   options
                       .getLogger()
                       .log(SentryLevel.ERROR, "Failed trying to send cached events.", e);
@@ -87,7 +87,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration implements Integra
       options
           .getLogger()
           .log(SentryLevel.DEBUG, "SendCachedEventFireAndForgetIntegration installed.");
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(SentryLevel.ERROR, "Failed to call the executor. Cached events will not be sent", e);

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -551,7 +551,7 @@ public final class SentryClient implements ISentryClient {
     if (beforeSend != null) {
       try {
         event = beforeSend.execute(event, hint);
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options
             .getLogger()
             .log(

--- a/sentry/src/main/java/io/sentry/SentryCrashLastRunState.java
+++ b/sentry/src/main/java/io/sentry/SentryCrashLastRunState.java
@@ -51,8 +51,9 @@ public final class SentryCrashLastRunState {
             nativeMarker.delete();
           }
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         // ignore
+        // TODO: Take ILogger via ctor and log here
       }
 
       crashedLastRun = exists;

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
@@ -24,7 +24,8 @@ public final class SentryEnvelopeItemHeader {
     if (getLength != null) {
       try {
         return getLength.call();
-      } catch (Exception ignored) {
+      } catch (Throwable ignored) {
+        // TODO: Take ILogger via ctor or hook into internal static logger
         return -1;
       }
     }

--- a/sentry/src/main/java/io/sentry/SentryTraceHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryTraceHeader.java
@@ -34,7 +34,7 @@ public final class SentryTraceHeader {
     try {
       this.traceId = new SentryId(parts[0]);
       this.spanId = new SpanId(parts[1]);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       throw new InvalidSentryTraceHeaderException(value, e);
     }
   }

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -103,7 +103,7 @@ public final class UncaughtExceptionHandlerIntegration
                   "Timed out waiting to flush event to disk before crashing. Event: %s",
                   event.getEventId());
         }
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options
             .getLogger()
             .log(SentryLevel.ERROR, "Error sending uncaught exception to Sentry.", e);

--- a/sentry/src/main/java/io/sentry/adapters/ContextsDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/ContextsDeserializerAdapter.java
@@ -103,7 +103,7 @@ public final class ContextsDeserializerAdapter implements JsonDeserializer<Conte
         }
         return contexts;
       }
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing Contexts", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/DateDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/DateDeserializerAdapter.java
@@ -30,7 +30,7 @@ public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
       throws JsonParseException {
     try {
       return json == null ? null : DateUtils.getDateTime(json.getAsString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(
@@ -40,7 +40,7 @@ public final class DateDeserializerAdapter implements JsonDeserializer<Date> {
     }
     try {
       return DateUtils.getDateTimeWithMillisPrecision(json.getAsString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(SentryLevel.ERROR, "Error when deserializing millis timestamp format.", e);

--- a/sentry/src/main/java/io/sentry/adapters/DateSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/DateSerializerAdapter.java
@@ -29,7 +29,7 @@ public final class DateSerializerAdapter implements JsonSerializer<Date> {
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(DateUtils.getTimestamp(src));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing Date", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/OrientationDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/OrientationDeserializerAdapter.java
@@ -33,7 +33,7 @@ public final class OrientationDeserializerAdapter
       return json == null
           ? null
           : Device.DeviceOrientation.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing DeviceOrientation", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/OrientationSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/OrientationSerializerAdapter.java
@@ -30,7 +30,7 @@ public final class OrientationSerializerAdapter
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing DeviceOrientation", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SentryIdDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryIdDeserializerAdapter.java
@@ -29,7 +29,7 @@ public final class SentryIdDeserializerAdapter implements JsonDeserializer<Sentr
       throws JsonParseException {
     try {
       return json == null ? null : new SentryId(json.getAsString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SentryId", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SentryIdSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryIdSerializerAdapter.java
@@ -28,7 +28,7 @@ public final class SentryIdSerializerAdapter implements JsonSerializer<SentryId>
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.toString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing SentryId", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SentryLevelDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryLevelDeserializerAdapter.java
@@ -29,7 +29,7 @@ public final class SentryLevelDeserializerAdapter implements JsonDeserializer<Se
       throws JsonParseException {
     try {
       return json == null ? null : SentryLevel.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SentryLevel", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SentryLevelSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SentryLevelSerializerAdapter.java
@@ -28,7 +28,7 @@ public final class SentryLevelSerializerAdapter implements JsonSerializer<Sentry
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing SentryLevel", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SpanIdDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanIdDeserializerAdapter.java
@@ -29,7 +29,7 @@ public final class SpanIdDeserializerAdapter implements JsonDeserializer<SpanId>
       throws JsonParseException {
     try {
       return json == null ? null : new SpanId(json.getAsString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SpanId", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SpanIdSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanIdSerializerAdapter.java
@@ -28,7 +28,7 @@ public final class SpanIdSerializerAdapter implements JsonSerializer<SpanId> {
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.toString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing SpanId", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SpanStatusDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanStatusDeserializerAdapter.java
@@ -30,7 +30,7 @@ public final class SpanStatusDeserializerAdapter implements JsonDeserializer<Spa
       throws JsonParseException {
     try {
       return json == null ? null : SpanStatus.valueOf(json.getAsString().toUpperCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing SpanStatus", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/SpanStatusSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/SpanStatusSerializerAdapter.java
@@ -29,7 +29,7 @@ public final class SpanStatusSerializerAdapter implements JsonSerializer<SpanSta
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.name().toLowerCase(Locale.ROOT));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing SpanStatus", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/TimeZoneDeserializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TimeZoneDeserializerAdapter.java
@@ -29,7 +29,7 @@ public final class TimeZoneDeserializerAdapter implements JsonDeserializer<TimeZ
       throws JsonParseException {
     try {
       return json == null ? null : TimeZone.getTimeZone(json.getAsString());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when deserializing TimeZone", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/adapters/TimeZoneSerializerAdapter.java
+++ b/sentry/src/main/java/io/sentry/adapters/TimeZoneSerializerAdapter.java
@@ -28,7 +28,7 @@ public final class TimeZoneSerializerAdapter implements JsonSerializer<TimeZone>
       final @NotNull JsonSerializationContext context) {
     try {
       return src == null ? null : new JsonPrimitive(src.getID());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Error when serializing TimeZone", e);
     }
     return null;

--- a/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
@@ -254,7 +254,7 @@ abstract class CacheStrategy {
         new BufferedReader(
             new InputStreamReader(new ByteArrayInputStream(item.getData()), UTF_8))) {
       return serializer.deserialize(reader, Session.class);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(ERROR, "Failed to deserialize the session.", e);
     }
     return null;
@@ -266,7 +266,7 @@ abstract class CacheStrategy {
       serializer.serialize(envelope, outputStream);
       // we need to set the same timestamp so the sorting from oldest to newest wont break.
       file.setLastModified(timestamp);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(ERROR, "Failed to serialize the new envelope to the disk.", e);
     }
   }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -141,7 +141,7 @@ public final class EnvelopeCache extends CacheStrategy implements IEnvelopeCache
             final File fileFromSession = getEnvelopeFile(fromSession);
             writeEnvelopeToDisk(fileFromSession, fromSession);
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           options.getLogger().log(SentryLevel.ERROR, "Error processing session.", e);
         }
 
@@ -209,7 +209,7 @@ public final class EnvelopeCache extends CacheStrategy implements IEnvelopeCache
       final String timestamp = DateUtils.getTimestamp(DateUtils.getCurrentDateTime());
       outputStream.write(timestamp.getBytes(UTF_8));
       outputStream.flush();
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(ERROR, "Error writing the crash marker file to the disk", e);
     }
   }
@@ -257,7 +257,7 @@ public final class EnvelopeCache extends CacheStrategy implements IEnvelopeCache
           } else {
             writeSessionToDisk(currentSessionFile, session);
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           options.getLogger().log(ERROR, "Item failed to process.", e);
         }
       } else {
@@ -288,7 +288,7 @@ public final class EnvelopeCache extends CacheStrategy implements IEnvelopeCache
 
     try (final OutputStream outputStream = new FileOutputStream(file)) {
       serializer.serialize(envelope, outputStream);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(ERROR, e, "Error writing Envelope %s to offline storage", file.getAbsolutePath());
@@ -308,7 +308,7 @@ public final class EnvelopeCache extends CacheStrategy implements IEnvelopeCache
     try (final OutputStream outputStream = new FileOutputStream(file);
         final Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
       serializer.serialize(session, writer);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(ERROR, e, "Error writing Session to offline storage: %s", session.getSessionId());

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -182,7 +182,7 @@ public final class AsyncHttpTransport implements ITransport {
       try {
         result = flush();
         options.getLogger().log(SentryLevel.DEBUG, "Envelope flushed");
-      } catch (Exception e) {
+      } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, e, "Envelope submission failed");
         throw e;
       } finally {

--- a/sentry/src/main/java/io/sentry/transport/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/transport/HttpConnection.java
@@ -153,7 +153,7 @@ final class HttpConnection {
     try (final OutputStream outputStream = connection.getOutputStream();
         final GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
       options.getSerializer().serialize(envelope, gzip);
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options
           .getLogger()
           .log(

--- a/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
@@ -22,7 +22,8 @@ public final class StdoutTransport implements ITransport {
 
     try {
       serializer.serialize(envelope, System.out);
-    } catch (Exception e) {
+    } catch (Throwable e) {
+      // TODO: debug log so we be aware serialization failed here
       // do nothing
     }
   }

--- a/sentry/src/main/java/io/sentry/util/Platform.java
+++ b/sentry/src/main/java/io/sentry/util/Platform.java
@@ -13,7 +13,7 @@ public final class Platform {
       // All system properties on Android:
       // https://developer.android.com/reference/java/lang/System#getProperties()
       isAndroid = "The Android Project".equals(System.getProperty("java.vendor"));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       isAndroid = false;
     }
   }


### PR DESCRIPTION
The goal is to change code locations we suppress error to avoid the SDK bubbling errors to customers. 

Firs try: I changed every match of `catch (Exception` to `catch (Throwable`. Not matching Kotlin code though, the main focus was to help avoid the case we had when debugging a crash on Unity with the Android SDK so mainly `sentry-java` and `sentry-android-core`.

Adding additional logging isn't in the scope of this PR. When it was simple I just added a debug log, but if no logger available, I added a TODO and we can have a follow up PR.

@maciejwalkowiak does this make sense on the Spring and other backend packages or should I revert?

Partially addresses #1806 (not doing the Kotlin code)