### PR TITLE
Fix serialization of Long inside of Request.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - SentryThread.current flag will not be overridden by DefaultAndroidEventProcessor if already set ([#2050](https://github.com/getsentry/sentry-java/pull/2050))
+- Fix serialization of Long inside of Request.data ([#2051](https://github.com/getsentry/sentry-java/pull/2051))
 
 ## 6.0.0-beta.3
 

--- a/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
@@ -37,11 +37,7 @@ public final class JsonReflectionObjectSerializer {
       return ((Byte) object).intValue();
     } else if (object instanceof Short) {
       return ((Short) object).intValue();
-    } else if (object instanceof Integer) {
-      return object;
-    } else if (object instanceof Float) {
-      return object;
-    } else if (object instanceof Double) {
+    } else if (object instanceof Number) {
       return object;
     } else if (object instanceof Boolean) {
       return object;

--- a/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
@@ -33,10 +33,6 @@ public final class JsonReflectionObjectSerializer {
     }
     if (object instanceof Character) {
       return object.toString();
-    } else if (object instanceof Byte) {
-      return ((Byte) object).intValue();
-    } else if (object instanceof Short) {
-      return ((Short) object).intValue();
     } else if (object instanceof Number) {
       return object;
     } else if (object instanceof Boolean) {

--- a/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
@@ -26,8 +26,8 @@ class JsonReflectionObjectSerializerTest {
             true
         )
         val expected = mapOf(
-            "byte" to 17,
-            "short" to 3,
+            "byte" to 17.toByte(),
+            "short" to 3.toShort(),
             "char" to "x",
             "integer" to 9001,
             "float" to 0.9f,

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.exception.SentryEnvelopeException
 import io.sentry.protocol.Device
+import io.sentry.protocol.Request
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentrySpan
@@ -842,6 +843,22 @@ class JsonSerializerTest {
         val deserialized = fixture.serializer.deserialize(StringReader(serialized), SentryEvent::class.java)
 
         assertNull(deserialized?.threads)
+    }
+
+    @Test
+    fun `Long can be serialized inside request data`() {
+        val request = Request()
+
+        data class LongContainer(val longValue: Long)
+
+        request.data = LongContainer(10)
+
+        val serialized = serializeToString(request)
+        val deserialized = fixture.serializer.deserialize(StringReader(serialized), Request::class.java)
+
+        val deserializedData = deserialized?.data as? Map<String, Any>
+        assertNotNull(deserializedData)
+        assertEquals(10, deserializedData["longValue"])
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -862,6 +862,34 @@ class JsonSerializerTest {
     }
 
     @Test
+    fun `Primitives can be serialized inside request data`() {
+        val request = Request()
+
+        request.data = JsonReflectionObjectSerializerTest.ClassWithPrimitiveFields(
+            17,
+            3,
+            'x',
+            9001,
+            0.9f,
+            0.99,
+            true
+        )
+
+        val serialized = serializeToString(request)
+        val deserialized = fixture.serializer.deserialize(StringReader(serialized), Request::class.java)
+
+        val deserializedData = deserialized?.data as? Map<String, Any>
+        assertNotNull(deserializedData)
+        assertEquals(17, deserializedData["byte"])
+        assertEquals(3, deserializedData["short"])
+        assertEquals("x", deserializedData["char"])
+        assertEquals(9001, deserializedData["integer"])
+        assertEquals(0.9, deserializedData["float"])
+        assertEquals(0.99, deserializedData["double"])
+        assertEquals(true, deserializedData["boolean"])
+    }
+
+    @Test
     fun `json serializer uses logger set on SentryOptions`() {
         val logger = mock<ILogger>()
         val options = SentryOptions()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Handle `Number` inside `JsonReflectionObjectSerializer` which includes `Long`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/2044

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
