### PR TITLE
Fix corrupted UUID on Motorola devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 6.7.0
+## Unreleased
 
 ### Fixes
 
 - Fix `Gpu.vendorId` should be a String ([#2343](https://github.com/getsentry/sentry-java/pull/2343))
 - Don't set device name on Android if `sendDefaultPii` is disabled ([#2354](https://github.com/getsentry/sentry-java/pull/2354))
+- Fix corrupted UUID on Motorola devices ([#2363](https://github.com/getsentry/sentry-java/pull/2363))
 
 ### Features
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3376,6 +3376,7 @@ public final class io/sentry/util/StringUtils {
 	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
 	public static fun countOf (Ljava/lang/String;C)I
 	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;
+	public static fun normalizeUUID (Ljava/lang/String;)Ljava/lang/String;
 	public static fun removeSurrounding (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 

--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -1,12 +1,13 @@
 package io.sentry;
 
 import io.sentry.util.Objects;
+import io.sentry.util.StringUtils;
 import java.io.IOException;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
 public final class SpanId implements JsonSerializable {
-  public static final SpanId EMPTY_ID = new SpanId(new UUID(0, 0).toString());
+  public static final SpanId EMPTY_ID = new SpanId(new UUID(0, 0));
 
   private final @NotNull String value;
 
@@ -19,7 +20,7 @@ public final class SpanId implements JsonSerializable {
   }
 
   private SpanId(final @NotNull UUID uuid) {
-    this(uuid.toString().replace("-", "").substring(0, 16));
+    this(StringUtils.normalizeUUID(uuid.toString()).replace("-", "").substring(0, 16));
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/protocol/SentryId.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryId.java
@@ -5,6 +5,7 @@ import io.sentry.JsonDeserializer;
 import io.sentry.JsonObjectReader;
 import io.sentry.JsonObjectWriter;
 import io.sentry.JsonSerializable;
+import io.sentry.util.StringUtils;
 import java.io.IOException;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
@@ -27,12 +28,12 @@ public final class SentryId implements JsonSerializable {
   }
 
   public SentryId(final @NotNull String sentryIdString) {
-    this.uuid = fromStringSentryId(sentryIdString);
+    this.uuid = fromStringSentryId(StringUtils.normalizeUUID(sentryIdString));
   }
 
   @Override
   public String toString() {
-    return uuid.toString().replace("-", "");
+    return StringUtils.normalizeUUID(uuid.toString()).replace("-", "");
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -18,6 +18,9 @@ public final class StringUtils {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
+  private static final String CORRUPTED_NIL_UUID = "0000-0000";
+  private static final String PROPER_NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
   private StringUtils() {}
 
   public static @Nullable String getStringAfterDot(final @Nullable String str) {
@@ -137,5 +140,20 @@ public final class StringUtils {
       }
     }
     return count;
+  }
+
+  /**
+   * Normalizes UUID string representation to adhere to the actual UUID standard
+   *
+   * <p>Because Motorola decided that nil UUIDs should look like this: "0000-0000" ;)
+   *
+   * @param uuidString the original UUID string representation
+   * @return proper UUID string, in case it's a corrupted one
+   */
+  public static String normalizeUUID(final @NotNull String uuidString) {
+    if (uuidString.equals(CORRUPTED_NIL_UUID)) {
+      return PROPER_NIL_UUID;
+    }
+    return uuidString;
   }
 }

--- a/sentry/src/test/java/io/sentry/protocol/SentryIdTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryIdTest.kt
@@ -1,0 +1,13 @@
+package io.sentry.protocol
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SentryIdTest {
+
+    @Test
+    fun `does not throw when instantiated with corrupted UUID`() {
+        val id = SentryId("0000-0000")
+        assertEquals("00000000000000000000000000000000", id.toString())
+    }
+}

--- a/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.util
 
 import org.mockito.kotlin.mock
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -114,5 +115,18 @@ class StringUtilsTest {
         val hashEmpty = StringUtils.calculateStringHash("", mock())
 
         assertNull(hashEmpty)
+    }
+
+    @Test
+    fun `returns proper nil UUID if the given string is corrupted`() {
+        val normalized = StringUtils.normalizeUUID("0000-0000")
+        assertEquals("00000000-0000-0000-0000-000000000000", normalized)
+    }
+
+    @Test
+    fun `returns the unchanged UUID if it was not corrupted`() {
+        val original = UUID.randomUUID().toString()
+        val normalized = StringUtils.normalizeUUID(original)
+        assertEquals(original, normalized)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We tested it with Bruno and indeed it returns a corrupted UUID on his device, no matter which method is used to instantiate the UUID:
![image](https://user-images.githubusercontent.com/4999776/201904094-a3981f71-c8fe-4df7-a98a-fae8b3d83c10.png)

So this is just a band aid for those cases

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2325 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
