### PR TITLE
add cpu start/end timestamps to concurrent profiling transactions

### DIFF
--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -83,15 +84,12 @@ class EnvelopeTests : BaseUiTest() {
         relayIdlingResource.increment()
         relayIdlingResource.increment()
         relayIdlingResource.increment()
+
         val transaction = Sentry.startTransaction("e2etests", "test1")
-        Thread.sleep(5)
         val transaction2 = Sentry.startTransaction("e2etests", "test2")
-        Thread.sleep(5)
         val transaction3 = Sentry.startTransaction("e2etests", "test3")
         transaction.finish()
-        Thread.sleep(5)
         transaction2.finish()
-        Thread.sleep(5)
         transaction3.finish()
 
         relay.assert {
@@ -127,12 +125,10 @@ class EnvelopeTests : BaseUiTest() {
                 assertNotEquals(endTimes[0], endTimes[1])
                 assertNotEquals(endTimes[0], endTimes[2])
                 assertNotEquals(endTimes[1], endTimes[2])
-                assertNotEquals(startCpuTimes[0], startCpuTimes[1])
-                assertNotEquals(startCpuTimes[0], startCpuTimes[2])
-                assertNotEquals(startCpuTimes[1], startCpuTimes[2])
-                assertNotEquals(endCpuTimes[0], endCpuTimes[1])
-                assertNotEquals(endCpuTimes[0], endCpuTimes[2])
-                assertNotEquals(endCpuTimes[1], endCpuTimes[2])
+
+                // The cpu timestamps shouldn't be all the same
+                assertFalse(startCpuTimes[0] == startCpuTimes[1] && startCpuTimes[1] == startCpuTimes[2])
+                assertFalse(endCpuTimes[0] == endCpuTimes[1] && endCpuTimes[1] == endCpuTimes[2])
 
                 // The first and last transactions should be aligned to the start/stop of profile
                 assertEquals(endTimes.maxOrNull()!! - startTimes.minOrNull()!!, profilingTraceData.durationNs.toLong())

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -17,7 +17,6 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -84,10 +84,14 @@ class EnvelopeTests : BaseUiTest() {
         relayIdlingResource.increment()
         relayIdlingResource.increment()
         val transaction = Sentry.startTransaction("e2etests", "test1")
+        Thread.sleep(5)
         val transaction2 = Sentry.startTransaction("e2etests", "test2")
+        Thread.sleep(5)
         val transaction3 = Sentry.startTransaction("e2etests", "test3")
         transaction.finish()
+        Thread.sleep(5)
         transaction2.finish()
+        Thread.sleep(5)
         transaction3.finish()
 
         relay.assert {
@@ -115,12 +119,20 @@ class EnvelopeTests : BaseUiTest() {
                 assertContains(transactions.map { t -> t.id }, transactionItem.eventId.toString())
                 val startTimes = transactions.map { t -> t.relativeStartNs }
                 val endTimes = transactions.mapNotNull { t -> t.relativeEndNs }
+                val startCpuTimes = transactions.map { t -> t.relativeStartCpuMs }
+                val endCpuTimes = transactions.mapNotNull { t -> t.relativeEndCpuMs }
                 assertNotEquals(startTimes[0], startTimes[1])
                 assertNotEquals(startTimes[0], startTimes[2])
                 assertNotEquals(startTimes[1], startTimes[2])
                 assertNotEquals(endTimes[0], endTimes[1])
                 assertNotEquals(endTimes[0], endTimes[2])
                 assertNotEquals(endTimes[1], endTimes[2])
+                assertNotEquals(startCpuTimes[0], startCpuTimes[1])
+                assertNotEquals(startCpuTimes[0], startCpuTimes[2])
+                assertNotEquals(startCpuTimes[1], startCpuTimes[2])
+                assertNotEquals(endCpuTimes[0], endCpuTimes[1])
+                assertNotEquals(endCpuTimes[0], endCpuTimes[2])
+                assertNotEquals(endCpuTimes[1], endCpuTimes[2])
 
                 // The first and last transactions should be aligned to the start/stop of profile
                 assertEquals(endTimes.maxOrNull()!! - startTimes.minOrNull()!!, profilingTraceData.durationNs.toLong())

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -86,8 +86,8 @@ class EnvelopeTests : BaseUiTest() {
         relayIdlingResource.increment()
 
         val transaction = Sentry.startTransaction("e2etests", "test1")
-        val transaction2 = Sentry.startTransaction("e2etests", "test2")
-        val transaction3 = Sentry.startTransaction("e2etests", "test3")
+        val transaction2 = Sentry.startTransaction("e2etests1", "test2")
+        val transaction3 = Sentry.startTransaction("e2etests2", "test3")
         transaction.finish()
         transaction2.finish()
         transaction3.finish()
@@ -110,28 +110,35 @@ class EnvelopeTests : BaseUiTest() {
                 it.assertNoOtherItems()
                 assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
                 assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
-                assertTrue(profilingTraceData.transactionName == "e2etests")
+                assertTrue(profilingTraceData.transactionName == "e2etests2")
 
-                // Transaction timestamps should be all different from each other
-                val transactions = profilingTraceData.transactions
+                // The transaction list is not ordered, since it's stored using a map to be able to quickly check the
+                // existence of a certain id. So we order the list to make more meaningful checks on timestamps.
+                val transactions = profilingTraceData.transactions.sortedBy { it.relativeStartNs }
                 assertContains(transactions.map { t -> t.id }, transactionItem.eventId.toString())
+                assertEquals(transactions.last().id, transactionItem.eventId.toString())
                 val startTimes = transactions.map { t -> t.relativeStartNs }
                 val endTimes = transactions.mapNotNull { t -> t.relativeEndNs }
                 val startCpuTimes = transactions.map { t -> t.relativeStartCpuMs }
                 val endCpuTimes = transactions.mapNotNull { t -> t.relativeEndCpuMs }
-                assertNotEquals(startTimes[0], startTimes[1])
-                assertNotEquals(startTimes[0], startTimes[2])
-                assertNotEquals(startTimes[1], startTimes[2])
-                assertNotEquals(endTimes[0], endTimes[1])
-                assertNotEquals(endTimes[0], endTimes[2])
-                assertNotEquals(endTimes[1], endTimes[2])
 
-                // The cpu timestamps shouldn't be all the same
+                // Transaction timestamps should be all different from each other
+                assertTrue(startTimes[0] < startTimes[1])
+                assertTrue(startTimes[1] < startTimes[2])
+                assertTrue(endTimes[0] < endTimes[1])
+                assertTrue(endTimes[1] < endTimes[2])
+
+                // The cpu timestamps use milliseconds precision, so few of them could have the same timestamps
+                // However, it's basically impossible that all of them have the same timestamps
                 assertFalse(startCpuTimes[0] == startCpuTimes[1] && startCpuTimes[1] == startCpuTimes[2])
+                assertTrue(startCpuTimes[0] <= startCpuTimes[1])
+                assertTrue(startCpuTimes[1] <= startCpuTimes[2])
                 assertFalse(endCpuTimes[0] == endCpuTimes[1] && endCpuTimes[1] == endCpuTimes[2])
+                assertTrue(endCpuTimes[0] <= endCpuTimes[1])
+                assertTrue(endCpuTimes[1] <= endCpuTimes[2])
 
                 // The first and last transactions should be aligned to the start/stop of profile
-                assertEquals(endTimes.maxOrNull()!! - startTimes.minOrNull()!!, profilingTraceData.durationNs.toLong())
+                assertEquals(endTimes.last() - startTimes.first(), profilingTraceData.durationNs.toLong())
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -798,16 +798,18 @@ public final class io/sentry/ProfilingTraceData$JsonKeys {
 
 public final class io/sentry/ProfilingTransactionData : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/ITransaction;Ljava/lang/Long;)V
+	public fun <init> (Lio/sentry/ITransaction;Ljava/lang/Long;Ljava/lang/Long;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getId ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
+	public fun getRelativeEndCpuMs ()Ljava/lang/Long;
 	public fun getRelativeEndNs ()Ljava/lang/Long;
+	public fun getRelativeStartCpuMs ()Ljava/lang/Long;
 	public fun getRelativeStartNs ()Ljava/lang/Long;
 	public fun getTraceId ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun hashCode ()I
-	public fun notifyFinish (Ljava/lang/Long;Ljava/lang/Long;)V
+	public fun notifyFinish (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
 	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
 	public fun setId (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;)V
@@ -824,9 +826,11 @@ public final class io/sentry/ProfilingTransactionData$Deserializer : io/sentry/J
 }
 
 public final class io/sentry/ProfilingTransactionData$JsonKeys {
-	public static final field END_ND Ljava/lang/String;
+	public static final field END_CPU_MS Ljava/lang/String;
+	public static final field END_NS Ljava/lang/String;
 	public static final field ID Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;
+	public static final field START_CPU_MS Ljava/lang/String;
 	public static final field START_NS Ljava/lang/String;
 	public static final field TRACE_ID Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
@@ -121,15 +121,14 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
   @Override
   public int hashCode() {
     return Objects.hash(
-      id,
-      traceId,
-      name,
-      relativeStartNs,
-      relativeEndNs,
-      relativeStartCpuMs,
-      relativeEndCpuMs,
-      unknown
-    );
+        id,
+        traceId,
+        name,
+        relativeStartNs,
+        relativeEndNs,
+        relativeStartCpuMs,
+        relativeEndCpuMs,
+        unknown);
   }
 
   // JsonSerializable

--- a/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
@@ -16,18 +16,22 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
   private @NotNull String name; // transaction name
   private @NotNull Long relativeStartNs; // timestamp in nanoseconds this transaction started
   private @Nullable Long relativeEndNs; // timestamp in nanoseconds this transaction ended
+  private @NotNull Long relativeStartCpuMs; // cpu time in milliseconds this transaction started
+  private @Nullable Long relativeEndCpuMs; // cpu time in milliseconds this transaction ended
 
   private @Nullable Map<String, Object> unknown;
 
   public ProfilingTransactionData() {
-    this(NoOpTransaction.getInstance(), 0L);
+    this(NoOpTransaction.getInstance(), 0L, 0L);
   }
 
-  public ProfilingTransactionData(@NotNull ITransaction transaction, @NotNull Long startNs) {
+  public ProfilingTransactionData(
+      @NotNull ITransaction transaction, @NotNull Long startNs, @NotNull Long startCpuMs) {
     this.id = transaction.getEventId().toString();
     this.traceId = transaction.getSpanContext().getTraceId().toString();
     this.name = transaction.getName();
     this.relativeStartNs = startNs;
+    this.relativeStartCpuMs = startCpuMs;
   }
 
   /**
@@ -38,10 +42,16 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
    * @param profileStartNs The timestamp the profile started, so that timestamps can be converted in
    *     times relative to the profile start timestamp.
    */
-  public void notifyFinish(@NotNull Long endNs, @NotNull Long profileStartNs) {
+  public void notifyFinish(
+      @NotNull Long endNs,
+      @NotNull Long profileStartNs,
+      @NotNull Long endCpuMs,
+      @NotNull Long profileStartCpuMs) {
     if (this.relativeEndNs == null) {
       this.relativeEndNs = endNs - profileStartNs;
       this.relativeStartNs = relativeStartNs - profileStartNs;
+      this.relativeEndCpuMs = endCpuMs - profileStartCpuMs;
+      this.relativeStartCpuMs = relativeStartCpuMs - profileStartCpuMs;
     }
   }
 
@@ -63,6 +73,14 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
 
   public @Nullable Long getRelativeEndNs() {
     return relativeEndNs;
+  }
+
+  public @Nullable Long getRelativeEndCpuMs() {
+    return relativeEndCpuMs;
+  }
+
+  public @NotNull Long getRelativeStartCpuMs() {
+    return relativeStartCpuMs;
   }
 
   public void setId(@NotNull String id) {
@@ -94,6 +112,8 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
         && traceId.equals(that.traceId)
         && name.equals(that.name)
         && relativeStartNs.equals(that.relativeStartNs)
+        && relativeStartCpuMs.equals(that.relativeStartCpuMs)
+        && Objects.equals(relativeEndCpuMs, that.relativeEndCpuMs)
         && Objects.equals(relativeEndNs, that.relativeEndNs)
         && Objects.equals(unknown, that.unknown);
   }
@@ -110,7 +130,9 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
     public static final String TRACE_ID = "trace_id";
     public static final String NAME = "name";
     public static final String START_NS = "relative_start_ns";
-    public static final String END_ND = "relative_end_ns";
+    public static final String END_NS = "relative_end_ns";
+    public static final String START_CPU_MS = "relative_cpu_start_ms";
+    public static final String END_CPU_MS = "relative_cpu_end_ms";
   }
 
   @Override
@@ -121,7 +143,9 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
     writer.name(JsonKeys.TRACE_ID).value(logger, traceId);
     writer.name(JsonKeys.NAME).value(logger, name);
     writer.name(JsonKeys.START_NS).value(logger, relativeStartNs);
-    writer.name(JsonKeys.END_ND).value(logger, relativeEndNs);
+    writer.name(JsonKeys.END_NS).value(logger, relativeEndNs);
+    writer.name(JsonKeys.START_CPU_MS).value(logger, relativeStartCpuMs);
+    writer.name(JsonKeys.END_CPU_MS).value(logger, relativeEndCpuMs);
     if (unknown != null) {
       for (String key : unknown.keySet()) {
         Object value = unknown.get(key);
@@ -179,10 +203,22 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
               data.relativeStartNs = startNs;
             }
             break;
-          case JsonKeys.END_ND:
+          case JsonKeys.END_NS:
             Long endNs = reader.nextLongOrNull();
             if (endNs != null) {
               data.relativeEndNs = endNs;
+            }
+            break;
+          case JsonKeys.START_CPU_MS:
+            Long startCpuMs = reader.nextLongOrNull();
+            if (startCpuMs != null) {
+              data.relativeStartCpuMs = startCpuMs;
+            }
+            break;
+          case JsonKeys.END_CPU_MS:
+            Long endCpuMs = reader.nextLongOrNull();
+            if (endCpuMs != null) {
+              data.relativeEndCpuMs = endCpuMs;
             }
             break;
           default:

--- a/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
@@ -120,7 +120,16 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, traceId, name, relativeStartNs, relativeEndNs, unknown);
+    return Objects.hash(
+      id,
+      traceId,
+      name,
+      relativeStartNs,
+      relativeEndNs,
+      relativeStartCpuMs,
+      relativeEndCpuMs,
+      unknown
+    );
   }
 
   // JsonSerializable


### PR DESCRIPTION
## :scroll: Description
add cpu start/end timestamps to transactions in profile envelope payloads
added ui test to check times are different

#skip-changelog


## :bulb: Motivation and Context
Profiling traces have a clock field to indicate how timestamps were captured in the trace itself and it can be dual/cpu/wall/global time.
If the timestamps are cpu time, there's no way to filter the trace based on start/end timestamps, as the payload only sends wall time.


## :green_heart: How did you test it?
I added a ui test to check correctness of cpu timestamps


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
