### PR TITLE
fix(java): Ensure potential callback exceptions are caught #2123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Ensure potential callback exceptions are caught #2123 ([#2291](https://github.com/getsentry/sentry-java/pull/2291))
+
 ## 6.5.0
 
 ### Fixes

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -803,9 +803,13 @@ public final class Hub implements IHub {
   private Scope buildLocalScope(
       final @NotNull Scope scope, final @Nullable ScopeCallback callback) {
     if (callback != null) {
-      final Scope localScope = new Scope(scope);
-      callback.run(localScope);
-      return localScope;
+      try {
+        final Scope localScope = new Scope(scope);
+        callback.run(localScope);
+        return localScope;
+      } catch (Throwable t) {
+        options.getLogger().log(SentryLevel.ERROR, "Error in the 'ScopeCallback' callback.", t);
+      }
     }
     return scope;
   }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -113,7 +113,7 @@ public final class Sentry {
       throws IllegalAccessException, InstantiationException, NoSuchMethodException,
           InvocationTargetException {
     final T options = clazz.createInstance();
-    optionsConfiguration.configure(options);
+    applyOptionsConfiguration(optionsConfiguration, options);
     init(options, globalHubMode);
   }
 
@@ -136,8 +136,19 @@ public final class Sentry {
       final @NotNull OptionsConfiguration<SentryOptions> optionsConfiguration,
       final boolean globalHubMode) {
     final SentryOptions options = new SentryOptions();
-    optionsConfiguration.configure(options);
+    applyOptionsConfiguration(optionsConfiguration, options);
     init(options, globalHubMode);
+  }
+
+  private static <T extends SentryOptions> void applyOptionsConfiguration(
+      OptionsConfiguration<T> optionsConfiguration, T options) {
+    try {
+      optionsConfiguration.configure(options);
+    } catch (Throwable t) {
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Error in the 'OptionsConfiguration.configure' callback.", t);
+    }
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -29,7 +29,13 @@ final class TracesSampler {
 
     Double profilesSampleRate = null;
     if (options.getProfilesSampler() != null) {
-      profilesSampleRate = options.getProfilesSampler().sample(samplingContext);
+      try {
+        profilesSampleRate = options.getProfilesSampler().sample(samplingContext);
+      } catch (Throwable t) {
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Error in the 'ProfilesSamplerCallback' callback.", t);
+      }
     }
     if (profilesSampleRate == null) {
       profilesSampleRate = options.getProfilesSampleRate();
@@ -37,7 +43,14 @@ final class TracesSampler {
     Boolean profilesSampled = profilesSampleRate != null && sample(profilesSampleRate);
 
     if (options.getTracesSampler() != null) {
-      final Double samplerResult = options.getTracesSampler().sample(samplingContext);
+      Double samplerResult = null;
+      try {
+        samplerResult = options.getTracesSampler().sample(samplingContext);
+      } catch (Throwable t) {
+        options
+            .getLogger()
+            .log(SentryLevel.ERROR, "Error in the 'TracesSamplerCallback' callback.", t);
+      }
       if (samplerResult != null) {
         return new TracesSamplingDecision(
             sample(samplerResult), samplerResult, profilesSampled, profilesSampleRate);

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -429,6 +429,27 @@ class HubTest {
         assertEquals("testValue", argumentCaptor.allValues[0].tags["test"])
         assertNull(argumentCaptor.allValues[1].tags["test"])
     }
+
+    @Test
+    fun `when captureEvent is called with a ScopeCallback that crashes then the event should still be captured`() {
+        val (sut, mockClient) = getEnabledHub()
+        val logger = mock<ILogger>()
+        sut.options.isDebug = true
+        sut.options.setLogger(logger)
+
+        val exception = Exception("scope callback exception")
+        sut.captureEvent(SentryEvent(), null) {
+            throw exception
+        }
+
+        verify(mockClient).captureEvent(
+            any(),
+            anyOrNull(),
+            anyOrNull()
+        )
+
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
+    }
     //endregion
 
     //region captureMessage tests
@@ -503,6 +524,27 @@ class HubTest {
 
         assertEquals("testValue", argumentCaptor.allValues[0].tags["test"])
         assertNull(argumentCaptor.allValues[1].tags["test"])
+    }
+
+    @Test
+    fun `when captureMessage is called with a ScopeCallback that crashes then the message should still be captured`() {
+        val (sut, mockClient) = getEnabledHub()
+        val logger = mock<ILogger>()
+        sut.options.isDebug = true
+        sut.options.setLogger(logger)
+
+        val exception = Exception("scope callback exception")
+        sut.captureMessage("Hello World") {
+            throw exception
+        }
+
+        verify(mockClient).captureMessage(
+            any(),
+            anyOrNull(),
+            anyOrNull()
+        )
+
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
     }
 
     //endregion
@@ -617,6 +659,27 @@ class HubTest {
         assertNull(argumentCaptor.allValues[1].tags["test"])
     }
 
+    @Test
+    fun `when captureException is called with a ScopeCallback that crashes then the exception should still be captured`() {
+        val (sut, mockClient) = getEnabledHub()
+        val logger = mock<ILogger>()
+        sut.options.isDebug = true
+        sut.options.setLogger(logger)
+
+        val exception = Exception("scope callback exception")
+        sut.captureException(Throwable()) {
+            throw exception
+        }
+
+        verify(mockClient).captureEvent(
+            any(),
+            anyOrNull(),
+            anyOrNull()
+        )
+
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
+    }
+
     //endregion
 
     //region captureUserFeedback tests
@@ -704,6 +767,25 @@ class HubTest {
         sut.withScope(scopeCallback)
         verify(scopeCallback).run(any())
     }
+
+    @Test
+    fun `when withScope throws an exception then it should be caught`() {
+        val logger = mock<ILogger>()
+
+        val hub = generateHub { options ->
+            options.setLogger(logger)
+            options.isDebug = true
+        }
+
+        val exception = Exception("scope callback exception")
+        val scopeCallback = ScopeCallback {
+            throw exception
+        }
+
+        hub.withScope(scopeCallback)
+
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
+    }
     //endregion
 
     //region configureScope tests
@@ -726,6 +808,25 @@ class HubTest {
 
         sut.configureScope(scopeCallback)
         verify(scopeCallback).run(any())
+    }
+
+    @Test
+    fun `when configureScope throws an exception then it should be caught`() {
+        val logger = mock<ILogger>()
+
+        val hub = generateHub { options ->
+            options.setLogger(logger)
+            options.isDebug = true
+        }
+
+        val exception = Exception("scope callback exception")
+        val scopeCallback = ScopeCallback {
+            throw exception
+        }
+
+        hub.configureScope(scopeCallback)
+
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
     }
     //endregion
 

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -432,10 +432,7 @@ class HubTest {
 
     @Test
     fun `when captureEvent is called with a ScopeCallback that crashes then the event should still be captured`() {
-        val (sut, mockClient) = getEnabledHub()
-        val logger = mock<ILogger>()
-        sut.options.isDebug = true
-        sut.options.setLogger(logger)
+        val (sut, mockClient, logger) = getEnabledHub()
 
         val exception = Exception("scope callback exception")
         sut.captureEvent(SentryEvent(), null) {
@@ -528,10 +525,7 @@ class HubTest {
 
     @Test
     fun `when captureMessage is called with a ScopeCallback that crashes then the message should still be captured`() {
-        val (sut, mockClient) = getEnabledHub()
-        val logger = mock<ILogger>()
-        sut.options.isDebug = true
-        sut.options.setLogger(logger)
+        val (sut, mockClient, logger) = getEnabledHub()
 
         val exception = Exception("scope callback exception")
         sut.captureMessage("Hello World") {
@@ -661,10 +655,7 @@ class HubTest {
 
     @Test
     fun `when captureException is called with a ScopeCallback that crashes then the exception should still be captured`() {
-        val (sut, mockClient) = getEnabledHub()
-        val logger = mock<ILogger>()
-        sut.options.isDebug = true
-        sut.options.setLogger(logger)
+        val (sut, mockClient, logger) = getEnabledHub()
 
         val exception = Exception("scope callback exception")
         sut.captureException(Throwable()) {
@@ -770,12 +761,7 @@ class HubTest {
 
     @Test
     fun `when withScope throws an exception then it should be caught`() {
-        val logger = mock<ILogger>()
-
-        val hub = generateHub { options ->
-            options.setLogger(logger)
-            options.isDebug = true
-        }
+        val (hub, _, logger) = getEnabledHub()
 
         val exception = Exception("scope callback exception")
         val scopeCallback = ScopeCallback {
@@ -812,12 +798,7 @@ class HubTest {
 
     @Test
     fun `when configureScope throws an exception then it should be caught`() {
-        val logger = mock<ILogger>()
-
-        val hub = generateHub { options ->
-            options.setLogger(logger)
-            options.isDebug = true
-        }
+        val (hub, _, logger) = getEnabledHub()
 
         val exception = Exception("scope callback exception")
         val scopeCallback = ScopeCallback {
@@ -1630,16 +1611,21 @@ class HubTest {
         return Hub(options)
     }
 
-    private fun getEnabledHub(): Pair<Hub, ISentryClient> {
+    private fun getEnabledHub(): Triple<Hub, ISentryClient, ILogger> {
+        val logger = mock<ILogger>()
+
         val options = SentryOptions()
         options.cacheDirPath = file.absolutePath
         options.dsn = "https://key@sentry.io/proj"
         options.setSerializer(mock())
         options.tracesSampleRate = 1.0
+        options.isDebug = true
+        options.setLogger(logger)
+
         val sut = Hub(options)
         val mockClient = mock<ISentryClient>()
         sut.bindClient(mockClient)
-        return Pair(sut, mockClient)
+        return Triple(sut, mockClient, logger)
     }
 
     private fun hashedFolder(): String {

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -1,6 +1,9 @@
 package io.sentry
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import java.security.SecureRandom
 import kotlin.test.Test
@@ -11,7 +14,14 @@ import kotlin.test.assertTrue
 
 class TracesSamplerTest {
     class Fixture {
-        internal fun getSut(randomResult: Double? = null, tracesSampleRate: Double? = null, profilesSampleRate: Double? = null, tracesSamplerResult: Double? = Double.MIN_VALUE, profilesSamplerResult: Double? = Double.MIN_VALUE): TracesSampler {
+        internal fun getSut(
+            randomResult: Double? = null,
+            tracesSampleRate: Double? = null,
+            profilesSampleRate: Double? = null,
+            tracesSamplerCallback: SentryOptions.TracesSamplerCallback? = null,
+            profilesSamplerCallback: SentryOptions.ProfilesSamplerCallback? = null,
+            logger: ILogger? = null
+        ): TracesSampler {
             val random = mock<SecureRandom>()
             if (randomResult != null) {
                 whenever(random.nextDouble()).thenReturn(randomResult)
@@ -23,11 +33,15 @@ class TracesSamplerTest {
             if (profilesSampleRate != null) {
                 options.profilesSampleRate = profilesSampleRate
             }
-            if (tracesSamplerResult != Double.MIN_VALUE) {
-                options.tracesSampler = SentryOptions.TracesSamplerCallback { tracesSamplerResult }
+            if (tracesSamplerCallback != null) {
+                options.tracesSampler = tracesSamplerCallback
             }
-            if (profilesSamplerResult != Double.MIN_VALUE) {
-                options.profilesSampler = SentryOptions.ProfilesSamplerCallback { profilesSamplerResult }
+            if (profilesSamplerCallback != null) {
+                options.profilesSampler = profilesSamplerCallback
+            }
+            if (logger != null) {
+                options.isDebug = true
+                options.setLogger(logger)
             }
             return TracesSampler(options, random)
         }
@@ -80,7 +94,11 @@ class TracesSamplerTest {
 
     @Test
     fun `when tracesSampleRate is not set, tracesSampler is set and random returns lower number returns true`() {
-        val sampler = fixture.getSut(randomResult = 0.1, tracesSamplerResult = 0.2, profilesSamplerResult = 0.2)
+        val sampler = fixture.getSut(
+            randomResult = 0.1,
+            tracesSamplerCallback = { 0.2 },
+            profilesSamplerCallback = { 0.2 }
+        )
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -93,7 +111,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when profilesSampleRate is not set, profilesSampler is set and random returns lower number returns true`() {
-        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 1.0, profilesSamplerResult = 0.2)
+        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 1.0, profilesSamplerCallback = { 0.2 })
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -107,7 +125,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when tracesSampleRate is not set, tracesSampler is set and random returns greater number returns false`() {
-        val sampler = fixture.getSut(randomResult = 0.9, tracesSamplerResult = 0.2)
+        val sampler = fixture.getSut(randomResult = 0.9, tracesSamplerCallback = { 0.2 })
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -120,7 +138,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when profilesSampleRate is not set, profilesSampler is set and random returns greater number returns false`() {
-        val sampler = fixture.getSut(randomResult = 0.9, tracesSampleRate = 1.0, profilesSamplerResult = 0.2)
+        val sampler = fixture.getSut(randomResult = 0.9, tracesSampleRate = 1.0, profilesSamplerCallback = { 0.2 })
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -134,7 +152,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when tracesSampler returns null and parentSampled is set sampler uses it as a sampling decision`() {
-        val sampler = fixture.getSut(tracesSamplerResult = null)
+        val sampler = fixture.getSut(tracesSamplerCallback = null)
         val transactionContextParentSampled = TransactionContext("name", "op")
         transactionContextParentSampled.parentSampled = true
         val samplingDecision = sampler.sample(
@@ -149,7 +167,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when profilesSampler returns null and parentSampled is set sampler uses it as a sampling decision`() {
-        val sampler = fixture.getSut(tracesSampleRate = 1.0, profilesSamplerResult = null)
+        val sampler = fixture.getSut(tracesSampleRate = 1.0, profilesSamplerCallback = null)
         val transactionContextParentSampled = TransactionContext("name", "op")
         transactionContextParentSampled.setParentSampled(true, true)
         val samplingDecision = sampler.sample(
@@ -165,7 +183,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when tracesSampler returns null and tracesSampleRate is set sampler uses it as a sampling decision`() {
-        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 0.2, tracesSamplerResult = null)
+        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 0.2, tracesSamplerCallback = null)
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -178,7 +196,7 @@ class TracesSamplerTest {
 
     @Test
     fun `when profilesSampler returns null and profilesSampleRate is set sampler uses it as a sampling decision`() {
-        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 1.0, profilesSampleRate = 0.2, profilesSamplerResult = null)
+        val sampler = fixture.getSut(randomResult = 0.1, tracesSampleRate = 1.0, profilesSampleRate = 0.2, profilesSamplerCallback = null)
         val samplingDecision = sampler.sample(
             SamplingContext(
                 TransactionContext("name", "op"),
@@ -293,5 +311,75 @@ class TracesSamplerTest {
         assertNull(samplingDecisionContextUnsampledWithProfile.sampleRate)
         assertFalse(samplingDecisionContextUnsampledWithProfile.profileSampled)
         assertNull(samplingDecisionContextUnsampledWithProfile.profileSampleRate)
+    }
+
+    @Test
+    fun `when ProfilesSamplerCallback throws an exception then profiling is disabled and an error is logged`() {
+        val logger = mock<ILogger>()
+
+        val exception = Exception("faulty ProfilesSamplerCallback")
+        val sampler = fixture.getSut(
+            tracesSampleRate = 1.0,
+            profilesSamplerCallback = {
+                throw exception
+            },
+            logger = logger
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null)
+        )
+        assertFalse(decision.profileSampled)
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
+    }
+
+    @Test
+    fun `when a profilingRate and a ProfilesSamplerCallback is set but the callback throws an exception then profiling should still be enabled`() {
+        val exception = Exception("faulty ProfilesSamplerCallback")
+        val sampler = fixture.getSut(
+            randomResult = 0.0,
+            tracesSampleRate = 1.0,
+            profilesSampleRate = 1.0,
+            profilesSamplerCallback = {
+                throw exception
+            }
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null)
+        )
+        assertTrue(decision.profileSampled)
+    }
+
+    @Test
+    fun `when TracesSamplerCallback throws an exception then tracing is disabled and an error is logged`() {
+        val logger = mock<ILogger>()
+
+        val exception = Exception("faulty TracesSamplerCallback")
+        val sampler = fixture.getSut(
+            tracesSamplerCallback = {
+                throw exception
+            },
+            logger = logger
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null)
+        )
+        assertFalse(decision.sampled)
+        verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
+    }
+
+    @Test
+    fun `when a tracesSampleRate and a TracesSamplerCallback is set but the callback throws an exception then tracing should still be enabled`() {
+        val exception = Exception("faulty TracesSamplerCallback")
+        val sampler = fixture.getSut(
+            randomResult = 0.0,
+            tracesSampleRate = 1.0,
+            tracesSamplerCallback = {
+                throw exception
+            }
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null)
+        )
+        assertTrue(decision.sampled)
     }
 }


### PR DESCRIPTION
## :scroll: Description
Try/Catches callback executions and add logging in case of errors.


## :bulb: Motivation and Context
If certain callbacks provided via the Sentry, Hub or SentryOptions crash during execution, it could crash the whole application. So let's catch 'em all 😄 

Related issues:
* https://github.com/getsentry/sentry-java/issues/2123
* https://github.com/getsentry/team-mobile/issues/21

Callbacks which were already handled:
* BeforeSendCallback
* BeforeBreadcrumbCallback

Callbacks:
* SentryOptions.TracesSamplerCallback
* SentryOptions.ProfilesSamplerCallback
* OptionsConfiguration.configure
* Hub.captureMessage
* Hub.captureException
* Hub.captureEvent
* Hub.withScope
* Hub.configureScope

## :green_heart: How did you test it?
Added tests where required

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ x ] I reviewed the submitted code
- [ x ] I added tests to verify the changes
- [ x ] I updated the docs if needed
- [ x ] No breaking changes


## :crystal_ball: Next steps
