### PR TITLE
feat: Configure publishing for compose multiplatform artifacts

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -43,3 +43,5 @@ targets:
       maven:io.sentry:sentry-graphql:
       maven:io.sentry:sentry-android-navigation:
       maven:io.sentry:sentry-compose:
+      maven:io.sentry:sentry-compose-android:
+      maven:io.sentry:sentry-compose-desktop:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all clean compile dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease
+.PHONY: all clean compile dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease javadocs
 
-all: stop clean checkFormat compile dryRelease
+all: stop clean javadocs compile
 assembleBenchmarks: stop clean assembleBenchmarkTestRelease
 assembleUiTests: stop clean assembleUiTestRelease
 
@@ -12,6 +12,9 @@ clean:
 # build and run tests
 compile:
 	./gradlew build
+
+javadocs:
+  ./gradlew aggregateJavadocs
 
 # do a dry release (like a local deploy)
 dryRelease:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ compile:
 	./gradlew build
 
 javadocs:
-  ./gradlew aggregateJavadocs
+	./gradlew aggregateJavadocs
 
 # do a dry release (like a local deploy)
 dryRelease:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean compile dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease javadocs
+.PHONY: all clean compile javadocs dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease
 
 all: stop clean javadocs compile
 assembleBenchmarks: stop clean assembleBenchmarkTestRelease

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,13 +104,17 @@ subprojects {
         val sep = File.separator
 
         configure<DistributionContainer> {
-            this.getByName("main").contents {
-                // non android modules
-                from("build${sep}libs")
-                from("build${sep}publications${sep}maven")
-                // android modules
-                from("build${sep}outputs${sep}aar")
-                from("build${sep}publications${sep}release")
+            if (this@subprojects.name.contains("-compose")) {
+                this.configureForMultiplatform(this@subprojects)
+            } else {
+                this.getByName("main").contents {
+                    // non android modules
+                    from("build${sep}libs")
+                    from("build${sep}publications${sep}maven")
+                    // android modules
+                    from("build${sep}outputs${sep}aar")
+                    from("build${sep}publications${sep}release")
+                }
             }
         }
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -21,6 +21,7 @@ object Config {
         val grettyVersion = "4.0.0"
         val gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
         val dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:$kotlinVersion"
+        val dokkaPluginAlias = "org.jetbrains.dokka"
         val composeGradlePlugin = "org.jetbrains.compose:compose-gradle-plugin:$composeVersion"
     }
 

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -1,0 +1,60 @@
+import org.gradle.api.Project
+import org.gradle.api.distribution.DistributionContainer
+import org.gradle.api.file.CopySpec
+import java.io.File
+
+// configure distZip tasks for multiplatform
+fun DistributionContainer.configureForMultiplatform(project: Project) {
+    val sep = File.separator
+
+    this.maybeCreate("android").contents {
+        from("build${sep}publications${sep}androidRelease")
+        from("build${sep}outputs${sep}aar") {
+            rename {
+                it.replace("-release", "-android-${project.version}")
+            }
+        }
+        from("build${sep}libs") {
+            include("*android*")
+            withJavadoc(renameTo = "compose-android")
+        }
+    }
+    this.getByName("main").contents {
+        from("build${sep}publications${sep}kotlinMultiplatform")
+        from("build${sep}kotlinToolingMetadata")
+        from("build${sep}libs") {
+            include("*compose-kotlin*")
+            rename {
+                it.replace("-kotlin", "")
+            }
+            withJavadoc()
+        }
+    }
+    this.maybeCreate("desktop").contents {
+        // kotlin multiplatform modules
+        from("build${sep}publications${sep}desktop")
+        from("build${sep}libs") {
+            include("*desktop*")
+            withJavadoc(renameTo = "compose-desktop")
+        }
+    }
+
+    // make other distZip tasks run together with the main distZip
+    project.tasks.named("distZip").configure {
+        val taskRegex = Regex("(.*)DistZip")
+        dependsOn(*project.tasks.filter { task ->
+            task.name.matches(taskRegex)
+        }.toTypedArray())
+    }
+}
+
+private fun CopySpec.withJavadoc(renameTo: String = "compose") {
+    include("*javadoc*")
+    rename {
+        if (it.contains("javadoc")) {
+            it.replace("compose", renameTo)
+        } else {
+            it
+        }
+    }
+}

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -42,9 +42,11 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
     // make other distZip tasks run together with the main distZip
     project.tasks.named("distZip").configure {
         val taskRegex = Regex("(.*)DistZip")
-        dependsOn(*project.tasks.filter { task ->
-            task.name.matches(taskRegex)
-        }.toTypedArray())
+        dependsOn(
+            *project.tasks.filter { task ->
+                task.name.matches(taskRegex)
+            }.toTypedArray()
+        )
     }
 }
 

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -3,6 +3,10 @@ import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.file.CopySpec
 import java.io.File
 
+private object Consts {
+    val taskRegex = Regex("(.*)DistZip")
+}
+
 // configure distZip tasks for multiplatform
 fun DistributionContainer.configureForMultiplatform(project: Project) {
     val sep = File.separator
@@ -40,14 +44,11 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
     }
 
     // make other distZip tasks run together with the main distZip
-    project.tasks.named("distZip").configure {
-        val taskRegex = Regex("(.*)DistZip")
-        dependsOn(
-            *project.tasks.filter { task ->
-                task.name.matches(taskRegex)
-            }.toTypedArray()
-        )
-    }
+    project.tasks.getByName("distZip").dependsOn(
+        *project.tasks.filter { task ->
+            task.name.matches(Consts.taskRegex)
+        }.toTypedArray()
+    )
 }
 
 private fun CopySpec.withJavadoc(renameTo: String = "compose") {

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     kotlin("multiplatform")
@@ -113,4 +114,16 @@ tasks.withType<Test> {
 tasks.withType<Detekt> {
     // Target version of the generated JVM bytecode. It is used for type resolution.
     jvmTarget = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType<DokkaTask>().configureEach {
+    // suppress unattached source sets for docs
+    dokkaSourceSets {
+        matching {
+            it.name.contains("androidandroid", ignoreCase = true) ||
+                it.name.contains("testfixtures", ignoreCase = true)
+        }.configureEach {
+            suppress.set(true)
+        }
+    }
 }

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     jacoco
     id(Config.QualityPlugins.gradleVersions)
     id(Config.QualityPlugins.detektPlugin)
+    id(Config.BuildPlugins.dokkaPluginAlias)
     `maven-publish` // necessary for publishMavenLocal task to publish correct artifacts
 }
 

--- a/sentry-compose/gradle.properties
+++ b/sentry-compose/gradle.properties
@@ -1,2 +1,1 @@
 kotlin.mpp.stability.nowarn=true
-import_orphan_source_sets=false

--- a/sentry-compose/gradle.properties
+++ b/sentry-compose/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.mpp.stability.nowarn=true
+import_orphan_source_sets=false


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
Configure multiplatform distributions to publish compose artifacts. The maven-publish task spits out everything into the same folder for all targets (common, android and desktop), so we have to manually configure the distribution task to pick up from the correct locations for each target. There's also a different artifact gonna be publish for each target, that's why the release registry has to be updated as well:

https://github.com/getsentry/sentry-release-registry/pull/79
