### PR TITLE
chore: Add child spans creation to GestureActivity

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/GesturesActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/GesturesActivity.kt
@@ -4,17 +4,23 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import io.sentry.Sentry
 import io.sentry.samples.android.R.layout
 import io.sentry.samples.android.databinding.ActivityGesturesBinding
 import io.sentry.samples.android.databinding.FragmentRecyclerBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.UUID
+import kotlin.math.abs
 
 @Suppress("DEPRECATION")
 class GesturesActivity : AppCompatActivity() {
@@ -39,6 +45,11 @@ class GesturesActivity : AppCompatActivity() {
 
         setContentView(binding.root)
     }
+
+    override fun onResume() {
+        super.onResume()
+        Sentry.getSpan()?.finish()
+    }
 }
 
 class ScrollingFragment : Fragment() {
@@ -48,6 +59,19 @@ class ScrollingFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View = inflater.inflate(layout.fragment_scrolling, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<ScrollView>(R.id.scrolling_container).setOnScrollChangeListener { v, scrollX, scrollY, oldScrollX, oldScrollY ->
+            if (abs(oldScrollY - scrollY) > 100) {
+                val child = Sentry.getSpan()?.startChild("load_more")
+                lifecycleScope.launch {
+                    delay(1000)
+                    child?.finish()
+                }
+            }
+        }
+    }
 }
 
 class RecyclerFragment : Fragment() {


### PR DESCRIPTION
_#skip-changelog_

This is for more accurate representation of the UI events transactions