### PR TITLE
Feat/client reports

### DIFF
--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -6,6 +6,9 @@ import io.sentry.RequestDetails;
 import io.sentry.SentryEnvelope;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.clientreport.ClientReportRecorder;
+import io.sentry.clientreport.DiscardReason;
+import io.sentry.hints.Retryable;
 import io.sentry.transport.ITransport;
 import io.sentry.transport.RateLimiter;
 import io.sentry.transport.ReusableCountLatch;
@@ -37,14 +40,22 @@ public final class ApacheHttpClientTransport implements ITransport {
   private final @NotNull RequestDetails requestDetails;
   private final @NotNull CloseableHttpAsyncClient httpclient;
   private final @NotNull RateLimiter rateLimiter;
+  private final @NotNull ClientReportRecorder clientReportRecorder;
   private final @NotNull ReusableCountLatch currentlyRunning;
 
   public ApacheHttpClientTransport(
       final @NotNull SentryOptions options,
       final @NotNull RequestDetails requestDetails,
       final @NotNull CloseableHttpAsyncClient httpclient,
-      final @NotNull RateLimiter rateLimiter) {
-    this(options, requestDetails, httpclient, rateLimiter, new ReusableCountLatch());
+      final @NotNull RateLimiter rateLimiter,
+      final @NotNull ClientReportRecorder clientReportRecorder) {
+    this(
+        options,
+        requestDetails,
+        httpclient,
+        rateLimiter,
+        clientReportRecorder,
+        new ReusableCountLatch());
   }
 
   ApacheHttpClientTransport(
@@ -52,6 +63,7 @@ public final class ApacheHttpClientTransport implements ITransport {
       final @NotNull RequestDetails requestDetails,
       final @NotNull CloseableHttpAsyncClient httpclient,
       final @NotNull RateLimiter rateLimiter,
+      final @NotNull ClientReportRecorder clientReportRecorder,
       final @NotNull ReusableCountLatch currentlyRunning) {
     this.options = Objects.requireNonNull(options, "options is required");
     this.requestDetails = Objects.requireNonNull(requestDetails, "requestDetails is required");
@@ -59,6 +71,8 @@ public final class ApacheHttpClientTransport implements ITransport {
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter is required");
     this.currentlyRunning =
         Objects.requireNonNull(currentlyRunning, "currentlyRunning is required");
+    this.clientReportRecorder =
+        Objects.requireNonNull(clientReportRecorder, "clientReportRecorder is required");
     this.httpclient.start();
   }
 
@@ -71,68 +85,93 @@ public final class ApacheHttpClientTransport implements ITransport {
       final SentryEnvelope filteredEnvelope = rateLimiter.filter(envelope, sentrySdkHint);
 
       if (filteredEnvelope != null) {
-        currentlyRunning.increment();
+        final SentryEnvelope envelopeWithClientReport =
+            clientReportRecorder.attachReportToEnvelope(filteredEnvelope, options);
 
-        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            final GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
-          options.getSerializer().serialize(filteredEnvelope, gzip);
+        if (envelopeWithClientReport != null) {
+          currentlyRunning.increment();
 
-          final SimpleHttpRequest request =
-              SimpleHttpRequests.post(requestDetails.getUrl().toString());
-          request.setBody(
-              outputStream.toByteArray(), ContentType.create("application/x-sentry-envelope"));
-          request.setHeader("Content-Encoding", "gzip");
-          request.setHeader("Accept", "application/json");
+          try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+              final GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+            options.getSerializer().serialize(envelopeWithClientReport, gzip);
 
-          for (Map.Entry<String, String> header : requestDetails.getHeaders().entrySet()) {
-            request.setHeader(header.getKey(), header.getValue());
-          }
+            final SimpleHttpRequest request =
+                SimpleHttpRequests.post(requestDetails.getUrl().toString());
+            request.setBody(
+                outputStream.toByteArray(), ContentType.create("application/x-sentry-envelope"));
+            request.setHeader("Content-Encoding", "gzip");
+            request.setHeader("Accept", "application/json");
 
-          if (options.getLogger().isEnabled(DEBUG)) {
-            options
-                .getLogger()
-                .log(DEBUG, "Currently running %d requests", currentlyRunning.getCount());
-          }
+            for (Map.Entry<String, String> header : requestDetails.getHeaders().entrySet()) {
+              request.setHeader(header.getKey(), header.getValue());
+            }
 
-          httpclient.execute(
-              request,
-              new FutureCallback<SimpleHttpResponse>() {
-                @Override
-                public void completed(SimpleHttpResponse response) {
-                  if (response.getCode() != 200) {
-                    options
-                        .getLogger()
-                        .log(ERROR, "Request failed, API returned %s", response.getCode());
-                  } else {
-                    options.getLogger().log(INFO, "Envelope sent successfully.");
+            if (options.getLogger().isEnabled(DEBUG)) {
+              options
+                  .getLogger()
+                  .log(DEBUG, "Currently running %d requests", currentlyRunning.getCount());
+            }
+
+            httpclient.execute(
+                request,
+                new FutureCallback<SimpleHttpResponse>() {
+                  @Override
+                  public void completed(SimpleHttpResponse response) {
+                    if (response.getCode() != 200) {
+                      options
+                          .getLogger()
+                          .log(ERROR, "Request failed, API returned %s", response.getCode());
+
+                      if (!(sentrySdkHint instanceof Retryable)) {
+                        if (response.getCode() >= 500) {
+                          clientReportRecorder.recordLostEnvelope(
+                              DiscardReason.NETWORK_ERROR, envelopeWithClientReport, options);
+                        }
+                      }
+                    } else {
+                      options.getLogger().log(INFO, "Envelope sent successfully.");
+                    }
+                    final Header retryAfter = response.getFirstHeader("Retry-After");
+                    final Header rateLimits = response.getFirstHeader("X-Sentry-Rate-Limits");
+                    rateLimiter.updateRetryAfterLimits(
+                        rateLimits != null ? rateLimits.getValue() : null,
+                        retryAfter != null ? retryAfter.getValue() : null,
+                        response.getCode());
+                    currentlyRunning.decrement();
                   }
-                  final Header retryAfter = response.getFirstHeader("Retry-After");
-                  final Header rateLimits = response.getFirstHeader("X-Sentry-Rate-Limits");
-                  rateLimiter.updateRetryAfterLimits(
-                      rateLimits != null ? rateLimits.getValue() : null,
-                      retryAfter != null ? retryAfter.getValue() : null,
-                      response.getCode());
-                  currentlyRunning.decrement();
-                }
 
-                @Override
-                public void failed(Exception ex) {
-                  options.getLogger().log(ERROR, "Error while sending an envelope", ex);
-                  currentlyRunning.decrement();
-                }
+                  @Override
+                  public void failed(Exception ex) {
+                    options.getLogger().log(ERROR, "Error while sending an envelope", ex);
+                    if (!(sentrySdkHint instanceof Retryable)) {
+                      clientReportRecorder.recordLostEnvelope(
+                          DiscardReason.NETWORK_ERROR, envelopeWithClientReport, options);
+                    }
+                    currentlyRunning.decrement();
+                  }
 
-                @Override
-                public void cancelled() {
-                  options.getLogger().log(WARNING, "Request cancelled");
-                  currentlyRunning.decrement();
-                }
-              });
-        } catch (Throwable e) {
-          options.getLogger().log(ERROR, "Error when sending envelope", e);
+                  @Override
+                  public void cancelled() {
+                    options.getLogger().log(WARNING, "Request cancelled");
+                    if (!(sentrySdkHint instanceof Retryable)) {
+                      clientReportRecorder.recordLostEnvelope(
+                          DiscardReason.NETWORK_ERROR, envelopeWithClientReport, options);
+                    }
+                    currentlyRunning.decrement();
+                  }
+                });
+          } catch (Throwable e) {
+            options.getLogger().log(ERROR, "Error when sending envelope", e);
+            if (!(sentrySdkHint instanceof Retryable)) {
+              clientReportRecorder.recordLostEnvelope(
+                  DiscardReason.NETWORK_ERROR, envelopeWithClientReport, options);
+            }
+          }
         }
       }
     } else {
       options.getLogger().log(SentryLevel.WARNING, "Submit cancelled");
+      clientReportRecorder.recordLostEnvelope(DiscardReason.QUEUE_OVERFLOW, envelope, options);
     }
   }
 

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransportFactory.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransportFactory.java
@@ -62,8 +62,10 @@ public final class ApacheHttpClientTransportFactory implements ITransportFactory
                     .setResponseTimeout(options.getReadTimeoutMillis(), TimeUnit.MILLISECONDS)
                     .build())
             .build();
-    final RateLimiter rateLimiter = new RateLimiter(options.getLogger());
+    final RateLimiter rateLimiter =
+        new RateLimiter(options.getLogger(), options.getClientReportRecorder(), options);
 
-    return new ApacheHttpClientTransport(options, requestDetails, httpclient, rateLimiter);
+    return new ApacheHttpClientTransport(
+        options, requestDetails, httpclient, rateLimiter, options.getClientReportRecorder());
   }
 }

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportClientReportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportClientReportTest.kt
@@ -1,0 +1,201 @@
+package io.sentry.transport.apache
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.ILogger
+import io.sentry.RequestDetails
+import io.sentry.SentryEnvelope
+import io.sentry.SentryEvent
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions
+import io.sentry.TypeCheckHint
+import io.sentry.clientreport.ClientReportRecorder
+import io.sentry.clientreport.DiscardReason
+import io.sentry.hints.Retryable
+import io.sentry.transport.RateLimiter
+import io.sentry.transport.ReusableCountLatch
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
+import org.apache.hc.core5.concurrent.FutureCallback
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class ApacheHttpClientTransportClientReportTest {
+
+    class Fixture {
+        val options: SentryOptions
+        val logger = mock<ILogger>()
+        val rateLimiter = mock<RateLimiter>()
+        val clientReportRecorder = mock<ClientReportRecorder>()
+        val requestDetails = RequestDetails("http://key@localhost/proj", mapOf("header-name" to "header-value"))
+        val client = mock<CloseableHttpAsyncClient>()
+        val currentlyRunning = spy<ReusableCountLatch>()
+        val executorService = Executors.newFixedThreadPool(2)
+        val envelopeBeforeClientReportAttached: SentryEnvelope
+        val envelopeAfterClientReportAttached: SentryEnvelope
+
+        init {
+            whenever(rateLimiter.filter(any(), anyOrNull())).thenAnswer { it.arguments[0] }
+            options = SentryOptions()
+            options.setSerializer(mock())
+            options.setDiagnosticLevel(SentryLevel.WARNING)
+            options.setDebug(true)
+            options.setLogger(logger)
+
+            envelopeBeforeClientReportAttached = SentryEnvelope.from(options.serializer, SentryEvent(), null)
+            envelopeAfterClientReportAttached = SentryEnvelope.from(options.serializer, SentryEvent(), null)
+            whenever(clientReportRecorder.attachReportToEnvelope(same(envelopeBeforeClientReportAttached), any()))
+                .thenReturn(envelopeAfterClientReportAttached)
+        }
+
+        fun getSut(response: SimpleHttpResponse? = null, queueFull: Boolean = false): ApacheHttpClientTransport {
+
+            val transport = ApacheHttpClientTransport(options, requestDetails, client, rateLimiter, clientReportRecorder, currentlyRunning)
+
+            if (response != null) {
+                whenever(client.execute(any(), any())).thenAnswer {
+                    (it.arguments[1] as FutureCallback<SimpleHttpResponse>).completed(response)
+                    CompletableFuture.completedFuture(response)
+                }
+            }
+
+            if (queueFull) {
+                whenever(currentlyRunning.count).thenReturn(options.maxQueueSize)
+            }
+            return transport
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @AfterTest
+    fun `shutdown executor`() {
+        fixture.executorService.shutdownNow()
+    }
+
+    @Test
+    fun `attaches client report to envelope`() {
+        val sut = fixture.getSut(SimpleHttpResponse(200))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached)
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope when queue is full for non retryable`() {
+        val sut = fixture.getSut(queueFull = true)
+
+        sut.send(fixture.envelopeBeforeClientReportAttached)
+
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.QUEUE_OVERFLOW), eq(fixture.envelopeBeforeClientReportAttached), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope when queue is full for retryable`() {
+        val sut = fixture.getSut(queueFull = true)
+
+        sut.send(fixture.envelopeBeforeClientReportAttached, retryableHint())
+
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.QUEUE_OVERFLOW), same(fixture.envelopeBeforeClientReportAttached), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on 500 error for non retryable`() {
+        val sut = fixture.getSut(SimpleHttpResponse(500))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached)
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.NETWORK_ERROR), same(fixture.envelopeAfterClientReportAttached), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 500 error for retryable`() {
+        val sut = fixture.getSut(SimpleHttpResponse(500))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached, retryableHint())
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 429 error for non retryable`() {
+        val sut = fixture.getSut(SimpleHttpResponse(429))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached)
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 429 error for retryable`() {
+        val sut = fixture.getSut(SimpleHttpResponse(429))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached, retryableHint())
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on io exception for retryable`() {
+        val sut = fixture.getSut()
+        whenever(fixture.client.execute(any(), any())).thenThrow(RuntimeException("thrown on purpose"))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached, retryableHint())
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on io exception for non retryable`() {
+        val sut = fixture.getSut()
+        whenever(fixture.client.execute(any(), any())).thenThrow(RuntimeException("thrown on purpose"))
+
+        sut.send(fixture.envelopeBeforeClientReportAttached)
+
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeClientReportAttached), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.NETWORK_ERROR), same(fixture.envelopeAfterClientReportAttached), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    private fun retryableHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestRetryable())
+}
+
+class TestRetryable : Retryable {
+    private var retry = false
+
+    override fun setRetry(retry: Boolean) {
+        this.retry = retry
+    }
+
+    override fun isRetry(): Boolean {
+        return this.retry
+    }
+}

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -15,6 +15,7 @@ import io.sentry.SentryEnvelope
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
+import io.sentry.clientreport.NoOpClientReportRecorder
 import io.sentry.transport.RateLimiter
 import io.sentry.transport.ReusableCountLatch
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
@@ -33,6 +34,7 @@ class ApacheHttpClientTransportTest {
         val options: SentryOptions
         val logger = mock<ILogger>()
         val rateLimiter = mock<RateLimiter>()
+        val clientReportRecorder = NoOpClientReportRecorder()
         val requestDetails = RequestDetails("http://key@localhost/proj", mapOf("header-name" to "header-value"))
         val client = mock<CloseableHttpAsyncClient>()
         val currentlyRunning = spy<ReusableCountLatch>()
@@ -49,7 +51,7 @@ class ApacheHttpClientTransportTest {
 
         fun getSut(response: SimpleHttpResponse? = null, queueFull: Boolean = false): ApacheHttpClientTransport {
 
-            val transport = ApacheHttpClientTransport(options, requestDetails, client, rateLimiter, currentlyRunning)
+            val transport = ApacheHttpClientTransport(options, requestDetails, client, rateLimiter, clientReportRecorder, currentlyRunning)
 
             if (response != null) {
                 whenever(client.execute(any(), any())).thenAnswer {

--- a/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
+++ b/sentry/src/main/java/io/sentry/AsyncHttpTransportFactory.java
@@ -18,6 +18,10 @@ public final class AsyncHttpTransportFactory implements ITransportFactory {
     Objects.requireNonNull(requestDetails, "requestDetails is required");
 
     return new AsyncHttpTransport(
-        options, new RateLimiter(options.getLogger()), options.getTransportGate(), requestDetails);
+        options,
+        new RateLimiter(options.getLogger(), options.getClientReportRecorder(), options),
+        options.getTransportGate(),
+        requestDetails,
+        options.getClientReportRecorder());
   }
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -3,11 +3,13 @@ package io.sentry;
 import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
 
 import io.sentry.Stack.StackItem;
+import io.sentry.clientreport.DiscardReason;
 import io.sentry.hints.SessionEndHint;
 import io.sentry.hints.SessionStartHint;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.transport.DataCategory;
 import io.sentry.util.ExceptionUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.Pair;
@@ -577,6 +579,9 @@ public final class Hub implements IHub {
                   SentryLevel.DEBUG,
                   "Transaction %s was dropped due to sampling decision.",
                   transaction.getEventId());
+          options
+              .getClientReportRecorder()
+              .recordLostEvent(DiscardReason.SAMPLE_RATE, DataCategory.Transaction, options);
         } else {
           StackItem item = null;
           try {

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.clientreport.ClientReport;
 import io.sentry.protocol.App;
 import io.sentry.protocol.Browser;
 import io.sentry.protocol.Contexts;
@@ -98,6 +99,7 @@ public final class JsonSerializer implements ISerializer {
     deserializersByClass.put(SpanStatus.class, new SpanStatus.Deserializer());
     deserializersByClass.put(User.class, new User.Deserializer());
     deserializersByClass.put(UserFeedback.class, new UserFeedback.Deserializer());
+    deserializersByClass.put(ClientReport.class, new ClientReport.Deserializer());
   }
 
   // Deserialize

--- a/sentry/src/main/java/io/sentry/SentryItemType.java
+++ b/sentry/src/main/java/io/sentry/SentryItemType.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.clientreport.ClientReport;
 import io.sentry.protocol.SentryTransaction;
 import java.io.IOException;
 import java.util.Locale;
@@ -13,7 +14,8 @@ public enum SentryItemType implements JsonSerializable {
   UserFeedback("user_report"), // Sentry backend still uses user_report
   Attachment("attachment"),
   Transaction("transaction"),
-  Unknown("__unknown__"); // DataCategory.Unknown
+  Unknown("__unknown__"), // DataCategory.Unknown
+  ClientReport("client_report");
 
   private final String itemType;
 
@@ -24,6 +26,8 @@ public enum SentryItemType implements JsonSerializable {
       return Transaction;
     } else if (item instanceof Session) {
       return Session;
+    } else if (item instanceof ClientReport) {
+      return ClientReport;
     } else {
       return Attachment;
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2,6 +2,9 @@ package io.sentry;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.cache.IEnvelopeCache;
+import io.sentry.clientreport.ClientReportRecorder;
+import io.sentry.clientreport.ClientReportRecorderImpl;
+import io.sentry.clientreport.NoOpClientReportRecorder;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
@@ -302,6 +305,9 @@ public class SentryOptions {
    * Sentry tags to events.
    */
   private final @NotNull List<String> contextTags = new CopyOnWriteArrayList<>();
+
+  /** Whether to send client reports containing information about number of dropped events. */
+  private @NotNull boolean sendClientReports = true;
 
   /**
    * Adds an event processor
@@ -1464,6 +1470,37 @@ public class SentryOptions {
    */
   public void addContextTag(final @NotNull String contextTag) {
     this.contextTags.add(contextTag);
+  }
+
+  /**
+   * Returns whether sending of client reports has been enabled.
+   *
+   * @return true if enabled; false if disabled
+   */
+  public @NotNull Boolean isSendClientReports() {
+    return sendClientReports;
+  }
+
+  /**
+   * Enables / disables sending of client reports.
+   *
+   * @param sendClientReports true enables client reports; false disables them
+   */
+  public void setSendClientReports(@NotNull Boolean sendClientReports) {
+    this.sendClientReports = sendClientReports;
+  }
+
+  /**
+   * Returns a ClientReportRecorder or a NoOp if sending of client reports has been disabled.
+   *
+   * @return a client report recorder or NoOp
+   */
+  public @NotNull ClientReportRecorder getClientReportRecorder() {
+    if (isSendClientReports()) {
+      return ClientReportRecorderImpl.getInstance();
+    } else {
+      return new NoOpClientReportRecorder();
+    }
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
@@ -9,6 +9,7 @@ import io.sentry.SentryItemType;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.Session;
+import io.sentry.clientreport.DiscardReason;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -123,6 +124,10 @@ abstract class CacheStrategy {
     if (currentEnvelope == null || !isValidEnvelope(currentEnvelope)) {
       return;
     }
+
+    options
+        .getClientReportRecorder()
+        .recordLostEnvelope(DiscardReason.CACHE_OVERFLOW, currentEnvelope, options);
 
     final Session currentSession = getFirstSession(currentEnvelope);
 

--- a/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
+++ b/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
@@ -1,0 +1,76 @@
+package io.sentry.clientreport;
+
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.transport.DataCategory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class AtomicClientReportStorage implements ClientReportStorage {
+
+  private final @NotNull Map<ClientReportKey, AtomicLong> lostEventCounts;
+
+  public AtomicClientReportStorage() {
+    Map<ClientReportKey, AtomicLong> map = new ConcurrentHashMap<>();
+
+    for (DiscardReason discardReason : DiscardReason.values()) {
+      for (DataCategory category : DataCategory.values()) {
+        map.put(
+            new ClientReportKey(discardReason.getReason(), category.getCategory()),
+            new AtomicLong(0));
+      }
+    }
+
+    lostEventCounts = Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public void addCount(ClientReportKey key, Long count) {
+    @Nullable AtomicLong quantity = lostEventCounts.get(key);
+
+    if (quantity != null) {
+      quantity.addAndGet(count);
+    }
+  }
+
+  @Override
+  public List<DiscardedEvent> resetCountsAndGet() {
+    List<DiscardedEvent> discardedEvents = new ArrayList<>(lostEventCounts.size());
+
+    for (Map.Entry<ClientReportKey, AtomicLong> entry : lostEventCounts.entrySet()) {
+      Long quantity = entry.getValue().getAndSet(0);
+      if (quantity > 0) {
+        discardedEvents.add(
+            new DiscardedEvent(entry.getKey().getReason(), entry.getKey().getCategory(), quantity));
+      }
+    }
+    return discardedEvents;
+  }
+
+  @Override
+  public void debug(@NotNull SentryOptions options) {
+    ILogger logger = options.getLogger();
+    if (!logger.isEnabled(SentryLevel.DEBUG)) {
+      return;
+    }
+
+    try {
+      logger.log(SentryLevel.DEBUG, "Client report (" + lostEventCounts.size() + " entries)");
+
+      for (Map.Entry<ClientReportKey, AtomicLong> entry : lostEventCounts.entrySet()) {
+        logger.log(SentryLevel.DEBUG, entry.getKey() + "= " + entry.getValue());
+      }
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, e, "Unable print client report recorder debug info.");
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReport.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReport.java
@@ -1,0 +1,132 @@
+package io.sentry.clientreport;
+
+import io.sentry.DateUtils;
+import io.sentry.ILogger;
+import io.sentry.JsonDeserializer;
+import io.sentry.JsonObjectReader;
+import io.sentry.JsonObjectWriter;
+import io.sentry.JsonSerializable;
+import io.sentry.JsonUnknown;
+import io.sentry.SentryLevel;
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class ClientReport implements JsonUnknown, JsonSerializable {
+
+  private final @NotNull Date timestamp;
+  private final @NotNull List<DiscardedEvent> discardedEvents;
+  private @Nullable Map<String, Object> unknown;
+
+  public ClientReport(@NotNull Date timestamp, @NotNull List<DiscardedEvent> discardedEvents) {
+    this.timestamp = timestamp;
+    this.discardedEvents = discardedEvents;
+  }
+
+  public @NotNull Date getTimestamp() {
+    return timestamp;
+  }
+
+  public @NotNull List<DiscardedEvent> getDiscardedEvents() {
+    return discardedEvents;
+  }
+
+  @Override
+  public String toString() {
+    return "ClientReport{"
+        + "timestamp="
+        + timestamp
+        + ", discardedEvents="
+        + discardedEvents
+        + '}';
+  }
+
+  public static final class JsonKeys {
+    public static final String TIMESTAMP = "timestamp";
+    public static final String DISCARDED_EVENTS = "discarded_events";
+  }
+
+  @Override
+  public @Nullable Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
+  @Override
+  public void setUnknown(@Nullable Map<String, Object> unknown) {
+    this.unknown = unknown;
+  }
+
+  @Override
+  public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
+      throws IOException {
+    writer.beginObject();
+
+    writer.name(JsonKeys.TIMESTAMP).value(DateUtils.getTimestamp(timestamp));
+    writer.name(JsonKeys.DISCARDED_EVENTS).value(logger, discardedEvents);
+
+    if (unknown != null) {
+      for (String key : unknown.keySet()) {
+        Object value = unknown.get(key);
+        writer.name(key).value(logger, value);
+      }
+    }
+
+    writer.endObject();
+  }
+
+  public static final class Deserializer implements JsonDeserializer<ClientReport> {
+    @Override
+    public @NotNull ClientReport deserialize(
+        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+      Date timestamp = null;
+      List<DiscardedEvent> discardedEvents = new ArrayList<>();
+      Map<String, Object> unknown = null;
+
+      reader.beginObject();
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.TIMESTAMP:
+            timestamp = reader.nextDateOrNull(logger);
+            break;
+          case JsonKeys.DISCARDED_EVENTS:
+            List<DiscardedEvent> deserializedDiscardedEvents =
+                reader.nextList(logger, new DiscardedEvent.Deserializer());
+            discardedEvents.addAll(deserializedDiscardedEvents);
+            break;
+          default:
+            if (unknown == null) {
+              unknown = new HashMap<>();
+            }
+            reader.nextUnknown(logger, unknown, nextName);
+            break;
+        }
+      }
+      reader.endObject();
+
+      if (timestamp == null) {
+        throw missingRequiredFieldException(JsonKeys.TIMESTAMP, logger);
+      }
+      if (discardedEvents.isEmpty()) {
+        throw missingRequiredFieldException(JsonKeys.DISCARDED_EVENTS, logger);
+      }
+
+      ClientReport clientReport = new ClientReport(timestamp, discardedEvents);
+      clientReport.setUnknown(unknown);
+      return clientReport;
+    }
+
+    private Exception missingRequiredFieldException(String field, ILogger logger) {
+      String message = "Missing required field \"" + field + "\"";
+      Exception exception = new IllegalStateException(message);
+      logger.log(SentryLevel.ERROR, message, exception);
+      return exception;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportKey.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportKey.java
@@ -1,0 +1,40 @@
+package io.sentry.clientreport;
+
+import java.util.Objects;
+
+final class ClientReportKey {
+  private final String reason;
+  private final String category;
+
+  ClientReportKey(String reason, String category) {
+    this.reason = reason;
+    this.category = category;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ClientReportKey)) return false;
+    ClientReportKey that = (ClientReportKey) o;
+    return Objects.equals(getReason(), that.getReason())
+        && Objects.equals(getCategory(), that.getCategory());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getReason(), getCategory());
+  }
+
+  @Override
+  public String toString() {
+    return "ClientReportKey{" + "reason='" + reason + '\'' + ", category='" + category + '\'' + '}';
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -1,0 +1,31 @@
+package io.sentry.clientreport;
+
+import io.sentry.SentryEnvelope;
+import io.sentry.SentryEnvelopeItem;
+import io.sentry.SentryOptions;
+import io.sentry.transport.DataCategory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface ClientReportRecorder {
+  void recordLostEnvelope(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelope envelope,
+      @NotNull SentryOptions options);
+
+  void recordLostEnvelopeItem(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelopeItem envelopeItem,
+      @NotNull SentryOptions options);
+
+  void recordLostEvent(
+      @NotNull DiscardReason reason,
+      @NotNull DataCategory category,
+      @NotNull SentryOptions options);
+
+  @NotNull
+  SentryEnvelope attachReportToEnvelope(
+      @NotNull SentryEnvelope envelope, @NotNull SentryOptions options);
+
+  void debug(@NotNull SentryOptions options);
+}

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorderImpl.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorderImpl.java
@@ -1,0 +1,176 @@
+package io.sentry.clientreport;
+
+import io.sentry.DateUtils;
+import io.sentry.SentryEnvelope;
+import io.sentry.SentryEnvelopeItem;
+import io.sentry.SentryItemType;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.transport.DataCategory;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class ClientReportRecorderImpl implements ClientReportRecorder {
+
+  private static volatile @Nullable ClientReportRecorderImpl SHARED_INSTANCE = null;
+
+  public static @NotNull ClientReportRecorderImpl getInstance() {
+    if (SHARED_INSTANCE == null) {
+      synchronized (ClientReportRecorderImpl.class) {
+        if (SHARED_INSTANCE == null) {
+          SHARED_INSTANCE = new ClientReportRecorderImpl();
+        }
+      }
+    }
+
+    return SHARED_INSTANCE;
+  }
+
+  private final ClientReportStorage storage;
+
+  private ClientReportRecorderImpl() {
+    this.storage = new AtomicClientReportStorage();
+  }
+
+  @Override
+  public @NotNull SentryEnvelope attachReportToEnvelope(
+      @NotNull SentryEnvelope envelope, @NotNull SentryOptions options) {
+    @Nullable ClientReport clientReport = resetCountsAndGenerateClientReport();
+    if (clientReport == null) {
+      return envelope;
+    }
+
+    try {
+      options.getLogger().log(SentryLevel.DEBUG, "Attaching client report to envelope.");
+
+      List<SentryEnvelopeItem> items = new ArrayList<>();
+
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        items.add(item);
+      }
+
+      items.add(SentryEnvelopeItem.fromClientReport(options.getSerializer(), clientReport));
+
+      return new SentryEnvelope(envelope.getHeader(), items);
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Unable to attach client report to envelope.");
+      return envelope;
+    }
+  }
+
+  @Override
+  public void recordLostEnvelope(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelope envelope,
+      @NotNull SentryOptions options) {
+    if (envelope == null) {
+      return;
+    }
+
+    try {
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        recordLostEnvelopeItem(reason, item, options);
+      }
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Unable to record lost envelope.");
+    }
+  }
+
+  @Override
+  public void recordLostEnvelopeItem(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelopeItem envelopeItem,
+      @NotNull SentryOptions options) {
+    if (envelopeItem == null) {
+      return;
+    }
+
+    try {
+      @NotNull SentryItemType itemType = envelopeItem.getHeader().getType();
+      if (SentryItemType.ClientReport.equals(itemType)) {
+        try {
+          ClientReport clientReport = envelopeItem.getClientReport(options.getSerializer());
+          restoreCountsFromClientReport(clientReport);
+        } catch (Exception e) {
+          options
+              .getLogger()
+              .log(SentryLevel.ERROR, "Unable to restore counts from previous client report.");
+        }
+      } else {
+        recordLostEventInternal(
+            reason.getReason(), categoryFromItemType(itemType).getCategory(), 1L);
+      }
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Unable to record lost envelope item.");
+    }
+  }
+
+  @Override
+  public void recordLostEvent(
+      @NotNull DiscardReason reason,
+      @NotNull DataCategory category,
+      @NotNull SentryOptions options) {
+    try {
+      recordLostEventInternal(reason.getReason(), category.getCategory(), 1L);
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Unable to record lost event.");
+    }
+  }
+
+  @Override
+  public void debug(@NotNull SentryOptions options) {
+    storage.debug(options);
+  }
+
+  private void recordLostEventInternal(
+      @NotNull String reason, @NotNull String category, @NotNull Long countToAdd) {
+    ClientReportKey key = new ClientReportKey(reason, category);
+    storage.addCount(key, countToAdd);
+  }
+
+  @Nullable
+  ClientReport resetCountsAndGenerateClientReport() {
+    Date currentDate = DateUtils.getCurrentDateTime();
+    List<DiscardedEvent> discardedEvents = storage.resetCountsAndGet();
+
+    if (discardedEvents.isEmpty()) {
+      return null;
+    } else {
+      return new ClientReport(currentDate, discardedEvents);
+    }
+  }
+
+  private void restoreCountsFromClientReport(@Nullable ClientReport clientReport) {
+    if (clientReport == null) {
+      return;
+    }
+
+    for (DiscardedEvent discardedEvent : clientReport.getDiscardedEvents()) {
+      recordLostEventInternal(
+          discardedEvent.getReason(), discardedEvent.getCategory(), discardedEvent.getQuantity());
+    }
+  }
+
+  private DataCategory categoryFromItemType(SentryItemType itemType) {
+    if (SentryItemType.Event.equals(itemType)) {
+      return DataCategory.Error;
+    }
+    if (SentryItemType.Session.equals(itemType)) {
+      return DataCategory.Session;
+    }
+    if (SentryItemType.Transaction.equals(itemType)) {
+      return DataCategory.Transaction;
+    }
+    if (SentryItemType.UserFeedback.equals(itemType)) {
+      return DataCategory.UserReport;
+    }
+    if (SentryItemType.Attachment.equals(itemType)) {
+      return DataCategory.Attachment;
+    }
+
+    return DataCategory.Default;
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportStorage.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportStorage.java
@@ -1,0 +1,13 @@
+package io.sentry.clientreport;
+
+import io.sentry.SentryOptions;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+public interface ClientReportStorage {
+  void addCount(ClientReportKey key, Long count);
+
+  List<DiscardedEvent> resetCountsAndGet();
+
+  void debug(@NotNull SentryOptions options);
+}

--- a/sentry/src/main/java/io/sentry/clientreport/DiscardReason.java
+++ b/sentry/src/main/java/io/sentry/clientreport/DiscardReason.java
@@ -1,0 +1,23 @@
+package io.sentry.clientreport;
+
+public enum DiscardReason {
+  QUEUE_OVERFLOW("queue_overflow"),
+  CACHE_OVERFLOW("cache_overflow"),
+  RATELIMIT_BACKOFF("ratelimit_backoff"),
+  NETWORK_ERROR("network_error"),
+  SAMPLE_RATE("sample_rate"),
+  BEFORE_SEND("before_send"),
+  EVENT_PROCESSOR("event_processor"), // also for ignored exceptions
+  STORAGE_ERROR("storage_error"), // TODO MOBILE-207 what should we use?
+  ;
+
+  private final String reason;
+
+  DiscardReason(String reason) {
+    this.reason = reason;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/DiscardedEvent.java
+++ b/sentry/src/main/java/io/sentry/clientreport/DiscardedEvent.java
@@ -1,0 +1,145 @@
+package io.sentry.clientreport;
+
+import io.sentry.ILogger;
+import io.sentry.JsonDeserializer;
+import io.sentry.JsonObjectReader;
+import io.sentry.JsonObjectWriter;
+import io.sentry.JsonSerializable;
+import io.sentry.JsonUnknown;
+import io.sentry.SentryLevel;
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class DiscardedEvent implements JsonUnknown, JsonSerializable {
+
+  private final @NotNull String reason;
+  private final @NotNull String category;
+  private final @NotNull Long quantity;
+  private @Nullable Map<String, Object> unknown;
+
+  public DiscardedEvent(@NotNull String reason, @NotNull String category, @NotNull Long quantity) {
+    this.reason = reason;
+    this.category = category;
+    this.quantity = quantity;
+  }
+
+  public @NotNull String getReason() {
+    return reason;
+  }
+
+  public @NotNull String getCategory() {
+    return category;
+  }
+
+  public @NotNull Long getQuantity() {
+    return quantity;
+  }
+
+  @Override
+  public String toString() {
+    return "DiscardedEvent{"
+        + "reason='"
+        + reason
+        + '\''
+        + ", category='"
+        + category
+        + '\''
+        + ", quantity="
+        + quantity
+        + '}';
+  }
+
+  public static final class JsonKeys {
+    public static final String REASON = "reason";
+    public static final String CATEGORY = "category";
+    public static final String QUANTITY = "quantity";
+  }
+
+  @Override
+  public @Nullable Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
+  @Override
+  public void setUnknown(@Nullable Map<String, Object> unknown) {
+    this.unknown = unknown;
+  }
+
+  @Override
+  public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
+      throws IOException {
+    writer.beginObject();
+
+    writer.name(JsonKeys.REASON).value(reason);
+    writer.name(JsonKeys.CATEGORY).value(category);
+    writer.name(JsonKeys.QUANTITY).value(quantity);
+
+    if (unknown != null) {
+      for (String key : unknown.keySet()) {
+        Object value = unknown.get(key);
+        writer.name(key).value(logger, value);
+      }
+    }
+
+    writer.endObject();
+  }
+
+  public static final class Deserializer implements JsonDeserializer<DiscardedEvent> {
+    @Override
+    public @NotNull DiscardedEvent deserialize(
+        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+      String reason = null;
+      String category = null;
+      Long quanity = null;
+      Map<String, Object> unknown = null;
+
+      reader.beginObject();
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.REASON:
+            reason = reader.nextStringOrNull();
+            break;
+          case JsonKeys.CATEGORY:
+            category = reader.nextStringOrNull();
+            break;
+          case JsonKeys.QUANTITY:
+            quanity = reader.nextLongOrNull();
+            break;
+          default:
+            if (unknown == null) {
+              unknown = new HashMap<>();
+            }
+            reader.nextUnknown(logger, unknown, nextName);
+            break;
+        }
+      }
+      reader.endObject();
+
+      if (reason == null) {
+        throw missingRequiredFieldException(JsonKeys.REASON, logger);
+      }
+      if (category == null) {
+        throw missingRequiredFieldException(JsonKeys.CATEGORY, logger);
+      }
+      if (quanity == null) {
+        throw missingRequiredFieldException(JsonKeys.QUANTITY, logger);
+      }
+
+      DiscardedEvent discardedEvent = new DiscardedEvent(reason, category, quanity);
+      discardedEvent.setUnknown(unknown);
+      return discardedEvent;
+    }
+
+    private Exception missingRequiredFieldException(String field, ILogger logger) {
+      String message = "Missing required field \"" + field + "\"";
+      Exception exception = new IllegalStateException(message);
+      logger.log(SentryLevel.ERROR, message, exception);
+      return exception;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/clientreport/NoOpClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/NoOpClientReportRecorder.java
@@ -1,0 +1,45 @@
+package io.sentry.clientreport;
+
+import io.sentry.SentryEnvelope;
+import io.sentry.SentryEnvelopeItem;
+import io.sentry.SentryOptions;
+import io.sentry.transport.DataCategory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpClientReportRecorder implements ClientReportRecorder {
+  @Override
+  public void recordLostEnvelope(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelope envelope,
+      @NotNull SentryOptions options) {
+    // do nothing
+  }
+
+  @Override
+  public void recordLostEnvelopeItem(
+      @NotNull DiscardReason reason,
+      @Nullable SentryEnvelopeItem envelopeItem,
+      @NotNull SentryOptions options) {
+    // do nothing
+  }
+
+  @Override
+  public void recordLostEvent(
+      @NotNull DiscardReason reason,
+      @NotNull DataCategory category,
+      @NotNull SentryOptions options) {
+    // do nothing
+  }
+
+  @Override
+  public @NotNull SentryEnvelope attachReportToEnvelope(
+      @NotNull SentryEnvelope envelope, @NotNull SentryOptions options) {
+    return envelope;
+  }
+
+  @Override
+  public void debug(@NotNull SentryOptions options) {
+    // do nothing
+  }
+}

--- a/sentry/src/main/java/io/sentry/transport/DataCategory.java
+++ b/sentry/src/main/java/io/sentry/transport/DataCategory.java
@@ -1,0 +1,25 @@
+package io.sentry.transport;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum DataCategory {
+  All("__all__"),
+  Default("default"), // same as Error
+  Error("error"),
+  Session("session"),
+  Attachment("attachment"),
+  Transaction("transaction"),
+  Security("security"),
+  UserReport("user_report"),
+  Unknown("unknown");
+
+  private final String category;
+
+  DataCategory(final @NotNull String category) {
+    this.category = category;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+}

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -88,7 +88,7 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
     return unfinishedTasksCount.getCount() < maxQueueSize;
   }
 
-  private static final class CancelledFuture<T> implements Future<T> {
+  static final class CancelledFuture<T> implements Future<T> {
     @Override
     public boolean cancel(final boolean mayInterruptIfRunning) {
       return true;

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -16,12 +16,17 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.cache.EnvelopeCache
+import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
+import io.sentry.clientreport.ClientReportTestHelper.Companion.resetCountsAndGenerateClientReport
+import io.sentry.clientreport.DiscardReason
+import io.sentry.clientreport.DiscardedEvent
 import io.sentry.hints.SessionEndHint
 import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.test.callMethod
+import io.sentry.transport.DataCategory
 import io.sentry.util.HintUtils
 import java.io.File
 import java.nio.file.Files
@@ -45,11 +50,13 @@ class HubTest {
     @BeforeTest
     fun `set up`() {
         file = Files.createTempDirectory("sentry-disk-cache-test").toAbsolutePath().toFile()
+        resetCountsAndGenerateClientReport()
     }
 
     @AfterTest
     fun shutdown() {
         file.deleteRecursively()
+        resetCountsAndGenerateClientReport()
         Sentry.close()
     }
 
@@ -1135,6 +1142,22 @@ class HubTest {
         sentryTracer.finish()
         val traceState = sentryTracer.traceState()
         verify(mockClient, never()).captureTransaction(any(), eq(traceState), any(), eq(null))
+    }
+
+    @Test
+    fun `transactions lost due to sampling are recorded as lost`() {
+        val options = SentryOptions()
+        options.cacheDirPath = file.absolutePath
+        options.dsn = "https://key@sentry.io/proj"
+        options.setSerializer(mock())
+        val sut = Hub(options)
+        val mockClient = mock<ISentryClient>()
+        sut.bindClient(mockClient)
+
+        val sentryTracer = SentryTracer(TransactionContext("name", "op", false), sut)
+        sentryTracer.finish()
+
+        assertClientReport(listOf(DiscardedEvent(DiscardReason.SAMPLE_RATE.reason, DataCategory.Transaction.category, 1)))
     }
     //endregion
 

--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportMultiThreadingTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportMultiThreadingTest.kt
@@ -1,0 +1,214 @@
+package io.sentry.clientreport
+
+import io.sentry.Sentry
+import io.sentry.SentryEnvelope
+import io.sentry.SentryEnvelopeHeader
+import io.sentry.SentryEnvelopeItem
+import io.sentry.SentryOptions
+import io.sentry.dsnString
+import io.sentry.protocol.SentryId
+import io.sentry.transport.DataCategory
+import java.util.UUID
+import java.util.concurrent.ExecutorCompletionService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientReportMultiThreadingTest {
+
+    lateinit var opts: SentryOptions
+    val reasons = DiscardReason.values()
+    val categories = listOf(DataCategory.Error, DataCategory.Attachment, DataCategory.Session, DataCategory.Transaction, DataCategory.UserReport)
+
+    @BeforeTest
+    fun setup() {
+        ClientReportRecorderImpl.getInstance().resetCountsAndGenerateClientReport()
+    }
+
+    @AfterTest
+    fun teardown() {
+        ClientReportRecorderImpl.getInstance().resetCountsAndGenerateClientReport()
+    }
+
+    @Test
+    fun testMultiThreadedCountIncrements() {
+        setupSentry()
+
+        val clientReportRecorder = ClientReportRecorderImpl.getInstance()
+
+        val numberOfIncrementThreads = 10
+        val numberOfIncrementsPerThread = 10 * 1000
+
+        val executor = Executors.newFixedThreadPool(numberOfIncrementThreads)
+        val completionService = ExecutorCompletionService<Unit>(executor)
+
+        println("forking from thread ${Thread.currentThread()}")
+
+        val futures = mutableListOf<Future<Unit>>()
+
+        val t1 = System.currentTimeMillis()
+
+        (1..numberOfIncrementThreads).forEach { nThread ->
+            futures.add(
+                completionService.submit {
+                    println("running #$nThread on thread ${Thread.currentThread()}")
+
+                    (1..numberOfIncrementsPerThread).forEach {
+                        clientReportRecorder.recordLostEvent(randomReason(), randomCategory(), opts)
+                    }
+                }
+            )
+        }
+
+        futures.forEach {
+            completionService.take().get()
+        }
+
+        val t2 = System.currentTimeMillis()
+        println("took ${t2 - t1}ms")
+
+        clientReportRecorder.debug(opts)
+        val clientReport = clientReportRecorder.resetCountsAndGenerateClientReport()
+        val numberOfLostItems = clientReport?.discardedEvents?.sumOf { it.quantity.toInt() } ?: 0L
+
+        assertEquals(numberOfIncrementThreads * numberOfIncrementsPerThread, numberOfLostItems)
+    }
+
+    @Test
+    fun testMultiThreadedCountIncrementsAndResets() {
+        setupSentry()
+
+        val clientReportRecorder = ClientReportRecorderImpl.getInstance()
+
+        val numberOfIncrementThreads = 10
+        val numberOfIncrementsPerThread = 10 * 1000
+        val numberOfResets = 50
+
+        val executor = Executors.newFixedThreadPool(numberOfIncrementThreads + 1)
+        val completionService = ExecutorCompletionService<Unit>(executor)
+
+        println("forking from thread ${Thread.currentThread()}")
+
+        val futures = mutableListOf<Future<Unit>>()
+        val clientReports = mutableListOf<ClientReport>()
+
+        val t1 = System.currentTimeMillis()
+
+        (1..numberOfIncrementThreads).forEach { nThread ->
+            futures.add(
+                completionService.submit {
+                    println("running #$nThread on thread ${Thread.currentThread()}")
+
+                    (1..numberOfIncrementsPerThread).forEach {
+                        clientReportRecorder.recordLostEvent(randomReason(), randomCategory(), opts)
+                    }
+                }
+            )
+        }
+
+        futures.add(
+            completionService.submit {
+                println("reset loop running on thread ${Thread.currentThread()}")
+
+                (1..numberOfResets).forEach {
+                    clientReportRecorder.resetCountsAndGenerateClientReport()?.let { clientReports.add(it) }
+                    Thread.sleep(20)
+                }
+            }
+        )
+
+        futures.forEach {
+            completionService.take().get()
+        }
+
+        val t2 = System.currentTimeMillis()
+        println("took ${t2 - t1}ms")
+
+        clientReportRecorder.debug(opts)
+        clientReportRecorder.resetCountsAndGenerateClientReport()?.let { clientReports.add(it) }
+        val numberOfLostItems = clientReports.sumOf { clientReport -> clientReport.discardedEvents.sumOf { it.quantity.toInt() } }
+
+        assertEquals(numberOfIncrementThreads * numberOfIncrementsPerThread, numberOfLostItems)
+    }
+
+    @Test
+    fun testMultiThreadedCountIncrementsResetsAndReadds() {
+        setupSentry()
+
+        val clientReportRecorder = ClientReportRecorderImpl.getInstance()
+
+        val numberOfIncrementThreads = 10
+        val numberOfIncrementsPerThread = 10 * 1000
+        val numberOfResets = 50
+
+        val executor = Executors.newFixedThreadPool(numberOfIncrementThreads + 1)
+        val completionService = ExecutorCompletionService<Unit>(executor)
+
+        println("forking from thread ${Thread.currentThread()}")
+
+        val futures = mutableListOf<Future<Unit>>()
+
+        val t1 = System.currentTimeMillis()
+
+        (1..numberOfIncrementThreads).forEach { nThread ->
+            futures.add(
+                completionService.submit {
+                    println("running #$nThread on thread ${Thread.currentThread()}")
+
+                    (1..numberOfIncrementsPerThread).forEach {
+                        clientReportRecorder.recordLostEvent(randomReason(), randomCategory(), opts)
+                    }
+                }
+            )
+        }
+
+        futures.add(
+            completionService.submit {
+                println("reset loop running on thread ${Thread.currentThread()}")
+
+                (1..numberOfResets).forEach {
+                    val clientReport = clientReportRecorder.resetCountsAndGenerateClientReport()
+                    Thread.sleep(20)
+                    clientReport?.let { clientReport ->
+                        val envelopeItem = SentryEnvelopeItem.fromClientReport(opts.serializer, clientReport)
+                        val header = SentryEnvelopeHeader(SentryId(UUID.randomUUID()))
+                        val envelope = SentryEnvelope(header, listOf(envelopeItem))
+                        clientReportRecorder.recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope, opts)
+                    }
+                }
+            }
+        )
+
+        futures.forEach {
+            completionService.take().get()
+        }
+
+        val t2 = System.currentTimeMillis()
+        println("took ${t2 - t1}ms")
+
+        clientReportRecorder.debug(opts)
+        val clientReport = clientReportRecorder.resetCountsAndGenerateClientReport()
+        val numberOfLostItems = clientReport?.discardedEvents?.sumOf { it.quantity.toInt() } ?: 0L
+
+        assertEquals(numberOfIncrementThreads * numberOfIncrementsPerThread, numberOfLostItems)
+    }
+
+    private fun setupSentry(callback: Sentry.OptionsConfiguration<SentryOptions>? = null) {
+        Sentry.init { options ->
+            options.dsn = dsnString
+            callback?.configure(options)
+            opts = options
+        }
+    }
+
+    private fun randomCategory(): DataCategory {
+        return categories.random()
+    }
+
+    private fun randomReason(): DiscardReason {
+        return reasons.random()
+    }
+}

--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
@@ -1,0 +1,223 @@
+package io.sentry.clientreport
+
+import io.sentry.DateUtils
+import io.sentry.EventProcessor
+import io.sentry.Sentry
+import io.sentry.SentryEnvelope
+import io.sentry.SentryEnvelopeHeader
+import io.sentry.SentryEnvelopeItem
+import io.sentry.SentryEvent
+import io.sentry.SentryOptions
+import io.sentry.TypeCheckHint
+import io.sentry.dsnString
+import io.sentry.hints.Retryable
+import io.sentry.protocol.SentryId
+import io.sentry.protocol.SentryTransaction
+import io.sentry.transport.DataCategory
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ClientReportTest {
+
+    lateinit var opts: SentryOptions
+    lateinit var clientReportRecorder: ClientReportRecorderImpl
+    lateinit var testHelper: ClientReportTestHelper
+
+    @BeforeTest
+    fun setup() {
+        ClientReportRecorderImpl.getInstance().resetCountsAndGenerateClientReport()
+    }
+
+    @AfterTest
+    fun teardown() {
+        ClientReportRecorderImpl.getInstance().resetCountsAndGenerateClientReport()
+    }
+
+    @Test
+    fun `lost envelope can be recorded`() {
+        givenClientReportRecorder()
+
+        val lostClientReport = ClientReport(
+            DateUtils.getCurrentDateTime(),
+            listOf(
+                DiscardedEvent(DiscardReason.SAMPLE_RATE.reason, DataCategory.Error.category, 3),
+                DiscardedEvent(DiscardReason.BEFORE_SEND.reason, DataCategory.Error.category, 2),
+                DiscardedEvent(DiscardReason.QUEUE_OVERFLOW.reason, DataCategory.Transaction.category, 1),
+            )
+        )
+
+        val envelope = testHelper.newEnvelope(SentryEnvelopeItem.fromClientReport(opts.serializer, lostClientReport))
+
+        clientReportRecorder.recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope, opts)
+
+        val clientReportAtEnd = clientReportRecorder.resetCountsAndGenerateClientReport()
+        testHelper.assertTotalCount(6, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.SAMPLE_RATE, DataCategory.Error, 3, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.BEFORE_SEND, DataCategory.Error, 2, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.QUEUE_OVERFLOW, DataCategory.Transaction, 1, clientReportAtEnd)
+    }
+
+    @Test
+    fun `lost event can be recorded`() {
+        givenClientReportRecorder()
+
+        clientReportRecorder.recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error, opts)
+
+        val clientReport = clientReportRecorder.resetCountsAndGenerateClientReport()
+        testHelper.assertTotalCount(1, clientReport)
+        testHelper.assertCountFor(DiscardReason.EVENT_PROCESSOR, DataCategory.Error, 1, clientReport)
+    }
+
+    @Test
+    fun `lost envelope item can be recorded`() {
+        givenClientReportRecorder()
+
+        val lostClientReport = ClientReport(
+            DateUtils.getCurrentDateTime(),
+            listOf(
+                DiscardedEvent(DiscardReason.SAMPLE_RATE.reason, DataCategory.Error.category, 3),
+                DiscardedEvent(DiscardReason.BEFORE_SEND.reason, DataCategory.Error.category, 2),
+                DiscardedEvent(DiscardReason.QUEUE_OVERFLOW.reason, DataCategory.Transaction.category, 1),
+            )
+        )
+
+        val envelopeItem = SentryEnvelopeItem.fromClientReport(opts.serializer, lostClientReport)
+
+        clientReportRecorder.recordLostEnvelopeItem(DiscardReason.NETWORK_ERROR, envelopeItem, opts)
+
+        val clientReportAtEnd = clientReportRecorder.resetCountsAndGenerateClientReport()
+        testHelper.assertTotalCount(6, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.SAMPLE_RATE, DataCategory.Error, 3, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.BEFORE_SEND, DataCategory.Error, 2, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.QUEUE_OVERFLOW, DataCategory.Transaction, 1, clientReportAtEnd)
+    }
+
+    @Test
+    fun `attaching client report to an envelope resets counts`() {
+        givenClientReportRecorder()
+
+        clientReportRecorder.recordLostEvent(DiscardReason.CACHE_OVERFLOW, DataCategory.Attachment, opts)
+        clientReportRecorder.recordLostEvent(DiscardReason.CACHE_OVERFLOW, DataCategory.Attachment, opts)
+        clientReportRecorder.recordLostEvent(DiscardReason.RATELIMIT_BACKOFF, DataCategory.Error, opts)
+        clientReportRecorder.recordLostEvent(DiscardReason.QUEUE_OVERFLOW, DataCategory.Error, opts)
+
+        val envelope = clientReportRecorder.attachReportToEnvelope(testHelper.newEnvelope(), opts)
+
+        testHelper.assertTotalCount(0, clientReportRecorder.resetCountsAndGenerateClientReport())
+
+        val envelopeReport = envelope.items.first().getClientReport(opts.serializer)!!
+        assertEquals(3, envelopeReport.discardedEvents.size)
+        assertEquals(2, envelopeReport.discardedEvents.first { it.reason == DiscardReason.CACHE_OVERFLOW.reason && it.category == DataCategory.Attachment.category }.quantity)
+        assertEquals(1, envelopeReport.discardedEvents.first { it.reason == DiscardReason.RATELIMIT_BACKOFF.reason && it.category == DataCategory.Error.category }.quantity)
+        assertEquals(1, envelopeReport.discardedEvents.first { it.reason == DiscardReason.QUEUE_OVERFLOW.reason && it.category == DataCategory.Error.category }.quantity)
+        assertTrue(
+            ChronoUnit.MILLIS.between(
+                LocalDateTime.now(),
+                envelopeReport.timestamp.toInstant().atZone(
+                    ZoneId.systemDefault()
+                ).toLocalDateTime()
+            ) < 10000
+        )
+    }
+
+    private fun givenClientReportRecorder(callback: Sentry.OptionsConfiguration<SentryOptions>? = null) {
+        setupSentry { options ->
+            callback?.configure(options)
+        }
+        clientReportRecorder = ClientReportRecorderImpl.getInstance()
+        testHelper = ClientReportTestHelper(opts)
+    }
+
+    private fun setupSentry(callback: Sentry.OptionsConfiguration<SentryOptions>? = null) {
+        Sentry.init { options ->
+            options.dsn = dsnString
+            callback?.configure(options)
+            opts = options
+        }
+    }
+}
+
+class DropEverythingEventProcessor : EventProcessor {
+
+    override fun process(event: SentryEvent, hint: MutableMap<String, Any>?): SentryEvent? {
+        return null
+    }
+
+    override fun process(
+        transaction: SentryTransaction,
+        hint: MutableMap<String, Any>?
+    ): SentryTransaction? {
+        return null
+    }
+}
+
+class ClientReportTestHelper(val options: SentryOptions) {
+
+    val reasons = DiscardReason.values()
+    val categories = listOf(DataCategory.Error, DataCategory.Attachment, DataCategory.Session, DataCategory.Transaction, DataCategory.UserReport)
+
+    fun assertTotalCount(expectedCount: Long, clientReport: ClientReport?) {
+        assertEquals(expectedCount, clientReport?.discardedEvents?.sumOf { it.quantity } ?: 0L)
+    }
+
+    fun assertCountFor(reason: DiscardReason, category: DataCategory, expectedCount: Long, clientReport: ClientReport?) {
+        val discardedEvent = clientReport?.discardedEvents?.first { it.category == category.category && it.reason == reason.reason }
+        assertEquals(expectedCount, discardedEvent?.quantity ?: 0L)
+    }
+
+    fun randomCategory(): DataCategory {
+        return categories.random()
+    }
+
+    fun randomReason(): DiscardReason {
+        return reasons.random()
+    }
+
+    fun newEnvelope(vararg items: SentryEnvelopeItem): SentryEnvelope {
+        val header = SentryEnvelopeHeader(SentryId(UUID.randomUUID()))
+        return SentryEnvelope(header, items.toList())
+    }
+
+    fun toEnvelopeItem(clientReport: ClientReport): SentryEnvelopeItem {
+        return SentryEnvelopeItem.fromClientReport(options.serializer, clientReport)
+    }
+
+    companion object {
+        fun retryableHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestRetryable())
+
+        fun resetCountsAndGenerateClientReport(): ClientReport? {
+            return ClientReportRecorderImpl.getInstance().resetCountsAndGenerateClientReport()
+        }
+
+        fun assertClientReport(expectedEvents: List<DiscardedEvent>) {
+            val clientReport = resetCountsAndGenerateClientReport()
+
+            assertEquals(expectedEvents.filter { it.quantity > 0 }.size, clientReport?.discardedEvents?.size ?: 0)
+
+            expectedEvents.forEach { expectedEvent ->
+                val actualEvent =
+                    clientReport?.discardedEvents?.firstOrNull { it.reason == expectedEvent.reason && it.category == expectedEvent.category }
+                assertEquals(expectedEvent.quantity, actualEvent?.quantity ?: 0, clientReport?.discardedEvents?.toString())
+            }
+        }
+    }
+}
+
+class TestRetryable : Retryable {
+    private var retry = false
+
+    override fun setRetry(retry: Boolean) {
+        this.retry = retry
+    }
+
+    override fun isRetry(): Boolean {
+        return this.retry
+    }
+}

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportClientReportTest.kt
@@ -1,0 +1,241 @@
+package io.sentry.transport
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.SentryEnvelope
+import io.sentry.SentryOptions
+import io.sentry.Session
+import io.sentry.clientreport.ClientReportRecorder
+import io.sentry.clientreport.ClientReportTestHelper.Companion.retryableHint
+import io.sentry.clientreport.DiscardReason
+import io.sentry.dsnString
+import io.sentry.protocol.User
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class AsyncHttpTransportClientReportTest {
+
+    private class Fixture {
+        var connection = mock<HttpConnection>()
+        var transportGate = mock<ITransportGate>()
+        var executor = mock<QueuedThreadPoolExecutor>()
+        var rateLimiter = mock<RateLimiter>()
+        var sentryOptions: SentryOptions = SentryOptions().apply {
+            dsn = dsnString
+            setSerializer(mock())
+            setEnvelopeDiskCache(mock())
+        }
+        var clientReportRecorder = mock<ClientReportRecorder>()
+        val envelopeBeforeAttachingClientReport = SentryEnvelope.from(sentryOptions.serializer, createSession(), null)
+        val envelopeAfterAttachingClientReport = SentryEnvelope.from(sentryOptions.serializer, createSession(), null)
+
+        fun getSUT(): AsyncHttpTransport {
+            return AsyncHttpTransport(executor, sentryOptions, rateLimiter, transportGate, clientReportRecorder, connection)
+        }
+
+        private fun createSession(): Session {
+            return Session("123", User(), "env", "release")
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `attaches client report to envelope`() {
+        // given
+        givenSetup(TransportResult.success())
+
+        // when
+        fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 500 error for retryable`() {
+        // given
+        givenSetup(TransportResult.error(500))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport, retryableHint())
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on 500 error for non retryable`() {
+        // given
+        givenSetup(TransportResult.error(500))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.NETWORK_ERROR), same(fixture.envelopeAfterAttachingClientReport), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on full queue for non retryable`() {
+        // given
+        givenSetup(cancel = true)
+
+        // when
+        fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+
+        // then
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.QUEUE_OVERFLOW), same(fixture.envelopeBeforeAttachingClientReport), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on full queue for retryable`() {
+        // given
+        givenSetup(cancel = true)
+
+        // when
+        fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport, retryableHint())
+
+        // then
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.QUEUE_OVERFLOW), same(fixture.envelopeBeforeAttachingClientReport), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope on io exception for non retryable`() {
+        // given
+        givenSetup()
+        whenever(fixture.connection.send(any())).thenThrow(IOException("thrown on purpose"))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.NETWORK_ERROR), same(fixture.envelopeAfterAttachingClientReport), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on io exception for retryable`() {
+        // given
+        givenSetup()
+        whenever(fixture.connection.send(any())).thenThrow(IOException("thrown on purpose"))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport, retryableHint())
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 429 error for retryable`() {
+        // given
+        givenSetup(TransportResult.error(429))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport, retryableHint())
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope on 429 error for non retryable`() {
+        // given
+        givenSetup(TransportResult.error(429))
+
+        // when
+        assertFailsWith(java.lang.IllegalStateException::class) {
+            fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+        }
+
+        // then
+        verify(fixture.clientReportRecorder, times(1)).attachReportToEnvelope(same(fixture.envelopeBeforeAttachingClientReport), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `records lost envelope if transport not connected for non retryable`() {
+        // given
+        givenSetup(transportConnected = false)
+
+        // when
+        fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport)
+
+        // then
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelope(eq(DiscardReason.NETWORK_ERROR), same(fixture.envelopeBeforeAttachingClientReport), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `does not record lost envelope if transport not connected for retryable`() {
+        // given
+        givenSetup(transportConnected = false)
+
+        // when
+        fixture.getSUT().send(fixture.envelopeBeforeAttachingClientReport, retryableHint())
+
+        // then
+        verify(fixture.clientReportRecorder, never()).attachReportToEnvelope(any(), any())
+        verify(fixture.clientReportRecorder, never()).recordLostEnvelope(any(), any(), any())
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    private fun givenSetup(result: TransportResult? = null, cancel: Boolean? = null, transportConnected: Boolean? = null) {
+        if (cancel == true) {
+            whenever(fixture.executor.submit(any())).thenAnswer { QueuedThreadPoolExecutor.CancelledFuture<Any>() }
+        } else {
+            whenever(fixture.executor.submit(any())).thenAnswer { (it.arguments[0] as Runnable).run(); null }
+        }
+
+        whenever(fixture.transportGate.isConnected).thenReturn(transportConnected ?: true)
+        whenever(fixture.rateLimiter.filter(any(), anyOrNull())).thenAnswer { it.arguments[0] }
+
+        result?.let {
+            whenever(fixture.connection.send(any())).thenReturn(result)
+        }
+
+        whenever(
+            fixture.clientReportRecorder.attachReportToEnvelope(
+                eq(fixture.envelopeBeforeAttachingClientReport),
+                any()
+            )
+        ).thenReturn(fixture.envelopeAfterAttachingClientReport)
+    }
+}

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -17,6 +17,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.Session
 import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
+import io.sentry.clientreport.NoOpClientReportRecorder
 import io.sentry.dsnString
 import io.sentry.protocol.User
 import java.io.IOException
@@ -35,6 +36,7 @@ class AsyncHttpTransportTest {
             setSerializer(mock())
             setEnvelopeDiskCache(mock())
         }
+        var clientReportRecorder = NoOpClientReportRecorder()
 
         init {
             // this is an executor service running immediately in the current thread. Of course this defeats the
@@ -44,7 +46,7 @@ class AsyncHttpTransportTest {
         }
 
         fun getSUT(): AsyncHttpTransport {
-            return AsyncHttpTransport(executor, sentryOptions, rateLimiter, transportGate, connection)
+            return AsyncHttpTransport(executor, sentryOptions, rateLimiter, transportGate, clientReportRecorder, connection)
         }
     }
 


### PR DESCRIPTION
## :scroll: Description
Adds recording discarded events and sending them with client reports to
Sentry. Discarded events give insight into where the SDK drops certain
events like, for example, beforeSend or rate limiting.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/1894


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
