### PR TITLE
Fix: Add TimberTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix: bring back support for `Timber.tag` ([#1974](https://github.com/getsentry/sentry-java/pull/1974))
+
 ## 5.7.1
 
 * Fix: Sentry Timber integration does not submit msg.formatted breadcrumbs (#1957)

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -9,7 +9,6 @@ import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.SentryLevel
 import io.sentry.getExc
-import org.junit.Ignore
 import timber.log.Timber
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -159,9 +158,6 @@ class SentryTimberTreeTest {
     }
 
     @Test
-    @Ignore(
-        "We have no possibility to get a tag from Timber since it is package-private"
-    )
     fun `Tree captures an event with TimberTag tag`() {
         val sut = fixture.getSut()
         Timber.plant(sut)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Brings back `TimberTag`. Closes #1900

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are relying heavily on `TimberTag` value. One of our dependencies is abusing Timber logging. We were using this tag to filter out these events. This is a blocker to upgrade Sentry for us.

I decided not to use reflection, since retrieving value is not enough. We would also have to write `tag` clearing logic via reflection.

Pros: 
- This approach will not break if internal Timber's tag management logic change in the future.
- No need to write tag clearing logic

Cons:
- Timber will format `message` string, which we don't use (performance)

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
