### PR TITLE
No longer disable OpenTelemetry exporters in default Java Agent config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- No longer disable OpenTelemetry exporters in default Java Agent config ([#2408](https://github.com/getsentry/sentry-java/pull/2408))
+
 ## 6.9.1
 
 ### Fixes

--- a/sentry-opentelemetry/sentry-opentelemetry-agent/README.md
+++ b/sentry-opentelemetry/sentry-opentelemetry-agent/README.md
@@ -44,3 +44,17 @@ To enable debug logging for Sentry, please provide `SENTRY_DEBUG=true` as enviro
 add `debug=true` to your `sentry.properties`.
 
 To also show debug output for OpenTelemetry please add `-Dotel.javaagent.debug=true` to the command.
+
+## Getting rid of exporter error messages
+
+In case you are using this agent without needing to use any OpenTelemetry exporters you can add
+the following environment variables to turn off exporters and stop seeing error messages about 
+servers not being reachable in the logs.
+
+Example log message:
+```
+ERROR io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export metrics. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
+```
+
+To turn off exporting of traces you can set `OTEL_TRACES_EXPORTER=none`
+see [OpenTelemetry GitHub](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#otlp-exporter-span-metric-and-log-exporters)

--- a/sentry-opentelemetry/sentry-opentelemetry-agent/README.md
+++ b/sentry-opentelemetry/sentry-opentelemetry-agent/README.md
@@ -53,8 +53,16 @@ servers not being reachable in the logs.
 
 Example log message:
 ```
+ERROR io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export spans. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
 ERROR io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export metrics. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
 ```
 
+### Traces
+
 To turn off exporting of traces you can set `OTEL_TRACES_EXPORTER=none`
+see [OpenTelemetry GitHub](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#otlp-exporter-span-metric-and-log-exporters)
+
+### Metrics
+
+To turn off exporting of metrics you can set `OTEL_METRICS_EXPORTER=none`
 see [OpenTelemetry GitHub](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#otlp-exporter-span-metric-and-log-exporters)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
@@ -92,8 +92,6 @@ public final class SentryAutoConfigurationCustomizerProvider
 
   private Map<String, String> getDefaultProperties() {
     Map<String, String> properties = new HashMap<>();
-    properties.put("otel.traces.exporter", "none");
-    properties.put("otel.metrics.exporter", "none");
     properties.put("otel.propagators", "sentry");
     return properties;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Restore default exporter configuration for Sentry OpenTelemetry Java Agent.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To not confuse users who could use the Sentry Java Agent as drop in replacement for the original OpenTelemetry Java Agent we want to keep the default exporter settings and document how to get rid of ERROR messages in the logs.

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
