### PR TITLE
Respect incoming parent sampled decision when continuing a trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove verbose FrameMetricsAggregator failure logging ([#2293](https://github.com/getsentry/sentry-java/pull/2293))
 - Ignore broken regex for tracePropagationTarget ([#2288](https://github.com/getsentry/sentry-java/pull/2288))
 - Fix `SentryFileWriter`/`SentryFileOutputStream` append overwrites file contents ([#2304](https://github.com/getsentry/sentry-java/pull/2304))
+- Respect incoming parent sampled decision when continuing a trace ([#2311](https://github.com/getsentry/sentry-java/pull/2311))
 
 ### Features
 

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -80,10 +80,11 @@ public final class TransactionContext extends SpanContext {
       baggage.freeze();
 
       Double sampleRate = baggage.getSampleRateDouble();
+      Boolean sampled = parentSampled != null ? parentSampled.booleanValue() : true;
       if (sampleRate != null) {
-        samplingDecision = new TracesSamplingDecision(true, sampleRate);
+        samplingDecision = new TracesSamplingDecision(sampled, sampleRate);
       } else {
-        samplingDecision = new TracesSamplingDecision(true);
+        samplingDecision = new TracesSamplingDecision(sampled);
       }
     }
 

--- a/sentry/src/test/java/io/sentry/TransactionContextTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionContextTest.kt
@@ -1,8 +1,10 @@
 package io.sentry
 
 import io.sentry.protocol.SentryId
+import io.sentry.protocol.TransactionNameSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -25,5 +27,49 @@ class TransactionContextTest {
         assertNull(context.sampled)
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
+    }
+
+    @Test
+    fun `when context is created from trace header and baggage header, parent sampling decision of false is set from trace header`() {
+        val traceHeader = SentryTraceHeader(SentryId(), SpanId(), false)
+        val baggageHeader = Baggage.fromHeader("sentry-trace_id=a,sentry-transaction=sentryTransaction,sentry-sample_rate=0.3")
+        val context = TransactionContext.fromSentryTrace("name", TransactionNameSource.CUSTOM, "op", traceHeader, baggageHeader)
+        assertNull(context.sampled)
+        assertNull(context.profileSampled)
+        assertFalse(context.parentSampled!!)
+        assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
+    }
+
+    @Test
+    fun `when context is created from trace header and baggage header, parent sampling decision of false is set from trace header if no sample rate is available`() {
+        val traceHeader = SentryTraceHeader(SentryId(), SpanId(), false)
+        val baggageHeader = Baggage.fromHeader("sentry-trace_id=a,sentry-transaction=sentryTransaction")
+        val context = TransactionContext.fromSentryTrace("name", TransactionNameSource.CUSTOM, "op", traceHeader, baggageHeader)
+        assertNull(context.sampled)
+        assertNull(context.profileSampled)
+        assertFalse(context.parentSampled!!)
+        assertNull(context.parentSamplingDecision!!.sampleRate)
+    }
+
+    @Test
+    fun `when context is created from trace header and baggage header, parent sampling decision of true is set from trace header`() {
+        val traceHeader = SentryTraceHeader(SentryId(), SpanId(), true)
+        val baggageHeader = Baggage.fromHeader("sentry-trace_id=a,sentry-transaction=sentryTransaction,sentry-sample_rate=0.3")
+        val context = TransactionContext.fromSentryTrace("name", TransactionNameSource.CUSTOM, "op", traceHeader, baggageHeader)
+        assertNull(context.sampled)
+        assertNull(context.profileSampled)
+        assertTrue(context.parentSampled!!)
+        assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
+    }
+
+    @Test
+    fun `when context is created from trace header and baggage header, parent sampling decision of true is set from trace header if no sample rate is available`() {
+        val traceHeader = SentryTraceHeader(SentryId(), SpanId(), true)
+        val baggageHeader = Baggage.fromHeader("sentry-trace_id=a,sentry-transaction=sentryTransaction")
+        val context = TransactionContext.fromSentryTrace("name", TransactionNameSource.CUSTOM, "op", traceHeader, baggageHeader)
+        assertNull(context.sampled)
+        assertNull(context.profileSampled)
+        assertTrue(context.parentSampled!!)
+        assertNull(context.parentSamplingDecision!!.sampleRate)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When introducing `baggage` we ignored the `sampled` decision coming in via `sentry-trace`. This caused incoming `sampled=false` to not be honored.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2308 

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
