### PR TITLE
Allow opting out of device info collection that requires Inter-Process Communication (IPC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Replace `tracestate` header with `baggage` header ([#2078](https://github.com/getsentry/sentry-java/pull/2078))
+- Allow opting out of device info collection that requires Inter-Process Communication (IPC) ([#2100](https://github.com/getsentry/sentry-java/pull/2100))
 
 ## 6.1.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -129,7 +129,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isAnrEnabled ()Z
 	public fun isAnrReportInDebug ()Z
 	public fun isAttachScreenshot ()Z
-	public fun isCollectIpcDeviceInfo ()Z
+	public fun isCollectAdditionalContext ()Z
 	public fun isEnableActivityLifecycleBreadcrumbs ()Z
 	public fun isEnableActivityLifecycleTracingAutoFinish ()Z
 	public fun isEnableAppComponentBreadcrumbs ()Z
@@ -142,7 +142,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setAnrReportInDebug (Z)V
 	public fun setAnrTimeoutIntervalMillis (J)V
 	public fun setAttachScreenshot (Z)V
-	public fun setCollectIpcDeviceInfo (Z)V
+	public fun setCollectAdditionalContext (Z)V
 	public fun setDebugImagesLoader (Lio/sentry/android/core/IDebugImagesLoader;)V
 	public fun setEnableActivityLifecycleBreadcrumbs (Z)V
 	public fun setEnableActivityLifecycleTracingAutoFinish (Z)V

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -129,6 +129,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isAnrEnabled ()Z
 	public fun isAnrReportInDebug ()Z
 	public fun isAttachScreenshot ()Z
+	public fun isCollectIpcDeviceInfo ()Z
 	public fun isEnableActivityLifecycleBreadcrumbs ()Z
 	public fun isEnableActivityLifecycleTracingAutoFinish ()Z
 	public fun isEnableAppComponentBreadcrumbs ()Z
@@ -141,6 +142,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setAnrReportInDebug (Z)V
 	public fun setAnrTimeoutIntervalMillis (J)V
 	public fun setAttachScreenshot (Z)V
+	public fun setCollectIpcDeviceInfo (Z)V
 	public fun setDebugImagesLoader (Lio/sentry/android/core/IDebugImagesLoader;)V
 	public fun setEnableActivityLifecycleBreadcrumbs (Z)V
 	public fun setEnableActivityLifecycleTracingAutoFinish (Z)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -147,7 +147,7 @@ final class AndroidOptionsInitializer {
     readDefaultOptionValues(options, context);
 
     options.addEventProcessor(
-        new DefaultAndroidEventProcessor(context, logger, buildInfoProvider, options));
+        new DefaultAndroidEventProcessor(context, buildInfoProvider, options));
     options.addEventProcessor(new PerformanceAndroidEventProcessor(options, activityFramesTracker));
 
     options.setTransportGate(new AndroidTransportGate(context, options.getLogger()));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -146,7 +146,8 @@ final class AndroidOptionsInitializer {
 
     readDefaultOptionValues(options, context);
 
-    options.addEventProcessor(new DefaultAndroidEventProcessor(context, logger, buildInfoProvider));
+    options.addEventProcessor(
+        new DefaultAndroidEventProcessor(context, logger, buildInfoProvider, options));
     options.addEventProcessor(new PerformanceAndroidEventProcessor(options, activityFramesTracker));
 
     options.setTransportGate(new AndroidTransportGate(context, options.getLogger()));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -332,16 +332,14 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setDeviceIO(final @NotNull Device device, final boolean applyScopeData) {
-    if (options.isCollectIpcDeviceInfo()) {
+    if (options.isCollectAdditionalContext()) {
       final Intent batteryIntent = getBatteryIntent();
       if (batteryIntent != null) {
         device.setBatteryLevel(getBatteryLevel(batteryIntent));
         device.setCharging(isCharging(batteryIntent));
         device.setBatteryTemperature(getBatteryTemperature(batteryIntent));
       }
-    }
 
-    if (options.isCollectIpcDeviceInfo()) {
       Boolean connected;
       switch (ConnectivityChecker.getConnectionStatus(context, options.getLogger())) {
         case NOT_CONNECTED:
@@ -354,9 +352,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           connected = null;
       }
       device.setOnline(connected);
-    }
 
-    if (options.isCollectIpcDeviceInfo()) {
       final ActivityManager.MemoryInfo memInfo = getMemInfo();
       if (memInfo != null) {
         // in bytes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -23,7 +23,6 @@ import android.util.DisplayMetrics;
 import io.sentry.DateUtils;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
-import io.sentry.ILogger;
 import io.sentry.SentryBaseEvent;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
@@ -71,29 +70,23 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private final @NotNull RootChecker rootChecker;
   private final @NotNull SentryAndroidOptions options;
 
-  private final @NotNull ILogger logger;
-
   public DefaultAndroidEventProcessor(
       final @NotNull Context context,
-      final @NotNull ILogger logger,
       final @NotNull BuildInfoProvider buildInfoProvider,
       final @NotNull SentryAndroidOptions options) {
     this(
         context,
-        logger,
         buildInfoProvider,
-        new RootChecker(context, buildInfoProvider, logger),
+        new RootChecker(context, buildInfoProvider, options.getLogger()),
         options);
   }
 
   DefaultAndroidEventProcessor(
       final @NotNull Context context,
-      final @NotNull ILogger logger,
       final @NotNull BuildInfoProvider buildInfoProvider,
       final @NotNull RootChecker rootChecker,
       final @NotNull SentryAndroidOptions options) {
     this.context = Objects.requireNonNull(context, "The application context is required.");
-    this.logger = Objects.requireNonNull(logger, "The Logger is required.");
     this.buildInfoProvider =
         Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
     this.rootChecker = Objects.requireNonNull(rootChecker, "The RootChecker is required.");
@@ -158,10 +151,12 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (HintUtils.shouldApplyScopeData(hint)) {
       return true;
     } else {
-      logger.log(
-          SentryLevel.DEBUG,
-          "Event was cached so not applying data relevant to the current app execution/version: %s",
-          event.getEventId());
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Event was cached so not applying data relevant to the current app execution/version: %s",
+              event.getEventId());
       return false;
     }
   }
@@ -229,7 +224,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   private void setPackageInfo(final @NotNull SentryBaseEvent event, final @NotNull App app) {
     final PackageInfo packageInfo =
-        ContextUtils.getPackageInfo(context, PackageManager.GET_PERMISSIONS, logger);
+        ContextUtils.getPackageInfo(context, PackageManager.GET_PERMISSIONS, options.getLogger());
     if (packageInfo != null) {
       String versionCode = ContextUtils.getVersionCode(packageInfo);
 
@@ -307,7 +302,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         device.setSimulator((Boolean) emulator);
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting emulator.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting emulator.", e);
     }
 
     DisplayMetrics displayMetrics = getDisplayMetrics();
@@ -348,7 +343,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     if (options.isCollectIpcDeviceInfo()) {
       Boolean connected;
-      switch (ConnectivityChecker.getConnectionStatus(context, logger)) {
+      switch (ConnectivityChecker.getConnectionStatus(context, options.getLogger())) {
         case NOT_CONNECTED:
           connected = false;
           break;
@@ -393,7 +388,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (device.getConnectionType() == null) {
       // wifi, ethernet or cellular, null if none
       device.setConnectionType(
-          ConnectivityChecker.getConnectionType(context, logger, buildInfoProvider));
+          ConnectivityChecker.getConnectionType(context, options.getLogger(), buildInfoProvider));
     }
   }
 
@@ -424,7 +419,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       // currentTimeMillis returns UTC already
       return DateUtils.getDateTime(System.currentTimeMillis() - SystemClock.elapsedRealtime());
     } catch (IllegalArgumentException e) {
-      logger.log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
+      options.getLogger().log(SentryLevel.ERROR, e, "Error getting the device's boot time.");
     }
     return null;
   }
@@ -442,10 +437,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         actManager.getMemoryInfo(memInfo);
         return memInfo;
       }
-      logger.log(SentryLevel.INFO, "Error getting MemoryInfo.");
+      options.getLogger().log(SentryLevel.INFO, "Error getting MemoryInfo.");
       return null;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
       return null;
     }
   }
@@ -464,7 +459,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return Build.MODEL.split(" ", -1)[0];
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting device family.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting device family.", e);
       return null;
     }
   }
@@ -487,7 +482,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
       return ((float) level / (float) scale) * percentMultiplier;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting device battery level.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting device battery level.", e);
       return null;
     }
   }
@@ -503,7 +498,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       return plugged == BatteryManager.BATTERY_PLUGGED_AC
           || plugged == BatteryManager.BATTERY_PLUGGED_USB;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting device charging state.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting device charging state.", e);
       return null;
     }
   }
