### PR TITLE
Ref: Make options.printUncaughtStackTrace primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Ref: Make options.printUncaughtStackTrace primitive type (#)
+
 ## 6.0.0-alpha.5
 
 * Feat: Screenshot is taken when there is an error (#1967)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Ref: Make options.printUncaughtStackTrace primitive type (#)
+* Ref: Make options.printUncaughtStackTrace primitive type (#1995)
 
 ## 6.0.0-alpha.5
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1137,7 +1137,6 @@ public class io/sentry/SentryOptions {
 	public fun getMaxSpans ()I
 	public fun getMaxTraceFileSize ()J
 	public fun getOutboxPath ()Ljava/lang/String;
-	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
 	public fun getReadTimeoutMillis ()I
@@ -1207,7 +1206,7 @@ public class io/sentry/SentryOptions {
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setMaxSpans (I)V
 	public fun setMaxTraceFileSize (J)V
-	public fun setPrintUncaughtStackTrace (Ljava/lang/Boolean;)V
+	public fun setPrintUncaughtStackTrace (Z)V
 	public fun setProfilingEnabled (Z)V
 	public fun setProguardUuid (Ljava/lang/String;)V
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -220,7 +220,7 @@ public class SentryOptions {
    * When enabled, UncaughtExceptionHandler will print exceptions (same as java would normally do),
    * if no other UncaughtExceptionHandler was registered before.
    */
-  private @Nullable Boolean printUncaughtStackTrace = false;
+  private boolean printUncaughtStackTrace = false;
 
   /** Sentry Executor Service that sends cached events and envelopes on App. start. */
   private @NotNull ISentryExecutorService executorService = NoOpSentryExecutorService.getInstance();
@@ -1008,15 +1008,6 @@ public class SentryOptions {
    * @return true if enabled or false otherwise.
    */
   public boolean isPrintUncaughtStackTrace() {
-    return Boolean.TRUE.equals(printUncaughtStackTrace);
-  }
-
-  /**
-   * Checks if printing exceptions by UncaughtExceptionHandler is enabled or disabled.
-   *
-   * @return true if enabled, false otherwise or null if not set.
-   */
-  public @Nullable Boolean getPrintUncaughtStackTrace() {
     return printUncaughtStackTrace;
   }
 
@@ -1025,7 +1016,7 @@ public class SentryOptions {
    *
    * @param printUncaughtStackTrace true if enabled or false otherwise.
    */
-  public void setPrintUncaughtStackTrace(final @Nullable Boolean printUncaughtStackTrace) {
+  public void setPrintUncaughtStackTrace(final boolean printUncaughtStackTrace) {
     this.printUncaughtStackTrace = printUncaughtStackTrace;
   }
 

--- a/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
@@ -162,7 +162,7 @@ class UncaughtExceptionHandlerIntegrationTest {
 
             val handlerMock = mock<UncaughtExceptionHandler>()
             val options = SentryOptions().noFlushTimeout()
-            options.printUncaughtStackTrace = true
+            options.isPrintUncaughtStackTrace = true
             val sut = UncaughtExceptionHandlerIntegration(handlerMock)
             sut.register(mock<IHub>(), options)
             sut.uncaughtException(mock<Thread>(), RuntimeException("This should be printed!"))


### PR DESCRIPTION
Continuation of https://github.com/getsentry/sentry-java/pull/1890 and #1750