### PR TITLE
Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs (#)
+* Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs (#1931)
 
 ## 5.6.2-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs (#)
+
 ## 5.6.2-beta.2
 
 * Fix: NPE while adding "response_body_size" breadcrumb, when response body length is unknown (#1908)

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -1,3 +1,11 @@
+public final class io/sentry/android/core/ActivityFramesTracker {
+	public fun <init> (Lio/sentry/android/core/LoadClass;)V
+	public fun addActivity (Landroid/app/Activity;)V
+	public fun setMetrics (Landroid/app/Activity;Lio/sentry/protocol/SentryId;)V
+	public fun stop ()V
+	public fun takeMetrics (Lio/sentry/protocol/SentryId;)Ljava/util/Map;
+}
+
 public final class io/sentry/android/core/ActivityLifecycleIntegration : android/app/Application$ActivityLifecycleCallbacks, io/sentry/Integration, java/io/Closeable {
 	public fun <init> (Landroid/app/Application;Lio/sentry/android/core/IBuildInfoProvider;Lio/sentry/android/core/ActivityFramesTracker;)V
 	public fun close ()V
@@ -70,6 +78,11 @@ public abstract interface class io/sentry/android/core/IBuildInfoProvider {
 public abstract interface class io/sentry/android/core/IDebugImagesLoader {
 	public abstract fun clearDebugImages ()V
 	public abstract fun loadDebugImages ()Ljava/util/List;
+}
+
+public final class io/sentry/android/core/LoadClass {
+	public fun <init> ()V
+	public fun loadClass (Ljava/lang/String;)Ljava/lang/Class;
 }
 
 public final class io/sentry/android/core/NdkIntegration : io/sentry/Integration, java/io/Closeable {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -12,7 +12,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-final class ActivityFramesTracker {
+/**
+ * A class that tracks slow and frozen frames using the FrameMetricsAggregator class from
+ * androidx.core package. It also checks if the FrameMetricsAggregator class is available at
+ * runtime.
+ */
+public final class ActivityFramesTracker {
 
   private @Nullable FrameMetricsAggregator frameMetricsAggregator = null;
   private boolean androidXAvailable = true;
@@ -20,7 +25,7 @@ final class ActivityFramesTracker {
   private final @NotNull Map<SentryId, Map<String, @NotNull MeasurementValue>>
       activityMeasurements = new ConcurrentHashMap<>();
 
-  ActivityFramesTracker(final @NotNull LoadClass loadClass) {
+  public ActivityFramesTracker(final @NotNull LoadClass loadClass) {
     androidXAvailable = checkAndroidXAvailability(loadClass);
     if (androidXAvailable) {
       frameMetricsAggregator = new FrameMetricsAggregator();
@@ -47,7 +52,7 @@ final class ActivityFramesTracker {
   }
 
   @SuppressWarnings("NullAway")
-  synchronized void addActivity(final @NotNull Activity activity) {
+  public synchronized void addActivity(final @NotNull Activity activity) {
     if (!isFrameMetricsAggregatorAvailable()) {
       return;
     }
@@ -55,7 +60,8 @@ final class ActivityFramesTracker {
   }
 
   @SuppressWarnings("NullAway")
-  synchronized void setMetrics(final @NotNull Activity activity, final @NotNull SentryId sentryId) {
+  public synchronized void setMetrics(
+      final @NotNull Activity activity, final @NotNull SentryId sentryId) {
     if (!isFrameMetricsAggregatorAvailable()) {
       return;
     }
@@ -112,7 +118,7 @@ final class ActivityFramesTracker {
   }
 
   @Nullable
-  synchronized Map<String, @NotNull MeasurementValue> takeMetrics(
+  public synchronized Map<String, @NotNull MeasurementValue> takeMetrics(
       final @NotNull SentryId sentryId) {
     if (!isFrameMetricsAggregatorAvailable()) {
       return null;
@@ -125,7 +131,7 @@ final class ActivityFramesTracker {
   }
 
   @SuppressWarnings("NullAway")
-  synchronized void stop() {
+  public synchronized void stop() {
     if (isFrameMetricsAggregatorAvailable()) {
       frameMetricsAggregator.stop();
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/LoadClass.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LoadClass.java
@@ -3,7 +3,7 @@ package io.sentry.android.core;
 import org.jetbrains.annotations.NotNull;
 
 /** An Adapter for making Class.forName testable */
-final class LoadClass {
+public final class LoadClass {
 
   /**
    * Try to load a class via reflection


### PR DESCRIPTION
## :scroll: Description
Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-dart/pull/772/files#r816056795
Also https://github.com/getsentry/sentry-java/pull/1922


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
