### PR TITLE
Feat/profiling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: Profiling rate decreased from 300hz to 100hz; fixed profiling traces folder creation on manual sdk init (#1997)
+
 ## 6.0.0-alpha.5
 
 * Feat: Screenshot is taken when there is an error (#1967)

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -125,7 +125,6 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun enableAllAutoBreadcrumbs (Z)V
 	public fun getAnrTimeoutIntervalMillis ()J
 	public fun getDebugImagesLoader ()Lio/sentry/android/core/IDebugImagesLoader;
-	public fun getProfilingTracesDirPath ()Ljava/lang/String;
 	public fun getProfilingTracesIntervalMillis ()I
 	public fun isAnrEnabled ()Z
 	public fun isAnrReportInDebug ()Z
@@ -149,7 +148,6 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableAutoActivityLifecycleTracing (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V
 	public fun setEnableUserInteractionBreadcrumbs (Z)V
-	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
 	public fun setProfilingTracesIntervalMillis (I)V
 }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -14,7 +14,6 @@ import io.sentry.SendFireAndForgetOutboxSender;
 import io.sentry.SentryLevel;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
-import io.sentry.util.FileUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -297,31 +296,12 @@ final class AndroidOptionsInitializer {
    * @param context the Application context
    * @param options the SentryAndroidOptions
    */
-  @SuppressWarnings("FutureReturnValueIgnored")
   private static void initializeCacheDirs(
       final @NotNull Context context, final @NotNull SentryAndroidOptions options) {
     final File cacheDir = new File(context.getCacheDir(), "sentry");
     final File profilingTracesDir = new File(cacheDir, "profiling_traces");
     options.setCacheDirPath(cacheDir.getAbsolutePath());
     options.setProfilingTracesDirPath(profilingTracesDir.getAbsolutePath());
-
-    // We don't have the options set by code (manual initialisation) at this point, so we have no
-    // way to know if profiling is manually enabled or not.
-    // In case it's disabled the overhead should be low enough
-    profilingTracesDir.mkdirs();
-    final File[] oldTracesDirContent = profilingTracesDir.listFiles();
-
-    options
-        .getExecutorService()
-        .submit(
-            () -> {
-              if (oldTracesDirContent == null) return;
-              // Method trace files are normally deleted at the end of traces, but if that fails
-              // for some reason we try to clear any old files here.
-              for (File f : oldTracesDirContent) {
-                FileUtils.deleteRecursively(f);
-              }
-            });
   }
 
   private static boolean isNdkAvailable(final @NotNull BuildInfoProvider buildInfoProvider) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -305,23 +305,23 @@ final class AndroidOptionsInitializer {
     options.setCacheDirPath(cacheDir.getAbsolutePath());
     options.setProfilingTracesDirPath(profilingTracesDir.getAbsolutePath());
 
-    if (options.isProfilingEnabled()) {
-      profilingTracesDir.mkdirs();
-      final File[] oldTracesDirContent = profilingTracesDir.listFiles();
+    // We don't have the options set by code (manual initialisation) at this point, so we have no
+    // way to know if profiling is manually enabled or not.
+    // In case it's disabled the overhead should be low enough
+    profilingTracesDir.mkdirs();
+    final File[] oldTracesDirContent = profilingTracesDir.listFiles();
 
-      options
-          .getExecutorService()
-          .submit(
-              () -> {
-                if (oldTracesDirContent == null) return;
-                // Method trace files are normally deleted at the end of traces, but if that fails
-                // for some
-                // reason we try to clear any old files here.
-                for (File f : oldTracesDirContent) {
-                  FileUtils.deleteRecursively(f);
-                }
-              });
-    }
+    options
+        .getExecutorService()
+        .submit(
+            () -> {
+              if (oldTracesDirContent == null) return;
+              // Method trace files are normally deleted at the end of traces, but if that fails
+              // for some reason we try to clear any old files here.
+              for (File f : oldTracesDirContent) {
+                FileUtils.deleteRecursively(f);
+              }
+            });
   }
 
   private static boolean isNdkAvailable(final @NotNull BuildInfoProvider buildInfoProvider) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -88,8 +88,8 @@ public final class SentryAndroidOptions extends SentryOptions {
   /** The cache dir. path for caching profiling traces */
   private @Nullable String profilingTracesDirPath;
 
-  /** Interval for profiling traces in milliseconds. Defaults to 300 times per second */
-  private int profilingTracesIntervalMillis = 1_000 / 300;
+  /** Interval for profiling traces in milliseconds. Defaults to 100 times per second */
+  private int profilingTracesIntervalMillis = 1_000 / 100;
 
   /** Interface that loads the debug images list */
   private @NotNull IDebugImagesLoader debugImagesLoader = NoOpDebugImagesLoader.getInstance();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -7,7 +7,6 @@ import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
 import io.sentry.protocol.SdkVersion;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /** Sentry SDK options for Android */
 public final class SentryAndroidOptions extends SentryOptions {
@@ -84,9 +83,6 @@ public final class SentryAndroidOptions extends SentryOptions {
    * Spans.
    */
   private boolean enableActivityLifecycleTracingAutoFinish = true;
-
-  /** The cache dir. path for caching profiling traces */
-  private @Nullable String profilingTracesDirPath;
 
   /** Interval for profiling traces in milliseconds. Defaults to 100 times per second */
   private int profilingTracesIntervalMillis = 1_000 / 100;
@@ -224,24 +220,6 @@ public final class SentryAndroidOptions extends SentryOptions {
     enableSystemEventBreadcrumbs = enable;
     enableAppLifecycleBreadcrumbs = enable;
     enableUserInteractionBreadcrumbs = enable;
-  }
-
-  /**
-   * Returns the profiling traces dir. path if set
-   *
-   * @return the profiling traces dir. path or null if not set
-   */
-  public @Nullable String getProfilingTracesDirPath() {
-    return profilingTracesDirPath;
-  }
-
-  /**
-   * Sets the profiling traces dir. path
-   *
-   * @param profilingTracesDirPath the profiling traces dir. path
-   */
-  public void setProfilingTracesDirPath(@Nullable String profilingTracesDirPath) {
-    this.profilingTracesDirPath = profilingTracesDirPath;
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -160,15 +160,7 @@ class AndroidOptionsInitializerTest {
                 "${File.separator}cache${File.separator}sentry${File.separator}profiling_traces"
             )!!
         )
-        assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
-    }
-
-    @Test
-    fun `profilingTracesDirPath should be created and cleared at initialization`() {
-        fixture.initSut()
-
-        assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
-        assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).list()!!.isEmpty())
+        assertFalse(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -160,14 +160,12 @@ class AndroidOptionsInitializerTest {
                 "${File.separator}cache${File.separator}sentry${File.separator}profiling_traces"
             )!!
         )
-        assertFalse(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
+        assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
     }
 
     @Test
-    fun `profilingTracesDirPath should be created and cleared when profiling is enabled`() {
-        fixture.initSut(configureOptions = {
-            isProfilingEnabled = true
-        })
+    fun `profilingTracesDirPath should be created and cleared at initialization`() {
+        fixture.initSut()
 
         assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).exists())
         assertTrue(File(fixture.sentryOptions.profilingTracesDirPath!!).list()!!.isEmpty())

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.Sentry
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
 import io.sentry.test.getCtor
@@ -28,10 +29,12 @@ class AndroidTransactionProfilerTest {
     private lateinit var file: File
 
     private class Fixture {
+        private val mockDsn = "http://key@localhost/proj"
         val buildInfo = mock<BuildInfoProvider> {
             whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
         }
         val options = SentryAndroidOptions().apply {
+            dsn = mockDsn
             isProfilingEnabled = true
         }
         val transaction1 = SentryTracer(TransactionContext("", ""), mock())
@@ -46,6 +49,7 @@ class AndroidTransactionProfilerTest {
         context = ApplicationProvider.getApplicationContext()
         file = context.cacheDir
         AndroidOptionsInitializer.init(fixture.options, createMockContext())
+        Sentry.init(fixture.options)
     }
 
     @AfterTest

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1137,7 +1137,6 @@ public class io/sentry/SentryOptions {
 	public fun getMaxSpans ()I
 	public fun getMaxTraceFileSize ()J
 	public fun getOutboxPath ()Ljava/lang/String;
-	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
 	public fun getProfilingTracesDirPath ()Ljava/lang/String;
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1138,6 +1138,7 @@ public class io/sentry/SentryOptions {
 	public fun getMaxTraceFileSize ()J
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getPrintUncaughtStackTrace ()Ljava/lang/Boolean;
+	public fun getProfilingTracesDirPath ()Ljava/lang/String;
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
 	public fun getReadTimeoutMillis ()I
@@ -1209,6 +1210,7 @@ public class io/sentry/SentryOptions {
 	public fun setMaxTraceFileSize (J)V
 	public fun setPrintUncaughtStackTrace (Ljava/lang/Boolean;)V
 	public fun setProfilingEnabled (Z)V
+	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
 	public fun setProguardUuid (Ljava/lang/String;)V
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V
 	public fun setReadTimeoutMillis (I)V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -233,7 +233,7 @@ public final class Sentry {
       options.setEnvelopeDiskCache(EnvelopeCache.create(options));
     }
 
-    String profilingTracesDirPath = options.getProfilingTracesDirPath();
+    final String profilingTracesDirPath = options.getProfilingTracesDirPath();
     if (options.isProfilingEnabled()
         && profilingTracesDirPath != null
         && !profilingTracesDirPath.isEmpty()) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -4,6 +4,7 @@ import io.sentry.cache.EnvelopeCache;
 import io.sentry.config.PropertiesProviderFactory;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
+import io.sentry.util.FileUtils;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
@@ -190,6 +191,7 @@ public final class Sentry {
     }
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private static boolean initConfigurations(final @NotNull SentryOptions options) {
     if (options.isEnableExternalConfiguration()) {
       options.merge(ExternalOptions.from(PropertiesProviderFactory.create(), options.getLogger()));
@@ -229,6 +231,28 @@ public final class Sentry {
       final File cacheDir = new File(options.getCacheDirPath());
       cacheDir.mkdirs();
       options.setEnvelopeDiskCache(EnvelopeCache.create(options));
+    }
+
+    String profilingTracesDirPath = options.getProfilingTracesDirPath();
+    if (options.isProfilingEnabled()
+        && profilingTracesDirPath != null
+        && !profilingTracesDirPath.isEmpty()) {
+
+      final File profilingTracesDir = new File(profilingTracesDirPath);
+      profilingTracesDir.mkdirs();
+      final File[] oldTracesDirContent = profilingTracesDir.listFiles();
+
+      options
+          .getExecutorService()
+          .submit(
+              () -> {
+                if (oldTracesDirContent == null) return;
+                // Method trace files are normally deleted at the end of traces, but if that fails
+                // for some reason we try to clear any old files here.
+                for (File f : oldTracesDirContent) {
+                  FileUtils.deleteRecursively(f);
+                }
+              });
     }
 
     return true;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -292,6 +292,9 @@ public class SentryOptions {
   /** Control if profiling is enabled or not for transactions */
   private boolean profilingEnabled = false;
 
+  /** The cache dir. path for caching profiling traces */
+  private @Nullable String profilingTracesDirPath;
+
   /** Max trace file size in bytes. */
   private long maxTraceFileSize = 5 * 1024 * 1024;
 
@@ -1475,6 +1478,24 @@ public class SentryOptions {
    */
   public void setProfilingEnabled(boolean profilingEnabled) {
     this.profilingEnabled = profilingEnabled;
+  }
+
+  /**
+   * Returns the profiling traces dir. path if set
+   *
+   * @return the profiling traces dir. path or null if not set
+   */
+  public @Nullable String getProfilingTracesDirPath() {
+    return profilingTracesDirPath;
+  }
+
+  /**
+   * Sets the profiling traces dir. path
+   *
+   * @param profilingTracesDirPath the profiling traces dir. path
+   */
+  public void setProfilingTracesDirPath(@Nullable String profilingTracesDirPath) {
+    this.profilingTracesDirPath = profilingTracesDirPath;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -180,6 +180,31 @@ class SentryTest {
         assertTrue(Sentry.isCrashedLastRun()!!)
     }
 
+    @Test
+    fun `profilingTracesDirPath should be created and cleared at initialization when profiling is enabled`() {
+        val tracesDirPath = getTempPath()
+        Sentry.init {
+            it.dsn = dsn
+            it.isProfilingEnabled = true
+            it.profilingTracesDirPath = tracesDirPath
+        }
+
+        assertTrue(File(tracesDirPath).exists())
+        assertTrue(File(tracesDirPath).list()!!.isEmpty())
+    }
+
+    @Test
+    fun `profilingTracesDirPath should not be created and cleared when profiling is disabled`() {
+        val tracesDirPath = getTempPath()
+        Sentry.init {
+            it.dsn = dsn
+            it.isProfilingEnabled = false
+            it.profilingTracesDirPath = tracesDirPath
+        }
+
+        assertFalse(File(tracesDirPath).exists())
+    }
+
     private fun getTempPath(): String {
         val tempFile = Files.createTempDirectory("cache").toFile()
         tempFile.delete()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
reduced profiling sampling rate from 300hz to 100hz
profiling trace folder is now created regardless of profiling enabled option

## :bulb: Motivation and Context
Manual initialisation happens after profiling traces folder creation, so we were losing profiling when it was set manually, as the traces folder was not being created


## :green_heart: How did you test it?
Running a sample with strict mode did not complain about folder creation

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No breaking changes
