### PR TITLE
fix: AbstractMethodError when getting Lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.3.1
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixed AbstractMethodError when getting Lifecycle ([#2228](https://github.com/getsentry/sentry-java/pull/2228))
+
 ## 6.4.1
 
 ### Fixes

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 android.useAndroidX=true
 
 # Release information
-versionName=6.3.0
+versionName=6.3.1
 
 # Override the SDK name on native crashes on Android
 sentryAndroidSdkName=sentry.native.android

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -1,6 +1,5 @@
 package io.sentry.android.core;
 
-import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import io.sentry.IHub;
 import io.sentry.Integration;
@@ -86,11 +85,11 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
     }
 
     watcher =
-      new LifecycleWatcher(
-        hub,
-        this.options.getSessionTrackingIntervalMillis(),
-        this.options.isEnableAutoSessionTracking(),
-        this.options.isEnableAppLifecycleBreadcrumbs());
+        new LifecycleWatcher(
+            hub,
+            this.options.getSessionTrackingIntervalMillis(),
+            this.options.isEnableAutoSessionTracking(),
+            this.options.isEnableAppLifecycleBreadcrumbs());
 
     try {
       ProcessLifecycleOwner.get().getLifecycle().addObserver(watcher);
@@ -103,9 +102,9 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
       options
           .getLogger()
           .log(
-            SentryLevel.ERROR,
-            "AppLifecycleIntegration failed to get Lifecycle and could not be installed.",
-            e);
+              SentryLevel.ERROR,
+              "AppLifecycleIntegration failed to get Lifecycle and could not be installed.",
+              e);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -57,7 +57,6 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
       try {
         Class.forName("androidx.lifecycle.DefaultLifecycleObserver");
         Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
-
         if (MainThreadChecker.isMainThread()) {
           addObserver(hub);
         } else {


### PR DESCRIPTION
## :scroll: Description
This came up through Unity. In some cases, Unity projects resolve their own external dependencies via adding and including `arr` files. This seems to lead to issues during runtime when the AppLifecycleIntegration tries to add its observer and results in an `AbstractMethodError`.

## :bulb: Motivation and Context

To deal with the `AbstractMethodError` gracefully, we can catch the error instead and bail before we create the watcher.

```
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime FATAL EXCEPTION: main
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime Process: studio.banditos.banditos5, PID: 30530
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime java.lang.AbstractMethodError: abstract method "void androidx.lifecycle.DefaultLifecycleObserver.onCreate(androidx.lifecycle.LifecycleOwner)"
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at androidx.lifecycle.FullLifecycleObserverAdapter.onStateChanged(FullLifecycleObserverAdapter.java:36)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:196)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.AppLifecycleIntegration.addObserver(AppLifecycleIntegration.java:92)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.AppLifecycleIntegration.register(AppLifecycleIntegration.java:60)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.Sentry.init(Sentry.java:189)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.Sentry.init(Sentry.java:118)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:87)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.SentryAndroid.init(SentryAndroid.java:56)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.SentryInitProvider.onCreate(SentryInitProvider.java:27)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2429)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.content.ContentProvider.attachInfo(ContentProvider.java:2399)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at io.sentry.android.core.SentryInitProvider.attachInfo(SentryInitProvider.java:44)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread.installProvider(ActivityThread.java:8210)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7746)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7566)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread.access$1500(ActivityThread.java:301)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2177)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.os.Handler.dispatchMessage(Handler.java:106)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.os.Looper.loop(Looper.java:246)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at android.app.ActivityThread.main(ActivityThread.java:8653)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at java.lang.reflect.Method.invoke(Native Method)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
2022/08/22 15:26:47.122 30530 30530 Error AndroidRuntime 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
