### PR TITLE
Feat: Add Fragment name hint for fragmentLifecycleBreadcrumbs

### DIFF
--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -116,7 +116,7 @@ class SentryFragmentLifecycleCallbacks(
             category = "ui.fragment.lifecycle"
             level = INFO
         }
-        hub.addBreadcrumb(breadcrumb)
+        hub.addBreadcrumb(breadcrumb, mapOf("fragmentClassName" to fragment::class.java.name))
     }
 
     private fun getFragmentName(fragment: Fragment): String {

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -268,6 +268,9 @@ class SentryFragmentLifecycleCallbacksTest {
                 assertEquals(INFO, breadcrumb.level)
                 assertEquals(expectedState, breadcrumb.getData("state"))
                 assertEquals(fixture.fragment.javaClass.simpleName, breadcrumb.getData("screen"))
+            },
+            check { hint: Map<String, Any> ->
+               assertEquals(fixture.fragment.javaClass.name, hint["fragmentClassName"])
             }
         )
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adding full Fragment class as a `hint` for Fragment breadcrumbs


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We use custom names for our screens which differs from Fragment name. It would be useful for us to modify this breadcrumb in `beforeBreadcrumb`. But for that we need full class name. #1679

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
