### PR TITLE
Add OpenTelemetryLinkErrorEventProcessor for linking errors to traces created via OpenTelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 - Add SENTRY_AUTO_INIT environment variable to control OpenTelemetry Agent init ([#2410](https://github.com/getsentry/sentry-java/pull/2410))
+- Add OpenTelemetryLinkErrorEventProcessor for linking errors to traces created via OpenTelemetry ([#2418](https://github.com/getsentry/sentry-java/pull/2418))
 
 ## 6.9.1
 

--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
@@ -28,6 +28,7 @@ public final class SentryAutoConfigurationCustomizerProvider
           options -> {
             options.setEnableExternalConfiguration(true);
             options.setInstrumenter(Instrumenter.OTEL);
+            options.addEventProcessor(new OpenTelemetryLinkErrorEventProcessor());
             final @Nullable SdkVersion sdkVersion = createSdkVersion(options);
             if (sdkVersion != null) {
               options.setSdkVersion(sdkVersion);

--- a/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
@@ -1,3 +1,8 @@
+public final class io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor : io/sentry/EventProcessor {
+	public fun <init> ()V
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
+}
+
 public final class io/sentry/opentelemetry/OtelSpanInfo {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;)V
 	public fun getDescription ()Ljava/lang/String;
@@ -24,13 +29,6 @@ public final class io/sentry/opentelemetry/SentrySpanProcessor : io/opentelemetr
 	public fun isStartRequired ()Z
 	public fun onEnd (Lio/opentelemetry/sdk/trace/ReadableSpan;)V
 	public fun onStart (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/trace/ReadWriteSpan;)V
-}
-
-public final class io/sentry/opentelemetry/SentrySpanStorage {
-	public fun get (Ljava/lang/String;)Lio/sentry/ISpan;
-	public static fun getInstance ()Lio/sentry/opentelemetry/SentrySpanStorage;
-	public fun removeAndGet (Ljava/lang/String;)Lio/sentry/ISpan;
-	public fun store (Ljava/lang/String;Lio/sentry/ISpan;)V
 }
 
 public final class io/sentry/opentelemetry/SpanDescriptionExtractor {

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor.java
@@ -1,0 +1,50 @@
+package io.sentry.opentelemetry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceId;
+import io.sentry.EventProcessor;
+import io.sentry.Hint;
+import io.sentry.HubAdapter;
+import io.sentry.ISpan;
+import io.sentry.Instrumenter;
+import io.sentry.SentryEvent;
+import io.sentry.SentrySpanStorage;
+import io.sentry.SpanContext;
+import io.sentry.protocol.SentryId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class OpenTelemetryLinkErrorEventProcessor implements EventProcessor {
+
+  private final @NotNull SentrySpanStorage spanStorage = SentrySpanStorage.getInstance();
+
+  @Override
+  public @Nullable SentryEvent process(final @NotNull SentryEvent event, final @NotNull Hint hint) {
+    if (Instrumenter.OTEL.equals(HubAdapter.getInstance().getOptions().getInstrumenter())) {
+      @NotNull final Span otelSpan = Span.current();
+      @NotNull final String traceId = otelSpan.getSpanContext().getTraceId();
+      @NotNull final String spanId = otelSpan.getSpanContext().getSpanId();
+
+      if (TraceId.isValid(traceId) && SpanId.isValid(spanId)) {
+        final @Nullable ISpan sentrySpan = spanStorage.get(spanId);
+        if (sentrySpan != null) {
+          final @NotNull SpanContext sentrySpanSpanContext = sentrySpan.getSpanContext();
+          final @NotNull String operation = sentrySpanSpanContext.getOperation();
+          final @Nullable io.sentry.SpanId parentSpanId = sentrySpanSpanContext.getParentSpanId();
+          final @NotNull SpanContext spanContext =
+              new SpanContext(
+                  new SentryId(traceId),
+                  new io.sentry.SpanId(spanId),
+                  operation,
+                  parentSpanId,
+                  null);
+
+          event.getContexts().setTrace(spanContext);
+        }
+      }
+    }
+
+    return event;
+  }
+}

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentryPropagator.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentryPropagator.java
@@ -11,6 +11,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import io.sentry.Baggage;
 import io.sentry.BaggageHeader;
 import io.sentry.ISpan;
+import io.sentry.SentrySpanStorage;
 import io.sentry.SentryTraceHeader;
 import io.sentry.exception.InvalidSentryTraceHeaderException;
 import java.util.Arrays;

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanProcessor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanProcessor.java
@@ -19,6 +19,7 @@ import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Instrumenter;
+import io.sentry.SentrySpanStorage;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanId;
 import io.sentry.SpanStatus;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1562,6 +1562,13 @@ public abstract interface class io/sentry/SentryOptions$TracesSamplerCallback {
 	public abstract fun sample (Lio/sentry/SamplingContext;)Ljava/lang/Double;
 }
 
+public final class io/sentry/SentrySpanStorage {
+	public fun get (Ljava/lang/String;)Lio/sentry/ISpan;
+	public static fun getInstance ()Lio/sentry/SentrySpanStorage;
+	public fun removeAndGet (Ljava/lang/String;)Lio/sentry/ISpan;
+	public fun store (Ljava/lang/String;Lio/sentry/ISpan;)V
+}
+
 public final class io/sentry/SentryTraceHeader {
 	public static final field SENTRY_TRACE_HEADER Ljava/lang/String;
 	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Ljava/lang/Boolean;)V

--- a/sentry/src/main/java/io/sentry/SentrySpanStorage.java
+++ b/sentry/src/main/java/io/sentry/SentrySpanStorage.java
@@ -6,6 +6,10 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Has been moved to `sentry` gradle module to include it in the bootstrap classloader without
+ * having to introduce yet another module for OpenTelemetry support.
+ */
 @ApiStatus.Internal
 public final class SentrySpanStorage {
   private static volatile @Nullable SentrySpanStorage INSTANCE;

--- a/sentry/src/main/java/io/sentry/SentrySpanStorage.java
+++ b/sentry/src/main/java/io/sentry/SentrySpanStorage.java
@@ -1,6 +1,5 @@
-package io.sentry.opentelemetry;
+package io.sentry;
 
-import io.sentry.ISpan;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Retrieve current `Span` from OpenTelemetry, then look up the Sentry span via `spanId` and add `traceId`, `spanId`, `parentSpanId` and `op` to the error events context keyed `"trace"`.

Had to move `SentrySpanStorage` from `sentry-opentelemetry-core` module to `sentry` module to avoid yet another module just for providing `SentrySpanStorage` in the bootstrap classloader.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With this change, Sentry UI can now show a link from transaction to error event and vice versa.

## :green_heart: How did you test it?
Manually via Spring Boot Sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
