### PR TITLE
SentryThread.current flag will not be overridden by DefaultAndroidEventProcessor if already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Update sentry-native to 0.4.17 ([#2033](https://github.com/getsentry/sentry-java/pull/2033))
 - Update Gradle to 7.4.2 and AGP to 7.2 ([#2042](https://github.com/getsentry/sentry-java/pull/2042))
 
+### Fixes
+
+- SentryThread.current flag will not be overridden by DefaultAndroidEventProcessor if already set ([#2050](https://github.com/getsentry/sentry-java/pull/2050))
+
 ## 6.0.0-beta.3
 
 ### Fixes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -211,7 +211,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setThreads(final @NotNull SentryEvent event) {
     if (event.getThreads() != null) {
       for (SentryThread thread : event.getThreads()) {
-        thread.setCurrent(MainThreadChecker.isMainThread(thread));
+        Boolean isCurrentThread = thread.isCurrent();
+        if (isCurrentThread == null || !isCurrentThread) {
+          thread.setCurrent(MainThreadChecker.isMainThread(thread));
+        }
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -212,7 +212,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (event.getThreads() != null) {
       for (SentryThread thread : event.getThreads()) {
         Boolean isCurrentThread = thread.isCurrent();
-        if (isCurrentThread == null || !isCurrentThread) {
+        if (isCurrentThread == null) {
           thread.setCurrent(MainThreadChecker.isMainThread(thread));
         }
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -211,8 +211,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setThreads(final @NotNull SentryEvent event) {
     if (event.getThreads() != null) {
       for (SentryThread thread : event.getThreads()) {
-        Boolean isCurrentThread = thread.isCurrent();
-        if (isCurrentThread == null) {
+        if (thread.isCurrent() == null) {
           thread.setCurrent(MainThreadChecker.isMainThread(thread));
         }
       }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -180,6 +180,26 @@ class DefaultAndroidEventProcessorTest {
     }
 
     @Test
+    fun `Current should remain true`() {
+        val sut = fixture.getSut(context)
+
+        val event = SentryEvent().apply {
+            threads = mutableListOf(
+                SentryThread().apply {
+                    id = 10L
+                    isCurrent = true
+                }
+            )
+        }
+
+        assertNotNull(sut.process(event, null)) {
+            assertNotNull(it.threads) { threads ->
+                assertTrue(threads.first().isCurrent == true)
+            }
+        }
+    }
+
+    @Test
     fun `When Event and hint is Cached, data should not be applied`() {
         val sut = fixture.getSut(context)
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
SentryThread.current flag will not be overridden by DefaultAndroidEventProcessor if already true

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/2047

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
