### PR TITLE
Add beforeSendTransaction which allows users to filter and change transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add beforeSendTransaction which allows users to filter and change transactions ([#2388](https://github.com/getsentry/sentry-java/pull/2388))
+
 ### Fixes
 
 - Use `canonicalName` in Fragment Integration for better de-obfuscation ([#2379](https://github.com/getsentry/sentry-java/pull/2379))

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -37,6 +37,16 @@ public class Main {
                 return event;
               });
 
+          options.setBeforeSendTransaction(
+              (transaction, hint) -> {
+                // Drop a transaction:
+                if (transaction.getTag("SomeTransactionTag") != null) {
+                  return null;
+                }
+
+                return transaction;
+              });
+
           // Allows inspecting and modifying, returning a new or simply rejecting (returning null)
           options.setBeforeBreadcrumb(
               (breadcrumb, hint) -> {

--- a/sentry-samples/sentry-samples-servlet/src/main/java/io/sentry/samples/servlet/SentryInitializer.java
+++ b/sentry-samples/sentry-samples-servlet/src/main/java/io/sentry/samples/servlet/SentryInitializer.java
@@ -35,6 +35,17 @@ public final class SentryInitializer implements ServletContextListener {
                 return event;
               });
 
+          // Modifications to transaction before it goes out. Could replace the transaction
+          // altogether
+          options.setBeforeSendTransaction(
+              (transaction, hint) -> {
+                // Drop a transaction altogether:
+                if (transaction.getTag("SomeTag") != null) {
+                  return null;
+                }
+                return transaction;
+              });
+
           // Allows inspecting and modifying, returning a new or simply rejecting (returning null)
           options.setBeforeBreadcrumb(
               (breadcrumb, hint) -> {

--- a/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -71,6 +71,7 @@ public class SentryAutoConfiguration {
     @Order(Ordered.HIGHEST_PRECEDENCE)
     public @NotNull Sentry.OptionsConfiguration<SentryOptions> sentryOptionsConfiguration(
         final @NotNull ObjectProvider<SentryOptions.BeforeSendCallback> beforeSendCallback,
+        final @NotNull ObjectProvider<SentryOptions.BeforeSendTransactionCallback> beforeSendTransactionCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
         final @NotNull ObjectProvider<SentryOptions.TracesSamplerCallback> tracesSamplerCallback,
@@ -81,6 +82,7 @@ public class SentryAutoConfiguration {
         final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
+        beforeSendTransactionCallback.ifAvailable(options::setBeforeSendTransaction);
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);
         eventProcessors.forEach(options::addEventProcessor);

--- a/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -15,6 +15,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.checkEvent
+import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.spring.jakarta.ContextTagsEventProcessor
 import io.sentry.spring.jakarta.HttpServletRequestSentryUserProvider
@@ -272,6 +273,15 @@ class SentryAutoConfigurationTest {
             .withUserConfiguration(CustomBeforeSendCallbackConfiguration::class.java)
             .run {
                 assertThat(it.getBean(SentryOptions::class.java).beforeSend).isInstanceOf(CustomBeforeSendCallback::class.java)
+            }
+    }
+
+    @Test
+    fun `registers beforeSendTransactionCallback on SentryOptions`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
+            .withUserConfiguration(CustomBeforeSendTransactionCallbackConfiguration::class.java)
+            .run {
+                assertThat(it.getBean(SentryOptions::class.java).beforeSendTransaction).isInstanceOf(CustomBeforeSendTransactionCallback::class.java)
             }
     }
 
@@ -718,6 +728,17 @@ class SentryAutoConfigurationTest {
 
     class CustomBeforeSendCallback : SentryOptions.BeforeSendCallback {
         override fun execute(event: SentryEvent, hint: Hint): SentryEvent? = null
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    open class CustomBeforeSendTransactionCallbackConfiguration {
+
+        @Bean
+        open fun beforeSendTransactionCallback() = CustomBeforeSendTransactionCallback()
+    }
+
+    class CustomBeforeSendTransactionCallback : SentryOptions.BeforeSendTransactionCallback {
+        override fun execute(event: SentryTransaction, hint: Hint): SentryTransaction? = null
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -71,6 +71,8 @@ public class SentryAutoConfiguration {
     @Order(Ordered.HIGHEST_PRECEDENCE)
     public @NotNull Sentry.OptionsConfiguration<SentryOptions> sentryOptionsConfiguration(
         final @NotNull ObjectProvider<SentryOptions.BeforeSendCallback> beforeSendCallback,
+        final @NotNull ObjectProvider<SentryOptions.BeforeSendTransactionCallback>
+                beforeSendTransactionCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
         final @NotNull ObjectProvider<SentryOptions.TracesSamplerCallback> tracesSamplerCallback,
@@ -81,6 +83,7 @@ public class SentryAutoConfiguration {
         final @NotNull InAppIncludesResolver inAppPackagesResolver) {
       return options -> {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
+        beforeSendTransactionCallback.ifAvailable(options::setBeforeSendTransaction);
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);
         eventProcessors.forEach(options::addEventProcessor);

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -15,6 +15,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.checkEvent
+import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.spring.ContextTagsEventProcessor
 import io.sentry.spring.HttpServletRequestSentryUserProvider
@@ -272,6 +273,15 @@ class SentryAutoConfigurationTest {
             .withUserConfiguration(CustomBeforeSendCallbackConfiguration::class.java)
             .run {
                 assertThat(it.getBean(SentryOptions::class.java).beforeSend).isInstanceOf(CustomBeforeSendCallback::class.java)
+            }
+    }
+
+    @Test
+    fun `registers beforeSendTransactionCallback on SentryOptions`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
+            .withUserConfiguration(CustomBeforeSendTransactionCallbackConfiguration::class.java)
+            .run {
+                assertThat(it.getBean(SentryOptions::class.java).beforeSendTransaction).isInstanceOf(CustomBeforeSendTransactionCallback::class.java)
             }
     }
 
@@ -718,6 +728,17 @@ class SentryAutoConfigurationTest {
 
     class CustomBeforeSendCallback : SentryOptions.BeforeSendCallback {
         override fun execute(event: SentryEvent, hint: Hint): SentryEvent? = null
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    open class CustomBeforeSendTransactionCallbackConfiguration {
+
+        @Bean
+        open fun beforeSendTransactionCallback() = CustomBeforeSendTransactionCallback()
+    }
+
+    class CustomBeforeSendTransactionCallback : SentryOptions.BeforeSendTransactionCallback {
+        override fun execute(event: SentryTransaction, hint: Hint): SentryTransaction? = null
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryInitBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryInitBeanPostProcessor.java
@@ -56,6 +56,9 @@ public class SentryInitBeanPostProcessor
             .getBeanProvider(SentryOptions.BeforeSendCallback.class)
             .ifAvailable(options::setBeforeSend);
         applicationContext
+          .getBeanProvider(SentryOptions.BeforeSendTransactionCallback.class)
+          .ifAvailable(options::setBeforeSendTransaction);
+        applicationContext
             .getBeanProvider(SentryOptions.BeforeBreadcrumbCallback.class)
             .ifAvailable(options::setBeforeBreadcrumb);
         applicationContext

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -56,6 +56,9 @@ public class SentryInitBeanPostProcessor
             .getBeanProvider(SentryOptions.BeforeSendCallback.class)
             .ifAvailable(options::setBeforeSend);
         applicationContext
+            .getBeanProvider(SentryOptions.BeforeSendTransactionCallback.class)
+            .ifAvailable(options::setBeforeSendTransaction);
+        applicationContext
             .getBeanProvider(SentryOptions.BeforeBreadcrumbCallback.class)
             .ifAvailable(options::setBeforeBreadcrumb);
         applicationContext

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1354,6 +1354,7 @@ public class io/sentry/SentryOptions {
 	public fun addTracingOrigin (Ljava/lang/String;)V
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
+	public fun getBeforeSendTransaction ()Lio/sentry/SentryOptions$BeforeSendTransactionCallback;
 	public fun getCacheDirPath ()Ljava/lang/String;
 	public fun getClientReportRecorder ()Lio/sentry/clientreport/IClientReportRecorder;
 	public fun getConnectionTimeoutMillis ()I
@@ -1432,6 +1433,7 @@ public class io/sentry/SentryOptions {
 	public fun setAttachThreads (Z)V
 	public fun setBeforeBreadcrumb (Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;)V
 	public fun setBeforeSend (Lio/sentry/SentryOptions$BeforeSendCallback;)V
+	public fun setBeforeSendTransaction (Lio/sentry/SentryOptions$BeforeSendTransactionCallback;)V
 	public fun setCacheDirPath (Ljava/lang/String;)V
 	public fun setConnectionTimeoutMillis (I)V
 	public fun setDebug (Z)V
@@ -1499,6 +1501,10 @@ public abstract interface class io/sentry/SentryOptions$BeforeBreadcrumbCallback
 
 public abstract interface class io/sentry/SentryOptions$BeforeSendCallback {
 	public abstract fun execute (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
+}
+
+public abstract interface class io/sentry/SentryOptions$BeforeSendTransactionCallback {
+	public abstract fun execute (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
 
 public abstract interface class io/sentry/SentryOptions$ProfilesSamplerCallback {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -571,6 +571,18 @@ public final class SentryClient implements ISentryClient {
       return SentryId.EMPTY_ID;
     }
 
+    transaction = executeBeforeSendTransaction(transaction, hint);
+
+    if (transaction == null) {
+      options
+          .getLogger()
+          .log(SentryLevel.DEBUG, "Transaction was dropped by beforeSendTransaction.");
+      options
+          .getClientReportRecorder()
+          .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Transaction);
+      return SentryId.EMPTY_ID;
+    }
+
     try {
       final SentryEnvelope envelope =
           buildEnvelope(
@@ -709,6 +721,35 @@ public final class SentryClient implements ISentryClient {
       }
     }
     return event;
+  }
+
+  private @Nullable SentryTransaction executeBeforeSendTransaction(
+      @NotNull SentryTransaction transaction, final @NotNull Hint hint) {
+    final SentryOptions.BeforeSendTransactionCallback beforeSendTransaction =
+        options.getBeforeSendTransaction();
+    if (beforeSendTransaction != null) {
+      try {
+        transaction = beforeSendTransaction.execute(transaction, hint);
+      } catch (Throwable e) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.ERROR,
+                "The BeforeSendTransaction callback threw an exception. It will be added as breadcrumb and continue.",
+                e);
+
+        final Breadcrumb breadcrumb = new Breadcrumb();
+        breadcrumb.setMessage("BeforeSendTransaction callback failed.");
+        breadcrumb.setCategory("SentryClient");
+        breadcrumb.setLevel(SentryLevel.ERROR);
+        if (e.getMessage() != null) {
+          breadcrumb.setData("sentry:message", e.getMessage());
+        }
+
+        transaction.addBreadcrumb(breadcrumb);
+      }
+    }
+    return transaction;
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -8,6 +8,7 @@ import io.sentry.clientreport.NoOpClientReportRecorder;
 import io.sentry.internal.modules.IModulesLoader;
 import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.protocol.SdkVersion;
+import io.sentry.protocol.SentryTransaction;
 import io.sentry.transport.ITransport;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
@@ -114,6 +115,12 @@ public class SentryOptions {
    * object or nothing to skip reporting the event
    */
   private @Nullable BeforeSendCallback beforeSend;
+
+  /**
+   * This function is called with an SDK specific transaction object and can return a modified
+   * transaction object or nothing to skip reporting the transaction
+   */
+  private @Nullable BeforeSendTransactionCallback beforeSendTransaction;
 
   /**
    * This function is called with an SDK specific breadcrumb object before the breadcrumb is added
@@ -610,6 +617,25 @@ public class SentryOptions {
    */
   public void setBeforeSend(@Nullable BeforeSendCallback beforeSend) {
     this.beforeSend = beforeSend;
+  }
+
+  /**
+   * Returns the BeforeSendTransaction callback
+   *
+   * @return the beforeSendTransaction callback or null if not set
+   */
+  public @Nullable BeforeSendTransactionCallback getBeforeSendTransaction() {
+    return beforeSendTransaction;
+  }
+
+  /**
+   * Sets the beforeSendTransaction callback
+   *
+   * @param beforeSendTransaction the beforeSendTransaction callback
+   */
+  public void setBeforeSendTransaction(
+      @Nullable BeforeSendTransactionCallback beforeSendTransaction) {
+    this.beforeSendTransaction = beforeSendTransaction;
   }
 
   /**
@@ -1778,6 +1804,21 @@ public class SentryOptions {
      */
     @Nullable
     SentryEvent execute(@NotNull SentryEvent event, @NotNull Hint hint);
+  }
+
+  /** The BeforeSendTransaction callback */
+  public interface BeforeSendTransactionCallback {
+
+    /**
+     * Mutates or drop a transaction before being sent
+     *
+     * @param transaction the transaction
+     * @param hint the hints
+     * @return the original transaction or the mutated transaction or null if transaction was
+     *     dropped
+     */
+    @Nullable
+    SentryTransaction execute(@NotNull SentryTransaction transaction, @NotNull Hint hint);
   }
 
   /** The BeforeBreadcrumb callback */


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Similar to `beforeSend` for errors `beforeSendTransaction` allows users to change and filter transactions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2358 

## :green_heart: How did you test it?
Unit tests, ran sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
