### PR TITLE
Change order of event filtering mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix: Allow disabling sending of client reports via Android Manifest and external options (#2007)
+* Fix: Change order of event filtering mechanisms (#2001)
 
 ## 6.0.0-alpha.6
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -81,6 +81,22 @@ public final class SentryClient implements ISentryClient {
 
     options.getLogger().log(SentryLevel.DEBUG, "Capturing event: %s", event.getEventId());
 
+    if (event != null) {
+      if (event.getThrowable() != null
+          && options.containsIgnoredExceptionForType(event.getThrowable())) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "Event was dropped as the exception %s is ignored",
+                event.getThrowable().getClass());
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
+        return SentryId.EMPTY_ID;
+      }
+    }
+
     if (shouldApplyScopeData(event, hint)) {
       // Event has already passed through here before it was cached
       // Going through again could be reading data that is no longer relevant
@@ -94,6 +110,21 @@ public final class SentryClient implements ISentryClient {
     }
 
     event = processEvent(event, hint, options.getEventProcessors());
+
+    if (event != null) {
+      event = executeBeforeSend(event, hint);
+
+      if (event == null) {
+        options.getLogger().log(SentryLevel.DEBUG, "Event was dropped by beforeSend");
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Error);
+      }
+    }
+
+    if (event == null) {
+      return SentryId.EMPTY_ID;
+    }
 
     Session session = null;
 
@@ -112,30 +143,6 @@ public final class SentryClient implements ISentryClient {
             .recordLostEvent(DiscardReason.SAMPLE_RATE, DataCategory.Error);
         // setting event as null to not be sent as its been discarded by sample rate
         event = null;
-      }
-    }
-
-    if (event != null) {
-      if (event.getThrowable() != null
-          && options.containsIgnoredExceptionForType(event.getThrowable())) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.DEBUG,
-                "Event was dropped as the exception %s is ignored",
-                event.getThrowable().getClass());
-        options
-            .getClientReportRecorder()
-            .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
-        return SentryId.EMPTY_ID;
-      }
-      event = executeBeforeSend(event, hint);
-
-      if (event == null) {
-        options.getLogger().log(SentryLevel.DEBUG, "Event was dropped by beforeSend");
-        options
-            .getClientReportRecorder()
-            .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Error);
       }
     }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -82,7 +82,7 @@ public final class SentryClient implements ISentryClient {
     options.getLogger().log(SentryLevel.DEBUG, "Capturing event: %s", event.getEventId());
 
     if (event != null) {
-      Throwable eventThrowable = event.getThrowable();
+      final Throwable eventThrowable = event.getThrowable();
       if (eventThrowable != null && options.containsIgnoredExceptionForType(eventThrowable)) {
         options
             .getLogger()

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -82,14 +82,14 @@ public final class SentryClient implements ISentryClient {
     options.getLogger().log(SentryLevel.DEBUG, "Capturing event: %s", event.getEventId());
 
     if (event != null) {
-      if (event.getThrowable() != null
-          && options.containsIgnoredExceptionForType(event.getThrowable())) {
+      Throwable eventThrowable = event.getThrowable();
+      if (eventThrowable != null && options.containsIgnoredExceptionForType(eventThrowable)) {
         options
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
                 "Event was dropped as the exception %s is ignored",
-                event.getThrowable().getClass());
+                eventThrowable.getClass());
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);


### PR DESCRIPTION
## :scroll: Description
Event drop vs session update inconsistencies have been discussed in the Client Infra TSC. Python implementation has been updated to serve as reference implementation. We now only want to update the session when an event is dropped due to sampling but not if it is dropped due to any other filtering mechanism (`beforeSend`, `eventProcessor`, `ignoredExceptionsForType`). Also the order of the filtering mechanisms should be aligned across SDKs.


## :bulb: Motivation and Context
Fixes: https://github.com/getsentry/sentry-java/issues/1916

More Info:
* https://github.com/getsentry/develop/pull/551
* https://github.com/getsentry/develop/issues/537
* https://github.com/getsentry/sentry-python/pull/1390
* https://github.com/getsentry/sentry-python/pull/1394


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes (see #2002)
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
* Clarify some open questions regarding early return vs sending the session update alone