### PR TITLE
Fixed crash in sample app profile size activity due to concurrent profiling

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@ Nulla interdum gravida augue, vel fringilla lorem bibendum vel. In hac habitasse
   <string name="profiling_duration">Duration of profile %.1f seconds</string>
   <string name="profiling_threads">Background threads to use: %d</string>
   <string name="profiling_running">Profiling is running</string>
+  <string name="profiling_no_dir_set">No profiling dir path set</string>
   <string name="profiling_start">Start Profiling</string>
   <string name="profiling_result">Profile trace file size = %d bytes \nItem payload size = %d bytes \nData sent to Sentry size = %d bytes</string>
 </resources>


### PR DESCRIPTION
## :scroll: Description
In the ProfilingActivity of the sample app we try to copy the profiling trace file, related to the manual transaction started, to make some checks on its size.
Now, due to concurrent profiling, we have to wait for other transactions possibly running at the same time because of auto instrumentation (like the button click)

#skip-changelog

## :bulb: Motivation and Context
The sample app was crashing when the manual transaction was shorter than the automatic one. This pr fixes it


## :green_heart: How did you test it?
No way!


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