@@ -515,7 +510,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return ((float) temperature) / 10; // celsius
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting battery temperature.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting battery temperature.", e);
     }
     return null;
   }
@@ -532,13 +527,15 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       deviceOrientation =
           DeviceOrientations.getOrientation(context.getResources().getConfiguration().orientation);
       if (deviceOrientation == null) {
-        logger.log(
-            SentryLevel.INFO,
-            "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
+        options
+            .getLogger()
+            .log(
+                SentryLevel.INFO,
+                "No device orientation available (ORIENTATION_SQUARE|ORIENTATION_UNDEFINED)");
         return null;
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting device orientation.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting device orientation.", e);
     }
     return deviceOrientation;
   }
@@ -554,7 +551,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting total internal storage amount.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting total internal storage amount.", e);
       return null;
     }
   }
@@ -609,7 +606,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting unused internal storage amount.", e);
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Error getting unused internal storage amount.", e);
       return null;
     }
   }
@@ -620,10 +619,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       if (path != null) { // && path.canRead()) { canRead() will read return false
         return new StatFs(path.getPath());
       }
-      logger.log(SentryLevel.INFO, "Not possible to read external files directory");
+      options.getLogger().log(SentryLevel.INFO, "Not possible to read external files directory");
       return null;
     }
