### PR TITLE
added cpu architecture and default environment in profiles envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Weakly reference Activity for transaction finished callback ([#2203](https://github.com/getsentry/sentry-java/pull/2203))
 - `attach-screenshot` set on Manual init. didn't work ([#2186](https://github.com/getsentry/sentry-java/pull/2186))
 - Remove extra space from `spring.factories` causing issues in old versions of Spring Boot ([#2181](https://github.com/getsentry/sentry-java/pull/2181))
+- Added cpu architecture and default environment in profiles envelope ([#2207](https://github.com/getsentry/sentry-java/pull/2207))
+
 
 ### Features
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -227,6 +227,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     if (memInfo != null) {
       totalMem = Long.toString(memInfo.totalMem);
     }
+    String[] abis = Build.SUPPORTED_ABIS;
 
     // cpu max frequencies are read with a lambda because reading files is involved, so it will be
     // done in the background when the trace file is read
@@ -235,6 +236,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
         transaction,
         Long.toString(transactionDurationNanos),
         buildInfoProvider.getSdkInfoVersion(),
+        abis != null && abis.length > 0 ? abis[0] : "",
         () -> CpuInfoUtils.getInstance().readMaxFrequencies(),
         buildInfoProvider.getManufacturer(),
         buildInfoProvider.getModel(),

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -57,6 +57,8 @@ class EnvelopeTests : BaseUiTest() {
                 assertTrue(transactionItem.transaction == "e2etests")
                 assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
                 assertTrue(profilingTraceData.transactionName == "e2etests")
+                assertTrue(profilingTraceData.environment.isNotEmpty())
+                assertTrue(profilingTraceData.cpuArchitecture.isNotEmpty())
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -710,9 +710,10 @@ public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
 
 public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;)V
-	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/lang/String;Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun getAndroidApiLevel ()I
 	public fun getBuildId ()Ljava/lang/String;
+	public fun getCpuArchitecture ()Ljava/lang/String;
 	public fun getDeviceCpuFrequencies ()Ljava/util/List;
 	public fun getDeviceLocale ()Ljava/lang/String;
 	public fun getDeviceManufacturer ()Ljava/lang/String;
@@ -738,6 +739,7 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
 	public fun setAndroidApiLevel (I)V
 	public fun setBuildId (Ljava/lang/String;)V
+	public fun setCpuArchitecture (Ljava/lang/String;)V
 	public fun setDeviceCpuFrequencies (Ljava/util/List;)V
 	public fun setDeviceIsEmulator (Z)V
 	public fun setDeviceLocale (Ljava/lang/String;)V
@@ -766,6 +768,7 @@ public final class io/sentry/ProfilingTraceData$Deserializer : io/sentry/JsonDes
 
 public final class io/sentry/ProfilingTraceData$JsonKeys {
 	public static final field ANDROID_API_LEVEL Ljava/lang/String;
+	public static final field ARCHITECTURE Ljava/lang/String;
 	public static final field BUILD_ID Ljava/lang/String;
 	public static final field DEVICE_CPU_FREQUENCIES Ljava/lang/String;
 	public static final field DEVICE_IS_EMULATOR Ljava/lang/String;


### PR DESCRIPTION
## :scroll: Description
Added cpu architecture in profiles envelope payload
Profiles environment defaults to "production"


## :bulb: Motivation and Context

- cpu architecture was requested to be added to the profiles data.
- We found that profiles didn't have any environment, even if the transaction had one set. I figured out it was set in the transaction in the `MainProcessor` in case it's null, so i added the same logic to the profiles, too.


## :green_heart: How did you test it?
I added assertions on these fields to the ui test that sends a profile envelope


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
