### PR TITLE
ci: Bump craft and update post-release script

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: 0.27.5
+minVersion: 0.28.1
 changelogPolicy: auto
 targets:
   - name: symbol-collector

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -5,12 +5,6 @@
 
 set -eux
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR/..
-
-OLD_VERSION="${1}"
-NEW_VERSION="${2}"
-
 git checkout main
 GRADLE_FILEPATH="gradle.properties"
 


### PR DESCRIPTION
We don't rely on version numbers here, so we can skip those. This will make `-u` flag happy (unbound variable), thus it should make script runner happy.

Possibly closes https://github.com/getsentry/sentry-java/issues/1817

#skip-changelog