### PR TITLE
Use charset string to support Android 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use charset string directly as StandardCharsets is not available on earlier Android versions ([#2111](https://github.com/getsentry/sentry-java/pull/2111))
+
 ## 6.1.1
 
 ### Features

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -3,7 +3,6 @@ package io.sentry;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Experimental
 public final class Baggage {
 
-  static final @NotNull String CHARSET = StandardCharsets.UTF_8.toString();
+  static final @NotNull String CHARSET = "UTF-8";
   static final @NotNull Integer MAX_BAGGAGE_STRING_LENGTH = 8192;
   static final @NotNull Integer MAX_BAGGAGE_LIST_MEMBER_COUNT = 64;
 

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -29,6 +29,7 @@ class BaggageTest {
 
         assertEquals("isProduction=false,serverNode=DF%2028,userId=alice", baggage.toHeaderString())
     }
+
     @Test
     fun `can parse single baggage string`() {
         val baggage = Baggage.fromHeader("userId=alice,serverNode=DF%2028,isProduction=false", logger)


### PR DESCRIPTION


## :scroll: Description
<!--- Describe your changes in detail -->

Use charset string directly as StandardCharsets is not available on earlier Android versions

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
> Field requires API level 19 (current min is 16): java.nio.charset.StandardCharsets#UTF_8

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
