### PR TITLE
Sentry recovers after a Thread had currentHub set to a NoOpHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry can now self heal after a Thread had its currentHub set to a NoOpHub ([#2076](https://github.com/getsentry/sentry-java/pull/2076))
+
 ## 6.0.0-rc.1
 
 ### Features

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -41,7 +41,7 @@ public final class Sentry {
       return mainHub;
     }
     IHub hub = currentHub.get();
-    if (hub == null) {
+    if (hub == null || hub instanceof NoOpHub) {
       hub = mainHub.clone();
       currentHub.set(hub);
     }


### PR DESCRIPTION
## :scroll: Description
When a call to `Sentry` happens before `Sentry.init`, the `currentHub` is set to a `NoOpHub`. If `Sentry.init` is then called in a different thread, the thread where `Sentry` was called before `init` is poisoned without this change. By checking if the `currentHub` is a `NoOpHub` we can allow the poisoned thread to self heal.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Happened to a customer who set up a thread pool and had executions happen before being able to initialize Sentry.


## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
Discuss if this has any consequences I can't see.

Resolves #2079