### PR TITLE
Reset frames tracker on activity started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Reset frames tracker on activity started ([#2269](https://github.com/getsentry/sentry-java/pull/2269))([#2270](https://github.com/getsentry/sentry-java/pull/2270))
+
 ## 6.5.0-beta.2
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -54,6 +54,7 @@ public final class ActivityFramesTracker {
     if (!isFrameMetricsAggregatorAvailable()) {
       return;
     }
+    frameMetricsAggregator.reset();
     frameMetricsAggregator.add(activity);
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -6,6 +6,8 @@ import androidx.core.app.FrameMetricsAggregator
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.ILogger
 import io.sentry.protocol.SentryId
@@ -124,6 +126,15 @@ class ActivityFramesTrackerTest {
         val sut = ActivityFramesTracker(fixture.loadClass)
 
         sut.addActivity(fixture.activity)
+    }
+
+    @Test
+    fun `addActivity resets aggregator`() {
+        val sut = fixture.getSut()
+
+        sut.addActivity(fixture.activity)
+
+        verify(fixture.aggregator, times(1)).reset()
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes the wrong reporting of frames by resetting the count via `onActivityStarted`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2264 

## :green_heart: How did you test it?
Played around with our sample app. Looks like it's working. Only saw some occurrences where the reset was logged before extracting the number of frames but that was on a total frame count of 0 so instantly done. Might have just been the logger printing the messages in wrong order. On total frame counts > 0 i never saw a reversed order.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
