### PR TITLE
Add sentry-servlet-jakarta module

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -24,6 +24,7 @@ targets:
       maven:io.sentry:sentry-spring:
       maven:io.sentry:sentry-spring-boot-starter:
       maven:io.sentry:sentry-servlet:
+      maven:io.sentry:sentry-servlet-jakarta:
       maven:io.sentry:sentry-logback:
       maven:io.sentry:sentry-log4j2:
       maven:io.sentry:sentry-jul:

--- a/.github/ISSUE_TEMPLATE/bug_report_java.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_java.yml
@@ -14,6 +14,7 @@ body:
         - sentry-apollo
         - sentry-kotlin-extensions
         - sentry-servlet
+        - sentry-servlet-jakarta
         - sentry-spring-boot-starter
         - sentry-spring
         - sentry-logback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Feat: Add sentry-servlet-jakarta module (#1987)
+
 ## 6.0.0-alpha.5
 
 * Feat: Screenshot is taken when there is an error (#1967)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -76,6 +76,7 @@ object Config {
         val springAop = "org.springframework:spring-aop"
         val aspectj = "org.aspectj:aspectjweaver"
         val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
+        val servletApiJakarta = "jakarta.servlet:jakarta.servlet-api:5.0.0"
 
         val apacheHttpClient = "org.apache.httpcomponents.client5:httpclient5:5.0.4"
 

--- a/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
+++ b/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
@@ -1,0 +1,12 @@
+public class io/sentry/servlet/jakarta/SentryServletContainerInitializer : jakarta/servlet/ServletContainerInitializer {
+	public fun <init> ()V
+	public fun onStartup (Ljava/util/Set;Ljakarta/servlet/ServletContext;)V
+}
+
+public class io/sentry/servlet/jakarta/SentryServletRequestListener : jakarta/servlet/ServletRequestListener {
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
+	public fun requestDestroyed (Ljakarta/servlet/ServletRequestEvent;)V
+	public fun requestInitialized (Ljakarta/servlet/ServletRequestEvent;)V
+}
+

--- a/sentry-servlet-jakarta/build.gradle.kts
+++ b/sentry-servlet-jakarta/build.gradle.kts
@@ -1,0 +1,98 @@
+import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
+import net.ltgt.gradle.errorprone.errorprone
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
+plugins {
+    `java-library`
+    kotlin("jvm")
+    jacoco
+    id(Config.QualityPlugins.errorProne)
+    id(Config.QualityPlugins.gradleVersions)
+    id(Config.BuildPlugins.springBoot) version Config.springBootVersion apply false
+    id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
+}
+
+the<DependencyManagementExtension>().apply {
+    imports {
+        mavenBom(SpringBootPlugin.BOM_COORDINATES)
+    }
+}
+
+configure<JavaPluginExtension> {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlinOptions.languageVersion = Config.springKotlinCompatibleLanguageVersion
+}
+
+dependencies {
+    api(projects.sentry)
+    compileOnly(Config.Libs.servletApiJakarta)
+
+    compileOnly(Config.CompileOnly.nopen)
+    errorprone(Config.CompileOnly.nopenChecker)
+    errorprone(Config.CompileOnly.errorprone)
+    errorprone(Config.CompileOnly.errorProneNullAway)
+    compileOnly(Config.CompileOnly.jetbrainsAnnotations)
+
+    // tests
+    testImplementation(Config.Libs.servletApiJakarta)
+    testImplementation(projects.sentryTestSupport)
+    testImplementation(kotlin(Config.kotlinStdLib))
+    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(Config.TestLibs.mockitoKotlin)
+    testImplementation(Config.TestLibs.awaitility)
+}
+
+configure<SourceSetContainer> {
+    test {
+        java.srcDir("src/test/java")
+    }
+}
+
+jacoco {
+    toolVersion = Config.QualityPlugins.Jacoco.version
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        html.required.set(false)
+    }
+}
+
+tasks {
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule { limit { minimum = Config.QualityPlugins.Jacoco.minimumCoverage } }
+        }
+    }
+    check {
+        dependsOn(jacocoTestCoverageVerification)
+        dependsOn(jacocoTestReport)
+    }
+}
+repositories {
+    mavenCentral()
+}
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    languageVersion = Config.springKotlinCompatibleLanguageVersion
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    languageVersion = Config.springKotlinCompatibleLanguageVersion
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.errorprone {
+        check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
+        option("NullAway:AnnotatedPackages", "io.sentry")
+    }
+}

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -1,0 +1,59 @@
+package io.sentry.servlet.jakarta;
+
+import io.sentry.EventProcessor;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Request;
+import io.sentry.util.Objects;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Attaches information about HTTP request to {@link SentryEvent}. */
+final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
+  private static final List<String> SENSITIVE_HEADERS =
+      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE");
+
+  private final @NotNull HttpServletRequest httpRequest;
+
+  public SentryRequestHttpServletRequestProcessor(@NotNull HttpServletRequest httpRequest) {
+    this.httpRequest = Objects.requireNonNull(httpRequest, "httpRequest is required");
+  }
+
+  // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
+  @SuppressWarnings("JdkObsolete")
+  @Override
+  public @NotNull SentryEvent process(
+      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+    final Request sentryRequest = new Request();
+    sentryRequest.setMethod(httpRequest.getMethod());
+    sentryRequest.setQueryString(httpRequest.getQueryString());
+    sentryRequest.setUrl(httpRequest.getRequestURL().toString());
+    sentryRequest.setHeaders(resolveHeadersMap(httpRequest));
+
+    event.setRequest(sentryRequest);
+    return event;
+  }
+
+  private @NotNull Map<String, String> resolveHeadersMap(
+      final @NotNull HttpServletRequest request) {
+    final Map<String, String> headersMap = new HashMap<>();
+    for (String headerName : Collections.list(request.getHeaderNames())) {
+      // do not copy personal information identifiable headers
+      if (!SENSITIVE_HEADERS.contains(headerName.toUpperCase(Locale.ROOT))) {
+        headersMap.put(headerName, toString(request.getHeaders(headerName)));
+      }
+    }
+    return headersMap;
+  }
+
+  private static @Nullable String toString(final @Nullable Enumeration<String> enumeration) {
+    return enumeration != null ? String.join(",", Collections.list(enumeration)) : null;
+  }
+}

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletContainerInitializer.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletContainerInitializer.java
@@ -1,0 +1,22 @@
+package io.sentry.servlet.jakarta;
+
+import com.jakewharton.nopen.annotation.Open;
+import jakarta.servlet.ServletContainerInitializer;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Servlet container initializer used to add the {@link SentryServletRequestListener} to the {@link
+ * ServletContext}.
+ */
+@Open
+public class SentryServletContainerInitializer implements ServletContainerInitializer {
+  @Override
+  public void onStartup(@Nullable Set<Class<?>> c, @NotNull ServletContext ctx)
+      throws ServletException {
+    ctx.addListener(SentryServletRequestListener.class);
+  }
+}

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
@@ -1,0 +1,60 @@
+package io.sentry.servlet.jakarta;
+
+import static io.sentry.TypeCheckHint.SERVLET_REQUEST;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.Breadcrumb;
+import io.sentry.HubAdapter;
+import io.sentry.IHub;
+import io.sentry.util.Objects;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestEvent;
+import jakarta.servlet.ServletRequestListener;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This request listener pushes a new scope into sentry that enriches a Sentry event with the
+ * details about the current request upon sending.
+ */
+@Open
+public class SentryServletRequestListener implements ServletRequestListener {
+
+  private final IHub hub;
+
+  public SentryServletRequestListener(@NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
+  }
+
+  public SentryServletRequestListener() {
+    this(HubAdapter.getInstance());
+  }
+
+  @Override
+  public void requestDestroyed(@NotNull ServletRequestEvent servletRequestEvent) {
+    hub.popScope();
+  }
+
+  @Override
+  public void requestInitialized(@NotNull ServletRequestEvent servletRequestEvent) {
+    hub.pushScope();
+
+    final ServletRequest servletRequest = servletRequestEvent.getServletRequest();
+    if (servletRequest instanceof HttpServletRequest) {
+      final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+
+      final Map<String, Object> hintMap = new HashMap<>();
+      hintMap.put(SERVLET_REQUEST, httpRequest);
+
+      hub.addBreadcrumb(
+          Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hintMap);
+
+      hub.configureScope(
+          scope -> {
+            scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(httpRequest));
+          });
+    }
+  }
+}

