### PR TITLE
Fix slow and frozen frames tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix slow and frozen frames tracking ([#2271](https://github.com/getsentry/sentry-java/pull/2271))
+
 ## 6.4.2
 
 ### Fixes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -137,7 +137,7 @@ public final class ActivityFramesTracker {
 
   @SuppressWarnings("NullAway")
   public synchronized void setMetrics(
-      final @NotNull Activity activity, final @NotNull SentryId sentryId) {
+      final @NotNull Activity activity, final @NotNull SentryId transactionId) {
     if (!isFrameMetricsAggregatorAvailable()) {
       return;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -128,7 +128,7 @@ public final class ActivityFramesTracker {
     private final int slowFrames;
     private final int frozenFrames;
 
-    private FrameCounts(int totalFrames, int slowFrames, int frozenFrames) {
+    private FrameCounts(final int totalFrames, final int slowFrames, final int frozenFrames) {
       this.totalFrames = totalFrames;
       this.slowFrames = slowFrames;
       this.frozenFrames = frozenFrames;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -10,6 +10,7 @@ import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,6 +28,8 @@ public final class ActivityFramesTracker {
 
   private final @NotNull Map<SentryId, Map<String, @NotNull MeasurementValue>>
       activityMeasurements = new ConcurrentHashMap<>();
+  private final @NotNull Map<Activity, FrameCounts> frameCountAtStartSnapshots =
+      new WeakHashMap<>();
 
   public ActivityFramesTracker(final @NotNull LoadClass loadClass, final @Nullable ILogger logger) {
     androidXAvailable =
@@ -55,33 +58,50 @@ public final class ActivityFramesTracker {
       return;
     }
     frameMetricsAggregator.add(activity);
+    snapshotFrameCountsAtStart(activity);
   }
 
-  @SuppressWarnings("NullAway")
-  public synchronized void setMetrics(
-      final @NotNull Activity activity, final @NotNull SentryId sentryId) {
-    if (!isFrameMetricsAggregatorAvailable()) {
-      return;
+  private void snapshotFrameCountsAtStart(final @NotNull Activity activity) {
+    FrameCounts frameCounts = calculateCurrentFrameCounts();
+    if (frameCounts != null) {
+      frameCountAtStartSnapshots.put(activity, frameCounts);
     }
+  }
+
+  private @Nullable FrameCounts diffFrameCountsAtEnd(final @NotNull Activity activity) {
+    @Nullable
+    final FrameCounts frameCountsAtStartFromMap = frameCountAtStartSnapshots.remove(activity);
+    @NotNull
+    final FrameCounts frameCountsAtStart =
+        frameCountsAtStartFromMap == null ? new FrameCounts(0, 0, 0) : frameCountsAtStartFromMap;
+
+    @Nullable final FrameCounts frameCountsAtEnd = calculateCurrentFrameCounts();
+    if (frameCountsAtEnd == null) {
+      return null;
+    }
+
+    final int diffTotalFrames = frameCountsAtEnd.totalFrames - frameCountsAtStart.totalFrames;
+    final int diffSlowFrames = frameCountsAtEnd.slowFrames - frameCountsAtStart.slowFrames;
+    final int diffFrozenFrames = frameCountsAtEnd.frozenFrames - frameCountsAtStart.frozenFrames;
+
+    return new FrameCounts(diffTotalFrames, diffSlowFrames, diffFrozenFrames);
+  }
+
+  private @Nullable FrameCounts calculateCurrentFrameCounts() {
+    if (!isFrameMetricsAggregatorAvailable()) {
+      return null;
+    }
+
+    if (frameMetricsAggregator == null) {
+      return null;
+    }
+    final @Nullable SparseIntArray[] framesRates = frameMetricsAggregator.getMetrics();
 
     int totalFrames = 0;
     int slowFrames = 0;
     int frozenFrames = 0;
 
-    SparseIntArray[] framesRates = null;
-    try {
-      framesRates = frameMetricsAggregator.remove(activity);
-    } catch (Throwable ignored) {
-      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
-      // that was never added.
-      // there's no contains method.
-      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
-      // there was no
-      // Observers, See
-      // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
-    }
-
-    if (framesRates != null) {
+    if (framesRates != null && framesRates.length > 0) {
       final SparseIntArray totalIndexArray = framesRates[FrameMetricsAggregator.TOTAL_INDEX];
       if (totalIndexArray != null) {
         for (int i = 0; i < totalIndexArray.size(); i++) {
@@ -100,13 +120,53 @@ public final class ActivityFramesTracker {
       }
     }
 
-    if (totalFrames == 0 && slowFrames == 0 && frozenFrames == 0) {
+    return new FrameCounts(totalFrames, slowFrames, frozenFrames);
+  }
+
+  private static final class FrameCounts {
+    private final int totalFrames;
+    private final int slowFrames;
+    private final int frozenFrames;
+
+    private FrameCounts(int totalFrames, int slowFrames, int frozenFrames) {
+      this.totalFrames = totalFrames;
+      this.slowFrames = slowFrames;
+      this.frozenFrames = frozenFrames;
+    }
+  }
+
+  @SuppressWarnings("NullAway")
+  public synchronized void setMetrics(
+      final @NotNull Activity activity, final @NotNull SentryId sentryId) {
+    if (!isFrameMetricsAggregatorAvailable()) {
       return;
     }
 
-    final MeasurementValue tfValues = new MeasurementValue(totalFrames, NONE_UNIT);
-    final MeasurementValue sfValues = new MeasurementValue(slowFrames, NONE_UNIT);
-    final MeasurementValue ffValues = new MeasurementValue(frozenFrames, NONE_UNIT);
+    try {
+      // NOTE: removing an activity does not reset the frame counts, only reset() does
+      frameMetricsAggregator.remove(activity);
+    } catch (Throwable ignored) {
+      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
+      // that was never added.
+      // there's no contains method.
+      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
+      // there was no
+      // Observers, See
+      // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+    }
+
+    final @Nullable FrameCounts frameCounts = diffFrameCountsAtEnd(activity);
+
+    if (frameCounts == null
+        || (frameCounts.totalFrames == 0
+            && frameCounts.slowFrames == 0
+            && frameCounts.frozenFrames == 0)) {
+      return;
+    }
+
+    final MeasurementValue tfValues = new MeasurementValue(frameCounts.totalFrames, NONE_UNIT);
+    final MeasurementValue sfValues = new MeasurementValue(frameCounts.slowFrames, NONE_UNIT);
+    final MeasurementValue ffValues = new MeasurementValue(frameCounts.frozenFrames, NONE_UNIT);
     final Map<String, @NotNull MeasurementValue> measurements = new HashMap<>();
     measurements.put("frames_total", tfValues);
     measurements.put("frames_slow", sfValues);
@@ -132,6 +192,7 @@ public final class ActivityFramesTracker {
   public synchronized void stop() {
     if (isFrameMetricsAggregatorAvailable()) {
       frameMetricsAggregator.stop();
+      frameMetricsAggregator.reset();
     }
     activityMeasurements.clear();
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -170,8 +170,8 @@ class ActivityFramesTrackerTest {
         sut.setMetrics(fixture.activity, fixture.sentryId)
         sut.setMetrics(otherActivity, otherSentryId)
 
-        val metrics = sut.takeMetrics(fixture.sentryId)
-        val otherMetrics = sut.takeMetrics(otherSentryId)
+        val metrics = sut.takeMetrics(fixture.sentryId)!!
+        val otherMetrics = sut.takeMetrics(otherSentryId)!!
 
         val totalFrames = metrics!!["frames_total"]
         assertEquals(totalFrames!!.value, 21f) // 15 + 3 + 3

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -324,7 +324,7 @@ class ActivityFramesTrackerTest {
 
         sut.stop()
 
-        verify(fixture.aggregator, times(1)).reset()
+        verify(fixture.aggregator).reset()
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fixes the wrong reporting of frames by snapshotting slow and frozen frame values at the start and end, then calculating a delta.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2264 

## :green_heart: How did you test it?
Sample App; Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
Once merged, release `6.4.3` then merge `6.4.x` into `main`.