### PR TITLE
Remove extra space from `spring.factories` causing issues in old versions of Spring Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Remove extra space from `spring.factories` causing issues in old versions of Spring Boot ([#2181](https://github.com/getsentry/sentry-java/pull/2181))
+
 ## 6.3.0
 
 ### Features

--- a/sentry-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/sentry-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.sentry.spring.boot.SentryAutoConfiguration,\
-io.sentry.spring.boot.SentryLogbackAppenderAutoConfiguration, \
+io.sentry.spring.boot.SentryLogbackAppenderAutoConfiguration,\
 io.sentry.spring.boot.SentryWebfluxAutoConfiguration


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Remove extra space from `spring.factories` causing issues in old versions of Spring Boot

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2178 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
