### PR TITLE
Pass MDC tags as Sentry tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Ref: Remove not needed interface abstractions on Android (#1953)
+* Feat: Pass MDC tags as Sentry tags (#1954)
 
 ## 6.0.0-alpha.3
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -202,13 +202,13 @@ public class SentryHandler extends Handler {
       mdcProperties =
           CollectionUtils.filterMapEntries(mdcProperties, entry -> entry.getValue() != null);
       if (!mdcProperties.isEmpty()) {
-        if (!options.getMdcTags().isEmpty()) {
-          for (final String mdcTag : options.getMdcTags()) {
+        if (!options.getContextTags().isEmpty()) {
+          for (final String contextTag : options.getContextTags()) {
             // if mdc tag is listed in SentryOptions, apply as event tag
-            if (mdcProperties.containsKey(mdcTag)) {
-              event.setTag(mdcTag, mdcProperties.get(mdcTag));
+            if (mdcProperties.containsKey(contextTag)) {
+              event.setTag(contextTag, mdcProperties.get(contextTag));
               // remove from all tags applied to logging event
-              mdcProperties.remove(mdcTag);
+              mdcProperties.remove(contextTag);
             }
           }
         }

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryHandlerTest {
-    private class Fixture(minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, val configureWithLogManager: Boolean = false, val transport: ITransport = mock(), mdcTags: List<String>? = null) {
+    private class Fixture(minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, val configureWithLogManager: Boolean = false, val transport: ITransport = mock(), contextTags: List<String>? = null) {
         var logger: Logger
         var handler: SentryHandler
 
@@ -32,7 +32,7 @@ class SentryHandlerTest {
             val options = SentryOptions()
             options.dsn = "http://key@localhost/proj"
             options.setTransportFactory { _, _ -> transport }
-            mdcTags?.forEach { options.addMdcTag(it) }
+            contextTags?.forEach { options.addContextTag(it) }
             logger = Logger.getLogger("jul.SentryHandlerTest")
             handler = SentryHandler(options, configureWithLogManager)
             handler.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
@@ -315,15 +315,15 @@ class SentryHandlerTest {
 
     @Test
     fun `sets tags as Sentry tags from MDC`() {
-        fixture = Fixture(minimumEventLevel = Level.WARNING, mdcTags = listOf("mdcTag1"))
+        fixture = Fixture(minimumEventLevel = Level.WARNING, contextTags = listOf("contextTag1"))
         MDC.put("key", "value")
-        MDC.put("mdcTag1", "mdcTag1Value")
+        MDC.put("contextTag1", "contextTag1Value")
         fixture.logger.warning("testing MDC tags")
 
         verify(fixture.transport).send(
             checkEvent { event ->
                 assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
-                assertEquals(mapOf("mdcTag1" to "mdcTag1Value"), event.tags)
+                assertEquals(mapOf("contextTag1" to "contextTag1Value"), event.tags)
             },
             anyOrNull()
         )

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryHandlerTest {
-    private class Fixture(minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, val configureWithLogManager: Boolean = false, val transport: ITransport = mock()) {
+    private class Fixture(minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, val configureWithLogManager: Boolean = false, val transport: ITransport = mock(), mdcTags: List<String>? = null) {
         var logger: Logger
         var handler: SentryHandler
 
@@ -32,6 +32,7 @@ class SentryHandlerTest {
             val options = SentryOptions()
             options.dsn = "http://key@localhost/proj"
             options.setTransportFactory { _, _ -> transport }
+            mdcTags?.forEach { options.addMdcTag(it) }
             logger = Logger.getLogger("jul.SentryHandlerTest")
             handler = SentryHandler(options, configureWithLogManager)
             handler.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
@@ -307,6 +308,22 @@ class SentryHandlerTest {
         verify(fixture.transport).send(
             checkEvent { event ->
                 assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `sets tags as Sentry tags from MDC`() {
+        fixture = Fixture(minimumEventLevel = Level.WARNING, mdcTags = listOf("mdcTag1"))
+        MDC.put("key", "value")
+        MDC.put("mdcTag1", "mdcTag1Value")
+        fixture.logger.warning("testing MDC tags")
+
+        verify(fixture.transport).send(
+            checkEvent { event ->
+                assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
+                assertEquals(mapOf("mdcTag1" to "mdcTag1Value"), event.tags)
             },
             anyOrNull()
         )

--- a/sentry-log4j2/api/sentry-log4j2.api
+++ b/sentry-log4j2/api/sentry-log4j2.api
@@ -4,9 +4,9 @@ public final class io/sentry/log4j2/BuildConfig {
 }
 
 public class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
-	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/Boolean;Lio/sentry/ITransportFactory;Lio/sentry/IHub;)V
+	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/Boolean;Lio/sentry/ITransportFactory;Lio/sentry/IHub;[Ljava/lang/String;)V
 	public fun append (Lorg/apache/logging/log4j/core/LogEvent;)V
-	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Ljava/lang/Boolean;Lorg/apache/logging/log4j/core/Filter;)Lio/sentry/log4j2/SentryAppender;
+	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Ljava/lang/Boolean;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;)Lio/sentry/log4j2/SentryAppender;
 	protected fun createBreadcrumb (Lorg/apache/logging/log4j/core/LogEvent;)Lio/sentry/Breadcrumb;
 	protected fun createEvent (Lorg/apache/logging/log4j/core/LogEvent;)Lio/sentry/SentryEvent;
 	public fun start ()V

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -46,7 +46,7 @@ public class SentryAppender extends AbstractAppender {
   private @NotNull Level minimumEventLevel = Level.ERROR;
   private final @Nullable Boolean debug;
   private final @NotNull IHub hub;
-  private final @Nullable List<String> mdcTags;
+  private final @Nullable List<String> contextTags;
 
   public SentryAppender(
       final @NotNull String name,
@@ -57,7 +57,7 @@ public class SentryAppender extends AbstractAppender {
       final @Nullable Boolean debug,
       final @Nullable ITransportFactory transportFactory,
       final @NotNull IHub hub,
-      final @Nullable String[] mdcTags) {
+      final @Nullable String[] contextTags) {
     super(name, filter, null, true, null);
     this.dsn = dsn;
     if (minimumBreadcrumbLevel != null) {
@@ -69,7 +69,7 @@ public class SentryAppender extends AbstractAppender {
     this.debug = debug;
     this.transportFactory = transportFactory;
     this.hub = hub;
-    this.mdcTags = mdcTags != null ? Arrays.asList(mdcTags) : null;
+    this.contextTags = contextTags != null ? Arrays.asList(contextTags) : null;
   }
 
   /**
@@ -91,7 +91,7 @@ public class SentryAppender extends AbstractAppender {
       @Nullable @PluginAttribute("dsn") final String dsn,
       @Nullable @PluginAttribute("debug") final Boolean debug,
       @Nullable @PluginElement("filter") final Filter filter,
-      @Nullable @PluginAttribute("mdcTags") final String mdcTags) {
+      @Nullable @PluginAttribute("contextTags") final String contextTags) {
 
     if (name == null) {
       LOGGER.error("No name provided for SentryAppender");
@@ -106,7 +106,7 @@ public class SentryAppender extends AbstractAppender {
         debug,
         null,
         HubAdapter.getInstance(),
-        mdcTags != null ? mdcTags.split(",") : null);
+        contextTags != null ? contextTags.split(",") : null);
   }
 
   @Override
@@ -122,9 +122,9 @@ public class SentryAppender extends AbstractAppender {
               }
               options.setSentryClientName(BuildConfig.SENTRY_LOG4J2_SDK_NAME);
               options.setSdkVersion(createSdkVersion(options));
-              if (mdcTags != null) {
-                for (final String mdcTag : mdcTags) {
-                  options.addMdcTag(mdcTag);
+              if (contextTags != null) {
+                for (final String contextTag : contextTags) {
+                  options.addContextTag(contextTag);
                 }
               }
               Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
@@ -187,13 +187,13 @@ public class SentryAppender extends AbstractAppender {
         CollectionUtils.filterMapEntries(
             loggingEvent.getContextData().toMap(), entry -> entry.getValue() != null);
     if (!contextData.isEmpty()) {
-      if (mdcTags != null && !mdcTags.isEmpty()) {
-        for (final String mdcTag : mdcTags) {
+      if (contextTags != null && !contextTags.isEmpty()) {
+        for (final String contextTag : contextTags) {
           // if mdc tag is listed in SentryOptions, apply as event tag
-          if (contextData.containsKey(mdcTag)) {
-            event.setTag(mdcTag, contextData.get(mdcTag));
+          if (contextData.containsKey(contextTag)) {
+            event.setTag(contextTag, contextData.get(contextTag));
             // remove from all tags applied to logging event
-            contextData.remove(mdcTag);
+            contextData.remove(contextTag);
           }
         }
       }

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -16,7 +16,6 @@ import io.sentry.SentryOptions;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.util.CollectionUtils;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -107,7 +106,7 @@ public class SentryAppender extends AbstractAppender {
         debug,
         null,
         HubAdapter.getInstance(),
-      mdcTags != null ? mdcTags.split(",") : null);
+        mdcTags != null ? mdcTags.split(",") : null);
   }
 
   @Override

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -43,13 +43,13 @@ class SentryAppenderTest {
             whenever(transportFactory.create(any(), any())).thenReturn(transport)
         }
 
-        fun getSut(transportFactory: ITransportFactory? = null, minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, debug: Boolean? = null, mdcTags: List<String>? = null): ExtendedLogger {
+        fun getSut(transportFactory: ITransportFactory? = null, minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, debug: Boolean? = null, contextTags: List<String>? = null): ExtendedLogger {
             if (transportFactory != null) {
                 this.transportFactory = transportFactory
             }
             loggerContext.start()
             val config: Configuration = loggerContext.configuration
-            val appender = SentryAppender("sentry", null, "http://key@localhost/proj", minimumBreadcrumbLevel, minimumEventLevel, debug, this.transportFactory, HubAdapter.getInstance(), mdcTags?.toTypedArray())
+            val appender = SentryAppender("sentry", null, "http://key@localhost/proj", minimumBreadcrumbLevel, minimumEventLevel, debug, this.transportFactory, HubAdapter.getInstance(), contextTags?.toTypedArray())
             config.addAppender(appender)
 
             val ref = AppenderRef.createAppenderRef("sentry", null, null)
@@ -243,15 +243,15 @@ class SentryAppenderTest {
 
     @Test
     fun `sets tags from ThreadContext as Sentry tags`() {
-        val logger = fixture.getSut(minimumEventLevel = Level.WARN, mdcTags = listOf("mdcTag1"))
+        val logger = fixture.getSut(minimumEventLevel = Level.WARN, contextTags = listOf("contextTag1"))
         ThreadContext.put("key", "value")
-        ThreadContext.put("mdcTag1", "mdcTag1Value")
+        ThreadContext.put("contextTag1", "contextTag1Value")
         logger.warn("testing MDC tags")
 
         verify(fixture.transport).send(
             checkEvent { event ->
                 assertEquals(mapOf("key" to "value"), event.contexts["Context Data"])
-                assertEquals(mapOf("mdcTag1" to "mdcTag1Value"), event.tags)
+                assertEquals(mapOf("contextTag1" to "contextTag1Value"), event.tags)
             },
             anyOrNull()
         )

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -112,7 +112,20 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         CollectionUtils.filterMapEntries(
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
-      event.getContexts().put("MDC", mdcProperties);
+      if (!options.getMdcTags().isEmpty()) {
+        for (final String mdcTag : options.getMdcTags()) {
+          // if mdc tag is listed in SentryOptions, apply as event tag
+          if (mdcProperties.containsKey(mdcTag)) {
+            event.setTag(mdcTag, mdcProperties.get(mdcTag));
+            // remove from all tags applied to logging event
+            mdcProperties.remove(mdcTag);
+          }
+        }
+      }
+      // put the rest of mdc tags in contexts
+      if (!mdcProperties.isEmpty()) {
+        event.getContexts().put("MDC", mdcProperties);
+      }
     }
 
     return event;

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -112,13 +112,13 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         CollectionUtils.filterMapEntries(
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
-      if (!options.getMdcTags().isEmpty()) {
-        for (final String mdcTag : options.getMdcTags()) {
+      if (!options.getContextTags().isEmpty()) {
+        for (final String contextTag : options.getContextTags()) {
           // if mdc tag is listed in SentryOptions, apply as event tag
-          if (mdcProperties.containsKey(mdcTag)) {
-            event.setTag(mdcTag, mdcProperties.get(mdcTag));
+          if (mdcProperties.containsKey(contextTag)) {
+            event.setTag(contextTag, mdcProperties.get(contextTag));
             // remove from all tags applied to logging event
-            mdcProperties.remove(mdcTag);
+            mdcProperties.remove(contextTag);
           }
         }
       }

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryAppenderTest {
-    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, mdcTags: List<String>? = null) {
+    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, contextTags: List<String>? = null) {
         val logger: Logger = LoggerFactory.getLogger(SentryAppenderTest::class.java)
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
         val transportFactory = mock<ITransportFactory>()
@@ -43,7 +43,7 @@ class SentryAppenderTest {
             val appender = SentryAppender()
             val options = SentryOptions()
             options.dsn = dsn
-            mdcTags?.forEach { options.addMdcTag(it) }
+            contextTags?.forEach { options.addContextTag(it) }
             appender.setOptions(options)
             appender.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
             appender.setMinimumEventLevel(minimumEventLevel)
@@ -220,15 +220,15 @@ class SentryAppenderTest {
 
     @Test
     fun `sets tags as sentry tags from MDC`() {
-        fixture = Fixture(minimumEventLevel = Level.WARN, mdcTags = listOf("mdcTag1"))
+        fixture = Fixture(minimumEventLevel = Level.WARN, contextTags = listOf("contextTag1"))
         MDC.put("key", "value")
-        MDC.put("mdcTag1", "mdcTag1Value")
+        MDC.put("contextTag1", "contextTag1Value")
         fixture.logger.warn("testing MDC tags")
 
         verify(fixture.transport).send(
             checkEvent { event ->
                 assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
-                assertEquals(mapOf("mdcTag1" to "mdcTag1Value"), event.tags)
+                assertEquals(mapOf("contextTag1" to "contextTag1Value"), event.tags)
             },
             anyOrNull()
         )

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryAppenderTest {
-    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null) {
+    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, mdcTags: List<String>? = null) {
         val logger: Logger = LoggerFactory.getLogger(SentryAppenderTest::class.java)
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
         val transportFactory = mock<ITransportFactory>()
@@ -43,6 +43,7 @@ class SentryAppenderTest {
             val appender = SentryAppender()
             val options = SentryOptions()
             options.dsn = dsn
+            mdcTags?.forEach { options.addMdcTag(it) }
             appender.setOptions(options)
             appender.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
             appender.setMinimumEventLevel(minimumEventLevel)
@@ -212,6 +213,22 @@ class SentryAppenderTest {
         verify(fixture.transport).send(
             checkEvent { event ->
                 assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `sets tags as sentry tags from MDC`() {
+        fixture = Fixture(minimumEventLevel = Level.WARN, mdcTags = listOf("mdcTag1"))
+        MDC.put("key", "value")
+        MDC.put("mdcTag1", "mdcTag1Value")
+        fixture.logger.warn("testing MDC tags")
+
+        verify(fixture.transport).send(
+            checkEvent { event ->
+                assertEquals(mapOf("key" to "value"), event.contexts["MDC"])
+                assertEquals(mapOf("mdcTag1" to "mdcTag1Value"), event.tags)
             },
             anyOrNull()
         )

--- a/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
@@ -3,4 +3,4 @@ dsn=https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563
 debug=true
 environment=staging
 in-app-includes=io.sentry.samples
-mdc-tags=userId,requestId
+context-tags=userId,requestId

--- a/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
@@ -3,3 +3,4 @@ dsn=https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563
 debug=true
 environment=staging
 in-app-includes=io.sentry.samples
+mdc-tags=userId,requestId

--- a/sentry-samples/sentry-samples-log4j2/src/main/java/io/sentry/samples/log4j2/Main.java
+++ b/sentry-samples/sentry-samples-log4j2/src/main/java/io/sentry/samples/log4j2/Main.java
@@ -13,8 +13,11 @@ public class Main {
     // Update the DSN in log4j2.xml to see these events in your Sentry dashboard.
     LOGGER.debug("Hello Sentry!");
 
-    // ThreadContext parameters are converted to Sentry Event tags
+    // ThreadContext tags listed in log4j2.xml are converted to Sentry Event tags
     ThreadContext.put("userId", UUID.randomUUID().toString());
+    ThreadContext.put("requestId", UUID.randomUUID().toString());
+    // ThreadContext tag not listed in log4j2.xml
+    ThreadContext.put("context-tag", "context-tag-value");
 
     // logging arguments are converted to Sentry Event parameters
     LOGGER.info("User has made a purchase of product: {}", 445);

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
@@ -12,7 +12,7 @@
             minimumBreadcrumbLevel="DEBUG"
             minimumEventLevel="WARN"
             debug="true"
-            mdcTags="userId"
+            mdcTags="userId,requestId"
     />
   </Appenders>
   <Loggers>

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
@@ -12,7 +12,7 @@
             minimumBreadcrumbLevel="DEBUG"
             minimumEventLevel="WARN"
             debug="true"
-            mdcTags="userId,requestId"
+            contextTags="userId,requestId"
     />
   </Appenders>
   <Loggers>

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
@@ -11,6 +11,8 @@
             dsn="https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563"
             minimumBreadcrumbLevel="DEBUG"
             minimumEventLevel="WARN"
+            debug="true"
+            mdcTags="userId"
     />
   </Appenders>
   <Loggers>

--- a/sentry-samples/sentry-samples-logback/src/main/java/io/sentry/samples/logback/Main.java
+++ b/sentry-samples/sentry-samples-logback/src/main/java/io/sentry/samples/logback/Main.java
@@ -11,8 +11,11 @@ public class Main {
   public static void main(String[] args) {
     LOGGER.debug("Hello Sentry!");
 
-    // MDC parameters are converted to Sentry Event tags
+    // MDC tags listed in logback.xml are converted to Sentry Event tags
     MDC.put("userId", UUID.randomUUID().toString());
+    MDC.put("requestId", UUID.randomUUID().toString());
+    // MDC tag not listed in logback.xml
+    MDC.put("context-tag", "context-tag-value");
 
     // logging arguments are converted to Sentry Event parameters
     LOGGER.info("User has made a purchase of product: {}", 445);

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -11,8 +11,8 @@
       <debug>true</debug>
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
       <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
-      <mdcTag>userId</mdcTag>
-      <mdcTag>requestId</mdcTag>
+      <contextTag>userId</contextTag>
+      <contextTag>requestId</contextTag>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -11,6 +11,7 @@
       <debug>true</debug>
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
       <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
+      <mdcTag>userId</mdcTag>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->

--- a/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
+++ b/sentry-samples/sentry-samples-logback/src/main/resources/logback.xml
@@ -12,6 +12,7 @@
       <!-- NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard -->
       <dsn>https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563</dsn>
       <mdcTag>userId</mdcTag>
+      <mdcTag>requestId</mdcTag>
     </options>
     <!-- Demonstrates how to modify the minimum values -->
     <!-- Default for Events is ERROR -->

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -124,12 +124,13 @@ public abstract interface class io/sentry/EventProcessor {
 
 public final class io/sentry/ExternalOptions {
 	public fun <init> ()V
+	public fun addContextTag (Ljava/lang/String;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
-	public fun addMdcTag (Ljava/lang/String;)V
 	public fun addTracingOrigin (Ljava/lang/String;)V
 	public static fun from (Lio/sentry/config/PropertiesProvider;Lio/sentry/ILogger;)Lio/sentry/ExternalOptions;
+	public fun getContextTags ()Ljava/util/List;
 	public fun getDebug ()Ljava/lang/Boolean;
 	public fun getDist ()Ljava/lang/String;
 	public fun getDsn ()Ljava/lang/String;
@@ -140,7 +141,6 @@ public final class io/sentry/ExternalOptions {
 	public fun getInAppExcludes ()Ljava/util/List;
 	public fun getInAppIncludes ()Ljava/util/List;
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
-	public fun getMdcTags ()Ljava/util/List;
 	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
@@ -995,18 +995,19 @@ public final class io/sentry/SentryLevel : java/lang/Enum, io/sentry/JsonSeriali
 
 public class io/sentry/SentryOptions {
 	public fun <init> ()V
+	public fun addContextTag (Ljava/lang/String;)V
 	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
 	public fun addIntegration (Lio/sentry/Integration;)V
-	public fun addMdcTag (Ljava/lang/String;)V
 	public fun addScopeObserver (Lio/sentry/IScopeObserver;)V
 	public fun addTracingOrigin (Ljava/lang/String;)V
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
 	public fun getCacheDirPath ()Ljava/lang/String;
 	public fun getConnectionTimeoutMillis ()I
+	public fun getContextTags ()Ljava/util/List;
 	public fun getDiagnosticLevel ()Lio/sentry/SentryLevel;
 	public fun getDist ()Ljava/lang/String;
 	public fun getDistinctId ()Ljava/lang/String;
@@ -1029,7 +1030,6 @@ public class io/sentry/SentryOptions {
 	public fun getMaxQueueSize ()I
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
 	public fun getMaxSpans ()I
-	public fun getMdcTags ()Ljava/util/List;
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProguardUuid ()Ljava/lang/String;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -127,6 +127,7 @@ public final class io/sentry/ExternalOptions {
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
+	public fun addMdcTag (Ljava/lang/String;)V
 	public fun addTracingOrigin (Ljava/lang/String;)V
 	public static fun from (Lio/sentry/config/PropertiesProvider;Lio/sentry/ILogger;)Lio/sentry/ExternalOptions;
 	public fun getDebug ()Ljava/lang/Boolean;
@@ -139,6 +140,7 @@ public final class io/sentry/ExternalOptions {
 	public fun getInAppExcludes ()Ljava/util/List;
 	public fun getInAppIncludes ()Ljava/util/List;
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
+	public fun getMdcTags ()Ljava/util/List;
 	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
@@ -998,6 +1000,7 @@ public class io/sentry/SentryOptions {
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
 	public fun addIntegration (Lio/sentry/Integration;)V
+	public fun addMdcTag (Ljava/lang/String;)V
 	public fun addScopeObserver (Lio/sentry/IScopeObserver;)V
 	public fun addTracingOrigin (Ljava/lang/String;)V
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
@@ -1026,6 +1029,7 @@ public class io/sentry/SentryOptions {
 	public fun getMaxQueueSize ()I
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
 	public fun getMaxSpans ()I
+	public fun getMdcTags ()Ljava/util/List;
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProguardUuid ()Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -32,7 +32,7 @@ public final class ExternalOptions {
   private final @NotNull List<String> inAppExcludes = new CopyOnWriteArrayList<>();
   private final @NotNull List<String> inAppIncludes = new CopyOnWriteArrayList<>();
   private final @NotNull List<String> tracingOrigins = new CopyOnWriteArrayList<>();
-  private final @NotNull List<String> mdcTags = new CopyOnWriteArrayList<>();
+  private final @NotNull List<String> contextTags = new CopyOnWriteArrayList<>();
   private @Nullable String proguardUuid;
   private final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType =
       new CopyOnWriteArraySet<>();
@@ -82,8 +82,8 @@ public final class ExternalOptions {
     for (final String tracingOrigin : propertiesProvider.getList("tracing-origins")) {
       options.addTracingOrigin(tracingOrigin);
     }
-    for (final String mdcTag : propertiesProvider.getList("mdc-tags")) {
-      options.addMdcTag(mdcTag);
+    for (final String contextTag : propertiesProvider.getList("context-tags")) {
+      options.addContextTag(contextTag);
     }
     options.setProguardUuid(propertiesProvider.getProperty("proguard-uuid"));
 
@@ -216,8 +216,8 @@ public final class ExternalOptions {
     return inAppIncludes;
   }
 
-  public @NotNull List<String> getMdcTags() {
-    return mdcTags;
+  public @NotNull List<String> getContextTags() {
+    return contextTags;
   }
 
   public @Nullable String getProguardUuid() {
@@ -244,8 +244,8 @@ public final class ExternalOptions {
     this.tracingOrigins.add(tracingOrigin);
   }
 
-  public void addMdcTag(final @NotNull String mdcTag) {
-    this.mdcTags.add(mdcTag);
+  public void addContextTag(final @NotNull String contextTag) {
+    this.contextTags.add(contextTag);
   }
 
   public void addIgnoredExceptionForType(final @NotNull Class<? extends Throwable> exceptionType) {

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -32,6 +32,7 @@ public final class ExternalOptions {
   private final @NotNull List<String> inAppExcludes = new CopyOnWriteArrayList<>();
   private final @NotNull List<String> inAppIncludes = new CopyOnWriteArrayList<>();
   private final @NotNull List<String> tracingOrigins = new CopyOnWriteArrayList<>();
+  private final @NotNull List<String> mdcTags = new CopyOnWriteArrayList<>();
   private @Nullable String proguardUuid;
   private final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType =
       new CopyOnWriteArraySet<>();
@@ -80,6 +81,9 @@ public final class ExternalOptions {
     }
     for (final String tracingOrigin : propertiesProvider.getList("tracing-origins")) {
       options.addTracingOrigin(tracingOrigin);
+    }
+    for (final String mdcTag : propertiesProvider.getList("mdc-tags")) {
+      options.addMdcTag(mdcTag);
     }
     options.setProguardUuid(propertiesProvider.getProperty("proguard-uuid"));
 
@@ -212,6 +216,10 @@ public final class ExternalOptions {
     return inAppIncludes;
   }
 
+  public @NotNull List<String> getMdcTags() {
+    return mdcTags;
+  }
+
   public @Nullable String getProguardUuid() {
     return proguardUuid;
   }
@@ -234,6 +242,10 @@ public final class ExternalOptions {
 
   public void addTracingOrigin(final @NotNull String tracingOrigin) {
     this.tracingOrigins.add(tracingOrigin);
+  }
+
+  public void addMdcTag(final @NotNull String mdcTag) {
+    this.mdcTags.add(mdcTag);
   }
 
   public void addIgnoredExceptionForType(final @NotNull Class<? extends Throwable> exceptionType) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -298,6 +298,11 @@ public class SentryOptions {
   private @Nullable String proguardUuid;
 
   /**
+   * Contains a list of MDC tags names that are meant to be applied as Sentry tags to events.
+   */
+  private final @NotNull List<String> mdcTags = new CopyOnWriteArrayList<>();
+
+  /**
    * Adds an event processor
    *
    * @param eventProcessor the event processor
@@ -1440,6 +1445,22 @@ public class SentryOptions {
    */
   public void setProguardUuid(final @Nullable String proguardUuid) {
     this.proguardUuid = proguardUuid;
+  }
+
+  /**
+   * Returns MDC tags names applied to Sentry events as Sentry tags.
+   * @return mdc tags
+   */
+  public @NotNull List<String> getMdcTags() {
+    return mdcTags;
+  }
+
+  /**
+   * Adds MDC tag name that is applied to Sentry events as Sentry tag.
+   * @param mdcTag - the MDC tag
+   */
+  public void addMdcTag(final @NotNull String mdcTag) {
+    this.mdcTags.add(mdcTag);
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1610,6 +1610,10 @@ public class SentryOptions {
     for (final String tracingOrigin : tracingOrigins) {
       addTracingOrigin(tracingOrigin);
     }
+    final List<String> mdcTags = new ArrayList<>(options.getMdcTags());
+    for (final String mdcTag : mdcTags) {
+      addMdcTag(mdcTag);
+    }
     if (options.getProguardUuid() != null) {
       setProguardUuid(options.getProguardUuid());
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -297,8 +297,11 @@ public class SentryOptions {
   /** Proguard UUID. */
   private @Nullable String proguardUuid;
 
-  /** Contains a list of MDC tags names that are meant to be applied as Sentry tags to events. */
-  private final @NotNull List<String> mdcTags = new CopyOnWriteArrayList<>();
+  /**
+   * Contains a list of context tags names (for example from MDC) that are meant to be applied as
+   * Sentry tags to events.
+   */
+  private final @NotNull List<String> contextTags = new CopyOnWriteArrayList<>();
 
   /**
    * Adds an event processor
@@ -1446,21 +1449,21 @@ public class SentryOptions {
   }
 
   /**
-   * Returns MDC tags names applied to Sentry events as Sentry tags.
+   * Returns Context tags names applied to Sentry events as Sentry tags.
    *
-   * @return mdc tags
+   * @return context tags
    */
-  public @NotNull List<String> getMdcTags() {
-    return mdcTags;
+  public @NotNull List<String> getContextTags() {
+    return contextTags;
   }
 
   /**
-   * Adds MDC tag name that is applied to Sentry events as Sentry tag.
+   * Adds context tag name that is applied to Sentry events as Sentry tag.
    *
-   * @param mdcTag - the MDC tag
+   * @param contextTag - the context tag
    */
-  public void addMdcTag(final @NotNull String mdcTag) {
-    this.mdcTags.add(mdcTag);
+  public void addContextTag(final @NotNull String contextTag) {
+    this.contextTags.add(contextTag);
   }
 
   /** The BeforeSend callback */
@@ -1610,9 +1613,9 @@ public class SentryOptions {
     for (final String tracingOrigin : tracingOrigins) {
       addTracingOrigin(tracingOrigin);
     }
-    final List<String> mdcTags = new ArrayList<>(options.getMdcTags());
-    for (final String mdcTag : mdcTags) {
-      addMdcTag(mdcTag);
+    final List<String> contextTags = new ArrayList<>(options.getContextTags());
+    for (final String contextTag : contextTags) {
+      addContextTag(contextTag);
     }
     if (options.getProguardUuid() != null) {
       setProguardUuid(options.getProguardUuid());

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -297,9 +297,7 @@ public class SentryOptions {
   /** Proguard UUID. */
   private @Nullable String proguardUuid;
 
-  /**
-   * Contains a list of MDC tags names that are meant to be applied as Sentry tags to events.
-   */
+  /** Contains a list of MDC tags names that are meant to be applied as Sentry tags to events. */
   private final @NotNull List<String> mdcTags = new CopyOnWriteArrayList<>();
 
   /**
@@ -1449,6 +1447,7 @@ public class SentryOptions {
 
   /**
    * Returns MDC tags names applied to Sentry events as Sentry tags.
+   *
    * @return mdc tags
    */
   public @NotNull List<String> getMdcTags() {
@@ -1457,6 +1456,7 @@ public class SentryOptions {
 
   /**
    * Adds MDC tag name that is applied to Sentry events as Sentry tag.
+   *
    * @param mdcTag - the MDC tag
    */
   public void addMdcTag(final @NotNull String mdcTag) {

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -137,6 +137,13 @@ class ExternalOptionsTest {
     }
 
     @Test
+    fun `creates options with mdc tags using external properties`() {
+        withPropertiesFile("mdc-tags=userId,xxx") {
+            assertEquals(listOf("userId", "xxx"), it.mdcTags)
+        }
+    }
+
+    @Test
     fun `creates options with proguardUuid using external properties`() {
         withPropertiesFile("proguard-uuid=id") {
             assertEquals("id", it.proguardUuid)

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -137,9 +137,9 @@ class ExternalOptionsTest {
     }
 
     @Test
-    fun `creates options with mdc tags using external properties`() {
-        withPropertiesFile("mdc-tags=userId,xxx") {
-            assertEquals(listOf("userId", "xxx"), it.mdcTags)
+    fun `creates options with context tags using external properties`() {
+        withPropertiesFile("context-tags=userId,xxx") {
+            assertEquals(listOf("userId", "xxx"), it.contextTags)
         }
     }
 

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -199,8 +199,8 @@ class SentryOptionsTest {
         externalOptions.addInAppExclude("io.off")
         externalOptions.addTracingOrigin("localhost")
         externalOptions.addTracingOrigin("api.foo.com")
-        externalOptions.addMdcTag("userId")
-        externalOptions.addMdcTag("requestId")
+        externalOptions.addContextTag("userId")
+        externalOptions.addContextTag("requestId")
         val options = SentryOptions()
 
         options.merge(externalOptions)
@@ -219,7 +219,7 @@ class SentryOptionsTest {
         assertEquals(listOf("com.app"), options.inAppIncludes)
         assertEquals(listOf("io.off"), options.inAppExcludes)
         assertEquals(listOf("localhost", "api.foo.com"), options.tracingOrigins)
-        assertEquals(listOf("userId", "requestId"), options.mdcTags)
+        assertEquals(listOf("userId", "requestId"), options.contextTags)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -199,6 +199,8 @@ class SentryOptionsTest {
         externalOptions.addInAppExclude("io.off")
         externalOptions.addTracingOrigin("localhost")
         externalOptions.addTracingOrigin("api.foo.com")
+        externalOptions.addMdcTag("userId")
+        externalOptions.addMdcTag("requestId")
         val options = SentryOptions()
 
         options.merge(externalOptions)
@@ -217,6 +219,7 @@ class SentryOptionsTest {
         assertEquals(listOf("com.app"), options.inAppIncludes)
         assertEquals(listOf("io.off"), options.inAppExcludes)
         assertEquals(listOf("localhost", "api.foo.com"), options.tracingOrigins)
+        assertEquals(listOf("userId", "requestId"), options.mdcTags)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Add option to specify MDC tag names that are mean to be applied as Sentry tags to Sentry events instead of putting into event contexts as we used to do.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1148

## :green_heart: How did you test it?

Unit & Integration tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes
