### PR TITLE
Fix: Do not add breadcrumbs on the root scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Do not add breadcrumbs on the root scope (#1864)
+
 ## 5.5.2
 
 * Fix: Detect App Cold start correctly for Hybrid SDKs (#1855)

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -211,6 +211,7 @@ class SentryHandlerTest {
     @Test
     fun `attaches breadcrumbs with level higher than minimumBreadcrumbLevel`() {
         fixture = Fixture(minimumBreadcrumbLevel = Level.CONFIG, minimumEventLevel = Level.WARNING)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
         val utcTime = LocalDateTime.now(ZoneId.of("UTC"))
 
         fixture.logger.config("this should be a breadcrumb #1")
@@ -239,6 +240,7 @@ class SentryHandlerTest {
     @Test
     fun `does not attach breadcrumbs with level lower than minimumBreadcrumbLevel`() {
         fixture = Fixture(minimumBreadcrumbLevel = Level.INFO, minimumEventLevel = Level.WARNING)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         fixture.logger.config("this should NOT be a breadcrumb")
         fixture.logger.info("this should be a breadcrumb")
@@ -258,6 +260,7 @@ class SentryHandlerTest {
     @Test
     fun `attaches breadcrumbs for default appender configuration`() {
         fixture = Fixture()
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         fixture.logger.config("this should not be a breadcrumb as the level is lower than the minimum INFO")
         fixture.logger.info("this should be a breadcrumb")

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -332,6 +332,7 @@ class SentryAppenderTest {
     @Test
     fun `attaches breadcrumbs with level higher than minimumBreadcrumbLevel`() {
         val logger = fixture.getSut(minimumEventLevel = Level.WARN, minimumBreadcrumbLevel = Level.DEBUG)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
         val utcTime = LocalDateTime.now(fixture.utcTimeZone)
 
         logger.debug("this should be a breadcrumb #1")
@@ -360,6 +361,7 @@ class SentryAppenderTest {
     @Test
     fun `does not attach breadcrumbs with level lower than minimumBreadcrumbLevel`() {
         val logger = fixture.getSut(minimumEventLevel = Level.WARN, minimumBreadcrumbLevel = Level.INFO)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         logger.debug("this should NOT be a breadcrumb")
         logger.info("this should be a breadcrumb")
@@ -379,6 +381,7 @@ class SentryAppenderTest {
     @Test
     fun `attaches breadcrumbs for default appender configuration`() {
         val logger = fixture.getSut()
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         logger.debug("this should not be a breadcrumb as the level is lower than the minimum INFO")
         logger.info("this should be a breadcrumb")

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -307,6 +307,7 @@ class SentryAppenderTest {
     @Test
     fun `attaches breadcrumbs with level higher than minimumBreadcrumbLevel`() {
         fixture = Fixture(minimumBreadcrumbLevel = Level.DEBUG, minimumEventLevel = Level.WARN)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
         val utcTime = LocalDateTime.now(fixture.utcTimeZone)
 
         fixture.logger.debug("this should be a breadcrumb #1")
@@ -335,6 +336,7 @@ class SentryAppenderTest {
     @Test
     fun `does not attach breadcrumbs with level lower than minimumBreadcrumbLevel`() {
         fixture = Fixture(minimumBreadcrumbLevel = Level.INFO, minimumEventLevel = Level.WARN)
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         fixture.logger.debug("this should NOT be a breadcrumb")
         fixture.logger.info("this should be a breadcrumb")
@@ -354,6 +356,7 @@ class SentryAppenderTest {
     @Test
     fun `attaches breadcrumbs for default appender configuration`() {
         fixture = Fixture()
+        Sentry.pushScope() // breadcrumbs don't get added to the root scope
 
         fixture.logger.debug("this should not be a breadcrumb as the level is lower than the minimum INFO")
         fixture.logger.info("this should be a breadcrumb")

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -295,7 +295,12 @@ public final class Hub implements IHub {
     } else if (breadcrumb == null) {
       options.getLogger().log(SentryLevel.WARNING, "addBreadcrumb called with null parameter.");
     } else {
-      stack.peek().getScope().addBreadcrumb(breadcrumb, hint);
+      final StackItem stackItem = stack.peekNonRoot();
+      if (stackItem != null) {
+        stackItem.getScope().addBreadcrumb(breadcrumb, hint);
+      } else {
+        options.getLogger().log(SentryLevel.WARNING, "addBreadcrumb called on root scope.");
+      }
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Stack.java
+++ b/sentry/src/main/java/io/sentry/Stack.java
@@ -5,6 +5,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingDeque;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 final class Stack {
 
@@ -70,6 +71,17 @@ final class Stack {
     // peek can never return null since Stack can be created only with an item and pop does not drop
     // the last item.
     return items.peek();
+  }
+
+  @Nullable
+  StackItem peekNonRoot() {
+    synchronized (items) {
+      if (items.size() != 1) {
+        return items.peek();
+      } else {
+        return null;
+      }
+    }
   }
 
   void pop() {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -117,6 +117,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
         (1..10).forEach { _ -> sut.addBreadcrumb(Breadcrumb(), null) }
         var actual = 0
         sut.configureScope {
@@ -148,6 +149,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
         val crumb = Breadcrumb()
         crumb.message = "original"
         sut.addBreadcrumb(crumb)
@@ -164,6 +166,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
         val expected = Breadcrumb()
         sut.addBreadcrumb(expected)
         var breadcrumbs: Queue<Breadcrumb>? = null
@@ -181,6 +184,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
 
         val actual = Breadcrumb()
         sut.addBreadcrumb(actual)
@@ -219,6 +223,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
         var breadcrumbs: Queue<Breadcrumb>? = null
         sut.configureScope { breadcrumbs = it.breadcrumbs }
         sut.addBreadcrumb("message", "category")
@@ -233,6 +238,7 @@ class HubTest {
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         val sut = Hub(options)
+        sut.pushScope()
         var breadcrumbs: Queue<Breadcrumb>? = null
         sut.configureScope { breadcrumbs = it.breadcrumbs }
         sut.addBreadcrumb("message", "category")
@@ -785,6 +791,7 @@ class HubTest {
     @Test
     fun `when clearBreadcrumbs is called on disabled client, do nothing`() {
         val hub = generateHub()
+        hub.pushScope()
         var scope: Scope? = null
         hub.configureScope {
             scope = it
@@ -801,6 +808,7 @@ class HubTest {
     @Test
     fun `when clearBreadcrumbs is called, clear breadcrumbs`() {
         val hub = generateHub()
+        hub.pushScope()
         var scope: Scope? = null
         hub.configureScope {
             scope = it


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not add breadcrumbs on the root scope.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discussed with @bruno-garcia, breadcrumbs added to the root scope will be attached to all events captured in child scopes, which can lead to reaching max breadcrumbs, if scope is not pushed. The proposed solution by @bruno-garcia is to not add breadcrumbs in root scope.

## :green_heart: How did you test it?

Unit tests.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes