### PR TITLE
Feat/report permissions

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
@@ -2,7 +2,6 @@ package io.sentry.android.core;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.os.Build;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
@@ -29,7 +28,8 @@ final class ContextUtils {
    * @return the Application's PackageInfo if possible, or null
    */
   @Nullable
-  static PackageInfo getPackageInfo(final @NotNull Context context, final int flags, final @NotNull ILogger logger) {
+  static PackageInfo getPackageInfo(
+      final @NotNull Context context, final int flags, final @NotNull ILogger logger) {
     try {
       return context.getPackageManager().getPackageInfo(context.getPackageName(), flags);
     } catch (Throwable e) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
@@ -2,6 +2,7 @@ package io.sentry.android.core;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
@@ -19,8 +20,18 @@ final class ContextUtils {
    */
   @Nullable
   static PackageInfo getPackageInfo(final @NotNull Context context, final @NotNull ILogger logger) {
+    return getPackageInfo(context, 0, logger);
+  }
+
+  /**
+   * Return the Application's PackageInfo with the specified flags if possible, or null.
+   *
+   * @return the Application's PackageInfo if possible, or null
+   */
+  @Nullable
+  static PackageInfo getPackageInfo(final @NotNull Context context, final int flags, final @NotNull ILogger logger) {
     try {
-      return context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      return context.getPackageManager().getPackageInfo(context.getPackageName(), flags);
     } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Error getting package info.", e);
       return null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -216,7 +216,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setPackageInfo(final @NotNull SentryBaseEvent event, final @NotNull App app) {
-    final PackageInfo packageInfo = ContextUtils.getPackageInfo(context, PackageManager.GET_PERMISSIONS, logger);
+    final PackageInfo packageInfo =
+        ContextUtils.getPackageInfo(context, PackageManager.GET_PERMISSIONS, logger);
     if (packageInfo != null) {
       String versionCode = ContextUtils.getVersionCode(packageInfo);
 
@@ -738,10 +739,13 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       final String[] requestedPermissions = packageInfo.requestedPermissions;
       final int[] requestedPermissionsFlags = packageInfo.requestedPermissionsFlags;
 
-      if (requestedPermissions != null && requestedPermissions.length > 0 &&
-        requestedPermissionsFlags != null && requestedPermissionsFlags.length > 0) {
+      if (requestedPermissions != null
+          && requestedPermissions.length > 0
+          && requestedPermissionsFlags != null
+          && requestedPermissionsFlags.length > 0) {
         for (int i = 0; i < requestedPermissions.length; i++) {
-          if ((requestedPermissionsFlags[i] & REQUESTED_PERMISSION_GRANTED) == REQUESTED_PERMISSION_GRANTED) {
+          if ((requestedPermissionsFlags[i] & REQUESTED_PERMISSION_GRANTED)
+              == REQUESTED_PERMISSION_GRANTED) {
             permissions.put(requestedPermissions[i], "granted");
           } else {
             permissions.put(requestedPermissions[i], "not_granted");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -44,7 +44,8 @@ class DefaultAndroidEventProcessorTest {
     private lateinit var context: Context
 
     private val className = "io.sentry.android.core.DefaultAndroidEventProcessor"
-    private val ctorTypes = arrayOf(Context::class.java, ILogger::class.java, BuildInfoProvider::class.java)
+    private val ctorTypes =
+        arrayOf(Context::class.java, ILogger::class.java, BuildInfoProvider::class.java)
 
     init {
         Locale.setDefault(Locale.US)
@@ -109,6 +110,13 @@ class DefaultAndroidEventProcessorTest {
         assertNotNull(sut.process(SentryEvent(), null)) {
             assertNotNull(it.contexts.app)
             assertNotNull(it.dist)
+
+            // assert adds permissions as unknown
+            val permissions = it.contexts.app!!.unknown
+            assertTrue {
+                permissions!!.isNotEmpty() &&
+                    permissions.keys.all { permission -> permission. startsWith("android.permission") }
+            }
         }
     }
 
@@ -252,17 +260,24 @@ class DefaultAndroidEventProcessorTest {
 
         sut.process(SentryEvent(), null)
 
-        verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
+        verify(
+            (fixture.options.logger as DiagnosticLogger).logger,
+            never()
+        )!!.log(eq(SentryLevel.ERROR), any<String>(), any())
     }
 
     @Test
     fun `Processor won't throw exception when theres a hint`() {
-        val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
+        val processor =
+            DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
 
         val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
         processor.process(SentryEvent(), hintsMap)
 
-        verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
+        verify(
+            (fixture.options.logger as DiagnosticLogger).logger,
+            never()
+        )!!.log(eq(SentryLevel.ERROR), any<String>(), any())
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -115,7 +115,7 @@ class DefaultAndroidEventProcessorTest {
             val permissions = it.contexts.app!!.unknown
             assertTrue {
                 permissions!!.isNotEmpty() &&
-                    permissions.keys.all { permission -> permission. startsWith("android.permission") }
+                    permissions.keys.all { permission -> permission.startsWith("android.permission") }
             }
         }
     }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
     <!-- extra recommended permission, we'd be able to collect device ringing breadcrumbs (PhoneStateBreadcrumbsIntegration) -->
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
+    <!-- Just some random permissions to showcase the permission context sent to Sentry -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
     <!--  if your minSdkVersion < 16, this would make usable on minSdkVersion >= 14-->
     <uses-sdk
         tools:overrideLibrary="io.sentry.android"/>
@@ -43,6 +47,10 @@
 
       <activity
             android:name=".GesturesActivity"
+            android:exported="false" />
+
+      <activity
+            android:name=".PermissionsActivity"
             android:exported="false" />
 
         <!--    NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard-->

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -178,6 +178,12 @@ public class MainActivity extends AppCompatActivity {
               crashCount);
         });
 
+    binding.openPermissionsActivity.setOnClickListener(
+      view -> {
+        startActivity(new Intent(this, PermissionsActivity.class));
+      }
+    );
+
     setContentView(binding.getRoot());
   }
 

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -179,10 +179,9 @@ public class MainActivity extends AppCompatActivity {
         });
 
     binding.openPermissionsActivity.setOnClickListener(
-      view -> {
-        startActivity(new Intent(this, PermissionsActivity.class));
-      }
-    );
+        view -> {
+          startActivity(new Intent(this, PermissionsActivity.class));
+        });
 
     setContentView(binding.getRoot());
   }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
@@ -24,7 +24,6 @@ class PermissionsActivity : AppCompatActivity() {
 
         binding = ActivityPermissionsBinding.inflate(layoutInflater)
 
-
         binding.cameraPermission.setOnClickListener {
             requestPermissionLauncher.launch(Manifest.permission.CAMERA)
         }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
@@ -1,0 +1,42 @@
+package io.sentry.samples.android
+
+import android.Manifest
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.appcompat.app.AppCompatActivity
+import io.sentry.samples.android.databinding.ActivityPermissionsBinding
+
+class PermissionsActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityPermissionsBinding
+    private val requestPermissionLauncher =
+        registerForActivityResult(RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                Toast.makeText(this, "The permission was granted", Toast.LENGTH_LONG).show()
+            } else {
+                Toast.makeText(this, "The permission was denied", Toast.LENGTH_LONG).show()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityPermissionsBinding.inflate(layoutInflater)
+
+
+        binding.cameraPermission.setOnClickListener {
+            requestPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+
+        binding.writePermission.setOnClickListener {
+            requestPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
+
+        binding.permissionsCrash.setOnClickListener {
+            throw RuntimeException("Permissions Activity Exception")
+        }
+
+        setContentView(binding.root)
+    }
+}

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -105,6 +105,12 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/test_timber_integration"/>
+
+    <Button
+      android:id="@+id/open_permissions_activity"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/open_permissions_activity"/>
   </LinearLayout>
 
 </ScrollView>

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_permissions.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_permissions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="vertical"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  >
+
+  <Button
+    android:id="@+id/camera_permission"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/camera_permission" />
+
+  <Button
+    android:id="@+id/write_permission"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/write_permission" />
+
+  <Button
+    android:id="@+id/permissions_crash"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/crash_from_java" />
+
+</LinearLayout>

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="open_sample_fragment">Open Sample Fragment</string>
   <string name="open_third_fragment">Open Third Fragment</string>
   <string name="open_gestures_activity">Open Gestures Activity</string>
+  <string name="open_permissions_activity">Open Permissions Activity</string>
   <string name="test_timber_integration">Test Timber</string>
   <string name="back_main">Back to Main Activity</string>
   <string name="tap_me">text</string>
@@ -30,4 +31,6 @@ Aliquam pharetra, velit eu vulputate tempus, sapien purus accumsan orci, non ult
 
 Nulla interdum gravida augue, vel fringilla lorem bibendum vel. In hac habitasse platea dictumst. Praesent dapibus congue velit, vel mollis eros mattis vel. Maecenas mattis sapien lacus, ut interdum dui vulputate a. Vivamus dapibus, est ac maximus aliquam, mauris lorem vehicula nisl, eget viverra metus nunc ut libero. Quisque aliquet, dolor sit amet pellentesque semper, nisi nunc ornare velit, id porta nibh magna sit amet tortor. Curabitur finibus, lectus at convallis elementum, est sem malesuada massa, vel varius lorem justo a libero. Donec a nulla consequat, dignissim tortor id, ultrices dolor. Ut auctor vel ante sed faucibus. Ut ac dolor vel lacus facilisis bibendum.
   </string>
+  <string name="camera_permission">Camera Permission</string>
+  <string name="write_permission">Write External Storage Permission</string>
 </resources>


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Reads granted/non-granted permissions in the event processor
* Adds them as part of the `App` object of the protocol. For now uses the `unknown` field.

![image](https://user-images.githubusercontent.com/4999776/166675420-a2754192-90a3-4b9d-b004-badcf3ad256b.png)

## Some open questions
* Should we change protocol to account for permissions field?
* Should this target 6.x.x or rather `main`? (would require some changed for the `unknown` map)
* Is it fine to have full permission name (as in, `android.permission.CAMERA`) as key for the map or should make it pretty?
* Should we change `granted`/`not_granted` to something different?

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1347
