### PR TITLE
Replace user `other` with `data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Make user segment a top level property ([#2257](https://github.com/getsentry/sentry-java/pull/2257))
-- Make user segment a top level property ([#2258](https://github.com/getsentry/sentry-java/pull/2258))
+- Replace user `other` with `data` ([#2258](https://github.com/getsentry/sentry-java/pull/2258))
 
 ## 6.5.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Make user segment a top level property ([#2257](https://github.com/getsentry/sentry-java/pull/2257))
+- Make user segment a top level property ([#2258](https://github.com/getsentry/sentry-java/pull/2258))
 
 ## 6.5.0-beta.1
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -62,15 +62,15 @@ public class SentryUserFilter extends OncePerRequestFilter {
       Optional.ofNullable(userFromProvider.getId()).ifPresent(existingUser::setId);
       Optional.ofNullable(userFromProvider.getIpAddress()).ifPresent(existingUser::setIpAddress);
       Optional.ofNullable(userFromProvider.getUsername()).ifPresent(existingUser::setUsername);
-      if (userFromProvider.getOthers() != null && !userFromProvider.getOthers().isEmpty()) {
-        Map<String, String> existingUserOthers = existingUser.getOthers();
-        if (existingUserOthers == null) {
-          existingUserOthers = new ConcurrentHashMap<>();
+      if (userFromProvider.getData() != null && !userFromProvider.getData().isEmpty()) {
+        Map<String, String> existingUserData = existingUser.getData();
+        if (existingUserData == null) {
+          existingUserData = new ConcurrentHashMap<>();
         }
-        for (final Map.Entry<String, String> entry : userFromProvider.getOthers().entrySet()) {
-          existingUserOthers.put(entry.getKey(), entry.getValue());
+        for (final Map.Entry<String, String> entry : userFromProvider.getData().entrySet()) {
+          existingUserData.put(entry.getKey(), entry.getValue());
         }
-        existingUser.setOthers(existingUserOthers);
+        existingUser.setData(existingUserData);
       }
     }
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2970,6 +2970,7 @@ public final class io/sentry/protocol/TransactionNameSource : java/lang/Enum {
 public final class io/sentry/protocol/User : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/protocol/User;)V
+	public fun getData ()Ljava/util/Map;
 	public fun getEmail ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
 	public fun getIpAddress ()Ljava/lang/String;
@@ -2978,6 +2979,7 @@ public final class io/sentry/protocol/User : io/sentry/JsonSerializable, io/sent
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getUsername ()Ljava/lang/String;
 	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
+	public fun setData (Ljava/util/Map;)V
 	public fun setEmail (Ljava/lang/String;)V
 	public fun setId (Ljava/lang/String;)V
 	public fun setIpAddress (Ljava/lang/String;)V
@@ -2994,6 +2996,7 @@ public final class io/sentry/protocol/User$Deserializer : io/sentry/JsonDeserial
 }
 
 public final class io/sentry/protocol/User$JsonKeys {
+	public static final field DATA Ljava/lang/String;
 	public static final field EMAIL Ljava/lang/String;
 	public static final field ID Ljava/lang/String;
 	public static final field IP_ADDRESS Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -296,9 +296,9 @@ public final class Baggage {
       return user.getSegment();
     }
 
-    final Map<String, String> others = user.getOthers();
-    if (others != null) {
-      return others.get("segment");
+    final Map<String, String> userData = user.getData();
+    if (userData != null) {
+      return userData.get("segment");
     } else {
       return null;
     }

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -150,7 +150,7 @@ public final class User implements JsonUnknown, JsonSerializable {
   /**
    * Gets other user related data.
    *
-   * @deprecated use getData instead
+   * @deprecated use {{@link User#getData()}} instead
    * @return the other user data.
    */
   @Deprecated
@@ -162,7 +162,7 @@ public final class User implements JsonUnknown, JsonSerializable {
   /**
    * Sets other user related data.
    *
-   * @deprecated use setData instead
+   * @deprecated use {{@link User#setData(Map)}} instead
    * @param other the other user related data..
    */
   @Deprecated
@@ -276,6 +276,7 @@ public final class User implements JsonUnknown, JsonSerializable {
                     (Map<String, String>) reader.nextObjectOrNull());
             break;
           case JsonKeys.OTHER:
+            // restore `other` from legacy JSON
             if (user.data == null || user.data.isEmpty()) {
               user.data =
                   CollectionUtils.newConcurrentHashMap(

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -40,7 +40,7 @@ public final class User implements JsonUnknown, JsonSerializable {
    * Additional arbitrary fields, as stored in the database (and sometimes as sent by clients). All
    * data from `self.other` should end up here after store normalization.
    */
-  private @Nullable Map<String, @NotNull String> other;
+  private @Nullable Map<String, @NotNull String> data;
 
   /** unknown fields, only internal usage. */
   private @Nullable Map<String, @NotNull Object> unknown;
@@ -53,7 +53,7 @@ public final class User implements JsonUnknown, JsonSerializable {
     this.id = user.id;
     this.ipAddress = user.ipAddress;
     this.segment = user.segment;
-    this.other = CollectionUtils.newConcurrentHashMap(user.other);
+    this.data = CollectionUtils.newConcurrentHashMap(user.data);
     this.unknown = CollectionUtils.newConcurrentHashMap(user.unknown);
   }
 
@@ -150,19 +150,43 @@ public final class User implements JsonUnknown, JsonSerializable {
   /**
    * Gets other user related data.
    *
+   * @deprecated use getData instead
    * @return the other user data.
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public @Nullable Map<String, @NotNull String> getOthers() {
-    return other;
+    return getData();
   }
 
   /**
    * Sets other user related data.
    *
+   * @deprecated use setData instead
    * @param other the other user related data..
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public void setOthers(final @Nullable Map<String, @NotNull String> other) {
-    this.other = CollectionUtils.newConcurrentHashMap(other);
+    this.setData(other);
+  }
+
+  /**
+   * Gets additional arbitrary fields of the user.
+   *
+   * @return the other user data.
+   */
+  public @Nullable Map<String, @NotNull String> getData() {
+    return data;
+  }
+
+  /**
+   * Sets additional arbitrary fields of the user.
+   *
+   * @param data the other user related data..
+   */
+  public void setData(final @Nullable Map<String, @NotNull String> data) {
+    this.data = CollectionUtils.newConcurrentHashMap(data);
   }
 
   // region json
@@ -185,6 +209,7 @@ public final class User implements JsonUnknown, JsonSerializable {
     public static final String SEGMENT = "segment";
     public static final String IP_ADDRESS = "ip_address";
     public static final String OTHER = "other";
+    public static final String DATA = "data";
   }
 
   @Override
@@ -206,8 +231,8 @@ public final class User implements JsonUnknown, JsonSerializable {
     if (ipAddress != null) {
       writer.name(JsonKeys.IP_ADDRESS).value(ipAddress);
     }
-    if (other != null) {
-      writer.name(JsonKeys.OTHER).value(logger, other);
+    if (data != null) {
+      writer.name(JsonKeys.DATA).value(logger, data);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -245,10 +270,17 @@ public final class User implements JsonUnknown, JsonSerializable {
           case JsonKeys.IP_ADDRESS:
             user.ipAddress = reader.nextStringOrNull();
             break;
-          case JsonKeys.OTHER:
-            user.other =
+          case JsonKeys.DATA:
+            user.data =
                 CollectionUtils.newConcurrentHashMap(
                     (Map<String, String>) reader.nextObjectOrNull());
+            break;
+          case JsonKeys.OTHER:
+            if (user.data == null || user.data.isEmpty()) {
+              user.data =
+                  CollectionUtils.newConcurrentHashMap(
+                      (Map<String, String>) reader.nextObjectOrNull());
+            }
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -30,8 +30,8 @@ class ScopeTest {
         user.id = "123"
         user.ipAddress = "123.x"
         user.username = "userName"
-        val others = mutableMapOf(Pair("others", "others"))
-        user.others = others
+        val data = mutableMapOf(Pair("data", "data"))
+        user.data = data
 
         scope.user = user
 

--- a/sentry/src/test/java/io/sentry/protocol/UserSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/UserSerializationTest.kt
@@ -43,6 +43,15 @@ class UserSerializationTest {
         assertEquals(expectedJson, actualJson)
     }
 
+    @Test
+    fun deserializeLegacy() {
+        val inputJson = sanitizedFile("json/user_legacy.json")
+        val expectedJson = sanitizedFile("json/user.json")
+        val actual = deserialize(inputJson)
+        val actualJson = serialize(actual)
+        assertEquals(expectedJson, actualJson)
+    }
+
     // Helper
 
     private fun sanitizedFile(path: String): String {

--- a/sentry/src/test/java/io/sentry/protocol/UserSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/UserSerializationTest.kt
@@ -44,7 +44,7 @@ class UserSerializationTest {
     }
 
     @Test
-    fun deserializeLegacy() {
+    fun `deserialize legacy`() {
         val inputJson = sanitizedFile("json/user_legacy.json")
         val expectedJson = sanitizedFile("json/user.json")
         val actual = deserialize(inputJson)

--- a/sentry/src/test/java/io/sentry/protocol/UserTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/UserTest.kt
@@ -17,7 +17,7 @@ class UserTest {
         assertNotNull(clone)
         assertNotSame(user, clone)
 
-        assertNotSame(user.others, clone.others)
+        assertNotSame(user.data, clone.data)
 
         assertNotSame(user.unknown, clone.unknown)
     }
@@ -32,7 +32,7 @@ class UserTest {
         assertEquals("123.x", clone.ipAddress)
         assertEquals("userName", clone.username)
         assertEquals("userSegment", clone.segment)
-        assertEquals("others", clone.others!!["others"])
+        assertEquals("data", clone.data!!["data"])
         assertEquals("unknown", clone.unknown!!["unknown"])
     }
 
@@ -46,8 +46,8 @@ class UserTest {
         user.ipAddress = "456.x"
         user.username = "newUserName"
         user.segment = "newUserSegment"
-        user.others!!["others"] = "newOthers"
-        user.others!!["anotherOne"] = "anotherOne"
+        user.data!!["data"] = "newOthers"
+        user.data!!["anotherOne"] = "anotherOne"
         val newUnknown = mapOf(Pair("unknown", "newUnknown"), Pair("otherUnknown", "otherUnknown"))
         user.setUnknown(newUnknown)
 
@@ -56,27 +56,27 @@ class UserTest {
         assertEquals("123.x", clone.ipAddress)
         assertEquals("userName", clone.username)
         assertEquals("userSegment", clone.segment)
-        assertEquals("others", clone.others!!["others"])
-        assertEquals(1, clone.others!!.size)
+        assertEquals("data", clone.data!!["data"])
+        assertEquals(1, clone.data!!.size)
         assertEquals("unknown", clone.unknown!!["unknown"])
         assertEquals(1, clone.unknown!!.size)
     }
 
     @Test
-    fun `setting null others do not crash`() {
+    fun `setting null data do not crash`() {
         val user = createUser()
-        user.others = null
+        user.data = null
 
-        assertNull(user.others)
+        assertNull(user.data)
     }
 
     @Test
-    fun `when setOther receives immutable map as an argument, its still possible to add more others to the user`() {
+    fun `when setOther receives immutable map as an argument, its still possible to add more data to the user`() {
         val user = User().apply {
-            others = Collections.unmodifiableMap(mapOf("key1" to "value1"))
-            others!!["key2"] = "value2"
+            data = Collections.unmodifiableMap(mapOf("key1" to "value1"))
+            data!!["key2"] = "value2"
         }
-        assertNotNull(user.others) {
+        assertNotNull(user.data) {
             assertEquals(mapOf("key1" to "value1", "key2" to "value2"), it)
         }
     }
@@ -88,8 +88,8 @@ class UserTest {
             ipAddress = "123.x"
             username = "userName"
             segment = "userSegment"
-            val others = mutableMapOf(Pair("others", "others"))
-            setOthers(others)
+            val data = mutableMapOf(Pair("data", "data"))
+            setData(data)
             val unknown = mapOf(Pair("unknown", "unknown"))
             setUnknown(unknown)
         }

--- a/sentry/src/test/resources/json/sentry_base_event.json
+++ b/sentry/src/test/resources/json/sentry_base_event.json
@@ -159,7 +159,7 @@
     "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
     "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
     "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-    "other":
+    "data":
     {
       "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
     }

--- a/sentry/src/test/resources/json/sentry_event.json
+++ b/sentry/src/test/resources/json/sentry_event.json
@@ -306,7 +306,7 @@
         "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
         "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
         "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-        "other":
+        "data":
         {
             "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
         }

--- a/sentry/src/test/resources/json/sentry_transaction.json
+++ b/sentry/src/test/resources/json/sentry_transaction.json
@@ -202,7 +202,7 @@
         "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
         "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
         "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-        "other":
+        "data":
         {
             "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
         }

--- a/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
@@ -202,7 +202,7 @@
         "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
         "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
         "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-        "other":
+        "data":
         {
             "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
         }

--- a/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
+++ b/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
@@ -194,7 +194,7 @@
         "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
         "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
         "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-        "other":
+        "data":
         {
             "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
         }

--- a/sentry/src/test/resources/json/user_legacy.json
+++ b/sentry/src/test/resources/json/user_legacy.json
@@ -3,7 +3,7 @@
     "id": "efb2084b-1871-4b59-8897-b4bd9f196a01",
     "username": "60c05dff-7140-4d94-9a61-c9cdd9ca9b96",
     "ip_address": "51d22b77-f663-4dbe-8103-8b749d1d9a48",
-    "data":
+    "other":
     {
         "dc2813d0-0f66-4a3f-a995-71268f61a8fa": "991659ad-7c59-4dd3-bb89-0bd5c74014bd"
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`data` is now used instead of `other` on `User`. Can still parse `other` from JSON but will move it to `data`.

This way the custom properties will show up the same way in the UI as they do on other SDKs (e.g. JS).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2242

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
