### PR TITLE
Ref: Remove Attachment ContentType since the Server infers it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Feat: Relax TransactionNameProvider (#1861)
 * Ref: Simplify DateUtils with ISO8601Utils (#1837)
-* Ref: Remove Attachment ContentType since the Server infers it (#)
+* Ref: Remove Attachment ContentType since the Server infers it (#1874)
 
 ## 6.0.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Feat: Relax TransactionNameProvider (#1861)
 * Ref: Simplify DateUtils with ISO8601Utils (#1837)
+* Ref: Remove Attachment ContentType since the Server infers it (#)
 
 ## 6.0.0-alpha.1
 

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -10,20 +10,11 @@ public final class Attachment {
   private @Nullable byte[] bytes;
   private @Nullable String pathname;
   private final @NotNull String filename;
-  private final @NotNull String contentType;
+  private final @Nullable String contentType;
   private final boolean addToTransactions;
 
   /** The special type of this attachment */
   private @Nullable String attachmentType = DEFAULT_ATTACHMENT_TYPE;
-
-  /**
-   * We could use Files.probeContentType(path) to determine the content type of the filename. This
-   * needs a path, but file.toPath or Paths.get only work on above Android API level 26, see
-   * https://developer.android.com/reference/java/nio/file/Paths. There are also ways via
-   * URLConnection, but we don't want to use this in constructors. Therefore we use the default
-   * content type of Sentry.
-   */
-  private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
   /** A standard attachment without special meaning */
   private static final String DEFAULT_ATTACHMENT_TYPE = "event.attachment";
@@ -36,7 +27,7 @@ public final class Attachment {
    * @param filename The name of the attachment to display in Sentry.
    */
   public Attachment(final @NotNull byte[] bytes, final @NotNull String filename) {
-    this(bytes, filename, DEFAULT_CONTENT_TYPE);
+    this(bytes, filename, null);
   }
 
   /**
@@ -50,7 +41,7 @@ public final class Attachment {
   public Attachment(
       final @NotNull byte[] bytes,
       final @NotNull String filename,
-      final @NotNull String contentType) {
+      final @Nullable String contentType) {
     this(bytes, filename, contentType, false);
   }
 
@@ -66,7 +57,7 @@ public final class Attachment {
   public Attachment(
       final @NotNull byte[] bytes,
       final @NotNull String filename,
-      final @NotNull String contentType,
+      final @Nullable String contentType,
       final boolean addToTransactions) {
     this.bytes = bytes;
     this.filename = filename;
@@ -100,7 +91,7 @@ public final class Attachment {
    * @param filename The name of the attachment to display in Sentry.
    */
   public Attachment(final @NotNull String pathname, final @NotNull String filename) {
-    this(pathname, filename, DEFAULT_CONTENT_TYPE);
+    this(pathname, filename, null);
   }
 
   /**
@@ -118,7 +109,7 @@ public final class Attachment {
   public Attachment(
       final @NotNull String pathname,
       final @NotNull String filename,
-      final @NotNull String contentType) {
+      final @Nullable String contentType) {
     this(pathname, filename, contentType, false);
   }
 
@@ -138,7 +129,7 @@ public final class Attachment {
   public Attachment(
       final @NotNull String pathname,
       final @NotNull String filename,
-      final @NotNull String contentType,
+      final @Nullable String contentType,
       final boolean addToTransactions) {
     this.pathname = pathname;
     this.filename = filename;
@@ -164,7 +155,7 @@ public final class Attachment {
   public Attachment(
       final @NotNull String pathname,
       final @NotNull String filename,
-      final @NotNull String contentType,
+      final @Nullable String contentType,
       final boolean addToTransactions,
       final @Nullable String attachmentType) {
     this.pathname = pathname;
@@ -202,11 +193,12 @@ public final class Attachment {
   }
 
   /**
-   * Gets the content type of the attachment. Default is "application/octet-stream".
+   * Gets the content type of the attachment. The server infers "application/octet-stream" if not
+   * set.
    *
-   * @return the content type.
+   * @return the content type or null if not set.
    */
-  public @NotNull String getContentType() {
+  public @Nullable String getContentType() {
     return contentType;
   }
 

--- a/sentry/src/test/java/io/sentry/AttachmentTest.kt
+++ b/sentry/src/test/java/io/sentry/AttachmentTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertTrue
 class AttachmentTest {
 
     private class Fixture {
-        val defaultContentType = "application/octet-stream"
         val contentType = "application/json"
         val filename = "logs.txt"
         val bytes = "content".toByteArray()
@@ -25,7 +24,6 @@ class AttachmentTest {
         assertEquals(fixture.bytes, attachment.bytes)
         assertNull(attachment.pathname)
         assertEquals(fixture.filename, attachment.filename)
-        assertEquals(fixture.defaultContentType, attachment.contentType)
     }
 
     @Test
@@ -35,7 +33,6 @@ class AttachmentTest {
         assertEquals(fixture.pathname, attachment.pathname)
         assertNull(attachment.bytes)
         assertEquals(fixture.filename, attachment.filename)
-        assertEquals(fixture.defaultContentType, attachment.contentType)
     }
 
     @Test
@@ -62,7 +59,6 @@ class AttachmentTest {
         assertEquals(fixture.pathname, attachment.pathname)
         assertNull(attachment.bytes)
         assertEquals(otherFileName, attachment.filename)
-        assertEquals(fixture.defaultContentType, attachment.contentType)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -703,8 +703,7 @@ class JsonSerializerTest {
         val actualJson = serializeToString(envelope)
 
         val expectedJson = "{\"event_id\":\"${eventID}\"}\n" +
-            "{\"content_type\":\"${attachment.contentType}\"," +
-            "\"filename\":\"${attachment.filename}\"," +
+            "{\"filename\":\"${attachment.filename}\"," +
             "\"type\":\"attachment\"," +
             "\"attachment_type\":\"event.attachment\"," +
             "\"length\":${attachment.bytes?.size}}\n" +


### PR DESCRIPTION
## :scroll: Description
Ref: Remove Attachment ContentType since the Server infers it


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-cocoa/issues/1196


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
