### PR TITLE
SentryOptions#merge is now public and can be used to load ExternalOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Implement local scope by adding overloads to the capture methods that accept a ScopeCallback ([#2084](https://github.com/getsentry/sentry-java/pull/2084))
+- SentryOptions.merge is now public and can be used to load ExternalOptions ([#2088](https://github.com/getsentry/sentry-java/pull/2088))
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Implement local scope by adding overloads to the capture methods that accept a ScopeCallback ([#2084](https://github.com/getsentry/sentry-java/pull/2084))
-- SentryOptions.merge is now public and can be used to load ExternalOptions ([#2088](https://github.com/getsentry/sentry-java/pull/2088))
+- SentryOptions#merge is now public and can be used to load ExternalOptions ([#2088](https://github.com/getsentry/sentry-java/pull/2088))
 
 ## 6.0.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1240,6 +1240,7 @@ public class io/sentry/SentryOptions {
 	public fun isSendDefaultPii ()Z
 	public fun isTraceSampling ()Z
 	public fun isTracingEnabled ()Z
+	public fun merge (Lio/sentry/ExternalOptions;)V
 	public fun setAttachServerName (Z)V
 	public fun setAttachStacktrace (Z)V
 	public fun setAttachThreads (Z)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1710,7 +1710,7 @@ public class SentryOptions {
    *
    * @param options options loaded from external locations
    */
-  void merge(final @NotNull ExternalOptions options) {
+  public void merge(final @NotNull ExternalOptions options) {
     if (options.getDsn() != null) {
       setDsn(options.getDsn());
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allows developers to deserialize `ExternalOptions` and then merge them into `SentryOptions`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/2086

## :green_heart: How did you test it?
-

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
