### PR TITLE
Fix: Do not create SentryExceptionResolver bean when Spring MVC is not on the classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Do not create SentryExceptionResolver bean when Spring MVC is not on the classpath (#1865)
+
 ## 5.5.2
 
 * Fix: Detect App Cold start correctly for Hybrid SDKs (#1855)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "sentry.dsn")
@@ -206,6 +207,7 @@ public class SentryAutoConfiguration {
 
       @Bean
       @ConditionalOnMissingBean
+      @ConditionalOnClass(HandlerExceptionResolver.class)
       public @NotNull SentryExceptionResolver sentryExceptionResolver(
           final @NotNull IHub sentryHub, final @NotNull SentryProperties options) {
         return new SentryExceptionResolver(sentryHub, options.getExceptionResolverOrder());

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -21,6 +21,7 @@ import io.sentry.SentryOptions
 import io.sentry.checkEvent
 import io.sentry.protocol.User
 import io.sentry.spring.HttpServletRequestSentryUserProvider
+import io.sentry.spring.SentryExceptionResolver
 import io.sentry.spring.SentryUserFilter
 import io.sentry.spring.SentryUserProvider
 import io.sentry.spring.SpringSecuritySentryUserProvider
@@ -47,6 +48,7 @@ import org.springframework.core.annotation.Order
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.servlet.HandlerExceptionResolver
 import java.lang.RuntimeException
 import javax.servlet.Filter
 import kotlin.test.Test
@@ -359,6 +361,15 @@ class SentryAutoConfigurationTest {
                 userProviders.forEach {
                     assertFalse(it is SpringSecuritySentryUserProvider)
                 }
+            }
+    }
+
+    @Test
+    fun `when Spring MVC is not on the classpath, SentryExceptionResolver is not configured`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true")
+            .withClassLoader(FilteredClassLoader(HandlerExceptionResolver::class.java))
+            .run {
+                assertThat(it).doesNotHaveBean(SentryExceptionResolver::class.java)
             }
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not create SentryExceptionResolver bean when Spring MVC is not on the classpath

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1863

## :green_heart: How did you test it?

Integration test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes