### PR TITLE
Remove profiler main thread io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use correct set-cookie for the HTTP Client response object ([#2326](https://github.com/getsentry/sentry-java/pull/2326))
 - Fix NoSuchElementException in CircularFifoQueue when cloning a Scope ([#2328](https://github.com/getsentry/sentry-java/pull/2328))
+- Remove profiler main thread io ([#2348](https://github.com/getsentry/sentry-java/pull/2348))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `Gpu.vendorId` should be a String ([#2343](https://github.com/getsentry/sentry-java/pull/2343))
+- Remove profiler main thread io ([#2348](https://github.com/getsentry/sentry-java/pull/2348))
 
 ### Features
 
@@ -16,7 +17,6 @@
 
 - Use correct set-cookie for the HTTP Client response object ([#2326](https://github.com/getsentry/sentry-java/pull/2326))
 - Fix NoSuchElementException in CircularFifoQueue when cloning a Scope ([#2328](https://github.com/getsentry/sentry-java/pull/2328))
-- Remove profiler main thread io ([#2348](https://github.com/getsentry/sentry-java/pull/2348))
 
 ### Features
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -139,18 +139,16 @@ object Config {
     }
 
     object TestLibs {
-        private val androidxTestVersion = "1.4.0"
-
-        // todo This beta version is needed to run ui tests on Android 13.
-        //  It will be replaced by androidxTestVersion when 1.5.0 will be out.
-        private val androidxTestVersionBeta = "1.5.0-beta01"
-        private val espressoVersion = "3.4.0"
+        // todo These rc versions are needed to run ui tests on Android 13.
+        //  They will be replaced by stable version when 1.5.0/3.5.0 will be out.
+        private val androidxTestVersion = "1.5.0-rc01"
+        private val espressoVersion = "3.5.0-rc01"
 
         val androidJUnitRunner = "androidx.test.runner.AndroidJUnitRunner"
         val kotlinTestJunit = "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-        val androidxCore = "androidx.test:core:$androidxTestVersionBeta"
+        val androidxCore = "androidx.test:core:$androidxTestVersion"
         val androidxRunner = "androidx.test:runner:$androidxTestVersion"
-        val androidxTestCoreKtx = "androidx.test:core-ktx:$androidxTestVersionBeta"
+        val androidxTestCoreKtx = "androidx.test:core-ktx:$androidxTestVersion"
         val androidxTestRules = "androidx.test:rules:$androidxTestVersion"
         val espressoCore = "androidx.test.espresso:espresso-core:$espressoVersion"
         val espressoIdlingResource = "androidx.test.espresso:espresso-idling-resource:$espressoVersion"

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -180,8 +180,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @SuppressLint("NewApi")
-  private void onFirstTransactionStarted(
-      final @NotNull ITransaction transaction, final @NotNull File traceFile) {
+  private void onFirstTransactionStarted(final @NotNull ITransaction transaction) {
     // We create a file with a uuid name, so no need to check if it already exists
     traceFile = new File(traceFilesDir, UUID.randomUUID() + ".trace");
 
@@ -245,7 +244,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @SuppressLint("NewApi")
-  private void onTransactionFinish(final @NotNull ITransaction transaction, final boolean isTimeout) {
+  private void onTransactionFinish(
+      final @NotNull ITransaction transaction, final boolean isTimeout) {
 
     // onTransactionStart() is only available since Lollipop
     // and SystemClock.elapsedRealtimeNanos() since Jelly Bean

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -262,6 +262,15 @@ class AndroidTransactionProfilerTest {
     }
 
     @Test
+    fun `profiler uses background threads`() {
+        val profiler = fixture.getSut(context)
+        fixture.options.executorService = mock()
+        profiler.onTransactionStart(fixture.transaction1)
+        profiler.onTransactionFinish(fixture.transaction1)
+        verify(fixture.hub, never()).captureEnvelope(any())
+    }
+
+    @Test
     fun `onTransactionFinish works only if previously started`() {
         val profiler = fixture.getSut(context)
         profiler.onTransactionFinish(fixture.transaction1)

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -64,6 +64,11 @@ class EnvelopeTests : BaseUiTest() {
         transaction.finish()
         relay.assert {
             assertEnvelope {
+                val transactionItem: SentryTransaction = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals("e2etests", transactionItem.transaction)
+            }
+            assertEnvelope {
                 val profilingTraceData: ProfilingTraceData = it.assertItem()
                 it.assertNoOtherItems()
                 assertEquals(profilingTraceData.transactionId, transaction.eventId.toString())
@@ -88,11 +93,6 @@ class EnvelopeTests : BaseUiTest() {
                 val transactionData = profilingTraceData.transactions
                     .firstOrNull { t -> t.id == transaction.eventId.toString() }
                 assertNotNull(transactionData)
-            }
-            assertEnvelope {
-                val transactionItem: SentryTransaction = it.assertItem()
-                it.assertNoOtherItems()
-                assertEquals("e2etests", transactionItem.transaction)
             }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()
@@ -130,6 +130,12 @@ class EnvelopeTests : BaseUiTest() {
             }
             // The profile is sent only in the last transaction envelope
             assertEnvelope {
+                val transactionItem: SentryTransaction = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
+            }
+            // The profile is sent only in the last transaction envelope
+            assertEnvelope {
                 val profilingTraceData: ProfilingTraceData = it.assertItem()
                 it.assertNoOtherItems()
                 assertEquals("e2etests2", profilingTraceData.transactionName)
@@ -162,12 +168,6 @@ class EnvelopeTests : BaseUiTest() {
                 // The first and last transactions should be aligned to the start/stop of profile
                 assertEquals(endTimes.last() - startTimes.first(), profilingTraceData.durationNs.toLong())
             }
-            // The profile is sent only in the last transaction envelope
-            assertEnvelope {
-                val transactionItem: SentryTransaction = it.assertItem()
-                it.assertNoOtherItems()
-                assertEquals(transaction3.eventId.toString(), transactionItem.eventId.toString())
-            }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()
         }
@@ -196,13 +196,13 @@ class EnvelopeTests : BaseUiTest() {
         finished = true
 
         relay.assert {
-            // The profile failed to be sent. Trying to read the envelope from the data transmitted throws an exception
-            assertFails { assertEnvelope {} }
             assertEnvelope {
                 val transactionItem: SentryTransaction = it.assertItem()
                 it.assertNoOtherItems()
                 assertEquals("e2etests", transactionItem.transaction)
             }
+            // The profile failed to be sent. Trying to read the envelope from the data transmitted throws an exception
+            assertFails { assertEnvelope {} }
             assertNoOtherEnvelopes()
             assertNoOtherRequests()
         }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -9,7 +9,6 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ProfilingTraceData
-import io.sentry.ProfilingTransactionData
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.android.core.SentryAndroidOptions
@@ -20,7 +19,6 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
@@ -59,14 +59,20 @@ class ProfilingActivity : AppCompatActivity() {
                 executors.submit { runMathOperations() }
             }
             executors.submit { swipeList() }
-            binding.profilingStart.postDelayed({ finishTransactionAndPrintResults(t) }, (seconds * 1000).toLong())
+
+            Thread {
+                Thread.sleep((seconds * 1000).toLong())
+                finishTransactionAndPrintResults(t)
+                binding.root.post {
+                    binding.profilingProgressBar.visibility = View.GONE
+                }
+            }.start()
         }
         setContentView(binding.root)
     }
 
     private fun finishTransactionAndPrintResults(t: ITransaction) {
         t.finish()
-        binding.profilingProgressBar.visibility = View.GONE
         profileFinished = true
         val profilesDirPath = Sentry.getCurrentHub().options.profilingTracesDirPath
         if (profilesDirPath == null) {
@@ -82,25 +88,31 @@ class ProfilingActivity : AppCompatActivity() {
             Thread.sleep((timeout - duration).coerceAtLeast(0))
         }
 
-        // Get the last trace file, which is the current profile
-        val origProfileFile = File(profilesDirPath).listFiles()?.maxByOrNull { f -> f.lastModified() }
-        // Create a new profile file and copy the content of the original file into it
-        val profile = File(cacheDir, UUID.randomUUID().toString())
-        origProfileFile?.copyTo(profile)
+        try {
+            // Get the last trace file, which is the current profile
+            val origProfileFile = File(profilesDirPath).listFiles()?.maxByOrNull { f -> f.lastModified() }
+            // Create a new profile file and copy the content of the original file into it
+            val profile = File(cacheDir, UUID.randomUUID().toString())
+            origProfileFile?.copyTo(profile)
 
-        val profileLength = profile.length()
-        val traceData = ProfilingTraceData(profile, t)
-        // Create envelope item from copied profile
-        val item =
-            SentryEnvelopeItem.fromProfilingTrace(traceData, Long.MAX_VALUE, Sentry.getCurrentHub().options.serializer)
-        val itemData = item.data
+            val profileLength = profile.length()
+            val traceData = ProfilingTraceData(profile, t)
+            // Create envelope item from copied profile
+            val item =
+                SentryEnvelopeItem.fromProfilingTrace(traceData, Long.MAX_VALUE, Sentry.getCurrentHub().options.serializer)
+            val itemData = item.data
 
-        // Compress the envelope item using Gzip
-        val bos = ByteArrayOutputStream()
-        GZIPOutputStream(bos).bufferedWriter().use { it.write(String(itemData)) }
+            // Compress the envelope item using Gzip
+            val bos = ByteArrayOutputStream()
+            GZIPOutputStream(bos).bufferedWriter().use { it.write(String(itemData)) }
 
-        binding.profilingResult.text =
-            getString(R.string.profiling_result, profileLength, itemData.size, bos.toByteArray().size)
+            binding.root.post {
+                binding.profilingResult.text =
+                    getString(R.string.profiling_result, profileLength, itemData.size, bos.toByteArray().size)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     private fun swipeList() {


### PR DESCRIPTION
## :scroll: Description
Removed a useless file exist check in AndroidTransactionProfiler
Offloaded AndroidTransactionProfiler methods to background threads using executor service


## :bulb: Motivation and Context
When using Android Strict Mode, the file io that was happening in the main thread (file existence checks) were generating warnings, as in this [issue](https://github.com/getsentry/sentry-java/issues/2317)

Closes #2317

## :green_heart: How did you test it?
I updated the unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
