### PR TITLE
Fix start timestamp not set in ActivityLifecycleIntegration

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -182,6 +182,10 @@ public final class ActivityLifecycleIntegration
             }
           });
 
+      if (!(firstActivityCreated || appStartTime == null || coldStart == null)) {
+        transactionOptions.setStartTimestamp(appStartTime);
+      }
+
       // we can only bind to the scope if there's no running transaction
       ITransaction transaction =
           hub.startTransaction(
@@ -190,8 +194,6 @@ public final class ActivityLifecycleIntegration
 
       // in case appStartTime isn't available, we don't create a span for it.
       if (!(firstActivityCreated || appStartTime == null || coldStart == null)) {
-        transactionOptions.setStartTimestamp(appStartTime);
-
         // start specific span for app start
         appStartSpan =
             transaction.startChild(


### PR DESCRIPTION
#skip-changelog
Guess changelog is not needed since the bug hasn't been released yet

## :scroll: Description
<!--- Describe your changes in detail -->
Messed up a refactoring

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Start timestamp was set after calling `startTransaction` so had no effect. This fixes it.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
