### PR TITLE
Implement local scope by adding overloads to the capture methods that accept a ScopeCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Implement local scope by adding overloads to the capture methods that accept a ScopeCallback ([#2075](https://github.com/getsentry/sentry-java/pull/2075))
+
 ## 6.0.0-rc.1
 
 ### Features
+
 - Allow optimization and obfuscation of the SDK by reducing proguard rules ([#2031](https://github.com/getsentry/sentry-java/pull/2031))
 
 ### Fixes

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryDataFetcherExceptionHandlerTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryDataFetcherExceptionHandlerTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
+import io.sentry.Hint
 import io.sentry.IHub
 import kotlin.test.Test
 
@@ -21,7 +22,7 @@ class SentryDataFetcherExceptionHandlerTest {
         val parameters = DataFetcherExceptionHandlerParameters.newExceptionParameters().exception(exception).build()
         handler.onException(parameters)
 
-        verify(hub).captureException(eq(exception), anyOrNull())
+        verify(hub).captureException(eq(exception), anyOrNull<Hint>())
         verify(delegate).onException(parameters)
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -208,8 +208,11 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun bindClient (Lio/sentry/ISentryClient;)V
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -248,8 +251,11 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun bindClient (Lio/sentry/ISentryClient;)V
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -303,10 +309,16 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
@@ -539,8 +551,11 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun bindClient (Lio/sentry/ISentryClient;)V
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceState;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -842,10 +857,16 @@ public final class io/sentry/Sentry {
 	public static fun bindClient (Lio/sentry/ISentryClient;)V
 	public static fun captureEvent (Lio/sentry/SentryEvent;)Lio/sentry/protocol/SentryId;
 	public static fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public static fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public static fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureException (Ljava/lang/Throwable;)Lio/sentry/protocol/SentryId;
 	public static fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public static fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public static fun captureException (Ljava/lang/Throwable;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;)Lio/sentry/protocol/SentryId;
+	public static fun captureMessage (Ljava/lang/String;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
+	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public static fun clearBreadcrumbs ()V
 	public static fun close ()V

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -75,7 +75,13 @@ public final class Hub implements IHub {
 
   @Override
   public @NotNull SentryId captureEvent(
-      final @NotNull SentryEvent event, final @Nullable Hint hint) {
+    final @NotNull SentryEvent event, final @Nullable Hint hint) {
+    return captureEvent(event, hint, null);
+  }
+
+  @Override
+  public @NotNull SentryId captureEvent(
+      final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       options
@@ -88,7 +94,8 @@ public final class Hub implements IHub {
       try {
         assignTraceContext(event);
         final StackItem item = stack.peek();
-        sentryId = item.getClient().captureEvent(event, item.getScope(), hint);
+        Scope scope = chooseScope(callback, item);
+        sentryId = item.getClient().captureEvent(event, scope, hint);
         this.lastEventId = sentryId;
       } catch (Throwable e) {
         options

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -75,13 +75,15 @@ public final class Hub implements IHub {
 
   @Override
   public @NotNull SentryId captureEvent(
-    final @NotNull SentryEvent event, final @Nullable Hint hint) {
+      final @NotNull SentryEvent event, final @Nullable Hint hint) {
     return captureEvent(event, hint, null);
   }
 
   @Override
   public @NotNull SentryId captureEvent(
-      final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
+      final @NotNull SentryEvent event,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       options
@@ -109,13 +111,15 @@ public final class Hub implements IHub {
 
   @Override
   public @NotNull SentryId captureMessage(
-    final @NotNull String message, final @NotNull SentryLevel level) {
+      final @NotNull String message, final @NotNull SentryLevel level) {
     return captureMessage(message, level, null);
   }
 
   @Override
   public @NotNull SentryId captureMessage(
-      final @NotNull String message, final @NotNull SentryLevel level, final @Nullable ScopeCallback callback) {
+      final @NotNull String message,
+      final @NotNull SentryLevel level,
+      final @Nullable ScopeCallback callback) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       options
@@ -168,19 +172,21 @@ public final class Hub implements IHub {
   @Override
   public @NotNull SentryId captureException(
       final @NotNull Throwable throwable, final @Nullable Hint hint) {
-      return captureException(throwable, hint, null);
+    return captureException(throwable, hint, null);
   }
 
   @Override
   public @NotNull SentryId captureException(
-    final @NotNull Throwable throwable, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
+      final @NotNull Throwable throwable,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {
       options
-        .getLogger()
-        .log(
-          SentryLevel.WARNING,
-          "Instance is disabled and this 'captureException' call is a no-op.");
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "Instance is disabled and this 'captureException' call is a no-op.");
     } else if (throwable == null) {
       options.getLogger().log(SentryLevel.WARNING, "captureException called with null parameter.");
     } else {
@@ -192,9 +198,9 @@ public final class Hub implements IHub {
         sentryId = item.getClient().captureEvent(event, scope, hint);
       } catch (Throwable e) {
         options
-          .getLogger()
-          .log(
-            SentryLevel.ERROR, "Error while capturing exception: " + throwable.getMessage(), e);
+            .getLogger()
+            .log(
+                SentryLevel.ERROR, "Error while capturing exception: " + throwable.getMessage(), e);
       }
     }
     this.lastEventId = sentryId;

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -30,8 +30,18 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
+  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+    return Sentry.captureEvent(event, hint, callback);
+  }
+
+  @Override
   public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level) {
     return Sentry.captureMessage(message, level);
+  }
+
+  @Override
+  public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+    return Sentry.captureMessage(message, level, callback);
   }
 
   @ApiStatus.Internal
@@ -43,6 +53,11 @@ public final class HubAdapter implements IHub {
   @Override
   public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint) {
     return Sentry.captureException(throwable, hint);
+  }
+
+  @Override
+  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+    return Sentry.captureException(throwable, hint, callback);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -30,7 +30,8 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureEvent(
+      @NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
     return Sentry.captureEvent(event, hint, callback);
   }
 
@@ -40,7 +41,8 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureMessage(
+      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
     return Sentry.captureMessage(message, level, callback);
   }
 
@@ -56,7 +58,8 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureException(
+      @NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
     return Sentry.captureException(throwable, hint, callback);
   }
 

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -31,7 +31,7 @@ public final class HubAdapter implements IHub {
 
   @Override
   public @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+      @NotNull SentryEvent event, @Nullable Hint hint, @NotNull ScopeCallback callback) {
     return Sentry.captureEvent(event, hint, callback);
   }
 
@@ -42,7 +42,7 @@ public final class HubAdapter implements IHub {
 
   @Override
   public @NotNull SentryId captureMessage(
-      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+      @NotNull String message, @NotNull SentryLevel level, @NotNull ScopeCallback callback) {
     return Sentry.captureMessage(message, level, callback);
   }
 
@@ -59,7 +59,7 @@ public final class HubAdapter implements IHub {
 
   @Override
   public @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+      @NotNull Throwable throwable, @Nullable Hint hint, @NotNull ScopeCallback callback) {
     return Sentry.captureException(throwable, hint, callback);
   }
 

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -60,6 +60,28 @@ public interface IHub {
   SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level);
 
   /**
+   * Captures the message.
+   *
+   * @param message The message to send.
+   * @param level The message level.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  @NotNull
+  SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback);
+
+  /**
+   * Captures the message.
+   *
+   * @param message The message to send.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  default @NotNull SentryId captureMessage(@NotNull String message, @Nullable ScopeCallback callback) {
+    return captureMessage(message, SentryLevel.INFO, callback);
+  }
+
+  /**
    * Captures an envelope.
    *
    * @param envelope the SentryEnvelope to send.
@@ -96,8 +118,30 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureException(@NotNull Throwable throwable) {
-    return captureException(throwable, null);
+    return captureException(throwable, null, null);
   }
+
+  /**
+   * Captures the exception.
+   *
+   * @param throwable The exception.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  default @NotNull SentryId captureException(@NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
+    return captureException(throwable, null, callback);
+  }
+
+  /**
+   * Captures the exception.
+   *
+   * @param throwable The exception.
+   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  @NotNull SentryId captureException(
+    final @NotNull Throwable throwable, final @Nullable Hint hint, final @Nullable ScopeCallback callback);
 
   /**
    * Captures a manually created user feedback and sends it to Sentry.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -36,8 +36,31 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureEvent(@NotNull SentryEvent event) {
-    return captureEvent(event, null);
+    return captureEvent(event, (Hint) null);
   }
+
+  /**
+   * Captures the event.
+   *
+   * @param event the event
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  default @NotNull SentryId captureEvent(@NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
+    return captureEvent(event, null, callback);
+  }
+
+  /**
+   * Captures the event.
+   *
+   * @param event the event
+   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  @NotNull SentryId captureEvent(
+    final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback);
+
 
   /**
    * Captures the message.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -158,7 +158,7 @@ public interface IHub {
    */
   default @NotNull SentryId captureException(
       @NotNull Throwable throwable, final @NotNull ScopeCallback callback) {
-    return captureException(throwable, null, callback);
+    return captureException(throwable, new Hint(), callback);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -36,7 +36,7 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureEvent(@NotNull SentryEvent event) {
-    return captureEvent(event, (Hint) null);
+    return captureEvent(event, new Hint());
   }
 
   /**
@@ -47,8 +47,8 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
-    return captureEvent(event, null, callback);
+      @NotNull SentryEvent event, final @NotNull ScopeCallback callback) {
+    return captureEvent(event, new Hint(), callback);
   }
 
   /**
@@ -63,7 +63,7 @@ public interface IHub {
   SentryId captureEvent(
       final @NotNull SentryEvent event,
       final @Nullable Hint hint,
-      final @Nullable ScopeCallback callback);
+      final @NotNull ScopeCallback callback);
 
   /**
    * Captures the message.
@@ -95,7 +95,7 @@ public interface IHub {
    */
   @NotNull
   SentryId captureMessage(
-      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback);
+      @NotNull String message, @NotNull SentryLevel level, @NotNull ScopeCallback callback);
 
   /**
    * Captures the message.
@@ -105,7 +105,7 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureMessage(
-      @NotNull String message, @Nullable ScopeCallback callback) {
+      @NotNull String message, @NotNull ScopeCallback callback) {
     return captureMessage(message, SentryLevel.INFO, callback);
   }
 
@@ -146,7 +146,7 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureException(@NotNull Throwable throwable) {
-    return captureException(throwable, null, null);
+    return captureException(throwable, new Hint());
   }
 
   /**
@@ -157,7 +157,7 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   default @NotNull SentryId captureException(
-      @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
+      @NotNull Throwable throwable, final @NotNull ScopeCallback callback) {
     return captureException(throwable, null, callback);
   }
 
@@ -173,7 +173,7 @@ public interface IHub {
   SentryId captureException(
       final @NotNull Throwable throwable,
       final @Nullable Hint hint,
-      final @Nullable ScopeCallback callback);
+      final @NotNull ScopeCallback callback);
 
   /**
    * Captures a manually created user feedback and sends it to Sentry.

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -46,7 +46,8 @@ public interface IHub {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  default @NotNull SentryId captureEvent(@NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
+  default @NotNull SentryId captureEvent(
+      @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
     return captureEvent(event, null, callback);
   }
 
@@ -58,9 +59,11 @@ public interface IHub {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  @NotNull SentryId captureEvent(
-    final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback);
-
+  @NotNull
+  SentryId captureEvent(
+      final @NotNull SentryEvent event,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback);
 
   /**
    * Captures the message.
@@ -91,7 +94,8 @@ public interface IHub {
    * @return The Id (SentryId object) of the event
    */
   @NotNull
-  SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback);
+  SentryId captureMessage(
+      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback);
 
   /**
    * Captures the message.
@@ -100,7 +104,8 @@ public interface IHub {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  default @NotNull SentryId captureMessage(@NotNull String message, @Nullable ScopeCallback callback) {
+  default @NotNull SentryId captureMessage(
+      @NotNull String message, @Nullable ScopeCallback callback) {
     return captureMessage(message, SentryLevel.INFO, callback);
   }
 
@@ -151,7 +156,8 @@ public interface IHub {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  default @NotNull SentryId captureException(@NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
+  default @NotNull SentryId captureException(
+      @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
     return captureException(throwable, null, callback);
   }
 
@@ -163,8 +169,11 @@ public interface IHub {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  @NotNull SentryId captureException(
-    final @NotNull Throwable throwable, final @Nullable Hint hint, final @Nullable ScopeCallback callback);
+  @NotNull
+  SentryId captureException(
+      final @NotNull Throwable throwable,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback);
 
   /**
    * Captures a manually created user feedback and sends it to Sentry.

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -31,6 +31,11 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
+  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+    return SentryId.EMPTY_ID;
+  }
+
+  @Override
   public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level) {
     return SentryId.EMPTY_ID;
   }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -31,7 +31,8 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureEvent(@NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureEvent(
+      @NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 
@@ -41,7 +42,8 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureMessage(
+      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 
@@ -56,7 +58,8 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+  public @NotNull SentryId captureException(
+      @NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -36,12 +36,22 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
+  public @NotNull SentryId captureMessage(@NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+    return SentryId.EMPTY_ID;
+  }
+
+  @Override
   public @NotNull SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Hint hint) {
     return SentryId.EMPTY_ID;
   }
 
   @Override
   public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint) {
+    return SentryId.EMPTY_ID;
+  }
+
+  @Override
+  public @NotNull SentryId captureException(@NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -32,7 +32,7 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @NotNull SentryId captureEvent(
-      @NotNull SentryEvent event, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+      @NotNull SentryEvent event, @Nullable Hint hint, @NotNull ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 
@@ -43,7 +43,7 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @NotNull SentryId captureMessage(
-      @NotNull String message, @NotNull SentryLevel level, @Nullable ScopeCallback callback) {
+      @NotNull String message, @NotNull SentryLevel level, @NotNull ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 
@@ -59,7 +59,7 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @NotNull SentryId captureException(
-      @NotNull Throwable throwable, @Nullable Hint hint, @Nullable ScopeCallback callback) {
+      @NotNull Throwable throwable, @Nullable Hint hint, @NotNull ScopeCallback callback) {
     return SentryId.EMPTY_ID;
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -284,7 +284,7 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureEvent(
-      final @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
+      final @NotNull SentryEvent event, final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureEvent(event, callback);
   }
 
@@ -311,7 +311,7 @@ public final class Sentry {
   public static @NotNull SentryId captureEvent(
       final @NotNull SentryEvent event,
       final @Nullable Hint hint,
-      final @Nullable ScopeCallback callback) {
+      final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureEvent(event, hint, callback);
   }
 
@@ -333,7 +333,7 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureMessage(
-      final @NotNull String message, final @Nullable ScopeCallback callback) {
+      final @NotNull String message, final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, callback);
   }
 
@@ -360,7 +360,7 @@ public final class Sentry {
   public static @NotNull SentryId captureMessage(
       final @NotNull String message,
       final @NotNull SentryLevel level,
-      final @Nullable ScopeCallback callback) {
+      final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, level, callback);
   }
 
@@ -382,7 +382,7 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureException(
-      final @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
+      final @NotNull Throwable throwable, final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, callback);
   }
 
@@ -409,7 +409,7 @@ public final class Sentry {
   public static @NotNull SentryId captureException(
       final @NotNull Throwable throwable,
       final @Nullable Hint hint,
-      final @Nullable ScopeCallback callback) {
+      final @NotNull ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, hint, callback);
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -279,6 +279,17 @@ public final class Sentry {
   /**
    * Captures the event.
    *
+   * @param event The event.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureEvent(final @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
+    return getCurrentHub().captureEvent(event, callback);
+  }
+
+  /**
+   * Captures the event.
+   *
    * @param event the event
    * @param hint SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
@@ -286,6 +297,19 @@ public final class Sentry {
   public static @NotNull SentryId captureEvent(
       final @NotNull SentryEvent event, final @Nullable Hint hint) {
     return getCurrentHub().captureEvent(event, hint);
+  }
+
+  /**
+   * Captures the event.
+   *
+   * @param event The event.
+   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureEvent(
+    final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
+    return getCurrentHub().captureEvent(event, hint, callback);
   }
 
   /**
@@ -305,7 +329,7 @@ public final class Sentry {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  public static @NotNull SentryId captureMessage(final @NotNull String message, final @NotNull ScopeCallback callback) {
+  public static @NotNull SentryId captureMessage(final @NotNull String message, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, callback);
   }
 
@@ -330,7 +354,7 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureMessage(
-    final @NotNull String message, final @NotNull SentryLevel level, final @NotNull ScopeCallback callback) {
+    final @NotNull String message, final @NotNull SentryLevel level, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, level, callback);
   }
 
@@ -351,7 +375,7 @@ public final class Sentry {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  public static @NotNull SentryId captureException(final @NotNull Throwable throwable, final @NotNull ScopeCallback callback) {
+  public static @NotNull SentryId captureException(final @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, callback);
   }
 
@@ -376,7 +400,7 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureException(
-    final @NotNull Throwable throwable, final @Nullable Hint hint, final @NotNull ScopeCallback callback) {
+    final @NotNull Throwable throwable, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, hint, callback);
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -302,12 +302,36 @@ public final class Sentry {
    * Captures the message.
    *
    * @param message The message to send.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureMessage(final @NotNull String message, final @NotNull ScopeCallback callback) {
+    return getCurrentHub().captureMessage(message, callback);
+  }
+
+  /**
+   * Captures the message.
+   *
+   * @param message The message to send.
    * @param level The message level.
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureMessage(
       final @NotNull String message, final @NotNull SentryLevel level) {
     return getCurrentHub().captureMessage(message, level);
+  }
+
+  /**
+   * Captures the message.
+   *
+   * @param message The message to send.
+   * @param level The message level.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureMessage(
+    final @NotNull String message, final @NotNull SentryLevel level, final @NotNull ScopeCallback callback) {
+    return getCurrentHub().captureMessage(message, level, callback);
   }
 
   /**
@@ -324,12 +348,36 @@ public final class Sentry {
    * Captures the exception.
    *
    * @param throwable The exception.
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureException(final @NotNull Throwable throwable, final @NotNull ScopeCallback callback) {
+    return getCurrentHub().captureException(throwable, callback);
+  }
+
+  /**
+   * Captures the exception.
+   *
+   * @param throwable The exception.
    * @param hint SDK specific but provides high level information about the origin of the event
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureException(
       final @NotNull Throwable throwable, final @Nullable Hint hint) {
     return getCurrentHub().captureException(throwable, hint);
+  }
+
+  /**
+   * Captures the exception.
+   *
+   * @param throwable The exception.
+   * @param hint SDK specific but provides high level information about the origin of the event
+   * @param callback The callback to configure the scope for a single invocation.
+   * @return The Id (SentryId object) of the event
+   */
+  public static @NotNull SentryId captureException(
+    final @NotNull Throwable throwable, final @Nullable Hint hint, final @NotNull ScopeCallback callback) {
+    return getCurrentHub().captureException(throwable, hint, callback);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -283,7 +283,8 @@ public final class Sentry {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  public static @NotNull SentryId captureEvent(final @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
+  public static @NotNull SentryId captureEvent(
+      final @NotNull SentryEvent event, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureEvent(event, callback);
   }
 
@@ -308,7 +309,9 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureEvent(
-    final @NotNull SentryEvent event, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
+      final @NotNull SentryEvent event,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureEvent(event, hint, callback);
   }
 
@@ -329,7 +332,8 @@ public final class Sentry {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  public static @NotNull SentryId captureMessage(final @NotNull String message, final @Nullable ScopeCallback callback) {
+  public static @NotNull SentryId captureMessage(
+      final @NotNull String message, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, callback);
   }
 
@@ -354,7 +358,9 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureMessage(
-    final @NotNull String message, final @NotNull SentryLevel level, final @Nullable ScopeCallback callback) {
+      final @NotNull String message,
+      final @NotNull SentryLevel level,
+      final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureMessage(message, level, callback);
   }
 
@@ -375,7 +381,8 @@ public final class Sentry {
    * @param callback The callback to configure the scope for a single invocation.
    * @return The Id (SentryId object) of the event
    */
-  public static @NotNull SentryId captureException(final @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
+  public static @NotNull SentryId captureException(
+      final @NotNull Throwable throwable, final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, callback);
   }
 
@@ -400,7 +407,9 @@ public final class Sentry {
    * @return The Id (SentryId object) of the event
    */
   public static @NotNull SentryId captureException(
-    final @NotNull Throwable throwable, final @Nullable Hint hint, final @Nullable ScopeCallback callback) {
+      final @NotNull Throwable throwable,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
     return getCurrentHub().captureException(throwable, hint, callback);
   }
 

--- a/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DirectoryProcessorTest.kt
@@ -67,7 +67,7 @@ class DirectoryProcessorTest {
         whenever(fixture.serializer.deserialize(any(), eq(SentryEvent::class.java))).thenReturn(event)
 
         fixture.getSut().processDirectory(file)
-        verify(fixture.hub).captureEvent(any(), argWhere { !HintUtils.hasType(it, ApplyScopeData::class.java) })
+        verify(fixture.hub).captureEvent(any(), argWhere<Hint> { !HintUtils.hasType(it, ApplyScopeData::class.java) })
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
-import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
@@ -398,13 +397,13 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         sut.captureEvent(SentryEvent(), null) {
-            it.setTag("test", "test")
+            it.setTag("test", "testValue")
         }
 
         verify(mockClient).captureEvent(
             any(),
             check {
-                assertNotNull(it.tags["test"])
+                assertEquals("testValue", it.tags["test"])
             },
             anyOrNull()
         )
@@ -416,10 +415,10 @@ class HubTest {
         val argumentCaptor = argumentCaptor<Scope>()
 
         sut.captureEvent(SentryEvent(), null) {
-            it.setTag("test", "test")
+            it.setTag("test", "testValue")
         }
 
-        sut.captureEvent(SentryEvent(), null, null)
+        sut.captureEvent(SentryEvent())
 
         verify(mockClient, times(2)).captureEvent(
             any(),
@@ -427,7 +426,7 @@ class HubTest {
             anyOrNull()
         )
 
-        assertNotNull(argumentCaptor.allValues[0].tags["test"])
+        assertEquals("testValue", argumentCaptor.allValues[0].tags["test"])
         assertNull(argumentCaptor.allValues[1].tags["test"])
     }
     //endregion
@@ -473,14 +472,14 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         sut.captureMessage("test") {
-            it.setTag("test", "test")
+            it.setTag("test", "testValue")
         }
 
         verify(mockClient).captureMessage(
             any(),
             any(),
             check {
-                assertNotNull(it.tags["test"])
+                assertEquals("testValue", it.tags["test"])
             }
         )
     }
@@ -490,11 +489,11 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
         val argumentCaptor = argumentCaptor<Scope>()
 
-        sut.captureMessage("test") {
-            it.setTag("test", "test")
+        sut.captureMessage("testMessage") {
+            it.setTag("test", "testValue")
         }
 
-        sut.captureMessage("test", null)
+        sut.captureMessage("test", SentryLevel.INFO)
 
         verify(mockClient, times(2)).captureMessage(
             any(),
@@ -502,7 +501,7 @@ class HubTest {
             argumentCaptor.capture(),
         )
 
-        assertNotNull(argumentCaptor.allValues[0].tags["test"])
+        assertEquals("testValue", argumentCaptor.allValues[0].tags["test"])
         assertNull(argumentCaptor.allValues[1].tags["test"])
     }
 
@@ -543,7 +542,7 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         sut.captureException(Throwable())
-        verify(mockClient).captureEvent(any(), any(), isNull())
+        verify(mockClient).captureEvent(any(), any(), any())
     }
 
     @Test
@@ -585,13 +584,13 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         sut.captureException(Throwable(), null) {
-            it.setTag("test", "test")
+            it.setTag("test", "testValue")
         }
 
         verify(mockClient).captureEvent(
             any(),
             check {
-                assertNotNull(it.tags["test"])
+                assertEquals("testValue", it.tags["test"])
             },
             anyOrNull()
         )
@@ -603,10 +602,10 @@ class HubTest {
         val argumentCaptor = argumentCaptor<Scope>()
 
         sut.captureException(Throwable(), null) {
-            it.setTag("test", "test")
+            it.setTag("test", "testValue")
         }
 
-        sut.captureException(Throwable(), null, null)
+        sut.captureException(Throwable())
 
         verify(mockClient, times(2)).captureEvent(
             any(),
@@ -614,7 +613,7 @@ class HubTest {
             anyOrNull()
         )
 
-        assertNotNull(argumentCaptor.allValues[0].tags["test"])
+        assertEquals("testValue", argumentCaptor.allValues[0].tags["test"])
         assertNull(argumentCaptor.allValues[1].tags["test"])
     }
 

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1,6 +1,20 @@
 package io.sentry
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argWhere
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.cache.EnvelopeCache
 import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
 import io.sentry.clientreport.DiscardReason

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -81,7 +81,7 @@ class OutboxSenderTest {
         val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
         sut.processEnvelopeFile(path, hints)
 
-        verify(fixture.hub).captureEvent(eq(expected), any())
+        verify(fixture.hub).captureEvent(eq(expected), any<Hint>())
         assertFalse(File(path).exists())
         // Additionally make sure we have no errors logged
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any(), any<Any>())
@@ -147,7 +147,7 @@ class OutboxSenderTest {
         val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
         sut.processEnvelopeFile(path, hints)
 
-        verify(fixture.hub).captureEvent(any(), any())
+        verify(fixture.hub).captureEvent(any(), any<Hint>())
         assertFalse(File(path).exists())
         // Additionally make sure we have no errors logged
         verify(fixture.logger, never()).log(eq(SentryLevel.ERROR), any(), any<Any>())

--- a/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
@@ -50,7 +50,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
         sut.uncaughtException(threadMock, throwableMock)
-        verify(hubMock).captureEvent(any(), any())
+        verify(hubMock).captureEvent(any(), any<Hint>())
     }
 
     @Test
@@ -85,7 +85,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         val sut = UncaughtExceptionHandlerIntegration(handlerMock)
         sut.register(hubMock, options)
         sut.uncaughtException(threadMock, throwableMock)
-        verify(hubMock).captureEvent(any(), any())
+        verify(hubMock).captureEvent(any(), any<Hint>())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Add overloads with scope callback for `captureEvent`, `captureException` and `captureMessage` to allow users to modify the scope for a single invocation of the capture methods.


## :bulb: Motivation and Context
fixes #1829 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Update Docs
