### PR TITLE
ci: Bump min craft version to 0.27.5

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 0.25.3
+minVersion: 0.27.5
 changelogPolicy: auto
 targets:
   - name: symbol-collector


### PR DESCRIPTION
Starting `0.27.5` we can use unattended Maven deployment process - https://github.com/getsentry/craft/pull/346