### PR TITLE
Fix: Change scope of servlet-api to compileOnly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Change scope of servlet-api to compileOnly (#1880)
+
 ## 5.5.3
 
 * Fix: Do not create SentryExceptionResolver bean when Spring MVC is not on the classpath (#1865)

--- a/sentry-servlet/build.gradle.kts
+++ b/sentry-servlet/build.gradle.kts
@@ -31,7 +31,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     api(projects.sentry)
-    implementation(Config.Libs.servletApi)
+    compileOnly(Config.Libs.servletApi)
 
     compileOnly(Config.CompileOnly.nopen)
     errorprone(Config.CompileOnly.nopenChecker)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Change scope of servlet-api to compileOnly.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`servlet-api` should be a compile dependency, users should include servlet-api independently or the application server application runs on provides this dependency in runtime.

Fixes #1878

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes
