### PR TITLE
Improve public facing API for creating Baggage from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Features
+### Fixes
 
 - Improve public facing API for creating Baggage from header ([#2284](https://github.com/getsentry/sentry-java/pull/2284))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Improve public facing API for creating Baggage from header ([#2284](https://github.com/getsentry/sentry-java/pull/2284))
+
 ## 6.5.0-beta.3
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -24,8 +24,10 @@ public final class io/sentry/Baggage {
 	public fun <init> (Lio/sentry/ILogger;)V
 	public fun <init> (Ljava/util/Map;Ljava/lang/String;ZLio/sentry/ILogger;)V
 	public fun freeze ()V
+	public static fun fromHeader (Ljava/lang/String;)Lio/sentry/Baggage;
 	public static fun fromHeader (Ljava/lang/String;Lio/sentry/ILogger;)Lio/sentry/Baggage;
 	public static fun fromHeader (Ljava/lang/String;ZLio/sentry/ILogger;)Lio/sentry/Baggage;
+	public static fun fromHeader (Ljava/util/List;)Lio/sentry/Baggage;
 	public static fun fromHeader (Ljava/util/List;Lio/sentry/ILogger;)Lio/sentry/Baggage;
 	public static fun fromHeader (Ljava/util/List;ZLio/sentry/ILogger;)Lio/sentry/Baggage;
 	public fun get (Ljava/lang/String;)Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -35,11 +35,31 @@ public final class Baggage {
   final @NotNull ILogger logger;
 
   @NotNull
+  public static Baggage fromHeader(final String headerValue) {
+    return Baggage.fromHeader(
+        headerValue, false, HubAdapter.getInstance().getOptions().getLogger());
+  }
+
+  @NotNull
+  public static Baggage fromHeader(final @Nullable List<String> headerValues) {
+    return Baggage.fromHeader(
+        headerValues, false, HubAdapter.getInstance().getOptions().getLogger());
+  }
+
+  @ApiStatus.Internal
+  @NotNull
+  public static Baggage fromHeader(final String headerValue, final @NotNull ILogger logger) {
+    return Baggage.fromHeader(headerValue, false, logger);
+  }
+
+  @ApiStatus.Internal
+  @NotNull
   public static Baggage fromHeader(
       final @Nullable List<String> headerValues, final @NotNull ILogger logger) {
     return Baggage.fromHeader(headerValues, false, logger);
   }
 
+  @ApiStatus.Internal
   @NotNull
   public static Baggage fromHeader(
       final @Nullable List<String> headerValues,
@@ -53,11 +73,7 @@ public final class Baggage {
     }
   }
 
-  @NotNull
-  public static Baggage fromHeader(final String headerValue, final @NotNull ILogger logger) {
-    return Baggage.fromHeader(headerValue, false, logger);
-  }
-
+  @ApiStatus.Internal
   @NotNull
   public static Baggage fromHeader(
       final @Nullable String headerValue,
@@ -104,10 +120,12 @@ public final class Baggage {
     return new Baggage(keyValues, thirdPartyHeader, mutable, logger);
   }
 
+  @ApiStatus.Internal
   public Baggage(final @NotNull ILogger logger) {
     this(new HashMap<>(), null, true, logger);
   }
 
+  @ApiStatus.Internal
   public Baggage(
       final @NotNull Map<String, String> keyValues,
       final @Nullable String thirdPartyHeader,
@@ -119,10 +137,12 @@ public final class Baggage {
     this.thirdPartyHeader = thirdPartyHeader;
   }
 
+  @ApiStatus.Internal
   public void freeze() {
     this.mutable = false;
   }
 
+  @ApiStatus.Internal
   public boolean isMutable() {
     return mutable;
   }
@@ -196,6 +216,7 @@ public final class Baggage {
     return URLDecoder.decode(value, CHARSET);
   }
 
+  @ApiStatus.Internal
   public @Nullable String get(final @Nullable String key) {
     if (key == null) {
       return null;
@@ -204,76 +225,94 @@ public final class Baggage {
     return keyValues.get(key);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getTraceId() {
     return get(DSCKeys.TRACE_ID);
   }
 
+  @ApiStatus.Internal
   public void setTraceId(final @Nullable String traceId) {
     set(DSCKeys.TRACE_ID, traceId);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getPublicKey() {
     return get(DSCKeys.PUBLIC_KEY);
   }
 
+  @ApiStatus.Internal
   public void setPublicKey(final @Nullable String publicKey) {
     set(DSCKeys.PUBLIC_KEY, publicKey);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getEnvironment() {
     return get(DSCKeys.ENVIRONMENT);
   }
 
+  @ApiStatus.Internal
   public void setEnvironment(final @Nullable String environment) {
     set(DSCKeys.ENVIRONMENT, environment);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getRelease() {
     return get(DSCKeys.RELEASE);
   }
 
+  @ApiStatus.Internal
   public void setRelease(final @Nullable String release) {
     set(DSCKeys.RELEASE, release);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getUserId() {
     return get(DSCKeys.USER_ID);
   }
 
+  @ApiStatus.Internal
   public void setUserId(final @Nullable String userId) {
     set(DSCKeys.USER_ID, userId);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getUserSegment() {
     return get(DSCKeys.USER_SEGMENT);
   }
 
+  @ApiStatus.Internal
   public void setUserSegment(final @Nullable String userSegment) {
     set(DSCKeys.USER_SEGMENT, userSegment);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getTransaction() {
     return get(DSCKeys.TRANSACTION);
   }
 
+  @ApiStatus.Internal
   public void setTransaction(final @Nullable String transaction) {
     set(DSCKeys.TRANSACTION, transaction);
   }
 
+  @ApiStatus.Internal
   public @Nullable String getSampleRate() {
     return get(DSCKeys.SAMPLE_RATE);
   }
 
+  @ApiStatus.Internal
   public void setSampleRate(final @Nullable String sampleRate) {
     set(DSCKeys.SAMPLE_RATE, sampleRate);
   }
 
+  @ApiStatus.Internal
   public void set(final @NotNull String key, final @Nullable String value) {
     if (mutable) {
       this.keyValues.put(key, value);
     }
   }
 
+  @ApiStatus.Internal
   public void setValuesFromTransaction(
       final @NotNull ITransaction transaction,
       final @Nullable User user,
@@ -328,6 +367,7 @@ public final class Baggage {
         && !TransactionNameSource.URL.equals(transactionNameSource);
   }
 
+  @ApiStatus.Internal
   public @Nullable Double getSampleRateDouble() {
     final String sampleRateString = getSampleRate();
     if (sampleRateString != null) {
@@ -343,6 +383,7 @@ public final class Baggage {
     return null;
   }
 
+  @ApiStatus.Internal
   @Nullable
   public TraceContext toTraceContext() {
     final String traceIdString = getTraceId();
@@ -363,6 +404,7 @@ public final class Baggage {
     }
   }
 
+  @ApiStatus.Internal
   public static final class DSCKeys {
     public static final String TRACE_ID = "sentry-trace_id";
     public static final String PUBLIC_KEY = "sentry-public_key";

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -512,6 +512,18 @@ class BaggageTest {
         assertEquals("%22%28%29%2C%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%7B%7D=value", baggage.toHeaderString(null))
     }
 
+    @Test
+    fun `can skip logger for header from single string`() {
+        val baggage = Baggage.fromHeader("sentry-trace_id=a,sentry-transaction=sentryTransaction")
+        assertEquals("sentry-trace_id=a,sentry-transaction=sentryTransaction", baggage.toHeaderString(null))
+    }
+
+    @Test
+    fun `can skip logger for header from list of strings`() {
+        val baggage = Baggage.fromHeader(listOf("sentry-trace_id=a", "sentry-transaction=sentryTransaction"))
+        assertEquals("sentry-trace_id=a,sentry-transaction=sentryTransaction", baggage.toHeaderString(null))
+    }
+
     /**
      * token          = 1*tchar
      * tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"


### PR DESCRIPTION
## :scroll: Description
Remove `ILogger` param from public facing API when creating a `Baggage` object from header String(s).


## :bulb: Motivation and Context
Retrieving options / logger is only possible using methods marked as `@ApiStatus.Internal` so instead we skip the param and retrieve it inside using `HubAdapter.getInstance().getOptions().getLogger()`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
