### PR TITLE
Add KDoc and boolean flags for compose integration

### DIFF
--- a/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
+++ b/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
@@ -17,7 +17,7 @@ import io.sentry.TypeCheckHint
 import java.lang.ref.WeakReference
 
 /**
- * A [NavController.OnDestinationChangedListener] that captures a [Breadcrumb] and starts an idle
+ * A [NavController.OnDestinationChangedListener] that captures a [Breadcrumb] and starts an
  * [ITransaction] and sends them to Sentry for each [onDestinationChanged] call.
  *
  * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for

--- a/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
+++ b/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
@@ -11,10 +11,20 @@ import io.sentry.IHub
 import io.sentry.ITransaction
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
+import io.sentry.SentryOptions
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint
 import java.lang.ref.WeakReference
 
+/**
+ * A [NavController.OnDestinationChangedListener] that captures a [Breadcrumb] and starts an idle
+ * [ITransaction] and sends them to Sentry for each [onDestinationChanged] call.
+ *
+ * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for
+ * navigation events.
+ * @param enableNavigationTracing Whether the integration should start a new idle [ITransaction]
+ * with [SentryOptions.idleTimeout] for navigation events.
+ */
 class SentryNavigationListener @JvmOverloads constructor(
     private val hub: IHub = HubAdapter.getInstance(),
     private val enableNavigationBreadcrumbs: Boolean = true,

--- a/sentry-compose/api/android/sentry-compose.api
+++ b/sentry-compose/api/android/sentry-compose.api
@@ -7,6 +7,6 @@ public final class io/sentry/compose/BuildConfig {
 }
 
 public final class io/sentry/compose/SentryNavigationIntegrationKt {
-	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
+	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;ZZLandroidx/compose/runtime/Composer;II)Landroidx/navigation/NavHostController;
 }
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -3,21 +3,23 @@ package io.sentry.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
-import io.sentry.HubAdapter
-import io.sentry.IHub
+import io.sentry.Breadcrumb
+import io.sentry.ITransaction
+import io.sentry.SentryOptions
 import io.sentry.android.navigation.SentryNavigationListener
 
 internal class SentryLifecycleObserver(
     private val navController: NavController,
-    private val hub: IHub = HubAdapter.getInstance(),
     private val navListener: NavController.OnDestinationChangedListener =
-        SentryNavigationListener(hub)
+        SentryNavigationListener()
 ) : LifecycleEventObserver {
 
     override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
@@ -33,13 +35,34 @@ internal class SentryLifecycleObserver(
     }
 }
 
-// As described in https://developer.android.com/codelabs/jetpack-compose-advanced-state-side-effects#6
+/**
+ * A [DisposableEffect] that captures a [Breadcrumb] and starts an idle [ITransaction] and sends
+ * them to Sentry for when attached to the respective [NavHostController].
+ *
+ * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for
+ * navigation events.
+ * @param enableNavigationTracing Whether the integration should start a new idle [ITransaction]
+ * with [SentryOptions.idleTimeout] for navigation events.
+ */
 @Composable
 @NonRestartableComposable
-public fun NavHostController.withSentryObservableEffect(): NavHostController {
+public fun NavHostController.withSentryObservableEffect(
+    enableNavigationBreadcrumbs: Boolean = true,
+    enableNavigationTracing: Boolean = true
+): NavHostController {
+    val enableBreadcrumbsSnapshot by rememberUpdatedState(enableNavigationBreadcrumbs)
+    val enableTracingSnapshot by rememberUpdatedState(enableNavigationTracing)
+
+    // As described in https://developer.android.com/codelabs/jetpack-compose-advanced-state-side-effects#6
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     DisposableEffect(lifecycle, this) {
-        val observer = SentryLifecycleObserver(this@withSentryObservableEffect)
+        val observer = SentryLifecycleObserver(
+            this@withSentryObservableEffect,
+            navListener = SentryNavigationListener(
+                enableNavigationBreadcrumbs = enableBreadcrumbsSnapshot,
+                enableNavigationTracing = enableTracingSnapshot
+            )
+        )
 
         lifecycle.addObserver(observer)
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -36,7 +36,7 @@ internal class SentryLifecycleObserver(
 }
 
 /**
- * A [DisposableEffect] that captures a [Breadcrumb] and starts an idle [ITransaction] and sends
+ * A [DisposableEffect] that captures a [Breadcrumb] and starts an [ITransaction] and sends
  * them to Sentry for when attached to the respective [NavHostController].
  *
  * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -41,7 +41,7 @@ internal class SentryLifecycleObserver(
  *
  * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for
  * navigation events.
- * @param enableNavigationTracing Whether the integration should start a new idle [ITransaction]
+ * @param enableNavigationTracing Whether the integration should start a new [ITransaction]
  * with [SentryOptions.idleTimeout] for navigation events.
  */
 @Composable

--- a/sentry-compose/src/androidTest/kotlin/io/sentry/compose/SentryLifecycleObserverTest.kt
+++ b/sentry-compose/src/androidTest/kotlin/io/sentry/compose/SentryLifecycleObserverTest.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import io.sentry.IHub
 import io.sentry.android.navigation.SentryNavigationListener
 import kotlin.test.Test
 

--- a/sentry-compose/src/androidTest/kotlin/io/sentry/compose/SentryLifecycleObserverTest.kt
+++ b/sentry-compose/src/androidTest/kotlin/io/sentry/compose/SentryLifecycleObserverTest.kt
@@ -12,11 +12,10 @@ internal class SentryLifecycleObserverTest {
 
     class Fixture {
         val navListener = mock<SentryNavigationListener>()
-        val hub = mock<IHub>()
         val navController = mock<NavController>()
 
         fun getSut(): SentryLifecycleObserver {
-            return SentryLifecycleObserver(navController, hub, navListener)
+            return SentryLifecycleObserver(navController, navListener)
         }
     }
 


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Adds KDoc for new integrations
* Adds boolean flags for `withSentryObservableEffect` composable to control breadcrumbs and tracing 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
