### PR TITLE
No longer close OutputStream that is passed into JsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- No longer close OutputStream that is passed into JsonSerializer (#2029)
+
 ### Features
 
 - Allow setting SDK info (name & version) in manifest ([#2016](https://github.com/getsentry/sentry-java/pull/2016))

--- a/sentry/src/main/java/io/sentry/ISerializer.java
+++ b/sentry/src/main/java/io/sentry/ISerializer.java
@@ -17,6 +17,13 @@ public interface ISerializer {
 
   <T> void serialize(@NotNull T entity, @NotNull Writer writer) throws IOException;
 
+  /**
+   * Serializes an envelope
+   *
+   * @param envelope an envelope
+   * @param outputStream which will not be closed automatically
+   * @throws Exception an exception
+   */
   void serialize(@NotNull SentryEnvelope envelope, @NotNull OutputStream outputStream)
       throws Exception;
 

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -166,31 +166,34 @@ public final class JsonSerializer implements ISerializer {
     final BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
     final Writer writer = new BufferedWriter(new OutputStreamWriter(bufferedOutputStream, UTF_8));
 
-    envelope
-        .getHeader()
-        .serialize(new JsonObjectWriter(writer, options.getMaxDepth()), options.getLogger());
-    writer.write("\n");
+    try {
+      envelope
+          .getHeader()
+          .serialize(new JsonObjectWriter(writer, options.getMaxDepth()), options.getLogger());
+      writer.write("\n");
 
-    for (final SentryEnvelopeItem item : envelope.getItems()) {
-      try {
-        // When this throws we don't write anything and continue with the next item.
-        final byte[] data = item.getData();
+      for (final SentryEnvelopeItem item : envelope.getItems()) {
+        try {
+          // When this throws we don't write anything and continue with the next item.
+          final byte[] data = item.getData();
 
-        item.getHeader()
-            .serialize(new JsonObjectWriter(writer, options.getMaxDepth()), options.getLogger());
-        writer.write("\n");
-        writer.flush();
+          item.getHeader()
+              .serialize(new JsonObjectWriter(writer, options.getMaxDepth()), options.getLogger());
+          writer.write("\n");
+          writer.flush();
 
-        outputStream.write(data);
+          outputStream.write(data);
 
-        writer.write("\n");
-      } catch (Exception exception) {
-        options
-            .getLogger()
-            .log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);
+          writer.write("\n");
+        } catch (Exception exception) {
+          options
+              .getLogger()
+              .log(SentryLevel.ERROR, "Failed to create envelope item. Dropping it.", exception);
+        }
       }
+    } finally {
+      writer.flush();
     }
-    writer.flush();
   }
 
   @Override

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.exception.SentryEnvelopeException
@@ -18,6 +19,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.io.StringReader
 import java.io.StringWriter
@@ -860,6 +862,14 @@ class JsonSerializerTest {
             },
             any<Any>()
         )
+    }
+
+    @Test
+    fun `json serializer does not close the stream that is passed in`() {
+        val stream = mock<OutputStream>()
+        JsonSerializer(SentryOptions()).serialize(SentryEnvelope.from(fixture.serializer, SentryEvent(), null), stream)
+
+        verify(stream, never()).close()
     }
 
     private fun assertSessionData(expectedSession: Session?) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
No longer (auto) close the `OutputStream` that is passed into `JsonSerializer`. This caused problems when passing in `System.out` from `StdoutTransport` as it closed the stream.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2027 for `6.x`


## :green_heart: How did you test it?
* Unit Test
* code sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
