### PR TITLE
Upgrade gson to 2.9.0 to avoid CVE-2022-25647

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -45,7 +45,8 @@ object Config {
         val okhttpBom = "com.squareup.okhttp3:okhttp-bom:$okHttpVersion"
         val okhttp = "com.squareup.okhttp3:okhttp"
         // only bump gson if https://github.com/google/gson/issues/1597 is fixed
-        private val gsonVersion = "2.8.5"
+        // upgraded anyways due to CVE-2022-25647 (#2059)
+        private val gsonVersion = "2.9.0"
         val gsonDep = "com.google.code.gson:gson"
         val gson = "$gsonDep:$gsonVersion"
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.8.1"

--- a/sentry/src/main/java/io/sentry/UnknownPropertiesTypeAdapterFactory.java
+++ b/sentry/src/main/java/io/sentry/UnknownPropertiesTypeAdapterFactory.java
@@ -44,6 +44,7 @@ final class UnknownPropertiesTypeAdapterFactory implements TypeAdapterFactory {
         (TypeAdapter<IUnknownPropertiesConsumer>) gson.getDelegateAdapter(this, typeToken);
     // Excluder is necessary to check if the field can be processed
     // Basically it's not required, but it makes the check more complete
+    @SuppressWarnings("deprecation")
     final Excluder excluder = gson.excluder();
     // This is crucial to map fields and JSON object properties since Gson supports name remapping
     final FieldNamingStrategy fieldNamingStrategy = gson.fieldNamingStrategy();
@@ -107,7 +108,9 @@ final class UnknownPropertiesTypeAdapterFactory implements TypeAdapterFactory {
     public @Nullable T read(final JsonReader in) {
       // In its simplest solution, we can just collect a JSON tree because its much easier to
       // process
+      @SuppressWarnings("deprecation")
       JsonParser parser = new JsonParser();
+      @SuppressWarnings("deprecation")
       JsonElement jsonElement = parser.parse(in);
 
       if (jsonElement == null || jsonElement.isJsonNull()) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Upgrade gson to 2.9.0 to avoid CVE-2022-25647

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While this should avoid CVE-2022-25647 (#2059) it will likely cause problems for older versions of the android gradle plugin (see https://github.com/getsentry/sentry-android/issues/171).

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
