### PR TITLE
Concurrent profiling 3 - truncation reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Features
 
+- Concurrent profiling 3 - added truncation reason ([#2247](https://github.com/getsentry/sentry-java/pull/2247))
 - Concurrent profiling 2 - added list of transactions ([#2218](https://github.com/getsentry/sentry-java/pull/2218))
 - Concurrent profiling 1 - added envelope payload data format ([#2216](https://github.com/getsentry/sentry-java/pull/2216))
 - Send source for transactions ([#2180](https://github.com/getsentry/sentry-java/pull/2180))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.Future;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 
 final class AndroidTransactionProfiler implements ITransactionProfiler {
 
@@ -292,7 +291,9 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
         versionName,
         versionCode,
         options.getEnvironment(),
-        );
+        isTimeout
+            ? ProfilingTraceData.TRUNCATION_REASON_TIMEOUT
+            : ProfilingTraceData.TRUNCATION_REASON_NORMAL);
   }
 
   /**
@@ -314,10 +315,5 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       options.getLogger().log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
       return null;
     }
-  }
-
-  @TestOnly
-  void setTimedOutProfilingData(@Nullable ProfilingTraceData data) {
-    this.timedOutProfilingData = data;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -291,7 +291,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
         options.getProguardUuid(),
         versionName,
         versionCode,
-        options.getEnvironment());
+        options.getEnvironment(),
+        );
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -4,12 +4,17 @@ import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.ILogger
+import io.sentry.ISentryExecutorService
+import io.sentry.ProfilingTraceData
 import io.sentry.SentryLevel
 import io.sentry.SentryTracer
 import io.sentry.TransactionContext
@@ -39,12 +44,14 @@ class AndroidTransactionProfilerTest {
             whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
         }
         val mockLogger = mock<ILogger>()
-        val options = SentryAndroidOptions().apply {
-            dsn = mockDsn
-            profilesSampleRate = 1.0
-            isDebug = true
-            setLogger(mockLogger)
-        }
+        val options = spy(
+            SentryAndroidOptions().apply {
+                dsn = mockDsn
+                profilesSampleRate = 1.0
+                isDebug = true
+                setLogger(mockLogger)
+            }
+        )
         val transaction1 = SentryTracer(TransactionContext("", ""), mock())
         val transaction2 = SentryTracer(TransactionContext("", ""), mock())
         val transaction3 = SentryTracer(TransactionContext("", ""), mock())
@@ -229,23 +236,47 @@ class AndroidTransactionProfilerTest {
     fun `onTransactionFinish returns timedOutData to the timed out transaction once, even after other transactions`() {
         val profiler = fixture.getSut(context)
 
+        val executorService = mock<ISentryExecutorService>()
+        val captor = argumentCaptor<Runnable>()
+        whenever(executorService.schedule(captor.capture(), any())).thenReturn(null)
+        whenever(fixture.options.executorService).thenReturn(executorService)
         // Start and finish first transaction profiling
         profiler.onTransactionStart(fixture.transaction1)
-        val traceData = profiler.onTransactionFinish(fixture.transaction1)
 
-        // Set timed out data
-        profiler.setTimedOutProfilingData(traceData)
+        // Set timed out data by calling the timeout scheduled job
+        captor.firstValue.run()
 
-        // Start and finish second transaction profiling
+        // Start and finish second transaction. Since profiler returned data, it means no other profiling is running
         profiler.onTransactionStart(fixture.transaction2)
         assertEquals(fixture.transaction2.eventId.toString(), profiler.onTransactionFinish(fixture.transaction2)!!.transactionId)
 
         // First transaction finishes: timed out data is returned
-        val traceData2 = profiler.onTransactionFinish(fixture.transaction1)
-        assertEquals(traceData, traceData2)
+        val traceData = profiler.onTransactionFinish(fixture.transaction1)
+        assertEquals(traceData!!.transactionId, fixture.transaction1.eventId.toString())
 
         // If first transaction is finished again, nothing is returned
         assertNull(profiler.onTransactionFinish(fixture.transaction1))
+    }
+
+    @Test
+    fun `timedOutData has timeout truncation reason`() {
+        val profiler = fixture.getSut(context)
+
+        val executorService = mock<ISentryExecutorService>()
+        val captor = argumentCaptor<Runnable>()
+        whenever(executorService.schedule(captor.capture(), any())).thenReturn(null)
+        whenever(fixture.options.executorService).thenReturn(executorService)
+
+        // Start and finish first transaction profiling
+        profiler.onTransactionStart(fixture.transaction1)
+
+        // Set timed out data by calling the timeout scheduled job
+        captor.firstValue.run()
+
+        // First transaction finishes: timed out data is returned
+        val traceData = profiler.onTransactionFinish(fixture.transaction1)
+        assertEquals(traceData!!.transactionId, fixture.transaction1.eventId.toString())
+        assertEquals(ProfilingTraceData.TRUNCATION_REASON_TIMEOUT, traceData.truncationReason)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -44,14 +44,12 @@ class AndroidTransactionProfilerTest {
             whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
         }
         val mockLogger = mock<ILogger>()
-        val options = spy(
-            SentryAndroidOptions().apply {
-                dsn = mockDsn
-                profilesSampleRate = 1.0
-                isDebug = true
-                setLogger(mockLogger)
-            }
-        )
+        val options = spy(SentryAndroidOptions()).apply {
+            dsn = mockDsn
+            profilesSampleRate = 1.0
+            isDebug = true
+            setLogger(mockLogger)
+        }
         val transaction1 = SentryTracer(TransactionContext("", ""), mock())
         val transaction2 = SentryTracer(TransactionContext("", ""), mock())
         val transaction3 = SentryTracer(TransactionContext("", ""), mock())

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -109,6 +109,7 @@ class EnvelopeTests : BaseUiTest() {
                 assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
                 assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
                 assertTrue(profilingTraceData.transactionName == "e2etests")
+                assertTrue(profilingTraceData.truncationReason == "normal")
 
                 // Transaction timestamps should be all different from each other
                 val transactions = profilingTraceData.transactions

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -85,8 +85,8 @@ class EnvelopeTests : BaseUiTest() {
         relayIdlingResource.increment()
 
         val transaction = Sentry.startTransaction("e2etests", "test1")
-        val transaction2 = Sentry.startTransaction("e2etests", "test2")
-        val transaction3 = Sentry.startTransaction("e2etests", "test3")
+        val transaction2 = Sentry.startTransaction("e2etests1", "test2")
+        val transaction3 = Sentry.startTransaction("e2etests2", "test3")
         transaction.finish()
         transaction2.finish()
         transaction3.finish()
@@ -109,7 +109,7 @@ class EnvelopeTests : BaseUiTest() {
                 it.assertNoOtherItems()
                 assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
                 assertEquals(profilingTraceData.transactionId, transactionItem.eventId.toString())
-                assertTrue(profilingTraceData.transactionName == "e2etests")
+                assertTrue(profilingTraceData.transactionName == "e2etests2")
                 assertTrue(profilingTraceData.truncationReason == "normal")
 
                 // The transaction list is not ordered, since it's stored using a map to be able to quickly check the

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -711,8 +711,11 @@ public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
 }
 
 public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field TRUNCATION_REASON_BACKGROUNDED Ljava/lang/String;
+	public static final field TRUNCATION_REASON_NORMAL Ljava/lang/String;
+	public static final field TRUNCATION_REASON_TIMEOUT Ljava/lang/String;
 	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;)V
-	public fun <init> (Ljava/io/File;Ljava/util/List;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/lang/String;Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/io/File;Ljava/util/List;Lio/sentry/ITransaction;Ljava/lang/String;ILjava/lang/String;Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun getAndroidApiLevel ()I
 	public fun getBuildId ()Ljava/lang/String;
 	public fun getCpuArchitecture ()Ljava/lang/String;
@@ -734,6 +737,7 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 	public fun getTransactionId ()Ljava/lang/String;
 	public fun getTransactionName ()Ljava/lang/String;
 	public fun getTransactions ()Ljava/util/List;
+	public fun getTruncationReason ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getVersionCode ()Ljava/lang/String;
 	public fun getVersionName ()Ljava/lang/String;
@@ -791,6 +795,7 @@ public final class io/sentry/ProfilingTraceData$JsonKeys {
 	public static final field TRANSACTION_ID Ljava/lang/String;
 	public static final field TRANSACTION_LIST Ljava/lang/String;
 	public static final field TRANSACTION_NAME Ljava/lang/String;
+	public static final field TRUNCATION_REASON Ljava/lang/String;
 	public static final field VERSION_CODE Ljava/lang/String;
 	public static final field VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/ProfilingTraceData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTraceData.java
@@ -22,12 +22,11 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
    * SentryOptions} do not have the environment field set.
    */
   private static final String DEFAULT_ENVIRONMENT = "production";
-  @ApiStatus.Internal
-  public static final String TRUNCATION_REASON_NORMAL = "normal";
-  @ApiStatus.Internal
-  public static final String TRUNCATION_REASON_TIMEOUT = "timeout";
-  @ApiStatus.Internal
-  public static final String TRUNCATION_REASON_BACKGROUNDED = "backgrounded";
+
+  @ApiStatus.Internal public static final String TRUNCATION_REASON_NORMAL = "normal";
+  @ApiStatus.Internal public static final String TRUNCATION_REASON_TIMEOUT = "timeout";
+  // Backgrounded reason is not used, yet, but it's one of the possible values
+  @ApiStatus.Internal public static final String TRUNCATION_REASON_BACKGROUNDED = "backgrounded";
 
   private @NotNull File traceFile;
   private @Nullable Callable<List<Integer>> deviceCpuFrequenciesReader;
@@ -91,7 +90,7 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
         null,
         null,
         null,
-      TRUNCATION_REASON_NORMAL);
+        TRUNCATION_REASON_NORMAL);
   }
 
   public ProfilingTraceData(
@@ -151,9 +150,9 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
   }
 
   private boolean isTruncationReasonValid() {
-    return truncationReason.equals(TRUNCATION_REASON_NORMAL) ||
-      truncationReason.equals(TRUNCATION_REASON_TIMEOUT) ||
-      truncationReason.equals(TRUNCATION_REASON_BACKGROUNDED);
+    return truncationReason.equals(TRUNCATION_REASON_NORMAL)
+        || truncationReason.equals(TRUNCATION_REASON_TIMEOUT)
+        || truncationReason.equals(TRUNCATION_REASON_BACKGROUNDED);
   }
 
   private @Nullable Map<String, Object> unknown;


### PR DESCRIPTION
## :scroll: Description
We are adding the truncation reason in case a profile is truncated.
If no truncation occurs, we will send `normal`, while if a timeout occurs, we will send `timeout` as `truncation_reason` in the envelope payload.


## :bulb: Motivation and Context
The backend was unable to understand if a profile was terminated on purpose or due to an error.


## :green_heart: How did you test it?
Added a ui and unit test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
