### PR TITLE
Calling Sentry.init and specifying contextTags now has an effect on the jul SentryAppender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Allow setting native Android SDK name during build ([#2035](https://github.com/getsentry/sentry-java/pull/2035))
 - Include application permissions in Android events ([#2018](https://github.com/getsentry/sentry-java/pull/2018))
 - Automatically create transactions for UI events ([#1975](https://github.com/getsentry/sentry-java/pull/1975))
+- Calling Sentry.init and specifying contextTags now has an effect on the jul SentryAppender ([#2057](https://github.com/getsentry/sentry-java/pull/2057))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Calling Sentry.init and specifying contextTags now has an effect on the jul SentryAppender ([#2057](https://github.com/getsentry/sentry-java/pull/2057))
+
 ## 6.0.0-beta.4
 
 ### Fixes
@@ -15,7 +21,6 @@
 - Automatically create transactions for UI events ([#1975](https://github.com/getsentry/sentry-java/pull/1975))
 - Hints are now used via a Hint object and passed into beforeSend and EventProcessor as @NotNull Hint object ([#2045](https://github.com/getsentry/sentry-java/pull/2045))
 - Attachments can be manipulated via hint ([#2046](https://github.com/getsentry/sentry-java/pull/2046))
-- Calling Sentry.init and specifying contextTags now has an effect on the jul SentryAppender ([#2057](https://github.com/getsentry/sentry-java/pull/2057))
 
 ### Fixes
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -5,6 +5,7 @@ import static io.sentry.TypeCheckHint.SENTRY_SYNTHETIC_EXCEPTION;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
+import io.sentry.HubAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
@@ -42,7 +43,6 @@ public class SentryHandler extends Handler {
 
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.SEVERE;
-  private @NotNull SentryOptions options;
 
   /** Creates an instance of SentryHandler. */
   public SentryHandler() {
@@ -61,7 +61,6 @@ public class SentryHandler extends Handler {
   /** Creates an instance of SentryHandler. */
   @TestOnly
   SentryHandler(final @NotNull SentryOptions options, final boolean configureFromLogManager) {
-    this.options = options;
     setFilter(new DropSentryFilter());
     if (configureFromLogManager) {
       retrieveProperties();
@@ -202,8 +201,9 @@ public class SentryHandler extends Handler {
       mdcProperties =
           CollectionUtils.filterMapEntries(mdcProperties, entry -> entry.getValue() != null);
       if (!mdcProperties.isEmpty()) {
-        if (!options.getContextTags().isEmpty()) {
-          for (final String contextTag : options.getContextTags()) {
+        final List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
+        if (!contextTags.isEmpty()) {
+          for (final String contextTag : contextTags) {
             // if mdc tag is listed in SentryOptions, apply as event tag
             if (mdcProperties.containsKey(contextTag)) {
               event.setTag(contextTag, mdcProperties.get(contextTag));

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -201,6 +201,8 @@ public class SentryHandler extends Handler {
       mdcProperties =
           CollectionUtils.filterMapEntries(mdcProperties, entry -> entry.getValue() != null);
       if (!mdcProperties.isEmpty()) {
+        // get tags from HubAdapter options to allow getting the correct tags if Sentry has been
+        // initialized somewhere else
         final List<String> contextTags = HubAdapter.getInstance().getOptions().getContextTags();
         if (!contextTags.isEmpty()) {
           for (final String contextTag : contextTags) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
No longer used the options property in SentryAppender, instead get Options from HubAdapter.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #2043 for jul

## :green_heart: How did you test it?
Demo Code

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
