### PR TITLE
Fix file descriptor leak in FileIO instrumentation

### DIFF
--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -54,7 +54,7 @@ public final class SentryFileInputStream extends FileInputStream {
 
   private SentryFileInputStream(final @NotNull FileInputStreamInitData data)
       throws FileNotFoundException {
-    super(data.file);
+    super(getFileDescriptor(data.delegate));
     spanManager = new FileIOSpanManager(data.span, data.file, data.isSendDefaultPii);
     delegate = data.delegate;
   }
@@ -112,6 +112,14 @@ public final class SentryFileInputStream extends FileInputStream {
   @Override
   public void close() throws IOException {
     spanManager.finish(delegate);
+  }
+
+  private static FileDescriptor getFileDescriptor(FileInputStream stream) throws FileNotFoundException {
+    try {
+      return stream.getFD();
+    } catch (IOException error) {
+      throw new FileNotFoundException("No file descriptor");
+    }
   }
 
   public static final class Factory {


### PR DESCRIPTION
## :scroll: Description

There is a bug in FileIO tracing that causes leak in file descriptors.
The bug affects Android and Java.

## :bulb: Motivation and Context
The context and all the information is [here](https://github.com/getsentry/sentry-android-gradle-plugin/issues/375). 

When we create `new SentryFileInputStream(file)` or `new SentryFileOutputStream(file)`, 2 file descriptors are opened. But when we close the stream, only one is closed. The cause is in [this comment](https://github.com/getsentry/sentry-android-gradle-plugin/issues/375#issuecomment-1250127522).

## :green_heart: How did you test it?

```java

// write into several files with SentryFileOutputStream, close and delete them.
ExecutorService executor = Executors.newSingleThreadExecutor();
for (int i = 0; i < 10; i++) {
  final String name = "my-test-file-" + i + ".bin";
  executor.submit(
    () -> {
      File file = new File(name);
      try (FileOutputStream out = new SentryFileOutputStream(file, false)) {
        out.write("Hello world!".getBytes(StandardCharsets.UTF_8));
        out.flush();
        Thread.sleep(50);
      } catch (Exception error) {
        // ignore
      }
      file.delete();
    }
  );
}

// run "lsof" and check if they are still open
executor.submit(
  () -> {
    try {
      StringBuilder output = new StringBuilder();
      Process process = Runtime.getRuntime().exec("lsof");
      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
      while (true) {
        String line = reader.readLine();
        if (line == null) break;
        if (line.contains("my-test-file-")) {
          output.append(line);
          output.append("\n");
        }
      }
      System.out.println("> slof \n" + output);
      process.destroy();
    } catch (IOException e) {
      // ignore
    }
  }
);

executor.shutdown();
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

