### PR TITLE
Fix thread leak due to `Timer` being created and never cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix thread leak due to Timer being created and never cancelled ([#2131](https://github.com/getsentry/sentry-java/pull/2131))
+
 ## 6.1.2
 
 ### Fixes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -236,7 +236,7 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
         if (idleTimeout != null) {
           // reschedule the finish task for the idle transaction, so it keeps running for the same
           // view
-          activeTransaction.scheduleFinish(idleTimeout);
+          activeTransaction.scheduleFinish();
         }
         return;
       } else {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
@@ -181,4 +181,16 @@ class LifecycleWatcherTest {
         watcher.onStop(fixture.ownerMock)
         verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
+
+    @Test
+    fun `timer is created if session tracking is enabled`() {
+        val watcher = fixture.getSUT(enableAutoSessionTracking = true, enableAppLifecycleBreadcrumbs = false)
+        assertNotNull(watcher.timer)
+    }
+
+    @Test
+    fun `timer is not created if session tracking is disabled`() {
+        val watcher = fixture.getSUT(enableAutoSessionTracking = false, enableAppLifecycleBreadcrumbs = false)
+        assertNull(watcher.timer)
+    }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
@@ -304,7 +304,7 @@ class SentryGestureListenerTracingTest {
         // second view interaction
         sut.onSingleTapUp(fixture.event)
 
-        verify(fixture.transaction).scheduleFinish(anyOrNull())
+        verify(fixture.transaction).scheduleFinish()
     }
 
     internal open class ScrollableListView : AbsListView(mock()) {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -475,7 +475,7 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getSpans ()Ljava/util/List;
 	public abstract fun isSampled ()Ljava/lang/Boolean;
-	public abstract fun scheduleFinish (Ljava/lang/Long;)V
+	public abstract fun scheduleFinish ()V
 	public abstract fun setName (Ljava/lang/String;)V
 }
 
@@ -667,7 +667,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun getThrowable ()Ljava/lang/Throwable;
 	public fun isFinished ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
-	public fun scheduleFinish (Ljava/lang/Long;)V
+	public fun scheduleFinish ()V
 	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
@@ -1395,7 +1395,7 @@ public final class io/sentry/SentryTracer : io/sentry/ITransaction {
 	public fun getTimestamp ()Ljava/lang/Double;
 	public fun isFinished ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
-	public fun scheduleFinish (Ljava/lang/Long;)V
+	public fun scheduleFinish ()V
 	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/ITransaction.java
+++ b/sentry/src/main/java/io/sentry/ITransaction.java
@@ -51,10 +51,6 @@ public interface ITransaction extends ISpan {
   @NotNull
   SentryId getEventId();
 
-  /**
-   * Schedules when transaction should be automatically finished.
-   *
-   * @param idleTimeout - the time to wait before finishing the transaction
-   */
-  void scheduleFinish(final @NotNull Long idleTimeout);
+  /** Schedules when transaction should be automatically finished. */
+  void scheduleFinish();
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -63,7 +63,7 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
-  public void scheduleFinish(@NotNull Long idleTimeout) {}
+  public void scheduleFinish() {}
 
   @Override
   public boolean isFinished() {

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -65,7 +65,7 @@ public final class SentryTracer implements ITransaction {
   private final @Nullable Long idleTimeout;
 
   private @Nullable TimerTask timerTask;
-  private @Nullable Timer timer;
+  private @Nullable Timer timer = null;
   private final @NotNull Object timerLock = new Object();
   private final @NotNull SpanByTimestampComparator spanByTimestampComparator =
       new SpanByTimestampComparator();
@@ -113,8 +113,6 @@ public final class SentryTracer implements ITransaction {
     if (idleTimeout != null) {
       timer = new Timer(true);
       scheduleFinish();
-    } else {
-      timer = null;
     }
   }
 

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -690,4 +690,24 @@ class SentryTracerTest {
             anyOrNull()
         )
     }
+
+    @Test
+    fun `timer is created if idle timeout is set`() {
+        val transaction = fixture.getSut(waitForChildren = true, idleTimeout = 50, trimEnd = true, sampled = true)
+        assertNotNull(transaction.timer)
+    }
+
+    @Test
+    fun `timer is not created if idle timeout is not set`() {
+        val transaction = fixture.getSut(waitForChildren = true, idleTimeout = null, trimEnd = true, sampled = true)
+        assertNull(transaction.timer)
+    }
+
+    @Test
+    fun `timer is cancelled on finish`() {
+        val transaction = fixture.getSut(waitForChildren = true, idleTimeout = 50, trimEnd = true, sampled = true)
+        assertNotNull(transaction.timer)
+        transaction.finish(SpanStatus.OK)
+        assertNull(transaction.timer)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`Timer` was created for every transaction which caused a new thread to be spawned each time. With this PR the `Timer` is only created in `SentryTracer` if `idleTimeout` is set there. When the transaction is finished, the timer is cancelled.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/2115

## :green_heart: How did you test it?
- Spring Boot App with transactions, before PR threads would be spawned, with code from PR no timer threads are spawned

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
