### PR TITLE
Fix: Sentry Timber integration does not submit msg.formatted breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix: Sentry Timber integration does not submit msg.formatted breadcrumbs (#)
+
 ## 5.7.0
 
 * Feat: Automatically enable `Timber` and `Fragment` integrations if they are present on the classpath (#1936)

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -252,7 +252,7 @@ class SentryTimberTree(
                 msg.message != null -> Breadcrumb().apply {
                     level = sentryLevel
                     category = "Timber"
-                    message = msg.message
+                    message = msg.formatted ?: msg.message
                 }
                 throwableMsg != null -> Breadcrumb.error(throwableMsg).apply {
                     category = "exception"

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -216,6 +216,18 @@ class SentryTimberTreeTest {
     }
 
     @Test
+    fun `Tree adds a breadcrumb with formatted message and arguments, when provided`() {
+        val sut = fixture.getSut()
+        sut.e("test count: %d", 32)
+
+        verify(fixture.hub).addBreadcrumb(
+                check<Breadcrumb> {
+                    assertEquals("test count: 32", it.message)
+                }
+        )
+    }
+
+    @Test
     fun `Tree adds a breadcrumb if min level is equal`() {
         val sut = fixture.getSut()
         sut.i(Throwable("test"))


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/1956


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
