### PR TITLE
Concurrent profiling 2 - added list of transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### Features
 
-- Added list of ProfilingTransactionData to the profiling envelope payload ([#2216](https://github.com/getsentry/sentry-java/pull/2216))
+- Concurrent profiling 2 - added list of transactions ([#2218](https://github.com/getsentry/sentry-java/pull/2218))
+- Concurrent profiling 1 - added envelope payload data format ([#2216](https://github.com/getsentry/sentry-java/pull/2216))
 - Send source for transactions ([#2180](https://github.com/getsentry/sentry-java/pull/2180))
 - Add profilesSampleRate and profileSampler options for Android sdk ([#2184](https://github.com/getsentry/sentry-java/pull/2184))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -212,13 +212,6 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       return null;
     }
 
-    // We notify the data referring to this transaction that it finished
-    ProfilingTransactionData transactionData =
-        transactionMap.get(transaction.getEventId().toString());
-    if (transactionData != null) {
-      transactionData.notifyFinish(SystemClock.elapsedRealtimeNanos(), transactionStartNanos);
-    }
-
     if (transactionsCounter > 0) {
       transactionsCounter--;
     }
@@ -233,6 +226,12 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
             transactionsCounter);
 
     if (transactionsCounter != 0 && !isTimeout) {
+      // We notify the data referring to this transaction that it finished
+      ProfilingTransactionData transactionData =
+          transactionMap.get(transaction.getEventId().toString());
+      if (transactionData != null) {
+        transactionData.notifyFinish(SystemClock.elapsedRealtimeNanos(), transactionStartNanos);
+      }
       return null;
     }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -109,19 +109,21 @@ class EnvelopeTests : BaseUiTest() {
                 assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
                 assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
                 assertTrue(profilingTraceData.transactionName == "e2etests")
+
                 // Transaction timestamps should be all different from each other
                 val transactions = profilingTraceData.transactions
                 assertContains(transactions.map { t -> t.id }, transactionItem.eventId.toString())
                 val startTimes = transactions.map { t -> t.relativeStartNs }
-                val endTimes = transactions.map { t -> t.relativeEndNs }
-                assertEquals(0, startTimes[0])
+                val endTimes = transactions.mapNotNull { t -> t.relativeEndNs }
                 assertNotEquals(startTimes[0], startTimes[1])
                 assertNotEquals(startTimes[0], startTimes[2])
                 assertNotEquals(startTimes[1], startTimes[2])
-                assertNotEquals(0, endTimes[0])
                 assertNotEquals(endTimes[0], endTimes[1])
                 assertNotEquals(endTimes[0], endTimes[2])
                 assertNotEquals(endTimes[1], endTimes[2])
+
+                // The first and last transactions should be aligned to the start/stop of profile
+                assertEquals(endTimes.maxOrNull()!! - startTimes.minOrNull()!!, profilingTraceData.durationNs.toLong())
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -14,7 +14,9 @@ import io.sentry.SentryOptions
 import io.sentry.protocol.SentryTransaction
 import org.junit.runner.RunWith
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -65,6 +67,61 @@ class EnvelopeTests : BaseUiTest() {
                 val transactionData = profilingTraceData.transactions
                     .firstOrNull { t -> t.id == transactionItem.eventId.toString() }
                 assertNotNull(transactionData)
+            }
+            assertNoOtherEnvelopes()
+            assertNoOtherRequests()
+        }
+    }
+
+    @Test
+    fun checkEnvelopeConcurrentTransactions() {
+
+        initSentry(true) { options: SentryOptions ->
+            options.tracesSampleRate = 1.0
+            options.profilesSampleRate = 1.0
+        }
+        relayIdlingResource.increment()
+        relayIdlingResource.increment()
+        relayIdlingResource.increment()
+        val transaction = Sentry.startTransaction("e2etests", "test1")
+        val transaction2 = Sentry.startTransaction("e2etests", "test2")
+        val transaction3 = Sentry.startTransaction("e2etests", "test3")
+        transaction.finish()
+        transaction2.finish()
+        transaction3.finish()
+
+        relay.assert {
+            assertEnvelope {
+                val transactionItem: SentryTransaction = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals(transaction.eventId.toString(), transactionItem.eventId.toString())
+            }
+            assertEnvelope {
+                val transactionItem: SentryTransaction = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals(transaction2.eventId.toString(), transactionItem.eventId.toString())
+            }
+            // The profile is sent only in the last transaction envelope
+            assertEnvelope {
+                val transactionItem: SentryTransaction = it.assertItem()
+                val profilingTraceData: ProfilingTraceData = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
+                assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
+                assertTrue(profilingTraceData.transactionName == "e2etests")
+                // Transaction timestamps should be all different from each other
+                val transactions = profilingTraceData.transactions
+                assertContains(transactions.map { t -> t.id }, transactionItem.eventId.toString())
+                val startTimes = transactions.map { t -> t.relativeStartNs }
+                val endTimes = transactions.map { t -> t.relativeEndNs }
+                assertEquals(0, startTimes[0])
+                assertNotEquals(startTimes[0], startTimes[1])
+                assertNotEquals(startTimes[0], startTimes[2])
+                assertNotEquals(startTimes[1], startTimes[2])
+                assertNotEquals(0, endTimes[0])
+                assertNotEquals(endTimes[0], endTimes[1])
+                assertNotEquals(endTimes[0], endTimes[2])
+                assertNotEquals(endTimes[1], endTimes[2])
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3082,10 +3082,15 @@ public abstract class io/sentry/transport/TransportResult {
 
 public final class io/sentry/util/CollectionUtils {
 	public static fun filterMapEntries (Ljava/util/Map;Lio/sentry/util/CollectionUtils$Predicate;)Ljava/util/Map;
+	public static fun map (Ljava/util/List;Lio/sentry/util/CollectionUtils$Mapper;)Ljava/util/List;
 	public static fun newArrayList (Ljava/util/List;)Ljava/util/List;
 	public static fun newConcurrentHashMap (Ljava/util/Map;)Ljava/util/Map;
 	public static fun newHashMap (Ljava/util/Map;)Ljava/util/Map;
 	public static fun size (Ljava/lang/Iterable;)I
+}
+
+public abstract interface class io/sentry/util/CollectionUtils$Mapper {
+	public abstract fun map (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class io/sentry/util/CollectionUtils$Predicate {

--- a/sentry/src/main/java/io/sentry/util/CollectionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CollectionUtils.java
@@ -102,11 +102,40 @@ public final class CollectionUtils {
   }
 
   /**
+   * Returns a new list with the results of the function applied to all elements of the original
+   * list.
+   *
+   * @param list - the list to apply the function to
+   * @param f - the function
+   * @param <T> - original list element type
+   * @param <R> - returned list element type
+   * @return a new list
+   */
+  public static @NotNull <T, R> List<R> map(
+      final @NotNull List<T> list, final @NotNull Mapper<T, R> f) {
+    List<R> mappedList = new ArrayList<>();
+    for (T t : list) {
+      mappedList.add(f.map(t));
+    }
+    return mappedList;
+  }
+
+  /**
    * A simplified copy of Java 8 Predicate.
    *
    * @param <T> the type
    */
   public interface Predicate<T> {
     boolean test(T t);
+  }
+
+  /**
+   * A simple function to map an object into another.
+   *
+   * @param <T> the original type
+   * @param <R> the returned type
+   */
+  public interface Mapper<T, R> {
+    R map(T t);
   }
 }


### PR DESCRIPTION
## :scroll: Description
We want to support concurrent transactions. In order to do it, we are going to add the list of transactions occurred during a profile.
This pr adds the list of transactions occurred during a profile to the data sent in the envelope payload.
This is the second part of concurrent profiling support, after [this pr](https://github.com/getsentry/sentry-java/pull/2216) 


## :bulb: Motivation and Context
We want to avoid situations where the user cannot profile his transaction due to automatic transactions occurring at the same time, as pointed in [this issue](https://github.com/getsentry/sentry-java/issues/2209)
The strategy we will follow is described [here](https://www.notion.so/sentry/Profiling-concurrent-transactions-37da1625332e40799dc0e0bae90ced63)


## :green_heart: How did you test it?
Added unit test to check concurrent profiling logic
Added ui test to check the timestamps of transactions occurred during a profile


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
