### PR TITLE
Fix NoSuchElementException in CircularFifoQueue when cloning a Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Use correct set-cookie for the HTTP Client response object ([#2326](https://github.com/getsentry/sentry-java/pull/2326))
+- Fix NoSuchElementException in CircularFifoQueue when cloning a Scope ([#2328](https://github.com/getsentry/sentry-java/pull/2328))
 
 ### Features
 

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -97,7 +97,7 @@ public final class Scope {
     this.fingerprint = new ArrayList<>(scope.fingerprint);
     this.eventProcessors = new CopyOnWriteArrayList<>(scope.eventProcessors);
 
-    final Queue<Breadcrumb> breadcrumbsRef = scope.breadcrumbs;
+    final Breadcrumb[] breadcrumbsRef = scope.breadcrumbs.toArray(new Breadcrumb[0]);
 
     Queue<Breadcrumb> breadcrumbsClone = createBreadcrumbsList(scope.options.getMaxBreadcrumbs());
 

--- a/sentry/src/main/java/io/sentry/SynchronizedQueue.java
+++ b/sentry/src/main/java/io/sentry/SynchronizedQueue.java
@@ -131,4 +131,18 @@ final class SynchronizedQueue<E> extends SynchronizedCollection<E> implements Qu
       return decorated().remove();
     }
   }
+
+  @Override
+  public Object[] toArray() {
+    synchronized (lock) {
+      return decorated().toArray();
+    }
+  }
+
+  @Override
+  public <T> T[] toArray(T[] object) {
+    synchronized (lock) {
+      return decorated().toArray(object);
+    }
+  }
 }

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -218,12 +218,12 @@ class ScopeTest {
     }
 
     @Test
-    fun `copying scope won't crash if there are a lot of breadcrumbs`() {
+    fun `copying scope won't crash if there are concurrent operations`() {
         val options = SentryOptions().apply {
             maxBreadcrumbs = 10000
         }
         val scope = Scope(options)
-        for (i in 0..options.maxBreadcrumbs) {
+        for (i in 0 until options.maxBreadcrumbs) {
             scope.addBreadcrumb(Breadcrumb.info("item"))
         }
 


### PR DESCRIPTION
## :scroll: Description
Ensure that the breadcrumbs are copied in a thread safe manner when cloning a Scope.

## :bulb: Motivation and Context
This fixes a top crash we saw in the Google Play SDK Console.  
Related issues
* #2323
* #2183

If you know any better way to test this please let me know! (The test reliably crashed for me until I implemented the fix).

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
