### PR TITLE
Only send userid in Dynamic Sampling Context if sendDefaultPii is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Only send userid in Dynamic Sampling Context if sendDefaultPii is true ([#2147](https://github.com/getsentry/sentry-java/pull/2147))
+
 ### Features
 
 - New package `sentry-android-navigation` for AndroidX Navigation support ([#2136](https://github.com/getsentry/sentry-java/pull/2136))

--- a/sentry/src/main/java/io/sentry/TraceContext.java
+++ b/sentry/src/main/java/io/sentry/TraceContext.java
@@ -61,10 +61,19 @@ public final class TraceContext implements JsonUnknown, JsonSerializable {
         new Dsn(sentryOptions.getDsn()).getPublicKey(),
         sentryOptions.getRelease(),
         sentryOptions.getEnvironment(),
-        user != null ? user.getId() : null,
+        getUserId(sentryOptions, user),
         user != null ? getSegment(user) : null,
         transaction.getName(),
         sampleRateToString(sampleRate(samplingDecision)));
+  }
+
+  private static @Nullable String getUserId(
+      final @NotNull SentryOptions options, final @Nullable User user) {
+    if (options.isSendDefaultPii() && user != null) {
+      return user.getId();
+    }
+
+    return null;
   }
 
   private static @Nullable String getSegment(final @NotNull User user) {

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -575,7 +575,7 @@ class SentryTracerTest {
     }
 
     @Test
-    fun `returns baggage header without userId if not sendp pii`() {
+    fun `returns baggage header without userId if not send pii`() {
         val transaction = fixture.getSut({
             it.isTraceSampling = true
             it.environment = "production"
@@ -599,8 +599,34 @@ class SentryTracerTest {
             assertTrue(it.value.contains("sentry-release=1.0.99-rc.7,"))
             assertTrue(it.value.contains("sentry-environment=production,"))
             assertTrue(it.value.contains("sentry-transaction=name,"))
-            assertFalse(it.value.contains("sentry-user_id=userId12345,"))
+            assertFalse(it.value.contains("sentry-user_id"))
             assertTrue(it.value.contains("sentry-user_segment=pro$".toRegex()))
+        }
+    }
+
+    @Test
+    fun `returns baggage header without userId if send pii and null user`() {
+        val transaction = fixture.getSut({
+            it.isTraceSampling = true
+            it.environment = "production"
+            it.release = "1.0.99-rc.7"
+            it.isSendDefaultPii = true
+        })
+
+        fixture.hub.setUser(null)
+
+        val header = transaction.toBaggageHeader()
+        assertNotNull(header) {
+            assertEquals("baggage", it.name)
+            assertNotNull(it.value)
+            println(it.value)
+            assertTrue(it.value.contains("sentry-trace_id=[^,]+".toRegex()))
+            assertTrue(it.value.contains("sentry-public_key=key,"))
+            assertTrue(it.value.contains("sentry-release=1.0.99-rc.7,"))
+            assertTrue(it.value.contains("sentry-environment=production,"))
+            assertTrue(it.value.contains("sentry-transaction=name"))
+            assertFalse(it.value.contains("sentry-user_id"))
+            assertFalse(it.value.contains("sentry-user_segment"))
         }
     }
 

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -481,6 +481,7 @@ class SentryTracerTest {
     fun `returns trace state`() {
         val transaction = fixture.getSut({
             it.isTraceSampling = true
+            it.isSendDefaultPii = true
         })
         fixture.hub.setUser(
             User().apply {
@@ -496,6 +497,29 @@ class SentryTracerTest {
             assertEquals("release@3.0.0", it.release)
             assertEquals(transaction.name, it.transaction)
             assertEquals("user-id", it.userId)
+            assertEquals("pro", it.userSegment)
+        }
+    }
+
+    @Test
+    fun `returns trace state without userId if not send pii`() {
+        val transaction = fixture.getSut({
+            it.isTraceSampling = true
+        })
+        fixture.hub.setUser(
+            User().apply {
+                id = "user-id"
+                others = mapOf("segment" to "pro")
+            }
+        )
+        val trace = transaction.traceContext()
+        assertNotNull(trace) {
+            assertEquals(transaction.spanContext.traceId, it.traceId)
+            assertEquals("key", it.publicKey)
+            assertEquals("environment", it.environment)
+            assertEquals("release@3.0.0", it.release)
+            assertEquals(transaction.name, it.transaction)
+            assertNull(it.userId)
             assertEquals("pro", it.userSegment)
         }
     }
@@ -525,6 +549,7 @@ class SentryTracerTest {
             it.isTraceSampling = true
             it.environment = "production"
             it.release = "1.0.99-rc.7"
+            it.isSendDefaultPii = true
         })
 
         fixture.hub.setUser(
@@ -545,6 +570,36 @@ class SentryTracerTest {
             assertTrue(it.value.contains("sentry-environment=production,"))
             assertTrue(it.value.contains("sentry-transaction=name,"))
             assertTrue(it.value.contains("sentry-user_id=userId12345,"))
+            assertTrue(it.value.contains("sentry-user_segment=pro$".toRegex()))
+        }
+    }
+
+    @Test
+    fun `returns baggage header without userId if not sendp pii`() {
+        val transaction = fixture.getSut({
+            it.isTraceSampling = true
+            it.environment = "production"
+            it.release = "1.0.99-rc.7"
+        })
+
+        fixture.hub.setUser(
+            User().apply {
+                id = "userId12345"
+                others = mapOf("segment" to "pro")
+            }
+        )
+
+        val header = transaction.toBaggageHeader()
+        assertNotNull(header) {
+            assertEquals("baggage", it.name)
+            assertNotNull(it.value)
+            println(it.value)
+            assertTrue(it.value.contains("sentry-trace_id=[^,]+".toRegex()))
+            assertTrue(it.value.contains("sentry-public_key=key,"))
+            assertTrue(it.value.contains("sentry-release=1.0.99-rc.7,"))
+            assertTrue(it.value.contains("sentry-environment=production,"))
+            assertTrue(it.value.contains("sentry-transaction=name,"))
+            assertFalse(it.value.contains("sentry-user_id=userId12345,"))
             assertTrue(it.value.contains("sentry-user_segment=pro$".toRegex()))
         }
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
See https://github.com/getsentry/develop/pull/625


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Replaces https://github.com/getsentry/sentry-java/pull/2145 and not only skips `userId` in `baggage` but also in the envelope header `trace`.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
