### PR TITLE
Use toString for enum serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - SentryOptions.setProfilingTracesIntervalMillis has been deprecated
 - Added cpu architecture and default environment in profiles envelope ([#2207](https://github.com/getsentry/sentry-java/pull/2207))
 - SentryOptions.setProfilingEnabled has been deprecated in favor of setProfilesSampleRate
+- Use toString for enum serialization ([#2220](https://github.com/getsentry/sentry-java/pull/2220))
 
 ### Features
 

--- a/sentry/src/main/java/io/sentry/JsonObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectSerializer.java
@@ -46,6 +46,8 @@ public final class JsonObjectSerializer {
       serializeCollection(writer, logger, Arrays.asList((Object[]) object));
     } else if (object instanceof Map) {
       serializeMap(writer, logger, (Map<?, ?>) object);
+    } else if (object.getClass().isEnum()) {
+      writer.value(object.toString());
     } else {
       try {
         Object serializableObject = jsonReflectionObjectSerializer.serialize(object, logger);

--- a/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
@@ -39,6 +39,8 @@ public final class JsonReflectionObjectSerializer {
       return object;
     } else if (object instanceof String) {
       return object;
+    } else if (object.getClass().isEnum()) {
+      return object.toString();
     } else {
       if (visiting.contains(object)) {
         logger.log(SentryLevel.INFO, "Cyclic reference detected. Calling toString() on object.");

--- a/sentry/src/test/java/io/sentry/JsonObjectSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonObjectSerializerTest.kt
@@ -120,6 +120,38 @@ internal class JsonObjectSerializerTest {
     }
 
     @Test
+    fun `serialize enum`() {
+        fixture.getSUT().serialize(fixture.writer, fixture.logger, DataCategory.Session)
+        verify(fixture.writer).value("Session")
+    }
+
+    @Test
+    fun `serialize list of enum`() {
+        fixture.getSUT().serialize(fixture.writer, fixture.logger, listOf(DataCategory.Session))
+        verify(fixture.writer).beginArray()
+        verify(fixture.writer).value("Session")
+        verify(fixture.writer).endArray()
+    }
+
+    @Test
+    fun `serialize map of enum`() {
+        fixture.getSUT().serialize(fixture.writer, fixture.logger, mapOf("key" to DataCategory.Transaction))
+        verify(fixture.writer).beginObject()
+        verify(fixture.writer).name("key")
+        verify(fixture.writer).value("Transaction")
+        verify(fixture.writer).endObject()
+    }
+
+    @Test
+    fun `serialize object with enum property`() {
+        fixture.getSUT().serialize(fixture.writer, fixture.logger, ClassWithEnumProperty(DataCategory.Attachment))
+        verify(fixture.writer).beginObject()
+        verify(fixture.writer).name("enumProperty")
+        verify(fixture.writer).value("Attachment")
+        verify(fixture.writer).endObject()
+    }
+
+    @Test
     fun `serialize unknown object with data`() {
         val objectWithPrimitiveFields = UnknownClassWithData(
             17,
@@ -139,3 +171,5 @@ internal class JsonObjectSerializerTest {
         private val string: String
     )
 }
+
+data class ClassWithEnumProperty(val enumProperty: DataCategory)

--- a/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
@@ -257,6 +257,12 @@ class JsonReflectionObjectSerializerTest {
         verify(fixture.logger).log(SentryLevel.INFO, "Max depth exceeded. Calling toString() on object.")
     }
 
+    @Test
+    fun `enum`() {
+        val actual = fixture.getSut().serialize(DataCategory.Error, fixture.logger)
+        assertEquals("Error", actual)
+    }
+
     // Helper
 
     class ClassWithPrimitiveFields(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use `toString()` for enum entries being serialized.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`JsonReflectionObjectSerializer` would consume lots of memory when serializing an enum entry where the enum has more than just a few entries.

Fixes #2219 

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
