### PR TITLE
Fix: Do not start fragment span if not added to the Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Feat: Refactor OkHttp and Apollo to Kotlin functional interfaces (#1797)
 * Feat: Add secondary constructor to SentryInstrumentation (#1804)
-* Fix: Do not start fragment span if not added to the Activity (#)
+* Fix: Do not start fragment span if not added to the Activity (#1813)
 
 ## 5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Feat: Refactor OkHttp and Apollo to Kotlin functional interfaces (#1797)
 * Feat: Add secondary constructor to SentryInstrumentation (#1804)
+* Fix: Do not start fragment span if not added to the Activity (#)
 
 ## 5.4.0
 

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -57,7 +57,11 @@ class SentryFragmentLifecycleCallbacks(
     ) {
         addBreadcrumb(fragment, "created")
 
-        startTracing(fragment)
+        // we only start the tracing for the fragment if the fragment has been added to its activity
+        // and not only to the backstack
+        if (fragment.isAdded) {
+            startTracing(fragment)
+        }
     }
 
     override fun onFragmentViewCreated(

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -36,7 +36,8 @@ class SentryFragmentLifecycleCallbacksTest {
         fun getSut(
             enableFragmentLifecycleBreadcrumbs: Boolean = true,
             enableAutoFragmentLifecycleTracing: Boolean = false,
-            tracesSampleRate: Double? = 1.0
+            tracesSampleRate: Double? = 1.0,
+            isAdded: Boolean = true
         ): SentryFragmentLifecycleCallbacks {
             whenever(hub.options).thenReturn(
                 SentryOptions().apply {
@@ -48,6 +49,7 @@ class SentryFragmentLifecycleCallbacksTest {
             whenever(hub.configureScope(any())).thenAnswer {
                 (it.arguments[0] as ScopeCallback).run(scope)
             }
+            whenever(fragment.isAdded).thenReturn(isAdded)
             return SentryFragmentLifecycleCallbacks(
                 hub = hub,
                 enableFragmentLifecycleBreadcrumbs = enableFragmentLifecycleBreadcrumbs,
@@ -194,6 +196,15 @@ class SentryFragmentLifecycleCallbacksTest {
                 assertEquals("Fragment", it)
             }
         )
+    }
+
+    @Test
+    fun `When fragment is created but not added to activity, it should not start tracing`() {
+        val sut = fixture.getSut(enableAutoFragmentLifecycleTracing = true, isAdded = false)
+
+        sut.onFragmentCreated(fixture.fragmentManager, fixture.fragment, savedInstanceState = null)
+
+        verify(fixture.transaction, never()).startChild(any(), any())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Fix: Do not start fragment span if not added to the Activity


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1787


## :green_heart: How did you test it?
running https://github.com/LouisFn/SentryFrozenFrame and repo's sample with added/visible fragments

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
