### PR TITLE
Transaction source as String instead of enum

### DIFF
--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -51,6 +51,7 @@ class SentryTracingFilterTest {
             request.method = "POST"
             request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, "/product/{id}")
             whenever(transactionNameProvider.provideTransactionName(request)).thenReturn("POST /product/{id}")
+            whenever(transactionNameProvider.provideTransactionSource()).thenReturn(TransactionNameSource.CUSTOM)
             if (sentryTraceHeader != null) {
                 request.addHeader("sentry-trace", sentryTraceHeader)
                 whenever(hub.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2878,7 +2878,7 @@ public final class io/sentry/protocol/SentryTransaction$JsonKeys {
 }
 
 public final class io/sentry/protocol/TransactionInfo : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
-	public fun <init> (Lio/sentry/protocol/TransactionNameSource;)V
+	public fun <init> (Ljava/lang/String;)V
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
 	public fun setUnknown (Ljava/util/Map;)V
@@ -2895,14 +2895,14 @@ public final class io/sentry/protocol/TransactionInfo$JsonKeys {
 	public fun <init> ()V
 }
 
-public final class io/sentry/protocol/TransactionNameSource : java/lang/Enum, io/sentry/JsonSerializable {
+public final class io/sentry/protocol/TransactionNameSource : java/lang/Enum {
 	public static final field COMPONENT Lio/sentry/protocol/TransactionNameSource;
 	public static final field CUSTOM Lio/sentry/protocol/TransactionNameSource;
 	public static final field ROUTE Lio/sentry/protocol/TransactionNameSource;
 	public static final field TASK Lio/sentry/protocol/TransactionNameSource;
 	public static final field URL Lio/sentry/protocol/TransactionNameSource;
 	public static final field VIEW Lio/sentry/protocol/TransactionNameSource;
-	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
+	public fun apiName ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/protocol/TransactionNameSource;
 	public static fun values ()[Lio/sentry/protocol/TransactionNameSource;
 }

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -140,7 +140,7 @@ public final class TransactionContext extends SpanContext {
     }
   }
 
-  public TransactionNameSource getTransactionNameSource() {
+  public @NotNull TransactionNameSource getTransactionNameSource() {
     return transactionNameSource;
   }
 }

--- a/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
@@ -89,7 +89,7 @@ public final class SentryTransaction extends SentryBaseEvent
       }
     }
 
-    this.transactionInfo = new TransactionInfo(sentryTracer.getTransactionNameSource());
+    this.transactionInfo = new TransactionInfo(sentryTracer.getTransactionNameSource().apiName());
   }
 
   @ApiStatus.Internal
@@ -232,7 +232,7 @@ public final class SentryTransaction extends SentryBaseEvent
               null,
               new ArrayList<>(),
               new HashMap<>(),
-              new TransactionInfo(TransactionNameSource.CUSTOM));
+              new TransactionInfo(TransactionNameSource.CUSTOM.apiName()));
       Map<String, Object> unknown = null;
 
       SentryBaseEvent.Deserializer baseEventDeserializer = new SentryBaseEvent.Deserializer();

--- a/sentry/src/main/java/io/sentry/protocol/TransactionInfo.java
+++ b/sentry/src/main/java/io/sentry/protocol/TransactionInfo.java
@@ -17,10 +17,10 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class TransactionInfo implements JsonSerializable, JsonUnknown {
 
-  private final @Nullable TransactionNameSource source;
+  private final @Nullable String source;
   private @Nullable Map<String, Object> unknown;
 
-  public TransactionInfo(final @Nullable TransactionNameSource source) {
+  public TransactionInfo(final @Nullable String source) {
     this.source = source;
   }
 
@@ -65,14 +65,14 @@ public final class TransactionInfo implements JsonSerializable, JsonUnknown {
         @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
-      TransactionNameSource source = null;
+      String source = null;
       Map<String, Object> unknown = null;
 
       while (reader.peek() == JsonToken.NAME) {
         final String nextName = reader.nextName();
         switch (nextName) {
           case JsonKeys.SOURCE:
-            source = reader.nextOrNull(logger, new TransactionNameSource.Deserializer());
+            source = reader.nextStringOrNull();
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/main/java/io/sentry/protocol/TransactionNameSource.java
+++ b/sentry/src/main/java/io/sentry/protocol/TransactionNameSource.java
@@ -1,17 +1,10 @@
 package io.sentry.protocol;
 
-import io.sentry.ILogger;
-import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
-import io.sentry.JsonObjectWriter;
-import io.sentry.JsonSerializable;
-import java.io.IOException;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
-public enum TransactionNameSource implements JsonSerializable {
+public enum TransactionNameSource {
   /**
    * User-defined name
    *
@@ -87,18 +80,7 @@ public enum TransactionNameSource implements JsonSerializable {
 //  UNKNOWN
 ;
 
-  @Override
-  public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
-      throws IOException {
-    writer.value(name().toLowerCase(Locale.ROOT));
-  }
-
-  static final class Deserializer implements JsonDeserializer<TransactionNameSource> {
-
-    @Override
-    public @NotNull TransactionNameSource deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
-      return TransactionNameSource.valueOf(reader.nextString().toUpperCase(Locale.ROOT));
-    }
+  public String apiName() {
+    return name().toLowerCase(Locale.ROOT);
   }
 }

--- a/sentry/src/test/java/io/sentry/protocol/SentryTransactionSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryTransactionSerializationTest.kt
@@ -27,7 +27,7 @@ class SentryTransactionSerializationTest {
             mapOf(
                 "386384cb-1162-49e7-aea1-db913d4fca63" to MeasurementValueSerializationTest.Fixture().getSut()
             ),
-            TransactionInfo(TransactionNameSource.CUSTOM)
+            TransactionInfo(TransactionNameSource.CUSTOM.apiName())
         ).apply {
             SentryBaseEventSerializationTest.Fixture().update(this)
         }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To avoid serialization problems, e.g. when a cross platform SDK has sources the Java SDK doesn't know about.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
