### PR TITLE
feat: Make upstream dependencies compileOnly in integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+### Features
+
+- Switch upstream dependencies to `compileOnly` in integrations ([#2175](https://github.com/getsentry/sentry-java/pull/2175))
+
 ### Fixes
 
 - Lazily retrieve HostnameCache in MainEventProcessor ([#2170](https://github.com/getsentry/sentry-java/pull/2170))
-- Switch upstream dependencies to `compileOnly` in integrations ([#2175](https://github.com/getsentry/sentry-java/pull/2175))
 
 ## 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Lazily retrieve HostnameCache in MainEventProcessor ([#2170](https://github.com/getsentry/sentry-java/pull/2170))
 - Switch upstream dependencies to `compileOnly` in integrations ([#2175](https://github.com/getsentry/sentry-java/pull/2175))
-g
+
 ## 6.2.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Fixes
 
 - Lazily retrieve HostnameCache in MainEventProcessor ([#2170](https://github.com/getsentry/sentry-java/pull/2170))
-
+- Switch upstream dependencies to `compileOnly` in integrations ([#2175](https://github.com/getsentry/sentry-java/pull/2175))
+g
 ## 6.2.1
 
 ### Fixes

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -49,7 +49,6 @@ android {
 
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
         checkReleaseBuilds = false
-        disable += "LogNotTimber"
     }
 
     // needed because of Kotlin 1.4.x

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -106,4 +106,6 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(projects.sentryAndroidFragment)
     testImplementation(projects.sentryAndroidTimber)
+    testRuntimeOnly(Config.Libs.timber)
+    testRuntimeOnly(Config.Libs.fragment)
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -33,7 +33,7 @@ public final class SentryAndroid {
 
   private static final String TIMBER_CLASS_NAME = "timber.log.Timber";
   private static final String FRAGMENT_CLASS_NAME =
-    "androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks";
+      "androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks";
 
   private SentryAndroid() {}
 
@@ -89,15 +89,16 @@ public final class SentryAndroid {
           options -> {
             final LoadClass classLoader = new LoadClass();
             final boolean isTimberUpstreamAvailable =
-              classLoader.isClassAvailable(TIMBER_CLASS_NAME, options);
+                classLoader.isClassAvailable(TIMBER_CLASS_NAME, options);
             final boolean isFragmentUpstreamAvailable =
-              classLoader.isClassAvailable(FRAGMENT_CLASS_NAME, options);
+                classLoader.isClassAvailable(FRAGMENT_CLASS_NAME, options);
             final boolean isFragmentAvailable =
-              (isFragmentUpstreamAvailable &&
-                classLoader.isClassAvailable(SENTRY_FRAGMENT_INTEGRATION_CLASS_NAME, options));
+                (isFragmentUpstreamAvailable
+                    && classLoader.isClassAvailable(
+                        SENTRY_FRAGMENT_INTEGRATION_CLASS_NAME, options));
             final boolean isTimberAvailable =
-              (isTimberUpstreamAvailable &&
-                classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options));
+                (isTimberUpstreamAvailable
+                    && classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options));
 
             AndroidOptionsInitializer.init(
                 options, context, logger, isFragmentAvailable, isTimberAvailable);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -31,6 +31,10 @@ public final class SentryAndroid {
   static final String SENTRY_TIMBER_INTEGRATION_CLASS_NAME =
       "io.sentry.android.timber.SentryTimberIntegration";
 
+  private static final String TIMBER_CLASS_NAME = "timber.log.Timber";
+  private static final String FRAGMENT_CLASS_NAME =
+    "androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks";
+
   private SentryAndroid() {}
 
   /**
@@ -84,10 +88,16 @@ public final class SentryAndroid {
           OptionsContainer.create(SentryAndroidOptions.class),
           options -> {
             final LoadClass classLoader = new LoadClass();
+            final boolean isTimberUpstreamAvailable =
+              classLoader.isClassAvailable(TIMBER_CLASS_NAME, options);
+            final boolean isFragmentUpstreamAvailable =
+              classLoader.isClassAvailable(FRAGMENT_CLASS_NAME, options);
             final boolean isFragmentAvailable =
-                classLoader.isClassAvailable(SENTRY_FRAGMENT_INTEGRATION_CLASS_NAME, options);
+              (isFragmentUpstreamAvailable &&
+                classLoader.isClassAvailable(SENTRY_FRAGMENT_INTEGRATION_CLASS_NAME, options));
             final boolean isTimberAvailable =
-                classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options);
+              (isTimberUpstreamAvailable &&
+                classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options));
 
             AndroidOptionsInitializer.init(
                 options, context, logger, isFragmentAvailable, isTimberAvailable);

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -66,9 +66,10 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    implementation(Config.Libs.fragment)
+    compileOnly(Config.Libs.fragment)
 
     // tests
+    testImplementation(Config.Libs.fragment)
     testImplementation(Config.TestLibs.kotlinTestJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)

--- a/sentry-android-okhttp/build.gradle.kts
+++ b/sentry-android-okhttp/build.gradle.kts
@@ -68,12 +68,14 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    implementation(Config.Libs.okhttpBom)
-    implementation(Config.Libs.okhttp)
+    compileOnly(Config.Libs.okhttpBom)
+    compileOnly(Config.Libs.okhttp)
 
     implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
 
     // tests
+    testImplementation(Config.Libs.okhttpBom)
+    testImplementation(Config.Libs.okhttp)
     testImplementation(Config.TestLibs.kotlinTestJunit)
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -71,11 +71,12 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    api(Config.Libs.timber)
+    compileOnly(Config.Libs.timber)
 
     implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
 
     // tests
+    testImplementation(Config.Libs.timber)
     testImplementation(Config.TestLibs.kotlinTestJunit)
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation(projects.sentryAndroidTimber)
     implementation(projects.sentryCompose)
     implementation(Config.Libs.fragment)
+    implementation(Config.Libs.timber)
 
 //    how to exclude androidx if release health feature is disabled
 //    implementation(projects.sentryAndroid) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Switch to compileOnly upstream dependencies in integrations, so we do not override user-defined version and use what they actually have on their classpath.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2125 

## :green_heart: How did you test it?
Tested manually here and on SAGP

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed https://github.com/getsentry/sentry-docs/pull/5298
- [ ] No breaking changes


## :crystal_ball: Next steps
@adinauer I'm not sure if you want to do this for backend things, I think it can also be applicable there? We could create another issue, for now I'm afraid of breaking something there