--- a/sentry-servlet-jakarta/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/sentry-servlet-jakarta/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+io.sentry.servlet.jakarta.SentryServletContainerInitializer

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
@@ -1,0 +1,163 @@
+package io.sentry.servlet.jakarta
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.SentryEvent
+import io.sentry.SentryOptions
+import jakarta.servlet.http.HttpServletRequest
+import java.net.URI
+import java.util.Collections
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SentryRequestHttpServletRequestProcessorTest {
+
+    @Test
+    fun `attaches basic information from HTTP request to SentryEvent`() {
+        val request = mockRequest(
+            url = "http://example.com?param1=xyz",
+            headers = mapOf(
+                "some-header" to "some-header value",
+                "Accept" to "application/json"
+            )
+        )
+        val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+        val event = SentryEvent()
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.request)
+        val eventRequest = event.request!!
+        assertEquals("GET", eventRequest.method)
+        assertEquals(
+            mapOf(
+                "some-header" to "some-header value",
+                "Accept" to "application/json"
+            ),
+            eventRequest.headers
+        )
+        assertEquals("http://example.com", eventRequest.url)
+        assertEquals("param1=xyz", eventRequest.queryString)
+    }
+
+    @Test
+    fun `attaches header with multiple values`() {
+        val request = mockRequest(
+            url = "http://example.com?param1=xyz",
+            headers = mapOf(
+                "another-header" to listOf("another value", "another value2")
+            )
+        )
+        val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+        val event = SentryEvent()
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.request) {
+            assertEquals(
+                mapOf(
+                    "another-header" to "another value,another value2"
+                ),
+                it.headers
+            )
+        }
+    }
+
+    @Test
+    fun `does not attach cookies`() {
+        val request = mockRequest(
+            url = "http://example.com?param1=xyz",
+            headers = mapOf(
+                "Cookie" to "name=value"
+            )
+        )
+        val sentryOptions = SentryOptions()
+        sentryOptions.isSendDefaultPii = false
+        val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+        val event = SentryEvent()
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.request) {
+            assertNull(it.cookies)
+        }
+    }
+
+    @Test
+    fun `does not attach sensitive headers`() {
+        val request = mockRequest(
+            url = "http://example.com?param1=xyz",
+            headers = mapOf(
+                "some-header" to "some-header value",
+                "X-FORWARDED-FOR" to "192.168.0.1",
+                "authorization" to "Token",
+                "Authorization" to "Token",
+                "Cookie" to "some cookies"
+            )
+        )
+        val sentryOptions = SentryOptions()
+        sentryOptions.isSendDefaultPii = false
+        val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
+        val event = SentryEvent()
+
+        eventProcessor.process(event, null)
+
+        assertNotNull(event.request) { req ->
+            assertNotNull(req.headers) {
+                assertFalse(it.containsKey("X-FORWARDED-FOR"))
+                assertFalse(it.containsKey("Authorization"))
+                assertFalse(it.containsKey("authorization"))
+                assertFalse(it.containsKey("Cookies"))
+                assertTrue(it.containsKey("some-header"))
+            }
+        }
+    }
+}
+
+fun mockRequest(url: String, method: String = "GET", headers: Map<String, Any?> = emptyMap()): HttpServletRequest {
+    val uri = URI(url)
+    val request = mock<HttpServletRequest>()
+    whenever(request.method).thenReturn(method)
+    whenever(request.scheme).thenReturn(uri.scheme)
+    whenever(request.serverName).thenReturn(uri.host)
+    whenever(request.serverPort).thenReturn(uri.port)
+    whenever(request.requestURI).thenReturn(uri.rawPath)
+    whenever(request.queryString).thenReturn(uri.rawQuery)
+
+    whenever(request.headerNames).thenReturn(Collections.enumeration(headers.keys))
+    whenever(request.getHeaders(any())).then { invocation ->
+        when (val headerValue = headers[invocation.arguments.first()]) {
+            is Collection<*> -> Collections.enumeration(headerValue)
+            else -> Collections.enumeration(listOf(headerValue))
+        }
+    }
+
+    whenever(request.requestURL).thenReturn(toRequestUrl(uri))
+
+    return request
+}
+
+fun toRequestUrl(uri: URI): StringBuffer? {
+    val scheme: String = uri.scheme
+    val server: String = uri.host
+    val port: Int = uri.port
+    val uri: String = uri.rawPath
+    val url = StringBuffer(scheme).append("://").append(server)
+    if (port > 0 && (
+        "http".equals(scheme, ignoreCase = true) && port != 80 ||
+            "https".equals(scheme, ignoreCase = true) && port != 443
+        )
+    ) {
+        url.append(':').append(port)
+    }
+
+    if (uri?.isNotBlank()) {
+        url.append(uri)
+    }
+    return url
+}

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletContainerInitializerTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletContainerInitializerTest.kt
@@ -1,0 +1,26 @@
+package io.sentry.servlet.jakarta
+
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import jakarta.servlet.ServletContext
+import java.util.EventListener
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SentryServletContainerInitializerTest {
+
+    private val initializer =
+        SentryServletContainerInitializer()
+
+    @Test
+    fun `adds SentryServletRequestListener on startup`() {
+        val servletContext = mock<ServletContext>()
+        initializer.onStartup(null, servletContext)
+        verify(servletContext).addListener(
+            check { it: Class<out EventListener> ->
+                assertEquals(SentryServletRequestListener::class.java, it)
+            }
+        )
+    }
+}

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletRequestListenerTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletRequestListenerTest.kt
@@ -1,0 +1,59 @@
+package io.sentry.servlet.jakarta
+
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.Breadcrumb
+import io.sentry.IHub
+import jakarta.servlet.ServletRequestEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SentryServletRequestListenerTest {
+    private class Fixture {
+        val hub = mock<IHub>()
+        val listener =
+            SentryServletRequestListener(hub)
+        val request = mockRequest(
+            url = "http://localhost:8080/some-uri",
+            method = "POST"
+        )
+        val event = mock<ServletRequestEvent>()
+
+        init {
+            whenever(event.servletRequest).thenReturn(request)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `pushes scope when request gets initialized`() {
+        fixture.listener.requestInitialized(fixture.event)
+
+        verify(fixture.hub).pushScope()
+    }
+
+    @Test
+    fun `adds breadcrumb when request gets initialized`() {
+        fixture.listener.requestInitialized(fixture.event)
+
+        verify(fixture.hub).addBreadcrumb(
+            check { it: Breadcrumb ->
+                assertEquals("/some-uri", it.getData("url"))
+                assertEquals("POST", it.getData("method"))
+                assertEquals("http", it.type)
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `pops scope when request gets destroyed`() {
+        fixture.listener.requestDestroyed(fixture.event)
+
+        verify(fixture.hub).popScope()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
     "sentry-logback",
     "sentry-jul",
     "sentry-servlet",
+    "sentry-servlet-jakarta",
     "sentry-apache-http-client-5",
     "sentry-spring",
     "sentry-spring-boot-starter",


### PR DESCRIPTION
## :scroll: Description
Add `sentry-servlet-jakarta` module to support `jakarta.servlet-api` which has been moved from `javax.servlet-api`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially fixes https://github.com/getsentry/sentry-java/issues/1789
Spring and Spring Boot require more investigation: https://github.com/getsentry/sentry-java/issues/1984

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
