### PR TITLE
chore: update & pin GHA dependencies

### DIFF
--- a/.github/workflows/add-platform-label.yml
+++ b/.github/workflows/add-platform-label.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # pin@1.0.4
         with:
-          add-labels: "Platform: Java"
+          add-labels: 'Platform: Java'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: 'Build'
 on:
   push:
     branches:
@@ -17,17 +17,17 @@ jobs:
         # TODO: windows-latest
         os: [ubuntu-latest, macos-latest]
         # Zulu Community distribution of OpenJDK
-        java: ["11"]
+        java: ['11']
 
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
 
-      - name: "Set up Java: ${{ matrix.java }}"
+      - name: 'Set up Java: ${{ matrix.java }}'
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-          distribution: "adopt"
+          distribution: 'adopt'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -62,6 +62,6 @@ jobs:
       - name: Upload coverage to Codecov
         # We need coverage data from only one the builds
         if: runner.os == 'Linux' && matrix.java == '11'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
         with:
           name: sentry-java

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:
-    - cron: "17 23 * * 3"
+    - cron: '17 23 * * 3'
 
 jobs:
   analyze:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["cpp", "java"]
+        language: ['cpp', 'java']
 
     steps:
       - name: Checkout repository
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2
         with:
           languages: ${{ matrix.language }}
 
@@ -42,4 +42,4 @@ jobs:
           ./gradlew assemble
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -13,8 +13,8 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
-          java-version: "11"
+          distribution: 'adopt'
+          java-version: '11'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/generate-javadocs.yml
+++ b/.github/workflows/generate-javadocs.yml
@@ -1,4 +1,4 @@
-name: "Generate Javadocs"
+name: 'Generate Javadocs'
 on:
   release:
     types: [released]
@@ -13,8 +13,8 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
-          java-version: "11"
+          distribution: 'adopt'
+          java-version: '11'
 
       - name: Cache Gradle packages
         uses: actions/cache@v2
@@ -30,7 +30,7 @@ jobs:
         run: |
           ./gradlew aggregateJavadocs
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # pin@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,4 +1,4 @@
-name: "Validate Gradle Wrapper"
+name: 'Validate Gradle Wrapper'
 on:
   push:
     branches:
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b # pin@v1

--- a/.github/workflows/integration-tests-benchmarks.yml
+++ b/.github/workflows/integration-tests-benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
         run: make stop
 
       - name: Run All Tests in SauceLab
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@9f8b2c03deea98eb6db7b75bffb1595f2da535db # pin@v1
         if: github.event_name != 'pull_request'
         with:
           sauce-username: ${{ secrets.SAUCE_USERNAME }}
@@ -44,7 +44,7 @@ jobs:
           config-file: .sauce/sentry-uitest-android-benchmark.yml
 
       - name: Run one test in SauceLab
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@9f8b2c03deea98eb6db7b75bffb1595f2da535db # pin@v1
         if: github.event_name == 'pull_request'
         with:
           sauce-username: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -1,4 +1,4 @@
-name: "Integration Tests - Ui tests"
+name: 'Integration Tests - Ui tests'
 on:
   push:
     branches:
@@ -15,11 +15,11 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
 
-      - name: "Set up Java: 11"
+      - name: 'Set up Java: 11'
         uses: actions/setup-java@v2
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: '11'
+          distribution: 'adopt'
 
       # Clean, build and release a test apk
       - name: Make assembleUiTests
@@ -31,7 +31,7 @@ jobs:
         run: make stop
 
       - name: Run Tests in SauceLab
-        uses: saucelabs/saucectl-run-action@v1
+        uses: saucelabs/saucectl-run-action@9f8b2c03deea98eb6db7b75bffb1595f2da535db # pin@v1
         with:
           sauce-username: ${{ secrets.SAUCE_USERNAME }}
           sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}


### PR DESCRIPTION
closes #1442

used: `pin-github-action --allow 'actions/*,getsentry/*' build.yml` (and other files) & manually reverted some formatting changes it's making (line breaks on long lines)...

There should be no need to do this again + new PRs will automatically get a failure through Danger.

#skip-changelog