### PR TITLE
Populate event.modules with dependencies metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Customizable fragment lifecycle breadcrumbs ([#2299](https://github.com/getsentry/sentry-java/pull/2299))
 - Provide hook for Jetpack Compose navigation instrumentation ([#2320](https://github.com/getsentry/sentry-java/pull/2320))
+- Populate `event.modules` with dependencies metadata ([#2324](https://github.com/getsentry/sentry-java/pull/2324))
 
 ### Dependencies
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -1,7 +1,5 @@
 package io.sentry.android.core;
 
-import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
-
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageInfo;
@@ -15,22 +13,17 @@ import io.sentry.android.core.cache.AndroidEnvelopeCache;
 import io.sentry.android.core.internal.modules.AssetsModulesLoader;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
-import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
 
 /**
  * Android Options initializer, it reads configurations from AndroidManifest and sets to the

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -1,5 +1,7 @@
 package io.sentry.android.core;
 
+import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
+
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageInfo;
@@ -22,8 +24,6 @@ import java.io.InputStream;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
 
 /**
  * Android Options initializer, it reads configurations from AndroidManifest and sets to the

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -12,15 +12,23 @@ import io.sentry.SendFireAndForgetEnvelopeSender;
 import io.sentry.SendFireAndForgetOutboxSender;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.cache.AndroidEnvelopeCache;
+import io.sentry.android.core.internal.modules.AssetsModulesLoader;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
+import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.TreeMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -154,6 +162,7 @@ final class AndroidOptionsInitializer {
     options.setTransportGate(new AndroidTransportGate(context, options.getLogger()));
     options.setTransactionProfiler(
         new AndroidTransactionProfiler(context, options, buildInfoProvider));
+    options.setModulesLoader(new AssetsModulesLoader(context, options.getLogger()));
   }
 
   private static void installDefaultIntegrations(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -1,0 +1,72 @@
+package io.sentry.android.core.internal.modules;
+
+import android.content.Context;
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.internal.modules.IModulesLoader;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.ref.WeakReference;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class AssetsModulesLoader implements IModulesLoader {
+
+  private @Nullable Map<String, String> cachedModules = null;
+  private final @NotNull ILogger logger;
+  private final @NotNull WeakReference<Context> contextRef;
+
+  public AssetsModulesLoader(final @NotNull Context context, final @NotNull ILogger logger) {
+    this.logger = logger;
+    this.contextRef = new WeakReference<>(context);
+  }
+
+  @Override public @Nullable Map<String, String> getOrLoadModules() {
+    if (cachedModules != null) {
+      return cachedModules;
+    }
+    cachedModules = extractModules();
+    return cachedModules;
+  }
+
+  @SuppressWarnings("CharsetObjectCanBeUsed")
+  private Map<String, String> extractModules() {
+    final Map<String, String> modules = new TreeMap<>();
+    try {
+      final Context context = contextRef.get();
+      if (context == null) {
+        return modules;
+      }
+
+      try (final BufferedReader reader =
+             new BufferedReader(new InputStreamReader(context.getAssets().open("sentry-external-modules.txt"), Charset.forName("UTF-8")))) {
+        String module = reader.readLine();
+        while (module != null) {
+          int sep = module.lastIndexOf(':');
+          final String group = module.substring(0, sep);
+          final String version = module.substring(sep + 1);
+          modules.put(group, version);
+          module = reader.readLine();
+        }
+        logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
+      } catch (FileNotFoundException e) {
+        logger.log(SentryLevel.INFO, "sentry-external-modules.txt file was not found.");
+      } catch (IOException e) {
+        logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
+      } catch (RuntimeException e) {
+        logger.log(SentryLevel.ERROR, "sentry-external-modules.txt file is malformed.", e);
+      }
+    } catch (SecurityException e) {
+      logger.log(SentryLevel.INFO, "Access to resources denied.", e);
+    }
+    return modules;
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.internal.modules.IModulesLoader;
+import io.sentry.internal.modules.ModulesLoader;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -18,54 +19,28 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class AssetsModulesLoader implements IModulesLoader {
+public final class AssetsModulesLoader extends ModulesLoader {
 
-  private @Nullable Map<String, String> cachedModules = null;
-  private final @NotNull ILogger logger;
   private final @NotNull WeakReference<Context> contextRef;
 
   public AssetsModulesLoader(final @NotNull Context context, final @NotNull ILogger logger) {
-    this.logger = logger;
+    super(logger);
     this.contextRef = new WeakReference<>(context);
   }
 
-  @Override public @Nullable Map<String, String> getOrLoadModules() {
-    if (cachedModules != null) {
-      return cachedModules;
-    }
-    cachedModules = extractModules();
-    return cachedModules;
-  }
-
-  @SuppressWarnings("CharsetObjectCanBeUsed")
-  private Map<String, String> extractModules() {
+  @Override
+  protected Map<String, String> loadModules() {
     final Map<String, String> modules = new TreeMap<>();
-    try {
-      final Context context = contextRef.get();
-      if (context == null) {
-        return modules;
-      }
+    final Context context = contextRef.get();
+    if (context == null) {
+      return modules;
+    }
 
-      try (final BufferedReader reader =
-             new BufferedReader(new InputStreamReader(context.getAssets().open("sentry-external-modules.txt"), Charset.forName("UTF-8")))) {
-        String module = reader.readLine();
-        while (module != null) {
-          int sep = module.lastIndexOf(':');
-          final String group = module.substring(0, sep);
-          final String version = module.substring(sep + 1);
-          modules.put(group, version);
-          module = reader.readLine();
-        }
-        logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
-      } catch (FileNotFoundException e) {
-        logger.log(SentryLevel.INFO, "sentry-external-modules.txt file was not found.");
-      } catch (IOException e) {
-        logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
-      } catch (RuntimeException e) {
-        logger.log(SentryLevel.ERROR, "sentry-external-modules.txt file is malformed.", e);
-      }
-    } catch (SecurityException e) {
-      logger.log(SentryLevel.INFO, "Access to resources denied.", e);
+    try {
+      final InputStream stream = context.getAssets().open(EXTERNAL_MODULES_FILENAME);
+      return parseStream(stream);
+    } catch (IOException e) {
+      logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
     }
     return modules;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -3,20 +3,15 @@ package io.sentry.android.core.internal.modules;
 import android.content.Context;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
-import io.sentry.internal.modules.IModulesLoader;
 import io.sentry.internal.modules.ModulesLoader;
-import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.TreeMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class AssetsModulesLoader extends ModulesLoader {
@@ -39,6 +34,8 @@ public final class AssetsModulesLoader extends ModulesLoader {
     try {
       final InputStream stream = context.getAssets().open(EXTERNAL_MODULES_FILENAME);
       return parseStream(stream);
+    } catch (FileNotFoundException e) {
+      logger.log(SentryLevel.INFO, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
     } catch (IOException e) {
       logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -7,7 +7,6 @@ import io.sentry.internal.modules.ModulesLoader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.TreeMap;
 import org.jetbrains.annotations.ApiStatus;
@@ -16,20 +15,16 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class AssetsModulesLoader extends ModulesLoader {
 
-  private final @NotNull WeakReference<Context> contextRef;
+  private final @NotNull Context context;
 
   public AssetsModulesLoader(final @NotNull Context context, final @NotNull ILogger logger) {
     super(logger);
-    this.contextRef = new WeakReference<>(context);
+    this.context = context;
   }
 
   @Override
   protected Map<String, String> loadModules() {
     final Map<String, String> modules = new TreeMap<>();
-    final Context context = contextRef.get();
-    if (context == null) {
-      return modules;
-    }
 
     try {
       final InputStream stream = context.getAssets().open(EXTERNAL_MODULES_FILENAME);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -11,6 +11,7 @@ import io.sentry.ILogger
 import io.sentry.MainEventProcessor
 import io.sentry.SentryOptions
 import io.sentry.android.core.cache.AndroidEnvelopeCache
+import io.sentry.android.core.internal.modules.AssetsModulesLoader
 import io.sentry.android.fragment.FragmentLifecycleIntegration
 import io.sentry.android.timber.SentryTimberIntegration
 import org.junit.runner.RunWith
@@ -370,5 +371,12 @@ class AndroidOptionsInitializerTest {
         fixture.initSut()
 
         assertTrue { fixture.sentryOptions.envelopeDiskCache is AndroidEnvelopeCache }
+    }
+
+    @Test
+    fun `AssetsModulesLoader is set to options`() {
+        fixture.initSut()
+
+        assertTrue { fixture.sentryOptions.modulesLoader is AssetsModulesLoader }
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/modules/AssetsModulesLoaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/modules/AssetsModulesLoaderTest.kt
@@ -1,0 +1,104 @@
+package io.sentry.android.core.internal.modules
+
+import android.content.Context
+import android.content.res.AssetManager
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.ILogger
+import java.io.FileNotFoundException
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AssetsModulesLoaderTest {
+
+    class Fixture {
+        val context = mock<Context>()
+        val assets = mock<AssetManager>()
+        val logger = mock<ILogger>()
+
+        fun getSut(
+            fileName: String = "sentry-external-modules.txt",
+            content: String? = null,
+            throws: Boolean = false
+        ): AssetsModulesLoader {
+            if (content != null) {
+                whenever(assets.open(fileName)).thenReturn(
+                    content.byteInputStream(Charset.defaultCharset())
+                )
+            }
+            if (throws) {
+                whenever(assets.open(fileName)).thenThrow(FileNotFoundException())
+            }
+            whenever(context.assets).thenReturn(assets)
+            return AssetsModulesLoader(context, logger)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `reads modules from assets into map`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3:okhttp:3.14.9
+            com.squareup.okio:okio:1.17.2
+            """.trimIndent()
+        )
+
+        assertEquals(
+            mapOf(
+                "com.squareup.okhttp3:okhttp" to "3.14.9",
+                "com.squareup.okio:okio" to "1.17.2"
+            ),
+            sut.orLoadModules
+        )
+    }
+
+    @Test
+    fun `caches modules after first read`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3:okhttp:3.14.9
+            com.squareup.okio:okio:1.17.2
+            """.trimIndent()
+        )
+
+        // first, call method to get modules cached
+        sut.orLoadModules
+
+        // then call it second time
+        assertEquals(
+            mapOf(
+                "com.squareup.okhttp3:okhttp" to "3.14.9",
+                "com.squareup.okio:okio" to "1.17.2"
+            ),
+            sut.orLoadModules
+        )
+        // the context only called once when there's no in-memory cache
+        verify(fixture.context, times(1)).assets
+    }
+
+    @Test
+    fun `when file does not exist, swallows exception and returns empty map`() {
+        val sut = fixture.getSut(throws = true)
+
+        assertEquals(emptyMap(), sut.orLoadModules)
+    }
+
+    @Test
+    fun `when content is malformed, swallows exception and returns empty map`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3;3.14.9
+            """.trimIndent()
+        )
+
+        assertEquals(emptyMap(), sut.orLoadModules)
+    }
+}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/modules/AssetsModulesLoaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/modules/AssetsModulesLoaderTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.core.internal.modules
 import android.content.Context
 import android.content.res.AssetManager
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.ILogger
@@ -11,6 +10,7 @@ import java.io.FileNotFoundException
 import java.nio.charset.Charset
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AssetsModulesLoaderTest {
 
@@ -80,14 +80,14 @@ class AssetsModulesLoaderTest {
             sut.orLoadModules
         )
         // the context only called once when there's no in-memory cache
-        verify(fixture.context, times(1)).assets
+        verify(fixture.context).assets
     }
 
     @Test
     fun `when file does not exist, swallows exception and returns empty map`() {
         val sut = fixture.getSut(throws = true)
 
-        assertEquals(emptyMap(), sut.orLoadModules)
+        assertTrue(sut.orLoadModules!!.isEmpty())
     }
 
     @Test
@@ -99,6 +99,6 @@ class AssetsModulesLoaderTest {
             """.trimIndent()
         )
 
-        assertEquals(emptyMap(), sut.orLoadModules)
+        assertTrue(sut.orLoadModules!!.isEmpty())
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1379,6 +1379,7 @@ public class io/sentry/SentryOptions {
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
 	public fun getMaxSpans ()I
 	public fun getMaxTraceFileSize ()J
+	public fun getModulesLoader ()Lio/sentry/internal/modules/IModulesLoader;
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getProfilesSampleRate ()Ljava/lang/Double;
 	public fun getProfilesSampler ()Lio/sentry/SentryOptions$ProfilesSamplerCallback;
@@ -1457,6 +1458,7 @@ public class io/sentry/SentryOptions {
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setMaxSpans (I)V
 	public fun setMaxTraceFileSize (J)V
+	public fun setModulesLoader (Lio/sentry/internal/modules/IModulesLoader;)V
 	public fun setPrintUncaughtStackTrace (Z)V
 	public fun setProfilesSampleRate (Ljava/lang/Double;)V
 	public fun setProfilesSampler (Lio/sentry/SentryOptions$ProfilesSamplerCallback;)V
@@ -2188,6 +2190,28 @@ public final class io/sentry/instrumentation/file/SentryFileWriter : java/io/Out
 	public fun <init> (Ljava/io/FileDescriptor;)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Z)V
+}
+
+public abstract interface class io/sentry/internal/modules/IModulesLoader {
+	public abstract fun getOrLoadModules ()Ljava/util/Map;
+}
+
+public abstract class io/sentry/internal/modules/ModulesLoader : io/sentry/internal/modules/IModulesLoader {
+	public static final field EXTERNAL_MODULES_FILENAME Ljava/lang/String;
+	protected final field logger Lio/sentry/ILogger;
+	public fun <init> (Lio/sentry/ILogger;)V
+	public fun getOrLoadModules ()Ljava/util/Map;
+	protected abstract fun loadModules ()Ljava/util/Map;
+	protected fun parseStream (Ljava/io/InputStream;)Ljava/util/Map;
+}
+
+public final class io/sentry/internal/modules/NoOpModulesLoader : io/sentry/internal/modules/IModulesLoader {
+	public static fun getInstance ()Lio/sentry/internal/modules/NoOpModulesLoader;
+	public fun getOrLoadModules ()Ljava/util/Map;
+}
+
+public final class io/sentry/internal/modules/ResourcesModulesLoader : io/sentry/internal/modules/ModulesLoader {
+	public fun <init> (Lio/sentry/ILogger;)V
 }
 
 public final class io/sentry/protocol/App : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import io.sentry.hints.Cached;
+import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.protocol.DebugImage;
 import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.SentryException;
@@ -60,6 +61,7 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
     setCommons(event);
     setExceptions(event);
     setDebugMeta(event);
+    setModules(event);
 
     if (shouldApplyScopeData(event, hint)) {
       processNonCachedEvent(event);
@@ -87,6 +89,13 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
         images.add(debugImage);
         event.setDebugMeta(debugMeta);
       }
+    }
+  }
+
+  private void setModules(final @NotNull SentryEvent event) {
+    final Map<String, String> modules = event.getModules();
+    if (modules == null) {
+      event.setModules(options.getModulesLoader().getOrLoadModules());
     }
   }
 

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -92,9 +92,16 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
   }
 
   private void setModules(final @NotNull SentryEvent event) {
-    final Map<String, String> modules = event.getModules();
+    final Map<String, String> modules = options.getModulesLoader().getOrLoadModules();
     if (modules == null) {
-      event.setModules(options.getModulesLoader().getOrLoadModules());
+      return;
+    }
+
+    final Map<String, String> eventModules = event.getModules();
+    if (eventModules == null) {
+      event.setModules(modules);
+    } else {
+      eventModules.putAll(modules);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import io.sentry.hints.Cached;
-import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.protocol.DebugImage;
 import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.SentryException;

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -3,6 +3,9 @@ package io.sentry;
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.cache.IEnvelopeCache;
 import io.sentry.config.PropertiesProviderFactory;
+import io.sentry.internal.modules.IModulesLoader;
+import io.sentry.internal.modules.NoOpModulesLoader;
+import io.sentry.internal.modules.ResourcesModulesLoader;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.transport.NoOpEnvelopeCache;
@@ -268,6 +271,12 @@ public final class Sentry {
                   FileUtils.deleteRecursively(f);
                 }
               });
+    }
+
+    final IModulesLoader modulesLoader = options.getModulesLoader();
+    // only override the ModulesLoader if it's not already set by Android
+    if (modulesLoader instanceof NoOpModulesLoader) {
+      options.setModulesLoader(new ResourcesModulesLoader(options.getLogger()));
     }
 
     return true;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1764,8 +1764,8 @@ public class SentryOptions {
   }
 
   @ApiStatus.Internal
-  public void setModulesLoader(final @NotNull IModulesLoader modulesLoader) {
-    this.modulesLoader = modulesLoader;
+  public void setModulesLoader(final @Nullable IModulesLoader modulesLoader) {
+    this.modulesLoader = modulesLoader != null ? modulesLoader : NoOpModulesLoader.getInstance();
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -5,7 +5,10 @@ import io.sentry.cache.IEnvelopeCache;
 import io.sentry.clientreport.ClientReportRecorder;
 import io.sentry.clientreport.IClientReportRecorder;
 import io.sentry.clientreport.NoOpClientReportRecorder;
+import io.sentry.internal.modules.IModulesLoader;
+import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.protocol.SdkVersion;
+import io.sentry.transport.ITransport;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.transport.NoOpTransportGate;
@@ -181,7 +184,7 @@ public class SentryOptions {
   private final @NotNull List<String> inAppIncludes = new CopyOnWriteArrayList<>();
 
   /**
-   * The transport factory creates instances of {@link io.sentry.transport.ITransport} - internal
+   * The transport factory creates instances of {@link ITransport} - internal
    * construct of the client that abstracts away the event sending.
    */
   private @NotNull ITransportFactory transportFactory = NoOpTransportFactory.getInstance();
@@ -354,6 +357,11 @@ public class SentryOptions {
 
   /** ClientReportRecorder to track count of lost events / transactions / ... * */
   @NotNull IClientReportRecorder clientReportRecorder = new ClientReportRecorder(this);
+
+  /**
+   * Modules (dependencies, packages) that will be send along with each event.
+   */
+  private @NotNull IModulesLoader modulesLoader = NoOpModulesLoader.getInstance();
 
   /**
    * Adds an event processor
@@ -1743,6 +1751,21 @@ public class SentryOptions {
   @ApiStatus.Internal
   public @NotNull IClientReportRecorder getClientReportRecorder() {
     return clientReportRecorder;
+  }
+
+  /**
+   * Returns a ModulesLoader to load external modules (dependencies/packages) of the program.
+   *
+   * @return a modules loader or no-op
+   */
+  @ApiStatus.Internal
+  public @NotNull IModulesLoader getModulesLoader() {
+    return modulesLoader;
+  }
+
+  @ApiStatus.Internal
+  public void setModulesLoader(final @NotNull IModulesLoader modulesLoader) {
+    this.modulesLoader = modulesLoader;
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -184,8 +184,8 @@ public class SentryOptions {
   private final @NotNull List<String> inAppIncludes = new CopyOnWriteArrayList<>();
 
   /**
-   * The transport factory creates instances of {@link ITransport} - internal
-   * construct of the client that abstracts away the event sending.
+   * The transport factory creates instances of {@link ITransport} - internal construct of the
+   * client that abstracts away the event sending.
    */
   private @NotNull ITransportFactory transportFactory = NoOpTransportFactory.getInstance();
 
@@ -358,9 +358,7 @@ public class SentryOptions {
   /** ClientReportRecorder to track count of lost events / transactions / ... * */
   @NotNull IClientReportRecorder clientReportRecorder = new ClientReportRecorder(this);
 
-  /**
-   * Modules (dependencies, packages) that will be send along with each event.
-   */
+  /** Modules (dependencies, packages) that will be send along with each event. */
   private @NotNull IModulesLoader modulesLoader = NoOpModulesLoader.getInstance();
 
   /**

--- a/sentry/src/main/java/io/sentry/internal/modules/IModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/IModulesLoader.java
@@ -6,5 +6,6 @@ import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public interface IModulesLoader {
-  @Nullable Map<String, String> getOrLoadModules();
+  @Nullable
+  Map<String, String> getOrLoadModules();
 }

--- a/sentry/src/main/java/io/sentry/internal/modules/IModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/IModulesLoader.java
@@ -1,0 +1,10 @@
+package io.sentry.internal.modules;
+
+import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public interface IModulesLoader {
+  @Nullable Map<String, String> getOrLoadModules();
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
@@ -1,0 +1,61 @@
+package io.sentry.internal.modules;
+
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public abstract class ModulesLoader implements IModulesLoader {
+
+  public static final String EXTERNAL_MODULES_FILENAME = "sentry-external-modules.txt";
+  protected final @NotNull ILogger logger;
+  private @Nullable Map<String, String> cachedModules = null;
+
+  public ModulesLoader(final @NotNull ILogger logger) {
+    this.logger = logger;
+  }
+
+  @Override public @Nullable Map<String, String> getOrLoadModules() {
+    if (cachedModules != null) {
+      return cachedModules;
+    }
+    cachedModules = loadModules();
+    return cachedModules;
+  }
+
+  protected abstract Map<String, String> loadModules();
+
+  @SuppressWarnings("CharsetObjectCanBeUsed")
+  protected Map<String, String> parseStream(final @NotNull InputStream stream) {
+    final Map<String, String> modules = new TreeMap<>();
+    try (final BufferedReader reader =
+           new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8")))) {
+      String module = reader.readLine();
+      while (module != null) {
+        int sep = module.lastIndexOf(':');
+        final String group = module.substring(0, sep);
+        final String version = module.substring(sep + 1);
+        modules.put(group, version);
+        module = reader.readLine();
+      }
+      logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
+    } catch (FileNotFoundException e) {
+      logger.log(SentryLevel.INFO, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
+    } catch (IOException e) {
+      logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
+    } catch (RuntimeException e) {
+      logger.log(SentryLevel.ERROR, e, "%s file is malformed.", EXTERNAL_MODULES_FILENAME);
+    }
+    return modules;
+  }
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
@@ -3,7 +3,6 @@ package io.sentry.internal.modules;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -25,7 +24,8 @@ public abstract class ModulesLoader implements IModulesLoader {
     this.logger = logger;
   }
 
-  @Override public @Nullable Map<String, String> getOrLoadModules() {
+  @Override
+  public @Nullable Map<String, String> getOrLoadModules() {
     if (cachedModules != null) {
       return cachedModules;
     }
@@ -39,7 +39,7 @@ public abstract class ModulesLoader implements IModulesLoader {
   protected Map<String, String> parseStream(final @NotNull InputStream stream) {
     final Map<String, String> modules = new TreeMap<>();
     try (final BufferedReader reader =
-           new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8")))) {
+        new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8")))) {
       String module = reader.readLine();
       while (module != null) {
         int sep = module.lastIndexOf(':');

--- a/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ModulesLoader.java
@@ -49,8 +49,6 @@ public abstract class ModulesLoader implements IModulesLoader {
         module = reader.readLine();
       }
       logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
-    } catch (FileNotFoundException e) {
-      logger.log(SentryLevel.INFO, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
     } catch (IOException e) {
       logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
     } catch (RuntimeException e) {

--- a/sentry/src/main/java/io/sentry/internal/modules/NoOpModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/NoOpModulesLoader.java
@@ -13,7 +13,8 @@ public final class NoOpModulesLoader implements IModulesLoader {
 
   private NoOpModulesLoader() {}
 
-  @Override public @Nullable Map<String, String> getOrLoadModules() {
+  @Override
+  public @Nullable Map<String, String> getOrLoadModules() {
     return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/internal/modules/NoOpModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/NoOpModulesLoader.java
@@ -1,0 +1,19 @@
+package io.sentry.internal.modules;
+
+import java.util.Map;
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpModulesLoader implements IModulesLoader {
+
+  private static final NoOpModulesLoader instance = new NoOpModulesLoader();
+
+  public static NoOpModulesLoader getInstance() {
+    return instance;
+  }
+
+  private NoOpModulesLoader() {}
+
+  @Override public @Nullable Map<String, String> getOrLoadModules() {
+    return null;
+  }
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
@@ -1,0 +1,70 @@
+package io.sentry.internal.modules;
+
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class ResourcesModulesLoader implements IModulesLoader {
+
+  private @Nullable Map<String, String> cachedModules = null;
+  private final @NotNull ILogger logger;
+
+  public ResourcesModulesLoader(final @NotNull ILogger logger) {
+    this.logger = logger;
+  }
+
+  @Override public @Nullable Map<String, String> getOrLoadModules() {
+    if (cachedModules != null) {
+      return cachedModules;
+    }
+    cachedModules = extractModules();
+    return cachedModules;
+  }
+
+  @SuppressWarnings("CharsetObjectCanBeUsed")
+  private Map<String, String> extractModules() {
+    final Map<String, String> modules = new TreeMap<>();
+    try {
+      final InputStream resourcesStream =
+        getClass().getClassLoader().getResourceAsStream("sentry-external-modules.txt");
+
+      if (resourcesStream == null) {
+        logger.log(SentryLevel.DEBUG, "sentry-external-modules.txt file was not found.");
+        return modules;
+      }
+
+      try (final BufferedReader reader =
+             new BufferedReader(new InputStreamReader(resourcesStream, Charset.forName("UTF-8")))) {
+        String module = reader.readLine();
+        while (module != null) {
+          int sep = module.lastIndexOf(':');
+          final String group = module.substring(0, sep);
+          final String version = module.substring(sep + 1);
+          modules.put(group, version);
+          module = reader.readLine();
+        }
+        logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
+      } catch (FileNotFoundException e) {
+        logger.log(SentryLevel.INFO, "sentry-external-modules.txt file was not found.");
+      } catch (IOException e) {
+        logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
+      } catch (RuntimeException e) {
+        logger.log(SentryLevel.ERROR, "sentry-external-modules.txt file is malformed.", e);
+      }
+    } catch (SecurityException e) {
+      logger.log(SentryLevel.INFO, "Access to resources denied.", e);
+    }
+    return modules;
+  }
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
@@ -22,11 +22,12 @@ public final class ResourcesModulesLoader extends ModulesLoader {
     this.classLoader = classLoader;
   }
 
-  @Override protected Map<String, String> loadModules() {
+  @Override
+  protected Map<String, String> loadModules() {
     final Map<String, String> modules = new TreeMap<>();
     try {
       final InputStream resourcesStream =
-        classLoader.getResourceAsStream(EXTERNAL_MODULES_FILENAME);
+          classLoader.getResourceAsStream(EXTERNAL_MODULES_FILENAME);
 
       if (resourcesStream == null) {
         logger.log(SentryLevel.INFO, "%s file was not found.", EXTERNAL_MODULES_FILENAME);

--- a/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
@@ -11,18 +11,25 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class ResourcesModulesLoader extends ModulesLoader {
 
+  private final @NotNull ClassLoader classLoader;
+
   public ResourcesModulesLoader(final @NotNull ILogger logger) {
+    this(logger, ResourcesModulesLoader.class.getClassLoader());
+  }
+
+  ResourcesModulesLoader(final @NotNull ILogger logger, final @NotNull ClassLoader classLoader) {
     super(logger);
+    this.classLoader = classLoader;
   }
 
   @Override protected Map<String, String> loadModules() {
     final Map<String, String> modules = new TreeMap<>();
     try {
       final InputStream resourcesStream =
-        getClass().getClassLoader().getResourceAsStream(EXTERNAL_MODULES_FILENAME);
+        classLoader.getResourceAsStream(EXTERNAL_MODULES_FILENAME);
 
       if (resourcesStream == null) {
-        logger.log(SentryLevel.DEBUG, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
+        logger.log(SentryLevel.INFO, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
         return modules;
       }
 

--- a/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
@@ -2,66 +2,31 @@ package io.sentry.internal.modules;
 
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.TreeMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class ResourcesModulesLoader implements IModulesLoader {
-
-  private @Nullable Map<String, String> cachedModules = null;
-  private final @NotNull ILogger logger;
+public final class ResourcesModulesLoader extends ModulesLoader {
 
   public ResourcesModulesLoader(final @NotNull ILogger logger) {
-    this.logger = logger;
+    super(logger);
   }
 
-  @Override public @Nullable Map<String, String> getOrLoadModules() {
-    if (cachedModules != null) {
-      return cachedModules;
-    }
-    cachedModules = extractModules();
-    return cachedModules;
-  }
-
-  @SuppressWarnings("CharsetObjectCanBeUsed")
-  private Map<String, String> extractModules() {
+  @Override protected Map<String, String> loadModules() {
     final Map<String, String> modules = new TreeMap<>();
     try {
       final InputStream resourcesStream =
-        getClass().getClassLoader().getResourceAsStream("sentry-external-modules.txt");
+        getClass().getClassLoader().getResourceAsStream(EXTERNAL_MODULES_FILENAME);
 
       if (resourcesStream == null) {
-        logger.log(SentryLevel.DEBUG, "sentry-external-modules.txt file was not found.");
+        logger.log(SentryLevel.DEBUG, "%s file was not found.", EXTERNAL_MODULES_FILENAME);
         return modules;
       }
 
-      try (final BufferedReader reader =
-             new BufferedReader(new InputStreamReader(resourcesStream, Charset.forName("UTF-8")))) {
-        String module = reader.readLine();
-        while (module != null) {
-          int sep = module.lastIndexOf(':');
-          final String group = module.substring(0, sep);
-          final String version = module.substring(sep + 1);
-          modules.put(group, version);
-          module = reader.readLine();
-        }
-        logger.log(SentryLevel.DEBUG, "Extracted %d modules from resources.", modules.size());
-      } catch (FileNotFoundException e) {
-        logger.log(SentryLevel.INFO, "sentry-external-modules.txt file was not found.");
-      } catch (IOException e) {
-        logger.log(SentryLevel.ERROR, "Error extracting modules.", e);
-      } catch (RuntimeException e) {
-        logger.log(SentryLevel.ERROR, "sentry-external-modules.txt file is malformed.", e);
-      }
+      return parseStream(resourcesStream);
     } catch (SecurityException e) {
       logger.log(SentryLevel.INFO, "Access to resources denied.", e);
     }

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -491,7 +491,7 @@ class MainEventProcessorTest {
     }
 
     @Test
-    fun `when event has modules, does not override them`() {
+    fun `when event has modules, appends to them`() {
         val sut = fixture.getSut(modules = mapOf("group1:artifact1" to "2.0.0"))
 
         var event = SentryEvent().apply {
@@ -499,8 +499,9 @@ class MainEventProcessorTest {
         }
         event = sut.process(event, Hint())
 
-        assertEquals(1, event.modules!!.size)
+        assertEquals(2, event.modules!!.size)
         assertEquals("1.0.0", event.modules!!["group:artifact"])
+        assertEquals("2.0.0", event.modules!!["group1:artifact1"])
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -13,7 +13,6 @@ import io.sentry.protocol.User
 import io.sentry.util.HintUtils
 import org.awaitility.kotlin.await
 import org.mockito.Mockito
-import java.lang.RuntimeException
 import java.net.InetAddress
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -37,12 +36,25 @@ class MainEventProcessorTest {
         lateinit var sentryTracer: SentryTracer
         private val hostnameCacheMock = Mockito.mockStatic(HostnameCache::class.java)
 
-        fun getSut(attachThreads: Boolean = true, attachStackTrace: Boolean = true, environment: String? = "environment", tags: Map<String, String> = emptyMap(), sendDefaultPii: Boolean? = null, serverName: String? = "server", host: String? = null, resolveHostDelay: Long? = null, hostnameCacheDuration: Long = 10, proguardUuid: String? = null): MainEventProcessor {
+        fun getSut(
+            attachThreads: Boolean = true,
+            attachStackTrace: Boolean = true,
+            environment: String? = "environment",
+            tags: Map<String, String> = emptyMap(),
+            sendDefaultPii: Boolean? = null,
+            serverName: String? = "server",
+            host: String? = null,
+            resolveHostDelay: Long? = null,
+            hostnameCacheDuration: Long = 10,
+            proguardUuid: String? = null,
+            modules: Map<String, String>? = null
+        ): MainEventProcessor {
             sentryOptions.isAttachThreads = attachThreads
             sentryOptions.isAttachStacktrace = attachStackTrace
             sentryOptions.isAttachServerName = true
             sentryOptions.environment = environment
             sentryOptions.serverName = serverName
+            sentryOptions.setModulesLoader { modules }
             if (sendDefaultPii != null) {
                 sentryOptions.isSendDefaultPii = sendDefaultPii
             }
@@ -348,7 +360,8 @@ class MainEventProcessorTest {
 
     @Test
     fun `uses cache to retrieve servername for subsequent events`() {
-        val processor = fixture.getSut(serverName = null, host = "aHost", hostnameCacheDuration = 1000)
+        val processor =
+            fixture.getSut(serverName = null, host = "aHost", hostnameCacheDuration = 1000)
         val firstEvent = SentryEvent()
         processor.process(firstEvent, Hint())
         assertEquals("aHost", firstEvent.serverName)
@@ -477,9 +490,37 @@ class MainEventProcessorTest {
         }
     }
 
-    private fun generateCrashedEvent(crashedThread: Thread = Thread.currentThread()) = SentryEvent().apply {
-        val mockThrowable = mock<Throwable>()
-        val actualThrowable = UncaughtExceptionHandlerIntegration.getUnhandledThrowable(crashedThread, mockThrowable)
-        throwable = actualThrowable
+    @Test
+    fun `when event has modules, does not override them`() {
+        val sut = fixture.getSut(modules = mapOf("group1:artifact1" to "2.0.0"))
+
+        var event = SentryEvent().apply {
+            modules = mapOf("group:artifact" to "1.0.0")
+        }
+        event = sut.process(event, Hint())
+
+        assertEquals(1, event.modules!!.size)
+        assertEquals("1.0.0", event.modules!!["group:artifact"])
     }
+
+    @Test
+    fun `sets event modules`() {
+        val sut = fixture.getSut(modules = mapOf("group1:artifact1" to "2.0.0"))
+
+        var event = SentryEvent()
+        event = sut.process(event, Hint())
+
+        assertEquals(1, event.modules!!.size)
+        assertEquals("2.0.0", event.modules!!["group1:artifact1"])
+    }
+
+    private fun generateCrashedEvent(crashedThread: Thread = Thread.currentThread()) =
+        SentryEvent().apply {
+            val mockThrowable = mock<Throwable>()
+            val actualThrowable = UncaughtExceptionHandlerIntegration.getUnhandledThrowable(
+                crashedThread,
+                mockThrowable
+            )
+            throwable = actualThrowable
+        }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -7,6 +7,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import io.sentry.cache.EnvelopeCache
 import io.sentry.cache.IEnvelopeCache
+import io.sentry.internal.modules.IModulesLoader
+import io.sentry.internal.modules.ResourcesModulesLoader
 import io.sentry.protocol.SentryId
 import org.junit.rules.TemporaryFolder
 import java.io.File
@@ -19,6 +21,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+
 class SentryTest {
 
     private val dsn = "http://key@localhost/proj"
@@ -293,6 +296,35 @@ class SentryTest {
         }
 
         assertTrue { sentryOptions!!.envelopeDiskCache is CustomEnvelopCache }
+    }
+
+    @Test
+    fun `overrides modules loader if it's not set`() {
+        var sentryOptions: SentryOptions? = null
+
+        Sentry.init {
+            it.dsn = dsn
+            sentryOptions = it
+        }
+
+        assertTrue { sentryOptions!!.modulesLoader is ResourcesModulesLoader }
+    }
+
+    @Test
+    fun `does not override modules loader if it's already set`() {
+        var sentryOptions: SentryOptions? = null
+
+        Sentry.init {
+            it.dsn = dsn
+            it.setModulesLoader(CustomModulesLoader())
+            sentryOptions = it
+        }
+
+        assertTrue { sentryOptions!!.modulesLoader is CustomModulesLoader }
+    }
+
+    private class CustomModulesLoader: IModulesLoader {
+        override fun getOrLoadModules(): MutableMap<String, String>? = null
     }
 
     private class CustomEnvelopCache : IEnvelopeCache {

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -323,7 +323,7 @@ class SentryTest {
         assertTrue { sentryOptions!!.modulesLoader is CustomModulesLoader }
     }
 
-    private class CustomModulesLoader: IModulesLoader {
+    private class CustomModulesLoader : IModulesLoader {
         override fun getOrLoadModules(): MutableMap<String, String>? = null
     }
 

--- a/sentry/src/test/java/io/sentry/internal/modules/ResourcesModulesLoaderTest.kt
+++ b/sentry/src/test/java/io/sentry/internal/modules/ResourcesModulesLoaderTest.kt
@@ -1,0 +1,96 @@
+package io.sentry.internal.modules
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.sentry.ILogger
+import java.nio.charset.Charset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResourcesModulesLoaderTest {
+
+    class Fixture {
+        val logger = mock<ILogger>()
+        val classLoader = mock<ClassLoader>()
+
+        fun getSut(
+            fileName: String = "sentry-external-modules.txt",
+            content: String? = null
+        ): ResourcesModulesLoader {
+            if (content != null) {
+                whenever(classLoader.getResourceAsStream(fileName)).thenReturn(
+                    content.byteInputStream(Charset.defaultCharset())
+                )
+            }
+            return ResourcesModulesLoader(logger, classLoader)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `reads modules from resources into map`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3:okhttp:3.14.9
+            com.squareup.okio:okio:1.17.2
+            """.trimIndent()
+        )
+
+        assertEquals(
+            mapOf(
+                "com.squareup.okhttp3:okhttp" to "3.14.9",
+                "com.squareup.okio:okio" to "1.17.2"
+            ),
+            sut.orLoadModules
+        )
+    }
+
+    @Test
+    fun `caches modules after first read`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3:okhttp:3.14.9
+            com.squareup.okio:okio:1.17.2
+            """.trimIndent()
+        )
+
+        // first, call method to get modules cached
+        sut.orLoadModules
+
+        // then call it second time
+        assertEquals(
+            mapOf(
+                "com.squareup.okhttp3:okhttp" to "3.14.9",
+                "com.squareup.okio:okio" to "1.17.2"
+            ),
+            sut.orLoadModules
+        )
+        // the classloader only called once when there's no in-memory cache
+        verify(fixture.classLoader, times(1)).getResourceAsStream(any())
+    }
+
+    @Test
+    fun `when file does not exist, returns empty map`() {
+        val sut = fixture.getSut()
+
+        assertEquals(emptyMap(), sut.orLoadModules)
+    }
+
+    @Test
+    fun `when content is malformed, swallows exception and returns empty map`() {
+        val sut = fixture.getSut(
+            content =
+            """
+            com.squareup.okhttp3;3.14.9
+            """.trimIndent()
+        )
+
+        assertEquals(emptyMap(), sut.orLoadModules)
+    }
+}

--- a/sentry/src/test/java/io/sentry/internal/modules/ResourcesModulesLoaderTest.kt
+++ b/sentry/src/test/java/io/sentry/internal/modules/ResourcesModulesLoaderTest.kt
@@ -2,13 +2,13 @@ package io.sentry.internal.modules
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.sentry.ILogger
 import java.nio.charset.Charset
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ResourcesModulesLoaderTest {
 
@@ -72,14 +72,14 @@ class ResourcesModulesLoaderTest {
             sut.orLoadModules
         )
         // the classloader only called once when there's no in-memory cache
-        verify(fixture.classLoader, times(1)).getResourceAsStream(any())
+        verify(fixture.classLoader).getResourceAsStream(any())
     }
 
     @Test
     fun `when file does not exist, returns empty map`() {
         val sut = fixture.getSut()
 
-        assertEquals(emptyMap(), sut.orLoadModules)
+        assertTrue(sut.orLoadModules!!.isEmpty())
     }
 
     @Test
@@ -91,6 +91,6 @@ class ResourcesModulesLoaderTest {
             """.trimIndent()
         )
 
-        assertEquals(emptyMap(), sut.orLoadModules)
+        assertTrue(sut.orLoadModules!!.isEmpty())
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Adds platform-specific dependencies readers for Java and Android, that parse `sentry-external-modules.txt` file ingested by the gradle plugin into the final jar/apk
* Sends those dependencies as part of every SentryEvent

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1470 
Relates to https://github.com/getsentry/sentry-android-gradle-plugin/pull/396
Part of https://github.com/getsentry/team-mobile/issues/54

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
