### PR TITLE
tmp: test latest app-sdk-metrics action

### DIFF
--- a/.github/workflows/integration-tests-benchmarks.yml
+++ b/.github/workflows/integration-tests-benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
         run: ./gradlew :sentry-android-integration-tests:test-app-sentry:assembleRelease
 
       - name: Collect app metrics
-        uses: getsentry/action-app-sdk-overhead-metrics@v1
+        uses: getsentry/action-app-sdk-overhead-metrics@a99530cc923ebfc82ee701f0d3d0d74a6bd08096
         with:
           config: sentry-android-integration-tests/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
don't merge - just testing https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/3 also in a real repo

#skip-changelog