### PR TITLE
Feat: Allow setting SDK info (name & version) in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Feat: Allow setting SDK info (name & version) in manifest (#2016)
 
 ## 6.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Breaking changes:
     * Remove `IUnknownPropertiesConsumer`
 * Bump: Kotlin to 1.5 and compatibility to 1.4 for sentry-android-timber (#1815)
 
+* Feat: Allow setting SDK info (name & version) in manifest (#2016)
+
 ## 5.7.3
 
 * Fix: Sentry Timber integration throws an exception when using args (#1986)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,6 @@ Breaking changes:
     * Remove `IUnknownPropertiesConsumer`
 * Bump: Kotlin to 1.5 and compatibility to 1.4 for sentry-android-timber (#1815)
 
-* Feat: Allow setting SDK info (name & version) in manifest (#2016)
-
 ## 5.7.3
 
 * Fix: Sentry Timber integration throws an exception when using args (#1986)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing to sentry-java
 
-We love pull requests from everyone. 
+We love pull requests from everyone.
 We suggest opening an issue to discuss bigger changes before investing on a big PR.
 
 # Requirements
 
-The project currently requires you run JDK version `1.8.x`.
+The project currently requires you run JDK 11.
 
-## Android 
+## Android
 
 This repository is a monorepo which includes Java and Android libraries.
 If you'd like to contribute to Java and don't have an Android SDK with NDK installed,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
+import io.sentry.protocol.SdkVersion;
 import io.sentry.util.Objects;
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +32,8 @@ final class ManifestMetadataReader {
   static final String NDK_SCOPE_SYNC_ENABLE = "io.sentry.ndk.scope-sync.enable";
   static final String RELEASE = "io.sentry.release";
   static final String ENVIRONMENT = "io.sentry.environment";
+  static final String SDK_NAME = "io.sentry.sdk.name";
+  static final String SDK_VERSION = "io.sentry.sdk.version";
 
   // TODO: remove on 6.x in favor of SESSION_AUTO_TRACKING_ENABLE
   static final String SESSION_TRACKING_ENABLE = "io.sentry.session-tracking.enable";
@@ -241,6 +244,19 @@ final class ManifestMetadataReader {
 
         options.setProguardUuid(
             readString(metadata, logger, PROGUARD_UUID, options.getProguardUuid()));
+
+        SdkVersion sdkVersion = options.getSdkVersion();
+        Objects.requireNonNull(sdkVersion, "Property options.sdkVersion must not be null.");
+        final String sdkVersionName = readString(metadata, logger, SDK_NAME, sdkVersion.getName());
+        if (sdkVersionName != null) {
+          sdkVersion.setName(sdkVersionName);
+        }
+        final String sdkVersionVersion =
+            readString(metadata, logger, SDK_VERSION, sdkVersion.getVersion());
+        if (sdkVersionVersion != null) {
+          sdkVersion.setVersion(sdkVersionVersion);
+        }
+        options.setSdkVersion(sdkVersion);
       }
 
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -245,18 +245,21 @@ final class ManifestMetadataReader {
         options.setProguardUuid(
             readString(metadata, logger, PROGUARD_UUID, options.getProguardUuid()));
 
-        SdkVersion sdkVersion = options.getSdkVersion();
-        Objects.requireNonNull(sdkVersion, "Property options.sdkVersion must not be null.");
-        final String sdkVersionName = readString(metadata, logger, SDK_NAME, sdkVersion.getName());
-        if (sdkVersionName != null) {
-          sdkVersion.setName(sdkVersionName);
+        SdkVersion sdkInfo = options.getSdkVersion();
+        if (sdkInfo != null) {
+          final String sdkName = readString(metadata, logger, SDK_NAME, sdkInfo.getName());
+          if (sdkName != null) {
+            sdkInfo.setName(sdkName);
+          }
+          final String sdkVersion = readString(metadata, logger, SDK_VERSION, sdkInfo.getVersion());
+          if (sdkVersion != null) {
+            sdkInfo.setVersion(sdkVersion);
+          }
+          options.setSdkVersion(sdkInfo);
+        } else {
+          // Should always be set by the Options constructor but let's error out if that changes.
+          Objects.requireNonNull(sdkInfo, "Property options.sdkVersion must not be null.");
         }
-        final String sdkVersionVersion =
-            readString(metadata, logger, SDK_VERSION, sdkVersion.getVersion());
-        if (sdkVersionVersion != null) {
-          sdkVersion.setVersion(sdkVersionVersion);
-        }
-        options.setSdkVersion(sdkVersion);
       }
 
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -246,20 +246,13 @@ final class ManifestMetadataReader {
             readString(metadata, logger, PROGUARD_UUID, options.getProguardUuid()));
 
         SdkVersion sdkInfo = options.getSdkVersion();
-        if (sdkInfo != null) {
-          final String sdkName = readString(metadata, logger, SDK_NAME, sdkInfo.getName());
-          if (sdkName != null) {
-            sdkInfo.setName(sdkName);
-          }
-          final String sdkVersion = readString(metadata, logger, SDK_VERSION, sdkInfo.getVersion());
-          if (sdkVersion != null) {
-            sdkInfo.setVersion(sdkVersion);
-          }
-          options.setSdkVersion(sdkInfo);
-        } else {
-          // Should always be set by the Options constructor but let's error out if that changes.
-          Objects.requireNonNull(sdkInfo, "Property options.sdkVersion must not be null.");
+        if (sdkInfo == null) {
+          // Is already set by the Options constructor, let's use an empty default otherwise.
+          sdkInfo = new SdkVersion("", "");
         }
+        sdkInfo.setName(readStringNotNull(metadata, logger, SDK_NAME, sdkInfo.getName()));
+        sdkInfo.setVersion(readStringNotNull(metadata, logger, SDK_VERSION, sdkInfo.getVersion()));
+        options.setSdkVersion(sdkInfo);
       }
 
       options
@@ -288,6 +281,16 @@ final class ManifestMetadataReader {
       final @NotNull ILogger logger,
       final @NotNull String key,
       final @Nullable String defaultValue) {
+    final String value = metadata.getString(key, defaultValue);
+    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    return value;
+  }
+
+  private static @NotNull String readStringNotNull(
+      final @NotNull Bundle metadata,
+      final @NotNull ILogger logger,
+      final @NotNull String key,
+      final @NotNull String defaultValue) {
     final String value = metadata.getString(key, defaultValue);
     logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
     return value;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -564,41 +564,11 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata does not override SDK name from options`() {
-        // Arrange
-        val expectedValue = "custom.sdk"
-        fixture.options.sdkVersion!!.name = expectedValue
-        val bundle = bundleOf(ManifestMetadataReader.SDK_NAME to "foo")
-        val context = fixture.getContext(metaData = bundle)
-
-        // Act
-        ManifestMetadataReader.applyMetadata(context, fixture.options)
-
-        // Assert
-        assertEquals(expectedValue, fixture.options.sdkVersion?.name)
-    }
-
-    @Test
     fun `applyMetadata reads SDK version from metadata`() {
         // Arrange
         val expectedValue = "1.2.3-alpha.0"
 
         val bundle = bundleOf(ManifestMetadataReader.SDK_VERSION to expectedValue)
-        val context = fixture.getContext(metaData = bundle)
-
-        // Act
-        ManifestMetadataReader.applyMetadata(context, fixture.options)
-
-        // Assert
-        assertEquals(expectedValue, fixture.options.sdkVersion?.version)
-    }
-
-    @Test
-    fun `applyMetadata does not override SDK version from options`() {
-        // Arrange
-        val expectedValue = "1.2.3-alpha.0"
-        fixture.options.sdkVersion!!.version = expectedValue
-        val bundle = bundleOf(ManifestMetadataReader.SDK_VERSION to "foo")
         val context = fixture.getContext(metaData = bundle)
 
         // Act

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -549,6 +549,66 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
+    fun `applyMetadata reads SDK name from metadata`() {
+        // Arrange
+        val expectedValue = "custom.sdk"
+
+        val bundle = bundleOf(ManifestMetadataReader.SDK_NAME to expectedValue)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertEquals(expectedValue, fixture.options.sdkVersion?.name)
+    }
+
+    @Test
+    fun `applyMetadata does not override SDK name from options`() {
+        // Arrange
+        val expectedValue = "custom.sdk"
+        fixture.options.sdkVersion!!.name = expectedValue
+        val bundle = bundleOf(ManifestMetadataReader.SDK_NAME to "foo")
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertEquals(expectedValue, fixture.options.sdkVersion?.name)
+    }
+
+    @Test
+    fun `applyMetadata reads SDK version from metadata`() {
+        // Arrange
+        val expectedValue = "1.2.3-alpha.0"
+
+        val bundle = bundleOf(ManifestMetadataReader.SDK_VERSION to expectedValue)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertEquals(expectedValue, fixture.options.sdkVersion?.version)
+    }
+
+    @Test
+    fun `applyMetadata does not override SDK version from options`() {
+        // Arrange
+        val expectedValue = "1.2.3-alpha.0"
+        fixture.options.sdkVersion!!.version = expectedValue
+        val bundle = bundleOf(ManifestMetadataReader.SDK_VERSION to "foo")
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertEquals(expectedValue, fixture.options.sdkVersion?.version)
+    }
+
+    @Test
     fun `applyMetadata reads enableScopeSync to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.NDK_SCOPE_SYNC_ENABLE to false)


### PR DESCRIPTION
## :scroll: Description
Enables users to override the SDK info

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows other SDKs that use sentry-cocoa internally to identify the events. Enables https://github.com/getsentry/sentry-unity/issues/616

## :green_heart: How did you test it?
Added a test case


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

