### PR TITLE
Calling Sentry.init and specifying contextTags now has an effect on the Logback SentryAppender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - SentryThread.current flag will not be overridden by DefaultAndroidEventProcessor if already set ([#2050](https://github.com/getsentry/sentry-java/pull/2050))
+- Calling Sentry.init and specifying contextTags now has an effect on the Logback SentryAppender ([#2052](https://github.com/getsentry/sentry-java/pull/2052))
 
 ## 6.0.0-beta.3
 

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -115,7 +115,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         CollectionUtils.filterMapEntries(
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
-      // get tags from HubAdapter options to allow getting the correct tags if Sentry has been initialized somewhere else
+      // get tags from HubAdapter options to allow getting the correct tags if Sentry has been
+      // initialized somewhere else
       final List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
       if (!contextTags.isEmpty()) {
         for (final String contextTag : contextTags) {

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -115,6 +115,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         CollectionUtils.filterMapEntries(
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
+      // get tags from HubAdapter options to allow getting the correct tags if Sentry has been initialized somewhere else
       final List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
       if (!contextTags.isEmpty()) {
         for (final String contextTag : contextTags) {

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -42,6 +42,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   public void start() {
+    // NOTE: logback.xml properties will only be applied if the SDK has not yet been initialized
     if (!Sentry.isEnabled()) {
       if (options.getDsn() == null || !options.getDsn().endsWith("_IS_UNDEFINED")) {
         options.setEnableExternalConfiguration(true);
@@ -54,8 +55,6 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
           addWarn("Failed to init Sentry during appender initialization: " + e.getMessage());
         }
       } else {
-        // NOTE: logback.xml properties will not be applied in this case as the SDK has already been
-        // initialized
         options
             .getLogger()
             .log(SentryLevel.WARNING, "DSN is null. SentryAppender is not being initialized");

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -116,7 +116,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         CollectionUtils.filterMapEntries(
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
-      List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
+      final List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
       if (!contextTags.isEmpty()) {
         for (final String contextTag : contextTags) {
           // if mdc tag is listed in SentryOptions, apply as event tag


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
No longer used the options property in SentryAppender, instead get Options from HubAdapter.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/getsentry/sentry-java/issues/2043 for Logback

## :green_heart: How did you test it?
Demo Code

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
