### PR TITLE
No longer serialize static fields; use toString as fallback

### DIFF
--- a/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
@@ -84,6 +84,9 @@ public final class JsonReflectionObjectSerializer {
       if (Modifier.isTransient(field.getModifiers())) {
         continue;
       }
+      if (Modifier.isStatic(field.getModifiers())) {
+        continue;
+      }
       String fieldName = field.getName();
       try {
         field.setAccessible(true);
@@ -94,6 +97,11 @@ public final class JsonReflectionObjectSerializer {
         logger.log(SentryLevel.INFO, "Cannot access field " + fieldName + ".");
       }
     }
+
+    if (map.isEmpty()) {
+      map.put("toString", object.toString());
+    }
+
     return map;
   }
 

--- a/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonReflectionObjectSerializerTest.kt
@@ -3,7 +3,10 @@ package io.sentry
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import org.junit.Test
+import java.util.Locale
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class JsonReflectionObjectSerializerTest {
 
@@ -87,11 +90,16 @@ class JsonReflectionObjectSerializerTest {
     }
 
     @Test
-    fun `serialize object without fields`() {
+    fun `serialize object without fields using toString`() {
         val objectWithoutFields = ClassWithoutFields()
-        val expected = mapOf<String, Any>()
+        val expected = mapOf<String, Any>(
+            "toString" to ""
+        )
         val actual = fixture.getSut().serialize(objectWithoutFields, fixture.logger)
-        assertEquals(expected, actual)
+        assertNotNull(actual)
+        assertTrue(actual is Map<*, *>)
+        assertEquals(1, actual.size)
+        assertEquals(objectWithoutFields.toString(), actual["toString"])
     }
 
     @Test
@@ -261,6 +269,12 @@ class JsonReflectionObjectSerializerTest {
     fun `enum`() {
         val actual = fixture.getSut().serialize(DataCategory.Error, fixture.logger)
         assertEquals("Error", actual)
+    }
+
+    @Test
+    fun `locale`() {
+        val actual = fixture.getSut().serialize(Locale.US, fixture.logger)
+        assertEquals(mapOf("toString" to "en_US"), actual)
     }
 
     // Helper


### PR DESCRIPTION
## :scroll: Description
Skip `static` fields when serializing objects using reflection and use `toString()` as a fallback in case there were no fields on the object.

## :bulb: Motivation and Context
Serializing something like `Locale` caused OOM as listing its static fields contained references to other locales that in turn referenced back causing an infinite loop.

Fixes #2301 

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
