### PR TITLE
Fix ANR on dropped uncaught exception events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix `Gpu.vendorId` should be a String ([#2343](https://github.com/getsentry/sentry-java/pull/2343))
 - Don't set device name on Android if `sendDefaultPii` is disabled ([#2354](https://github.com/getsentry/sentry-java/pull/2354))
+- Fix ANR on dropped uncaught exception events ([#2368](https://github.com/getsentry/sentry-java/pull/2368))
 
 ### Features
 

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -7,6 +7,7 @@ import io.sentry.hints.DiskFlushNotification;
 import io.sentry.hints.Flushable;
 import io.sentry.hints.SessionEnd;
 import io.sentry.protocol.Mechanism;
+import io.sentry.protocol.SentryId;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.Closeable;
@@ -97,15 +98,18 @@ public final class UncaughtExceptionHandlerIntegration
 
         final Hint hint = HintUtils.createWithTypeCheckHint(exceptionHint);
 
-        hub.captureEvent(event, hint);
-        // Block until the event is flushed to disk
-        if (!exceptionHint.waitFlush()) {
-          options
-              .getLogger()
-              .log(
-                  SentryLevel.WARNING,
-                  "Timed out waiting to flush event to disk before crashing. Event: %s",
-                  event.getEventId());
+        final @NotNull SentryId sentryId = hub.captureEvent(event, hint);
+        final boolean isEventDropped = sentryId.equals(SentryId.EMPTY_ID);
+        if (!isEventDropped) {
+          // Block until the event is flushed to disk
+          if (!exceptionHint.waitFlush()) {
+            options
+                .getLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "Timed out waiting to flush event to disk before crashing. Event: %s",
+                    event.getEventId());
+          }
         }
       } catch (Throwable e) {
         options


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We were trying to flush the event to disk, even though the event was dropped and we never called `markFlushed`, hence it was blocking for 15seconds everytime the event is dropped 🙈 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2346 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
