### PR TITLE
Add baggage header to RestTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add baggage header to RestTemplate ([#2206](https://github.com/getsentry/sentry-java/pull/2206))
+
 ## 6.3.1
 
 ### Fixes

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -46,6 +46,9 @@ class SentrySpanRestTemplateCustomizerTest {
                 sentryOptions.tracingOrigins.add("other-api")
             }
 
+            sentryOptions.dsn = "https://key@sentry.io/proj"
+            sentryOptions.isTraceSampling = true
+
             mockServer.enqueue(
                 MockResponse()
                     .setBody("OK")
@@ -78,6 +81,7 @@ class SentrySpanRestTemplateCustomizerTest {
         assertThat(recordedRequest.headers["sentry-trace"]!!).startsWith(fixture.transaction.spanContext.traceId.toString())
             .endsWith("-1")
             .doesNotContain(fixture.transaction.spanContext.spanId.toString())
+        assertThat(recordedRequest.headers["baggage"]!!).contains(fixture.transaction.spanContext.traceId.toString())
     }
 
     @Test

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -5,6 +5,7 @@ import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_REQUEST_BODY;
 import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_RESPONSE;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IHub;
@@ -50,6 +51,10 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
 
       if (TracingOrigins.contain(hub.getOptions().getTracingOrigins(), request.getURI())) {
         request.getHeaders().add(sentryTraceHeader.getName(), sentryTraceHeader.getValue());
+        @Nullable BaggageHeader baggage = span.toBaggageHeader();
+        if (baggage != null) {
+          request.getHeaders().add(baggage.getName(), baggage.getValue());
+        }
       }
 
       try {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `baggage` header to outgoing `RestTemplate` calls.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support Dynamic Sampling for outgoing requests using `RestTemplate`

See #2205

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
