### PR TITLE
Fix memory leak caused by throwableToSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix memory leak caused by throwableToSpan ([#2227](https://github.com/getsentry/sentry-java/pull/2227))
+
 ## 6.4.0
 
 ### Fixes


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The `Hub` holds on to a `WeakHashMap` called `throwableToSpan` which maps root causes of exceptions to `Span`s. The memory leak was caused by the `Span` holding a strong reference to the `throwable` which contains the root cause that is also used as the key for the `WeakHashMap`. This means the value of the `WeakHashMap` was causing its own key not to be garbage collected and the memory was never freed.

The fix is to weakly hold on to the `Span` so it can be garbage collected and thus also the key can be garbage collected afterwards.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2225 

## :green_heart: How did you test it?
Manual testing using debugger on a modified sample application, then using `visualvm` to trigger GC manually.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
