### PR TITLE
Profile envelopes sent directly from profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Features
 
+- Profile envelopes are sent directly from profiler ([#2298](https://github.com/getsentry/sentry-java/pull/2298))
 - Add captureProfile method to hub and client ([#2290](https://github.com/getsentry/sentry-java/pull/2290))
 
 ## 6.5.0

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.core
 import io.sentry.ITransaction
 import io.sentry.ITransactionProfiler
 import io.sentry.NoOpTransactionProfiler
-import io.sentry.ProfilingTraceData
 import io.sentry.protocol.DebugImage
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -110,6 +109,6 @@ class SentryAndroidOptionsTest {
 
     private class CustomTransactionProfiler : ITransactionProfiler {
         override fun onTransactionStart(transaction: ITransaction) {}
-        override fun onTransactionFinish(transaction: ITransaction): ProfilingTraceData? = null
+        override fun onTransactionFinish(transaction: ITransaction) {}
     }
 }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -192,7 +192,7 @@ class EnvelopeTests : BaseUiTest() {
     }
 
     @Test
-    fun sendTimedOutProfile() {
+    fun checkTimedOutProfile() {
         // We increase the IdlingResources timeout to exceed the profiling timeout
         IdlingPolicies.setIdlingResourceTimeout(1, TimeUnit.MINUTES)
         initSentry(true) { options: SentryOptions ->
@@ -231,6 +231,8 @@ class EnvelopeTests : BaseUiTest() {
         benchmarkScenario.moveToState(Lifecycle.State.DESTROYED)
         transaction.finish()
         IdlingRegistry.getInstance().unregister(ProfilingSampleActivity.scrollingIdlingResource)
+        // Let this test send all data, so that it doesn't interfere with other tests
+        Thread.sleep(1000)
     }
 
     private fun swipeList(times: Int) {

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -204,7 +204,6 @@ class EnvelopeTests : BaseUiTest() {
         // We don't call transaction.finish() and let the timeout do its job
 
         relay.assert {
-            // The profile failed to be sent. Trying to read the envelope from the data transmitted throws an exception
             assertEnvelope {
                 val profilingTraceData: ProfilingTraceData = it.assertItem()
                 it.assertNoOtherItems()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -3,6 +3,7 @@ package io.sentry.uitest.android
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers
@@ -14,6 +15,7 @@ import io.sentry.SentryOptions
 import io.sentry.protocol.SentryTransaction
 import org.junit.runner.RunWith
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -180,9 +182,34 @@ class EnvelopeTests : BaseUiTest() {
             // The profile failed to be sent. Trying to read the envelope from the data transmitted throws an exception
             assertFails { assertEnvelope {} }
             assertEnvelope {
-                it.assertItem<SentryTransaction>()
-                // Since the profile is empty, it is discarded and not sent to Sentry
+                val transactionItem: SentryTransaction = it.assertItem()
                 it.assertNoOtherItems()
+                assertEquals("e2etests", transactionItem.transaction)
+            }
+            assertNoOtherEnvelopes()
+            assertNoOtherRequests()
+        }
+    }
+
+    @Test
+    fun sendTimedOutProfile() {
+        // We increase the IdlingResources timeout to exceed the profiling timeout
+        IdlingPolicies.setIdlingResourceTimeout(1, TimeUnit.MINUTES)
+        initSentry(true) { options: SentryOptions ->
+            options.tracesSampleRate = 1.0
+            options.profilesSampleRate = 1.0
+        }
+        relayIdlingResource.increment()
+        Sentry.startTransaction("e2etests", "testTimeout")
+        // We don't call transaction.finish() and let the timeout do its job
+
+        relay.assert {
+            // The profile failed to be sent. Trying to read the envelope from the data transmitted throws an exception
+            assertEnvelope {
+                val profilingTraceData: ProfilingTraceData = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals("e2etests", profilingTraceData.transactionName)
+                assertEquals(ProfilingTraceData.TRUNCATION_REASON_TIMEOUT, profilingTraceData.truncationReason)
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -67,8 +67,6 @@ class MockRelay(
     /** Shutdown the mock relay server and clear everything. */
     fun shutdown() {
         responses.clear()
-        unassertedEnvelopes.clear()
-        unassertedRequests.clear()
         relay.shutdown()
     }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -67,6 +67,8 @@ class MockRelay(
     /** Shutdown the mock relay server and clear everything. */
     fun shutdown() {
         responses.clear()
+        unassertedEnvelopes.clear()
+        unassertedRequests.clear()
         relay.shutdown()
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -519,7 +519,7 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 }
 
 public abstract interface class io/sentry/ITransactionProfiler {
-	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;)Lio/sentry/ProfilingTraceData;
+	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;)V
 	public abstract fun onTransactionStart (Lio/sentry/ITransaction;)V
 }
 
@@ -784,7 +784,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 
 public final class io/sentry/NoOpTransactionProfiler : io/sentry/ITransactionProfiler {
 	public static fun getInstance ()Lio/sentry/NoOpTransactionProfiler;
-	public fun onTransactionFinish (Lio/sentry/ITransaction;)Lio/sentry/ProfilingTraceData;
+	public fun onTransactionFinish (Lio/sentry/ITransaction;)V
 	public fun onTransactionStart (Lio/sentry/ITransaction;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -273,7 +273,6 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
-	public fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -316,7 +315,6 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
-	public fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
@@ -380,7 +378,6 @@ public abstract interface class io/sentry/IHub {
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
@@ -450,7 +447,6 @@ public abstract interface class io/sentry/ISentryClient {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Scope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/Scope;)Lio/sentry/protocol/SentryId;
-	public abstract fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
 	public abstract fun captureSession (Lio/sentry/Session;Lio/sentry/Hint;)V
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
@@ -671,7 +667,6 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
-	public fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
@@ -1161,7 +1156,6 @@ public final class io/sentry/SentryBaseEvent$Serializer {
 public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/Scope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
-	public fun captureProfile (Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;Lio/sentry/Hint;)V
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Scope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Scope;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
@@ -1182,6 +1176,7 @@ public final class io/sentry/SentryEnvelope {
 	public fun <init> (Lio/sentry/SentryEnvelopeHeader;Ljava/lang/Iterable;)V
 	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;Lio/sentry/SentryEnvelopeItem;)V
 	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SdkVersion;Ljava/lang/Iterable;)V
+	public static fun from (Lio/sentry/ISerializer;Lio/sentry/ProfilingTraceData;JLio/sentry/protocol/SdkVersion;)Lio/sentry/SentryEnvelope;
 	public static fun from (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;Lio/sentry/protocol/SdkVersion;)Lio/sentry/SentryEnvelope;
 	public static fun from (Lio/sentry/ISerializer;Lio/sentry/Session;Lio/sentry/protocol/SdkVersion;)Lio/sentry/SentryEnvelope;
 	public fun getHeader ()Lio/sentry/SentryEnvelopeHeader;

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -602,35 +602,6 @@ public final class Hub implements IHub {
 
   @ApiStatus.Internal
   @Override
-  public @NotNull SentryId captureProfile(final @NotNull ProfilingTraceData profilingTraceData) {
-    Objects.requireNonNull(profilingTraceData, "Profiling trace data is required");
-
-    SentryId sentryId = SentryId.EMPTY_ID;
-    if (!isEnabled()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.WARNING,
-              "Instance is disabled and this 'captureProfile' call is a no-op.");
-    } else {
-      StackItem item = null;
-      try {
-        item = stack.peek();
-        sentryId = item.getClient().captureProfile(profilingTraceData);
-      } catch (Throwable e) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.ERROR,
-                "Error while capturing profile with id: " + profilingTraceData.getProfileId(),
-                e);
-      }
-    }
-    return sentryId;
-  }
-
-  @ApiStatus.Internal
-  @Override
   public @NotNull SentryId captureTransaction(
       final @NotNull SentryTransaction transaction,
       final @Nullable TraceContext traceContext,

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.exception.SentryEnvelopeException;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
@@ -172,14 +173,9 @@ public final class HubAdapter implements IHub {
     return Sentry.getCurrentHub().clone();
   }
 
-  @Override
-  public @NotNull SentryId captureProfile(final @NotNull ProfilingTraceData profilingTraceData) {
-    return Sentry.getCurrentHub().captureProfile(profilingTraceData);
-  }
-
   /**
    * @deprecated please use {{@link Hub#captureTransaction(SentryTransaction, TraceContext, Hint)}}
-   *     and {{@link Hub#captureProfile(ProfilingTraceData)}} instead.
+   *     and {{@link Hub#captureEnvelope(SentryEnvelope)}} instead.
    */
   @Deprecated
   public @NotNull SentryId captureTransaction(
@@ -188,7 +184,18 @@ public final class HubAdapter implements IHub {
       @Nullable Hint hint,
       @Nullable ProfilingTraceData profilingTraceData) {
     if (profilingTraceData != null) {
-      captureProfile(profilingTraceData);
+      SentryEnvelope envelope;
+      try {
+        envelope =
+            SentryEnvelope.from(
+                getOptions().getSerializer(),
+                profilingTraceData,
+                getOptions().getMaxTraceFileSize(),
+                getOptions().getSdkVersion());
+        captureEnvelope(envelope);
+      } catch (SentryEnvelopeException e) {
+        getOptions().getLogger().log(SentryLevel.ERROR, "Failed to capture profile.", e);
+      }
     }
     return captureTransaction(transaction, traceContext, hint);
   }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -342,16 +342,6 @@ public interface IHub {
   IHub clone();
 
   /**
-   * Captures a profile and enqueues it for sending to Sentry server.
-   *
-   * @param profilingTraceData the profiling trace data
-   * @return profile's id
-   */
-  @ApiStatus.Internal
-  @NotNull
-  SentryId captureProfile(final @NotNull ProfilingTraceData profilingTraceData);
-
-  /**
    * Captures the transaction and enqueues it for sending to Sentry server.
    *
    * @param transaction the transaction

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -193,16 +193,6 @@ public interface ISentryClient {
   }
 
   /**
-   * Captures a profile.
-   *
-   * @param profilingTraceData The profiling trace data captured
-   * @return The Id (SentryId object) of the profile
-   */
-  @NotNull
-  @ApiStatus.Internal
-  SentryId captureProfile(@NotNull ProfilingTraceData profilingTraceData);
-
-  /**
    * Captures a transaction.
    *
    * @param transaction the {@link ITransaction} to send

--- a/sentry/src/main/java/io/sentry/ITransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/ITransactionProfiler.java
@@ -2,13 +2,11 @@ package io.sentry;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /** Used for performing operations when a transaction is started or ended. */
 @ApiStatus.Internal
 public interface ITransactionProfiler {
   void onTransactionStart(@NotNull ITransaction transaction);
 
-  @Nullable
-  ProfilingTraceData onTransactionFinish(@NotNull ITransaction transaction);
+  void onTransactionFinish(@NotNull ITransaction transaction);
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -47,11 +47,6 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull SentryId captureProfile(@NotNull ProfilingTraceData profilingTraceData) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
   public @NotNull SentryId captureEnvelope(@NotNull SentryEnvelope envelope, @Nullable Hint hint) {
     return SentryId.EMPTY_ID;
   }
@@ -139,7 +134,7 @@ public final class NoOpHub implements IHub {
 
   /**
    * @deprecated please use {{@link Hub#captureTransaction(SentryTransaction, TraceContext, Hint)}}
-   *     and {{@link Hub#captureProfile(ProfilingTraceData)}} instead.
+   *     and {{@link Hub#captureEnvelope(SentryEnvelope)}} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -44,11 +44,6 @@ final class NoOpSentryClient implements ISentryClient {
   }
 
   @Override
-  public @NotNull SentryId captureProfile(@NotNull ProfilingTraceData profilingTraceData) {
-    return SentryId.EMPTY_ID;
-  }
-
-  @Override
   public @NotNull SentryId captureTransaction(
       @NotNull SentryTransaction transaction,
       @Nullable TraceContext traceContext,

--- a/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class NoOpTransactionProfiler implements ITransactionProfiler {
 
@@ -17,7 +16,5 @@ public final class NoOpTransactionProfiler implements ITransactionProfiler {
   public void onTransactionStart(@NotNull ITransaction transaction) {}
 
   @Override
-  public @Nullable ProfilingTraceData onTransactionFinish(@NotNull ITransaction transaction) {
-    return null;
-  }
+  public void onTransactionFinish(@NotNull ITransaction transaction) {}
 }

--- a/sentry/src/main/java/io/sentry/SentryEnvelope.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelope.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.exception.SentryEnvelopeException;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
@@ -75,5 +76,20 @@ public final class SentryEnvelope {
 
     return new SentryEnvelope(
         event.getEventId(), sdkVersion, SentryEnvelopeItem.fromEvent(serializer, event));
+  }
+
+  public static @NotNull SentryEnvelope from(
+      final @NotNull ISerializer serializer,
+      final @NotNull ProfilingTraceData profilingTraceData,
+      final long maxTraceFileSize,
+      final @Nullable SdkVersion sdkVersion)
+      throws SentryEnvelopeException {
+    Objects.requireNonNull(serializer, "Serializer is required.");
+    Objects.requireNonNull(profilingTraceData, "Profiling trace data is required.");
+
+    return new SentryEnvelope(
+        new SentryId(profilingTraceData.getProfileId()),
+        sdkVersion,
+        SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, maxTraceFileSize, serializer));
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -303,9 +303,8 @@ public final class SentryTracer implements ITransaction {
   public void finish(@Nullable SpanStatus status) {
     this.finishStatus = FinishStatus.finishing(status);
     if (!root.isFinished() && (!waitForChildren || hasAllChildrenFinished())) {
-      ProfilingTraceData profilingTraceData = null;
       if (Boolean.TRUE.equals(isSampled()) && Boolean.TRUE.equals(isProfileSampled())) {
-        profilingTraceData = hub.getOptions().getTransactionProfiler().onTransactionFinish(this);
+        hub.getOptions().getTransactionProfiler().onTransactionFinish(this);
       }
 
       // try to get the high precision timestamp from the root span
@@ -366,10 +365,6 @@ public final class SentryTracer implements ITransaction {
       }
 
       transaction.getMeasurements().putAll(measurements);
-
-      if (profilingTraceData != null) {
-        hub.captureProfile(profilingTraceData);
-      }
       hub.captureTransaction(transaction, traceContext(), null);
     }
   }

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1302,8 +1302,8 @@ class HubTest {
     @Test
     fun `when startTransaction and profiling is enabled, transaction is profiled only if sampled`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
-        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenReturn(mock())
         val mockClient = mock<ISentryClient>()
+        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureProfile(mock()) }
         val hub = generateHub {
             it.setTransactionProfiler(mockTransactionProfiler)
         }
@@ -1324,8 +1324,8 @@ class HubTest {
     @Test
     fun `when startTransaction and is sampled but profiling is disabled, transaction is not profiled`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
-        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenReturn(mock())
         val mockClient = mock<ISentryClient>()
+        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureProfile(mock()) }
         val hub = generateHub {
             it.profilesSampleRate = 0.0
             it.setTransactionProfiler(mockTransactionProfiler)

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1363,29 +1363,13 @@ class HubTest {
     }
     //endregion
 
-    //region captureProfile tests
-    @Test
-    fun `when captureProfile is called on disabled client, do nothing`() {
-        val options = SentryOptions()
-        options.cacheDirPath = file.absolutePath
-        options.dsn = "https://key@sentry.io/proj"
-        options.setSerializer(mock())
-        val sut = Hub(options)
-        val mockClient = mock<ISentryClient>()
-        sut.bindClient(mockClient)
-        sut.close()
-
-        val sentryTracer = SentryTracer(TransactionContext("name", "op"), sut)
-        sentryTracer.finish()
-        sut.captureProfile(ProfilingTraceData(profilingTraceFile, sentryTracer))
-        verify(mockClient, never()).captureProfile(any())
-    }
+    //region profiling tests
 
     @Test
     fun `when startTransaction and profiling is enabled, transaction is profiled only if sampled`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
         val mockClient = mock<ISentryClient>()
-        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureProfile(mock()) }
+        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureEnvelope(mock()) }
         val hub = generateHub {
             it.setTransactionProfiler(mockTransactionProfiler)
         }
@@ -1394,20 +1378,20 @@ class HubTest {
         val contexts = TransactionContext("name", "op", TracesSamplingDecision(false, null, true, null))
         val transaction = hub.startTransaction(contexts)
         transaction.finish()
-        verify(mockClient, never()).captureProfile(any())
+        verify(mockClient, never()).captureEnvelope(any())
 
         // Transaction is sampled, so it should be profiled
         val sampledContexts = TransactionContext("name", "op", TracesSamplingDecision(true, null, true, null))
         val sampledTransaction = hub.startTransaction(sampledContexts)
         sampledTransaction.finish()
-        verify(mockClient).captureProfile(any())
+        verify(mockClient).captureEnvelope(any())
     }
 
     @Test
     fun `when startTransaction and is sampled but profiling is disabled, transaction is not profiled`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
         val mockClient = mock<ISentryClient>()
-        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureProfile(mock()) }
+        whenever(mockTransactionProfiler.onTransactionFinish(any())).thenAnswer { mockClient.captureEnvelope(mock()) }
         val hub = generateHub {
             it.profilesSampleRate = 0.0
             it.setTransactionProfiler(mockTransactionProfiler)
@@ -1416,7 +1400,7 @@ class HubTest {
         val contexts = TransactionContext("name", "op")
         val transaction = hub.startTransaction(contexts)
         transaction.finish()
-        verify(mockClient, never()).captureProfile(any())
+        verify(mockClient, never()).captureEnvelope(any())
     }
     //endregion
 

--- a/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
@@ -1,7 +1,6 @@
 package io.sentry
 
 import kotlin.test.Test
-import kotlin.test.assertNull
 
 class NoOpTransactionProfilerTest {
     private var profiler = NoOpTransactionProfiler.getInstance()
@@ -11,6 +10,6 @@ class NoOpTransactionProfilerTest {
         profiler.onTransactionStart(NoOpTransaction.getInstance())
 
     @Test
-    fun `onTransactionFinish returns null`() =
-        assertNull(profiler.onTransactionFinish(NoOpTransaction.getInstance()))
+    fun `onTransactionFinish does not throw`() =
+        profiler.onTransactionFinish(NoOpTransaction.getInstance())
 }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -1043,34 +1043,48 @@ class SentryClientTest {
     }
 
     @Test
-    fun `when captureProfile`() {
+    fun `when captureEnvelope with ProfilingTraceData`() {
         val client = fixture.getSut()
-        client.captureProfile(fixture.profilingTraceData)
+        val options = fixture.sentryOptions
+        val envelope = SentryEnvelope.from(options.serializer, fixture.profilingTraceData, options.maxTraceFileSize, options.sdkVersion)
+        client.captureEnvelope(envelope)
         verifyProfilingTraceInEnvelope(SentryId(fixture.profilingTraceData.profileId))
     }
 
     @Test
-    fun `captureTransaction with profile calls captureProfile and captureTransaction`() {
+    fun `captureTransaction with profile calls captureEnvelope and captureTransaction`() {
         val transaction = SentryTransaction(fixture.sentryTracer)
         val client = spy(fixture.getSut())
         client.captureTransaction(transaction, null, null, null, fixture.profilingTraceData)
         verify(client).captureTransaction(transaction, null, null, null)
-        verify(client).captureProfile(fixture.profilingTraceData)
+        verify(client).captureEnvelope(
+            check {
+                assertEquals(1, it.items.count())
+                assertEnvelopeItem<ProfilingTraceData>(it.items.toList()) { _, item ->
+                    assertEquals(item.profileId, fixture.profilingTraceData.profileId)
+                }
+            },
+            anyOrNull()
+        )
     }
 
     @Test
-    fun `when captureProfile with empty trace file, profile is not sent`() {
+    fun `when capture profile with empty trace file, profile is not sent`() {
         val client = fixture.getSut()
-        client.captureProfile(fixture.profilingTraceData)
+        val options = fixture.sentryOptions
+        val envelope = SentryEnvelope.from(options.serializer, fixture.profilingTraceData, options.maxTraceFileSize, options.sdkVersion)
+        client.captureEnvelope(envelope)
         fixture.profilingTraceFile.writeText("")
         assertFails { verifyProfilingTraceInEnvelope(SentryId(fixture.profilingTraceData.profileId)) }
     }
 
     @Test
-    fun `when captureProfile with non existing profiling trace file, profile is not sent`() {
+    fun `when capture profile with non existing profiling trace file, profile is not sent`() {
         val client = fixture.getSut()
-        client.captureProfile(fixture.profilingNonExistingTraceData)
-        assertFails { verifyProfilingTraceInEnvelope(SentryId(fixture.profilingTraceData.profileId)) }
+        val options = fixture.sentryOptions
+        val envelope = SentryEnvelope.from(options.serializer, fixture.profilingNonExistingTraceData, options.maxTraceFileSize, options.sdkVersion)
+        client.captureEnvelope(envelope)
+        assertFails { verifyProfilingTraceInEnvelope(SentryId(fixture.profilingNonExistingTraceData.profileId)) }
     }
 
     @Test
@@ -2046,7 +2060,8 @@ class SentryClientTest {
                     item.header.type == SentryItemType.Profile
                 }
                 assertNotNull(profilingTraceItem?.data)
-            }
+            },
+            anyOrNull()
         )
     }
 


### PR DESCRIPTION
## :scroll: Description
The `AndroidTransactionProfiler` now directly sends profile envelopes. This means we don't have to pass the `ProfileTraceData` anymore anyway. 
So we could drop the old timed out profiles handling, as they are directly sent when they time out


## :bulb: Motivation and Context
This change allows profiles to be sent independently from transactions.
It also fixes and simplify timed out profiles handling. Previously we had to wait for a transaction to finish to attach the timed out profile to it and send the envelope. Now the envelope is sent as soon as the profile times out.


## :green_heart: How did you test it?
I added a ui test to check the profile is sent on timeout without finishing the transaction
I added few unit tests to check the `captureProfile` method of the hub is called by the profiler itself.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
