### PR TITLE
Prevent NPE by checking SentryTracer.timer for null again inside synchronized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Prevent NPE by checking SentryTracer.timer for null again inside synchronized ([#2200](https://github.com/getsentry/sentry-java/pull/2200))
 - `attach-screenshot` set on Manual init. didn't work ([#2186](https://github.com/getsentry/sentry-java/pull/2186))
 - Remove extra space from `spring.factories` causing issues in old versions of Spring Boot ([#2181](https://github.com/getsentry/sentry-java/pull/2181))
 

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -64,8 +64,8 @@ public final class SentryTracer implements ITransaction {
    */
   private final @Nullable Long idleTimeout;
 
-  private @Nullable TimerTask timerTask;
-  private @Nullable Timer timer = null;
+  private volatile @Nullable TimerTask timerTask;
+  private volatile @Nullable Timer timer = null;
   private final @NotNull Object timerLock = new Object();
   private final @NotNull SpanByTimestampComparator spanByTimestampComparator =
       new SpanByTimestampComparator();
@@ -344,8 +344,10 @@ public final class SentryTracer implements ITransaction {
 
       if (timer != null) {
         synchronized (timerLock) {
-          timer.cancel();
-          timer = null;
+          if (timer != null) {
+            timer.cancel();
+            timer = null;
+          }
         }
       }
 


### PR DESCRIPTION


## :scroll: Description
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
NPE caused by `timer` becoming `null` after acquiring the `synchronized` lock. Now we check again after acquiring the lock to ensure this doesn't happen.

Fixes #2196 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
