### PR TITLE
Weakly reference Activity for transaction finished callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Weakly reference Activity for transaction finished callback ([]())
 - `attach-screenshot` set on Manual init. didn't work ([#2186](https://github.com/getsentry/sentry-java/pull/2186))
 - Remove extra space from `spring.factories` causing issues in old versions of Spring Boot ([#2181](https://github.com/getsentry/sentry-java/pull/2181))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Weakly reference Activity for transaction finished callback ([]())
+- Weakly reference Activity for transaction finished callback ([#2203](https://github.com/getsentry/sentry-java/pull/2203))
 - `attach-screenshot` set on Manual init. didn't work ([#2186](https://github.com/getsentry/sentry-java/pull/2186))
 - Remove extra space from `spring.factories` causing issues in old versions of Spring Boot ([#2181](https://github.com/getsentry/sentry-java/pull/2181))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -23,6 +23,7 @@ import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +147,7 @@ public final class ActivityLifecycleIntegration
   }
 
   private void startTracing(final @NotNull Activity activity) {
+    WeakReference<Activity> weakActivity = new WeakReference<>(activity);
     if (performanceEnabled && !isRunningTransaction(activity) && hub != null) {
       // as we allow a single transaction running on the bound Scope, we finish the previous ones
       stopPreviousTransactions();
@@ -167,7 +169,10 @@ public final class ActivityLifecycleIntegration
                 (Date) null,
                 true,
                 (finishingTransaction) -> {
-                  activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                  @Nullable Activity unwrappedActivity = weakActivity.get();
+                  if (unwrappedActivity != null) {
+                    activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                  }
                 });
       } else {
         // start transaction with app start timestamp
@@ -178,7 +183,10 @@ public final class ActivityLifecycleIntegration
                 appStartTime,
                 true,
                 (finishingTransaction) -> {
-                  activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                  @Nullable Activity unwrappedActivity = weakActivity.get();
+                  if (unwrappedActivity != null) {
+                    activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                  }
                 });
         // start specific span for app start
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -173,6 +173,15 @@ public final class ActivityLifecycleIntegration
                   if (unwrappedActivity != null) {
                     activityFramesTracker.setMetrics(
                         unwrappedActivity, finishingTransaction.getEventId());
+                  } else {
+                    if (options != null) {
+                      options
+                          .getLogger()
+                          .log(
+                              SentryLevel.WARNING,
+                              "Unable to track activity frames as the Activity %s has been destroyed.",
+                              activityName);
+                    }
                   }
                 });
       } else {
@@ -188,6 +197,15 @@ public final class ActivityLifecycleIntegration
                   if (unwrappedActivity != null) {
                     activityFramesTracker.setMetrics(
                         unwrappedActivity, finishingTransaction.getEventId());
+                  } else {
+                    if (options != null) {
+                      options
+                          .getLogger()
+                          .log(
+                              SentryLevel.WARNING,
+                              "Unable to track activity frames as the Activity %s has been destroyed.",
+                              activityName);
+                    }
                   }
                 });
         // start specific span for app start

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -171,7 +171,8 @@ public final class ActivityLifecycleIntegration
                 (finishingTransaction) -> {
                   @Nullable Activity unwrappedActivity = weakActivity.get();
                   if (unwrappedActivity != null) {
-                    activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                    activityFramesTracker.setMetrics(
+                        unwrappedActivity, finishingTransaction.getEventId());
                   }
                 });
       } else {
@@ -185,7 +186,8 @@ public final class ActivityLifecycleIntegration
                 (finishingTransaction) -> {
                   @Nullable Activity unwrappedActivity = weakActivity.get();
                   if (unwrappedActivity != null) {
-                    activityFramesTracker.setMetrics(activity, finishingTransaction.getEventId());
+                    activityFramesTracker.setMetrics(
+                        unwrappedActivity, finishingTransaction.getEventId());
                   }
                 });
         // start specific span for app start


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Wrap `Activity` with `WeakReference` in `ActivityLifecycleIntegration` to not strongly hold on to it for the `TransactionFinishedCallback`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2201 


## :green_heart: How did you test it?
Emulator

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
