### PR TITLE
Fix javadoc in JsonReader

### DIFF
--- a/sentry/src/main/java/io/sentry/vendor/gson/stream/JsonReader.java
+++ b/sentry/src/main/java/io/sentry/vendor/gson/stream/JsonReader.java
@@ -176,7 +176,7 @@ import java.util.Arrays;
  * precision loss, extremely large values should be written and read as strings
  * in JSON.
  *
- * <a id="nonexecuteprefix"/><h3>Non-Execute Prefix</h3>
+ * <a id="nonexecuteprefix"></a><h3>Non-Execute Prefix</h3>
  * Web servers that serve private data using JSON may be vulnerable to <a
  * href="http://en.wikipedia.org/wiki/JSON#Cross-site_request_forgery">Cross-site
  * request forgery</a> attacks. In such an attack, a malicious site gains access
@@ -186,10 +186,10 @@ import java.util.Arrays;
  * by {@code <script>} tags, disarming the attack. Since the prefix is malformed
  * JSON, strict parsing fails when it is encountered. This class permits the
  * non-execute prefix when {@link #setLenient(boolean) lenient parsing} is
- * enabled.
+ * enabled.</p>
  *
  * <p>Each {@code JsonReader} may be used to read a single JSON stream. Instances
- * of this class are not thread safe.
+ * of this class are not thread safe.</p>
  *
  * @author Jesse Wilson
  * @since 1.6


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
Fix javadoc in `JsonReader`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Release build for `6.1.1` failed due to javadoc not being able to generate docs.

* Release build: https://github.com/getsentry/publish/runs/6937404260?check_suite_focus=true
* Build of the release commit: https://github.com/getsentry/sentry-java/runs/6937346695?check_suite_focus=true
* Release commit: https://github.com/getsentry/sentry-java/commit/07534f52d4aa7e181ab6938aa4415b0e46970d75

## :green_heart: How did you test it?
Ran `./gradlew aggregateJavadocs` locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