-    logger.log(SentryLevel.INFO, "External storage is not mounted or emulated.");
+    options.getLogger().log(SentryLevel.INFO, "External storage is not mounted or emulated.");
     return null;
   }
 
@@ -664,7 +663,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return file;
       }
     } else {
-      logger.log(SentryLevel.INFO, "Not possible to read getExternalFilesDirs");
+      options.getLogger().log(SentryLevel.INFO, "Not possible to read getExternalFilesDirs");
     }
     return null;
   }
@@ -681,7 +680,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long totalBlocks = getBlockCountLong(stat);
       return totalBlocks * blockSize;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting total external storage amount.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting total external storage amount.", e);
       return null;
     }
   }
@@ -705,7 +704,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       long availableBlocks = getAvailableBlocksLong(stat);
       return availableBlocks * blockSize;
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting unused external storage amount.", e);
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Error getting unused external storage amount.", e);
       return null;
     }
   }
@@ -719,7 +720,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return context.getResources().getDisplayMetrics();
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting DisplayMetrics.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting DisplayMetrics.", e);
       return null;
     }
   }
@@ -741,7 +742,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         os.setRooted((Boolean) rooted);
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting OperatingSystem.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting OperatingSystem.", e);
     }
 
     return os;
@@ -796,7 +797,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try (BufferedReader br = new BufferedReader(new FileReader(file))) {
       return br.readLine();
     } catch (IOException e) {
-      logger.log(SentryLevel.ERROR, errorMsg, e);
+      options.getLogger().log(SentryLevel.ERROR, errorMsg, e);
     }
 
     return defaultVersion;
@@ -820,7 +821,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         return context.getString(stringId);
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting application name.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting application name.", e);
     }
 
     return null;
@@ -842,7 +843,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     try {
       return Installation.id(context);
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting installationId.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting installationId.", e);
     }
     return null;
   }
