### PR TITLE
Feat: Enable enableScopeSync by default for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Feat: Enable enableScopeSync by default for Android (#)
+
 ## 5.6.2-beta.2
 
 * Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1908)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Feat: Enable enableScopeSync by default for Android (#)
+* Feat: Enable enableScopeSync by default for Android (#1928)
 
 ## 5.6.2-beta.2
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -42,7 +42,7 @@ public final class NdkIntegration implements Integration, Closeable {
       final String cachedDir = this.options.getCacheDirPath();
       if (cachedDir == null || cachedDir.isEmpty()) {
         this.options.getLogger().log(SentryLevel.ERROR, "No cache dir path is defined in options.");
-        this.options.setEnableNdk(false);
+        disableNdkIntegration(this.options);
         return;
       }
 
@@ -54,17 +54,22 @@ public final class NdkIntegration implements Integration, Closeable {
 
         this.options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
       } catch (NoSuchMethodException e) {
-        this.options.setEnableNdk(false);
+        disableNdkIntegration(this.options);
         this.options
             .getLogger()
             .log(SentryLevel.ERROR, "Failed to invoke the SentryNdk.init method.", e);
       } catch (Throwable e) {
-        this.options.setEnableNdk(false);
+        disableNdkIntegration(this.options);
         this.options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
       }
     } else {
-      this.options.setEnableNdk(false);
+      disableNdkIntegration(this.options);
     }
+  }
+
+  private void disableNdkIntegration(final @NotNull SentryOptions options) {
+    options.setEnableNdk(false);
+    options.setEnableScopeSync(false);
   }
 
   @TestOnly
@@ -88,7 +93,7 @@ public final class NdkIntegration implements Integration, Closeable {
       } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Failed to close SentryNdk.", e);
       } finally {
-        this.options.setEnableNdk(false);
+        disableNdkIntegration(this.options);
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -91,6 +91,9 @@ public final class SentryAndroidOptions extends SentryOptions {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
     setAttachServerName(false);
+
+    // enable scope sync for Android by default
+    setEnableScopeSync(true);
   }
 
   private @NotNull SdkVersion createSdkVersion() {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -551,14 +551,14 @@ class ManifestMetadataReaderTest {
     @Test
     fun `applyMetadata reads enableScopeSync to options`() {
         // Arrange
-        val bundle = bundleOf(ManifestMetadataReader.NDK_SCOPE_SYNC_ENABLE to true)
+        val bundle = bundleOf(ManifestMetadataReader.NDK_SCOPE_SYNC_ENABLE to false)
         val context = fixture.getContext(metaData = bundle)
 
         // Act
         ManifestMetadataReader.applyMetadata(context, fixture.options)
 
         // Assert
-        assertTrue(fixture.options.isEnableScopeSync)
+        assertFalse(fixture.options.isEnableScopeSync)
     }
 
     @Test
@@ -570,7 +570,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options)
 
         // Assert
-        assertFalse(fixture.options.isEnableScopeSync)
+        assertTrue(fixture.options.isEnableScopeSync)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
@@ -35,6 +35,7 @@ class NdkIntegrationTest {
 
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any<String>(), any())
         assertTrue(options.isEnableNdk)
+        assertTrue(options.isEnableScopeSync)
     }
 
     @Test
@@ -46,11 +47,13 @@ class NdkIntegrationTest {
         integration.register(fixture.hub, options)
 
         assertTrue(options.isEnableNdk)
+        assertTrue(options.isEnableScopeSync)
 
         integration.close()
 
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any<String>(), any())
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -64,6 +67,7 @@ class NdkIntegrationTest {
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any<String>(), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -77,6 +81,7 @@ class NdkIntegrationTest {
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any<String>(), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -90,6 +95,7 @@ class NdkIntegrationTest {
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any<String>(), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -101,11 +107,13 @@ class NdkIntegrationTest {
         integration.register(fixture.hub, options)
 
         assertTrue(options.isEnableNdk)
+        assertTrue(options.isEnableScopeSync)
 
         integration.close()
 
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any<String>(), any())
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -119,6 +127,7 @@ class NdkIntegrationTest {
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any<String>(), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -132,6 +141,7 @@ class NdkIntegrationTest {
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     @Test
@@ -145,12 +155,13 @@ class NdkIntegrationTest {
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any())
 
         assertFalse(options.isEnableNdk)
+        assertFalse(options.isEnableScopeSync)
     }
 
     private fun getOptions(enableNdk: Boolean = true, cacheDir: String? = "abc"): SentryAndroidOptions {
         return SentryAndroidOptions().apply {
             setLogger(fixture.logger)
-            setDebug(true)
+            isDebug = true
             isEnableNdk = enableNdk
             cacheDirPath = cacheDir
         }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -55,6 +55,13 @@ class SentryAndroidOptionsTest {
         assertNotNull(sentryOptions.debugImagesLoader)
     }
 
+    @Test
+    fun `enable scope sync by default for Android`() {
+        val sentryOptions = SentryAndroidOptions()
+
+        assertTrue(sentryOptions.isEnableScopeSync)
+    }
+
     private class CustomDebugImagesLoader : IDebugImagesLoader {
         override fun loadDebugImages(): List<DebugImage>? = null
         override fun clearDebugImages() {}

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -32,7 +32,11 @@ public final class SentryNdk {
   public static void init(@NotNull final SentryAndroidOptions options) {
     SentryNdkUtil.addPackage(options.getSdkVersion());
     initSentryNative(options);
-    options.addScopeObserver(new NdkScopeObserver(options));
+
+    // only add scope sync if the feature is enabled.
+    if (options.isEnableScopeSync()) {
+      options.addScopeObserver(new NdkScopeObserver(options));
+    }
 
     options.setDebugImagesLoader(new DebugImagesLoader(options, new NativeModuleListLoader()));
   }

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -33,7 +33,7 @@ public final class SentryNdk {
     SentryNdkUtil.addPackage(options.getSdkVersion());
     initSentryNative(options);
 
-    // only add scope sync if the feature is enabled.
+    // only add scope sync observer if the scope sync is enabled.
     if (options.isEnableScopeSync()) {
       options.addScopeObserver(new NdkScopeObserver(options));
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -250,8 +250,8 @@ public class SentryOptions {
   private final @NotNull List<IScopeObserver> observers = new ArrayList<>();
 
   /**
-   * Enable the Java to NDK Scope sync.
-   * The default value for sentry-java is disabled and enabled for sentry-android.
+   * Enable the Java to NDK Scope sync. The default value for sentry-java is disabled and enabled
+   * for sentry-android.
    */
   private boolean enableScopeSync;
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -249,7 +249,10 @@ public class SentryOptions {
   /** list of scope observers */
   private final @NotNull List<IScopeObserver> observers = new ArrayList<>();
 
-  /** Enable the Java to NDK Scope sync */
+  /**
+   * Enable the Java to NDK Scope sync.
+   * The default value for Java is disabled and enabled for Android.
+   */
   private boolean enableScopeSync;
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -251,7 +251,7 @@ public class SentryOptions {
 
   /**
    * Enable the Java to NDK Scope sync.
-   * The default value for Java is disabled and enabled for Android.
+   * The default value for sentry-java is disabled and enabled for sentry-android.
    */
   private boolean enableScopeSync;
 


### PR DESCRIPTION
## :scroll: Description
Feat: Enable enableScopeSync by default for Android


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1914


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
