### PR TITLE
PoC radiography integration

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -10,7 +10,7 @@ object Config {
     val kotlinCompatibleLanguageVersion = "1.4"
 
     object BuildPlugins {
-        val androidGradle = "com.android.tools.build:gradle:7.1.2"
+        val androidGradle = "com.android.tools.build:gradle:7.1.3"
         val kotlinGradlePlugin = "gradle-plugin"
         val buildConfig = "com.github.gmazzo.buildconfig"
         val buildConfigVersion = "3.0.3"

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation(projects.sentryAndroidFragment)
     implementation(projects.sentryAndroidTimber)
     implementation(Config.Libs.fragment)
+    implementation("com.squareup.radiography:radiography:2.4.1")
 
 //    how to exclude androidx if release health feature is disabled
 //    implementation(projects.sentryAndroid) {

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -18,14 +18,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Locale;
+import radiography.Radiography;
+import radiography.ScanScopes;
+import radiography.ViewStateRenderers;
 import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
 
   private int crashCount = 0;
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -176,6 +181,22 @@ public class MainActivity extends AppCompatActivity {
               new RuntimeException("Uncaught Exception from Java."),
               "Something wrong happened %d times",
               crashCount);
+        });
+
+    binding.attachRadiography.setOnClickListener(
+        view -> {
+          Sentry.withScope(
+              scope -> {
+                // you can pass params to scan()
+                // DefaultsIncludingPii can be used if defaultPii is enabled
+                final String radiography =
+                    Radiography.scan(
+                        ScanScopes.AllWindowsScope, ViewStateRenderers.DefaultsIncludingPii);
+                final Attachment attachment =
+                    new Attachment(radiography.getBytes(UTF_8), "radiography.txt");
+                scope.addAttachment(attachment);
+                Sentry.captureMessage("message with radiography attachment");
+              });
         });
 
     setContentView(binding.getRoot());

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -105,6 +105,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/test_timber_integration"/>
+
+    <Button
+        android:id="@+id/attach_radiography"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/attach_radiography"/>
   </LinearLayout>
 
 </ScrollView>

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
   <string name="test_timber_integration">Test Timber</string>
   <string name="back_main">Back to Main Activity</string>
   <string name="tap_me">text</string>
+  <string name="attach_radiography">Attach Radiography</string>
   <string name="lipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nibh lorem, venenatis sed nulla vel, venenatis sodales augue. Mauris varius elit eu ligula volutpat, sed tincidunt orci porttitor. Donec et dignissim lacus, sed luctus ipsum. Praesent ornare luctus tortor sit amet ultricies. Cras iaculis et diam et vulputate. Cras ut iaculis mauris, non pellentesque diam. Nunc in laoreet diam, vitae accumsan eros. Morbi non nunc ac eros molestie placerat vitae id dolor. Quisque ornare aliquam ipsum, a dapibus tortor. In eu sodales tellus.
 
 Aliquam tristique, nisi eu sodales rhoncus, ex arcu blandit quam, sed suscipit enim lorem at metus. Vivamus nec aliquet dolor. Nulla molestie sem eget nunc sollicitudin placerat. Duis lobortis nisi at dui scelerisque tincidunt. Aenean fringilla tempus justo vel finibus. Sed ut mi vulputate leo lobortis interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam tempus interdum scelerisque. Integer vitae turpis imperdiet tellus facilisis pretium.


### PR DESCRIPTION
_#skip-changelog_

That's just a PoC of radiography as an attachment.
Ideally Sentry UI would render that nicely.

It should be a separate package since it needs to add the `com.squareup.radiography:radiography` dependency.
We can check at runtime if it's available in the classpath and add the integration automatically.
The package should also be installed automatically with the SAGP if `radiography` is in the classpath.
Support for Jetpack compose depends on `androidx.compose.ui:ui-tooling` in the classpath, that can also be added automatic if compose is in the classpath.

Closes https://github.com/getsentry/sentry-java/issues/1647