### PR TITLE
Use correct set-cookie for the HTTP Client response object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use correct set-cookie for the HTTP Client response object ([#2299](https://github.com/getsentry/sentry-java/pull/2299))
+
 ### Features
 
 - Customizable fragment lifecycle breadcrumbs ([#2299](https://github.com/getsentry/sentry-java/pull/2299))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Use correct set-cookie for the HTTP Client response object ([#2299](https://github.com/getsentry/sentry-java/pull/2299))
+- Use correct set-cookie for the HTTP Client response object ([#2326](https://github.com/getsentry/sentry-java/pull/2326))
 
 ### Features
 

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -194,7 +194,7 @@ class SentryOkHttpInterceptor(
         }
 
         val sentryResponse = io.sentry.protocol.Response().apply {
-            // Cookie is only sent if isSendDefaultPii is enabled due to PII
+            // Set-Cookie is only sent if isSendDefaultPii is enabled due to PII
             cookies = if (hub.options.isSendDefaultPii) response.headers["Set-Cookie"] else null
             headers = getHeaders(response.headers)
             statusCode = response.code

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -195,7 +195,7 @@ class SentryOkHttpInterceptor(
 
         val sentryResponse = io.sentry.protocol.Response().apply {
             // Cookie is only sent if isSendDefaultPii is enabled due to PII
-            cookies = if (hub.options.isSendDefaultPii) response.headers["Cookie"] else null
+            cookies = if (hub.options.isSendDefaultPii) response.headers["Set-Cookie"] else null
             headers = getHeaders(response.headers)
             statusCode = response.code
 


### PR DESCRIPTION
## :scroll: Description
Use correct set-cookie for the HTTP Client response object


## :bulb: Motivation and Context
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [X] No breaking changes


## :crystal_ball: Next steps
