### PR TITLE
Fix NPE while adding "response_body_size" breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1883)
+* Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1884)
 
 ## 5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1883)
+
 ## 5.6.0
 
 * Fix: Change scope of servlet-api to compileOnly (#1880)

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -86,7 +86,7 @@ public final class SentryFeignClient implements Client {
     breadcrumb.setData("request_body_size", request.body() != null ? request.body().length : 0);
     if (response != null) {
       breadcrumb.setData(
-          "response_body_size", response.body() != null ? response.body().length : 0);
+          "response_body_size", response.body() != null ? response.body().length() : 0);
     }
     hub.addBreadcrumb(breadcrumb);
   }

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -84,8 +84,8 @@ public final class SentryFeignClient implements Client {
             request.httpMethod().name(),
             response != null ? response.status() : null);
     breadcrumb.setData("request_body_size", request.body() != null ? request.body().length : 0);
-    if (response != null && response.body().length() != null) {
-      breadcrumb.setData("response_body_size", response.body().length());
+    if (response != null) {
+      breadcrumb.setData("response_body_size", response.body() != null ? response.body().length : 0);
     }
     hub.addBreadcrumb(breadcrumb);
   }

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -85,7 +85,8 @@ public final class SentryFeignClient implements Client {
             response != null ? response.status() : null);
     breadcrumb.setData("request_body_size", request.body() != null ? request.body().length : 0);
     if (response != null) {
-      breadcrumb.setData("response_body_size", response.body() != null ? response.body().length : 0);
+      breadcrumb.setData(
+          "response_body_size", response.body() != null ? response.body().length : 0);
     }
     hub.addBreadcrumb(breadcrumb);
   }

--- a/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
+++ b/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
@@ -140,7 +140,7 @@ class SentryFeignClientTest {
 
     @Test
     fun `adds breadcrumb when http calls succeeds even though response body is null`() {
-        val sut = fixture.getSut(responseBody = null)
+        val sut = fixture.getSut(responseBody = "")
         sut.postWithBody("request-body")
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {

--- a/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
+++ b/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
@@ -138,6 +138,19 @@ class SentryFeignClientTest {
         )
     }
 
+    @Test
+    fun `adds breadcrumb when http calls succeeds even though response body is null`() {
+        val sut = fixture.getSut(responseBody = null)
+        sut.postWithBody("request-body")
+        verify(fixture.hub).addBreadcrumb(
+            check<Breadcrumb> {
+                assertEquals("http", it.type)
+                assertEquals(0, it.data["response_body_size"])
+                assertEquals(12, it.data["request_body_size"])
+            }
+        )
+    }
+
     @SuppressWarnings("SwallowedException")
     @Test
     fun `adds breadcrumb when http calls results in exception`() {


### PR DESCRIPTION
When response body is null, set size to 0
in a same fashion "request_body_size" is set.
Add test.
Add note to the changelog

Closes #1883 , see description there

## :green_heart: How did you test it?

I wrote a test.
Had no time to build the project and run the tests locally, TBH

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes
