### PR TITLE
Feat: Add locale to device context and deprecate language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#1824)
+* Feat: Add locale to device context and deprecate language (#)
 
 ## 5.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Ref: Rename Fragment span operation from `ui.fragment.load` to `ui.load` (#1824)
-* Feat: Add locale to device context and deprecate language (#)
+* Feat: Add locale to device context and deprecate language (#1832)
 
 ## 5.4.3
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -310,8 +310,13 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (device.getId() == null) {
       device.setId(getDeviceId());
     }
+
+    final Locale locale = Locale.getDefault();
     if (device.getLanguage() == null) {
-      device.setLanguage(Locale.getDefault().toString()); // eg en_US
+      device.setLanguage(locale.getLanguage());
+    }
+    if (device.getLocale() == null) {
+      device.setLocale(locale.toString()); // eg en_US
     }
 
     return device;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -27,6 +27,7 @@ import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.test.getCtor
 import org.junit.runner.RunWith
+import java.util.*
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -374,6 +375,18 @@ class DefaultAndroidEventProcessorTest {
 //            assertNotNull(device.externalFreeStorage)
 //            assertNotNull(device.externalStorageSize)
 //            assertNotNull(device.connectionType)
+        }
+    }
+
+    @Test
+    fun `Event sets language and locale`() {
+        val sut = fixture.getSut(context)
+        val locale = Locale.getDefault()
+
+        assertNotNull(sut.process(SentryEvent(), null)) {
+            val device = it.contexts.device!!
+            assertEquals(device.language, locale.language)
+            assertEquals(device.locale, locale.toString())
         }
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -45,6 +45,10 @@ class DefaultAndroidEventProcessorTest {
     private val className = "io.sentry.android.core.DefaultAndroidEventProcessor"
     private val ctorTypes = arrayOf(Context::class.java, ILogger::class.java, IBuildInfoProvider::class.java)
 
+    init {
+        Locale.setDefault(Locale.US)
+    }
+
     private class Fixture {
         val buildInfo = mock<IBuildInfoProvider>()
         val options = SentryOptions().apply {
@@ -381,12 +385,11 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `Event sets language and locale`() {
         val sut = fixture.getSut(context)
-        val locale = Locale.getDefault()
 
         assertNotNull(sut.process(SentryEvent(), null)) {
             val device = it.contexts.device!!
-            assertEquals(device.language, locale.language)
-            assertEquals(device.locale, locale.toString())
+            assertEquals("en", device.language)
+            assertEquals("en_US", device.locale)
         }
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -27,7 +27,7 @@ import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.test.getCtor
 import org.junit.runner.RunWith
-import java.util.*
+import java.util.Locale
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1532,6 +1532,7 @@ public final class io/sentry/protocol/Device : io/sentry/IUnknownPropertiesConsu
 	public fun getFreeStorage ()Ljava/lang/Long;
 	public fun getId ()Ljava/lang/String;
 	public fun getLanguage ()Ljava/lang/String;
+	public fun getLocale ()Ljava/lang/String;
 	public fun getManufacturer ()Ljava/lang/String;
 	public fun getMemorySize ()Ljava/lang/Long;
 	public fun getModel ()Ljava/lang/String;
@@ -1563,6 +1564,7 @@ public final class io/sentry/protocol/Device : io/sentry/IUnknownPropertiesConsu
 	public fun setFreeStorage (Ljava/lang/Long;)V
 	public fun setId (Ljava/lang/String;)V
 	public fun setLanguage (Ljava/lang/String;)V
+	public fun setLocale (Ljava/lang/String;)V
 	public fun setLowMemory (Ljava/lang/Boolean;)V
 	public fun setManufacturer (Ljava/lang/String;)V
 	public fun setMemorySize (Ljava/lang/Long;)V

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -146,7 +146,7 @@ public final class Device implements IUnknownPropertiesConsumer {
     this.batteryLevel = device.batteryLevel;
     final String[] archsRef = device.archs;
     this.archs = archsRef != null ? archsRef.clone() : null;
-    this.setLocale(device.getLocale());
+    this.locale = device.locale;
 
     final TimeZone timezoneRef = device.timezone;
     this.timezone = timezoneRef != null ? (TimeZone) timezoneRef.clone() : null;

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -93,7 +93,18 @@ public final class Device implements IUnknownPropertiesConsumer {
   private @Nullable TimeZone timezone;
 
   private @Nullable String id;
-  private @Nullable String language;
+
+  /**
+   * This method returns the language code for this locale, which will either be the empty string or
+   * a lowercase ISO 639 code.
+   *
+   * @deprecated use {@link Device#getLocale()}
+   */
+  @Deprecated private @Nullable String language;
+
+  /** The locale of the device. For example, en-US. */
+  private @Nullable String locale;
+
   private @Nullable String connectionType;
 
   /** battery's temperature in celsius */
@@ -135,6 +146,7 @@ public final class Device implements IUnknownPropertiesConsumer {
     this.batteryLevel = device.batteryLevel;
     final String[] archsRef = device.archs;
     this.archs = archsRef != null ? archsRef.clone() : null;
+    this.setLocale(device.getLocale());
 
     final TimeZone timezoneRef = device.timezone;
     this.timezone = timezoneRef != null ? (TimeZone) timezoneRef.clone() : null;
@@ -382,6 +394,14 @@ public final class Device implements IUnknownPropertiesConsumer {
 
   public void setBatteryTemperature(final @Nullable Float batteryTemperature) {
     this.batteryTemperature = batteryTemperature;
+  }
+
+  public @Nullable String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(final @Nullable String locale) {
+    this.locale = locale;
   }
 
   @TestOnly


### PR DESCRIPTION
## :scroll: Description
Feat: Add locale to device context and deprecate language
`language` now returns only the language eg `en` instead of `en_US`, since the `language` field was never indexed, its not a breaking change on discover and alerts


## :bulb: Motivation and Context
`language` was actually the `locale`, and `locale` was missing.
Closes https://github.com/getsentry/sentry-java/issues/1834


## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
add Support for https://develop.sentry.dev/sdk/event-payloads/contexts/#culture-context