### PR TITLE
Fix R8 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use `canonicalName` in Fragment Integration for better de-obfuscation ([#2379](https://github.com/getsentry/sentry-java/pull/2379))
+- Fix Timber and Fragment integrations auto-installation for obfuscated builds ([#2379](https://github.com/getsentry/sentry-java/pull/2379))
+
 ## 6.8.0
 
 ### Fixes

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -11,9 +11,11 @@
 -keep class androidx.lifecycle.ProcessLifecycleOwner { <init>(...); }
 ##---------------End: proguard configuration for androidx.lifecycle  ----------
 
-# To mitigate the issue on R8 site (https://issuetracker.google.com/issues/235733922) 
+# To mitigate the issue on R8 site (https://issuetracker.google.com/issues/235733922)
 # which comes through AGP 7.3.0-betaX and 7.4.0-alphaX
 -keepclassmembers enum io.sentry.** { *; }
+
+-keeppackagenames io.sentry.**
 
 # don't warn jetbrains annotations
 -dontwarn org.jetbrains.annotations.**

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -15,6 +15,7 @@
 # which comes through AGP 7.3.0-betaX and 7.4.0-alphaX
 -keepclassmembers enum io.sentry.** { *; }
 
+# To filter out io.sentry frames from stacktraces
 -keeppackagenames io.sentry.**
 
 # don't warn jetbrains annotations

--- a/sentry-android-fragment/proguard-rules.pro
+++ b/sentry-android-fragment/proguard-rules.pro
@@ -1,6 +1,6 @@
 ##---------------Begin: proguard configuration for Fragment  ----------
 
-# The Android SDK checks at runtime if this class is available via Class.forName
+# The Android SDK checks at runtime if these classes are available via Class.forName
 -keep class io.sentry.android.fragment.FragmentLifecycleIntegration { <init>(...); }
 -keepnames class androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks
 

--- a/sentry-android-fragment/proguard-rules.pro
+++ b/sentry-android-fragment/proguard-rules.pro
@@ -2,6 +2,7 @@
 
 # The Android SDK checks at runtime if this class is available via Class.forName
 -keep class io.sentry.android.fragment.FragmentLifecycleIntegration { <init>(...); }
+-keepnames class androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks
 
 # To ensure that stack traces is unambiguous
 # https://developer.android.com/studio/build/shrink-code#decode-stack-trace

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -143,7 +143,7 @@ class SentryFragmentLifecycleCallbacks(
     }
 
     private fun getFragmentName(fragment: Fragment): String {
-        return fragment.javaClass.simpleName
+        return fragment.javaClass.canonicalName ?: fragment.javaClass.simpleName
     }
 
     private fun isRunningSpan(fragment: Fragment): Boolean =

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -272,7 +272,7 @@ class SentryFragmentLifecycleCallbacksTest {
                 assertEquals("navigation", breadcrumb.type)
                 assertEquals(INFO, breadcrumb.level)
                 assertEquals(expectedState, breadcrumb.getData("state"))
-                assertEquals(fixture.fragment.javaClass.simpleName, breadcrumb.getData("screen"))
+                assertEquals(fixture.fragment.javaClass.canonicalName, breadcrumb.getData("screen"))
             },
             anyOrNull()
         )

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -198,7 +198,7 @@ class SentryFragmentLifecycleCallbacksTest {
                 assertEquals(SentryFragmentLifecycleCallbacks.FRAGMENT_LOAD_OP, it)
             },
             check {
-                assertEquals("Fragment", it)
+                assertEquals("androidx.fragment.app.Fragment", it)
             }
         )
     }

--- a/sentry-android-timber/proguard-rules.pro
+++ b/sentry-android-timber/proguard-rules.pro
@@ -1,6 +1,6 @@
 ##---------------Begin: proguard configuration for Timber  ----------
 
-# The Android SDK checks at runtime if this class is available via Class.forName
+# The Android SDK checks at runtime if these classes are available via Class.forName
 -keep class io.sentry.android.timber.SentryTimberIntegration { <init>(...); }
 -keepnames class timber.log.Timber
 

--- a/sentry-android-timber/proguard-rules.pro
+++ b/sentry-android-timber/proguard-rules.pro
@@ -2,6 +2,7 @@
 
 # The Android SDK checks at runtime if this class is available via Class.forName
 -keep class io.sentry.android.timber.SentryTimberIntegration { <init>(...); }
+-keepnames class timber.log.Timber
 
 # To ensure that stack traces is unambiguous
 # https://developer.android.com/studio/build/shrink-code#decode-stack-trace


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
While using minified builds I noticed that timber and fragment integrations do not get autoinstalled. Turns out it's because we're checking for presence of upstream dependencies classes (e.g. `timber.log.Timber`), but the get obfuscated too indeed. So this PR will keep their names so we can successfully check them. Along the way fixed another 2 issues:
* Use canonicalName instead of simpleName in Fragment Integration for better de-obfuscation
* Keep `io.sentry` package name to filter ouе our frames from stacktraces when sending the crashes. This adds ~5kb for the final apk size, but I guess this is not a big price.
 
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2362 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
