### PR TITLE
AndroidTransactionProfiler is now initialized the first time a transa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
-* Fix: Profiling rate decreased from 300hz to 100hz; fixed profiling traces folder creation on manual sdk init (#1997)
+* Fix: Profiling rate decreased from 300hz to 100hz (#1997)
+* Fix: Android profiling initializes on first profile start
 * Fix: Allow disabling sending of client reports via Android Manifest and external options (#2007)
 
 ## 6.0.0-alpha.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Starting with version `6.6.0` of the `sentry`, [Sentry's version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry. If you are using [sentry.io](https://sentry.io), no action is needed.
 
 * Fix: Profiling rate decreased from 300hz to 100hz (#1997)
-* Fix: Android profiling initializes on first profile start
+* Fix: Android profiling initializes on first profile start (#2009)
 * Fix: Allow disabling sending of client reports via Android Manifest and external options (#2007)
 
 ## 6.0.0-alpha.6

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -49,6 +49,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   private final @NotNull BuildInfoProvider buildInfoProvider;
   private final @Nullable PackageInfo packageInfo;
   private long transactionStartNanos = 0;
+  private boolean isInitialized = false;
 
   public AndroidTransactionProfiler(
       final @NotNull Context context,
@@ -59,6 +60,14 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     this.buildInfoProvider =
         Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
     this.packageInfo = ContextUtils.getPackageInfo(context, options.getLogger());
+  }
+
+  private void init() {
+    // We initialize it only once
+    if (isInitialized) {
+      return;
+    }
+    isInitialized = true;
     final String tracesFilesDirPath = options.getProfilingTracesDirPath();
     if (!options.isProfilingEnabled()) {
       options.getLogger().log(SentryLevel.INFO, "Profiling is disabled in options.");
@@ -93,7 +102,10 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     // Debug.startMethodTracingSampling() is only available since Lollipop
     if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return;
 
-    // traceFilesDir is null or intervalUs is 0 only if there was a problem in the constructor, but
+    // Let's initialize trace folder and profiling interval
+    init();
+
+    // traceFilesDir is null or intervalUs is 0 only if there was a problem in the init, but
     // we already logged that
     if (traceFilesDir == null || intervalUs == 0 || !traceFilesDir.exists()) {
       return;


### PR DESCRIPTION
## :scroll: Description
AndroidTransactionProfiler is now initialized the first time a transaction is started, since in the constructor we don't have the options, yet

## :bulb: Motivation and Context
When `AndroidTransactionProfiler` is created and set in the options, in the `AndroidOptionsInitializer`, we don't know what options were set through `SentryAndroid.init()` yet, as the profiler is created right before it.
We can set the internal variables of the profiler that depends on the options on the first profile, as we would be sure to already have all options set up.


## :green_heart: How did you test it?
I'm building some ui tests (that will be released in another pr)


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes
