### PR TITLE
Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#)
+* Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#1824)
 
 ## 5.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#)
+
 ## 5.4.3
 
 * Fix: Only report App start measurement for full launch on Android (#1821)

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -161,6 +161,6 @@ class SentryFragmentLifecycleCallbacks(
     }
 
     companion object {
-        const val FRAGMENT_LOAD_OP = "ui.fragment.load"
+        const val FRAGMENT_LOAD_OP = "ui.load"
     }
 }


### PR DESCRIPTION
## :scroll: Description
Rename Fragment span operation from `ui.fragment.load` to `ui.load`


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1820


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [X] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
