### PR TITLE
Avoid sending empty profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Avoid sending empty profiles ([#2232](https://github.com/getsentry/sentry-java/pull/2232))
+
 ## 6.4.1
 
 ### Fixes

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
@@ -21,7 +21,7 @@ class ProfilingActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityProfilingBinding
     private val executors = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())
-    private var profileFinished = false
+    private var profileFinished = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -226,6 +226,9 @@ public final class SentryEnvelopeItem {
               // base64
               byte[] traceFileBytes = readBytesFromFile(traceFile.getPath(), maxTraceFileSize);
               String base64Trace = Base64.encodeToString(traceFileBytes, NO_WRAP | NO_PADDING);
+              if (base64Trace.isEmpty()) {
+                throw new SentryEnvelopeException("Profiling trace file is empty");
+              }
               profilingTraceData.setSampledProfile(base64Trace);
               profilingTraceData.readDeviceCpuFrequencies();
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -90,6 +90,7 @@ class SentryClientTest {
 
         fun getSut(optionsCallback: ((SentryOptions) -> Unit)? = null): SentryClient {
             optionsCallback?.invoke(sentryOptions)
+            profilingTraceFile.writeText("sampledProfile")
             return SentryClient(sentryOptions)
         }
     }
@@ -1053,6 +1054,14 @@ class SentryClientTest {
         fixture.getSut().captureTransaction(transaction, null, null, null, fixture.profilingTraceData)
         assertFails { verifyAttachmentsInEnvelope(transaction.eventId) }
         verifyProfilingTraceInEnvelope(transaction.eventId)
+    }
+
+    @Test
+    fun `when captureTransaction with empty trace file, profiling data is not sent`() {
+        val transaction = SentryTransaction(fixture.sentryTracer)
+        fixture.getSut().captureTransaction(transaction, null, null, null, fixture.profilingTraceData)
+        fixture.profilingTraceFile.writeText("")
+        assertFails { verifyProfilingTraceInEnvelope(transaction.eventId) }
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Added a check on the sampled profile not to be empty in order to be sent


## :bulb: Motivation and Context
We received few profiles without any content. There is already a check if the profiling trace file doesn't exists or cannot be read, but no check if it is empty. I couldn't be able to reproduce the issue, other than changing the content of the file right before being sent. 
However, this should fix it


## :green_heart: How did you test it?
I added both a Unit and a Ui test to check empty profiles are discarded


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

