### PR TITLE
Workaround R8 bug by adding a new proguard rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Fix proguard rules to work R8 [issue](https://issuetracker.google.com/issues/235733922) around on AGP 7.3.0-betaX/7.4.0-alphaX ([#2094](https://github.com/getsentry/sentry-java/pull/2094))
+- Fix proguard rules to work R8 [issue](https://issuetracker.google.com/issues/235733922) around on AGP 7.3.0-betaX and 7.4.0-alphaX ([#2094](https://github.com/getsentry/sentry-java/pull/2094))
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Implement local scope by adding overloads to the capture methods that accept a ScopeCallback ([#2084](https://github.com/getsentry/sentry-java/pull/2084))
 
+### Fixes
+
+- Fix proguard rules to work R8 [issue](https://issuetracker.google.com/issues/235733922) around on AGP 7.3.0-betaX/7.4.0-alphaX ([#2094](https://github.com/getsentry/sentry-java/pull/2094))
+
 ## 6.0.0
 
 ### Sentry Self-hosted Compatibility

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -11,6 +11,10 @@
 -keep class androidx.lifecycle.ProcessLifecycleOwner { <init>(...); }
 ##---------------End: proguard configuration for androidx.lifecycle  ----------
 
+# To mitigate the issue on R8 site (https://issuetracker.google.com/issues/235733922) 
+# which comes through AGP 7.3.0-betaX and 7.4.0-alphaX
+-keepclassmembers enum io.sentry.** { *; }
+
 # don't warn jetbrains annotations
 -dontwarn org.jetbrains.annotations.**
 # don't warn about missing classes (mainly for Guardsquare's proguard).


### PR DESCRIPTION
To mitigate failures with R8 on AGP 7.3.0-betaX and 7.4.0-alphaX https://issuetracker.google.com/issues/235733922
