### PR TITLE
ref: Use perl instead of sed for craft scripts

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -15,4 +15,4 @@ GRADLE_FILEPATH="gradle.properties"
 
 # Replace `versionName` with the given version
 VERSION_NAME_PATTERN="versionName"
-sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH
+perl -pi -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$NEW_VERSION/g" $GRADLE_FILEPATH

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -15,7 +15,7 @@ git checkout main
 GRADLE_FILEPATH="gradle.properties"
 
 # Add a new unreleased entry in the changelog
-sed -i "" 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
+perl -pi -e 's/# Changelog/# Changelog\n\n## Unreleased/' CHANGELOG.md
 
 # Increment `versionName` and make it a snapshot
 # Incrementing the version name before the release (`bump-version.sh`) sets a
@@ -32,7 +32,7 @@ version_digit_to_bump="$( awk "/$VERSION_NAME_PATTERN/" $GRADLE_FILEPATH | egrep
 # Using `*` instead of `+` for compatibility. The result is the same,
 # since the version to be bumped is extracted using `+`.
 new_version="$( echo $version | sed "s/[0-9]*$/$version_digit_to_bump/g" )"
-sed -i "" -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$new_version-SNAPSHOT/g" $GRADLE_FILEPATH
+perl -pi -e "s/$VERSION_NAME_PATTERN=.*$/$VERSION_NAME_PATTERN=$new_version-SNAPSHOT/g" $GRADLE_FILEPATH
 
 git add .
 git commit -m "Prepare $new_version"


### PR DESCRIPTION
Because sed is sad and it breaks.

#skip-changelog