### PR TITLE
Fix: Make App start cold/warm visible to Hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Bump: log4j to 2.16.0 (#1845)
+* Fix: Make App start cold/warm visible to Hybrid SDKs (#)
 
 ## 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Bump: log4j to 2.16.0 (#1845)
-* Fix: Make App start cold/warm visible to Hybrid SDKs (#)
+* Fix: Make App start cold/warm visible to Hybrid SDKs (#1848)
 
 ## 5.5.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -34,6 +34,7 @@ public final class io/sentry/android/core/AppLifecycleIntegration : io/sentry/In
 }
 
 public final class io/sentry/android/core/AppStartState {
+	public fun getAppStartInterval ()Ljava/lang/Long;
 	public fun getAppStartTime ()Ljava/util/Date;
 	public static fun getInstance ()Lio/sentry/android/core/AppStartState;
 	public fun isColdStart ()Z

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -260,7 +260,7 @@ public final class ActivityLifecycleIntegration
 
   @Override
   public synchronized void onActivityResumed(final @NonNull Activity activity) {
-    if (!firstActivityResumed && performanceEnabled) {
+    if (!firstActivityResumed) {
 
       // we only finish the app start if the process is of foregroundImportance
       if (foregroundImportance) {
@@ -277,7 +277,7 @@ public final class ActivityLifecycleIntegration
       }
 
       // finishes app start span
-      if (appStartSpan != null) {
+      if (performanceEnabled && appStartSpan != null) {
         appStartSpan.finish();
       }
       firstActivityResumed = true;
@@ -355,7 +355,7 @@ public final class ActivityLifecycleIntegration
   }
 
   private void setColdStart(final @Nullable Bundle savedInstanceState) {
-    if (!firstActivityCreated && performanceEnabled) {
+    if (!firstActivityCreated) {
       // if Activity has savedInstanceState then its a warm start
       // https://developer.android.com/topic/performance/vitals/launch-time#warm
       AppStartState.getInstance().setColdStart(savedInstanceState == null);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
@@ -44,7 +44,7 @@ public final class AppStartState {
   }
 
   @Nullable
-  synchronized Long getAppStartInterval() {
+  public synchronized Long getAppStartInterval() {
     if (appStartMillis == null || appStartEndMillis == null) {
       return null;
     }


### PR DESCRIPTION
## :scroll: Description
Fix: Make App start cold/warm visible to Hybrid SDKs


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-react-native/issues/1968
React native reads the Cold or Warm start from the Android SDK, but the Android SDK only sets it if performance is enabled on the Android SDK as well, by default, performance is not enabled, only on the RN SDK, hence we have to flip the flag anyway, even if performance is disabled on the Android SDK.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
