### PR TITLE
chore(ci): break ci if missing artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
+          if-no-files-found: error
           path: |
             ./*/build/distributions/*.zip
             ./sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/*


### PR DESCRIPTION
Default behavior is to warn and one must read the build detail to spot that.

Example: A build that was successful, now fails with:

![image](https://user-images.githubusercontent.com/1633368/145738880-022b1d2a-34be-4772-adef-a68d17e32679.png)

#skip-changelog