### PR TITLE
fix: Do not include stacktrace into Timber message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: Do not include stacktrace frames into Timber message (#1898)
+
 ## 5.6.1
 
 * Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1884)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Fix: Do not include stacktrace frames into Timber message (#1898)
 
+Breaking changes:
+`Timber.tag` is no longer supported by our [Timber integration](https://docs.sentry.io/platforms/android/configuration/integrations/timber/) and will not appear on Sentry for error events. 
+Please vote on this [issue](https://github.com/getsentry/sentry-java/issues/1900), if you'd like us to provide support for that.
+
 ## 5.6.1
 
 * Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1884)

--- a/sentry-android-timber/api/sentry-android-timber.api
+++ b/sentry-android-timber/api/sentry-android-timber.api
@@ -19,5 +19,26 @@ public final class io/sentry/android/timber/SentryTimberIntegration : io/sentry/
 
 public final class io/sentry/android/timber/SentryTimberTree : timber/log/Timber$Tree {
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/SentryLevel;Lio/sentry/SentryLevel;)V
+	public fun d (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun d (Ljava/lang/Throwable;)V
+	public fun d (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun e (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun e (Ljava/lang/Throwable;)V
+	public fun e (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun i (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun i (Ljava/lang/Throwable;)V
+	public fun i (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (ILjava/lang/String;[Ljava/lang/Object;)V
+	public fun log (ILjava/lang/Throwable;)V
+	public fun log (ILjava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun v (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun v (Ljava/lang/Throwable;)V
+	public fun v (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun w (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun w (Ljava/lang/Throwable;)V
+	public fun w (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun wtf (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun wtf (Ljava/lang/Throwable;)V
+	public fun wtf (Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
 }
 

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -199,8 +199,8 @@ class SentryTimberTree(
         val level = getSentryLevel(priority)
         val sentryMessage = Message().apply {
             this.message = message
-            if (message != null && args.isNotEmpty()) {
-                this.formatted = message.format(*args)
+            if (!message.isNullOrEmpty() && args.isNotEmpty()) {
+                this.formatted = message?.format(*args)
             }
             this.params = args.map { it.toString() }
         }

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -253,7 +253,9 @@ class SentryTimberTree(
                     category = "Timber"
                     message = msg.message
                 }
-                throwableMsg != null -> Breadcrumb.error(throwableMsg)
+                throwableMsg != null -> Breadcrumb.error(throwableMsg).apply {
+                    category = "exception"
+                }
                 else -> null
             }
 

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -192,7 +192,7 @@ class SentryTimberTree(
         vararg args: Any?
     ) {
         if (message.isNullOrEmpty() && throwable == null) {
-            return  // Swallow message if it's null and there's no throwable
+            return // Swallow message if it's null and there's no throwable
         }
 
         val level = getSentryLevel(priority)

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -17,42 +17,218 @@ class SentryTimberTree(
     private val minBreadcrumbLevel: SentryLevel
 ) : Timber.Tree() {
 
+    /** Log a verbose message with optional format args. */
+    override fun v(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.VERBOSE, null, message, *args)
+    }
+
+    /** Log a verbose exception and a message with optional format args. */
+    override fun v(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.VERBOSE, t, message, *args)
+    }
+
+    /** Log a verbose exception. */
+    override fun v(t: Throwable?) {
+        logWithSentry(Log.VERBOSE, t, null)
+    }
+
+    /** Log a debug message with optional format args. */
+    override fun d(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.DEBUG, null, message, *args)
+    }
+
+    /** Log a debug exception and a message with optional format args. */
+    override fun d(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.DEBUG, t, message, *args)
+    }
+
+    /** Log a debug exception. */
+    override fun d(t: Throwable?) {
+        logWithSentry(Log.DEBUG, t, null)
+    }
+
+    /** Log an info message with optional format args. */
+    override fun i(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.INFO, null, message, *args)
+    }
+
+    /** Log an info exception and a message with optional format args. */
+    override fun i(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.INFO, t, message, *args)
+    }
+
+    /** Log an info exception. */
+    override fun i(t: Throwable?) {
+        logWithSentry(Log.INFO, t, null)
+    }
+
+    /** Log a warning message with optional format args. */
+    override fun w(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.WARN, null, message, *args)
+    }
+
+    /** Log a warning exception and a message with optional format args. */
+    override fun w(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.WARN, t, message, *args)
+    }
+
+    /** Log a warning exception. */
+    override fun w(t: Throwable?) {
+        logWithSentry(Log.WARN, t, null)
+    }
+
+    /** Log an error message with optional format args. */
+    override fun e(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.ERROR, null, message, *args)
+    }
+
+    /** Log an error exception and a message with optional format args. */
+    override fun e(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.ERROR, t, message, *args)
+    }
+
+    /** Log an error exception. */
+    override fun e(t: Throwable?) {
+        logWithSentry(Log.ERROR, t, null)
+    }
+
+    /** Log an assert message with optional format args. */
+    override fun wtf(
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.ASSERT, null, message, *args)
+    }
+
+    /** Log an assert exception and a message with optional format args. */
+    override fun wtf(
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(Log.ASSERT, t, message, *args)
+    }
+
+    /** Log an assert exception. */
+    override fun wtf(t: Throwable?) {
+        logWithSentry(Log.ASSERT, t, null)
+    }
+
+    /** Log at `priority` a message with optional format args. */
+    override fun log(
+        priority: Int,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(priority, null, message, *args)
+    }
+
+    /** Log at `priority` an exception and a message with optional format args. */
+    override fun log(
+        priority: Int,
+        t: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        logWithSentry(priority, t, message, *args)
+    }
+
+    /** Log at `priority` an exception. */
+    override fun log(
+        priority: Int,
+        t: Throwable?
+    ) {
+        logWithSentry(priority, t, null)
+    }
+
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?
+    ) {
+        // no-op as we've overridden all the methods
+    }
+
+    private fun logWithSentry(
+        priority: Int,
+        throwable: Throwable?,
+        message: String?,
+        vararg args: Any?
+    ) {
+        if (message.isNullOrEmpty() && throwable == null) {
+            return  // Swallow message if it's null and there's no throwable
+        }
+
+        val level = getSentryLevel(priority)
+        val sentryMessage = Message().apply {
+            this.message = message
+            if (message != null && args.isNotEmpty()) {
+                this.formatted = message.format(*args)
+            }
+            this.params = args.mapNotNull { it.toString() }
+        }
+
+        addBreadcrumb(level, sentryMessage)
+        captureEvent(level, sentryMessage, throwable)
+    }
+
     /**
      * do not log if it's lower than min. required level.
      */
-    private fun isLoggable(level: SentryLevel, minLevel: SentryLevel): Boolean = level.ordinal >= minLevel.ordinal
-
-    /**
-     * Captures a Sentry Event if the min. level is equal or higher than the min. required level.
-     */
-    override fun log(priority: Int, tag: String?, message: String, throwable: Throwable?) {
-        val level = getSentryLevel(priority)
-
-        captureEvent(level, tag, message, throwable)
-        addBreadcrumb(level, message)
-    }
+    private fun isLoggable(
+        level: SentryLevel,
+        minLevel: SentryLevel
+    ): Boolean = level.ordinal >= minLevel.ordinal
 
     /**
      * Captures an event with the given attributes
      */
-    private fun captureEvent(sentryLevel: SentryLevel, tag: String?, msg: String, throwable: Throwable?) {
+    private fun captureEvent(
+        sentryLevel: SentryLevel,
+        msg: Message,
+        throwable: Throwable?
+    ) {
         if (isLoggable(sentryLevel, minEventLevel)) {
             val sentryEvent = SentryEvent().apply {
-
                 level = sentryLevel
-
-                throwable?.let {
-                    setThrowable(it)
-                }
-
-                message = Message().apply {
-                    formatted = msg
-                }
-
-                tag?.let {
-                    setTag("TimberTag", it)
-                }
-
+                throwable?.let { setThrowable(it) }
+                message = msg
                 logger = "Timber"
             }
 
@@ -63,13 +239,16 @@ class SentryTimberTree(
     /**
      * Adds a breadcrumb
      */
-    private fun addBreadcrumb(sentryLevel: SentryLevel, msg: String) {
+    private fun addBreadcrumb(
+        sentryLevel: SentryLevel,
+        msg: Message
+    ) {
         // checks the breadcrumb level
         if (isLoggable(sentryLevel, minBreadcrumbLevel)) {
             val breadCrumb = Breadcrumb().apply {
                 level = sentryLevel
                 category = "Timber"
-                message = msg
+                message = msg.message
             }
 
             hub.addBreadcrumb(breadCrumb)

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -11,6 +11,7 @@ import timber.log.Timber
 /**
  * Sentry Timber tree which is responsible to capture events via Timber
  */
+@Suppress("TooManyFunctions") // we have to override all methods to be able to tweak logging
 class SentryTimberTree(
     private val hub: IHub,
     private val minEventLevel: SentryLevel,

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -238,39 +238,35 @@ class SentryTimberTreeTest {
     }
 
     @Test
-    fun `Tree adds a breadcrumb with given level`() {
+    fun `Tree adds an info breadcrumb`() {
         val sut = fixture.getSut()
-        sut.e(Throwable("test"))
-        verify(fixture.hub).addBreadcrumb(
-            check<Breadcrumb> {
-                assertEquals(SentryLevel.ERROR, it.level)
-            }
-        )
-    }
-
-    @Test
-    fun `Tree adds a breadcrumb with Timber category`() {
-        val sut = fixture.getSut()
-        sut.e(Throwable("test"))
+        sut.i("message")
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("Timber", it.category)
+                assertEquals(SentryLevel.INFO, it.level)
+                assertEquals("message", it.message)
             }
         )
     }
 
     @Test
-    @Ignore(
-        "Should we still do it? We do not write stacktrace into a message anymore, " +
-            "but we could do that for the sake of breadcrumb"
-    )
-    fun `Tree adds a breadcrumb with exception message`() {
+    fun `Tree adds an error breadcrumb`() {
         val sut = fixture.getSut()
         sut.e(Throwable("test"))
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
-                assertTrue(it.message!!.contains("test"))
+                assertEquals("exception", it.category)
+                assertEquals(SentryLevel.ERROR, it.level)
+                assertEquals("test", it.message)
             }
         )
+    }
+
+    @Test
+    fun `Tree does not add a breadcrumb, if no message provided`() {
+        val sut = fixture.getSut()
+        sut.e(Throwable())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
 }

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -16,7 +16,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class SentryTimberTreeTest {
 

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     implementation(projects.sentryAndroid)
     implementation(projects.sentryAndroidOkhttp)
     implementation(projects.sentryAndroidFragment)
+    implementation(projects.sentryAndroidTimber)
     implementation(Config.Libs.fragment)
 
 //    how to exclude androidx if release health feature is disabled

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -169,12 +169,14 @@ public class MainActivity extends AppCompatActivity {
         view -> startActivity(new Intent(this, GesturesActivity.class)));
 
     binding.testTimberIntegration.setOnClickListener(
-      view -> {
-        crashCount++;
-        Timber.i("Some info here");
-        Timber.e(new RuntimeException("Uncaught Exception from Java."), "Something wrong happened %d times", crashCount);
-      }
-    );
+        view -> {
+          crashCount++;
+          Timber.i("Some info here");
+          Timber.e(
+              new RuntimeException("Uncaught Exception from Java."),
+              "Something wrong happened %d times",
+              crashCount);
+        });
 
     setContentView(binding.getRoot());
   }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -21,8 +21,11 @@ import java.io.Writer;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Locale;
+import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
+
+  private int crashCount = 0;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -164,6 +167,14 @@ public class MainActivity extends AppCompatActivity {
 
     binding.openGesturesActivity.setOnClickListener(
         view -> startActivity(new Intent(this, GesturesActivity.class)));
+
+    binding.testTimberIntegration.setOnClickListener(
+      view -> {
+        crashCount++;
+        Timber.i("Some info here");
+        Timber.e(new RuntimeException("Uncaught Exception from Java."), "Something wrong happened %d times", crashCount);
+      }
+    );
 
     setContentView(binding.getRoot());
   }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.os.StrictMode;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
+import io.sentry.android.timber.SentryTimberIntegration;
 
 /** Apps. main Application. */
 public class MyApplication extends Application {
@@ -19,6 +20,7 @@ public class MyApplication extends Application {
         this,
         options -> {
           options.addIntegration(new FragmentLifecycleIntegration(MyApplication.this, true, true));
+          options.addIntegration(new SentryTimberIntegration());
         });
   }
 

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -1,98 +1,110 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  tools:context=".MainActivity">
+
+  <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".MainActivity">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <Button
-        android:id="@+id/crash_from_java"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/crash_from_java" />
+      android:id="@+id/crash_from_java"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/crash_from_java" />
 
     <Button
-        android:id="@+id/send_message"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/send_message" />
+      android:id="@+id/send_message"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/send_message" />
 
     <Button
-        android:id="@+id/send_user_feedback"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/send_user_feedback" />
+      android:id="@+id/send_user_feedback"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/send_user_feedback" />
 
     <Button
-        android:id="@+id/add_attachment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/add_attachment" />
+      android:id="@+id/add_attachment"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/add_attachment" />
 
     <Button
-        android:id="@+id/capture_exception"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/capture_exception" />
+      android:id="@+id/capture_exception"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/capture_exception" />
 
     <Button
-        android:id="@+id/breadcrumb"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/breadcrumb" />
+      android:id="@+id/breadcrumb"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/breadcrumb" />
 
     <Button
-        android:id="@+id/set_user"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/set_user" />
+      android:id="@+id/set_user"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/set_user" />
 
     <Button
-        android:id="@+id/unset_user"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/unset_user" />
+      android:id="@+id/unset_user"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/unset_user" />
 
     <Button
-        android:id="@+id/anr"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/anr" />
+      android:id="@+id/anr"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/anr" />
 
     <Button
-        android:id="@+id/native_crash"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/crash_from_native" />
+      android:id="@+id/native_crash"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/crash_from_native" />
 
     <Button
-        android:id="@+id/native_capture"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/capture_from_native" />
+      android:id="@+id/native_capture"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/capture_from_native" />
 
     <Button
-        android:id="@+id/open_second_activity"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_second_activity" />
+      android:id="@+id/open_second_activity"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_second_activity" />
 
     <Button
-        android:id="@+id/open_sample_fragment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_sample_fragment" />
+      android:id="@+id/open_sample_fragment"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_sample_fragment" />
 
     <Button
-        android:id="@+id/open_third_fragment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_third_fragment" />
+      android:id="@+id/open_third_fragment"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_third_fragment" />
 
     <Button
-        android:id="@+id/open_gestures_activity"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_gestures_activity"/>
-</LinearLayout>
+      android:id="@+id/open_gestures_activity"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_gestures_activity"/>
+
+    <Button
+      android:id="@+id/test_timber_integration"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/test_timber_integration"/>
+  </LinearLayout>
+
+</ScrollView>

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="open_sample_fragment">Open Sample Fragment</string>
   <string name="open_third_fragment">Open Third Fragment</string>
   <string name="open_gestures_activity">Open Gestures Activity</string>
+  <string name="test_timber_integration">Test Timber</string>
   <string name="back_main">Back to Main Activity</string>
   <string name="tap_me">text</string>
   <string name="lipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nibh lorem, venenatis sed nulla vel, venenatis sodales augue. Mauris varius elit eu ligula volutpat, sed tincidunt orci porttitor. Donec et dignissim lacus, sed luctus ipsum. Praesent ornare luctus tortor sit amet ultricies. Cras iaculis et diam et vulputate. Cras ut iaculis mauris, non pellentesque diam. Nunc in laoreet diam, vitae accumsan eros. Morbi non nunc ac eros molestie placerat vitae id dolor. Quisque ornare aliquam ipsum, a dapibus tortor. In eu sodales tellus.


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Overridden all Timber.Tree methods to have full control over the log message
* Supply `formatted` and `params` fields if the log-call was made with args
* Do not include stackframes into a message

How this looks now:
![image](https://user-images.githubusercontent.com/4999776/152387888-ea1eecdd-d946-410a-a668-0af60570f385.png)

Grouping seems to work as well:
![image](https://user-images.githubusercontent.com/4999776/152387922-2b3df5da-40d5-44e7-a97c-84404f1f214d.png)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1177 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

1. We can't access tag from Timber because it's [package-private](https://github.com/JakeWharton/timber/blob/84b157605552e7b30f0d20e105d383b48ce8a030/timber/src/main/java/timber/log/Timber.java#L377-L386), so I had to drop it.
2. Since we set the Message ourselves, the stacktraces are not reported as breadcrumbs anymore (previously, Timber default implementation would put a stacktrace into a message variable and we would record a breadcrumb with the exception) - should we still do this?