### PR TITLE
#1054 added converting some MDC-tags for Sentry tags for more flexible issue grouping

### DIFF
--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +35,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private @Nullable ITransportFactory transportFactory;
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.ERROR;
+  private @NotNull Set<String> mdcToTags = new HashSet<>();
 
   @Override
   public void start() {
@@ -103,6 +106,13 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             loggingEvent.getMDCPropertyMap(), entry -> entry.getValue() != null);
     if (!mdcProperties.isEmpty()) {
       event.getContexts().put("MDC", mdcProperties);
+
+      mdcToTags.forEach(mdcName -> {
+        String mdcValue = mdcProperties.get(mdcName);
+        if (mdcValue != null) {
+          event.setTag(mdcName, mdcValue);
+        }
+      });
     }
 
     return event;
@@ -192,5 +202,13 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   @ApiStatus.Internal
   void setTransportFactory(final @Nullable ITransportFactory transportFactory) {
     this.transportFactory = transportFactory;
+  }
+
+  public @NotNull Set<String> getMdcToTags() {
+    return new HashSet<>(mdcToTags);
+  }
+
+  public void setMdcToTags(@NotNull Set<String> mdcToTags) {
+    this.mdcToTags = new HashSet<>(mdcToTags);
   }
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryLogbackInitializer.java
@@ -47,6 +47,8 @@ class SentryLogbackInitializer implements GenericApplicationListener {
       Optional.ofNullable(sentryProperties.getLogging().getMinimumEventLevel())
           .map(slf4jLevel -> Level.toLevel(slf4jLevel.name()))
           .ifPresent(sentryAppender::setMinimumEventLevel);
+      Optional.ofNullable(sentryProperties.getMdcToTags())
+          .ifPresent(sentryAppender::setMdcToTags);
 
       sentryAppender.start();
       rootLogger.addAppender(sentryAppender);

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.event.Level;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.Set;
+
 /** Configuration for Sentry integration. */
 @ConfigurationProperties("sentry")
 @Open
@@ -35,6 +37,9 @@ public class SentryProperties extends SentryOptions {
 
   /** Logging framework integration properties. */
   private @NotNull Logging logging = new Logging();
+
+  /** Property for creating Sentry tags from MDC-tags*/
+  private @Nullable Set<String> mdcToTags;
 
   public boolean isUseGitCommitIdAsRelease() {
     return useGitCommitIdAsRelease;
@@ -88,6 +93,14 @@ public class SentryProperties extends SentryOptions {
 
   public void setLogging(@NotNull Logging logging) {
     this.logging = logging;
+  }
+
+  public @Nullable Set<String> getMdcToTags() {
+    return mdcToTags;
+  }
+
+  public void setMdcToTags(Set<String> mdcToTags) {
+    this.mdcToTags = mdcToTags;
   }
 
   @Open

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryLogbackAppenderAutoConfigurationTest.kt
@@ -45,7 +45,12 @@ class SentryLogbackAppenderAutoConfigurationTest {
 
     @Test
     fun `sets SentryAppender properties`() {
-        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.logging.minimum-event-level=info", "sentry.logging.minimum-breadcrumb-level=debug")
+        contextRunner.withPropertyValues(
+            "sentry.dsn=http://key@localhost/proj",
+            "sentry.logging.minimum-event-level=info",
+            "sentry.logging.minimum-breadcrumb-level=debug",
+            "sentry.mdc-to-tags=process,user"
+        )
             .run {
                 val appenders = rootLogger.getAppenders(SentryAppender::class.java)
                 assertThat(appenders).hasSize(1)
@@ -53,6 +58,7 @@ class SentryLogbackAppenderAutoConfigurationTest {
 
                 assertThat(sentryAppender.minimumBreadcrumbLevel).isEqualTo(Level.DEBUG)
                 assertThat(sentryAppender.minimumEventLevel).isEqualTo(Level.INFO)
+                assertThat(sentryAppender.mdcToTags).containsExactlyInAnyOrderElementsOf(hashSetOf("process","user"))
             }
     }
 


### PR DESCRIPTION
#1054 added converting some MDC-tags for Sentry tags for more flexible issue grouping

## :scroll: Description
<!--- Describe your changes in detail -->
I have added changes to the SentryAppender for the logback, in which some mdc values are converted to sentry tags


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1054

While working with sentry, I found that there is little contextual information in the tags (sentry tags) in the issues.
At the same time, in fingerprint rules, grouping of issues is only using tags, but not values from the MDC context.

The Sentry SDK allows you to add tags to events, but it's much easier to create some Sentry tags from the MDC context

## :green_heart: How did you test it?
Only unit test(I have already extended SentryAppender in my project and added similar functionality there)


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
