### PR TITLE
fix: Exclude classes that we are checking at runtime from obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix: If transaction or span is finished, do not allow to mutate (#1940)
+* Fix: Keep used AndroidX classes from obfuscation (Fixes UI breadcrumbs and Slow/Frozen frames) (#1942)
 
 ## 5.6.2
 

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -1,3 +1,9 @@
+##---------------Begin: proguard configuration for androidx.core  ----------
+-keep class androidx.core.view.GestureDetectorCompat { <init>(...); }
+-keep class androidx.core.app.FrameMetricsAggregator { <init>(...); }
+-keep interface androidx.core.view.ScrollingView { *; }
+##---------------End: proguard configuration for androidx.core  ----------
+
 ##---------------Begin: proguard configuration for Gson  ----------
 # Gson uses generic type information stored in a class file when working with fields. Proguard
 # removes such information by default, so configure it to keep all of it.


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
