### PR TITLE
Fix ensure all options are processed before integrations are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix ensure all options are processed before integrations are loaded ([#2377](https://github.com/getsentry/sentry-java/pull/2377))
+
 ## 6.7.1
 
 ### Fixes

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -224,6 +224,7 @@ public final class io/sentry/android/core/UserInteractionIntegration : android/a
 
 public final class io/sentry/android/core/cache/AndroidEnvelopeCache : io/sentry/cache/EnvelopeCache {
 	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;)V
+	public fun getDirectory ()Ljava/io/File;
 	public static fun hasStartupCrashMarker (Lio/sentry/SentryOptions;)Z
 	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.res.AssetManager;
 import android.os.Build;
-import androidx.annotation.NonNull;
 import io.sentry.ILogger;
 import io.sentry.SendFireAndForgetEnvelopeSender;
 import io.sentry.SendFireAndForgetOutboxSender;
@@ -45,7 +44,7 @@ final class AndroidOptionsInitializer {
    */
   @TestOnly
   static void loadDefaultAndMetadataOptions(
-      final @NotNull SentryAndroidOptions options, @NotNull Context context) {
+      final @NotNull SentryAndroidOptions options, final @NotNull Context context) {
     final ILogger logger = new AndroidLogger();
     loadDefaultAndMetadataOptions(options, context, logger, new BuildInfoProvider(logger));
   }
@@ -85,7 +84,7 @@ final class AndroidOptionsInitializer {
 
   @TestOnly
   static void initializeIntegrationsAndProcessors(
-      @NonNull SentryAndroidOptions options, @NonNull Context context) {
+      final @NotNull SentryAndroidOptions options, final @NotNull Context context) {
     initializeIntegrationsAndProcessors(
         options,
         context,
@@ -96,12 +95,12 @@ final class AndroidOptionsInitializer {
   }
 
   static void initializeIntegrationsAndProcessors(
-      @NonNull SentryAndroidOptions options,
-      @NonNull Context context,
-      @NonNull BuildInfoProvider buildInfoProvider,
-      @NonNull LoadClass loadClass,
-      boolean isFragmentAvailable,
-      boolean isTimberAvailable) {
+      final @NotNull SentryAndroidOptions options,
+      final @NotNull Context context,
+      final @NotNull BuildInfoProvider buildInfoProvider,
+      final @NotNull LoadClass loadClass,
+      final boolean isFragmentAvailable,
+      final boolean isTimberAvailable) {
     final ActivityFramesTracker activityFramesTracker =
         new ActivityFramesTracker(loadClass, options);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -15,6 +15,7 @@ import io.sentry.android.core.cache.AndroidEnvelopeCache;
 import io.sentry.android.core.internal.modules.AssetsModulesLoader;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
+import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -77,7 +78,6 @@ final class AndroidOptionsInitializer {
 
     ManifestMetadataReader.applyMetadata(context, options, buildInfoProvider);
     initializeCacheDirs(context, options);
-    options.setEnvelopeDiskCache(new AndroidEnvelopeCache(options));
 
     readDefaultOptionValues(options, context, buildInfoProvider);
   }
@@ -101,6 +101,12 @@ final class AndroidOptionsInitializer {
       final @NotNull LoadClass loadClass,
       final boolean isFragmentAvailable,
       final boolean isTimberAvailable) {
+
+    if (options.getCacheDirPath() != null
+        && options.getEnvelopeDiskCache() instanceof NoOpEnvelopeCache) {
+      options.setEnvelopeDiskCache(new AndroidEnvelopeCache(options));
+    }
+
     final ActivityFramesTracker activityFramesTracker =
         new ActivityFramesTracker(loadClass, options);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -43,6 +43,7 @@ final class AndroidOptionsInitializer {
    * @param options the SentryAndroidOptions
    * @param context the Application context
    */
+  @TestOnly
   static void loadDefaultAndMetadataOptions(
       final @NotNull SentryAndroidOptions options, @NotNull Context context) {
     final ILogger logger = new AndroidLogger();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -102,11 +102,24 @@ public final class SentryAndroid {
                 (isTimberUpstreamAvailable
                     && classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options));
 
-            AndroidOptionsInitializer.init(
-                options, context, logger, isFragmentAvailable, isTimberAvailable);
+            final BuildInfoProvider buildInfoProvider = new BuildInfoProvider(logger);
+            final LoadClass loadClass = new LoadClass();
+
+            AndroidOptionsInitializer.loadDefaultAndMetadataOptions(
+                options, context, logger, buildInfoProvider);
+
             configuration.configure(options);
-            deduplicateIntegrations(options, isFragmentAvailable, isTimberAvailable);
             resetEnvelopeCacheIfNeeded(options);
+
+            AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
+                options,
+                context,
+                buildInfoProvider,
+                loadClass,
+                isFragmentAvailable,
+                isTimberAvailable);
+
+            deduplicateIntegrations(options, isFragmentAvailable, isTimberAvailable);
           },
           true);
     } catch (IllegalAccessException e) {
@@ -132,7 +145,8 @@ public final class SentryAndroid {
 
   /**
    * Deduplicate potentially duplicated Fragment and Timber integrations, which can be added
-   * automatically by our SDK as well as by the user. The user's ones win over ours.
+   * automatically by our SDK as well as by the user. The user's ones (provided first in the
+   * options.integrations list) win over ours.
    *
    * @param options SentryOptions to retrieve integrations from
    */
@@ -158,14 +172,14 @@ public final class SentryAndroid {
     }
 
     if (fragmentIntegrations.size() > 1) {
-      for (int i = 0; i < fragmentIntegrations.size() - 1; i++) {
+      for (int i = 1; i < fragmentIntegrations.size(); i++) {
         final Integration integration = fragmentIntegrations.get(i);
         options.getIntegrations().remove(integration);
       }
     }
 
     if (timberIntegrations.size() > 1) {
-      for (int i = 0; i < timberIntegrations.size() - 1; i++) {
+      for (int i = 1; i < timberIntegrations.size(); i++) {
         final Integration integration = timberIntegrations.get(i);
         options.getIntegrations().remove(integration);
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -9,10 +9,8 @@ import io.sentry.OptionsContainer;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.android.core.cache.AndroidEnvelopeCache;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
-import io.sentry.transport.NoOpEnvelopeCache;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -109,7 +107,6 @@ public final class SentryAndroid {
                 options, context, logger, buildInfoProvider);
 
             configuration.configure(options);
-            resetEnvelopeCacheIfNeeded(options);
 
             AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
                 options,
@@ -183,20 +180,6 @@ public final class SentryAndroid {
         final Integration integration = timberIntegrations.get(i);
         options.getIntegrations().remove(integration);
       }
-    }
-  }
-
-  /**
-   * Resets envelope cache if {@link SentryOptions#getCacheDirPath()} was set to null by the user
-   * and the IEnvelopCache implementation remained ours (AndroidEnvelopeCache), which relies on
-   * cacheDirPath set.
-   *
-   * @param options SentryOptions to retrieve cacheDirPath from
-   */
-  private static void resetEnvelopeCacheIfNeeded(final @NotNull SentryAndroidOptions options) {
-    if (options.getCacheDirPath() == null
-        && options.getEnvelopeDiskCache() instanceof AndroidEnvelopeCache) {
-      options.setEnvelopeDiskCache(NoOpEnvelopeCache.getInstance());
     }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -17,6 +17,7 @@ import io.sentry.util.Objects;
 import java.io.File;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 @ApiStatus.Internal
 public final class AndroidEnvelopeCache extends EnvelopeCache {
@@ -56,6 +57,11 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
         writeStartupCrashMarkerFile();
       }
     }
+  }
+
+  @TestOnly
+  public @NotNull File getDirectory() {
+    return directory;
   }
 
   private void writeStartupCrashMarkerFile() {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -80,13 +80,13 @@ class AndroidOptionsInitializerTest {
 
             AndroidOptionsInitializer.loadDefaultAndMetadataOptions(
                 sentryOptions,
-                mockContext,
+                context,
                 logger,
                 buildInfo
             )
             AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
                 sentryOptions,
-                mockContext,
+                context,
                 buildInfo,
                 createClassMock(classToLoad),
                 isFragmentAvailable,
@@ -410,7 +410,7 @@ class AndroidOptionsInitializerTest {
 
     @Test
     fun `When Frames Tracking is disabled, the Activity Frames Tracker should not be available`() {
-        fixture.initSut(hasAppContext = true, configureOptions = {
+        fixture.initSut(hasAppContext = true, useRealContext = true, configureOptions = {
             isEnableFramesTracking = false
         })
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -71,7 +71,21 @@ class AndroidTransactionProfilerTest {
     @BeforeTest
     fun `set up`() {
         context = ApplicationProvider.getApplicationContext()
-        AndroidOptionsInitializer.init(fixture.options, context, fixture.mockLogger, false, false)
+        val buildInfoProvider = BuildInfoProvider(fixture.mockLogger)
+        AndroidOptionsInitializer.loadDefaultAndMetadataOptions(
+            fixture.options,
+            context,
+            fixture.mockLogger,
+            buildInfoProvider
+        )
+        AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
+            fixture.options,
+            context,
+            buildInfoProvider,
+            LoadClass(),
+            false,
+            false
+        )
         // Profiler doesn't start if the folder doesn't exists.
         // Usually it's generated when calling Sentry.init, but for tests we can create it manually.
         File(fixture.options.profilingTracesDirPath!!).mkdirs()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -132,7 +132,8 @@ class SentryInitProviderTest {
         val mockContext = ContextUtilsTest.mockMetaData(metaData = metaData)
         metaData.putBoolean(ManifestMetadataReader.NDK_ENABLE, false)
 
-        AndroidOptionsInitializer.init(sentryOptions, mockContext)
+        AndroidOptionsInitializer.loadDefaultAndMetadataOptions(sentryOptions, mockContext)
+        AndroidOptionsInitializer.initializeIntegrationsAndProcessors(sentryOptions, mockContext)
 
         assertFalse(sentryOptions.isEnableNdk)
     }


### PR DESCRIPTION
## :scroll: Description
Right now some integrations are created between default/auto-init and the custom `SentryOptions.configure` callback. If an integration copies references from `SentryOptions` it can hold a stale configuration, as the  `SentryOptions.configure` block can change any option afterwards.

This is a quick fix, I guess in the long run we should take a look into streamlining the overall SDK init process to avoid these kind of issues.

This PR splits up the `AndroidOptionsInitializer.init` method into two parts:
- `loadDefaultAndMetadataOptions()`
- `initializeIntegrationsAndProcessors()`

This allows us to execute execute the custom `OptionsConfiguration.configure()` callback in-between, which ensures all options are set before any integrations and processors are created.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2373


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
