### PR TITLE
Upgrade logback to 1.2.9 to address LOGBACK-1591/CVE-2021-42550

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 5.5.1
 
 * Bump: log4j to 2.16.0 (#1845)
+* Bump: logback to 1.2.9
 * Fix: Make App start cold/warm visible to Hybrid SDKs (#1848)
 
 ## 5.5.0

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -56,7 +56,7 @@ object Config {
         val androidxCore = "androidx.core:core:1.3.2"
 
         val slf4jApi = "org.slf4j:slf4j-api:1.7.30"
-        val logbackVersion = "1.2.8"
+        val logbackVersion = "1.2.9"
         val logbackClassic = "ch.qos.logback:logback-classic:$logbackVersion"
 
         val log4j2Version = "2.16.0"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -56,7 +56,7 @@ object Config {
         val androidxCore = "androidx.core:core:1.3.2"
 
         val slf4jApi = "org.slf4j:slf4j-api:1.7.30"
-        val logbackVersion = "1.2.3"
+        val logbackVersion = "1.2.8"
         val logbackClassic = "ch.qos.logback:logback-classic:$logbackVersion"
 
         val log4j2Version = "2.16.0"


### PR DESCRIPTION
See
http://logback.qos.ch/news.html
https://jira.qos.ch/browse/LOGBACK-1591
https://cve.report/CVE-2021-42550
(Note that LOGBACK-1591/CVE-2021-42550 and log4Shell/CVE-2021-44228 are related but "of different severity levels")

## :scroll: Description
Bumped logback version to 1.2.9


## :bulb: Motivation and Context
Following log4j's vulnerability log4Shell/CVE-2021-44228, logback has released a new version which disables JNDI lookup to avoid the vulnerability LOGBACK-1591. Although the two vulnerabilities are "of different severity levels", it would be convenient to have sentry-java dependency on logback updated to the latest, non-JNDI, version 1.2.9. Thank you!


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
