### PR TITLE
fix: don't sent device name if DefaultPII is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `Gpu.vendorId` should be a String ([#2343](https://github.com/getsentry/sentry-java/pull/2343))
+- Don't set device name on Android if `sendDefaultPii` is disabled ([#2354](https://github.com/getsentry/sentry-java/pull/2354))
 
 ### Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We suggest opening an issue to discuss bigger changes before investing on a big 
 
 # Requirements
 
-The project currently requires you run JDK 11.
+The project currently requires you run JDK 17.
 
 ## Android
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -94,6 +94,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     // dont ref. to method reference, theres a bug on it
+    //noinspection Convert2MethodRef
     contextData = executorService.submit(() -> loadContextData());
 
     executorService.shutdown();
@@ -282,7 +283,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     // TODO: missing usable memory
 
     Device device = new Device();
-    device.setName(getDeviceName());
+    if (options.isSendDefaultPii()) {
+      device.setName(getDeviceName());
+    }
     device.setManufacturer(Build.MANUFACTURER);
     device.setBrand(Build.BRAND);
     device.setFamily(getFamily());


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #2063


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


