### PR TITLE
Set current thread flag in SentryThreadFactory

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryThreadFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryThreadFactory.java
@@ -90,11 +90,12 @@ final class SentryThreadFactory {
       for (Map.Entry<Thread, StackTraceElement[]> item : threads.entrySet()) {
 
         final Thread thread = item.getKey();
+        final boolean isCurrent = thread == currentThread;
         final boolean crashed =
-            (thread == currentThread)
+            isCurrent
                 || (mechanismThreadIds != null && mechanismThreadIds.contains(thread.getId()));
 
-        result.add(getSentryThread(crashed, item.getValue(), item.getKey()));
+        result.add(getSentryThread(isCurrent, crashed, item.getValue(), item.getKey()));
       }
     }
 
@@ -110,6 +111,7 @@ final class SentryThreadFactory {
    * @return a SentryThread
    */
   private @NotNull SentryThread getSentryThread(
+      final boolean isCurrent,
       final boolean crashed,
       final @NotNull StackTraceElement[] stackFramesElements,
       final @NotNull Thread thread) {
@@ -121,6 +123,7 @@ final class SentryThreadFactory {
     sentryThread.setDaemon(thread.isDaemon());
     sentryThread.setState(thread.getState().name());
     sentryThread.setCrashed(crashed);
+    sentryThread.setCurrent(isCurrent);
 
     final List<SentryStackFrame> frames =
         sentryStackTraceFactory.getStackFrames(stackFramesElements);

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -845,6 +845,24 @@ class JsonSerializerTest {
     }
 
     @Test
+    fun `threads are serialized with current thread flag`() {
+        val event = generateEmptySentryEvent()
+        val sentryThreadFactory = SentryThreadFactory(
+            SentryStackTraceFactory(listOf("io.sentry"), listOf()),
+            with(SentryOptions()) {
+                isAttachStacktrace = true
+                this
+            }
+        )
+        event.threads = sentryThreadFactory.currentThread
+
+        val serialized = serializeToString(event)
+        val deserialized = fixture.serializer.deserialize(StringReader(serialized), SentryEvent::class.java)
+
+        assertEquals(true, deserialized?.threads?.first()?.isCurrent)
+    }
+
+    @Test
     fun `json serializer uses logger set on SentryOptions`() {
         val logger = mock<ILogger>()
         val options = SentryOptions()


### PR DESCRIPTION
## :scroll: Description
Sets the current thread flag in `SentryThreadFactory`


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found via https://github.com/getsentry/sentry-java/issues/2047 but may not be the cause of that problem.

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
