### PR TITLE
Fix/flaky json serializer test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-### Fix
-
-* Flaky JsonSerializerTest has been fixed (#2021)
 
 ## 6.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fix
+
+* Flaky JsonSerializerTest has been fixed (#2021)
+
 ## 6.0.0-beta.3
 
 ### Fix

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -620,7 +620,7 @@ class JsonSerializerTest {
 
         assertEquals("transaction-name", element["transaction"] as String)
         assertEquals("transaction", element["type"] as String)
-        assertNotNull(element["start_timestamp"] as Double)
+        assertNotNull(element["start_timestamp"] as Number)
         assertNotNull(element["event_id"] as String)
         assertNotNull(element["spans"] as List<*>)
         assertEquals("myValue", (element["tags"] as Map<*, *>)["myTag"] as String)


### PR DESCRIPTION
## :scroll: Description
`start_timestamp` is sometimes serialized without decimals. This causes the test to fail because it is then converted to an `Integer`.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2020


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
