### PR TITLE
No longer close OutputStream that is passed into GsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+* No longer close OutputStream that is passed into GsonSerializer (#2030)
+
 ## 5.7.3
 
 * Fix: Sentry Timber integration throws an exception when using args (#1986)

--- a/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/GsonSerializerTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.exception.SentryEnvelopeException
@@ -24,6 +25,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.io.StringReader
 import java.io.StringWriter
@@ -725,6 +727,14 @@ class GsonSerializerTest {
             },
             any<Any>()
         )
+    }
+
+    @Test
+    fun `gson serializer does not close the stream that is passed in`() {
+        val stream = mock<OutputStream>()
+        GsonSerializer(SentryOptions()).serialize(SentryEnvelope.from(fixture.serializer, SentryEvent(), null), stream)
+
+        verify(stream, never()).close()
     }
 
     private fun assertSessionData(expectedSession: Session?) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
No longer (auto) close the `OutputStream` that is passed into `GsonSerializer`. This caused problems when passing in `System.out` from `StdoutTransport` as it closed the stream.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2027 for `5.x`


## :green_heart: How did you test it?
* Unit Test
* code sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
