### PR TITLE
Bump Spring Boot to 2.7.5

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -4,7 +4,7 @@ object Config {
     val kotlinVersion = "1.6.10"
     val kotlinStdLib = "stdlib-jdk8"
 
-    val springBootVersion = "2.7.4"
+    val springBootVersion = "2.7.5"
     val springBoot3Version = "3.0.0-RC2"
     val kotlinCompatibleLanguageVersion = "1.4"
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bump Spring Boot dependency to `2.7.5`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

NOTE: We expect the dependency to be there and do not drag it in. So we don't dictate the version in our clients applications.
Should take care of security vulnerability warnings caused by an older version of jackson that Spring depends on.

## :green_heart: How did you test it?
Ran automated tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