@@ -851,7 +852,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private @Nullable Map<String, String> getSideLoadedInfo() {
     String packageName = null;
     try {
-      final PackageInfo packageInfo = ContextUtils.getPackageInfo(context, logger);
+      final PackageInfo packageInfo = ContextUtils.getPackageInfo(context, options.getLogger());
       final PackageManager packageManager = context.getPackageManager();
 
       if (packageInfo != null && packageManager != null) {
@@ -876,7 +877,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       }
     } catch (IllegalArgumentException e) {
       // it'll never be thrown as we are querying its own App's package.
-      logger.log(SentryLevel.DEBUG, "%s package isn't installed.", packageName);
+      options.getLogger().log(SentryLevel.DEBUG, "%s package isn't installed.", packageName);
     }
 
     return null;
@@ -894,7 +895,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
         }
       }
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error getting side loaded info.", e);
+      options.getLogger().log(SentryLevel.ERROR, "Error getting side loaded info.", e);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -71,7 +71,7 @@ final class ManifestMetadataReader {
 
   static final String ATTACH_SCREENSHOT = "io.sentry.attach-screenshot";
   static final String CLIENT_REPORTS_ENABLE = "io.sentry.send-client-reports";
-  static final String COLLECT_IPC_DEVICE_INFO = "io.sentry.ipc-device-context";
+  static final String COLLECT_ADDITIONAL_CONTEXT = "io.sentry.additional-context";
 
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
@@ -211,8 +211,12 @@ final class ManifestMetadataReader {
         options.setSendClientReports(
             readBool(metadata, logger, CLIENT_REPORTS_ENABLE, options.isSendClientReports()));
 
-        options.setCollectIpcDeviceInfo(
-            readBool(metadata, logger, COLLECT_IPC_DEVICE_INFO, options.isCollectIpcDeviceInfo()));
+        options.setCollectAdditionalContext(
+            readBool(
+                metadata,
+                logger,
+                COLLECT_ADDITIONAL_CONTEXT,
+                options.isCollectAdditionalContext()));
 
         if (options.getTracesSampleRate() == null) {
           final Double tracesSampleRate = readDouble(metadata, logger, TRACES_SAMPLE_RATE);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -71,7 +71,7 @@ final class ManifestMetadataReader {
 
   static final String ATTACH_SCREENSHOT = "io.sentry.attach-screenshot";
   static final String CLIENT_REPORTS_ENABLE = "io.sentry.send-client-reports";
-  static final String COLLECT_IPC_DEVICE_INFO = "io.sentry.collect-ipc-device-info";
+  static final String COLLECT_IPC_DEVICE_INFO = "io.sentry.ipc-device-context";
 
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -71,6 +71,7 @@ final class ManifestMetadataReader {
 
   static final String ATTACH_SCREENSHOT = "io.sentry.attach-screenshot";
   static final String CLIENT_REPORTS_ENABLE = "io.sentry.send-client-reports";
+  static final String COLLECT_IPC_DEVICE_INFO = "io.sentry.collect-ipc-device-info";
 
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
@@ -209,6 +210,9 @@ final class ManifestMetadataReader {
 
         options.setSendClientReports(
             readBool(metadata, logger, CLIENT_REPORTS_ENABLE, options.isSendClientReports()));
+
+        options.setCollectIpcDeviceInfo(
+            readBool(metadata, logger, COLLECT_IPC_DEVICE_INFO, options.isCollectIpcDeviceInfo()));
 
         if (options.getTracesSampleRate() == null) {
           final Double tracesSampleRate = readDouble(metadata, logger, TRACES_SAMPLE_RATE);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -100,7 +100,7 @@ public final class SentryAndroidOptions extends SentryOptions {
    * Enables or disables collecting of device information which requires Inter-Process Communication
    * (IPC)
    */
-  private boolean collectIpcDeviceInfo = true;
+  private boolean collectAdditionalContext = true;
 
   public SentryAndroidOptions() {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
@@ -301,11 +301,11 @@ public final class SentryAndroidOptions extends SentryOptions {
     this.enableUserInteractionTracing = enableUserInteractionTracing;
   }
 
-  public boolean isCollectIpcDeviceInfo() {
-    return collectIpcDeviceInfo;
+  public boolean isCollectAdditionalContext() {
+    return collectAdditionalContext;
   }
 
-  public void setCollectIpcDeviceInfo(boolean collectIpcDeviceInfo) {
-    this.collectIpcDeviceInfo = collectIpcDeviceInfo;
+  public void setCollectAdditionalContext(boolean collectAdditionalContext) {
+    this.collectAdditionalContext = collectAdditionalContext;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -96,6 +96,12 @@ public final class SentryAndroidOptions extends SentryOptions {
   /** Enables or disables the attach screenshot feature when an error happened. */
   private boolean attachScreenshot;
 
+  /**
+   * Enables or disables collecting of device information which requires Inter-Process Communication
+   * (IPC)
+   */
+  private boolean collectIpcDeviceInfo = true;
+
   public SentryAndroidOptions() {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
@@ -293,5 +299,13 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   public void setEnableUserInteractionTracing(boolean enableUserInteractionTracing) {
     this.enableUserInteractionTracing = enableUserInteractionTracing;
+  }
+
+  public boolean isCollectIpcDeviceInfo() {
+    return collectIpcDeviceInfo;
+  }
+
+  public void setCollectIpcDeviceInfo(boolean collectIpcDeviceInfo) {
+    this.collectIpcDeviceInfo = collectIpcDeviceInfo;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -464,7 +464,7 @@ class DefaultAndroidEventProcessorTest {
 
     @Test
     fun `Does not collect device info that requires IPC if disabled`() {
-        fixture.options.isCollectIpcDeviceInfo = false
+        fixture.options.isCollectAdditionalContext = false
         val sut = fixture.getSut(context)
 
         assertNotNull(sut.process(SentryEvent(), Hint())) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -13,7 +13,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.DiagnosticLogger
 import io.sentry.Hint
-import io.sentry.ILogger
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryTracer
@@ -47,7 +46,7 @@ class DefaultAndroidEventProcessorTest {
 
     private val className = "io.sentry.android.core.DefaultAndroidEventProcessor"
     private val ctorTypes =
-        arrayOf(Context::class.java, ILogger::class.java, BuildInfoProvider::class.java, SentryAndroidOptions::class.java)
+        arrayOf(Context::class.java, BuildInfoProvider::class.java, SentryAndroidOptions::class.java)
 
     init {
         Locale.setDefault(Locale.US)
@@ -63,7 +62,7 @@ class DefaultAndroidEventProcessorTest {
         val sentryTracer = SentryTracer(TransactionContext("", ""), mock())
 
         fun getSut(context: Context): DefaultAndroidEventProcessor {
-            return DefaultAndroidEventProcessor(context, options.logger, buildInfo, options)
+            return DefaultAndroidEventProcessor(context, buildInfo, options)
         }
     }
 
@@ -85,7 +84,7 @@ class DefaultAndroidEventProcessorTest {
     fun `when null context is provided, invalid argument is thrown`() {
         val ctor = className.getCtor(ctorTypes)
 
-        val params = arrayOf(null, mock<ILogger>(), null, mock<SentryAndroidOptions>())
+        val params = arrayOf(null, null, mock<SentryAndroidOptions>())
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
@@ -93,7 +92,7 @@ class DefaultAndroidEventProcessorTest {
     fun `when null logger is provided, invalid argument is thrown`() {
         val ctor = className.getCtor(ctorTypes)
 
-        val params = arrayOf(mock<Context>(), null, null, mock<SentryAndroidOptions>())
+        val params = arrayOf(mock<Context>(), null, mock<SentryAndroidOptions>())
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
@@ -101,7 +100,7 @@ class DefaultAndroidEventProcessorTest {
     fun `when null options is provided, invalid argument is thrown`() {
         val ctor = className.getCtor(ctorTypes)
 
-        val params = arrayOf(mock<Context>(), mock<ILogger>(), mock<BuildInfoProvider>(), null)
+        val params = arrayOf(mock<Context>(), mock<BuildInfoProvider>(), null)
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
@@ -109,7 +108,7 @@ class DefaultAndroidEventProcessorTest {
     fun `when null buildInfo is provided, invalid argument is thrown`() {
         val ctor = className.getCtor(ctorTypes)
 
-        val params = arrayOf(null, null, mock<BuildInfoProvider>(), mock<SentryAndroidOptions>())
+        val params = arrayOf(null, mock<BuildInfoProvider>(), mock<SentryAndroidOptions>())
         assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
@@ -313,7 +312,7 @@ class DefaultAndroidEventProcessorTest {
     @Test
     fun `Processor won't throw exception when theres a hint`() {
         val processor =
-            DefaultAndroidEventProcessor(context, fixture.options.logger, fixture.buildInfo, mock())
+            DefaultAndroidEventProcessor(context, fixture.buildInfo, mock(), fixture.options)
 
         val hints = HintUtils.createWithTypeCheckHint(CachedEvent())
         processor.process(SentryEvent(), hints)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -919,4 +919,29 @@ class ManifestMetadataReaderTest {
         // Assert
         assertEquals(3000L, fixture.options.idleTimeout)
     }
+
+    @Test
+    fun `applyMetadata reads collect ipc device info to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.COLLECT_IPC_DEVICE_INFO to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertFalse(fixture.options.isCollectIpcDeviceInfo)
+    }
+
+    @Test
+    fun `applyMetadata reads collect ipc device info and keep default value if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options)
+
+        // Assert
+        assertTrue(fixture.options.isCollectIpcDeviceInfo)
+    }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -923,14 +923,14 @@ class ManifestMetadataReaderTest {
     @Test
     fun `applyMetadata reads collect ipc device info to options`() {
         // Arrange
-        val bundle = bundleOf(ManifestMetadataReader.COLLECT_IPC_DEVICE_INFO to false)
+        val bundle = bundleOf(ManifestMetadataReader.COLLECT_ADDITIONAL_CONTEXT to false)
         val context = fixture.getContext(metaData = bundle)
 
         // Act
         ManifestMetadataReader.applyMetadata(context, fixture.options)
 
         // Assert
-        assertFalse(fixture.options.isCollectIpcDeviceInfo)
+        assertFalse(fixture.options.isCollectAdditionalContext)
     }
 
     @Test
@@ -942,6 +942,6 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options)
 
         // Assert
-        assertTrue(fixture.options.isCollectIpcDeviceInfo)
+        assertTrue(fixture.options.isCollectAdditionalContext)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allow opting out of device info collection that requires Inter-Process Communication (IPC)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A way of avoiding https://github.com/getsentry/sentry-java/issues/2095

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
