### PR TITLE
Disable otel modules in craft for release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -40,9 +40,9 @@ targets:
       maven:io.sentry:sentry-android-fragment:
       maven:io.sentry:sentry-bom:
       maven:io.sentry:sentry-openfeign:
-      maven:io.sentry:sentry-opentelemetry-agent:
-      maven:io.sentry:sentry-opentelemetry-agentcustomization:
-      maven:io.sentry:sentry-opentelemetry-core:
+#      maven:io.sentry:sentry-opentelemetry-agent:
+#      maven:io.sentry:sentry-opentelemetry-agentcustomization:
+#      maven:io.sentry:sentry-opentelemetry-core:
       maven:io.sentry:sentry-apollo:
       maven:io.sentry:sentry-jdbc:
       maven:io.sentry:sentry-graphql:


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Release keeps failing, maybe this helps

it might be using `.craft.yml` from `main` instead of the release branch.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
