### PR TITLE
Bump: log4j to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bump: log4j to 2.16.0 (#1845)
+
 ## 5.5.0
 
 * Bump: log4j to 2.15.0 (#1839)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -59,7 +59,7 @@ object Config {
         val logbackVersion = "1.2.3"
         val logbackClassic = "ch.qos.logback:logback-classic:$logbackVersion"
 
-        val log4j2Version = "2.15.0"
+        val log4j2Version = "2.16.0"
         val log4j2Api = "org.apache.logging.log4j:log4j-api:$log4j2Version"
         val log4j2Core = "org.apache.logging.log4j:log4j-core:$log4j2Version"
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bump log4j-api,log4j-core from 2.15.0 to 2.16.0

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[CVE 2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046)
Apache Log4j2 Thread Context Message Pattern and Context Lookup Pattern vulnerable to a denial of service attack.



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
