### PR TITLE
feat: ndk scope sync on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Scope data set in Java is included in native/NDK crashes. Opt-out through setEnableScopeSync(false)  ([#1991](https://github.com/getsentry/sentry-java/pull/1991))
+
 ## 6.0.0-alpha.5
 
 * Feat: Screenshot is taken when there is an error (#1967)

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -253,7 +253,7 @@ public class SentryOptions {
    * Enable the Java to NDK Scope sync. The default value for sentry-java is disabled and enabled
    * for sentry-android.
    */
-  private boolean enableScopeSync;
+  private boolean enableScopeSync = true;
 
   /**
    * Enables loading additional options from external locations like {@code sentry.properties} file


### PR DESCRIPTION
Turn scope sync on by default