### PR TITLE
Fix ConcurrentModificationException due to FrameMetricsAggregator manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix ConcurrentModificationException due to FrameMetricsAggregator manipulation ([#2282](https://github.com/getsentry/sentry-java/pull/2282))
+
 ## 6.4.3
 
 - Fix slow and frozen frames tracking ([#2271](https://github.com/getsentry/sentry-java/pull/2271))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixes
+
 - Fix ConcurrentModificationException due to FrameMetricsAggregator manipulation ([#2282](https://github.com/getsentry/sentry-java/pull/2282))
 
 ## 6.4.3

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -1,6 +1,7 @@
 public final class io/sentry/android/core/ActivityFramesTracker {
 	public fun <init> (Lio/sentry/android/core/LoadClass;)V
 	public fun <init> (Lio/sentry/android/core/LoadClass;Lio/sentry/ILogger;)V
+	public fun <init> (Lio/sentry/android/core/LoadClass;Lio/sentry/ILogger;Lio/sentry/android/core/MainLooperHandler;)V
 	public fun addActivity (Landroid/app/Activity;)V
 	public fun setMetrics (Landroid/app/Activity;Lio/sentry/protocol/SentryId;)V
 	public fun stop ()V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -96,7 +96,13 @@ public final class ActivityFramesTracker {
     if (frameMetricsAggregator == null) {
       return null;
     }
-    final @Nullable SparseIntArray[] framesRates = frameMetricsAggregator.getMetrics();
+
+    @Nullable SparseIntArray[] framesRates = null;
+    try {
+      framesRates = frameMetricsAggregator.getMetrics();
+    } catch (Throwable t) {
+      // no-op
+    }
 
     int totalFrames = 0;
     int slowFrames = 0;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -343,32 +343,39 @@ class ActivityFramesTrackerTest {
     }
 
     @Test
-    fun `start, setMetrics and stop call to FrameMetricsTracker is done on the main thread, even when being called from a background thread`() {
+    fun `addActivity call to FrameMetricsTracker is done on the main thread, even when being called from a background thread`() {
         val sut = fixture.getSut()
 
-        // .addActivity
-        val callAddThread = Thread {
+        val addThread = Thread {
             sut.addActivity(fixture.activity)
         }
-        callAddThread.start()
-        callAddThread.join(500)
-        verify(fixture.handler, times(1)).post(any())
+        addThread.start()
+        addThread.join(500)
+        verify(fixture.handler).post(any())
+    }
 
-        // .setMetrics
+    @Test
+    fun `setMetrics call to FrameMetricsTracker is done on the main thread, even when being called from a background thread`() {
+        val sut = fixture.getSut()
+
         val setMetricsThread = Thread {
             sut.setMetrics(fixture.activity, fixture.sentryId)
         }
         setMetricsThread.start()
         setMetricsThread.join(500)
-        verify(fixture.handler, times(2)).post(any())
+        verify(fixture.handler).post(any())
+    }
 
-        // .stop
-        val callStopThread = Thread {
+    @Test
+    fun `stop call to FrameMetricsTracker is done on the main thread, even when being called from a background thread`() {
+        val sut = fixture.getSut()
+
+        val stopThread = Thread {
             sut.stop()
         }
-        callStopThread.start()
-        callStopThread.join(500)
-        verify(fixture.handler, times(3)).post(any())
+        stopThread.start()
+        stopThread.join(500)
+        verify(fixture.handler).post(any())
     }
 
     private fun getArray(frameTime: Int = 1, numFrames: Int = 1): Array<SparseIntArray?> {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -24,9 +24,10 @@ class ActivityFramesTrackerTest {
         val activity = mock<Activity>()
         val sentryId = SentryId()
         val loadClass = mock<LoadClass>()
+        val handler = mock<MainLooperHandler>()
 
         fun getSut(): ActivityFramesTracker {
-            return ActivityFramesTracker(aggregator)
+            return ActivityFramesTracker(aggregator, handler)
         }
     }
     private val fixture = Fixture()
@@ -339,6 +340,35 @@ class ActivityFramesTrackerTest {
         val sut = ActivityFramesTracker(fixture.loadClass)
 
         assertNull(sut.takeMetrics(fixture.sentryId))
+    }
+
+    @Test
+    fun `start, setMetrics and stop call to FrameMetricsTracker is done on the main thread, even when being called from a background thread`() {
+        val sut = fixture.getSut()
+
+        // .addActivity
+        val callAddThread = Thread {
+            sut.addActivity(fixture.activity)
+        }
+        callAddThread.start()
+        callAddThread.join(500)
+        verify(fixture.handler, times(1)).post(any())
+
+        // .setMetrics
+        val setMetricsThread = Thread {
+            sut.setMetrics(fixture.activity, fixture.sentryId)
+        }
+        setMetricsThread.start()
+        setMetricsThread.join(500)
+        verify(fixture.handler, times(2)).post(any())
+
+        // .stop
+        val callStopThread = Thread {
+            sut.stop()
+        }
+        callStopThread.start()
+        callStopThread.join(500)
+        verify(fixture.handler, times(3)).post(any())
     }
 
     private fun getArray(frameTime: Int = 1, numFrames: Int = 1): Array<SparseIntArray?> {


### PR DESCRIPTION
androidx.core.app.FrameMetricsAggregator is not thread safe, calling .remove() from a background thread may cause a
ConcurrentModificationException

## :scroll: Description
Ensure calling .remove() is done on the UI thread.

## :bulb: Motivation and Context
SentryTracer uses a `Timer` and `TimerTask` to finish open Transactions on a background thread. Finishing a transaction also triggers the calculation of the frame metrics as well as unregistering the activity from metric collection (`FrameMetricsAggregator.remove(activity)`), FrameMetricsAggregator is not thread safe, causing sporadic `ConcurrentModificationException`s.


## :green_heart: How did you test it?
Ensured current tests are not breaking, otherwise it's hard to test a ConcurrentModificationException.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
