### PR TITLE
Replace hint Map with Hints object

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -110,7 +110,7 @@ public final class io/sentry/android/core/ScreenshotEventProcessor : android/app
 	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityStarted (Landroid/app/Activity;)V
 	public fun onActivityStopped (Landroid/app/Activity;)V
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
 }
 
 public final class io/sentry/android/core/SentryAndroid {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -19,11 +19,11 @@ import io.sentry.Scope;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -126,10 +126,10 @@ public final class ActivityLifecycleIntegration
       breadcrumb.setCategory("ui.lifecycle");
       breadcrumb.setLevel(SentryLevel.INFO);
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(ANDROID_ACTIVITY, activity);
+      final Hints hints = new Hints();
+      hints.set(ANDROID_ACTIVITY, activity);
 
-      hub.addBreadcrumb(breadcrumb, hintMap);
+      hub.addBreadcrumb(breadcrumb, hints);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -11,13 +11,12 @@ import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.android.core.internal.util.DeviceOrientations;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Device;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,10 +99,10 @@ public final class AppComponentsBreadcrumbsIntegration
       breadcrumb.setData("position", orientation);
       breadcrumb.setLevel(SentryLevel.INFO);
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(ANDROID_CONFIGURATION, newConfig);
+      final Hints hints = new Hints();
+      hints.set(ANDROID_CONFIGURATION, newConfig);
 
-      hub.addBreadcrumb(breadcrumb, hintMap);
+      hub.addBreadcrumb(breadcrumb, hints);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -28,6 +28,7 @@ import io.sentry.android.core.internal.util.ConnectivityChecker;
 import io.sentry.android.core.internal.util.DeviceOrientations;
 import io.sentry.android.core.internal.util.MainThreadChecker;
 import io.sentry.android.core.internal.util.RootChecker;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.App;
 import io.sentry.protocol.Device;
 import io.sentry.protocol.OperatingSystem;
@@ -117,8 +118,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @Override
   public @NotNull SentryEvent process(
-      final @NotNull SentryEvent event, final @Nullable Map<String, Object> hint) {
-    final boolean applyScopeData = shouldApplyScopeData(event, hint);
+      final @NotNull SentryEvent event, final @NotNull Hints hints) {
+    final boolean applyScopeData = shouldApplyScopeData(event, hints);
     if (applyScopeData) {
       // we only set memory data if it's not a hard crash, when it's a hard crash the event is
       // enriched on restart, so non static data might be wrong, eg lowMemory or availMem will
@@ -143,8 +144,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private boolean shouldApplyScopeData(
-      final @NotNull SentryBaseEvent event, final @Nullable Map<String, Object> hint) {
-    if (HintUtils.shouldApplyScopeData(hint)) {
+      final @NotNull SentryBaseEvent event, final @NotNull Hints hints) {
+    if (HintUtils.shouldApplyScopeData(hints)) {
       return true;
     } else {
       logger.log(
@@ -857,8 +858,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @Override
   public @NotNull SentryTransaction process(
-      final @NotNull SentryTransaction transaction, final @Nullable Map<String, Object> hint) {
-    final boolean applyScopeData = shouldApplyScopeData(transaction, hint);
+      final @NotNull SentryTransaction transaction, final @NotNull Hints hints) {
+    final boolean applyScopeData = shouldApplyScopeData(transaction, hints);
 
     if (applyScopeData) {
       processNonCachedEvent(transaction);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserver.java
@@ -1,7 +1,6 @@
 package io.sentry.android.core;
 
 import static io.sentry.SentryLevel.ERROR;
-import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
 
 import android.os.FileObserver;
 import io.sentry.IEnvelopeSender;
@@ -10,13 +9,13 @@ import io.sentry.SentryLevel;
 import io.sentry.hints.ApplyScopeData;
 import io.sentry.hints.Cached;
 import io.sentry.hints.Flushable;
+import io.sentry.hints.Hints;
 import io.sentry.hints.Resettable;
 import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
+import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
@@ -60,10 +59,9 @@ final class EnvelopeFileObserver extends FileObserver {
 
     final CachedEnvelopeHint hint = new CachedEnvelopeHint(flushTimeoutMillis, logger);
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(SENTRY_TYPE_CHECK_HINT, hint);
+    final Hints hints = HintUtils.createWithTypeCheckHint(hint);
 
-    envelopeSender.processEnvelopeFile(this.rootPath + File.separator + relativePath, hintMap);
+    envelopeSender.processEnvelopeFile(this.rootPath + File.separator + relativePath, hints);
   }
 
   private static final class CachedEnvelopeHint

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -7,6 +7,7 @@ import static io.sentry.android.core.ActivityLifecycleIntegration.UI_LOAD_OP;
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
 import io.sentry.SpanContext;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentrySpan;
@@ -37,12 +38,12 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
    * Returns the event itself
    *
    * @param event the SentryEvent the SentryEvent
-   * @param hint the Hint the Hint
+   * @param hints the Hint the Hint
    * @return returns the event itself
    */
   @Override
   @Nullable
-  public SentryEvent process(@NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
     // that's only necessary because on newer versions of Unity, if not overriding this method, it's
     // throwing 'java.lang.AbstractMethodError: abstract method' and the reason is probably
     // compilation mismatch.
@@ -52,7 +53,7 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
   @SuppressWarnings("NullAway")
   @Override
   public synchronized @NotNull SentryTransaction process(
-      @NotNull SentryTransaction transaction, @Nullable Map<String, Object> hint) {
+      @NotNull SentryTransaction transaction, @NotNull Hints hints) {
 
     if (!options.isTracingEnabled()) {
       return transaction;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -17,13 +17,12 @@ import io.sentry.Attachment;
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,8 +67,7 @@ public final class ScreenshotEventProcessor
 
   @SuppressWarnings("NullAway")
   @Override
-  public @NotNull SentryEvent process(
-      final @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryEvent process(final @NotNull SentryEvent event, @NotNull Hints hints) {
     if (options.isAttachScreenshot() && event.isErrored() && currentActivity != null) {
       final Activity activity = currentActivity.get();
       if (isActivityValid(activity)
@@ -93,16 +91,12 @@ public final class ScreenshotEventProcessor
             // Some formats, like PNG which is lossless, will ignore the quality setting.
             bitmap.compress(Bitmap.CompressFormat.PNG, 0, byteArrayOutputStream);
 
-            if (hint == null) {
-              hint = new HashMap<>();
-            }
-
             if (byteArrayOutputStream.size() > 0) {
               // screenshot png is around ~100-150 kb
-              hint.put(
+              hints.set(
                   SENTRY_SCREENSHOT,
                   Attachment.fromScreenshot(byteArrayOutputStream.toByteArray()));
-              hint.put(ANDROID_ACTIVITY, activity);
+              hints.set(ANDROID_ACTIVITY, activity);
             } else {
               this.options
                   .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -43,6 +43,7 @@ import io.sentry.ILogger;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import io.sentry.util.StringUtils;
 import java.io.Closeable;
@@ -215,10 +216,10 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       }
       breadcrumb.setLevel(SentryLevel.INFO);
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(ANDROID_INTENT, intent);
+      final Hints hints = new Hints();
+      hints.set(ANDROID_INTENT, intent);
 
-      hub.addBreadcrumb(breadcrumb, hintMap);
+      hub.addBreadcrumb(breadcrumb, hints);
     }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -13,11 +13,10 @@ import io.sentry.IHub;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -107,10 +106,10 @@ public final class TempSensorBreadcrumbsIntegration
       breadcrumb.setLevel(SentryLevel.INFO);
       breadcrumb.setData("degree", event.values[0]); // Celsius
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(ANDROID_SENSOR_EVENT, event);
+      final Hints hints = new Hints();
+      hints.set(ANDROID_SENSOR_EVENT, event);
 
-      hub.addBreadcrumb(breadcrumb, hintMap);
+      hub.addBreadcrumb(breadcrumb, hints);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -11,9 +11,9 @@ import io.sentry.Breadcrumb;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.SentryAndroidOptions;
+import io.sentry.hints.Hints;
 import java.lang.ref.WeakReference;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -172,14 +172,14 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
       className = target.getClass().getSimpleName();
     }
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(ANDROID_MOTION_EVENT, motionEvent);
-    hintMap.put(ANDROID_VIEW, target);
+    final Hints hints = new Hints();
+    hints.set(ANDROID_MOTION_EVENT, motionEvent);
+    hints.set(ANDROID_VIEW, target);
 
     hub.addBreadcrumb(
         Breadcrumb.userInteraction(
             eventType, ViewUtils.getResourceId(target), className, additionalData),
-        hintMap);
+        hints);
   }
 
   private @Nullable View ensureWindowDecorView(final @NotNull String caller) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -16,17 +16,18 @@ import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.android.core.DefaultAndroidEventProcessor.EMULATOR
 import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
 import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
 import io.sentry.android.core.DefaultAndroidEventProcessor.SIDE_LOADED
+import io.sentry.hints.Hints
 import io.sentry.protocol.OperatingSystem
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryThread
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.test.getCtor
+import io.sentry.util.HintUtils
 import org.junit.runner.RunWith
 import java.util.Locale
 import kotlin.test.BeforeTest
@@ -106,7 +107,7 @@ class DefaultAndroidEventProcessorTest {
     fun `When Event and hint is not Cached, data should be applied`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryEvent(), null)) {
+        assertNotNull(sut.process(SentryEvent(), Hints())) {
             assertNotNull(it.contexts.app)
             assertNotNull(it.dist)
         }
@@ -116,7 +117,7 @@ class DefaultAndroidEventProcessorTest {
     fun `When Transaction and hint is not Cached, data should be applied`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), Hints())) {
             assertNotNull(it.contexts.app)
             assertNotNull(it.dist)
         }
@@ -133,7 +134,7 @@ class DefaultAndroidEventProcessorTest {
             threads = mutableListOf(sentryThread)
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertNotNull(it.threads) { threads ->
                 assertTrue(threads.first().isCurrent == true)
             }
@@ -152,7 +153,7 @@ class DefaultAndroidEventProcessorTest {
             )
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertNotNull(it.threads) { threads ->
                 assertFalse(threads.first().isCurrent == true)
             }
@@ -163,8 +164,8 @@ class DefaultAndroidEventProcessorTest {
     fun `When Event and hint is Cached, data should not be applied`() {
         val sut = fixture.getSut(context)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        assertNotNull(sut.process(SentryEvent(), hintsMap)) {
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        assertNotNull(sut.process(SentryEvent(), hints)) {
             assertNull(it.contexts.app)
             assertNull(it.debugMeta)
             assertNull(it.dist)
@@ -175,8 +176,8 @@ class DefaultAndroidEventProcessorTest {
     fun `When Transaction and hint is Cached, data should not be applied`() {
         val sut = fixture.getSut(context)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), hintsMap)) {
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), hints)) {
             assertNull(it.contexts.app)
             assertNull(it.dist)
         }
@@ -185,9 +186,8 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `When Event and hint is Cached, userId is applied anyway`() {
         val sut = fixture.getSut(context)
-
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        assertNotNull(sut.process(SentryEvent(), hintsMap)) {
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        assertNotNull(sut.process(SentryEvent(), hints)) {
             assertNotNull(it.user)
         }
     }
@@ -196,8 +196,8 @@ class DefaultAndroidEventProcessorTest {
     fun `When Transaction and hint is Cached, userId is applied anyway`() {
         val sut = fixture.getSut(context)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), hintsMap)) {
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), hints)) {
             assertNotNull(it.user)
         }
     }
@@ -213,7 +213,7 @@ class DefaultAndroidEventProcessorTest {
             setUser(user)
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertNotNull(it.user)
             assertSame(user, it.user)
         }
@@ -227,7 +227,7 @@ class DefaultAndroidEventProcessorTest {
             user = User()
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertNotNull(it.user)
             assertNotNull(it.user!!.id)
         }
@@ -250,7 +250,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Processor won't throw exception`() {
         val sut = fixture.getSut(context)
 
-        sut.process(SentryEvent(), null)
+        sut.process(SentryEvent(), Hints())
 
         verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
     }
@@ -259,8 +259,8 @@ class DefaultAndroidEventProcessorTest {
     fun `Processor won't throw exception when theres a hint`() {
         val processor = DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        processor.process(SentryEvent(), hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        processor.process(SentryEvent(), hints)
 
         verify((fixture.options.logger as DiagnosticLogger).logger, never())!!.log(eq(SentryLevel.ERROR), any<String>(), any())
     }
@@ -269,7 +269,7 @@ class DefaultAndroidEventProcessorTest {
     fun `When event is processed, sideLoaded info should be set`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryEvent(), null)) {
+        assertNotNull(sut.process(SentryEvent(), Hints())) {
             assertNotNull(it.getTag("isSideLoaded"))
         }
     }
@@ -285,7 +285,7 @@ class DefaultAndroidEventProcessorTest {
             contexts.setOperatingSystem(osLinux)
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertSame(osLinux, (it.contexts["os_linux"] as OperatingSystem))
             assertEquals("Android", it.contexts.operatingSystem!!.name)
         }
@@ -302,7 +302,7 @@ class DefaultAndroidEventProcessorTest {
             contexts.setOperatingSystem(osNoName)
         }
 
-        assertNotNull(sut.process(event, null)) {
+        assertNotNull(sut.process(event, Hints())) {
             assertSame(osNoName, (it.contexts["os_1"] as OperatingSystem))
             assertEquals("Android", it.contexts.operatingSystem!!.name)
         }
@@ -312,8 +312,8 @@ class DefaultAndroidEventProcessorTest {
     fun `When hint is Cached, memory data should not be applied`() {
         val sut = fixture.getSut(context)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        assertNotNull(sut.process(SentryEvent(), hintsMap)) {
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        assertNotNull(sut.process(SentryEvent(), hints)) {
             assertNull(it.contexts.device!!.freeMemory)
             assertNull(it.contexts.device!!.isLowMemory)
         }
@@ -323,7 +323,7 @@ class DefaultAndroidEventProcessorTest {
     fun `When hint is not Cached, memory data should be applied`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryEvent(), null)) {
+        assertNotNull(sut.process(SentryEvent(), Hints())) {
             assertNotNull(it.contexts.device!!.freeMemory)
             assertNotNull(it.contexts.device!!.isLowMemory)
         }
@@ -333,7 +333,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Device's context is set on transactions`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), Hints())) {
             assertNotNull(it.contexts.device)
         }
     }
@@ -342,7 +342,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Device's OS is set on transactions`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), Hints())) {
             assertNotNull(it.contexts.operatingSystem)
         }
     }
@@ -351,7 +351,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Transaction do not set device's context that requires heavy work`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), null)) {
+        assertNotNull(sut.process(SentryTransaction(fixture.sentryTracer), Hints())) {
             val device = it.contexts.device!!
             assertNull(device.batteryLevel)
             assertNull(device.isCharging)
@@ -371,7 +371,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Event sets device's context that requires heavy work`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryEvent(), null)) {
+        assertNotNull(sut.process(SentryEvent(), Hints())) {
             val device = it.contexts.device!!
             assertNotNull(device.freeMemory)
             assertNotNull(device.isLowMemory)
@@ -393,7 +393,7 @@ class DefaultAndroidEventProcessorTest {
     fun `Event sets language and locale`() {
         val sut = fixture.getSut(context)
 
-        assertNotNull(sut.process(SentryEvent(), null)) {
+        assertNotNull(sut.process(SentryEvent(), Hints())) {
             val device = it.contexts.device!!
             assertEquals("en", device.language)
             assertEquals("en_US", device.locale)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverTest.kt
@@ -74,7 +74,7 @@ class EnvelopeFileObserverTest {
 
         verify(fixture.envelopeSender).processEnvelopeFile(
             eq(fixture.path + File.separator + fixture.fileName),
-            check { it is ApplyScopeData }
+            check { HintUtils.hasType(it, ApplyScopeData::class.java) }
         )
     }
 
@@ -84,7 +84,7 @@ class EnvelopeFileObserverTest {
 
         verify(fixture.envelopeSender).processEnvelopeFile(
             eq(fixture.path + File.separator + fixture.fileName),
-            check { it is Resettable }
+            check { HintUtils.hasType(it, Resettable::class.java) }
         )
     }
 
@@ -94,15 +94,14 @@ class EnvelopeFileObserverTest {
 
         verify(fixture.envelopeSender).processEnvelopeFile(
             eq(fixture.path + File.separator + fixture.fileName),
-            check {
-                val hint = HintUtils.getSentrySdkHint(it)
-                (hint as SubmissionResult).setResult(true)
-                (hint as Retryable).isRetry = true
+            check { hints ->
+                HintUtils.runIfHasType(hints, SubmissionResult::class.java) { it.setResult(true) }
+                HintUtils.runIfHasType(hints, Retryable::class.java) { it.isRetry = true }
 
-                (hint as Resettable).reset()
+                HintUtils.runIfHasType(hints, Resettable::class.java) { it.reset() }
 
-                assertFalse(hint.isRetry)
-                assertFalse(hint.isSuccess)
+                assertFalse((HintUtils.getSentrySdkHint(hints) as Retryable).isRetry)
+                assertFalse((HintUtils.getSentrySdkHint(hints) as SubmissionResult).isSuccess)
             }
         )
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -7,6 +7,7 @@ import io.sentry.IHub
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
 import io.sentry.android.core.ActivityLifecycleIntegration.UI_LOAD_OP
+import io.sentry.hints.Hints
 import io.sentry.protocol.MeasurementValue
 import io.sentry.protocol.SentryTransaction
 import java.util.Date
@@ -45,7 +46,7 @@ class PerformanceAndroidEventProcessorTest {
         var tr = getTransaction()
         setAppStart()
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.containsKey("app_start_cold"))
     }
@@ -57,7 +58,7 @@ class PerformanceAndroidEventProcessorTest {
         var tr = getTransaction("app.start.warm")
         setAppStart(false)
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.containsKey("app_start_warm"))
     }
@@ -69,10 +70,10 @@ class PerformanceAndroidEventProcessorTest {
         var tr1 = getTransaction()
         setAppStart(false)
 
-        tr1 = sut.process(tr1, null)
+        tr1 = sut.process(tr1, Hints())
 
         var tr2 = getTransaction()
-        tr2 = sut.process(tr2, null)
+        tr2 = sut.process(tr2, Hints())
 
         assertTrue(tr1.measurements.containsKey("app_start_warm"))
         assertTrue(tr2.measurements.isEmpty())
@@ -84,7 +85,7 @@ class PerformanceAndroidEventProcessorTest {
 
         var tr = getTransaction()
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.isEmpty())
     }
@@ -95,7 +96,7 @@ class PerformanceAndroidEventProcessorTest {
 
         var tr = getTransaction()
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.isEmpty())
     }
@@ -106,7 +107,7 @@ class PerformanceAndroidEventProcessorTest {
 
         var tr = getTransaction("task")
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.isEmpty())
     }
@@ -116,7 +117,7 @@ class PerformanceAndroidEventProcessorTest {
         val sut = fixture.getSut()
         var tr = getTransaction("task")
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.isEmpty())
     }
@@ -126,7 +127,7 @@ class PerformanceAndroidEventProcessorTest {
         val sut = fixture.getSut(null)
         var tr = getTransaction("task")
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.isEmpty())
     }
@@ -141,7 +142,7 @@ class PerformanceAndroidEventProcessorTest {
         val metrics = mapOf("frames_total" to MeasurementValue(1f))
         whenever(fixture.activityFramesTracker.takeMetrics(any())).thenReturn(metrics)
 
-        tr = sut.process(tr, null)
+        tr = sut.process(tr, Hints())
 
         assertTrue(tr.measurements.containsKey("frames_total"))
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ScreenshotEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ScreenshotEventProcessorTest.kt
@@ -15,6 +15,7 @@ import io.sentry.MainEventProcessor
 import io.sentry.SentryEvent
 import io.sentry.TypeCheckHint.ANDROID_ACTIVITY
 import io.sentry.TypeCheckHint.SENTRY_SCREENSHOT
+import io.sentry.hints.Hints
 import org.junit.runner.RunWith
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -95,7 +96,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when process is called and attachScreenshot is disabled, does nothing`() {
         val sut = fixture.getSut(false)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         sut.onActivityCreated(fixture.activity, null)
 
@@ -108,7 +109,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when event is not errored, does nothing`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         sut.onActivityCreated(fixture.activity, null)
 
@@ -121,7 +122,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when there is not activity, does nothing`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         val event = fixture.mainProcessor.process(getEvent(), hints)
         sut.process(event, hints)
@@ -132,7 +133,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when activity is finishing, does nothing`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         whenever(fixture.activity.isFinishing).thenReturn(true)
         sut.onActivityCreated(fixture.activity, null)
@@ -146,7 +147,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when view is zeroed, does nothing`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         whenever(fixture.rootView.width).thenReturn(0)
         whenever(fixture.rootView.height).thenReturn(0)
@@ -161,7 +162,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when process is called and attachScreenshot is enabled, add attachment to hints`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         sut.onActivityCreated(fixture.activity, null)
 
@@ -179,7 +180,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when activity is destroyed, does nothing`() {
         val sut = fixture.getSut(true)
-        val hints = mutableMapOf<String, Any>()
+        val hints = Hints()
 
         sut.onActivityCreated(fixture.activity, null)
         sut.onActivityDestroyed(fixture.activity)

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -13,6 +13,7 @@ import io.sentry.ISpan
 import io.sentry.SentryLevel.INFO
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint.ANDROID_FRAGMENT
+import io.sentry.hints.Hints
 import java.util.WeakHashMap
 
 @Suppress("TooManyFunctions")
@@ -118,9 +119,9 @@ class SentryFragmentLifecycleCallbacks(
             level = INFO
         }
 
-        val hintsMap = mutableMapOf<String, Any>(ANDROID_FRAGMENT to fragment)
+        val hints = Hints().also { it.set(ANDROID_FRAGMENT, fragment) }
 
-        hub.addBreadcrumb(breadcrumb, hintsMap)
+        hub.addBreadcrumb(breadcrumb, hints)
     }
 
     private fun getFragmentName(fragment: Fragment): String {

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -8,6 +8,7 @@ import io.sentry.SpanStatus
 import io.sentry.TracingOrigins
 import io.sentry.TypeCheckHint.OKHTTP_REQUEST
 import io.sentry.TypeCheckHint.OKHTTP_RESPONSE
+import io.sentry.hints.Hints
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
@@ -62,16 +63,16 @@ class SentryOkHttpInterceptor(
                 breadcrumb.setData("request_body_size", it)
             }
 
-            val hintsMap = mutableMapOf<String, Any>(OKHTTP_REQUEST to request)
+            val hints = Hints().also { it.set(OKHTTP_REQUEST, request) }
             response?.let {
                 it.body?.contentLength().ifHasValidLength { responseBodySize ->
                     breadcrumb.setData("response_body_size", responseBodySize)
                 }
 
-                hintsMap[OKHTTP_RESPONSE] = it
+                hints[OKHTTP_RESPONSE] = it
             }
 
-            hub.addBreadcrumb(breadcrumb, hintsMap)
+            hub.addBreadcrumb(breadcrumb, hints)
         }
     }
 

--- a/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
+++ b/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
@@ -2,7 +2,7 @@ public final class io/sentry/transport/apache/ApacheHttpClientTransport : io/sen
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;Lorg/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient;Lio/sentry/transport/RateLimiter;)V
 	public fun close ()V
 	public fun flush (J)V
-	public fun send (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/transport/apache/ApacheHttpClientTransportFactory : io/sentry/ITransportFactory {

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportClientReportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportClientReportTest.kt
@@ -18,12 +18,12 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.SentryOptionsManipulator
-import io.sentry.TypeCheckHint
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.IClientReportRecorder
 import io.sentry.hints.Retryable
 import io.sentry.transport.RateLimiter
 import io.sentry.transport.ReusableCountLatch
+import io.sentry.util.HintUtils
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient
 import org.apache.hc.core5.concurrent.FutureCallback
@@ -209,7 +209,7 @@ class ApacheHttpClientTransportClientReportTest {
         verifyNoMoreInteractions(fixture.clientReportRecorder)
     }
 
-    private fun retryableHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestRetryable())
+    private fun retryableHint() = HintUtils.createWithTypeCheckHint(TestRetryable())
 }
 
 class TestRetryable : Retryable {

--- a/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
+++ b/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
@@ -19,6 +19,7 @@ import io.sentry.SentryLevel
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint.APOLLO_REQUEST
 import io.sentry.TypeCheckHint.APOLLO_RESPONSE
+import io.sentry.hints.Hints
 import java.util.concurrent.Executor
 
 class SentryApolloInterceptor(
@@ -115,8 +116,11 @@ class SentryApolloInterceptor(
                     breadcrumb.setData("response_body_size", contentLength)
                 }
 
-                val hintsMap = mutableMapOf(APOLLO_REQUEST to httpRequest, APOLLO_RESPONSE to httpResponse)
-                hub.addBreadcrumb(breadcrumb, hintsMap)
+                val hints = Hints().also {
+                    it.set(APOLLO_REQUEST, httpRequest)
+                    it.set(APOLLO_RESPONSE, httpResponse)
+                }
+                hub.addBreadcrumb(breadcrumb, hints)
             }
         }
     }

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryDataFetcherExceptionHandler.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryDataFetcherExceptionHandler.java
@@ -7,9 +7,8 @@ import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.DataFetcherExceptionHandlerResult;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -34,10 +33,10 @@ public final class SentryDataFetcherExceptionHandler implements DataFetcherExcep
   @SuppressWarnings("deprecation")
   public DataFetcherExceptionHandlerResult onException(
       final @NotNull DataFetcherExceptionHandlerParameters handlerParameters) {
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(GRAPHQL_HANDLER_PARAMETERS, handlerParameters);
+    final Hints hints = new Hints();
+    hints.set(GRAPHQL_HANDLER_PARAMETERS, handlerParameters);
 
-    hub.captureException(handlerParameters.getException(), hintMap);
+    hub.captureException(handlerParameters.getException(), hints);
     return delegate.onException(handlerParameters);
   }
 }

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -9,13 +9,13 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.util.CollectionUtils;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.ErrorManager;
@@ -81,16 +81,16 @@ public class SentryHandler extends Handler {
     }
     try {
       if (record.getLevel().intValue() >= minimumEventLevel.intValue()) {
-        final Map<String, Object> hintMap = new HashMap<>();
-        hintMap.put(SENTRY_SYNTHETIC_EXCEPTION, record);
+        final Hints hints = new Hints();
+        hints.set(SENTRY_SYNTHETIC_EXCEPTION, record);
 
-        Sentry.captureEvent(createEvent(record), hintMap);
+        Sentry.captureEvent(createEvent(record), hints);
       }
       if (record.getLevel().intValue() >= minimumBreadcrumbLevel.intValue()) {
-        final Map<String, Object> hintMap = new HashMap<>();
-        hintMap.put(JUL_LOG_RECORD, record);
+        final Hints hints = new Hints();
+        hints.set(JUL_LOG_RECORD, record);
 
-        Sentry.addBreadcrumb(createBreadcrumb(record), hintMap);
+        Sentry.addBreadcrumb(createBreadcrumb(record), hints);
       }
     } catch (RuntimeException e) {
       reportError(

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -13,12 +13,12 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -139,16 +139,16 @@ public class SentryAppender extends AbstractAppender {
   @Override
   public void append(final @NotNull LogEvent eventObject) {
     if (eventObject.getLevel().isMoreSpecificThan(minimumEventLevel)) {
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(SENTRY_SYNTHETIC_EXCEPTION, eventObject);
+      final Hints hints = new Hints();
+      hints.set(SENTRY_SYNTHETIC_EXCEPTION, eventObject);
 
-      hub.captureEvent(createEvent(eventObject), hintMap);
+      hub.captureEvent(createEvent(eventObject), hints);
     }
     if (eventObject.getLevel().isMoreSpecificThan(minimumBreadcrumbLevel)) {
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(LOG4J_LOG_EVENT, eventObject);
+      final Hints hints = new Hints();
+      hints.set(LOG4J_LOG_EVENT, eventObject);
 
-      hub.addBreadcrumb(createBreadcrumb(eventObject), hintMap);
+      hub.addBreadcrumb(createBreadcrumb(eventObject), hints);
     }
   }
 

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -15,12 +15,12 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.util.CollectionUtils;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -63,16 +63,16 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
     if (eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(SENTRY_SYNTHETIC_EXCEPTION, eventObject);
+      final Hints hints = new Hints();
+      hints.set(SENTRY_SYNTHETIC_EXCEPTION, eventObject);
 
-      Sentry.captureEvent(createEvent(eventObject), hintMap);
+      Sentry.captureEvent(createEvent(eventObject), hints);
     }
     if (eventObject.getLevel().isGreaterOrEqual(minimumBreadcrumbLevel)) {
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(LOGBACK_LOGGING_EVENT, eventObject);
+      final Hints hints = new Hints();
+      hints.set(LOGBACK_LOGGING_EVENT, eventObject);
 
-      Sentry.addBreadcrumb(createBreadcrumb(eventObject), hintMap);
+      Sentry.addBreadcrumb(createBreadcrumb(eventObject), hints);
     }
   }
 

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -11,11 +11,11 @@ import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -92,13 +92,13 @@ public final class SentryFeignClient implements Client {
       breadcrumb.setData("response_body_size", response.body().length());
     }
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(OPEN_FEIGN_REQUEST, request);
+    final Hints hints = new Hints();
+    hints.set(OPEN_FEIGN_REQUEST, request);
     if (response != null) {
-      hintMap.put(OPEN_FEIGN_RESPONSE, response);
+      hints.set(OPEN_FEIGN_RESPONSE, response);
     }
 
-    hub.addBreadcrumb(breadcrumb, hintMap);
+    hub.addBreadcrumb(breadcrumb, hints);
   }
 
   static final class RequestWrapper {

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -8,11 +8,10 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SpanStatus;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.User;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Main {
 
@@ -137,9 +136,9 @@ public class Main {
       SentryEvent event = new SentryEvent();
       event.setMessage(message);
 
-      final Map<String, Object> hintsMap = new HashMap<>();
-      hintsMap.put("level", SentryLevel.DEBUG);
-      Sentry.captureEvent(event, hintsMap);
+      final Hints hints = new Hints();
+      hints.set("level", SentryLevel.DEBUG);
+      Sentry.captureEvent(event, hints);
     }
 
     // Performance feature
@@ -171,7 +170,7 @@ public class Main {
 
   private static class SomeEventProcessor implements EventProcessor {
     @Override
-    public SentryEvent process(SentryEvent event, Map<String, Object> hint) {
+    public SentryEvent process(SentryEvent event, Hints hints) {
       // Here you can modify the event as you need
       if (event.getLevel() != null && event.getLevel().ordinal() > SentryLevel.INFO.ordinal()) {
         event.addBreadcrumb(new Breadcrumb("Processed by " + SomeEventProcessor.class));

--- a/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/CustomEventProcessor.java
@@ -2,10 +2,9 @@ package io.sentry.samples.spring.boot;
 
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryRuntime;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.stereotype.Component;
 
@@ -26,8 +25,7 @@ public class CustomEventProcessor implements EventProcessor {
   }
 
   @Override
-  public @NotNull SentryEvent process(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
     final SentryRuntime runtime = new SentryRuntime();
     runtime.setVersion(springBootVersion);
     runtime.setName("Spring Boot");

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -2,6 +2,7 @@ package io.sentry.servlet.jakarta;
 
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Request;
 import io.sentry.util.Objects;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,8 +30,7 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
   @SuppressWarnings("JdkObsolete")
   @Override
-  public @NotNull SentryEvent process(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
     final Request sentryRequest = new Request();
     sentryRequest.setMethod(httpRequest.getMethod());
     sentryRequest.setQueryString(httpRequest.getQueryString());

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryServletRequestListener.java
@@ -6,13 +6,12 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletRequestEvent;
 import jakarta.servlet.ServletRequestListener;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -45,11 +44,11 @@ public class SentryServletRequestListener implements ServletRequestListener {
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(SERVLET_REQUEST, httpRequest);
+      final Hints hints = new Hints();
+      hints.set(SERVLET_REQUEST, httpRequest);
 
       hub.addBreadcrumb(
-          Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hintMap);
+          Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hints);
 
       hub.configureScope(
           scope -> {

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
+import io.sentry.hints.Hints
 import jakarta.servlet.http.HttpServletRequest
 import java.net.URI
 import java.util.Collections
@@ -29,7 +30,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request)
         val eventRequest = event.request!!
@@ -56,7 +57,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) {
             assertEquals(
@@ -81,7 +82,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) {
             assertNull(it.cookies)
@@ -105,7 +106,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) { req ->
             assertNotNull(req.headers) {

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
@@ -2,6 +2,7 @@ package io.sentry.servlet;
 
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Request;
 import io.sentry.util.Objects;
 import java.util.Arrays;
@@ -29,8 +30,7 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
   @SuppressWarnings("JdkObsolete")
   @Override
-  public @NotNull SentryEvent process(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
     final Request sentryRequest = new Request();
     sentryRequest.setMethod(httpRequest.getMethod());
     sentryRequest.setQueryString(httpRequest.getQueryString());

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -6,9 +6,8 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
@@ -45,11 +44,11 @@ public class SentryServletRequestListener implements ServletRequestListener {
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(SERVLET_REQUEST, httpRequest);
+      final Hints hints = new Hints();
+      hints.set(SERVLET_REQUEST, httpRequest);
 
       hub.addBreadcrumb(
-          Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hintMap);
+          Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hints);
 
       hub.configureScope(
           scope -> {

--- a/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryRequestHttpServletRequestProcessorTest.kt
@@ -2,6 +2,7 @@ package io.sentry.servlet
 
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
+import io.sentry.hints.Hints
 import org.springframework.mock.web.MockServletContext
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import java.net.URI
@@ -24,7 +25,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request)
         val eventRequest = event.request!!
@@ -50,7 +51,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) {
             assertEquals(
@@ -73,7 +74,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) {
             assertNull(it.cookies)
@@ -95,7 +96,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = SentryRequestHttpServletRequestProcessor(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.request) { req ->
             assertNotNull(req.headers) {

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -19,6 +19,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.checkEvent
+import io.sentry.hints.Hints
 import io.sentry.protocol.User
 import io.sentry.spring.HttpServletRequestSentryUserProvider
 import io.sentry.spring.SentryExceptionResolver
@@ -661,7 +662,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomBeforeSendCallback : SentryOptions.BeforeSendCallback {
-        override fun execute(event: SentryEvent, hint: Map<String, Any?>?): SentryEvent? = null
+        override fun execute(event: SentryEvent, hints: Hints): SentryEvent? = null
     }
 
     @Configuration(proxyBeanMethods = false)
@@ -672,7 +673,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomBeforeBreadcrumbCallback : SentryOptions.BeforeBreadcrumbCallback {
-        override fun execute(breadcrumb: Breadcrumb, hint: Map<String, Any?>?): Breadcrumb? = null
+        override fun execute(breadcrumb: Breadcrumb, hints: Hints): Breadcrumb? = null
     }
 
     @Configuration(proxyBeanMethods = false)
@@ -683,7 +684,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomEventProcessor : EventProcessor {
-        override fun process(event: SentryEvent, hint: Map<String, Any?>?) = null
+        override fun process(event: SentryEvent, hints: Hints) = null
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -36,7 +36,7 @@ public class io/sentry/spring/SentryInitBeanPostProcessor : org/springframework/
 
 public class io/sentry/spring/SentryRequestHttpServletRequestProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/spring/tracing/TransactionNameProvider;Ljavax/servlet/http/HttpServletRequest;)V
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
 }
 
 public class io/sentry/spring/SentryRequestResolver {

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -8,11 +8,10 @@ import io.sentry.IHub;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Mechanism;
 import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
@@ -60,11 +59,11 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
     event.setLevel(SentryLevel.FATAL);
     event.setTransaction(transactionNameProvider.provideTransactionName(request));
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(SPRING_RESOLVER_REQUEST, request);
-    hintMap.put(SPRING_RESOLVER_RESPONSE, response);
+    final Hints hints = new Hints();
+    hints.set(SPRING_RESOLVER_REQUEST, request);
+    hints.set(SPRING_RESOLVER_RESPONSE, response);
 
-    hub.captureEvent(event, hintMap);
+    hub.captureEvent(event, hints);
 
     // null = run other HandlerExceptionResolvers to actually handle the exception
     return null;

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
@@ -3,12 +3,11 @@ package io.sentry.spring;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;
+import io.sentry.hints.Hints;
 import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
-import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /** Attaches transaction name from the HTTP request to {@link SentryEvent}. */
 @Open
@@ -26,7 +25,7 @@ public class SentryRequestHttpServletRequestProcessor implements EventProcessor 
 
   @Override
   public @NotNull SentryEvent process(
-      final @NotNull SentryEvent event, final @Nullable Map<String, Object> hint) {
+      final @NotNull SentryEvent event, final @NotNull Hints hints) {
     if (event.getTransaction() == null) {
       event.setTransaction(transactionNameProvider.provideTransactionName(request));
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
@@ -13,18 +13,16 @@ import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SentryOptions.RequestSize;
+import io.sentry.hints.Hints;
 import io.sentry.spring.tracing.SpringMvcTransactionNameProvider;
 import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -64,11 +62,11 @@ public class SentrySpringFilter extends OncePerRequestFilter {
       final HttpServletRequest request = resolveHttpServletRequest(servletRequest);
       hub.pushScope();
       try {
-        final Map<String, Object> hintMap = new HashMap<>();
-        hintMap.put(SPRING_REQUEST_FILTER_REQUEST, servletRequest);
-        hintMap.put(SPRING_REQUEST_FILTER_RESPONSE, response);
+        final Hints hints = new Hints();
+        hints.set(SPRING_REQUEST_FILTER_REQUEST, servletRequest);
+        hints.set(SPRING_REQUEST_FILTER_RESPONSE, response);
 
-        hub.addBreadcrumb(Breadcrumb.http(request.getRequestURI(), request.getMethod()), hintMap);
+        hub.addBreadcrumb(Breadcrumb.http(request.getRequestURI(), request.getMethod()), hints);
         configureScope(request);
         filterChain.doFilter(request, response);
       } finally {
@@ -150,8 +148,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
     }
 
     @Override
-    public @NotNull SentryEvent process(
-        @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+    public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
       if (event.getRequest() != null) {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -11,10 +11,9 @@ import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
 import io.sentry.TracingOrigins;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.http.HttpRequest;
@@ -81,13 +80,13 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
         Breadcrumb.http(request.getURI().toString(), request.getMethodValue(), responseStatusCode);
     breadcrumb.setData("request_body_size", body.length);
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(SPRING_REQUEST_INTERCEPTOR_REQUEST, request);
-    hintMap.put(SPRING_REQUEST_INTERCEPTOR_REQUEST_BODY, body);
+    final Hints hints = new Hints();
+    hints.set(SPRING_REQUEST_INTERCEPTOR_REQUEST, request);
+    hints.set(SPRING_REQUEST_INTERCEPTOR_REQUEST_BODY, body);
     if (response != null) {
-      hintMap.put(SPRING_REQUEST_INTERCEPTOR_RESPONSE, response);
+      hints.set(SPRING_REQUEST_INTERCEPTOR_RESPONSE, response);
     }
 
-    hub.addBreadcrumb(breadcrumb, hintMap);
+    hub.addBreadcrumb(breadcrumb, hints);
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
@@ -10,9 +10,8 @@ import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
 import io.sentry.TracingOrigins;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.web.reactive.function.client.ClientRequest;
@@ -77,12 +76,12 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
             request.method().name(),
             response != null ? response.rawStatusCode() : null);
 
-    final Map<String, Object> hintMap = new HashMap<>();
-    hintMap.put(SPRING_EXCHANGE_FILTER_REQUEST, request);
+    final Hints hints = new Hints();
+    hints.set(SPRING_EXCHANGE_FILTER_REQUEST, request);
     if (response != null) {
-      hintMap.put(SPRING_EXCHANGE_FILTER_RESPONSE, response);
+      hints.set(SPRING_EXCHANGE_FILTER_RESPONSE, response);
     }
 
-    hub.addBreadcrumb(breadcrumb, hintMap);
+    hub.addBreadcrumb(breadcrumb, hints);
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
@@ -7,10 +7,9 @@ import io.sentry.IHub;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Mechanism;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.annotation.Order;
@@ -44,11 +43,11 @@ public final class SentryWebExceptionHandler implements WebExceptionHandler {
       event.setLevel(SentryLevel.FATAL);
       event.setTransaction(TransactionNameProvider.provideTransactionName(serverWebExchange));
 
-      final Map<String, Object> hintMap = new HashMap<>();
-      hintMap.put(WEBFLUX_EXCEPTION_HANDLER_REQUEST, serverWebExchange.getRequest());
-      hintMap.put(WEBFLUX_EXCEPTION_HANDLER_RESPONSE, serverWebExchange.getResponse());
+      final Hints hints = new Hints();
+      hints.set(WEBFLUX_EXCEPTION_HANDLER_REQUEST, serverWebExchange.getRequest());
+      hints.set(WEBFLUX_EXCEPTION_HANDLER_RESPONSE, serverWebExchange.getResponse());
 
-      hub.captureEvent(event, hintMap);
+      hub.captureEvent(event, hints);
     }
     return Mono.error(ex);
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebFilter.java
@@ -5,9 +5,8 @@ import static io.sentry.TypeCheckHint.WEBFLUX_FILTER_RESPONSE;
 
 import io.sentry.Breadcrumb;
 import io.sentry.IHub;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -44,12 +43,12 @@ public final class SentryWebFilter implements WebFilter {
               final ServerHttpRequest request = serverWebExchange.getRequest();
               final ServerHttpResponse response = serverWebExchange.getResponse();
 
-              final Map<String, Object> hintMap = new HashMap<>();
-              hintMap.put(WEBFLUX_FILTER_REQUEST, request);
-              hintMap.put(WEBFLUX_FILTER_RESPONSE, response);
+              final Hints hints = new Hints();
+              hints.set(WEBFLUX_FILTER_REQUEST, request);
+              hints.set(WEBFLUX_FILTER_RESPONSE, response);
 
               hub.addBreadcrumb(
-                  Breadcrumb.http(request.getURI().toString(), request.getMethodValue()), hintMap);
+                  Breadcrumb.http(request.getURI().toString(), request.getMethodValue()), hints);
               hub.configureScope(
                   scope -> scope.setRequest(sentryRequestResolver.resolveSentryRequest(request)));
             });

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.IHub
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
+import io.sentry.hints.Hints
 import io.sentry.spring.tracing.SpringMvcTransactionNameProvider
 import org.springframework.mock.web.MockServletContext
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -37,7 +38,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val eventProcessor = fixture.getSut(request)
         val event = SentryEvent()
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.transaction)
         assertEquals("GET /some-path", event.transaction)
@@ -53,7 +54,7 @@ class SentryRequestHttpServletRequestProcessorTest {
         val event = SentryEvent()
         event.transaction = "some-transaction"
 
-        eventProcessor.process(event, null)
+        eventProcessor.process(event, Hints())
 
         assertNotNull(event.transaction)
         assertEquals("some-transaction", event.transaction)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -119,7 +119,7 @@ public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {
 
 public final class io/sentry/DuplicateEventDetectionEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
 }
 
 public final class io/sentry/EnvelopeReader : io/sentry/IEnvelopeReader {
@@ -130,12 +130,12 @@ public final class io/sentry/EnvelopeReader : io/sentry/IEnvelopeReader {
 public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
 	public synthetic fun processDirectory (Ljava/io/File;)V
-	public fun processEnvelopeFile (Ljava/lang/String;Ljava/util/Map;)V
+	public fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/hints/Hints;)V
 }
 
 public abstract interface class io/sentry/EventProcessor {
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
-	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/util/Map;)Lio/sentry/protocol/SentryTransaction;
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public final class io/sentry/ExternalOptions {
@@ -185,13 +185,13 @@ public final class io/sentry/ExternalOptions {
 
 public final class io/sentry/Hub : io/sentry/IHub {
 	public fun <init> (Lio/sentry/SentryOptions;)V
-	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public fun bindClient (Lio/sentry/ISentryClient;)V
-	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -225,13 +225,13 @@ public final class io/sentry/Hub : io/sentry/IHub {
 }
 
 public final class io/sentry/HubAdapter : io/sentry/IHub {
-	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public fun bindClient (Lio/sentry/ISentryClient;)V
-	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -271,27 +271,27 @@ public abstract interface class io/sentry/IEnvelopeReader {
 }
 
 public abstract interface class io/sentry/IEnvelopeSender {
-	public abstract fun processEnvelopeFile (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/hints/Hints;)V
 }
 
 public abstract interface class io/sentry/IHub {
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
-	public abstract fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public abstract fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public fun addBreadcrumb (Ljava/lang/String;)V
 	public fun addBreadcrumb (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun bindClient (Lio/sentry/ISentryClient;)V
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun clearBreadcrumbs ()V
 	public abstract fun clone ()Lio/sentry/IHub;
@@ -349,24 +349,24 @@ public abstract interface class io/sentry/IScopeObserver {
 
 public abstract interface class io/sentry/ISentryClient {
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
-	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
-	public abstract fun captureSession (Lio/sentry/Session;Ljava/util/Map;)V
+	public abstract fun captureSession (Lio/sentry/Session;Lio/sentry/hints/Hints;)V
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Scope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun close ()V
 	public abstract fun flush (J)V
@@ -504,8 +504,8 @@ public abstract interface class io/sentry/JsonUnknown {
 public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor, java/io/Closeable {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close ()V
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
-	public fun process (Lio/sentry/protocol/SentryTransaction;Ljava/util/Map;)Lio/sentry/protocol/SentryTransaction;
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
@@ -514,13 +514,13 @@ public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
 }
 
 public final class io/sentry/NoOpHub : io/sentry/IHub {
-	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public fun bindClient (Lio/sentry/ISentryClient;)V
-	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
 	public fun clone ()Lio/sentry/IHub;
@@ -640,7 +640,7 @@ public final class io/sentry/OptionsContainer {
 public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/IEnvelopeReader;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
 	public synthetic fun processDirectory (Ljava/io/File;)V
-	public fun processEnvelopeFile (Ljava/lang/String;Ljava/util/Map;)V
+	public fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -740,7 +740,7 @@ public final class io/sentry/Scope {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun addAttachment (Lio/sentry/Attachment;)V
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
-	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
 	public fun clear ()V
 	public fun clearAttachments ()V
@@ -814,14 +814,14 @@ public final class io/sentry/SendFireAndForgetOutboxSender : io/sentry/SendCache
 
 public final class io/sentry/Sentry {
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
-	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Ljava/util/Map;)V
+	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)V
 	public static fun addBreadcrumb (Ljava/lang/String;)V
 	public static fun addBreadcrumb (Ljava/lang/String;Ljava/lang/String;)V
 	public static fun bindClient (Lio/sentry/ISentryClient;)V
 	public static fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
-	public static fun captureEvent (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public static fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public static fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
-	public static fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
+	public static fun captureException (Ljava/lang/Throwable;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
@@ -943,10 +943,10 @@ public final class io/sentry/SentryBaseEvent$Serializer {
 }
 
 public final class io/sentry/SentryClient : io/sentry/ISentryClient {
-	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Ljava/util/Map;)Lio/sentry/protocol/SentryId;
-	public fun captureSession (Lio/sentry/Session;Ljava/util/Map;)V
-	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Ljava/util/Map;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
+	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Lio/sentry/hints/Hints;)Lio/sentry/protocol/SentryId;
+	public fun captureSession (Lio/sentry/Session;Lio/sentry/hints/Hints;)V
+	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Scope;Lio/sentry/hints/Hints;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun close ()V
 	public fun flush (J)V
@@ -1257,11 +1257,11 @@ public class io/sentry/SentryOptions {
 }
 
 public abstract interface class io/sentry/SentryOptions$BeforeBreadcrumbCallback {
-	public abstract fun execute (Lio/sentry/Breadcrumb;Ljava/util/Map;)Lio/sentry/Breadcrumb;
+	public abstract fun execute (Lio/sentry/Breadcrumb;Lio/sentry/hints/Hints;)Lio/sentry/Breadcrumb;
 }
 
 public abstract interface class io/sentry/SentryOptions$BeforeSendCallback {
-	public abstract fun execute (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
+	public abstract fun execute (Lio/sentry/SentryEvent;Lio/sentry/hints/Hints;)Lio/sentry/SentryEvent;
 }
 
 public final class io/sentry/SentryOptions$Proxy {
@@ -1704,13 +1704,13 @@ public final class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCach
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/cache/IEnvelopeCache;
 	public fun discard (Lio/sentry/SentryEnvelope;)V
 	public fun iterator ()Ljava/util/Iterator;
-	public fun store (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public abstract interface class io/sentry/cache/IEnvelopeCache : java/lang/Iterable {
 	public abstract fun discard (Lio/sentry/SentryEnvelope;)V
 	public fun store (Lio/sentry/SentryEnvelope;)V
-	public abstract fun store (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public abstract fun store (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/clientreport/ClientReport : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -1844,6 +1844,13 @@ public abstract interface class io/sentry/hints/DiskFlushNotification {
 
 public abstract interface class io/sentry/hints/Flushable {
 	public abstract fun waitFlush ()Z
+}
+
+public final class io/sentry/hints/Hints {
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/String;)V
+	public fun set (Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public abstract interface class io/sentry/hints/Resettable {
@@ -2825,7 +2832,7 @@ public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/
 	public fun <init> (Lio/sentry/transport/QueuedThreadPoolExecutor;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V
 	public fun flush (J)V
-	public fun send (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/transport/CurrentDateProvider : io/sentry/transport/ICurrentDateProvider {
@@ -2840,7 +2847,7 @@ public abstract interface class io/sentry/transport/ICurrentDateProvider {
 public abstract interface class io/sentry/transport/ITransport : java/io/Closeable {
 	public abstract fun flush (J)V
 	public fun send (Lio/sentry/SentryEnvelope;)V
-	public abstract fun send (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public abstract fun send (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public abstract interface class io/sentry/transport/ITransportGate {
@@ -2852,14 +2859,14 @@ public final class io/sentry/transport/NoOpEnvelopeCache : io/sentry/cache/IEnve
 	public fun discard (Lio/sentry/SentryEnvelope;)V
 	public static fun getInstance ()Lio/sentry/transport/NoOpEnvelopeCache;
 	public fun iterator ()Ljava/util/Iterator;
-	public fun store (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/transport/NoOpTransport : io/sentry/transport/ITransport {
 	public fun close ()V
 	public fun flush (J)V
 	public static fun getInstance ()Lio/sentry/transport/NoOpTransport;
-	public fun send (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public final class io/sentry/transport/NoOpTransportGate : io/sentry/transport/ITransportGate {
@@ -2870,7 +2877,7 @@ public final class io/sentry/transport/NoOpTransportGate : io/sentry/transport/I
 public final class io/sentry/transport/RateLimiter {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun <init> (Lio/sentry/transport/ICurrentDateProvider;Lio/sentry/SentryOptions;)V
-	public fun filter (Lio/sentry/SentryEnvelope;Ljava/lang/Object;)Lio/sentry/SentryEnvelope;
+	public fun filter (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)Lio/sentry/SentryEnvelope;
 	public fun updateRetryAfterLimits (Ljava/lang/String;Ljava/lang/String;I)V
 }
 
@@ -2888,7 +2895,7 @@ public final class io/sentry/transport/StdoutTransport : io/sentry/transport/ITr
 	public fun <init> (Lio/sentry/ISerializer;)V
 	public fun close ()V
 	public fun flush (J)V
-	public fun send (Lio/sentry/SentryEnvelope;Ljava/util/Map;)V
+	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/hints/Hints;)V
 }
 
 public abstract class io/sentry/transport/TransportResult {
@@ -2923,14 +2930,32 @@ public final class io/sentry/util/FileUtils {
 }
 
 public final class io/sentry/util/HintUtils {
-	public static fun getSentrySdkHint (Ljava/util/Map;)Ljava/lang/Object;
-	public static fun shouldApplyScopeData (Ljava/util/Map;)Z
+	public static fun createWithTypeCheckHint (Ljava/lang/Object;)Lio/sentry/hints/Hints;
+	public static fun getSentrySdkHint (Lio/sentry/hints/Hints;)Ljava/lang/Object;
+	public static fun hasType (Lio/sentry/hints/Hints;Ljava/lang/Class;)Z
+	public static fun runIfDoesNotHaveType (Lio/sentry/hints/Hints;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryNullableConsumer;)V
+	public static fun runIfHasType (Lio/sentry/hints/Hints;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;)V
+	public static fun runIfHasType (Lio/sentry/hints/Hints;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;Lio/sentry/util/HintUtils$SentryFallbackConsumer;)V
+	public static fun runIfHasTypeLogIfNot (Lio/sentry/hints/Hints;Ljava/lang/Class;Lio/sentry/ILogger;Lio/sentry/util/HintUtils$SentryConsumer;)V
+	public static fun setTypeCheckHint (Lio/sentry/hints/Hints;Ljava/lang/Object;)V
+	public static fun shouldApplyScopeData (Lio/sentry/hints/Hints;)Z
+}
+
+public abstract interface class io/sentry/util/HintUtils$SentryConsumer {
+	public abstract fun accept (Ljava/lang/Object;)V
+}
+
+public abstract interface class io/sentry/util/HintUtils$SentryFallbackConsumer {
+	public abstract fun accept (Ljava/lang/Object;Ljava/lang/Class;)V
+}
+
+public abstract interface class io/sentry/util/HintUtils$SentryNullableConsumer {
+	public abstract fun accept (Ljava/lang/Object;)V
 }
 
 public final class io/sentry/util/LogUtils {
 	public fun <init> ()V
-	public static fun logIfNotFlushable (Lio/sentry/ILogger;Ljava/lang/Object;)V
-	public static fun logIfNotRetryable (Lio/sentry/ILogger;Ljava/lang/Object;)V
+	public static fun logNotInstanceOf (Ljava/lang/Class;Ljava/lang/Object;Lio/sentry/ILogger;)V
 }
 
 public final class io/sentry/util/Objects {

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -1,19 +1,17 @@
 package io.sentry;
 
 import static io.sentry.SentryLevel.ERROR;
-import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
 
 import io.sentry.hints.Cached;
 import io.sentry.hints.Flushable;
+import io.sentry.hints.Hints;
 import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
+import io.sentry.util.HintUtils;
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 abstract class DirectoryProcessor {
 
@@ -67,18 +65,16 @@ abstract class DirectoryProcessor {
 
         final SendCachedEnvelopeHint hint = new SendCachedEnvelopeHint(flushTimeoutMillis, logger);
 
-        final Map<String, Object> hintMap = new HashMap<>();
-        hintMap.put(SENTRY_TYPE_CHECK_HINT, hint);
+        final Hints hints = HintUtils.createWithTypeCheckHint(hint);
 
-        processFile(file, hintMap);
+        processFile(file, hints);
       }
     } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, e, "Failed processing '%s'", directory.getAbsolutePath());
     }
   }
 
-  protected abstract void processFile(
-      final @NotNull File file, final @Nullable Map<String, Object> hint);
+  protected abstract void processFile(final @NotNull File file, final @NotNull Hints hints);
 
   protected abstract boolean isRelevantFileName(String fileName);
 

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,7 +22,7 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
 
   @Override
   public @Nullable SentryEvent process(
-      final @NotNull SentryEvent event, final @Nullable Map<String, Object> hint) {
+      final @NotNull SentryEvent event, final @NotNull Hints hints) {
     if (options.isEnableDeduplication()) {
       final Throwable throwable = event.getThrowable();
       if (throwable != null) {

--- a/sentry/src/main/java/io/sentry/EnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeSender.java
@@ -2,9 +2,9 @@ package io.sentry;
 
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.hints.Flushable;
+import io.sentry.hints.Hints;
 import io.sentry.hints.Retryable;
 import io.sentry.util.HintUtils;
-import io.sentry.util.LogUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -12,10 +12,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class EnvelopeSender extends DirectoryProcessor implements IEnvelopeSender {
@@ -36,7 +34,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
   }
 
   @Override
-  protected void processFile(final @NotNull File file, final @Nullable Map<String, Object> hint) {
+  protected void processFile(final @NotNull File file, final @NotNull Hints hints) {
     if (!file.isFile()) {
       logger.log(SentryLevel.DEBUG, "'%s' is not a file.", file.getAbsolutePath());
       return;
@@ -56,24 +54,24 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       return;
     }
 
-    Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
-
     try (final InputStream is = new BufferedInputStream(new FileInputStream(file))) {
       SentryEnvelope envelope = serializer.deserializeEnvelope(is);
       if (envelope == null) {
         logger.log(
             SentryLevel.ERROR, "Failed to deserialize cached envelope %s", file.getAbsolutePath());
       } else {
-        hub.captureEnvelope(envelope, hint);
+        hub.captureEnvelope(envelope, hints);
       }
 
-      if (sentrySdkHint instanceof Flushable) {
-        if (!((Flushable) sentrySdkHint).waitFlush()) {
-          logger.log(SentryLevel.WARNING, "Timed out waiting for envelope submission.");
-        }
-      } else {
-        LogUtils.logIfNotFlushable(logger, sentrySdkHint);
-      }
+      HintUtils.runIfHasTypeLogIfNot(
+          hints,
+          Flushable.class,
+          logger,
+          (flushable) -> {
+            if (!flushable.waitFlush()) {
+              logger.log(SentryLevel.WARNING, "Timed out waiting for envelope submission.");
+            }
+          });
     } catch (FileNotFoundException e) {
       logger.log(SentryLevel.ERROR, e, "File '%s' cannot be found.", file.getAbsolutePath());
     } catch (IOException e) {
@@ -81,27 +79,31 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
     } catch (Throwable e) {
       logger.log(
           SentryLevel.ERROR, e, "Failed to capture cached envelope %s", file.getAbsolutePath());
-      if (sentrySdkHint instanceof Retryable) {
-        ((Retryable) sentrySdkHint).setRetry(false);
-        logger.log(SentryLevel.INFO, e, "File '%s' won't retry.", file.getAbsolutePath());
-      } else {
-        LogUtils.logIfNotRetryable(logger, sentrySdkHint);
-      }
+      HintUtils.runIfHasTypeLogIfNot(
+          hints,
+          Retryable.class,
+          logger,
+          (retryable) -> {
+            retryable.setRetry(false);
+            logger.log(SentryLevel.INFO, e, "File '%s' won't retry.", file.getAbsolutePath());
+          });
     } finally {
       // Unless the transport marked this to be retried, it'll be deleted.
-      if (sentrySdkHint instanceof Retryable) {
-        if (!((Retryable) sentrySdkHint).isRetry()) {
-          safeDelete(file, "after trying to capture it");
-          logger.log(SentryLevel.DEBUG, "Deleted file %s.", file.getAbsolutePath());
-        } else {
-          logger.log(
-              SentryLevel.INFO,
-              "File not deleted since retry was marked. %s.",
-              file.getAbsolutePath());
-        }
-      } else {
-        LogUtils.logIfNotRetryable(logger, sentrySdkHint);
-      }
+      HintUtils.runIfHasTypeLogIfNot(
+          hints,
+          Retryable.class,
+          logger,
+          (retryable) -> {
+            if (!retryable.isRetry()) {
+              safeDelete(file, "after trying to capture it");
+              logger.log(SentryLevel.DEBUG, "Deleted file %s.", file.getAbsolutePath());
+            } else {
+              logger.log(
+                  SentryLevel.INFO,
+                  "File not deleted since retry was marked. %s.",
+                  file.getAbsolutePath());
+            }
+          });
     }
   }
 
@@ -111,11 +113,10 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
   }
 
   @Override
-  public void processEnvelopeFile(
-      final @NotNull String path, final @Nullable Map<String, Object> hint) {
+  public void processEnvelopeFile(final @NotNull String path, final @NotNull Hints hints) {
     Objects.requireNonNull(path, "Path is required.");
 
-    processFile(new File(path), hint);
+    processFile(new File(path), hints);
   }
 
   private void safeDelete(final @NotNull File file, final @NotNull String errorMessageSuffix) {

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -1,7 +1,7 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryTransaction;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,11 +14,11 @@ public interface EventProcessor {
    * May mutate or drop a SentryEvent
    *
    * @param event the SentryEvent
-   * @param hint the Hint
+   * @param hints the Hint
    * @return the event itself, a mutated SentryEvent or null
    */
   @Nullable
-  default SentryEvent process(@NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  default SentryEvent process(@NotNull SentryEvent event, @NotNull Hints hints) {
     return event;
   }
 
@@ -26,12 +26,11 @@ public interface EventProcessor {
    * May mutate or drop a SentryTransaction
    *
    * @param transaction the SentryTransaction
-   * @param hint the Hint
+   * @param hints the Hint
    * @return the event itself, a mutated SentryTransaction or null
    */
   @Nullable
-  default SentryTransaction process(
-      @NotNull SentryTransaction transaction, @Nullable Map<String, Object> hint) {
+  default SentryTransaction process(@NotNull SentryTransaction transaction, @NotNull Hints hints) {
     return transaction;
   }
 }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -1,11 +1,11 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,9 +26,8 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
-    return Sentry.captureEvent(event, hint);
+  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hints hints) {
+    return Sentry.captureEvent(event, hints);
   }
 
   @Override
@@ -39,14 +38,13 @@ public final class HubAdapter implements IHub {
   @ApiStatus.Internal
   @Override
   public @NotNull SentryId captureEnvelope(
-      @NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint) {
-    return Sentry.getCurrentHub().captureEnvelope(envelope, hint);
+      @NotNull SentryEnvelope envelope, @Nullable Hints hints) {
+    return Sentry.getCurrentHub().captureEnvelope(envelope, hints);
   }
 
   @Override
-  public @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Map<String, Object> hint) {
-    return Sentry.captureException(throwable, hint);
+  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hints hints) {
+    return Sentry.captureException(throwable, hints);
   }
 
   @Override
@@ -70,8 +68,8 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Map<String, Object> hint) {
-    Sentry.addBreadcrumb(breadcrumb, hint);
+  public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hints hints) {
+    Sentry.addBreadcrumb(breadcrumb, hints);
   }
 
   @Override
@@ -163,10 +161,10 @@ public final class HubAdapter implements IHub {
   public @NotNull SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
-      @Nullable Map<String, Object> hint,
+      @Nullable Hints hints,
       @Nullable ProfilingTraceData profilingTraceData) {
     return Sentry.getCurrentHub()
-        .captureTransaction(transaction, traceState, hint, profilingTraceData);
+        .captureTransaction(transaction, traceState, hints, profilingTraceData);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/IEnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/IEnvelopeSender.java
@@ -1,9 +1,8 @@
 package io.sentry;
 
-import java.util.Map;
+import io.sentry.hints.Hints;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public interface IEnvelopeSender {
-  void processEnvelopeFile(@NotNull String path, @Nullable Map<String, Object> hint);
+  void processEnvelopeFile(@NotNull String path, @NotNull Hints hints);
 }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -1,11 +1,11 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,11 +24,11 @@ public interface IHub {
    * Captures the event.
    *
    * @param event the event
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @NotNull
-  SentryId captureEvent(@NotNull SentryEvent event, @Nullable Map<String, Object> hint);
+  SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hints hints);
 
   /**
    * Captures the event.
@@ -64,11 +64,11 @@ public interface IHub {
    * Captures an envelope.
    *
    * @param envelope the SentryEnvelope to send.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @NotNull
-  SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint);
+  SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Hints hints);
 
   /**
    * Captures an envelope.
@@ -77,18 +77,18 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureEnvelope(@NotNull SentryEnvelope envelope) {
-    return captureEnvelope(envelope, null);
+    return captureEnvelope(envelope, new Hints());
   }
 
   /**
    * Captures the exception.
    *
    * @param throwable The exception.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @NotNull
-  SentryId captureException(@NotNull Throwable throwable, @Nullable Map<String, Object> hint);
+  SentryId captureException(@NotNull Throwable throwable, @Nullable Hints hints);
 
   /**
    * Captures the exception.
@@ -120,9 +120,9 @@ public interface IHub {
    * Adds a breadcrumb to the current Scope
    *
    * @param breadcrumb the breadcrumb
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    */
-  void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Map<String, Object> hint);
+  void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hints hints);
 
   /**
    * Adds a breadcrumb to the current Scope
@@ -130,7 +130,7 @@ public interface IHub {
    * @param breadcrumb the breadcrumb
    */
   default void addBreadcrumb(@NotNull Breadcrumb breadcrumb) {
-    addBreadcrumb(breadcrumb, null);
+    addBreadcrumb(breadcrumb, new Hints());
   }
 
   /**
@@ -272,7 +272,7 @@ public interface IHub {
    *
    * @param transaction the transaction
    * @param traceState the trace state
-   * @param hint the hint
+   * @param hints the hints
    * @param profilingTraceData the profiling trace data
    * @return transaction's id
    */
@@ -281,7 +281,7 @@ public interface IHub {
   SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
-      @Nullable Map<String, Object> hint,
+      @Nullable Hints hints,
       final @Nullable ProfilingTraceData profilingTraceData);
 
   /**
@@ -289,7 +289,7 @@ public interface IHub {
    *
    * @param transaction the transaction
    * @param traceState the trace state
-   * @param hint the hint
+   * @param hints the hints
    * @return transaction's id
    */
   @ApiStatus.Internal
@@ -297,15 +297,15 @@ public interface IHub {
   default SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
-      @Nullable Map<String, Object> hint) {
-    return captureTransaction(transaction, traceState, hint, null);
+      @Nullable Hints hints) {
+    return captureTransaction(transaction, traceState, hints, null);
   }
 
   @ApiStatus.Internal
   @NotNull
   default SentryId captureTransaction(
-      @NotNull SentryTransaction transaction, @Nullable Map<String, Object> hint) {
-    return captureTransaction(transaction, null, hint);
+      @NotNull SentryTransaction transaction, @Nullable Hints hints) {
+    return captureTransaction(transaction, null, hints);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -1,9 +1,9 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,12 +23,11 @@ public interface ISentryClient {
    *
    * @param event the event
    * @param scope An optional scope to be applied to the event.
-   * @param hint SDK specific but provides high level information about the origin of the event.
+   * @param hints SDK specific but provides high level information about the origin of the event.
    * @return The Id (SentryId object) of the event.
    */
   @NotNull
-  SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Scope scope, @Nullable Map<String, Object> hint);
+  SentryId captureEvent(@NotNull SentryEvent event, @Nullable Scope scope, @Nullable Hints hints);
 
   /** Flushes out the queue for up to timeout seconds and disable the client. */
   void close();
@@ -65,12 +64,11 @@ public interface ISentryClient {
    * Capture the event
    *
    * @param event the event
-   * @param hint SDK specific but provides high level information about the origin of the event.
+   * @param hints SDK specific but provides high level information about the origin of the event.
    * @return The Id (SentryId object) of the event.
    */
-  default @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
-    return captureEvent(event, null, hint);
+  default @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hints hints) {
+    return captureEvent(event, null, hints);
   }
 
   /**
@@ -117,26 +115,25 @@ public interface ISentryClient {
    * Captures the exception.
    *
    * @param throwable The exception.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @param scope An optional scope to be applied to the event.
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Scope scope, @Nullable Map<String, Object> hint) {
+      @NotNull Throwable throwable, @Nullable Scope scope, @Nullable Hints hints) {
     SentryEvent event = new SentryEvent(throwable);
-    return captureEvent(event, scope, hint);
+    return captureEvent(event, scope, hints);
   }
 
   /**
    * Captures the exception.
    *
    * @param throwable The exception.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
-  default @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Map<String, Object> hint) {
-    return captureException(throwable, null, hint);
+  default @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hints hints) {
+    return captureException(throwable, null, hints);
   }
 
   /**
@@ -161,10 +158,10 @@ public interface ISentryClient {
    * Captures a session. This method transform a session to an envelope and forwards to
    * captureEnvelope
    *
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @param session the Session
    */
-  void captureSession(@NotNull Session session, @Nullable Map<String, Object> hint);
+  void captureSession(@NotNull Session session, @Nullable Hints hints);
 
   /**
    * Captures a session. This method transform a session to an envelope and forwards to
@@ -180,11 +177,11 @@ public interface ISentryClient {
    * Captures an envelope.
    *
    * @param envelope the SentryEnvelope to send.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @Nullable
-  SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint);
+  SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Hints hints);
 
   /**
    * Captures an envelope.
@@ -201,15 +198,13 @@ public interface ISentryClient {
    *
    * @param transaction the {@link ITransaction} to send
    * @param scope An optional scope to be applied to the event.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @NotNull
   default SentryId captureTransaction(
-      @NotNull SentryTransaction transaction,
-      @Nullable Scope scope,
-      @Nullable Map<String, Object> hint) {
-    return captureTransaction(transaction, null, scope, hint);
+      @NotNull SentryTransaction transaction, @Nullable Scope scope, @Nullable Hints hints) {
+    return captureTransaction(transaction, null, scope, hints);
   }
 
   /**
@@ -218,7 +213,7 @@ public interface ISentryClient {
    * @param transaction the {@link ITransaction} to send
    * @param traceState the trace state
    * @param scope An optional scope to be applied to the event.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   @NotNull
@@ -227,8 +222,8 @@ public interface ISentryClient {
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
       @Nullable Scope scope,
-      @Nullable Map<String, Object> hint) {
-    return captureTransaction(transaction, traceState, scope, hint, null);
+      @Nullable Hints hints) {
+    return captureTransaction(transaction, traceState, scope, hints, null);
   }
 
   /**
@@ -237,7 +232,7 @@ public interface ISentryClient {
    * @param transaction the {@link ITransaction} to send
    * @param traceState the trace state
    * @param scope An optional scope to be applied to the event.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @param profilingTraceData An optional profiling trace data captured during the transaction
    * @return The Id (SentryId object) of the event
    */
@@ -247,7 +242,7 @@ public interface ISentryClient {
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
       @Nullable Scope scope,
-      @Nullable Map<String, Object> hint,
+      @Nullable Hints hints,
       @Nullable ProfilingTraceData profilingTraceData);
 
   /**

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -1,11 +1,11 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,8 +27,7 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hints hints) {
     return SentryId.EMPTY_ID;
   }
 
@@ -39,13 +38,12 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @NotNull SentryId captureEnvelope(
-      @NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint) {
+      @NotNull SentryEnvelope envelope, @Nullable Hints hints) {
     return SentryId.EMPTY_ID;
   }
 
   @Override
-  public @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Map<String, Object> hint) {
+  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hints hints) {
     return SentryId.EMPTY_ID;
   }
 
@@ -62,7 +60,7 @@ public final class NoOpHub implements IHub {
   public void close() {}
 
   @Override
-  public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Map<String, Object> hint) {}
+  public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hints hints) {}
 
   @Override
   public void setLevel(@Nullable SentryLevel level) {}
@@ -123,7 +121,7 @@ public final class NoOpHub implements IHub {
   public @NotNull SentryId captureTransaction(
       final @NotNull SentryTransaction transaction,
       final @Nullable TraceState traceState,
-      final @Nullable Map<String, Object> hint,
+      final @Nullable Hints hints,
       final @Nullable ProfilingTraceData profilingTraceData) {
     return SentryId.EMPTY_ID;
   }

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -1,8 +1,8 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,7 +23,7 @@ final class NoOpSentryClient implements ISentryClient {
 
   @Override
   public @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Scope scope, @Nullable Map<String, Object> hint) {
+      @NotNull SentryEvent event, @Nullable Scope scope, @Nullable Hints hints) {
     return SentryId.EMPTY_ID;
   }
 
@@ -37,11 +37,10 @@ final class NoOpSentryClient implements ISentryClient {
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}
 
   @Override
-  public void captureSession(@NotNull Session session, @Nullable Map<String, Object> hint) {}
+  public void captureSession(@NotNull Session session, @Nullable Hints hints) {}
 
   @Override
-  public SentryId captureEnvelope(
-      @NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint) {
+  public SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Hints hints) {
     return SentryId.EMPTY_ID;
   }
 
@@ -50,7 +49,7 @@ final class NoOpSentryClient implements ISentryClient {
       @NotNull SentryTransaction transaction,
       @Nullable TraceState traceState,
       @Nullable Scope scope,
-      @Nullable Map<String, Object> hint,
+      @Nullable Hints hints,
       @Nullable ProfilingTraceData profilingTraceData) {
     return SentryId.EMPTY_ID;
   }

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -4,6 +4,7 @@ import static io.sentry.SentryLevel.ERROR;
 import static io.sentry.cache.EnvelopeCache.PREFIX_CURRENT_SESSION_FILE;
 
 import io.sentry.hints.Flushable;
+import io.sentry.hints.Hints;
 import io.sentry.hints.Resettable;
 import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
@@ -23,7 +24,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,15 +53,13 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
   }
 
   @Override
-  protected void processFile(final @NotNull File file, @Nullable Map<String, Object> hint) {
+  protected void processFile(final @NotNull File file, @NotNull Hints hints) {
     Objects.requireNonNull(file, "File is required.");
 
     if (!isRelevantFileName(file.getName())) {
       logger.log(SentryLevel.DEBUG, "File '%s' should be ignored.", file.getAbsolutePath());
       return;
     }
-
-    Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
 
     try (final InputStream stream = new BufferedInputStream(new FileInputStream(file))) {
       final SentryEnvelope envelope = envelopeReader.read(stream);
@@ -71,25 +69,27 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
             "Stream from path %s resulted in a null envelope.",
             file.getAbsolutePath());
       } else {
-        processEnvelope(envelope, hint);
+        processEnvelope(envelope, hints);
         logger.log(SentryLevel.DEBUG, "File '%s' is done.", file.getAbsolutePath());
       }
     } catch (IOException e) {
       logger.log(SentryLevel.ERROR, "Error processing envelope.", e);
     } finally {
-      if (sentrySdkHint instanceof Retryable) {
-        if (!((Retryable) sentrySdkHint).isRetry()) {
-          try {
-            if (!file.delete()) {
-              logger.log(SentryLevel.ERROR, "Failed to delete: %s", file.getAbsolutePath());
+      HintUtils.runIfHasTypeLogIfNot(
+          hints,
+          Retryable.class,
+          logger,
+          (retryable) -> {
+            if (!retryable.isRetry()) {
+              try {
+                if (!file.delete()) {
+                  logger.log(SentryLevel.ERROR, "Failed to delete: %s", file.getAbsolutePath());
+                }
+              } catch (RuntimeException e) {
+                logger.log(SentryLevel.ERROR, e, "Failed to delete: %s", file.getAbsolutePath());
+              }
             }
-          } catch (RuntimeException e) {
-            logger.log(SentryLevel.ERROR, e, "Failed to delete: %s", file.getAbsolutePath());
-          }
-        }
-      } else {
-        LogUtils.logIfNotRetryable(logger, sentrySdkHint);
-      }
+          });
     }
   }
 
@@ -101,22 +101,19 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
   }
 
   @Override
-  public void processEnvelopeFile(@NotNull String path, @Nullable Map<String, Object> hint) {
+  public void processEnvelopeFile(@NotNull String path, @NotNull Hints hints) {
     Objects.requireNonNull(path, "Path is required.");
 
-    processFile(new File(path), hint);
+    processFile(new File(path), hints);
   }
 
-  private void processEnvelope(
-      final @NotNull SentryEnvelope envelope, final @Nullable Map<String, Object> hint)
+  private void processEnvelope(final @NotNull SentryEnvelope envelope, final @NotNull Hints hints)
       throws IOException {
     logger.log(
         SentryLevel.DEBUG,
         "Processing Envelope with %d item(s)",
         CollectionUtils.size(envelope.getItems()));
     int currentItem = 0;
-
-    Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
 
     for (final SentryEnvelopeItem item : envelope.getItems()) {
       currentItem++;
@@ -138,10 +135,10 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
               logUnexpectedEventId(envelope, event.getEventId(), currentItem);
               continue;
             }
-            hub.captureEvent(event, hint);
+            hub.captureEvent(event, hints);
             logItemCaptured(currentItem);
 
-            if (!waitFlush(sentrySdkHint)) {
+            if (!waitFlush(hints)) {
               logTimeout(event.getEventId());
               break;
             }
@@ -170,10 +167,10 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
               // transient property.
               transaction.getContexts().getTrace().setSampled(true);
             }
-            hub.captureTransaction(transaction, envelope.getHeader().getTrace(), hint);
+            hub.captureTransaction(transaction, envelope.getHeader().getTrace(), hints);
             logItemCaptured(currentItem);
 
-            if (!waitFlush(sentrySdkHint)) {
+            if (!waitFlush(hints)) {
               logTimeout(transaction.getEventId());
               break;
             }
@@ -186,14 +183,14 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
         final SentryEnvelope newEnvelope =
             new SentryEnvelope(
                 envelope.getHeader().getEventId(), envelope.getHeader().getSdkVersion(), item);
-        hub.captureEnvelope(newEnvelope, hint);
+        hub.captureEnvelope(newEnvelope, hints);
         logger.log(
             SentryLevel.DEBUG,
             "%s item %d is being captured.",
             item.getHeader().getType().getItemType(),
             currentItem);
 
-        if (!waitFlush(sentrySdkHint)) {
+        if (!waitFlush(hints)) {
           logger.log(
               SentryLevel.WARNING,
               "Timed out waiting for item type submission: %s",
@@ -202,6 +199,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
         }
       }
 
+      final Object sentrySdkHint = HintUtils.getSentrySdkHint(hints);
       if (sentrySdkHint instanceof SubmissionResult) {
         if (!((SubmissionResult) sentrySdkHint).isSuccess()) {
           // Failed to send an item of the envelope: Stop attempting to send the rest (an attachment
@@ -215,9 +213,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
       }
 
       // reset the Hint to its initial state as we use it multiple times.
-      if (sentrySdkHint instanceof Resettable) {
-        ((Resettable) sentrySdkHint).reset();
-      }
+      HintUtils.runIfHasType(hints, Resettable.class, (resettable) -> resettable.reset());
     }
   }
 
@@ -247,11 +243,12 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
     logger.log(SentryLevel.WARNING, "Timed out waiting for event id submission: %s", eventId);
   }
 
-  private boolean waitFlush(final @Nullable Object sentrySdkHint) {
+  private boolean waitFlush(final @NotNull Hints hints) {
+    @Nullable Object sentrySdkHint = HintUtils.getSentrySdkHint(hints);
     if (sentrySdkHint instanceof Flushable) {
       return ((Flushable) sentrySdkHint).waitFlush();
     } else {
-      LogUtils.logIfNotFlushable(logger, sentrySdkHint);
+      LogUtils.logNotInstanceOf(Flushable.class, sentrySdkHint, logger);
     }
     return true;
   }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.User;
@@ -288,15 +289,15 @@ public final class Scope {
    *
    * @param callback the BeforeBreadcrumb callback
    * @param breadcrumb the breadcrumb
-   * @param hint the hint
+   * @param hints the hints
    * @return the mutated breadcrumb or null if dropped
    */
   private @Nullable Breadcrumb executeBeforeBreadcrumb(
       final @NotNull SentryOptions.BeforeBreadcrumbCallback callback,
       @NotNull Breadcrumb breadcrumb,
-      final @Nullable Map<String, Object> hint) {
+      final @NotNull Hints hints) {
     try {
-      breadcrumb = callback.execute(breadcrumb, hint);
+      breadcrumb = callback.execute(breadcrumb, hints);
     } catch (Throwable e) {
       options
           .getLogger()
@@ -317,17 +318,19 @@ public final class Scope {
    * set
    *
    * @param breadcrumb the breadcrumb
-   * @param hint the hint
+   * @param hints the hint
    */
-  public void addBreadcrumb(
-      @NotNull Breadcrumb breadcrumb, final @Nullable Map<String, Object> hint) {
+  public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hints hints) {
     if (breadcrumb == null) {
       return;
+    }
+    if (hints == null) {
+      hints = new Hints();
     }
 
     SentryOptions.BeforeBreadcrumbCallback callback = options.getBeforeBreadcrumb();
     if (callback != null) {
-      breadcrumb = executeBeforeBreadcrumb(callback, breadcrumb, hint);
+      breadcrumb = executeBeforeBreadcrumb(callback, breadcrumb, hints);
     }
     if (breadcrumb != null) {
       this.breadcrumbs.add(breadcrumb);

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.config.PropertiesProviderFactory;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.util.FileUtils;
@@ -9,7 +10,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -281,12 +281,12 @@ public final class Sentry {
    * Captures the event.
    *
    * @param event the event
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureEvent(
-      final @NotNull SentryEvent event, final @Nullable Map<String, Object> hint) {
-    return getCurrentHub().captureEvent(event, hint);
+      final @NotNull SentryEvent event, final @Nullable Hints hints) {
+    return getCurrentHub().captureEvent(event, hints);
   }
 
   /**
@@ -325,12 +325,12 @@ public final class Sentry {
    * Captures the exception.
    *
    * @param throwable The exception.
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureException(
-      final @NotNull Throwable throwable, final @Nullable Map<String, Object> hint) {
-    return getCurrentHub().captureException(throwable, hint);
+      final @NotNull Throwable throwable, final @Nullable Hints hints) {
+    return getCurrentHub().captureException(throwable, hints);
   }
 
   /**
@@ -346,11 +346,11 @@ public final class Sentry {
    * Adds a breadcrumb to the current Scope
    *
    * @param breadcrumb the breadcrumb
-   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param hints SDK specific but provides high level information about the origin of the event
    */
   public static void addBreadcrumb(
-      final @NotNull Breadcrumb breadcrumb, final @Nullable Map<String, Object> hint) {
-    getCurrentHub().addBreadcrumb(breadcrumb, hint);
+      final @NotNull Breadcrumb breadcrumb, final @Nullable Hints hints) {
+    getCurrentHub().addBreadcrumb(breadcrumb, hints);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -5,6 +5,7 @@ import io.sentry.cache.IEnvelopeCache;
 import io.sentry.clientreport.ClientReportRecorder;
 import io.sentry.clientreport.IClientReportRecorder;
 import io.sentry.clientreport.NoOpClientReportRecorder;
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
@@ -1593,11 +1594,11 @@ public class SentryOptions {
      * Mutates or drop an event before being sent
      *
      * @param event the event
-     * @param hint the hint, usually the source of the event
+     * @param hints the hints
      * @return the original event or the mutated event or null if event was dropped
      */
     @Nullable
-    SentryEvent execute(@NotNull SentryEvent event, @Nullable Map<String, Object> hint);
+    SentryEvent execute(@NotNull SentryEvent event, @NotNull Hints hints);
   }
 
   /** The BeforeBreadcrumb callback */
@@ -1607,11 +1608,11 @@ public class SentryOptions {
      * Mutates or drop a callback before being added
      *
      * @param breadcrumb the breadcrumb
-     * @param hint the hint, usually the source of the breadcrumb
+     * @param hints the hints, usually the source of the breadcrumb
      * @return the original breadcrumb or the mutated breadcrumb of null if breadcrumb was dropped
      */
     @Nullable
-    Breadcrumb execute(@NotNull Breadcrumb breadcrumb, @Nullable Map<String, Object> hint);
+    Breadcrumb execute(@NotNull Breadcrumb breadcrumb, @NotNull Hints hints);
   }
 
   /** The traces sampler callback. */

--- a/sentry/src/main/java/io/sentry/SentryRuntimeEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/SentryRuntimeEventProcessor.java
@@ -1,8 +1,8 @@
 package io.sentry;
 
+import io.sentry.hints.Hints;
 import io.sentry.protocol.SentryRuntime;
 import io.sentry.protocol.SentryTransaction;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,13 +23,13 @@ final class SentryRuntimeEventProcessor implements EventProcessor {
 
   @Override
   public @NotNull SentryEvent process(
-      final @NotNull SentryEvent event, final @Nullable Map<String, Object> hint) {
+      final @NotNull SentryEvent event, final @Nullable Hints hints) {
     return process(event);
   }
 
   @Override
   public @NotNull SentryTransaction process(
-      final @NotNull SentryTransaction transaction, final @Nullable Map<String, Object> hint) {
+      final @NotNull SentryTransaction transaction, final @Nullable Hints hints) {
     return process(transaction);
   }
 

--- a/sentry/src/main/java/io/sentry/TypeCheckHint.java
+++ b/sentry/src/main/java/io/sentry/TypeCheckHint.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import org.jetbrains.annotations.ApiStatus;
 
+// TODO can this be an enum?
 /** Constants used for Type Check hints. */
 public final class TypeCheckHint {
 

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -1,17 +1,16 @@
 package io.sentry;
 
 import static io.sentry.SentryLevel.ERROR;
-import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
 
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.hints.DiskFlushNotification;
 import io.sentry.hints.Flushable;
+import io.sentry.hints.Hints;
 import io.sentry.hints.SessionEnd;
 import io.sentry.protocol.Mechanism;
+import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.Closeable;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
@@ -97,10 +96,9 @@ public final class UncaughtExceptionHandlerIntegration
         final SentryEvent event = new SentryEvent(throwable);
         event.setLevel(SentryLevel.FATAL);
 
-        final Map<String, Object> hintMap = new HashMap<>();
-        hintMap.put(SENTRY_TYPE_CHECK_HINT, hint);
+        final Hints hints = HintUtils.createWithTypeCheckHint(hint);
 
-        hub.captureEvent(event, hintMap);
+        hub.captureEvent(event, hints);
         // Block until the event is flushed to disk
         if (!hint.waitFlush()) {
           options

--- a/sentry/src/main/java/io/sentry/cache/IEnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/IEnvelopeCache.java
@@ -1,16 +1,15 @@
 package io.sentry.cache;
 
 import io.sentry.SentryEnvelope;
-import java.util.Map;
+import io.sentry.hints.Hints;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public interface IEnvelopeCache extends Iterable<SentryEnvelope> {
 
-  void store(@NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint);
+  void store(@NotNull SentryEnvelope envelope, @NotNull Hints hints);
 
   default void store(@NotNull SentryEnvelope envelope) {
-    store(envelope, null);
+    store(envelope, new Hints());
   }
 
   void discard(@NotNull SentryEnvelope envelope);

--- a/sentry/src/main/java/io/sentry/hints/Hints.java
+++ b/sentry/src/main/java/io/sentry/hints/Hints.java
@@ -1,0 +1,29 @@
+package io.sentry.hints;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class Hints {
+
+  private final @NotNull Map<String, Object> internalStorage = new HashMap<String, Object>();
+
+  public void set(@NotNull String hintType, @Nullable Object hint) {
+    internalStorage.put(hintType, hint);
+  }
+
+  public @Nullable Object get(@NotNull String hintType) {
+    return internalStorage.get(hintType);
+  }
+
+  // TODO maybe not public
+  public void remove(@NotNull String hintType) {
+    internalStorage.remove(hintType);
+  }
+
+  // TODO addAttachment(one)
+  // TODO getAttachments(): List
+  // TODO setAttachments(list)
+  // TODO clearAttachments()
+}

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -9,19 +9,18 @@ import io.sentry.cache.IEnvelopeCache;
 import io.sentry.clientreport.DiscardReason;
 import io.sentry.hints.Cached;
 import io.sentry.hints.DiskFlushNotification;
+import io.sentry.hints.Hints;
 import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
 import io.sentry.util.HintUtils;
 import io.sentry.util.LogUtils;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link ITransport} implementation that executes request asynchronously in a blocking manner using
@@ -66,19 +65,18 @@ public final class AsyncHttpTransport implements ITransport {
   }
 
   @Override
-  public void send(final @NotNull SentryEnvelope envelope, final @Nullable Map<String, Object> hint)
+  public void send(final @NotNull SentryEnvelope envelope, final @NotNull Hints hints)
       throws IOException {
     // For now no caching on envelopes
     IEnvelopeCache currentEnvelopeCache = envelopeCache;
     boolean cached = false;
-    Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
-    if (sentrySdkHint instanceof Cached) {
+    if (HintUtils.hasType(hints, Cached.class)) {
       currentEnvelopeCache = NoOpEnvelopeCache.getInstance();
       cached = true;
       options.getLogger().log(SentryLevel.DEBUG, "Captured Envelope is already cached");
     }
 
-    final SentryEnvelope filteredEnvelope = rateLimiter.filter(envelope, sentrySdkHint);
+    final SentryEnvelope filteredEnvelope = rateLimiter.filter(envelope, hints);
 
     if (filteredEnvelope == null) {
       if (cached) {
@@ -86,7 +84,7 @@ public final class AsyncHttpTransport implements ITransport {
       }
     } else {
       SentryEnvelope envelopeThatMayIncludeClientReport;
-      if (sentrySdkHint instanceof DiskFlushNotification) {
+      if (HintUtils.hasType(hints, DiskFlushNotification.class)) {
         envelopeThatMayIncludeClientReport =
             options.getClientReportRecorder().attachReportToEnvelope(filteredEnvelope);
       } else {
@@ -95,7 +93,7 @@ public final class AsyncHttpTransport implements ITransport {
 
       final Future<?> future =
           executor.submit(
-              new EnvelopeSender(envelopeThatMayIncludeClientReport, hint, currentEnvelopeCache));
+              new EnvelopeSender(envelopeThatMayIncludeClientReport, hints, currentEnvelopeCache));
 
       if (future != null && future.isCancelled()) {
         options
@@ -120,12 +118,11 @@ public final class AsyncHttpTransport implements ITransport {
           if (r instanceof EnvelopeSender) {
             final EnvelopeSender envelopeSender = (EnvelopeSender) r;
 
-            Object sentrySdkHint = HintUtils.getSentrySdkHint(envelopeSender.hint);
-            if (!(sentrySdkHint instanceof Cached)) {
-              envelopeCache.store(envelopeSender.envelope, envelopeSender.hint);
+            if (!HintUtils.hasType(envelopeSender.hints, Cached.class)) {
+              envelopeCache.store(envelopeSender.envelope, envelopeSender.hints);
             }
 
-            markHintWhenSendingFailed(sentrySdkHint, true);
+            markHintWhenSendingFailed(envelopeSender.hints, true);
             logger.log(SentryLevel.WARNING, "Envelope rejected");
           }
         };
@@ -159,17 +156,12 @@ public final class AsyncHttpTransport implements ITransport {
   /**
    * It marks the hints when sending has failed, so it's not necessary to wait the timeout
    *
-   * @param sentrySdkHint the Hint
+   * @param hints the Hints
    * @param retry if event should be retried or not
    */
-  private static void markHintWhenSendingFailed(
-      final @Nullable Object sentrySdkHint, final boolean retry) {
-    if (sentrySdkHint instanceof SubmissionResult) {
-      ((SubmissionResult) sentrySdkHint).setResult(false);
-    }
-    if (sentrySdkHint instanceof Retryable) {
-      ((Retryable) sentrySdkHint).setRetry(retry);
-    }
+  private static void markHintWhenSendingFailed(final @NotNull Hints hints, final boolean retry) {
+    HintUtils.runIfHasType(hints, SubmissionResult.class, result -> result.setResult(false));
+    HintUtils.runIfHasType(hints, Retryable.class, retryable -> retryable.setRetry(retry));
   }
 
   private static final class AsyncConnectionThreadFactory implements ThreadFactory {
@@ -185,16 +177,16 @@ public final class AsyncHttpTransport implements ITransport {
 
   private final class EnvelopeSender implements Runnable {
     private final @NotNull SentryEnvelope envelope;
-    private final @Nullable Map<String, Object> hint;
+    private final @NotNull Hints hints;
     private final @NotNull IEnvelopeCache envelopeCache;
     private final TransportResult failedResult = TransportResult.error();
 
     EnvelopeSender(
         final @NotNull SentryEnvelope envelope,
-        final @Nullable Map<String, Object> hint,
+        final @NotNull Hints hints,
         final @NotNull IEnvelopeCache envelopeCache) {
       this.envelope = Objects.requireNonNull(envelope, "Envelope is required.");
-      this.hint = hint;
+      this.hints = hints;
       this.envelopeCache = Objects.requireNonNull(envelopeCache, "EnvelopeCache is required.");
     }
 
@@ -208,26 +200,34 @@ public final class AsyncHttpTransport implements ITransport {
         options.getLogger().log(SentryLevel.ERROR, e, "Envelope submission failed");
         throw e;
       } finally {
-        Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
-        if (sentrySdkHint instanceof SubmissionResult) {
-          options
-              .getLogger()
-              .log(SentryLevel.DEBUG, "Marking envelope submission result: %s", result.isSuccess());
-          ((SubmissionResult) sentrySdkHint).setResult(result.isSuccess());
-        }
+        final TransportResult finalResult = result;
+        HintUtils.runIfHasType(
+            hints,
+            SubmissionResult.class,
+            (submissionResult) -> {
+              options
+                  .getLogger()
+                  .log(
+                      SentryLevel.DEBUG,
+                      "Marking envelope submission result: %s",
+                      finalResult.isSuccess());
+              submissionResult.setResult(finalResult.isSuccess());
+            });
       }
     }
 
     private @NotNull TransportResult flush() {
       TransportResult result = this.failedResult;
 
-      envelopeCache.store(envelope, hint);
+      envelopeCache.store(envelope, hints);
 
-      Object sentrySdkHint = HintUtils.getSentrySdkHint(hint);
-      if (sentrySdkHint instanceof DiskFlushNotification) {
-        ((DiskFlushNotification) sentrySdkHint).markFlushed();
-        options.getLogger().log(SentryLevel.DEBUG, "Disk flush envelope fired");
-      }
+      HintUtils.runIfHasType(
+          hints,
+          DiskFlushNotification.class,
+          (diskFlushNotification) -> {
+            diskFlushNotification.markFlushed();
+            options.getLogger().log(SentryLevel.DEBUG, "Disk flush envelope fired");
+          });
 
       if (transportGate.isConnected()) {
         final SentryEnvelope envelopeWithClientReport =
@@ -245,37 +245,48 @@ public final class AsyncHttpTransport implements ITransport {
 
             // ignore e.g. 429 as we're not the ones actively dropping
             if (result.getResponseCode() >= 400 && result.getResponseCode() != 429) {
-              if (!(sentrySdkHint instanceof Retryable)) {
-                options
-                    .getClientReportRecorder()
-                    .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelopeWithClientReport);
-              }
+              HintUtils.runIfDoesNotHaveType(
+                  hints,
+                  Retryable.class,
+                  (hint) -> {
+                    options
+                        .getClientReportRecorder()
+                        .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelopeWithClientReport);
+                  });
             }
 
             throw new IllegalStateException(message);
           }
         } catch (IOException e) {
           // Failure due to IO is allowed to retry the event
-          if (sentrySdkHint instanceof Retryable) {
-            ((Retryable) sentrySdkHint).setRetry(true);
-          } else {
-            LogUtils.logIfNotRetryable(options.getLogger(), sentrySdkHint);
-            options
-                .getClientReportRecorder()
-                .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelopeWithClientReport);
-          }
+          HintUtils.runIfHasType(
+              hints,
+              Retryable.class,
+              (retryable) -> {
+                retryable.setRetry(true);
+              },
+              (hint, clazz) -> {
+                LogUtils.logNotInstanceOf(clazz, hint, options.getLogger());
+                options
+                    .getClientReportRecorder()
+                    .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelopeWithClientReport);
+              });
           throw new IllegalStateException("Sending the event failed.", e);
         }
       } else {
         // If transportGate is blocking from sending, allowed to retry
-        if (sentrySdkHint instanceof Retryable) {
-          ((Retryable) sentrySdkHint).setRetry(true);
-        } else {
-          LogUtils.logIfNotRetryable(options.getLogger(), sentrySdkHint);
-          options
-              .getClientReportRecorder()
-              .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope);
-        }
+        HintUtils.runIfHasType(
+            hints,
+            Retryable.class,
+            (retryable) -> {
+              retryable.setRetry(true);
+            },
+            (hint, clazz) -> {
+              LogUtils.logNotInstanceOf(clazz, hint, options.getLogger());
+              options
+                  .getClientReportRecorder()
+                  .recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope);
+            });
       }
       return result;
     }

--- a/sentry/src/main/java/io/sentry/transport/ITransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ITransport.java
@@ -1,19 +1,17 @@
 package io.sentry.transport;
 
 import io.sentry.SentryEnvelope;
+import io.sentry.hints.Hints;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /** A transport is in charge of sending the event to the Sentry server. */
 public interface ITransport extends Closeable {
-  void send(@NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint)
-      throws IOException;
+  void send(@NotNull SentryEnvelope envelope, @NotNull Hints hints) throws IOException;
 
   default void send(@NotNull SentryEnvelope envelope) throws IOException {
-    send(envelope, null);
+    send(envelope, new Hints());
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/transport/NoOpEnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/transport/NoOpEnvelopeCache.java
@@ -2,11 +2,10 @@ package io.sentry.transport;
 
 import io.sentry.SentryEnvelope;
 import io.sentry.cache.IEnvelopeCache;
+import io.sentry.hints.Hints;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class NoOpEnvelopeCache implements IEnvelopeCache {
   private static final NoOpEnvelopeCache instance = new NoOpEnvelopeCache();
@@ -16,7 +15,7 @@ public final class NoOpEnvelopeCache implements IEnvelopeCache {
   }
 
   @Override
-  public void store(@NotNull SentryEnvelope envelope, @Nullable Map<String, Object> hint) {}
+  public void store(@NotNull SentryEnvelope envelope, @NotNull Hints hints) {}
 
   @Override
   public void discard(@NotNull SentryEnvelope envelope) {}

--- a/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
@@ -1,11 +1,10 @@
 package io.sentry.transport;
 
 import io.sentry.SentryEnvelope;
+import io.sentry.hints.Hints;
 import java.io.IOException;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class NoOpTransport implements ITransport {
@@ -19,7 +18,7 @@ public final class NoOpTransport implements ITransport {
   private NoOpTransport() {}
 
   @Override
-  public void send(final @NotNull SentryEnvelope envelope, final @Nullable Map<String, Object> hint)
+  public void send(final @NotNull SentryEnvelope envelope, final @NotNull Hints hints)
       throws IOException {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
@@ -2,11 +2,10 @@ package io.sentry.transport;
 
 import io.sentry.ISerializer;
 import io.sentry.SentryEnvelope;
+import io.sentry.hints.Hints;
 import io.sentry.util.Objects;
 import java.io.IOException;
-import java.util.Map;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class StdoutTransport implements ITransport {
 
@@ -17,7 +16,7 @@ public final class StdoutTransport implements ITransport {
   }
 
   @Override
-  public void send(final @NotNull SentryEnvelope envelope, final @Nullable Map<String, Object> hint)
+  public void send(final @NotNull SentryEnvelope envelope, final @NotNull Hints hints)
       throws IOException {
     Objects.requireNonNull(envelope, "SentryEnvelope is required");
 

--- a/sentry/src/main/java/io/sentry/util/HintUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HintUtils.java
@@ -2,10 +2,12 @@ package io.sentry.util;
 
 import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
 
+import io.sentry.ILogger;
 import io.sentry.hints.ApplyScopeData;
 import io.sentry.hints.Cached;
-import java.util.Map;
+import io.sentry.hints.Hints;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Util class for Applying or not scope's data to an event */
@@ -14,22 +16,97 @@ public final class HintUtils {
 
   private HintUtils() {}
 
+  @ApiStatus.Internal
+  public static Hints createWithTypeCheckHint(Object hint) {
+    Hints hints = new Hints();
+    setTypeCheckHint(hints, hint);
+    return hints;
+  }
+
+  @ApiStatus.Internal
+  public static void setTypeCheckHint(@NotNull Hints hints, Object hint) {
+    hints.set(SENTRY_TYPE_CHECK_HINT, hint);
+  }
+
+  @ApiStatus.Internal
+  public static @Nullable Object getSentrySdkHint(@NotNull Hints hints) {
+    return hints.get(SENTRY_TYPE_CHECK_HINT);
+  }
+
+  @ApiStatus.Internal
+  public static boolean hasType(@NotNull Hints hints, @NotNull Class<?> clazz) {
+    final Object sentrySdkHint = getSentrySdkHint(hints);
+    return clazz.isInstance(sentrySdkHint);
+  }
+
+  @ApiStatus.Internal
+  public static <T> void runIfDoesNotHaveType(
+      @NotNull Hints hints, @NotNull Class<T> clazz, SentryNullableConsumer<Object> lambda) {
+    runIfHasType(
+        hints,
+        clazz,
+        (ignored) -> {},
+        (hint, clazz2) -> {
+          lambda.accept(hint);
+        });
+  }
+
+  @ApiStatus.Internal
+  public static <T> void runIfHasType(
+      @NotNull Hints hints, @NotNull Class<T> clazz, SentryConsumer<T> lambda) {
+    runIfHasType(hints, clazz, lambda, (hint, clazz2) -> {});
+  }
+
+  @ApiStatus.Internal
+  public static <T> void runIfHasTypeLogIfNot(
+      @NotNull Hints hints, @NotNull Class<T> clazz, ILogger logger, SentryConsumer<T> lambda) {
+    runIfHasType(
+        hints,
+        clazz,
+        lambda,
+        (sentrySdkHint, expectedClass) -> {
+          LogUtils.logNotInstanceOf(expectedClass, sentrySdkHint, logger);
+        });
+  }
+
+  @SuppressWarnings("unchecked")
+  @ApiStatus.Internal
+  public static <T> void runIfHasType(
+      @NotNull Hints hints,
+      @NotNull Class<T> clazz,
+      SentryConsumer<T> lambda,
+      SentryFallbackConsumer fallbackLambda) {
+    Object sentrySdkHint = getSentrySdkHint(hints);
+    if (hasType(hints, clazz) && sentrySdkHint != null) {
+      lambda.accept((T) sentrySdkHint);
+    } else {
+      fallbackLambda.accept(sentrySdkHint, clazz);
+    }
+  }
+
   /**
    * Scope's data should be applied if: Hint is of the type ApplyScopeData or Hint is not Cached
    * (this includes a null hint)
    *
-   * @param hint the hint
    * @return true if it should apply scope's data or false otherwise
    */
-  public static boolean shouldApplyScopeData(final @Nullable Map<String, Object> hint) {
-    Object SentrySdkHint = getSentrySdkHint(hint);
-    return (!(SentrySdkHint instanceof Cached) || (SentrySdkHint instanceof ApplyScopeData));
+  @ApiStatus.Internal
+  public static boolean shouldApplyScopeData(@NotNull Hints hints) {
+    return !hasType(hints, Cached.class) || hasType(hints, ApplyScopeData.class);
   }
 
-  public static @Nullable Object getSentrySdkHint(final @Nullable Map<String, Object> hint) {
-    if (hint == null) {
-      return null;
-    }
-    return hint.get(SENTRY_TYPE_CHECK_HINT);
+  @FunctionalInterface
+  public interface SentryConsumer<T> {
+    void accept(@NotNull T t);
+  }
+
+  @FunctionalInterface
+  public interface SentryNullableConsumer<T> {
+    void accept(@Nullable T t);
+  }
+
+  @FunctionalInterface
+  public interface SentryFallbackConsumer {
+    void accept(@Nullable Object sentrySdkHint, @NotNull Class<?> clazz);
   }
 }

--- a/sentry/src/main/java/io/sentry/util/LogUtils.java
+++ b/sentry/src/main/java/io/sentry/util/LogUtils.java
@@ -9,19 +9,30 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class LogUtils {
 
-  public static void logIfNotFlushable(
-      final @NotNull ILogger logger, final @Nullable Object sentrySdkHint) {
+  public static void logNotInstanceOf(
+      final @NotNull Class<?> expectedClass,
+      final @Nullable Object sentrySdkHint,
+      final @NotNull ILogger logger) {
     logger.log(
         SentryLevel.DEBUG,
-        "%s is not Flushable",
-        sentrySdkHint != null ? sentrySdkHint.getClass().getCanonicalName() : "Hint");
+        "%s is not %s",
+        sentrySdkHint != null ? sentrySdkHint.getClass().getCanonicalName() : "Hint",
+        expectedClass.getCanonicalName());
   }
 
-  public static void logIfNotRetryable(
-      final @NotNull ILogger logger, final @Nullable Object sentrySdkHint) {
-    logger.log(
-        SentryLevel.DEBUG,
-        "%s is not Retryable",
-        sentrySdkHint != null ? sentrySdkHint.getClass().getCanonicalName() : "Hint");
-  }
+  //  public static void logIfNotFlushable(
+  //      final @NotNull ILogger logger, final @Nullable Object sentrySdkHint) {
+  //    logger.log(
+  //        SentryLevel.DEBUG,
+  //        "%s is not Flushable",
+  //        sentrySdkHint != null ? sentrySdkHint.getClass().getCanonicalName() : "Hint");
+  //  }
+  //
+  //  public static void logIfNotRetryable(
+  //      final @NotNull ILogger logger, final @Nullable Object sentrySdkHint) {
+  //    logger.log(
+  //        SentryLevel.DEBUG,
+  //        "%s is not Retryable",
+  //        sentrySdkHint != null ? sentrySdkHint.getClass().getCanonicalName() : "Hint");
+  //  }
 }

--- a/sentry/src/test/java/io/sentry/CustomEventProcessor.kt
+++ b/sentry/src/test/java/io/sentry/CustomEventProcessor.kt
@@ -1,5 +1,7 @@
 package io.sentry
 
+import io.sentry.hints.Hints
+
 class CustomEventProcessor : EventProcessor {
-    override fun process(event: SentryEvent, hint: Map<String, Any?>?): SentryEvent? = null
+    override fun process(event: SentryEvent, hints: Hints): SentryEvent? = null
 }

--- a/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.hints.ApplyScopeData
 import io.sentry.protocol.User
+import io.sentry.util.HintUtils
 import io.sentry.util.noFlushTimeout
 import java.io.File
 import java.nio.file.Files
@@ -66,7 +67,7 @@ class DirectoryProcessorTest {
         whenever(fixture.serializer.deserialize(any(), eq(SentryEvent::class.java))).thenReturn(event)
 
         fixture.getSut().processDirectory(file)
-        verify(fixture.hub).captureEvent(any(), argWhere { it !is ApplyScopeData })
+        verify(fixture.hub).captureEvent(any(), argWhere { !HintUtils.hasType(it, ApplyScopeData::class.java) })
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DuplicateEventDetectionEventProcessorTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import io.sentry.exception.ExceptionMechanismException
+import io.sentry.hints.Hints
 import io.sentry.protocol.Mechanism
 import java.lang.RuntimeException
 import kotlin.test.Test
@@ -25,9 +26,9 @@ class DuplicateEventDetectionEventProcessorTest {
     @Test
     fun `does not drop event if no previous event with same exception was processed`() {
         val processor = fixture.getSut()
-        processor.process(SentryEvent(), null)
+        processor.process(SentryEvent(), Hints())
 
-        val result = processor.process(SentryEvent(RuntimeException()), null)
+        val result = processor.process(SentryEvent(RuntimeException()), Hints())
 
         assertNotNull(result)
     }
@@ -36,9 +37,9 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `drops event with the same exception`() {
         val processor = fixture.getSut()
         val event = SentryEvent(RuntimeException())
-        processor.process(event, null)
+        processor.process(event, Hints())
 
-        val result = processor.process(event, null)
+        val result = processor.process(event, Hints())
         assertNull(result)
     }
 
@@ -46,9 +47,9 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `drops event with mechanism exception having an exception that has already been processed`() {
         val processor = fixture.getSut()
         val event = SentryEvent(RuntimeException())
-        processor.process(event, null)
+        processor.process(event, Hints())
 
-        val result = processor.process(SentryEvent(ExceptionMechanismException(Mechanism(), event.throwable!!, Thread.currentThread())), null)
+        val result = processor.process(SentryEvent(ExceptionMechanismException(Mechanism(), event.throwable!!, Thread.currentThread())), Hints())
         assertNull(result)
     }
 
@@ -56,9 +57,9 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `drops event with exception that has already been processed with event with mechanism exception`() {
         val processor = fixture.getSut()
         val sentryEvent = SentryEvent(ExceptionMechanismException(Mechanism(), RuntimeException(), Thread.currentThread()))
-        processor.process(sentryEvent, null)
+        processor.process(sentryEvent, Hints())
 
-        val result = processor.process(SentryEvent((sentryEvent.throwable as ExceptionMechanismException).throwable), null)
+        val result = processor.process(SentryEvent((sentryEvent.throwable as ExceptionMechanismException).throwable), Hints())
 
         assertNull(result)
     }
@@ -67,9 +68,9 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `drops event with the cause equal to exception in already processed event`() {
         val processor = fixture.getSut()
         val event = SentryEvent(RuntimeException())
-        processor.process(event, null)
+        processor.process(event, Hints())
 
-        val result = processor.process(SentryEvent(RuntimeException(event.throwable)), null)
+        val result = processor.process(SentryEvent(RuntimeException(event.throwable)), Hints())
 
         assertNull(result)
     }
@@ -78,9 +79,9 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `drops event with any of the causes has been already processed`() {
         val processor = fixture.getSut()
         val event = SentryEvent(RuntimeException())
-        processor.process(event, null)
+        processor.process(event, Hints())
 
-        val result = processor.process(SentryEvent(RuntimeException(RuntimeException(event.throwable))), null)
+        val result = processor.process(SentryEvent(RuntimeException(RuntimeException(event.throwable))), Hints())
 
         assertNull(result)
     }
@@ -89,7 +90,7 @@ class DuplicateEventDetectionEventProcessorTest {
     fun `does not deduplicate is deduplication is disabled`() {
         val processor = fixture.getSut(enableDeduplication = false)
         val event = SentryEvent(RuntimeException())
-        assertNotNull(processor.process(event, null))
-        assertNotNull(processor.process(event, null))
+        assertNotNull(processor.process(event, Hints()))
+        assertNotNull(processor.process(event, Hints()))
     }
 }

--- a/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
@@ -7,9 +7,10 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.cache.EnvelopeCache
+import io.sentry.hints.Hints
 import io.sentry.hints.Retryable
+import io.sentry.util.HintUtils
 import io.sentry.util.noFlushTimeout
 import java.io.File
 import java.nio.file.Files
@@ -97,8 +98,8 @@ class EnvelopeSenderTest {
         val testFile = File(Files.createTempFile(tempDirectory, "send-cached-event-test", EnvelopeCache.SUFFIX_ENVELOPE_FILE).toUri())
         testFile.deleteOnExit()
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processFile(testFile, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processFile(testFile, hints)
         verify(fixture.logger)!!.log(eq(SentryLevel.ERROR), eq(expected), eq("Failed to capture cached envelope %s"), eq(testFile.absolutePath))
         verifyNoMoreInteractions(fixture.hub)
         assertFalse(testFile.exists())
@@ -111,7 +112,7 @@ class EnvelopeSenderTest {
         val sut = fixture.getSut()
         val testFile = File(Files.createTempFile(tempDirectory, "send-cached-event-test", EnvelopeCache.SUFFIX_ENVELOPE_FILE).toUri())
         testFile.deleteOnExit()
-        sut.processFile(testFile, any())
+        sut.processFile(testFile, Hints())
         verify(fixture.logger)!!.log(eq(SentryLevel.ERROR), eq(expected), eq("Failed to capture cached envelope %s"), eq(testFile.absolutePath))
         verifyNoMoreInteractions(fixture.hub)
     }

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -14,11 +14,11 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.cache.EnvelopeCache
 import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
+import io.sentry.hints.Hints
 import io.sentry.hints.SessionEndHint
 import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
@@ -265,7 +265,7 @@ class HubTest {
         sut.close()
 
         sut.captureEvent(SentryEvent())
-        verify(mockClient, never()).captureEvent(any(), any<Map<String, Any?>>())
+        verify(mockClient, never()).captureEvent(any(), any<Hints>())
     }
 
     @Test
@@ -273,9 +273,9 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         val event = SentryEvent()
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
 
     @Test
@@ -283,11 +283,11 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
         whenever(mockClient.captureEvent(any(), any(), anyOrNull())).thenReturn(SentryId(UUID.randomUUID()))
         val event = SentryEvent()
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         val lastEventId = sut.lastEventId
         sut.close()
-        sut.captureEvent(event, hintsMap)
+        sut.captureEvent(event, hints)
         assertEquals(lastEventId, sut.lastEventId)
     }
 
@@ -296,9 +296,9 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         val event = SentryEvent()
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
         verify(mockClient, never()).captureSession(any(), any())
     }
 
@@ -307,9 +307,9 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         val event = SentryEvent()
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
         verify(mockClient, never()).captureSession(any(), any())
     }
 
@@ -323,10 +323,10 @@ class HubTest {
 
         val event = SentryEvent(exception)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         assertEquals(span.spanContext, event.contexts.trace)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
 
     @Test
@@ -339,10 +339,10 @@ class HubTest {
 
         val event = SentryEvent(RuntimeException(rootCause))
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         assertEquals(span.spanContext, event.contexts.trace)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
 
     @Test
@@ -356,10 +356,10 @@ class HubTest {
 
         val event = SentryEvent(RuntimeException(exceptionAssignedToSpan))
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         assertEquals(span.spanContext, event.contexts.trace)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
 
     @Test
@@ -374,10 +374,10 @@ class HubTest {
         val originalSpanContext = SpanContext("op")
         event.contexts.trace = originalSpanContext
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         assertEquals(originalSpanContext, event.contexts.trace)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
 
     @Test
@@ -386,10 +386,10 @@ class HubTest {
 
         val event = SentryEvent(RuntimeException())
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to { })
-        sut.captureEvent(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureEvent(event, hints)
         assertNull(event.contexts.trace)
-        verify(mockClient).captureEvent(eq(event), any(), eq(hintsMap))
+        verify(mockClient).captureEvent(eq(event), any(), eq(hints))
     }
     //endregion
 
@@ -455,8 +455,8 @@ class HubTest {
     fun `when captureException is called with a valid argument and hint, captureEvent on the client should be called`() {
         val (sut, mockClient) = getEnabledHub()
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to Object())
-        sut.captureException(Throwable(), hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint({})
+        sut.captureException(Throwable(), hints)
         verify(mockClient).captureEvent(any(), any(), any())
     }
 
@@ -973,7 +973,7 @@ class HubTest {
         sut.bindClient(mockClient)
 
         sut.startSession()
-        verify(mockClient).captureSession(any(), argWhere { HintUtils.getSentrySdkHint(it) is SessionStartHint })
+        verify(mockClient).captureSession(any(), argWhere { HintUtils.hasType(it, SessionStartHint::class.java) })
     }
 
     @Test
@@ -989,8 +989,8 @@ class HubTest {
 
         sut.startSession()
         sut.startSession()
-        verify(mockClient).captureSession(any(), argWhere { HintUtils.getSentrySdkHint(it) is SessionEndHint })
-        verify(mockClient, times(2)).captureSession(any(), argWhere { HintUtils.getSentrySdkHint(it) is SessionStartHint })
+        verify(mockClient).captureSession(any(), argWhere { HintUtils.hasType(it, SessionEndHint::class.java) })
+        verify(mockClient, times(2)).captureSession(any(), argWhere { HintUtils.hasType(it, SessionStartHint::class.java) })
     }
     //endregion
 
@@ -1039,8 +1039,8 @@ class HubTest {
 
         sut.startSession()
         sut.endSession()
-        verify(mockClient).captureSession(any(), argWhere { HintUtils.getSentrySdkHint(it) is SessionStartHint })
-        verify(mockClient).captureSession(any(), argWhere { HintUtils.getSentrySdkHint(it) is SessionEndHint })
+        verify(mockClient).captureSession(any(), argWhere { HintUtils.hasType(it, SessionStartHint::class.java) })
+        verify(mockClient).captureSession(any(), argWhere { HintUtils.hasType(it, SessionEndHint::class.java) })
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -5,12 +5,13 @@ import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.hints.ApplyScopeData
+import io.sentry.hints.Hints
 import io.sentry.protocol.DebugMeta
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.util.HintUtils
 import org.awaitility.kotlin.await
 import java.lang.RuntimeException
 import java.net.InetAddress
@@ -64,7 +65,7 @@ class MainEventProcessorTest {
 
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.exceptions) {
             assertSame(crashedThread.id, it.first().threadId)
@@ -85,7 +86,7 @@ class MainEventProcessorTest {
 
         val crashedThread = Thread()
         var event = generateCrashedEvent(crashedThread)
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.threads) { threads ->
             assertTrue(threads.any { it.isCrashed == true })
@@ -97,7 +98,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut()
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertEquals("release", event.release)
         assertEquals("environment", event.environment)
@@ -113,8 +114,8 @@ class MainEventProcessorTest {
         val sut = fixture.getSut()
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<ApplyScopeData>())
-        event = sut.process(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<ApplyScopeData>())
+        event = sut.process(event, hints)
 
         assertEquals("release", event.release)
         assertEquals("environment", event.environment)
@@ -134,7 +135,7 @@ class MainEventProcessorTest {
         event.release = "eventRelease"
         event.serverName = "eventServerName"
 
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertEquals("eventRelease", event.release)
         assertEquals("eventEnvironment", event.environment)
@@ -148,8 +149,8 @@ class MainEventProcessorTest {
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        event = sut.process(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        event = sut.process(event, hints)
 
         assertNull(event.release)
         assertNull(event.environment)
@@ -164,8 +165,8 @@ class MainEventProcessorTest {
         val crashedThread = Thread.currentThread()
         var event = generateCrashedEvent(crashedThread)
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CustomCachedApplyScopeDataHint())
-        event = sut.process(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CustomCachedApplyScopeDataHint())
+        event = sut.process(event, hints)
 
         assertEquals("release", event.release)
         assertEquals("environment", event.environment)
@@ -181,7 +182,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(attachThreads = false, attachStackTrace = false)
 
         var event = SentryEvent()
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNull(event.threads)
     }
@@ -191,7 +192,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut()
 
         var event = SentryEvent()
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.threads)
     }
@@ -201,7 +202,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(attachThreads = false, attachStackTrace = true)
 
         var event = SentryEvent()
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.threads) {
             assertEquals(1, it.count())
@@ -213,7 +214,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(attachThreads = false, attachStackTrace = true)
 
         var event = SentryEvent(RuntimeException("error"))
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNull(event.threads)
     }
@@ -222,7 +223,7 @@ class MainEventProcessorTest {
     fun `sets sdkVersion in the event`() {
         val sut = fixture.getSut()
         val event = SentryEvent()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.sdk) {
             assertEquals(it.name, "test")
             assertEquals(it.version, "1.2.3")
@@ -233,7 +234,7 @@ class MainEventProcessorTest {
     fun `when event and SentryOptions do not have environment set, sets production as environment`() {
         val sut = fixture.getSut(environment = null)
         val event = SentryEvent()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertEquals("production", event.environment)
     }
 
@@ -241,7 +242,7 @@ class MainEventProcessorTest {
     fun `when event does not have ip address set and sendDefaultPii is set to true, sets {{auto}} as the ip address`() {
         val sut = fixture.getSut(sendDefaultPii = true)
         val event = SentryEvent()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.user) {
             assertEquals("{{auto}}", it.ipAddress)
         }
@@ -254,7 +255,7 @@ class MainEventProcessorTest {
         event.user = User().apply {
             ipAddress = "192.168.0.1"
         }
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.user) {
             assertEquals("192.168.0.1", it.ipAddress)
         }
@@ -265,7 +266,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(sendDefaultPii = false)
         val event = SentryEvent()
         event.user = User()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.user) {
             assertNull(it.ipAddress)
         }
@@ -276,7 +277,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(environment = null)
         val event = SentryEvent()
         event.environment = "staging"
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertEquals("staging", event.environment)
     }
 
@@ -284,7 +285,7 @@ class MainEventProcessorTest {
     fun `when event does not have environment set and SentryOptions have environment set, uses environment from SentryOptions`() {
         val sut = fixture.getSut(environment = "custom")
         val event = SentryEvent()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertEquals("custom", event.environment)
     }
 
@@ -292,7 +293,7 @@ class MainEventProcessorTest {
     fun `sets tags from SentryOptions`() {
         val sut = fixture.getSut(tags = mapOf("tag1" to "value1", "tag2" to "value2"))
         val event = SentryEvent()
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.tags) {
             assertEquals("value1", it["tag1"])
             assertEquals("value2", it["tag2"])
@@ -304,7 +305,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(tags = mapOf("tag1" to "value1", "tag2" to "value2"))
         val event = SentryEvent()
         event.setTag("tag2", "event-tag-value")
-        sut.process(event, null)
+        sut.process(event, Hints())
         assertNotNull(event.tags) {
             assertEquals("value1", it["tag1"])
             assertEquals("event-tag-value", it["tag2"])
@@ -315,7 +316,7 @@ class MainEventProcessorTest {
     fun `sets servername retrieved from the local address`() {
         val processor = fixture.getSut(serverName = null, host = "aHost")
         val event = SentryEvent()
-        processor.process(event, null)
+        processor.process(event, Hints())
         assertEquals("aHost", event.serverName)
     }
 
@@ -323,7 +324,7 @@ class MainEventProcessorTest {
     fun `sets servername to null if retrieving takes longer time`() {
         val processor = fixture.getSut(serverName = null, host = "aHost", resolveHostDelay = 2000)
         val event = SentryEvent()
-        processor.process(event, null)
+        processor.process(event, Hints())
         assertNull(event.serverName)
     }
 
@@ -331,10 +332,10 @@ class MainEventProcessorTest {
     fun `uses cache to retrieve servername for subsequent events`() {
         val processor = fixture.getSut(serverName = null, host = "aHost", hostnameCacheDuration = 1000)
         val firstEvent = SentryEvent()
-        processor.process(firstEvent, null)
+        processor.process(firstEvent, Hints())
         assertEquals("aHost", firstEvent.serverName)
         val secondEvent = SentryEvent()
-        processor.process(secondEvent, null)
+        processor.process(secondEvent, Hints())
         assertEquals("aHost", secondEvent.serverName)
         verify(fixture.getLocalhost, times(1)).canonicalHostName
     }
@@ -343,7 +344,7 @@ class MainEventProcessorTest {
     fun `when cache expires, retrieves new host name from the local address`() {
         val processor = fixture.getSut(serverName = null, host = "aHost")
         val firstEvent = SentryEvent()
-        processor.process(firstEvent, null)
+        processor.process(firstEvent, Hints())
         assertEquals("aHost", firstEvent.serverName)
 
         reset(fixture.getLocalhost)
@@ -351,7 +352,7 @@ class MainEventProcessorTest {
 
         await.untilAsserted {
             val secondEvent = SentryEvent()
-            processor.process(secondEvent, null)
+            processor.process(secondEvent, Hints())
             assertEquals("newHost", secondEvent.serverName)
         }
     }
@@ -361,7 +362,7 @@ class MainEventProcessorTest {
         val processor = fixture.getSut(serverName = null, host = "aHost")
         val event = SentryEvent()
         event.serverName = "eventHost"
-        processor.process(event, null)
+        processor.process(event, Hints())
         assertEquals("eventHost", event.serverName)
     }
 
@@ -369,7 +370,7 @@ class MainEventProcessorTest {
     fun `does not set serverName on events if serverName is set on SentryOptions`() {
         val processor = fixture.getSut(serverName = "optionsHost", host = "aHost")
         val event = SentryEvent()
-        processor.process(event, null)
+        processor.process(event, Hints())
         assertEquals("optionsHost", event.serverName)
     }
 
@@ -378,7 +379,7 @@ class MainEventProcessorTest {
         val processor = fixture.getSut(serverName = "optionsHost")
 
         var transaction = SentryTransaction(fixture.sentryTracer)
-        transaction = processor.process(transaction, null)
+        transaction = processor.process(transaction, Hints())
 
         assertEquals("optionsHost", transaction.serverName)
     }
@@ -388,7 +389,7 @@ class MainEventProcessorTest {
         val processor = fixture.getSut()
 
         var transaction = SentryTransaction(fixture.sentryTracer)
-        transaction = processor.process(transaction, null)
+        transaction = processor.process(transaction, Hints())
 
         assertEquals("dist", transaction.dist)
     }
@@ -398,7 +399,7 @@ class MainEventProcessorTest {
         val processor = fixture.getSut(sendDefaultPii = true)
 
         var transaction = SentryTransaction(fixture.sentryTracer)
-        transaction = processor.process(transaction, null)
+        transaction = processor.process(transaction, Hints())
 
         assertNotNull(transaction.user)
     }
@@ -409,8 +410,8 @@ class MainEventProcessorTest {
 
         var event = SentryEvent()
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CustomCachedApplyScopeDataHint())
-        event = sut.process(event, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CustomCachedApplyScopeDataHint())
+        event = sut.process(event, hints)
 
         assertNull(event.threads)
     }
@@ -420,7 +421,7 @@ class MainEventProcessorTest {
         val sut = fixture.getSut(proguardUuid = "id1")
 
         var event = SentryEvent()
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.debugMeta) {
             assertNotNull(it.images) { images ->
@@ -436,7 +437,7 @@ class MainEventProcessorTest {
 
         var event = SentryEvent()
         event.debugMeta = DebugMeta()
-        event = sut.process(event, null)
+        event = sut.process(event, Hints())
 
         assertNotNull(event.debugMeta) {
             assertNotNull(it.images) { images ->

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import com.nhaarman.mockitokotlin2.mock
+import io.sentry.hints.Hints
 import io.sentry.protocol.SentryId
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,7 +30,7 @@ class NoOpHubTest {
 
     @Test
     fun `captureTransaction returns empty SentryId`() =
-        assertEquals(SentryId.EMPTY_ID, sut.captureTransaction(mock(), mock<Map<String, Any>>()))
+        assertEquals(SentryId.EMPTY_ID, sut.captureTransaction(mock(), mock<Hints>()))
 
     @Test
     fun `captureException returns empty SentryId`() =

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -9,11 +9,11 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.cache.EnvelopeCache
 import io.sentry.hints.Retryable
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
+import io.sentry.util.HintUtils
 import java.io.File
 import java.io.FileNotFoundException
 import java.nio.file.Files
@@ -62,8 +62,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope()
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
         assertFalse(File(path).exists())
         // Additionally make sure we have a error logged
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any(), any<Any>())
@@ -78,8 +78,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope()
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         verify(fixture.hub).captureEvent(eq(expected), any())
         assertFalse(File(path).exists())
@@ -115,8 +115,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope(fileName = "envelope-transaction.txt")
         assertTrue(File(path).exists())
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         verify(fixture.hub).captureTransaction(
             check {
@@ -144,8 +144,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope()
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         verify(fixture.hub).captureEvent(any(), any())
         assertFalse(File(path).exists())
@@ -162,8 +162,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope(fileName = "envelope_attachment.txt")
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         verify(fixture.hub).captureEnvelope(any(), any())
         assertFalse(File(path).exists())
@@ -180,8 +180,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope()
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         // Additionally make sure we have no errors logged
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any(), any<Any>())
@@ -198,8 +198,8 @@ class OutboxSenderTest {
         val path = getTempEnvelope()
         assertTrue(File(path).exists()) // sanity check
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(path, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(path, hints)
 
         // Additionally make sure we have no errors logged
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any(), any<Any>())
@@ -211,8 +211,8 @@ class OutboxSenderTest {
     fun `when processEnvelopeFile is called with a invalid path, logs error`() {
         val sut = fixture.getSut()
 
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Retryable>())
-        sut.processEnvelopeFile(File.separator + "i-hope-it-doesnt-exist" + File.separator + "file.txt", hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
+        sut.processEnvelopeFile(File.separator + "i-hope-it-doesnt-exist" + File.separator + "file.txt", hints)
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any<String>(), argWhere { it is FileNotFoundException })
     }
 

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import io.sentry.hints.Hints
 import io.sentry.protocol.Request
 import io.sentry.protocol.User
 import io.sentry.test.callMethod
@@ -858,7 +859,7 @@ class ScopeTest {
 
     private fun eventProcessor(): EventProcessor {
         return object : EventProcessor {
-            override fun process(event: SentryEvent, hint: MutableMap<String, Any>?): SentryEvent? {
+            override fun process(event: SentryEvent, hints: Hints): SentryEvent? {
                 return event
             }
         }

--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
@@ -11,14 +11,15 @@ import io.sentry.SentryEnvelopeItem
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.Session
-import io.sentry.TypeCheckHint
 import io.sentry.UserFeedback
 import io.sentry.dsnString
 import io.sentry.hints.DiskFlushNotification
+import io.sentry.hints.Hints
 import io.sentry.hints.Retryable
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.util.HintUtils
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -149,13 +150,13 @@ class ClientReportTest {
 
 class DropEverythingEventProcessor : EventProcessor {
 
-    override fun process(event: SentryEvent, hint: MutableMap<String, Any>?): SentryEvent? {
+    override fun process(event: SentryEvent, hints: Hints): SentryEvent? {
         return null
     }
 
     override fun process(
         transaction: SentryTransaction,
-        hint: MutableMap<String, Any>?
+        hints: Hints
     ): SentryTransaction? {
         return null
     }
@@ -193,9 +194,9 @@ class ClientReportTestHelper(val options: SentryOptions) {
     }
 
     companion object {
-        fun retryableHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestRetryable())
-        fun diskFlushNotificationHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestDiskFlushNotification())
-        fun retryableDiskFlushNotificationHint() = mutableMapOf<String, Any?>(TypeCheckHint.SENTRY_TYPE_CHECK_HINT to TestRetryableDiskFlushNotification())
+        fun retryableHint() = HintUtils.createWithTypeCheckHint(TestRetryable())
+        fun diskFlushNotificationHint() = HintUtils.createWithTypeCheckHint(TestDiskFlushNotification())
+        fun retryableDiskFlushNotificationHint() = HintUtils.createWithTypeCheckHint(TestRetryableDiskFlushNotification())
 
         fun assertClientReport(clientReportRecorder: IClientReportRecorder, expectedEvents: List<DiscardedEvent>) {
             val recorder = clientReportRecorder as ClientReportRecorder

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -17,10 +17,10 @@ import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.SentryOptionsManipulator
 import io.sentry.Session
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.clientreport.NoOpClientReportRecorder
 import io.sentry.dsnString
 import io.sentry.protocol.User
+import io.sentry.util.HintUtils
 import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -184,8 +184,8 @@ class AsyncHttpTransportTest {
         whenever(fixture.rateLimiter.filter(any(), anyOrNull())).thenReturn(null)
 
         // when
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        fixture.getSUT().send(envelope, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        fixture.getSUT().send(envelope, hints)
 
         // then
         verify(fixture.sentryOptions.envelopeDiskCache).discard(any())
@@ -242,8 +242,8 @@ class AsyncHttpTransportTest {
         val envelope = SentryEnvelope.from(fixture.sentryOptions.serializer, ev, null)
 
         // when
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CachedEvent())
-        fixture.getSUT().send(envelope, hintsMap)
+        val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
+        fixture.getSUT().send(envelope, hints)
 
         // then
         verify(fixture.sentryOptions.envelopeDiskCache).discard(any())

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -22,6 +22,7 @@ import io.sentry.TransactionContext
 import io.sentry.UserFeedback
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.IClientReportRecorder
+import io.sentry.hints.Hints
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
@@ -63,7 +64,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNotNull(result)
         assertEquals(1, result.items.count())
     }
@@ -79,7 +80,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("50:transaction:key, 2700:default;error;security:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -94,7 +95,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("1:transaction:key, 1:default;error;security:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNotNull(result)
         assertEquals(2, result.items.count())
     }
@@ -108,7 +109,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("50::key", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -121,7 +122,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("1::key, 60:default;error;security:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -134,7 +135,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("60:error:key, 1:error:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -147,7 +148,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits("1:error:key, 5:error:organization", null, 1)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -160,7 +161,7 @@ class RateLimiterTest {
 
         rateLimiter.updateRetryAfterLimits(null, null, 429)
 
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
         assertNull(result)
     }
 
@@ -185,7 +186,7 @@ class RateLimiterTest {
         val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, userFeedbackItem, sessionItem, attachmentItem))
 
         rateLimiter.updateRetryAfterLimits(null, null, 429)
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
 
         assertNull(result)
 
@@ -217,7 +218,7 @@ class RateLimiterTest {
         val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, userFeedbackItem, sessionItem, attachmentItem))
 
         rateLimiter.updateRetryAfterLimits("60:error:key, 1:error:organization", null, 1)
-        val result = rateLimiter.filter(envelope, null)
+        val result = rateLimiter.filter(envelope, Hints())
 
         assertNotNull(result)
         assertEquals(3, result.items.toList().size)

--- a/sentry/src/test/java/io/sentry/util/HintUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/HintUtilsTest.kt
@@ -2,9 +2,9 @@ package io.sentry.util
 
 import com.nhaarman.mockitokotlin2.mock
 import io.sentry.CustomCachedApplyScopeDataHint
-import io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT
 import io.sentry.hints.ApplyScopeData
 import io.sentry.hints.Cached
+import io.sentry.hints.Hints
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -13,24 +13,24 @@ class HintUtilsTest {
 
     @Test
     fun `if event is Cached, it should not apply scopes data`() {
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<Cached>())
-        assertFalse(HintUtils.shouldApplyScopeData(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint(mock<Cached>())
+        assertFalse(HintUtils.shouldApplyScopeData(hints))
     }
 
     @Test
     fun `if event is not Cached, it should apply scopes data`() {
-        assertTrue(HintUtils.shouldApplyScopeData(null))
+        assertTrue(HintUtils.shouldApplyScopeData(Hints()))
     }
 
     @Test
     fun `if event is ApplyScopeData, it should apply scopes data`() {
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to mock<ApplyScopeData>())
-        assertTrue(HintUtils.shouldApplyScopeData(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint(mock<ApplyScopeData>())
+        assertTrue(HintUtils.shouldApplyScopeData(hints))
     }
 
     @Test
     fun `if event is Cached but also ApplyScopeData, it should apply scopes data`() {
-        val hintsMap = mutableMapOf<String, Any>(SENTRY_TYPE_CHECK_HINT to CustomCachedApplyScopeDataHint())
-        assertTrue(HintUtils.shouldApplyScopeData(hintsMap))
+        val hints = HintUtils.createWithTypeCheckHint(CustomCachedApplyScopeDataHint())
+        assertTrue(HintUtils.shouldApplyScopeData(hints))
     }
 }


### PR DESCRIPTION
## :scroll: Description
Replaces `Map<String, Object>` for hints with a `Hints` object. Also changed from `@Nullable` to `@NotNull` in `beforeSend` and `EventProcessor`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it easier for developers to interact with hints without having to deal with certain cases (e.g. `hints == null`, hints not having an attachment entry, hints having a null attachment entry, ...)

See https://github.com/getsentry/sentry-javascript/issues/5036

Here's another PR building on top of this to allow manipulation of attachments via `beforeSend` and `eventProcessor`: TODO


## :green_heart: How did you test it?
Unit Tests, see linked PR


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
