### PR TITLE
updated ui test dependencies and benchmark device

### DIFF
--- a/.sauce/sentry-uitest-android-benchmark-lite.yml
+++ b/.sauce/sentry-uitest-android-benchmark-lite.yml
@@ -20,7 +20,7 @@ suites:
 
   - name: "Android 11 (api 30)"
     devices:
-      - id: Google_Pixel_2_real_us # Google Pixel 2 - api 30 (11)
+      - id: OnePlus_Nord_N200_5G_real_us # OnePlus Nord N200 5G - api 30 (11)
 
 artifacts:
   download:

--- a/.sauce/sentry-uitest-android-benchmark.yml
+++ b/.sauce/sentry-uitest-android-benchmark.yml
@@ -28,7 +28,7 @@ suites:
     devices:
       - id: OnePlus_9_Pro_real_us # OnePlus 9 Pro - api 30 (11) - high end
       - id: Google_Pixel_4_real_us # Google Pixel 4 - api 30 (11) - mid end
-      - id: Google_Pixel_2_real_us # Google Pixel 2 - api 30 (11) - low end
+      - id: OnePlus_Nord_N200_5G_real_us # OnePlus Nord N200 5G - api 30 (11) - low end
 
   - name: "Android 10 (api 29)"
     devices:

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -139,18 +139,16 @@ object Config {
     }
 
     object TestLibs {
-        private val androidxTestVersion = "1.4.0"
-
-        // todo This beta version is needed to run ui tests on Android 13.
-        //  It will be replaced by androidxTestVersion when 1.5.0 will be out.
-        private val androidxTestVersionBeta = "1.5.0-beta01"
-        private val espressoVersion = "3.4.0"
+        // todo These rc versions are needed to run ui tests on Android 13.
+        //  They will be replaced by stable version when 1.5.0/3.5.0 will be out.
+        private val androidxTestVersion = "1.5.0-rc01"
+        private val espressoVersion = "3.5.0-rc01"
 
         val androidJUnitRunner = "androidx.test.runner.AndroidJUnitRunner"
         val kotlinTestJunit = "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
-        val androidxCore = "androidx.test:core:$androidxTestVersionBeta"
+        val androidxCore = "androidx.test:core:$androidxTestVersion"
         val androidxRunner = "androidx.test:runner:$androidxTestVersion"
-        val androidxTestCoreKtx = "androidx.test:core-ktx:$androidxTestVersionBeta"
+        val androidxTestCoreKtx = "androidx.test:core-ktx:$androidxTestVersion"
         val androidxTestRules = "androidx.test:rules:$androidxTestVersion"
         val espressoCore = "androidx.test.espresso:espresso-core:$espressoVersion"
         val espressoIdlingResource = "androidx.test.espresso:espresso-idling-resource:$espressoVersion"


### PR DESCRIPTION
## :scroll: Description
updated ui test dependencies for Android 13
updated benchmark device
#skip-changelog


## :bulb: Motivation and Context
Ui test dependencies have been updated to work better on Android 13 (ui interactions through espresso was not working)
A device on Saucelabs is giving an error for a "Don't keep activities" developer option, which we have no control over. So we are changing it with another device with similar spec (Google Pixel 2 -> Oneplus Nord N200)


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
