### PR TITLE
all operations involving file reads were moved to background threads

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -199,13 +199,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       scheduledFinish = null;
     }
 
-    if (traceFile == null || !traceFile.exists()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.ERROR,
-              "Trace file %s does not exists",
-              traceFile == null ? "null" : traceFile.getPath());
+    if (traceFile == null) {
+      options.getLogger().log(SentryLevel.ERROR, "Trace file does not exists");
       return null;
     }
 
@@ -221,16 +216,18 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       totalMem = Long.toString(memInfo.totalMem);
     }
 
+    // cpu max frequencies are read with a lambda because reading files is involved, so it will be
+    // done in the background when the trace file is read
     return new ProfilingTraceData(
         traceFile,
         transaction,
         Long.toString(transactionDurationNanos),
         buildInfoProvider.getSdkInfoVersion(),
+        () -> CpuInfoUtils.getInstance().readMaxFrequencies(),
         buildInfoProvider.getManufacturer(),
         buildInfoProvider.getModel(),
         buildInfoProvider.getVersionRelease(),
         buildInfoProvider.isEmulator(),
-        CpuInfoUtils.getInstance().readMaxFrequencies(),
         totalMem,
         options.getProguardUuid(),
         versionName,

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -517,7 +517,7 @@ public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
 }
 
 public final class io/sentry/ProfilingTraceData {
-	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun getAndroid_api_level ()I
 	public fun getBuild_id ()Ljava/lang/String;
 	public fun getDevice_cpu_frequencies ()Ljava/util/List;
@@ -541,6 +541,7 @@ public final class io/sentry/ProfilingTraceData {
 	public fun getVersion_code ()Ljava/lang/String;
 	public fun getVersion_name ()Ljava/lang/String;
 	public fun isDevice_is_emulator ()Z
+	public fun readDeviceCpuFrequencies ()V
 	public fun setSampled_profile (Ljava/lang/String;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -185,9 +185,7 @@ public final class SentryClient implements ISentryClient {
       final SentryEnvelopeItem profilingTraceItem =
           SentryEnvelopeItem.fromProfilingTrace(
               profilingTraceData, options.getMaxTraceFileSize(), options.getSerializer());
-      if (profilingTraceItem != null) {
-        envelopeItems.add(profilingTraceItem);
-      }
+      envelopeItems.add(profilingTraceItem);
     }
 
     if (attachments != null) {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -78,8 +78,8 @@ class SentryClientTest {
 
         var attachment = Attachment("hello".toByteArray(), "hello.txt", "text/plain", true)
         val profilingTraceFile = Files.createTempFile("trace", ".trace").toFile()
-        var profilingTraceData = ProfilingTraceData(profilingTraceFile, sentryTracer, "1", 0, "", "", "", false, emptyList(), "", "", "", "", "")
-        var profilingNonExistingTraceData = ProfilingTraceData(File("non_existent.trace"), sentryTracer, "1", 0, "", "", "", false, emptyList(), "", "", "", "", "")
+        var profilingTraceData = ProfilingTraceData(profilingTraceFile, sentryTracer, "1", 0, { emptyList() }, "", "", "", false, "", "", "", "", "")
+        var profilingNonExistingTraceData = ProfilingTraceData(File("non_existent.trace"), sentryTracer, "1", 0, { emptyList() }, "", "", "", false, "", "", "", "", "")
 
         fun getSut() = SentryClient(sentryOptions)
     }
@@ -1328,7 +1328,7 @@ class SentryClientTest {
                 val profilingTraceItem = actual.items.firstOrNull { item ->
                     item.header.type == SentryItemType.Profile
                 }
-                assertNotNull(profilingTraceItem)
+                assertNotNull(profilingTraceItem?.data)
             },
             isNull()
         )

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -220,7 +220,7 @@ class SentryEnvelopeItemTest {
         }
 
         file.writeBytes(fixture.bytes)
-        val traceDataBytes = SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, serializer)?.data
+        val traceDataBytes = SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, serializer).data
         val reader = BufferedReader(InputStreamReader(ByteArrayInputStream(traceDataBytes)))
         val deserData = serializer.deserialize(reader, ProfilingTraceData::class.java)
         assertNotNull(deserData)
@@ -238,22 +238,26 @@ class SentryEnvelopeItemTest {
         assert(file.exists())
         val traceData = SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())
         assert(file.exists())
-        traceData?.data
+        traceData.data
         assertFalse(file.exists())
     }
 
     @Test
-    fun `fromProfilingTrace with invalid file returns null`() {
+    fun `fromProfilingTrace with invalid file throws`() {
         val file = File(fixture.pathname)
         val profilingTraceData = mock<ProfilingTraceData> {
             whenever(it.traceFile).thenReturn(file)
         }
 
-        assertNull(SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())?.data)
+        assertFailsWith<SentryEnvelopeException>("Dropping profiling trace data, because the file ${file.path} doesn't exists") {
+            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
+        }
         file.writeBytes(fixture.bytes)
-        assertNotNull(SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())?.data)
+        assertNotNull(SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data)
         file.setReadable(false)
-        assertNull(SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())?.data)
+        assertFailsWith<SentryEnvelopeException>("Dropping profiling trace data, because the file ${file.path} doesn't exists") {
+            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
+        }
     }
 
     @Test
@@ -265,7 +269,7 @@ class SentryEnvelopeItemTest {
         }
 
         val exception = assertFailsWith<SentryEnvelopeException> {
-            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())?.data
+            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
         }
 
         assertEquals(


### PR DESCRIPTION
## :scroll: Description
All operations involving IO have been moved to the background, as enabling the strict mode on Android was causing crashes
