### PR TITLE
Move ContextTagsEventProcessor from spring boot to spring module

### DIFF
--- a/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
+++ b/sentry-spring-boot-starter/api/sentry-spring-boot-starter.api
@@ -3,11 +3,6 @@ public final class io/sentry/spring/boot/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
-public final class io/sentry/spring/boot/ContextTagsEventProcessor : io/sentry/EventProcessor {
-	public fun <init> (Lio/sentry/SentryOptions;)V
-	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
-}
-
 public class io/sentry/spring/boot/InAppIncludesResolver : org/springframework/context/ApplicationContextAware {
 	public fun <init> ()V
 	public fun resolveInAppIncludes ()Ljava/util/List;

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -9,6 +9,7 @@ import io.sentry.Integration;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
+import io.sentry.spring.ContextTagsEventProcessor;
 import io.sentry.spring.SentryExceptionResolver;
 import io.sentry.spring.SentryRequestResolver;
 import io.sentry.spring.SentrySpringFilter;

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -20,6 +20,7 @@ import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.checkEvent
 import io.sentry.protocol.User
+import io.sentry.spring.ContextTagsEventProcessor
 import io.sentry.spring.HttpServletRequestSentryUserProvider
 import io.sentry.spring.SentryExceptionResolver
 import io.sentry.spring.SentryUserFilter

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -3,6 +3,11 @@ public final class io/sentry/spring/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
+public final class io/sentry/spring/ContextTagsEventProcessor : io/sentry/EventProcessor {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun process (Lio/sentry/SentryEvent;Ljava/util/Map;)Lio/sentry/SentryEvent;
+}
+
 public abstract interface annotation class io/sentry/spring/EnableSentry : java/lang/annotation/Annotation {
 	public abstract fun dsn ()Ljava/lang/String;
 	public abstract fun exceptionResolverOrder ()I

--- a/sentry-spring/build.gradle.kts
+++ b/sentry-spring/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly(Config.Libs.springSecurityWeb)
     compileOnly(Config.Libs.aspectj)
     compileOnly(Config.Libs.servletApi)
+    compileOnly(Config.Libs.slf4jApi)
 
     compileOnly(Config.Libs.springWebflux)
 

--- a/sentry-spring/src/main/java/io/sentry/spring/ContextTagsEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/ContextTagsEventProcessor.java
@@ -1,4 +1,4 @@
-package io.sentry.spring.boot;
+package io.sentry.spring;
 
 import io.sentry.EventProcessor;
 import io.sentry.SentryEvent;

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/ContextTagsEventProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/ContextTagsEventProcessorTest.kt
@@ -1,4 +1,4 @@
-package io.sentry.spring.boot
+package io.sentry.spring
 
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Move ContextTagsEventProcessor from spring boot to spring module

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So Spring (without boot) can also use the `ContextTagsEventProcessor`

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
