### PR TITLE
Fix: If transaction or span is finished, do not allow to mutate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: If transaction or span is finished, do not allow to mutate (#)
+
 ## 5.6.2
 
 * Ref: Make ActivityFramesTracker public to be used by Hybrid SDKs (#1931)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix: If transaction or span is finished, do not allow to mutate (#)
+* Fix: If transaction or span is finished, do not allow to mutate (#1940)
 
 ## 5.6.2
 

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -137,6 +137,10 @@ public final class SentryTracer implements ITransaction {
       final @NotNull String operation,
       final @Nullable String description,
       @Nullable Date timestamp) {
+    if (root.isFinished()) {
+      return NoOpSpan.getInstance();
+    }
+
     Objects.requireNonNull(parentSpanId, "parentSpanId is required");
     Objects.requireNonNull(operation, "operation is required");
     final Span span =
@@ -179,6 +183,10 @@ public final class SentryTracer implements ITransaction {
       final @NotNull String operation,
       final @Nullable String description,
       @Nullable Date timestamp) {
+    if (root.isFinished()) {
+      return NoOpSpan.getInstance();
+    }
+
     if (children.size() < hub.getOptions().getMaxSpans()) {
       return root.startChild(operation, description, timestamp);
     } else {
@@ -288,6 +296,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setOperation(final @NotNull String operation) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setOperation(operation);
   }
 
@@ -298,6 +310,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setDescription(final @Nullable String description) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setDescription(description);
   }
 
@@ -308,6 +324,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setStatus(final @Nullable SpanStatus status) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setStatus(status);
   }
 
@@ -318,6 +338,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setThrowable(final @Nullable Throwable throwable) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setThrowable(throwable);
   }
 
@@ -333,6 +357,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setTag(final @NotNull String key, final @NotNull String value) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setTag(key, value);
   }
 
@@ -348,6 +376,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setData(@NotNull String key, @NotNull Object value) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.root.setData(key, value);
   }
 
@@ -367,6 +399,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setName(@NotNull String name) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.name = name;
   }
 
@@ -379,6 +415,10 @@ public final class SentryTracer implements ITransaction {
   @Deprecated
   @ApiStatus.ScheduledForRemoval
   public void setRequest(final @Nullable Request request) {
+    if (root.isFinished()) {
+      return;
+    }
+
     this.request = request;
   }
 

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -94,12 +94,20 @@ public final class Span implements ISpan {
       final @NotNull String operation,
       final @Nullable String description,
       final @Nullable Date timestamp) {
+    if (finished.get()) {
+      return NoOpSpan.getInstance();
+    }
+
     return transaction.startChild(context.getSpanId(), operation, description, timestamp);
   }
 
   @Override
   public @NotNull ISpan startChild(
       final @NotNull String operation, final @Nullable String description) {
+    if (finished.get()) {
+      return NoOpSpan.getInstance();
+    }
+
     return transaction.startChild(context.getSpanId(), operation, description);
   }
 
@@ -152,6 +160,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setOperation(final @NotNull String operation) {
+    if (finished.get()) {
+      return;
+    }
+
     this.context.setOperation(operation);
   }
 
@@ -162,6 +174,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setDescription(final @Nullable String description) {
+    if (finished.get()) {
+      return;
+    }
+
     this.context.setDescription(description);
   }
 
@@ -172,6 +188,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setStatus(final @Nullable SpanStatus status) {
+    if (finished.get()) {
+      return;
+    }
+
     this.context.setStatus(status);
   }
 
@@ -187,6 +207,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setTag(final @NotNull String key, final @NotNull String value) {
+    if (finished.get()) {
+      return;
+    }
+
     this.context.setTag(key, value);
   }
 
@@ -210,6 +234,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setThrowable(final @Nullable Throwable throwable) {
+    if (finished.get()) {
+      return;
+    }
+
     this.throwable = throwable;
   }
 
@@ -237,6 +265,10 @@ public final class Span implements ISpan {
 
   @Override
   public void setData(@NotNull String key, @NotNull Object value) {
+    if (finished.get()) {
+      return;
+    }
+
     data.put(key, value);
   }
 

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -155,6 +155,37 @@ class SpanTest {
     }
 
     @Test
+    fun `when span is finished, do nothing`() {
+        val span = fixture.getSut()
+        span.description = "desc"
+        span.setTag("myTag", "myValue")
+        span.setData("myData", "myValue")
+        val ex = RuntimeException()
+        span.throwable = ex
+
+        span.finish(SpanStatus.OK)
+        assertTrue(span.isFinished)
+
+        assertEquals(NoOpSpan.getInstance(), span.startChild("op", "desc", null))
+        assertEquals(NoOpSpan.getInstance(), span.startChild("op", "desc"))
+
+        span.finish(SpanStatus.UNKNOWN_ERROR)
+        span.operation = "newOp"
+        span.description = "newDesc"
+        span.status = SpanStatus.ABORTED
+        span.setTag("myTag", "myNewValue")
+        span.throwable = RuntimeException()
+        span.setData("myData", "myNewValue")
+
+        assertEquals(SpanStatus.OK, span.status)
+        assertEquals("op", span.operation)
+        assertEquals("desc", span.description)
+        assertEquals("myValue", span.tags["myTag"])
+        assertEquals("myValue", span.data["myData"])
+        assertEquals(ex, span.throwable)
+    }
+
+    @Test
     fun `child trace state is equal to transaction trace state`() {
         val transaction = getTransaction()
         val span = transaction.startChild("operation", "description")


### PR DESCRIPTION
## :scroll: Description
Fix: If transaction or span is finished, do not allow to mutate


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1840


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
