### PR TITLE
feat: Add runtime classes for FileIOStream instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#1824)
 * Feat: Add locale to device context and deprecate language (#1832)
 * Ref: change `java.util.Random` to `java.security.SecureRandom` for possible security reasons (#1831)
+* Feat: Add `SentryFileInputStream` and `SentryFileOutputStream` for File I/O performance instrumentation (#1826)
 
 ## 5.4.3
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1432,49 +1432,6 @@ public abstract interface class io/sentry/hints/SubmissionResult {
 	public abstract fun setResult (Z)V
 }
 
-public class io/sentry/instrumentation/file/SentryFileInputStream : java/io/FileInputStream {
-	public fun <init> (Ljava/io/File;)V
-	public fun <init> (Ljava/io/File;Lio/sentry/IHub;)V
-	public fun <init> (Ljava/io/FileDescriptor;)V
-	public fun <init> (Ljava/io/FileDescriptor;Lio/sentry/IHub;)V
-	public fun <init> (Ljava/lang/String;)V
-	public fun close ()V
-	public fun read ()I
-	public fun read ([B)I
-	public fun read ([BII)I
-	public fun skip (J)J
-}
-
-public final class io/sentry/instrumentation/file/SentryFileInputStream$Factory {
-	public fun <init> ()V
-	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;)Ljava/io/FileInputStream;
-	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;Lio/sentry/IHub;)Ljava/io/FileInputStream;
-	public static fun create (Ljava/io/FileInputStream;Ljava/io/FileDescriptor;)Ljava/io/FileInputStream;
-	public static fun create (Ljava/io/FileInputStream;Ljava/lang/String;)Ljava/io/FileInputStream;
-}
-
-public class io/sentry/instrumentation/file/SentryFileOutputStream : java/io/FileOutputStream {
-	public fun <init> (Ljava/io/File;)V
-	public fun <init> (Ljava/io/File;Lio/sentry/IHub;)V
-	public fun <init> (Ljava/io/File;Z)V
-	public fun <init> (Ljava/io/FileDescriptor;)V
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Z)V
-	public fun close ()V
-	public fun write (I)V
-	public fun write ([B)V
-	public fun write ([BII)V
-}
-
-public final class io/sentry/instrumentation/file/SentryFileOutputStream$Factory {
-	public fun <init> ()V
-	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;)Ljava/io/FileOutputStream;
-	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Z)Ljava/io/FileOutputStream;
-	public static fun create (Ljava/io/FileOutputStream;Ljava/io/FileDescriptor;)Ljava/io/FileOutputStream;
-	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;)Ljava/io/FileOutputStream;
-	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;Z)Ljava/io/FileOutputStream;
-}
-
 public final class io/sentry/protocol/App : io/sentry/IUnknownPropertiesConsumer {
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1434,7 +1434,9 @@ public abstract interface class io/sentry/hints/SubmissionResult {
 
 public class io/sentry/instrumentation/file/SentryFileInputStream : java/io/FileInputStream {
 	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/File;Lio/sentry/IHub;)V
 	public fun <init> (Ljava/io/FileDescriptor;)V
+	public fun <init> (Ljava/io/FileDescriptor;Lio/sentry/IHub;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun close ()V
 	public fun read ()I
@@ -1446,12 +1448,14 @@ public class io/sentry/instrumentation/file/SentryFileInputStream : java/io/File
 public final class io/sentry/instrumentation/file/SentryFileInputStream$Factory {
 	public fun <init> ()V
 	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;)Ljava/io/FileInputStream;
+	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;Lio/sentry/IHub;)Ljava/io/FileInputStream;
 	public static fun create (Ljava/io/FileInputStream;Ljava/io/FileDescriptor;)Ljava/io/FileInputStream;
 	public static fun create (Ljava/io/FileInputStream;Ljava/lang/String;)Ljava/io/FileInputStream;
 }
 
 public class io/sentry/instrumentation/file/SentryFileOutputStream : java/io/FileOutputStream {
 	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/File;Lio/sentry/IHub;)V
 	public fun <init> (Ljava/io/File;Z)V
 	public fun <init> (Ljava/io/FileDescriptor;)V
 	public fun <init> (Ljava/lang/String;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1432,6 +1432,45 @@ public abstract interface class io/sentry/hints/SubmissionResult {
 	public abstract fun setResult (Z)V
 }
 
+public class io/sentry/instrumentation/file/SentryFileInputStream : java/io/FileInputStream {
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/FileDescriptor;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun close ()V
+	public fun read ()I
+	public fun read ([B)I
+	public fun read ([BII)I
+	public fun skip (J)J
+}
+
+public final class io/sentry/instrumentation/file/SentryFileInputStream$Factory {
+	public fun <init> ()V
+	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;)Ljava/io/FileInputStream;
+	public static fun create (Ljava/io/FileInputStream;Ljava/io/FileDescriptor;)Ljava/io/FileInputStream;
+	public static fun create (Ljava/io/FileInputStream;Ljava/lang/String;)Ljava/io/FileInputStream;
+}
+
+public class io/sentry/instrumentation/file/SentryFileOutputStream : java/io/FileOutputStream {
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/File;Z)V
+	public fun <init> (Ljava/io/FileDescriptor;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public fun close ()V
+	public fun write (I)V
+	public fun write ([B)V
+	public fun write ([BII)V
+}
+
+public final class io/sentry/instrumentation/file/SentryFileOutputStream$Factory {
+	public fun <init> ()V
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Z)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/FileDescriptor;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;Z)Ljava/io/FileOutputStream;
+}
+
 public final class io/sentry/protocol/App : io/sentry/IUnknownPropertiesConsumer {
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V
@@ -2011,6 +2050,7 @@ public final class io/sentry/util/Platform {
 }
 
 public final class io/sentry/util/StringUtils {
+	public static fun byteCountToString (J)Ljava/lang/String;
 	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
 	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;
 	public static fun removeSurrounding (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1432,6 +1432,45 @@ public abstract interface class io/sentry/hints/SubmissionResult {
 	public abstract fun setResult (Z)V
 }
 
+public final class io/sentry/instrumentation/file/SentryFileInputStream : java/io/FileInputStream {
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/FileDescriptor;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun close ()V
+	public fun read ()I
+	public fun read ([B)I
+	public fun read ([BII)I
+	public fun skip (J)J
+}
+
+public final class io/sentry/instrumentation/file/SentryFileInputStream$Factory {
+	public fun <init> ()V
+	public static fun create (Ljava/io/FileInputStream;Ljava/io/File;)Ljava/io/FileInputStream;
+	public static fun create (Ljava/io/FileInputStream;Ljava/io/FileDescriptor;)Ljava/io/FileInputStream;
+	public static fun create (Ljava/io/FileInputStream;Ljava/lang/String;)Ljava/io/FileInputStream;
+}
+
+public final class io/sentry/instrumentation/file/SentryFileOutputStream : java/io/FileOutputStream {
+	public fun <init> (Ljava/io/File;)V
+	public fun <init> (Ljava/io/File;Z)V
+	public fun <init> (Ljava/io/FileDescriptor;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Z)V
+	public fun close ()V
+	public fun write (I)V
+	public fun write ([B)V
+	public fun write ([BII)V
+}
+
+public final class io/sentry/instrumentation/file/SentryFileOutputStream$Factory {
+	public fun <init> ()V
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Z)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/FileDescriptor;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;Z)Ljava/io/FileOutputStream;
+}
+
 public final class io/sentry/protocol/App : io/sentry/IUnknownPropertiesConsumer {
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -10,11 +10,12 @@ import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-class FileIOSpanManager {
+final class FileIOSpanManager {
 
   private final @Nullable ISpan currentSpan;
   private final @Nullable File file;
 
+  private @Nullable Throwable throwable = null;
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
 
@@ -48,6 +49,7 @@ class FileIOSpanManager {
       return result;
     } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
+      throwable = exception;
       throw exception;
     }
   }
@@ -57,6 +59,7 @@ class FileIOSpanManager {
       delegate.close();
     } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
+      throwable = exception;
       throw exception;
     }
     finishSpan();
@@ -77,6 +80,7 @@ class FileIOSpanManager {
         currentSpan.setDescription(byteCountToString);
       }
       currentSpan.setData("file.size", byteCount);
+      currentSpan.setThrowable(throwable);
       currentSpan.finish(spanStatus);
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -18,7 +18,7 @@ final class FileIOSpanManager {
 
   private final @Nullable ISpan currentSpan;
   private final @Nullable File file;
-  private final @NotNull IHub hub;
+  private final boolean isSendDefaultPii;
 
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
@@ -29,10 +29,10 @@ final class FileIOSpanManager {
   }
 
   FileIOSpanManager(
-      final @Nullable ISpan currentSpan, final @Nullable File file, final @NotNull IHub hub) {
+      final @Nullable ISpan currentSpan, final @Nullable File file, final boolean isSendDefaultPii) {
     this.currentSpan = currentSpan;
     this.file = file;
-    this.hub = hub;
+    this.isSendDefaultPii = isSendDefaultPii;
   }
 
   /**
@@ -87,14 +87,13 @@ final class FileIOSpanManager {
       if (file != null) {
         final String description = file.getName() + " " + "(" + byteCountToString + ")";
         currentSpan.setDescription(description);
-        if (Platform.isAndroid() || hub.getOptions().isSendDefaultPii()) {
+        if (Platform.isAndroid() || isSendDefaultPii) {
           currentSpan.setData("file.path", file.getAbsolutePath());
         }
       } else {
         currentSpan.setDescription(byteCountToString);
       }
       currentSpan.setData("file.size", byteCount);
-      currentSpan.setThrowable(throwable);
       currentSpan.finish(spanStatus);
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -1,0 +1,92 @@
+package io.sentry.instrumentation.file;
+
+import io.sentry.ISpan;
+import io.sentry.Sentry;
+import io.sentry.SpanStatus;
+import io.sentry.util.StringUtils;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+class FileIOSpanManager {
+
+  private final @Nullable ISpan currentSpan;
+  private final @Nullable File file;
+
+  private @NotNull SpanStatus spanStatus = SpanStatus.OK;
+  private long byteCount;
+
+  static @Nullable ISpan startSpan(final @NotNull String op) {
+    final ISpan parent = Sentry.getSpan();
+    return parent != null ? parent.startChild(op) : null;
+  }
+
+  FileIOSpanManager(
+    final @Nullable ISpan currentSpan,
+    final @Nullable File file
+  ) {
+    this.currentSpan = currentSpan;
+    this.file = file;
+  }
+
+  <T> T performIO(final @NotNull FileIOCallable<T> operation) throws IOException {
+    try {
+      final T result = operation.call();
+      if (result instanceof Integer) {
+        final int res = (int) result;
+        if (res != -1) {
+          byteCount += res;
+        }
+      } else if (result instanceof Long) {
+        final long res = (long) result;
+        if (res != -1) {
+          byteCount += res;
+        }
+      }
+      return result;
+    } catch (Exception exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  void finish(final @NotNull Closeable delegate) throws IOException {
+    try {
+      delegate.close();
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+    finishSpan();
+  }
+
+  private void finishSpan() {
+    if (currentSpan != null) {
+      if (file != null) {
+        String description = file.getName()
+          + " "
+          + "("
+          + StringUtils.byteCountToString(byteCount)
+          + ")";
+        currentSpan.setDescription(description);
+        currentSpan.setData("filepath", file.getAbsolutePath());
+      }
+      currentSpan.finish(spanStatus);
+    }
+  }
+
+  /**
+   * A task that returns a result and may throw an IOException.
+   * Implementors define a single method with no arguments called
+   * {@code call}.
+   *
+   * Derived from {@link java.util.concurrent.Callable}
+   */
+  @FunctionalInterface
+  interface FileIOCallable<V> {
+
+    V call() throws IOException;
+  }
+}

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -20,7 +20,6 @@ final class FileIOSpanManager {
   private final @Nullable File file;
   private final @NotNull IHub hub;
 
-  private @Nullable Throwable throwable = null;
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
 
@@ -61,7 +60,9 @@ final class FileIOSpanManager {
       return result;
     } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
-      throwable = exception;
+      if (currentSpan != null) {
+        currentSpan.setThrowable(exception);
+      }
       throw exception;
     }
   }
@@ -71,7 +72,9 @@ final class FileIOSpanManager {
       delegate.close();
     } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
-      throwable = exception;
+      if (currentSpan != null) {
+        currentSpan.setThrowable(exception);
+      }
       throw exception;
     } finally {
       finishSpan();

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -46,7 +46,7 @@ class FileIOSpanManager {
         }
       }
       return result;
-    } catch (Exception exception) {
+    } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
       throw exception;
     }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -3,7 +3,6 @@ package io.sentry.instrumentation.file;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
-import io.sentry.util.Objects;
 import io.sentry.util.Pair;
 import io.sentry.util.Platform;
 import io.sentry.util.StringUtils;
@@ -31,10 +30,7 @@ final class FileIOSpanManager {
   }
 
   FileIOSpanManager(
-    final @Nullable ISpan currentSpan,
-    final @Nullable File file,
-    final @NotNull IHub hub
-  ) {
+      final @Nullable ISpan currentSpan, final @Nullable File file, final @NotNull IHub hub) {
     this.currentSpan = currentSpan;
     this.file = file;
     this.hub = hub;
@@ -43,12 +39,12 @@ final class FileIOSpanManager {
   /**
    * Performs file IO, counts the read/written bytes and handles exceptions in case of occurence
    *
-   * @param operation An IO operation to execute (e.g. {@link FileInputStream#read()} or {@link FileOutputStream#write(int)}
-   * The operation is of a type {@link Pair}, where the first element is the result of the IO operation,
-   * and the second element is the number of bytes read/written/skipped/etc.
+   * @param operation An IO operation to execute (e.g. {@link FileInputStream#read()} or {@link
+   *     FileOutputStream#write(int)} The operation is of a type {@link Pair}, where the first
+   *     element is the result of the IO operation, and the second element is the number of bytes
+   *     read/written/skipped/etc.
    */
-  <T> T performIO(final @NotNull FileIOCallable<T> operation)
-    throws IOException {
+  <T> T performIO(final @NotNull FileIOCallable<T> operation) throws IOException {
     try {
       final T result = operation.call();
       if (result instanceof Integer) {
@@ -86,11 +82,7 @@ final class FileIOSpanManager {
     if (currentSpan != null) {
       final String byteCountToString = StringUtils.byteCountToString(byteCount);
       if (file != null) {
-        final String description = file.getName()
-          + " "
-          + "("
-          + byteCountToString
-          + ")";
+        final String description = file.getName() + " " + "(" + byteCountToString + ")";
         currentSpan.setDescription(description);
         if (Platform.isAndroid() || hub.getOptions().isSendDefaultPii()) {
           currentSpan.setData("file.path", file.getAbsolutePath());
@@ -105,11 +97,10 @@ final class FileIOSpanManager {
   }
 
   /**
-   * A task that returns a result and may throw an IOException.
-   * Implementors define a single method with no arguments called
-   * {@code call}.
+   * A task that returns a result and may throw an IOException. Implementors define a single method
+   * with no arguments called {@code call}.
    *
-   * Derived from {@link java.util.concurrent.Callable}
+   * <p>Derived from {@link java.util.concurrent.Callable}
    */
   @FunctionalInterface
   interface FileIOCallable<V> {

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -3,7 +3,6 @@ package io.sentry.instrumentation.file;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
-import io.sentry.util.Pair;
 import io.sentry.util.Platform;
 import io.sentry.util.StringUtils;
 import java.io.Closeable;
@@ -29,7 +28,9 @@ final class FileIOSpanManager {
   }
 
   FileIOSpanManager(
-      final @Nullable ISpan currentSpan, final @Nullable File file, final boolean isSendDefaultPii) {
+      final @Nullable ISpan currentSpan,
+      final @Nullable File file,
+      final boolean isSendDefaultPii) {
     this.currentSpan = currentSpan;
     this.file = file;
     this.isSendDefaultPii = isSendDefaultPii;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -47,25 +47,22 @@ final class FileIOSpanManager {
    * The operation is of a type {@link Pair}, where the first element is the result of the IO operation,
    * and the second element is the number of bytes read/written/skipped/etc.
    */
-  <T> T performIO(final @NotNull FileIOCallable<Pair<T, T>> operation)
+  <T> T performIO(final @NotNull FileIOCallable<T> operation)
     throws IOException {
     try {
-      final Pair<T, T> result = operation.call();
-      final T res = result.getFirst();
-      if (res instanceof Integer) {
-        final int resUnboxed = (int) result.getFirst();
-        final int count = (int) result.getSecond();
+      final T result = operation.call();
+      if (result instanceof Integer) {
+        final int resUnboxed = (int) result;
         if (resUnboxed != -1) {
-          byteCount += count;
+          byteCount += resUnboxed;
         }
-      } else if (res instanceof Long) {
-        final long resUnboxed = (long) result.getFirst();
-        final long count = (long) result.getSecond();
+      } else if (result instanceof Long) {
+        final long resUnboxed = (long) result;
         if (resUnboxed != -1L) {
-          byteCount += count;
+          byteCount += resUnboxed;
         }
       }
-      return Objects.requireNonNull(res, "Result of File IO is required");
+      return result;
     } catch (IOException exception) {
       spanStatus = SpanStatus.INTERNAL_ERROR;
       throwable = exception;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -39,9 +39,8 @@ final class FileIOSpanManager {
    * Performs file IO, counts the read/written bytes and handles exceptions in case of occurence
    *
    * @param operation An IO operation to execute (e.g. {@link FileInputStream#read()} or {@link
-   *     FileOutputStream#write(int)} The operation is of a type {@link Pair}, where the first
-   *     element is the result of the IO operation, and the second element is the number of bytes
-   *     read/written/skipped/etc.
+   *     FileOutputStream#write(int)} The operation is of a type {@link Integer} or {@link Long},
+   *     where the output is the result of the IO operation (byte count read/written)
    */
   <T> T performIO(final @NotNull FileIOCallable<T> operation) throws IOException {
     try {

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -105,8 +105,8 @@ final class FileIOSpanManager {
    * <p>Derived from {@link java.util.concurrent.Callable}
    */
   @FunctionalInterface
-  interface FileIOCallable<V> {
+  interface FileIOCallable<T> {
 
-    V call() throws IOException;
+    T call() throws IOException;
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -64,15 +64,20 @@ class FileIOSpanManager {
 
   private void finishSpan() {
     if (currentSpan != null) {
+      String description;
       if (file != null) {
-        String description = file.getName()
+        description = file.getName()
           + " "
           + "("
           + StringUtils.byteCountToString(byteCount)
           + ")";
         currentSpan.setDescription(description);
-        currentSpan.setData("filepath", file.getAbsolutePath());
+        currentSpan.setData("file.path", file.getAbsolutePath());
+      } else {
+        description = StringUtils.byteCountToString(byteCount);
+        currentSpan.setDescription(description);
       }
+      currentSpan.setData("file.size", byteCount);
       currentSpan.finish(spanStatus);
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -64,18 +64,17 @@ class FileIOSpanManager {
 
   private void finishSpan() {
     if (currentSpan != null) {
-      String description;
+      final String byteCountToString = StringUtils.byteCountToString(byteCount);
       if (file != null) {
-        description = file.getName()
+        final String description = file.getName()
           + " "
           + "("
-          + StringUtils.byteCountToString(byteCount)
+          + byteCountToString
           + ")";
         currentSpan.setDescription(description);
         currentSpan.setData("file.path", file.getAbsolutePath());
       } else {
-        description = StringUtils.byteCountToString(byteCount);
-        currentSpan.setDescription(description);
+        currentSpan.setDescription(byteCountToString);
       }
       currentSpan.setData("file.size", byteCount);
       currentSpan.finish(spanStatus);

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file;
 
+import io.sentry.IHub;
 import io.sentry.ISpan;
 import java.io.File;
 import java.io.FileInputStream;
@@ -11,14 +12,16 @@ final class FileInputStreamInitData {
   final @Nullable File file;
   final @Nullable ISpan span;
   final @NotNull FileInputStream delegate;
+  final @NotNull IHub hub;
 
   public FileInputStreamInitData(
     final @Nullable File file,
     final @Nullable ISpan span,
-    final @NotNull FileInputStream delegate
-  ) {
+    final @NotNull FileInputStream delegate,
+    final @NotNull IHub hub) {
     this.file = file;
     this.span = span;
     this.delegate = delegate;
+    this.hub = hub;
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -8,12 +8,15 @@ import org.jetbrains.annotations.Nullable;
 
 final class FileInputStreamInitData {
 
-  @Nullable File file;
-  @Nullable ISpan span;
-  @NotNull FileInputStream delegate;
+  final @Nullable File file;
+  final @Nullable ISpan span;
+  final @NotNull FileInputStream delegate;
 
-  public FileInputStreamInitData(@Nullable File file, @Nullable ISpan span,
-    @NotNull FileInputStream delegate) {
+  public FileInputStreamInitData(
+    final @Nullable File file,
+    final @Nullable ISpan span,
+    final @NotNull FileInputStream delegate
+  ) {
     this.file = file;
     this.span = span;
     this.delegate = delegate;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -15,10 +15,10 @@ final class FileInputStreamInitData {
   final @NotNull IHub hub;
 
   public FileInputStreamInitData(
-    final @Nullable File file,
-    final @Nullable ISpan span,
-    final @NotNull FileInputStream delegate,
-    final @NotNull IHub hub) {
+      final @Nullable File file,
+      final @Nullable ISpan span,
+      final @NotNull FileInputStream delegate,
+      final @NotNull IHub hub) {
     this.file = file;
     this.span = span;
     this.delegate = delegate;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -1,6 +1,5 @@
 package io.sentry.instrumentation.file;
 
-import io.sentry.IHub;
 import io.sentry.ISpan;
 import java.io.File;
 import java.io.FileInputStream;
@@ -14,7 +13,7 @@ final class FileInputStreamInitData {
   final @NotNull FileInputStream delegate;
   final boolean isSendDefaultPii;
 
-  public FileInputStreamInitData(
+  FileInputStreamInitData(
       final @Nullable File file,
       final @Nullable ISpan span,
       final @NotNull FileInputStream delegate,

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -12,16 +12,16 @@ final class FileInputStreamInitData {
   final @Nullable File file;
   final @Nullable ISpan span;
   final @NotNull FileInputStream delegate;
-  final @NotNull IHub hub;
+  final boolean isSendDefaultPii;
 
   public FileInputStreamInitData(
       final @Nullable File file,
       final @Nullable ISpan span,
       final @NotNull FileInputStream delegate,
-      final @NotNull IHub hub) {
+      final boolean isSendDefaultPii) {
     this.file = file;
     this.span = span;
     this.delegate = delegate;
-    this.hub = hub;
+    this.isSendDefaultPii = isSendDefaultPii;
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileInputStreamInitData.java
@@ -1,0 +1,21 @@
+package io.sentry.instrumentation.file;
+
+import io.sentry.ISpan;
+import java.io.File;
+import java.io.FileInputStream;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class FileInputStreamInitData {
+
+  @Nullable File file;
+  @Nullable ISpan span;
+  @NotNull FileInputStream delegate;
+
+  public FileInputStreamInitData(@Nullable File file, @Nullable ISpan span,
+    @NotNull FileInputStream delegate) {
+    this.file = file;
+    this.span = span;
+    this.delegate = delegate;
+  }
+}

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -2,20 +2,23 @@ package io.sentry.instrumentation.file;
 
 import io.sentry.ISpan;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 final class FileOutputStreamInitData {
 
-  @Nullable File file;
-  @Nullable ISpan span;
-  boolean append;
-  @NotNull FileOutputStream delegate;
+  final @Nullable File file;
+  final @Nullable ISpan span;
+  final boolean append;
+  final @NotNull FileOutputStream delegate;
 
-  public FileOutputStreamInitData(@Nullable File file, boolean append, @Nullable ISpan span,
-    @NotNull FileOutputStream delegate) {
+  public FileOutputStreamInitData(
+    final @Nullable File file,
+    final boolean append,
+    final @Nullable ISpan span,
+    final @NotNull FileOutputStream delegate
+  ) {
     this.file = file;
     this.append = append;
     this.span = span;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -1,6 +1,5 @@
 package io.sentry.instrumentation.file;
 
-import io.sentry.IHub;
 import io.sentry.ISpan;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -15,7 +14,7 @@ final class FileOutputStreamInitData {
   final @NotNull FileOutputStream delegate;
   final boolean isSendDefaultPii;
 
-  public FileOutputStreamInitData(
+  FileOutputStreamInitData(
       final @Nullable File file,
       final boolean append,
       final @Nullable ISpan span,

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file;
 
+import io.sentry.IHub;
 import io.sentry.ISpan;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -12,16 +13,18 @@ final class FileOutputStreamInitData {
   final @Nullable ISpan span;
   final boolean append;
   final @NotNull FileOutputStream delegate;
+  final @NotNull IHub hub;
 
   public FileOutputStreamInitData(
     final @Nullable File file,
     final boolean append,
     final @Nullable ISpan span,
-    final @NotNull FileOutputStream delegate
-  ) {
+    final @NotNull FileOutputStream delegate,
+    @NotNull IHub hub) {
     this.file = file;
     this.append = append;
     this.span = span;
     this.delegate = delegate;
+    this.hub = hub;
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -13,18 +13,18 @@ final class FileOutputStreamInitData {
   final @Nullable ISpan span;
   final boolean append;
   final @NotNull FileOutputStream delegate;
-  final @NotNull IHub hub;
+  final boolean isSendDefaultPii;
 
   public FileOutputStreamInitData(
       final @Nullable File file,
       final boolean append,
       final @Nullable ISpan span,
       final @NotNull FileOutputStream delegate,
-      @NotNull IHub hub) {
+      final boolean isSendDefaultPii) {
     this.file = file;
     this.append = append;
     this.span = span;
     this.delegate = delegate;
-    this.hub = hub;
+    this.isSendDefaultPii = isSendDefaultPii;
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -16,11 +16,11 @@ final class FileOutputStreamInitData {
   final @NotNull IHub hub;
 
   public FileOutputStreamInitData(
-    final @Nullable File file,
-    final boolean append,
-    final @Nullable ISpan span,
-    final @NotNull FileOutputStream delegate,
-    @NotNull IHub hub) {
+      final @Nullable File file,
+      final boolean append,
+      final @Nullable ISpan span,
+      final @NotNull FileOutputStream delegate,
+      @NotNull IHub hub) {
     this.file = file;
     this.append = append;
     this.span = span;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileOutputStreamInitData.java
@@ -1,0 +1,24 @@
+package io.sentry.instrumentation.file;
+
+import io.sentry.ISpan;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class FileOutputStreamInitData {
+
+  @Nullable File file;
+  @Nullable ISpan span;
+  boolean append;
+  @NotNull FileOutputStream delegate;
+
+  public FileOutputStreamInitData(@Nullable File file, boolean append, @Nullable ISpan span,
+    @NotNull FileOutputStream delegate) {
+    this.file = file;
+    this.append = append;
+    this.span = span;
+    this.delegate = delegate;
+  }
+}

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -2,13 +2,11 @@ package io.sentry.instrumentation.file;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.ISpan;
-import io.sentry.SpanStatus;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
  * Note, that span is started when this InputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileInputStream#close()} is called.
  */
-@SuppressWarnings("unused") // used via bytecode manipulation (SAGP)
 @Open
 public class SentryFileInputStream extends FileInputStream {
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -38,11 +38,6 @@ public class SentryFileInputStream extends FileInputStream {
     this(fdObj, HubAdapter.getInstance());
   }
 
-  public SentryFileInputStream(final @Nullable String name, final @NotNull IHub hub)
-    throws FileNotFoundException {
-    this(init(name != null ? new File(name) : null, null, hub));
-  }
-
   public SentryFileInputStream(final @Nullable File file, final @NotNull IHub hub)
     throws FileNotFoundException {
     this(init(file, null, hub));
@@ -156,28 +151,10 @@ public class SentryFileInputStream extends FileInputStream {
 
     public static FileInputStream create(
       final @NotNull FileInputStream delegate,
-      final @Nullable String name,
-      final @NotNull IHub hub
-    ) throws FileNotFoundException {
-      return new SentryFileInputStream(
-        init(name != null ? new File(name) : null, delegate, hub));
-    }
-
-    public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
       final @Nullable File file,
       final @NotNull IHub hub
     ) throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate, hub));
-    }
-
-    public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
-      final @NotNull FileDescriptor descriptor,
-      final @NotNull IHub hub
-    ) {
-      return new SentryFileInputStream(init(descriptor, delegate, hub),
-        descriptor);
     }
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -37,12 +37,12 @@ final class SentryFileInputStream extends FileInputStream {
     this(fdObj, HubAdapter.getInstance());
   }
 
-  public SentryFileInputStream(final @Nullable File file, final @NotNull IHub hub)
+  SentryFileInputStream(final @Nullable File file, final @NotNull IHub hub)
       throws FileNotFoundException {
     this(init(file, null, hub));
   }
 
-  public SentryFileInputStream(final @NotNull FileDescriptor fdObj, final @NotNull IHub hub) {
+  SentryFileInputStream(final @NotNull FileDescriptor fdObj, final @NotNull IHub hub) {
     this(init(fdObj, null, hub), fdObj);
   }
 
@@ -137,7 +137,7 @@ final class SentryFileInputStream extends FileInputStream {
           init(descriptor, delegate, HubAdapter.getInstance()), descriptor);
     }
 
-    public static FileInputStream create(
+    static FileInputStream create(
         final @NotNull FileInputStream delegate, final @Nullable File file, final @NotNull IHub hub)
         throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate, hub));

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
  * An implementation of {@link java.io.FileInputStream} that creates a {@link io.sentry.ISpan} for
  * reading operation with filename and byte count set as description
  *
- * Note, that span is started when this InputStream is instantiated via constructor and finishes
+ * <p>Note, that span is started when this InputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileInputStream#close()} is called.
  */
 @Open
@@ -39,7 +39,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   public SentryFileInputStream(final @Nullable File file, final @NotNull IHub hub)
-    throws FileNotFoundException {
+      throws FileNotFoundException {
     this(init(file, null, hub));
   }
 
@@ -48,27 +48,22 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   private SentryFileInputStream(
-    final @NotNull FileInputStreamInitData data,
-    final @NotNull FileDescriptor fd
-  ) {
+      final @NotNull FileInputStreamInitData data, final @NotNull FileDescriptor fd) {
     super(fd);
     spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
     delegate = data.delegate;
   }
 
-  private SentryFileInputStream(
-    final @NotNull FileInputStreamInitData data
-  ) throws FileNotFoundException {
+  private SentryFileInputStream(final @NotNull FileInputStreamInitData data)
+      throws FileNotFoundException {
     super(data.file);
     spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
     delegate = data.delegate;
   }
 
   private static FileInputStreamInitData init(
-    final @Nullable File file,
-    @Nullable FileInputStream delegate,
-    final @NotNull IHub hub
-  ) throws FileNotFoundException {
+      final @Nullable File file, @Nullable FileInputStream delegate, final @NotNull IHub hub)
+      throws FileNotFoundException {
     final ISpan span = FileIOSpanManager.startSpan(hub, "file.read");
     if (delegate == null) {
       delegate = new FileInputStream(file);
@@ -77,10 +72,9 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   private static FileInputStreamInitData init(
-    final @NotNull FileDescriptor fd,
-    @Nullable FileInputStream delegate,
-    final @NotNull IHub hub
-  ) {
+      final @NotNull FileDescriptor fd,
+      @Nullable FileInputStream delegate,
+      final @NotNull IHub hub) {
     final ISpan span = FileIOSpanManager.startSpan(hub, "file.read");
     if (delegate == null) {
       delegate = new FileInputStream(fd);
@@ -93,10 +87,11 @@ public class SentryFileInputStream extends FileInputStream {
     // this is the only case, when the read() operation returns the byte value, and not the count
     // hence we need this special handling
     AtomicInteger result = new AtomicInteger(0);
-    spanManager.performIO(() -> {
-      result.set(delegate.read());
-      return result.get() != -1 ? 1 : 0;
-    });
+    spanManager.performIO(
+        () -> {
+          result.set(delegate.read());
+          return result.get() != -1 ? 1 : 0;
+        });
     return result.get();
   }
 
@@ -120,35 +115,29 @@ public class SentryFileInputStream extends FileInputStream {
     spanManager.finish(delegate);
   }
 
-  public final static class Factory {
+  public static final class Factory {
     public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
-      final @Nullable String name
-    ) throws FileNotFoundException {
+        final @NotNull FileInputStream delegate, final @Nullable String name)
+        throws FileNotFoundException {
       return new SentryFileInputStream(
-        init(name != null ? new File(name) : null, delegate, HubAdapter.getInstance()));
+          init(name != null ? new File(name) : null, delegate, HubAdapter.getInstance()));
     }
 
     public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
-      final @Nullable File file
-    ) throws FileNotFoundException {
+        final @NotNull FileInputStream delegate, final @Nullable File file)
+        throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate, HubAdapter.getInstance()));
     }
 
     public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
-      final @NotNull FileDescriptor descriptor
-    ) {
-      return new SentryFileInputStream(init(descriptor, delegate, HubAdapter.getInstance()),
-        descriptor);
+        final @NotNull FileInputStream delegate, final @NotNull FileDescriptor descriptor) {
+      return new SentryFileInputStream(
+          init(descriptor, delegate, HubAdapter.getInstance()), descriptor);
     }
 
     public static FileInputStream create(
-      final @NotNull FileInputStream delegate,
-      final @Nullable File file,
-      final @NotNull IHub hub
-    ) throws FileNotFoundException {
+        final @NotNull FileInputStream delegate, final @Nullable File file, final @NotNull IHub hub)
+        throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate, hub));
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Note, that span is started when this InputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileInputStream#close()} is called.
  */
-final class SentryFileInputStream extends FileInputStream {
+public final class SentryFileInputStream extends FileInputStream {
 
   private final @NotNull FileInputStream delegate;
   private final @NotNull FileIOSpanManager spanManager;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -1,7 +1,10 @@
 package io.sentry.instrumentation.file;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.HubAdapter;
+import io.sentry.IHub;
 import io.sentry.ISpan;
+import io.sentry.util.Pair;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
@@ -24,15 +27,29 @@ public class SentryFileInputStream extends FileInputStream {
   private final @NotNull FileIOSpanManager spanManager;
 
   public SentryFileInputStream(final @Nullable String name) throws FileNotFoundException {
-    this(init(name != null ? new File(name) : null, null));
+    this(name != null ? new File(name) : null, HubAdapter.getInstance());
   }
 
   public SentryFileInputStream(final @Nullable File file) throws FileNotFoundException {
-    this(init(file, null));
+    this(file, HubAdapter.getInstance());
   }
 
   public SentryFileInputStream(final @NotNull FileDescriptor fdObj) {
-    this(init(fdObj, null), fdObj);
+    this(fdObj, HubAdapter.getInstance());
+  }
+
+  public SentryFileInputStream(final @Nullable String name, final @NotNull IHub hub)
+    throws FileNotFoundException {
+    this(init(name != null ? new File(name) : null, null, hub));
+  }
+
+  public SentryFileInputStream(final @Nullable File file, final @NotNull IHub hub)
+    throws FileNotFoundException {
+    this(init(file, null, hub));
+  }
+
+  public SentryFileInputStream(final @NotNull FileDescriptor fdObj, final @NotNull IHub hub) {
+    this(init(fdObj, null, hub), fdObj);
   }
 
   private SentryFileInputStream(
@@ -40,7 +57,7 @@ public class SentryFileInputStream extends FileInputStream {
     final @NotNull FileDescriptor fd
   ) {
     super(fd);
-    spanManager = new FileIOSpanManager(data.span, data.file);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
     delegate = data.delegate;
   }
 
@@ -48,50 +65,64 @@ public class SentryFileInputStream extends FileInputStream {
     final @NotNull FileInputStreamInitData data
   ) throws FileNotFoundException {
     super(data.file);
-    spanManager = new FileIOSpanManager(data.span, data.file);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
     delegate = data.delegate;
   }
 
   private static FileInputStreamInitData init(
     final @Nullable File file,
-    @Nullable FileInputStream delegate
+    @Nullable FileInputStream delegate,
+    final @NotNull IHub hub
   ) throws FileNotFoundException {
-    final ISpan span = FileIOSpanManager.startSpan("file.read");
+    final ISpan span = FileIOSpanManager.startSpan(hub, "file.read");
     if (delegate == null) {
       delegate = new FileInputStream(file);
     }
-    return new FileInputStreamInitData(file, span, delegate);
+    return new FileInputStreamInitData(file, span, delegate, hub);
   }
 
   private static FileInputStreamInitData init(
     final @NotNull FileDescriptor fd,
-    @Nullable FileInputStream delegate
+    @Nullable FileInputStream delegate,
+    final @NotNull IHub hub
   ) {
-    final ISpan span = FileIOSpanManager.startSpan("file.read");
+    final ISpan span = FileIOSpanManager.startSpan(hub, "file.read");
     if (delegate == null) {
       delegate = new FileInputStream(fd);
     }
-    return new FileInputStreamInitData(null, span, delegate);
+    return new FileInputStreamInitData(null, span, delegate, hub);
   }
 
   @Override
   public int read() throws IOException {
-    return spanManager.performIO(delegate::read);
+    return spanManager.performIO(() -> {
+      int result = delegate.read();
+      return new Pair<>(result, 1);
+    });
   }
 
   @Override
   public int read(final byte @NotNull [] b) throws IOException {
-    return spanManager.performIO(delegate::read);
+    return spanManager.performIO(() -> {
+      int result = delegate.read(b);
+      return new Pair<>(result, b.length);
+    });
   }
 
   @Override
   public int read(final byte @NotNull [] b, final int off, final int len) throws IOException {
-    return spanManager.performIO(delegate::read);
+    return spanManager.performIO(() -> {
+      int result = delegate.read(b, off, len);
+      return new Pair<>(result, len);
+    });
   }
 
   @Override
   public long skip(final long n) throws IOException {
-    return spanManager.performIO(() -> delegate.skip(n));
+    return spanManager.performIO(() -> {
+      long result = delegate.skip(n);
+      return new Pair<>(result, result);
+    });
   }
 
   @Override
@@ -104,21 +135,49 @@ public class SentryFileInputStream extends FileInputStream {
       final @NotNull FileInputStream delegate,
       final @Nullable String name
     ) throws FileNotFoundException {
-      return new SentryFileInputStream(init(name != null ? new File(name) : null, delegate));
+      return new SentryFileInputStream(
+        init(name != null ? new File(name) : null, delegate, HubAdapter.getInstance()));
     }
 
     public static FileInputStream create(
       final @NotNull FileInputStream delegate,
       final @Nullable File file
     ) throws FileNotFoundException {
-      return new SentryFileInputStream(init(file, delegate));
+      return new SentryFileInputStream(init(file, delegate, HubAdapter.getInstance()));
     }
 
     public static FileInputStream create(
       final @NotNull FileInputStream delegate,
       final @NotNull FileDescriptor descriptor
     ) {
-      return new SentryFileInputStream(init(descriptor, delegate), descriptor);
+      return new SentryFileInputStream(init(descriptor, delegate, HubAdapter.getInstance()),
+        descriptor);
+    }
+
+    public static FileInputStream create(
+      final @NotNull FileInputStream delegate,
+      final @Nullable String name,
+      final @NotNull IHub hub
+    ) throws FileNotFoundException {
+      return new SentryFileInputStream(
+        init(name != null ? new File(name) : null, delegate, hub));
+    }
+
+    public static FileInputStream create(
+      final @NotNull FileInputStream delegate,
+      final @Nullable File file,
+      final @NotNull IHub hub
+    ) throws FileNotFoundException {
+      return new SentryFileInputStream(init(file, delegate, hub));
+    }
+
+    public static FileInputStream create(
+      final @NotNull FileInputStream delegate,
+      final @NotNull FileDescriptor descriptor,
+      final @NotNull IHub hub
+    ) {
+      return new SentryFileInputStream(init(descriptor, delegate, hub),
+        descriptor);
     }
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -31,21 +31,21 @@ public class SentryFileInputStream extends FileInputStream {
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
 
-  public SentryFileInputStream(@Nullable String name) throws FileNotFoundException {
+  public SentryFileInputStream(final @Nullable String name) throws FileNotFoundException {
     this(init(name != null ? new File(name) : null, null));
   }
 
-  public SentryFileInputStream(@Nullable File file) throws FileNotFoundException {
+  public SentryFileInputStream(final @Nullable File file) throws FileNotFoundException {
     this(init(file, null));
   }
 
-  public SentryFileInputStream(@NotNull FileDescriptor fdObj) {
+  public SentryFileInputStream(final @NotNull FileDescriptor fdObj) {
     this(init(fdObj, null), fdObj);
   }
 
   private SentryFileInputStream(
-    @NotNull FileInputStreamInitData data,
-    @NotNull FileDescriptor fd
+    final @NotNull FileInputStreamInitData data,
+    final @NotNull FileDescriptor fd
   ) {
     super(fd);
     file = null;
@@ -54,7 +54,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   private SentryFileInputStream(
-    @NotNull FileInputStreamInitData data
+    final @NotNull FileInputStreamInitData data
   ) throws FileNotFoundException {
     super(data.file);
     currentSpan = data.span;
@@ -63,7 +63,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   private static FileInputStreamInitData init(
-    @Nullable File file,
+    final @Nullable File file,
     @Nullable FileInputStream delegate
   ) throws FileNotFoundException {
     final ISpan span = startSpan();
@@ -74,7 +74,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   private static FileInputStreamInitData init(
-    @NotNull FileDescriptor fd,
+    final @NotNull FileDescriptor fd,
     @Nullable FileInputStream delegate
   ) {
     final ISpan span = startSpan();
@@ -106,7 +106,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   @Override
-  public int read(byte @NotNull [] b) throws IOException {
+  public int read(final byte @NotNull [] b) throws IOException {
     try {
       int result = delegate.read(b);
       if (result != -1) {
@@ -120,7 +120,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   @Override
-  public int read(byte @NotNull [] b, int off, int len) throws IOException {
+  public int read(final byte @NotNull [] b, final int off, final int len) throws IOException {
     try {
       int result = delegate.read(b, off, len);
       if (result != -1) {
@@ -134,7 +134,7 @@ public class SentryFileInputStream extends FileInputStream {
   }
 
   @Override
-  public long skip(long n) throws IOException {
+  public long skip(final long n) throws IOException {
     try {
       long result = delegate.skip(n);
       byteCount += result;
@@ -173,22 +173,22 @@ public class SentryFileInputStream extends FileInputStream {
 
   public final static class Factory {
     public static FileInputStream create(
-      @NotNull FileInputStream delegate,
-      @Nullable String name
+      final @NotNull FileInputStream delegate,
+      final @Nullable String name
     ) throws FileNotFoundException {
       return new SentryFileInputStream(init(name != null ? new File(name) : null, delegate));
     }
 
     public static FileInputStream create(
-      @NotNull FileInputStream delegate,
-      @Nullable File file
+      final @NotNull FileInputStream delegate,
+      final @Nullable File file
     ) throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate));
     }
 
     public static FileInputStream create(
-      @NotNull FileInputStream delegate,
-      @NotNull FileDescriptor descriptor
+      final @NotNull FileInputStream delegate,
+      final @NotNull FileDescriptor descriptor
     ) {
       return new SentryFileInputStream(init(descriptor, delegate), descriptor);
     }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -74,8 +74,6 @@ public class SentryFileInputStream extends FileInputStream {
     if (delegate == null) {
       delegate = new FileInputStream(fd);
     }
-    // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
-    // running on Android, should we do that?
     return new FileInputStreamInitData(null, span, delegate);
   }
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -91,8 +91,9 @@ final class SentryFileInputStream extends FileInputStream {
     AtomicInteger result = new AtomicInteger(0);
     spanManager.performIO(
         () -> {
-          result.set(delegate.read());
-          return result.get() != -1 ? 1 : 0;
+          final int res = delegate.read();
+          result.set(res);
+          return res != -1 ? 1 : 0;
         });
     return result.get();
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -1,6 +1,5 @@
 package io.sentry.instrumentation.file;
 
-import com.jakewharton.nopen.annotation.Open;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -49,16 +48,14 @@ final class SentryFileInputStream extends FileInputStream {
   private SentryFileInputStream(
       final @NotNull FileInputStreamInitData data, final @NotNull FileDescriptor fd) {
     super(fd);
-    spanManager =
-      new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
   private SentryFileInputStream(final @NotNull FileInputStreamInitData data)
       throws FileNotFoundException {
     super(data.file);
-    spanManager =
-      new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
@@ -80,8 +77,7 @@ final class SentryFileInputStream extends FileInputStream {
     if (delegate == null) {
       delegate = new FileInputStream(fd);
     }
-    return new FileInputStreamInitData(null, span, delegate,
-      hub.getOptions().isSendDefaultPii());
+    return new FileInputStreamInitData(null, span, delegate, hub.getOptions().isSendDefaultPii());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -39,7 +39,7 @@ public class SentryFileInputStream extends FileInputStream {
     this(init(file, null));
   }
 
-  public SentryFileInputStream(FileDescriptor fdObj) {
+  public SentryFileInputStream(@NotNull FileDescriptor fdObj) {
     this(init(fdObj, null), fdObj);
   }
 
@@ -82,12 +82,11 @@ public class SentryFileInputStream extends FileInputStream {
       delegate = new FileInputStream(fd);
     }
     // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
-    // TODO: running on Android, should we do that?
+    // running on Android, should we do that?
     return new FileInputStreamInitData(null, span, delegate);
   }
 
-  private static @Nullable
-  ISpan startSpan() {
+  private static @Nullable ISpan startSpan() {
     final ISpan parent = Sentry.getSpan();
     return parent != null ? parent.startChild("file.read") : null;
   }
@@ -175,21 +174,21 @@ public class SentryFileInputStream extends FileInputStream {
   public final static class Factory {
     public static FileInputStream create(
       @NotNull FileInputStream delegate,
-      String name
+      @Nullable String name
     ) throws FileNotFoundException {
       return new SentryFileInputStream(init(name != null ? new File(name) : null, delegate));
     }
 
     public static FileInputStream create(
       @NotNull FileInputStream delegate,
-      File file
+      @Nullable File file
     ) throws FileNotFoundException {
       return new SentryFileInputStream(init(file, delegate));
     }
 
     public static FileInputStream create(
       @NotNull FileInputStream delegate,
-      FileDescriptor descriptor
+      @NotNull FileDescriptor descriptor
     ) {
       return new SentryFileInputStream(init(descriptor, delegate), descriptor);
     }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -1,0 +1,197 @@
+package io.sentry.instrumentation.file;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.ISpan;
+import io.sentry.Sentry;
+import io.sentry.SpanStatus;
+import io.sentry.util.StringUtils;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An implementation of {@link java.io.FileInputStream} that creates a {@link io.sentry.ISpan} for
+ * reading operation with filename and byte count set as description
+ *
+ * Note, that span is started when this InputStream is instantiated via constructor and finishes
+ * when the {@link java.io.FileInputStream#close()} is called.
+ */
+@SuppressWarnings("unused") // used via bytecode manipulation (SAGP)
+@Open
+public class SentryFileInputStream extends FileInputStream {
+
+  private final @Nullable ISpan currentSpan;
+  private final @Nullable File file;
+  private final @NotNull FileInputStream delegate;
+
+  private @NotNull SpanStatus spanStatus = SpanStatus.OK;
+  private long byteCount;
+
+  public SentryFileInputStream(@Nullable String name) throws FileNotFoundException {
+    this(init(name != null ? new File(name) : null, null));
+  }
+
+  public SentryFileInputStream(@Nullable File file) throws FileNotFoundException {
+    this(init(file, null));
+  }
+
+  public SentryFileInputStream(FileDescriptor fdObj) {
+    this(init(fdObj, null), fdObj);
+  }
+
+  private SentryFileInputStream(
+    @NotNull FileInputStreamInitData data,
+    @NotNull FileDescriptor fd
+  ) {
+    super(fd);
+    file = null;
+    currentSpan = data.span;
+    delegate = data.delegate;
+  }
+
+  private SentryFileInputStream(
+    @NotNull FileInputStreamInitData data
+  ) throws FileNotFoundException {
+    super(data.file);
+    currentSpan = data.span;
+    file = data.file;
+    delegate = data.delegate;
+  }
+
+  private static FileInputStreamInitData init(
+    @Nullable File file,
+    @Nullable FileInputStream delegate
+  ) throws FileNotFoundException {
+    final ISpan span = startSpan();
+    if (delegate == null) {
+      delegate = new FileInputStream(file);
+    }
+    return new FileInputStreamInitData(file, span, delegate);
+  }
+
+  private static FileInputStreamInitData init(
+    @NotNull FileDescriptor fd,
+    @Nullable FileInputStream delegate
+  ) {
+    final ISpan span = startSpan();
+    if (delegate == null) {
+      delegate = new FileInputStream(fd);
+    }
+    // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
+    // TODO: running on Android, should we do that?
+    return new FileInputStreamInitData(null, span, delegate);
+  }
+
+  private static @Nullable
+  ISpan startSpan() {
+    final ISpan parent = Sentry.getSpan();
+    return parent != null ? parent.startChild("file.read") : null;
+  }
+
+  @Override
+  public int read() throws IOException {
+    try {
+      int result = delegate.read();
+      if (result != -1) {
+        byteCount++;
+      }
+      return result;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override
+  public int read(byte @NotNull [] b) throws IOException {
+    try {
+      int result = delegate.read(b);
+      if (result != -1) {
+        byteCount += result;
+      }
+      return result;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override
+  public int read(byte @NotNull [] b, int off, int len) throws IOException {
+    try {
+      int result = delegate.read(b, off, len);
+      if (result != -1) {
+        byteCount += result;
+      }
+      return result;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    try {
+      long result = delegate.skip(n);
+      byteCount += result;
+      return result;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      delegate.close();
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+    finishSpan();
+  }
+
+  private void finishSpan() {
+    if (currentSpan != null) {
+      if (file != null) {
+        String description = file.getName()
+          + " "
+          + "("
+          + StringUtils.byteCountToString(byteCount)
+          + ")";
+        currentSpan.setDescription(description);
+        currentSpan.setData("filepath", file.getAbsolutePath());
+      }
+      currentSpan.finish(spanStatus);
+    }
+  }
+
+  public final static class Factory {
+    public static FileInputStream create(
+      @NotNull FileInputStream delegate,
+      String name
+    ) throws FileNotFoundException {
+      return new SentryFileInputStream(init(name != null ? new File(name) : null, delegate));
+    }
+
+    public static FileInputStream create(
+      @NotNull FileInputStream delegate,
+      File file
+    ) throws FileNotFoundException {
+      return new SentryFileInputStream(init(file, delegate));
+    }
+
+    public static FileInputStream create(
+      @NotNull FileInputStream delegate,
+      FileDescriptor descriptor
+    ) {
+      return new SentryFileInputStream(init(descriptor, delegate), descriptor);
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -100,7 +100,7 @@ public class SentryFileInputStream extends FileInputStream {
   public int read(final byte @NotNull [] b) throws IOException {
     return spanManager.performIO(() -> {
       int result = delegate.read(b);
-      return new Pair<>(result, b.length);
+      return new Pair<>(result, result);
     });
   }
 
@@ -108,7 +108,7 @@ public class SentryFileInputStream extends FileInputStream {
   public int read(final byte @NotNull [] b, final int off, final int len) throws IOException {
     return spanManager.performIO(() -> {
       int result = delegate.read(b, off, len);
-      return new Pair<>(result, len);
+      return new Pair<>(result, result);
     });
   }
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -20,8 +20,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Note, that span is started when this InputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileInputStream#close()} is called.
  */
-@Open
-public class SentryFileInputStream extends FileInputStream {
+final class SentryFileInputStream extends FileInputStream {
 
   private final @NotNull FileInputStream delegate;
   private final @NotNull FileIOSpanManager spanManager;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -50,14 +50,16 @@ public class SentryFileInputStream extends FileInputStream {
   private SentryFileInputStream(
       final @NotNull FileInputStreamInitData data, final @NotNull FileDescriptor fd) {
     super(fd);
-    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
+    spanManager =
+      new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
   private SentryFileInputStream(final @NotNull FileInputStreamInitData data)
       throws FileNotFoundException {
     super(data.file);
-    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
+    spanManager =
+      new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
@@ -68,7 +70,7 @@ public class SentryFileInputStream extends FileInputStream {
     if (delegate == null) {
       delegate = new FileInputStream(file);
     }
-    return new FileInputStreamInitData(file, span, delegate, hub);
+    return new FileInputStreamInitData(file, span, delegate, hub.getOptions().isSendDefaultPii());
   }
 
   private static FileInputStreamInitData init(
@@ -79,7 +81,8 @@ public class SentryFileInputStream extends FileInputStream {
     if (delegate == null) {
       delegate = new FileInputStream(fd);
     }
-    return new FileInputStreamInitData(null, span, delegate, hub);
+    return new FileInputStreamInitData(null, span, delegate,
+      hub.getOptions().isSendDefaultPii());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -55,14 +55,14 @@ public class SentryFileOutputStream extends FileOutputStream {
   private SentryFileOutputStream(
       final @NotNull FileOutputStreamInitData data, final @NotNull FileDescriptor fd) {
     super(fd);
-    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
   private SentryFileOutputStream(final @NotNull FileOutputStreamInitData data)
       throws FileNotFoundException {
     super(data.file, data.append);
-    spanManager = new FileIOSpanManager(data.span, data.file, data.hub);
+    spanManager = new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
 
@@ -76,7 +76,8 @@ public class SentryFileOutputStream extends FileOutputStream {
     if (delegate == null) {
       delegate = new FileOutputStream(file);
     }
-    return new FileOutputStreamInitData(file, append, span, delegate, hub);
+    return new FileOutputStreamInitData(file, append, span, delegate,
+      hub.getOptions().isSendDefaultPii());
   }
 
   private static FileOutputStreamInitData init(
@@ -85,7 +86,8 @@ public class SentryFileOutputStream extends FileOutputStream {
     if (delegate == null) {
       delegate = new FileOutputStream(fd);
     }
-    return new FileOutputStreamInitData(null, false, span, delegate, hub);
+    return new FileOutputStreamInitData(null, false, span, delegate,
+      hub.getOptions().isSendDefaultPii());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.Nullable;
  * Note, that span is started when this OutputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileOutputStream#close()} is called.
  */
-@SuppressWarnings("unused") // used via bytecode manipulation (SAGP)
 @Open
 public class SentryFileOutputStream extends FileOutputStream {
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -1,0 +1,196 @@
+package io.sentry.instrumentation.file;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.ISpan;
+import io.sentry.Sentry;
+import io.sentry.SpanStatus;
+import io.sentry.util.StringUtils;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An implementation of {@link java.io.FileOutputStream} that creates a {@link io.sentry.ISpan} for
+ * writing operation with filename and byte count set as description
+ *
+ * Note, that span is started when this OutputStream is instantiated via constructor and finishes
+ * when the {@link java.io.FileOutputStream#close()} is called.
+ */
+@SuppressWarnings("unused") // used via bytecode manipulation (SAGP)
+@Open
+public class SentryFileOutputStream extends FileOutputStream {
+
+  private final @Nullable ISpan currentSpan;
+  private final @Nullable File file;
+  private final @NotNull FileOutputStream delegate;
+
+  private @NotNull SpanStatus spanStatus = SpanStatus.OK;
+  private long byteCount;
+
+  public SentryFileOutputStream(String name) throws FileNotFoundException {
+    this(init(name != null ? new File(name) : null, false, null));
+  }
+
+  public SentryFileOutputStream(String name, boolean append) throws FileNotFoundException {
+    this(init(name != null ? new File(name) : null, append, null));
+  }
+
+  public SentryFileOutputStream(File file) throws FileNotFoundException {
+    this(init(file, false, null));
+  }
+
+  public SentryFileOutputStream(File file, boolean append) throws FileNotFoundException {
+    this(init(file, append, null));
+  }
+
+  public SentryFileOutputStream(FileDescriptor fdObj) {
+    this(init(fdObj, null), fdObj);
+  }
+
+  private SentryFileOutputStream(
+    @NotNull FileOutputStreamInitData data,
+    @NotNull FileDescriptor fd
+  ) {
+    super(fd);
+    file = null;
+    currentSpan = data.span;
+    delegate = data.delegate;
+  }
+
+  private SentryFileOutputStream(
+    @NotNull FileOutputStreamInitData data
+  ) throws FileNotFoundException {
+    super(data.file, data.append);
+    currentSpan = data.span;
+    file = data.file;
+    delegate = data.delegate;
+  }
+
+  private static FileOutputStreamInitData init(
+    @Nullable File file,
+    boolean append,
+    @Nullable FileOutputStream delegate
+  ) throws FileNotFoundException {
+    final ISpan span = startSpan();
+    if (delegate == null) {
+      delegate = new FileOutputStream(file);
+    }
+    return new FileOutputStreamInitData(file, append, span, delegate);
+  }
+
+  private static FileOutputStreamInitData init(
+    @NotNull FileDescriptor fd,
+    @Nullable FileOutputStream delegate
+  ) {
+    final ISpan span = startSpan();
+    if (delegate == null) {
+      delegate = new FileOutputStream(fd);
+    }
+    // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
+    // TODO: running on Android, should we do that?
+    return new FileOutputStreamInitData(null, false, span, delegate);
+  }
+
+  private static @Nullable ISpan startSpan() {
+    final ISpan parent = Sentry.getSpan();
+    return parent != null ? parent.startChild("file.write") : null;
+  }
+
+  @Override public void write(int b) throws IOException {
+    try {
+      delegate.write(b);
+      byteCount++;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override public void write(byte[] b) throws IOException {
+    try {
+      delegate.write(b);
+      byteCount += b.length;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override public void write(byte[] b, int off, int len) throws IOException {
+    try {
+      delegate.write(b, off, len);
+      byteCount += len;
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+  }
+
+  @Override public void close() throws IOException {
+    try {
+      delegate.close();
+    } catch (IOException exception) {
+      spanStatus = SpanStatus.INTERNAL_ERROR;
+      throw exception;
+    }
+    finishSpan();
+  }
+
+  private void finishSpan() {
+    if (currentSpan != null) {
+      if (file != null) {
+        String description = file.getName()
+          + " "
+          + "("
+          + StringUtils.byteCountToString(byteCount)
+          + ")";
+        currentSpan.setDescription(description);
+        currentSpan.setData("filepath", file.getAbsolutePath());
+      }
+      currentSpan.finish(spanStatus);
+    }
+  }
+
+  public final static class Factory {
+    public static FileOutputStream create(
+      @NotNull FileOutputStream delegate,
+      String name
+    ) throws FileNotFoundException {
+      return new SentryFileOutputStream(
+        init(name != null ? new File(name) : null, false, delegate));
+    }
+
+    public static FileOutputStream create(
+      @NotNull FileOutputStream delegate,
+      String name,
+      boolean append
+    ) throws FileNotFoundException {
+      return new SentryFileOutputStream(
+        init(name != null ? new File(name) : null, append, delegate));
+    }
+
+    public static FileOutputStream create(
+      @NotNull FileOutputStream delegate,
+      File file
+    ) throws FileNotFoundException {
+      return new SentryFileOutputStream(init(file, false, delegate));
+    }
+
+    public static FileOutputStream create(
+      @NotNull FileOutputStream delegate,
+      File file,
+      boolean append
+    ) throws FileNotFoundException {
+      return new SentryFileOutputStream(init(file, append, delegate));
+    }
+
+    public static FileOutputStream create(@NotNull FileOutputStream delegate,
+      FileDescriptor fdObj) {
+      return new SentryFileOutputStream(init(fdObj, delegate), fdObj);
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -19,8 +19,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Note, that span is started when this OutputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileOutputStream#close()} is called.
  */
-@Open
-public class SentryFileOutputStream extends FileOutputStream {
+final class SentryFileOutputStream extends FileOutputStream {
 
   private final @NotNull FileOutputStream delegate;
   private final @NotNull FileIOSpanManager spanManager;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -31,23 +31,24 @@ public class SentryFileOutputStream extends FileOutputStream {
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
 
-  public SentryFileOutputStream(String name) throws FileNotFoundException {
+  public SentryFileOutputStream(@Nullable String name) throws FileNotFoundException {
     this(init(name != null ? new File(name) : null, false, null));
   }
 
-  public SentryFileOutputStream(String name, boolean append) throws FileNotFoundException {
+  public SentryFileOutputStream(@Nullable String name, boolean append)
+    throws FileNotFoundException {
     this(init(name != null ? new File(name) : null, append, null));
   }
 
-  public SentryFileOutputStream(File file) throws FileNotFoundException {
+  public SentryFileOutputStream(@Nullable File file) throws FileNotFoundException {
     this(init(file, false, null));
   }
 
-  public SentryFileOutputStream(File file, boolean append) throws FileNotFoundException {
+  public SentryFileOutputStream(@Nullable File file, boolean append) throws FileNotFoundException {
     this(init(file, append, null));
   }
 
-  public SentryFileOutputStream(FileDescriptor fdObj) {
+  public SentryFileOutputStream(@NotNull FileDescriptor fdObj) {
     this(init(fdObj, null), fdObj);
   }
 
@@ -91,7 +92,7 @@ public class SentryFileOutputStream extends FileOutputStream {
       delegate = new FileOutputStream(fd);
     }
     // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
-    // TODO: running on Android, should we do that?
+    // running on Android, should we do that?
     return new FileOutputStreamInitData(null, false, span, delegate);
   }
 
@@ -110,7 +111,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     }
   }
 
-  @Override public void write(byte[] b) throws IOException {
+  @Override public void write(byte @NotNull [] b) throws IOException {
     try {
       delegate.write(b);
       byteCount += b.length;
@@ -120,7 +121,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     }
   }
 
-  @Override public void write(byte[] b, int off, int len) throws IOException {
+  @Override public void write(byte @NotNull [] b, int off, int len) throws IOException {
     try {
       delegate.write(b, off, len);
       byteCount += len;
@@ -158,7 +159,7 @@ public class SentryFileOutputStream extends FileOutputStream {
   public final static class Factory {
     public static FileOutputStream create(
       @NotNull FileOutputStream delegate,
-      String name
+      @Nullable String name
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(
         init(name != null ? new File(name) : null, false, delegate));
@@ -166,7 +167,7 @@ public class SentryFileOutputStream extends FileOutputStream {
 
     public static FileOutputStream create(
       @NotNull FileOutputStream delegate,
-      String name,
+      @Nullable String name,
       boolean append
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(
@@ -175,21 +176,21 @@ public class SentryFileOutputStream extends FileOutputStream {
 
     public static FileOutputStream create(
       @NotNull FileOutputStream delegate,
-      File file
+      @Nullable File file
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(init(file, false, delegate));
     }
 
     public static FileOutputStream create(
       @NotNull FileOutputStream delegate,
-      File file,
+      @Nullable File file,
       boolean append
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(init(file, append, delegate));
     }
 
     public static FileOutputStream create(@NotNull FileOutputStream delegate,
-      FileDescriptor fdObj) {
+      @NotNull FileDescriptor fdObj) {
       return new SentryFileOutputStream(init(fdObj, delegate), fdObj);
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -31,30 +31,31 @@ public class SentryFileOutputStream extends FileOutputStream {
   private @NotNull SpanStatus spanStatus = SpanStatus.OK;
   private long byteCount;
 
-  public SentryFileOutputStream(@Nullable String name) throws FileNotFoundException {
+  public SentryFileOutputStream(final @Nullable String name) throws FileNotFoundException {
     this(init(name != null ? new File(name) : null, false, null));
   }
 
-  public SentryFileOutputStream(@Nullable String name, boolean append)
+  public SentryFileOutputStream(final @Nullable String name, final boolean append)
     throws FileNotFoundException {
     this(init(name != null ? new File(name) : null, append, null));
   }
 
-  public SentryFileOutputStream(@Nullable File file) throws FileNotFoundException {
+  public SentryFileOutputStream(final @Nullable File file) throws FileNotFoundException {
     this(init(file, false, null));
   }
 
-  public SentryFileOutputStream(@Nullable File file, boolean append) throws FileNotFoundException {
+  public SentryFileOutputStream(final @Nullable File file, final boolean append)
+    throws FileNotFoundException {
     this(init(file, append, null));
   }
 
-  public SentryFileOutputStream(@NotNull FileDescriptor fdObj) {
+  public SentryFileOutputStream(final @NotNull FileDescriptor fdObj) {
     this(init(fdObj, null), fdObj);
   }
 
   private SentryFileOutputStream(
-    @NotNull FileOutputStreamInitData data,
-    @NotNull FileDescriptor fd
+    final @NotNull FileOutputStreamInitData data,
+    final @NotNull FileDescriptor fd
   ) {
     super(fd);
     file = null;
@@ -63,7 +64,7 @@ public class SentryFileOutputStream extends FileOutputStream {
   }
 
   private SentryFileOutputStream(
-    @NotNull FileOutputStreamInitData data
+    final @NotNull FileOutputStreamInitData data
   ) throws FileNotFoundException {
     super(data.file, data.append);
     currentSpan = data.span;
@@ -72,8 +73,8 @@ public class SentryFileOutputStream extends FileOutputStream {
   }
 
   private static FileOutputStreamInitData init(
-    @Nullable File file,
-    boolean append,
+    final @Nullable File file,
+    final boolean append,
     @Nullable FileOutputStream delegate
   ) throws FileNotFoundException {
     final ISpan span = startSpan();
@@ -84,7 +85,7 @@ public class SentryFileOutputStream extends FileOutputStream {
   }
 
   private static FileOutputStreamInitData init(
-    @NotNull FileDescriptor fd,
+    final @NotNull FileDescriptor fd,
     @Nullable FileOutputStream delegate
   ) {
     final ISpan span = startSpan();
@@ -101,7 +102,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     return parent != null ? parent.startChild("file.write") : null;
   }
 
-  @Override public void write(int b) throws IOException {
+  @Override public void write(final int b) throws IOException {
     try {
       delegate.write(b);
       byteCount++;
@@ -111,7 +112,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     }
   }
 
-  @Override public void write(byte @NotNull [] b) throws IOException {
+  @Override public void write(final byte @NotNull [] b) throws IOException {
     try {
       delegate.write(b);
       byteCount += b.length;
@@ -121,7 +122,8 @@ public class SentryFileOutputStream extends FileOutputStream {
     }
   }
 
-  @Override public void write(byte @NotNull [] b, int off, int len) throws IOException {
+  @Override public void write(final byte @NotNull [] b, final int off, final int len)
+    throws IOException {
     try {
       delegate.write(b, off, len);
       byteCount += len;
@@ -158,39 +160,41 @@ public class SentryFileOutputStream extends FileOutputStream {
 
   public final static class Factory {
     public static FileOutputStream create(
-      @NotNull FileOutputStream delegate,
-      @Nullable String name
+      final @NotNull FileOutputStream delegate,
+      final @Nullable String name
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(
         init(name != null ? new File(name) : null, false, delegate));
     }
 
     public static FileOutputStream create(
-      @NotNull FileOutputStream delegate,
-      @Nullable String name,
-      boolean append
+      final @NotNull FileOutputStream delegate,
+      final @Nullable String name,
+      final boolean append
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(
         init(name != null ? new File(name) : null, append, delegate));
     }
 
     public static FileOutputStream create(
-      @NotNull FileOutputStream delegate,
-      @Nullable File file
+      final @NotNull FileOutputStream delegate,
+      final @Nullable File file
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(init(file, false, delegate));
     }
 
     public static FileOutputStream create(
-      @NotNull FileOutputStream delegate,
-      @Nullable File file,
-      boolean append
+      final @NotNull FileOutputStream delegate,
+      final @Nullable File file,
+      final boolean append
     ) throws FileNotFoundException {
       return new SentryFileOutputStream(init(file, append, delegate));
     }
 
-    public static FileOutputStream create(@NotNull FileOutputStream delegate,
-      @NotNull FileDescriptor fdObj) {
+    public static FileOutputStream create(
+      final @NotNull FileOutputStream delegate,
+      final @NotNull FileDescriptor fdObj
+    ) {
       return new SentryFileOutputStream(init(fdObj, delegate), fdObj);
     }
   }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -1,6 +1,5 @@
 package io.sentry.instrumentation.file;
 
-import com.jakewharton.nopen.annotation.Open;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -75,8 +74,8 @@ final class SentryFileOutputStream extends FileOutputStream {
     if (delegate == null) {
       delegate = new FileOutputStream(file);
     }
-    return new FileOutputStreamInitData(file, append, span, delegate,
-      hub.getOptions().isSendDefaultPii());
+    return new FileOutputStreamInitData(
+        file, append, span, delegate, hub.getOptions().isSendDefaultPii());
   }
 
   private static FileOutputStreamInitData init(
@@ -85,8 +84,8 @@ final class SentryFileOutputStream extends FileOutputStream {
     if (delegate == null) {
       delegate = new FileOutputStream(fd);
     }
-    return new FileOutputStreamInitData(null, false, span, delegate,
-      hub.getOptions().isSendDefaultPii());
+    return new FileOutputStreamInitData(
+        null, false, span, delegate, hub.getOptions().isSendDefaultPii());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -83,8 +83,6 @@ public class SentryFileOutputStream extends FileOutputStream {
     if (delegate == null) {
       delegate = new FileOutputStream(fd);
     }
-    // TODO: it's only possible to get filename from FileDescriptor via reflection AND when it's
-    // running on Android, should we do that?
     return new FileOutputStreamInitData(null, false, span, delegate);
   }
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Note, that span is started when this OutputStream is instantiated via constructor and finishes
  * when the {@link java.io.FileOutputStream#close()} is called.
  */
-final class SentryFileOutputStream extends FileOutputStream {
+public final class SentryFileOutputStream extends FileOutputStream {
 
   private final @NotNull FileOutputStream delegate;
   private final @NotNull FileIOSpanManager spanManager;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -1,7 +1,9 @@
 package io.sentry.instrumentation.file;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.HubAdapter;
 import io.sentry.ISpan;
+import io.sentry.util.Pair;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
@@ -50,7 +52,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     final @NotNull FileDescriptor fd
   ) {
     super(fd);
-    spanManager = new FileIOSpanManager(data.span, data.file);
+    spanManager = new FileIOSpanManager(data.span, data.file, HubAdapter.getInstance());
     delegate = data.delegate;
   }
 
@@ -58,7 +60,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     final @NotNull FileOutputStreamInitData data
   ) throws FileNotFoundException {
     super(data.file, data.append);
-    spanManager = new FileIOSpanManager(data.span, data.file);
+    spanManager = new FileIOSpanManager(data.span, data.file, HubAdapter.getInstance());
     delegate = data.delegate;
   }
 
@@ -67,7 +69,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     final boolean append,
     @Nullable FileOutputStream delegate
   ) throws FileNotFoundException {
-    final ISpan span = FileIOSpanManager.startSpan("file.write");
+    final ISpan span = FileIOSpanManager.startSpan(HubAdapter.getInstance(), "file.write");
     if (delegate == null) {
       delegate = new FileOutputStream(file);
     }
@@ -78,7 +80,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     final @NotNull FileDescriptor fd,
     @Nullable FileOutputStream delegate
   ) {
-    final ISpan span = FileIOSpanManager.startSpan("file.write");
+    final ISpan span = FileIOSpanManager.startSpan(HubAdapter.getInstance(), "file.write");
     if (delegate == null) {
       delegate = new FileOutputStream(fd);
     }
@@ -88,14 +90,14 @@ public class SentryFileOutputStream extends FileOutputStream {
   @Override public void write(final int b) throws IOException {
     spanManager.performIO(() -> {
       delegate.write(b);
-      return 1;
+      return new Pair<>(0, 1);
     });
   }
 
   @Override public void write(final byte @NotNull [] b) throws IOException {
     spanManager.performIO(() -> {
       delegate.write(b);
-      return b.length;
+      return new Pair<>(0, b.length);
     });
   }
 
@@ -103,7 +105,7 @@ public class SentryFileOutputStream extends FileOutputStream {
     throws IOException {
     spanManager.performIO(() -> {
       delegate.write(b, off, len);
-      return len;
+      return new Pair<>(0, len);
     });
   }
 

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -46,7 +46,7 @@ final class SentryFileOutputStream extends FileOutputStream {
     this(init(fdObj, null, HubAdapter.getInstance()), fdObj);
   }
 
-  public SentryFileOutputStream(final @Nullable File file, final @NotNull IHub hub)
+  SentryFileOutputStream(final @Nullable File file, final @NotNull IHub hub)
       throws FileNotFoundException {
     this(init(file, false, null, hub));
   }

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -70,6 +70,6 @@ public final class StringUtils {
       bytes /= 1000;
       ci.next();
     }
-    return String.format(Locale.US, "%.1f %cB", bytes / 1000.0, ci.current());
+    return String.format(Locale.ROOT, "%.1f %cB", bytes / 1000.0, ci.current());
   }
 }

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -1,5 +1,7 @@
 package io.sentry.util;
 
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -50,5 +52,23 @@ public final class StringUtils {
     } else {
       return str;
     }
+  }
+
+  /**
+   * Converts the given number of bytes to a human-readable string.
+   *
+   * @param bytes the number of bytes
+   * @return a string representing the human-readable byte count (e.g. 1kB, 20 MB, etc.)
+   */
+  public static String byteCountToString(long bytes) {
+    if (-1000 < bytes && bytes < 1000) {
+      return bytes + " B";
+    }
+    CharacterIterator ci = new StringCharacterIterator("kMGTPE");
+    while (bytes <= -999_950 || bytes >= 999_950) {
+      bytes /= 1000;
+      ci.next();
+    }
+    return String.format(Locale.US, "%.1f %cB", bytes / 1000.0, ci.current());
   }
 }

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -4,6 +4,7 @@ import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
@@ -60,7 +61,7 @@ public final class StringUtils {
    * @param bytes the number of bytes
    * @return a string representing the human-readable byte count (e.g. 1kB, 20 MB, etc.)
    */
-  public static String byteCountToString(long bytes) {
+  public static @NotNull String byteCountToString(long bytes) {
     if (-1000 < bytes && bytes < 1000) {
       return bytes + " B";
     }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -23,7 +23,7 @@ class SentryFileInputStreamTest {
         val hub = mock<IHub>()
         val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
 
-        fun getSut(
+        internal fun getSut(
             tmpFile: File? = null,
             activeTransaction: Boolean = true,
             delegate: FileInputStream? = null,

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -22,6 +22,7 @@ class SentryFileInputStreamTest {
     class Fixture {
         val hub = mock<IHub>()
         val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
+        private val options = SentryOptions()
 
         internal fun getSut(
             tmpFile: File? = null,
@@ -32,9 +33,7 @@ class SentryFileInputStreamTest {
         ): SentryFileInputStream {
             tmpFile?.writeText("Text")
             whenever(hub.options).thenReturn(
-                SentryOptions().apply {
-                    isSendDefaultPii = sendDefaultPii
-                }
+                options.apply { isSendDefaultPii = sendDefaultPii }
             )
             if (activeTransaction) {
                 whenever(hub.span).thenReturn(sentryTracer)

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -1,0 +1,206 @@
+package io.sentry.instrumentation.file
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.IHub
+import io.sentry.SentryOptions
+import io.sentry.SentryTracer
+import io.sentry.SpanStatus
+import io.sentry.SpanStatus.INTERNAL_ERROR
+import io.sentry.TransactionContext
+import io.sentry.util.Platform
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileDescriptor
+import java.io.FileInputStream
+import java.io.IOException
+import kotlin.test.assertEquals
+
+class SentryFileInputStreamTest {
+
+    class Fixture {
+        val hub = mock<IHub>()
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
+
+        fun getSut(
+            tmpFile: File? = null,
+            activeTransaction: Boolean = true,
+            delegate: FileInputStream? = null,
+            fileDescriptor: FileDescriptor? = null,
+            sendDefaultPii: Boolean = false
+        ): SentryFileInputStream {
+            tmpFile?.writeText("Text")
+            whenever(hub.options).thenReturn(SentryOptions().apply {
+                isSendDefaultPii = sendDefaultPii
+            })
+            if (activeTransaction) {
+                whenever(hub.span).thenReturn(sentryTracer)
+            }
+            return if (delegate == null) {
+                if (fileDescriptor == null) {
+                    SentryFileInputStream(tmpFile, hub)
+                } else {
+                    SentryFileInputStream(fileDescriptor, hub)
+                }
+            } else {
+                SentryFileInputStream.Factory.create(
+                    delegate,
+                    tmpFile,
+                    hub
+                ) as SentryFileInputStream
+            }
+        }
+    }
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    private val fixture = Fixture()
+
+    private val tmpFile: File get() = tmpDir.newFile("test.txt")
+
+    @Test
+    fun `when no active transaction does not capture a span`() {
+        fixture.getSut(tmpFile, activeTransaction = false)
+            .use { it.readAllBytes() }
+
+        assertEquals(fixture.sentryTracer.children.size, 0)
+    }
+
+    @Test
+    fun `when stream is not closed does not finish a span`() {
+        fixture.getSut(tmpFile)
+
+        assertEquals(fixture.sentryTracer.children.size, 1)
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.isFinished, false)
+    }
+
+    @Test
+    fun `when stream is closed captures a span`() {
+        val fis = fixture.getSut(tmpFile)
+        fis.close()
+
+        assertEquals(fixture.sentryTracer.children.size, 1)
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (0 B)")
+        assertEquals(fileIOSpan.data["file.size"], 0L)
+        assertEquals(fileIOSpan.throwable, null)
+        assertEquals(fileIOSpan.isFinished, true)
+        assertEquals(fileIOSpan.status, SpanStatus.OK)
+    }
+
+    @Test
+    fun `read one byte`() {
+        fixture.getSut(tmpFile).use { it.read() }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (1 B)")
+        assertEquals(fileIOSpan.data["file.size"], 1L)
+    }
+
+    @Test
+    fun `read array of bytes`() {
+        fixture.getSut(tmpFile).use { it.read(ByteArray(10)) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (10 B)")
+        assertEquals(fileIOSpan.data["file.size"], 10L)
+    }
+
+    @Test
+    fun `read array range of bytes`() {
+        fixture.getSut(tmpFile).use { it.read(ByteArray(10), 1, 3) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (3 B)")
+        assertEquals(fileIOSpan.data["file.size"], 3L)
+    }
+
+    @Test
+    fun `skip bytes`() {
+        fixture.getSut(tmpFile).use { it.skip(10) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (10 B)")
+        assertEquals(fileIOSpan.data["file.size"], 10L)
+    }
+
+    @Test
+    fun `read all bytes`() {
+        fixture.getSut(tmpFile).use { it.readAllBytes() }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (8.2 kB)")
+        assertEquals(fileIOSpan.data["file.size"], 8192L)
+    }
+
+    @Test
+    fun `when IO operation throws captures Throwable and sets status to INTERNAL_ERROR`() {
+        val file = tmpFile
+        val delegate = ThrowingFileInputStream(file)
+        try {
+            fixture.getSut(file, delegate = delegate).use { it.read() }
+        } catch (e: IOException) {
+            // ignored
+        }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.status, INTERNAL_ERROR)
+        assertEquals(fileIOSpan.throwable, delegate.throwable)
+    }
+
+    @Test
+    fun `when close() throws captures Throwable and sets status to INTERNAL_ERROR`() {
+        val file = tmpFile
+        val delegate = ThrowingFileInputStream(file)
+        try {
+            val fis = fixture.getSut(file, delegate = delegate)
+            fis.close()
+        } catch (e: IOException) {
+            // ignored
+        }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.status, INTERNAL_ERROR)
+        assertEquals(fileIOSpan.throwable, delegate.throwable)
+    }
+
+    @Test
+    fun `when instantiated with file descriptor only reports file size as description`() {
+        val file = tmpFile.apply { writeText("Text") }
+        val fd = FileInputStream(file).fd
+        fixture.getSut(fileDescriptor = fd).use { it.read() }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.description, "1 B")
+    }
+
+    @Test
+    fun `when run on JVM and sendDefaultPii is enabled reports file path`() {
+        val file = tmpFile
+        fixture.getSut(file, sendDefaultPii = true).use { it.readAllBytes() }
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.data["file.path"], file.absolutePath)
+    }
+
+    @After
+    fun tearDown() {
+        System.clearProperty("java.vendor")
+    }
+}
+
+class ThrowingFileInputStream(file: File) : FileInputStream(file) {
+    val throwable = IOException("Oops!")
+
+    override fun read(): Int {
+        throw throwable
+    }
+
+    override fun close() {
+        throw throwable
+    }
+}

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -107,8 +107,8 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.read(ByteArray(10)) }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (10 B)")
-        assertEquals(fileIOSpan.data["file.size"], 10L)
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.data["file.size"], 4L)
     }
 
     @Test
@@ -131,11 +131,11 @@ class SentryFileInputStreamTest {
 
     @Test
     fun `read all bytes`() {
-        fixture.getSut(tmpFile).use { it.readAllBytes() }
+        fixture.getSut(tmpFile).use { it.reader().readText() }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (8.2 kB)")
-        assertEquals(fileIOSpan.data["file.size"], 8192L)
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.data["file.size"], 4L)
     }
 
     @Test
@@ -185,11 +185,6 @@ class SentryFileInputStreamTest {
         fixture.getSut(file, sendDefaultPii = true).use { it.readAllBytes() }
         val fileIOSpan = fixture.sentryTracer.children.first()
         assertEquals(fileIOSpan.data["file.path"], file.absolutePath)
-    }
-
-    @After
-    fun tearDown() {
-        System.clearProperty("java.vendor")
     }
 }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -27,7 +27,6 @@ class SentryFileInputStreamTest {
         internal fun getSut(
             tmpFile: File? = null,
             activeTransaction: Boolean = true,
-            delegate: FileInputStream? = null,
             fileDescriptor: FileDescriptor? = null,
             sendDefaultPii: Boolean = false
         ): SentryFileInputStream {
@@ -38,19 +37,24 @@ class SentryFileInputStreamTest {
             if (activeTransaction) {
                 whenever(hub.span).thenReturn(sentryTracer)
             }
-            return if (delegate == null) {
-                if (fileDescriptor == null) {
-                    SentryFileInputStream(tmpFile, hub)
-                } else {
-                    SentryFileInputStream(fileDescriptor, hub)
-                }
+            return if (fileDescriptor == null) {
+                SentryFileInputStream(tmpFile, hub)
             } else {
-                SentryFileInputStream.Factory.create(
-                    delegate,
-                    tmpFile,
-                    hub
-                ) as SentryFileInputStream
+                SentryFileInputStream(fileDescriptor, hub)
             }
+        }
+
+        internal fun getSut(
+            tmpFile: File? = null,
+            delegate: FileInputStream
+        ): SentryFileInputStream {
+            whenever(hub.options).thenReturn(options)
+            whenever(hub.span).thenReturn(sentryTracer)
+            return SentryFileInputStream.Factory.create(
+                delegate,
+                tmpFile,
+                hub
+            ) as SentryFileInputStream
         }
     }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -8,8 +8,6 @@ import io.sentry.SentryTracer
 import io.sentry.SpanStatus
 import io.sentry.SpanStatus.INTERNAL_ERROR
 import io.sentry.TransactionContext
-import io.sentry.util.Platform
-import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -33,9 +31,11 @@ class SentryFileInputStreamTest {
             sendDefaultPii: Boolean = false
         ): SentryFileInputStream {
             tmpFile?.writeText("Text")
-            whenever(hub.options).thenReturn(SentryOptions().apply {
-                isSendDefaultPii = sendDefaultPii
-            })
+            whenever(hub.options).thenReturn(
+                SentryOptions().apply {
+                    isSendDefaultPii = sendDefaultPii
+                }
+            )
             if (activeTransaction) {
                 whenever(hub.span).thenReturn(sentryTracer)
             }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -18,7 +18,7 @@ class SentryFileOutputStreamTest {
         val hub = mock<IHub>()
         val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
 
-        fun getSut(
+        internal fun getSut(
             tmpFile: File? = null,
             activeTransaction: Boolean = true,
         ): SentryFileOutputStream {

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -37,7 +37,6 @@ class SentryFileOutputStreamTest {
 
     private val tmpFile: File get() = tmpDir.newFile("test.txt")
 
-
     @Test
     fun `when no active transaction does not capture a span`() {
         fixture.getSut(tmpFile, activeTransaction = false)

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -1,0 +1,107 @@
+package io.sentry.instrumentation.file
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.IHub
+import io.sentry.SentryOptions
+import io.sentry.SentryTracer
+import io.sentry.SpanStatus
+import io.sentry.TransactionContext
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertEquals
+
+class SentryFileOutputStreamTest {
+    class Fixture {
+        val hub = mock<IHub>()
+        val sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
+
+        fun getSut(
+            tmpFile: File? = null,
+            activeTransaction: Boolean = true,
+        ): SentryFileOutputStream {
+            whenever(hub.options).thenReturn(SentryOptions())
+            if (activeTransaction) {
+                whenever(hub.span).thenReturn(sentryTracer)
+            }
+            return SentryFileOutputStream(tmpFile, hub)
+        }
+    }
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    private val fixture = Fixture()
+
+    private val tmpFile: File get() = tmpDir.newFile("test.txt")
+
+
+    @Test
+    fun `when no active transaction does not capture a span`() {
+        fixture.getSut(tmpFile, activeTransaction = false)
+            .use { it.write("Text".toByteArray()) }
+
+        assertEquals(fixture.sentryTracer.children.size, 0)
+    }
+
+    @Test
+    fun `when stream is not closed does not finish a span`() {
+        fixture.getSut(tmpFile)
+
+        assertEquals(fixture.sentryTracer.children.size, 1)
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.isFinished, false)
+    }
+
+    @Test
+    fun `when stream is closed captures a span`() {
+        val fos = fixture.getSut(tmpFile)
+        fos.close()
+
+        assertEquals(fixture.sentryTracer.children.size, 1)
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (0 B)")
+        assertEquals(fileIOSpan.data["file.size"], 0L)
+        assertEquals(fileIOSpan.throwable, null)
+        assertEquals(fileIOSpan.isFinished, true)
+        assertEquals(fileIOSpan.status, SpanStatus.OK)
+    }
+
+    @Test
+    fun `write one byte`() {
+        fixture.getSut(tmpFile).use { it.write(29) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (1 B)")
+        assertEquals(fileIOSpan.data["file.size"], 1L)
+    }
+
+    @Test
+    fun `write array of bytes`() {
+        fixture.getSut(tmpFile).use { it.write(ByteArray(10)) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (10 B)")
+        assertEquals(fileIOSpan.data["file.size"], 10L)
+    }
+
+    @Test
+    fun `write array range of bytes`() {
+        fixture.getSut(tmpFile).use { it.write(ByteArray(10), 1, 3) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (3 B)")
+        assertEquals(fileIOSpan.data["file.size"], 3L)
+    }
+
+    @Test
+    fun `write all bytes`() {
+        fixture.getSut(tmpFile).use { it.write("Text".toByteArray()) }
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.data["file.size"], 4L)
+    }
+}

--- a/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
@@ -74,4 +74,26 @@ class StringUtilsTest {
     fun `removeSurrounding returns trimmed string if first char is the same as the last char and equal to delimiter`() {
         assertEquals("test", StringUtils.removeSurrounding("\"test\"", "\""))
     }
+
+    @Test
+    fun `byteCountToString appends B when byte count is in +-1000 range`() {
+        assertEquals("500 B", StringUtils.byteCountToString(500))
+        assertEquals("-500 B", StringUtils.byteCountToString(-500))
+    }
+
+    @Test
+    fun `byteCountToString appends kB when byte count is in kilobyte range`() {
+        assertEquals("100.5 kB", StringUtils.byteCountToString(100_500))
+        assertEquals("-100.5 kB", StringUtils.byteCountToString(-100_500))
+
+        assertEquals("999.0 kB", StringUtils.byteCountToString(999_000))
+    }
+
+    @Test
+    fun `byteCountToString appends MB when byte count is in megabyte range`() {
+        assertEquals("100.1 MB", StringUtils.byteCountToString(100_124_500))
+        assertEquals("-100.1 MB", StringUtils.byteCountToString(-100_124_500))
+
+        assertEquals("999.9 MB", StringUtils.byteCountToString(999_945_018))
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Added `SentryFileInputStream` implementation for `FileInputStream` instrumentation
* Added `SentryFileOutputStream` implementation for `FileOutputStream` instrumentation

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a supporting PR with runtime classes for File I/O instrumentation see https://github.com/getsentry/sentry-android-gradle-plugin/pull/239

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
* Will follow up with another PR for `FileReader/Writer`
* Will update docs to show how to manually use it