### PR TITLE
Overload withSentryObservableEffect to provide compose instrumentation hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ### Features
 - Provide hook for Jetpack Compose navigation instrumentation ([#2320](https://github.com/getsentry/sentry-java/pull/2320))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Features
+- Provide hook for Jetpack Compose navigation instrumentation ([#2320](https://github.com/getsentry/sentry-java/pull/2320))
+
 ## 6.6.0
 
 ### Fixes

--- a/sentry-compose/api/android/sentry-compose.api
+++ b/sentry-compose/api/android/sentry-compose.api
@@ -7,7 +7,6 @@ public final class io/sentry/compose/BuildConfig {
 }
 
 public final class io/sentry/compose/SentryNavigationIntegrationKt {
-	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
 	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;ZZLandroidx/compose/runtime/Composer;II)Landroidx/navigation/NavHostController;
 }
 

--- a/sentry-compose/api/android/sentry-compose.api
+++ b/sentry-compose/api/android/sentry-compose.api
@@ -7,6 +7,7 @@ public final class io/sentry/compose/BuildConfig {
 }
 
 public final class io/sentry/compose/SentryNavigationIntegrationKt {
+	public static final fun rememberNavController ([Landroidx/navigation/Navigator;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
 	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;ZZLandroidx/compose/runtime/Composer;II)Landroidx/navigation/NavHostController;
 }
 

--- a/sentry-compose/api/android/sentry-compose.api
+++ b/sentry-compose/api/android/sentry-compose.api
@@ -7,7 +7,7 @@ public final class io/sentry/compose/BuildConfig {
 }
 
 public final class io/sentry/compose/SentryNavigationIntegrationKt {
-	public static final fun rememberNavController ([Landroidx/navigation/Navigator;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
+	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
 	public static final fun withSentryObservableEffect (Landroidx/navigation/NavHostController;ZZLandroidx/compose/runtime/Composer;II)Landroidx/navigation/NavHostController;
 }
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -10,7 +10,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.Navigator
 import io.sentry.Breadcrumb
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
@@ -72,4 +74,10 @@ public fun NavHostController.withSentryObservableEffect(
         }
     }
     return this
+}
+
+@Composable
+public fun rememberNavController(vararg navigators: Navigator<out NavDestination>): NavHostController {
+    return androidx.navigation.compose.rememberNavController(navigators = navigators)
+        .withSentryObservableEffect()
 }

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -10,9 +10,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
-import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
-import androidx.navigation.Navigator
 import io.sentry.Breadcrumb
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
@@ -39,7 +37,7 @@ internal class SentryLifecycleObserver(
 
 /**
  * A [DisposableEffect] that captures a [Breadcrumb] and starts an [ITransaction] and sends
- * them to Sentry for when attached to the respective [NavHostController].
+ * them to Sentry for every navigation event when being attached to the respective [NavHostController].
  *
  * @param enableNavigationBreadcrumbs Whether the integration should capture breadcrumbs for
  * navigation events.
@@ -76,8 +74,14 @@ public fun NavHostController.withSentryObservableEffect(
     return this
 }
 
+/**
+ * A [DisposableEffect] that captures a [Breadcrumb] and starts an [ITransaction] and sends
+ * them to Sentry for every navigation event when being attached to the respective [NavHostController].
+ */
 @Composable
-public fun rememberNavController(vararg navigators: Navigator<out NavDestination>): NavHostController {
-    return androidx.navigation.compose.rememberNavController(navigators = navigators)
-        .withSentryObservableEffect()
+public fun NavHostController.withSentryObservableEffect(): NavHostController {
+    return withSentryObservableEffect(
+        enableNavigationBreadcrumbs = true,
+        enableNavigationTracing = true
+    )
 }

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryNavigationIntegration.kt
@@ -77,9 +77,12 @@ public fun NavHostController.withSentryObservableEffect(
 /**
  * A [DisposableEffect] that captures a [Breadcrumb] and starts an [ITransaction] and sends
  * them to Sentry for every navigation event when being attached to the respective [NavHostController].
+ *
+ * Used by the sentry android gradle plugin for Jetpack Compose instrumentation.
+ *
  */
 @Composable
-public fun NavHostController.withSentryObservableEffect(): NavHostController {
+internal fun NavHostController.withSentryObservableEffect(): NavHostController {
     return withSentryObservableEffect(
         enableNavigationBreadcrumbs = true,
         enableNavigationTracing = true


### PR DESCRIPTION
## :scroll: Description
Overload withSentryObservableEffect to provide compose instrumentation hook


## :bulb: Motivation and Context
In order to auto-instrument navigation in Jetpack Compose we simply want to adapt the original `rememberNavController` call with our sentry specific navigation listeners. This way the required bytecode changes can be kept to a minimum.

Related to [#2319](https://github.com/getsentry/sentry-java/issues/2319)

## :green_heart: How did you test it?
Right now just manually, need to investigate how all this Android specifics can be tested.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
