### PR TITLE
Fix ConcurrentModificationException due to FrameMetricsAggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- ConcurrentModificationException due to FrameMetricsAggregator ([#2281](https://github.com/getsentry/sentry-java/pull/2281))
+
 ## 6.5.0-beta.3
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -110,18 +110,20 @@ public final class ActivityFramesTracker {
       return;
     }
 
-    try {
-      // NOTE: removing an activity does not reset the frame counts, only reset() does
-      activity.runOnUiThread(() -> frameMetricsAggregator.remove(activity));
-    } catch (Throwable ignored) {
-      // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
-      // that was never added.
-      // there's no contains method.
-      // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
-      // there was no
-      // Observers, See
-      // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
-    }
+    activity.runOnUiThread(() -> {
+      try {
+        // NOTE: removing an activity does not reset the frame counts, only reset() does
+        frameMetricsAggregator.remove(activity);
+      } catch (Throwable ignored) {
+        // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
+        // that was never added.
+        // there's no contains method.
+        // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
+        // there was no
+        // Observers, See
+        // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+      }
+    });
 
     final @Nullable FrameCounts frameCounts = diffFrameCountsAtEnd(activity);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -110,20 +110,23 @@ public final class ActivityFramesTracker {
       return;
     }
 
-    activity.runOnUiThread(() -> {
-      try {
-        // NOTE: removing an activity does not reset the frame counts, only reset() does
-        frameMetricsAggregator.remove(activity);
-      } catch (Throwable ignored) {
-        // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
-        // that was never added.
-        // there's no contains method.
-        // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener and
-        // there was no
-        // Observers, See
-        // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
-      }
-    });
+    activity.runOnUiThread(
+        () -> {
+          try {
+            // NOTE: removing an activity does not reset the frame counts, only reset() does
+            frameMetricsAggregator.remove(activity);
+          } catch (Throwable ignored) {
+            // throws IllegalArgumentException when attempting to remove
+            // OnFrameMetricsAvailableListener
+            // that was never added.
+            // there's no contains method.
+            // throws NullPointerException when attempting to remove OnFrameMetricsAvailableListener
+            // and
+            // there was no
+            // Observers, See
+            // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+          }
+        });
 
     final @Nullable FrameCounts frameCounts = diffFrameCountsAtEnd(activity);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -112,7 +112,7 @@ public final class ActivityFramesTracker {
 
     try {
       // NOTE: removing an activity does not reset the frame counts, only reset() does
-      frameMetricsAggregator.remove(activity);
+      activity.runOnUiThread(() -> frameMetricsAggregator.remove(activity));
     } catch (Throwable ignored) {
       // throws IllegalArgumentException when attempting to remove OnFrameMetricsAvailableListener
       // that was never added.


### PR DESCRIPTION
androidx.core.app.FrameMetricsAggregator is not thread safe, calling .remove() from a background thread may cause a
ConcurrentModificationException

## :scroll: Description
Ensure calling .remove() is done on the UI thread.

## :bulb: Motivation and Context
SentryTracer uses a `Timer` and `TimerTask` to finish open Transactions on a background thread. Finishing a transaction also triggers the calculation of the frame metrics as well as unregistering the activity from metric collection (`FrameMetricsAggregator.remove(activity)`), FrameMetricsAggregator is not thread safe, causing sporadic `ConcurrentModificationException`s.


## :green_heart: How did you test it?
Ensured current tests are not breaking, otherwise it's hard to test a ConcurrentModificationException.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
