### PR TITLE
VendorId should be a String

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b # pin@v1
+      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # pin@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `Gpu.vendorId` should be a String ([#2343](https://github.com/getsentry/sentry-java/pull/2343))
+
 ## 6.7.0
 
 ### Fixes

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2511,7 +2511,7 @@ public final class io/sentry/protocol/Gpu : io/sentry/JsonSerializable, io/sentr
 	public fun getName ()Ljava/lang/String;
 	public fun getNpotSupport ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
-	public fun getVendorId ()Ljava/lang/Integer;
+	public fun getVendorId ()Ljava/lang/String;
 	public fun getVendorName ()Ljava/lang/String;
 	public fun getVersion ()Ljava/lang/String;
 	public fun isMultiThreadedRendering ()Ljava/lang/Boolean;
@@ -2523,7 +2523,7 @@ public final class io/sentry/protocol/Gpu : io/sentry/JsonSerializable, io/sentr
 	public fun setName (Ljava/lang/String;)V
 	public fun setNpotSupport (Ljava/lang/String;)V
 	public fun setUnknown (Ljava/util/Map;)V
-	public fun setVendorId (Ljava/lang/Integer;)V
+	public fun setVendorId (Ljava/lang/String;)V
 	public fun setVendorName (Ljava/lang/String;)V
 	public fun setVersion (Ljava/lang/String;)V
 }

--- a/sentry/src/main/java/io/sentry/protocol/Gpu.java
+++ b/sentry/src/main/java/io/sentry/protocol/Gpu.java
@@ -22,7 +22,7 @@ public final class Gpu implements JsonUnknown, JsonSerializable {
   /** The PCI identifier of the graphics device. */
   private @Nullable Integer id;
   /** The PCI vendor identifier of the graphics device. */
-  private @Nullable Integer vendorId;
+  private @Nullable String vendorId;
   /** The vendor name as reported by the graphics device. */
   private @Nullable String vendorName;
   /** The total GPU memory available in Megabytes. */
@@ -74,11 +74,11 @@ public final class Gpu implements JsonUnknown, JsonSerializable {
     this.id = id;
   }
 
-  public @Nullable Integer getVendorId() {
+  public @Nullable String getVendorId() {
     return vendorId;
   }
 
-  public void setVendorId(Integer vendorId) {
+  public void setVendorId(String vendorId) {
     this.vendorId = vendorId;
   }
 
@@ -213,7 +213,7 @@ public final class Gpu implements JsonUnknown, JsonSerializable {
             gpu.id = reader.nextIntegerOrNull();
             break;
           case JsonKeys.VENDOR_ID:
-            gpu.vendorId = reader.nextIntegerOrNull();
+            gpu.vendorId = reader.nextStringOrNull();
             break;
           case JsonKeys.VENDOR_NAME:
             gpu.vendorName = reader.nextStringOrNull();

--- a/sentry/src/test/java/io/sentry/protocol/GpuSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/GpuSerializationTest.kt
@@ -13,7 +13,7 @@ class GpuSerializationTest {
         fun getSut() = Gpu().apply {
             name = "d623a6b5-e1ab-4402-931b-c06f5a43a5ae"
             id = -596576280
-            vendorId = 1874778041
+            vendorId = "1874778041"
             vendorName = "d732cf76-07dc-48e2-8920-96d6bfc2439d"
             memorySize = -1484004451
             apiType = "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f"

--- a/sentry/src/test/java/io/sentry/protocol/GpuTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/GpuTest.kt
@@ -26,7 +26,7 @@ class GpuTest {
         val gpu = Gpu()
         gpu.name = "name"
         gpu.id = 10
-        gpu.vendorId = 20
+        gpu.vendorId = "20"
         gpu.vendorName = "vendor name"
         gpu.memorySize = 1024
         gpu.apiType = "api type"
@@ -40,7 +40,7 @@ class GpuTest {
 
         assertEquals("name", clone.name)
         assertEquals(10, clone.id)
-        assertEquals(20, clone.vendorId)
+        assertEquals("20", clone.vendorId)
         assertEquals("vendor name", clone.vendorName)
         assertEquals(1024, clone.memorySize)
         assertEquals("api type", clone.apiType)

--- a/sentry/src/test/resources/json/contexts.json
+++ b/sentry/src/test/resources/json/contexts.json
@@ -64,7 +64,7 @@
   {
     "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
     "id": -596576280,
-    "vendor_id": 1874778041,
+    "vendor_id": "1874778041",
     "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
     "memory_size": -1484004451,
     "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/gpu.json
+++ b/sentry/src/test/resources/json/gpu.json
@@ -1,7 +1,7 @@
 {
     "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
     "id": -596576280,
-    "vendor_id": 1874778041,
+    "vendor_id": "1874778041",
     "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
     "memory_size": -1484004451,
     "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/sentry_base_event.json
+++ b/sentry/src/test/resources/json/sentry_base_event.json
@@ -67,7 +67,7 @@
     {
       "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
       "id": -596576280,
-      "vendor_id": 1874778041,
+      "vendor_id": "1874778041",
       "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
       "memory_size": -1484004451,
       "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/sentry_event.json
+++ b/sentry/src/test/resources/json/sentry_event.json
@@ -214,7 +214,7 @@
         {
             "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
             "id": -596576280,
-            "vendor_id": 1874778041,
+            "vendor_id": "1874778041",
             "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
             "memory_size": -1484004451,
             "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/sentry_transaction.json
+++ b/sentry/src/test/resources/json/sentry_transaction.json
@@ -110,7 +110,7 @@
         {
             "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
             "id": -596576280,
-            "vendor_id": 1874778041,
+            "vendor_id": "1874778041",
             "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
             "memory_size": -1484004451,
             "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
@@ -110,7 +110,7 @@
         {
             "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
             "id": -596576280,
-            "vendor_id": 1874778041,
+            "vendor_id": "1874778041",
             "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
             "memory_size": -1484004451,
             "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",

--- a/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
+++ b/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
@@ -102,7 +102,7 @@
         {
             "name": "d623a6b5-e1ab-4402-931b-c06f5a43a5ae",
             "id": -596576280,
-            "vendor_id": 1874778041,
+            "vendor_id": "1874778041",
             "vendor_name": "d732cf76-07dc-48e2-8920-96d6bfc2439d",
             "memory_size": -1484004451,
             "api_type": "95dfc8bc-88ae-4d66-b85f-6c88ad45b80f",


### PR DESCRIPTION
## :scroll: Description
`gpu.vendorId` was defined as an Int, should be a String.


## :bulb: Motivation and Context
This is a breaking change but I'm wondering if anyone is using it. We could introduce a `@Deprecated void setVendorId(int vendorId) { setVendorId(String.valueOf(vendorId)); }` to minimize the impact, but I'm not sure if it's worth it.

Mobile Issue: https://github.com/getsentry/team-mobile/issues/67
Dart: https://github.com/getsentry/sentry-dart/pull/1112

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
