### PR TITLE
Fix NPE while adding "response_body_size" breadcrumb (#1907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fix: Do not include stacktrace frames into Timber message (#1898)
-* Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1907)
+* Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1908)
 
 Breaking changes:
 `Timber.tag` is no longer supported by our [Timber integration](https://docs.sentry.io/platforms/android/configuration/integrations/timber/) and will not appear on Sentry for error events. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 `Timber.tag` is no longer supported by our [Timber integration](https://docs.sentry.io/platforms/android/configuration/integrations/timber/) and will not appear on Sentry for error events. 
 Please vote on this [issue](https://github.com/getsentry/sentry-java/issues/1900), if you'd like us to provide support for that.
 
+* Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1907)
+
 ## 5.6.1
 
 * Fix: NPE while adding "response_body_size" breadcrumb, when response body is null (#1884)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ## Unreleased
 
 * Fix: Do not include stacktrace frames into Timber message (#1898)
+* Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1907)
 
 Breaking changes:
 `Timber.tag` is no longer supported by our [Timber integration](https://docs.sentry.io/platforms/android/configuration/integrations/timber/) and will not appear on Sentry for error events. 
 Please vote on this [issue](https://github.com/getsentry/sentry-java/issues/1900), if you'd like us to provide support for that.
-
-* Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1907)
 
 ## 5.6.1
 

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -84,9 +84,8 @@ public final class SentryFeignClient implements Client {
             request.httpMethod().name(),
             response != null ? response.status() : null);
     breadcrumb.setData("request_body_size", request.body() != null ? request.body().length : 0);
-    if (response != null) {
-      breadcrumb.setData(
-          "response_body_size", response.body() != null ? response.body().length() : 0);
+    if (response != null && response.body() != null && response.body().length() != null) {
+      breadcrumb.setData("response_body_size", response.body().length());
     }
     hub.addBreadcrumb(breadcrumb);
   }


### PR DESCRIPTION
## :scroll: Description

Closes https://github.com/getsentry/sentry-java/issues/1907 , see description there

## :green_heart: How did you test it?

Tested by researching API of dependency (OpenFeign)

## :pencil: Checklist
- [x] I reviewed the submitted code
- [ ] I didn't add tests, because it requires significant refactoring so that length could be `null` Integer
- [x] I updated the docs if needed
- [x] No breaking changes
