### PR TITLE
Feat: Android native SDK name override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Allow setting SDK info (name & version) in manifest ([#2016](https://github.com/getsentry/sentry-java/pull/2016))
+- Allow setting native Android SDK name during build ([#2035](https://github.com/getsentry/sentry-java/pull/2035))
 
 ## 6.0.0-beta.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,9 @@ android.useAndroidX=true
 # Release information
 versionName=6.0.0-beta.3
 
+# Override the SDK name on native crashes on Android
+sentryAndroidSdkName=sentry.native.android
+
 # disable renderscript, it's enabled by default
 android.defaults.buildfeatures.renderscript=false
 

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 }
 
 var sentryNativeSrc: String = "sentry-native"
+val sentryAndroidSdkName: String by project
 
 android {
     compileSdk = Config.Android.compileSdkVersion
@@ -30,6 +31,7 @@ android {
             cmake {
                 arguments.add(0, "-DANDROID_STL=c++_static")
                 arguments.add(0, "-DSENTRY_NATIVE_SRC=$sentryNativeSrc")
+                arguments.add(0, "-DSENTRY_SDK_NAME=$sentryAndroidSdkName")
             }
         }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context

Enables integrations, e.g. sentry-unity SDK, to override the native SDK name reported in errors

## :green_heart: How did you test it?
not sure how to test this except manually - are there some integration tests already that this could be included in?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes
- [ ] depends on #2033 to actually make a difference


