### PR TITLE
Upgrade logback to 1.2.9 to address LOGBACK-1591/CVE-2021-42550

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 5.5.1
 
 * Bump: log4j to 2.16.0 (#1845)
+* Bump: logback to 1.2.9
 * Fix: Make App start cold/warm visible to Hybrid SDKs (#1848)
 
 ## 5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Bump: log4j to 2.17.0 (#1852)
+* Bump: log4j to 2.17.0 (#1853)
 * Bump: logback to 1.2.9
 
 ## 5.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 * Bump: log4j to 2.17.0 (#1852)
+* Bump: logback to 1.2.9
 
 ## 5.5.1
 
 * Bump: log4j to 2.16.0 (#1845)
-* Bump: logback to 1.2.9
 * Fix: Make App start cold/warm visible to Hybrid SDKs (#1848)
 
 ## 5.5.0

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -56,7 +56,7 @@ object Config {
         val androidxCore = "androidx.core:core:1.3.2"
 
         val slf4jApi = "org.slf4j:slf4j-api:1.7.30"
-        val logbackVersion = "1.2.3"
+        val logbackVersion = "1.2.9"
         val logbackClassic = "ch.qos.logback:logback-classic:$logbackVersion"
 
         val log4j2Version = "2.17.0"


### PR DESCRIPTION
## :scroll: Description
Upgrade logback to 1.2.9 to address LOGBACK-1591/CVE-2021-42550


## :bulb: Motivation and Context
details https://github.com/getsentry/sentry-java/pull/1849


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
