### PR TITLE
Fix Android ui flaky tests checking order of envelopes

### DIFF
--- a/.sauce/sentry-uitest-android-benchmark-lite.yml
+++ b/.sauce/sentry-uitest-android-benchmark-lite.yml
@@ -19,6 +19,9 @@ espresso:
 suites:
 
   - name: "Android 11 (api 30)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: Google_Pixel_3a_real # Google Pixel 3a - api 30 (11)
 

--- a/.sauce/sentry-uitest-android-benchmark.yml
+++ b/.sauce/sentry-uitest-android-benchmark.yml
@@ -20,17 +20,26 @@ suites:
 
   # Devices are chosen so that there is a high-end and a low-end device for each api level
   - name: "Android 12 (api 31)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: Google_Pixel_6_Pro_real_us # Google Pixel 6 Pro - api 31 (12) - high end
       - id: Google_Pixel_6a_real_us # Google Pixel 6a - api 31 (12) - low end
 
   - name: "Android 11 (api 30)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: OnePlus_9_Pro_real_us # OnePlus 9 Pro - api 30 (11) - high end
       - id: Google_Pixel_4_real_us # Google Pixel 4 - api 30 (11) - mid end
       - id: Google_Pixel_3a_real # Google Pixel 3a - api 30 (11) - low end
 
   - name: "Android 10 (api 29)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: Google_Pixel_4_XL_real_us1 # Google Pixel 4 XL - api 29 (10)
       - id: Nokia_7_1_real_us # Nokia 7.1 - api 29 (10)

--- a/.sauce/sentry-uitest-android-ui.yml
+++ b/.sauce/sentry-uitest-android-ui.yml
@@ -19,18 +19,30 @@ espresso:
 suites:
 
   - name: "Android 13 Ui test (api 33)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: Google_Pixel_5_13_real_us # Google Pixel 5 - api 33 (13)
 
   - name: "Android 12 Ui test (api 31)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: Samsung_Galaxy_S22_Ultra_5G_real_us # Samsung Galaxy S22 Ultra 5G - api 31 (12)
 
   - name: "Android 11 Ui test (api 30)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: OnePlus_9_Pro_real_us # OnePlus 9 Pro - api 30 (11)
 
   - name: "Android 10 Ui test (api 29)"
+    testOptions:
+      clearPackageData: true
+      useTestOrchestrator: true
     devices:
       - id: OnePlus_7T_real_us # OnePlus 7T - api 29 (10)
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -167,7 +167,7 @@ object Config {
         val androidxTestRules = "androidx.test:rules:$androidxTestVersion"
         val espressoCore = "androidx.test.espresso:espresso-core:$espressoVersion"
         val espressoIdlingResource = "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
-        val androidxTestOrchestrator = "androidx.test:orchestrator:1.4.1"
+        val androidxTestOrchestrator = "androidx.test:orchestrator:1.4.2"
         val androidxJunit = "androidx.test.ext:junit:1.1.3"
         val androidxCoreKtx = "androidx.core:core-ktx:1.7.0"
         val robolectric = "org.robolectric:robolectric:4.7.3"

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -26,8 +26,11 @@ android {
         // https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#enable-gradle
         // This doesn't work on some devices with Android 11+. Clearing package data resets permissions.
         // Check the readme for more info.
-        // Test orchestrator was removed due to issues with SauceLabs
-//        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
+
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
     buildFeatures {

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -25,8 +25,11 @@ android {
         // https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#enable-gradle
         // This doesn't work on some devices with Android 11+. Clearing package data resets permissions.
         // Check the readme for more info.
-        // Test orchestrator was removed due to issues with SauceLabs
-//        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
+
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
     }
 
     buildFeatures {

--- a/sentry-test-support/src/main/kotlin/io/sentry/Assertions.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/Assertions.kt
@@ -32,7 +32,10 @@ fun checkTransaction(predicate: (SentryTransaction) -> Unit): SentryEnvelope {
 /**
  * Asserts an envelope item of [T] exists in [items] and returns the first one. Otherwise it throws an [AssertionError].
  */
-inline fun <reified T> assertEnvelopeItem(items: List<SentryEnvelopeItem>, predicate: (index: Int, item: T) -> Unit): T {
+inline fun <reified T> assertEnvelopeItem(
+    items: List<SentryEnvelopeItem>,
+    predicate: (index: Int, item: T) -> Unit = { _, _ -> }
+): T {
     val item = items.mapIndexedNotNull { index, it ->
         val deserialized = JsonSerializer(SentryOptions()).deserialize(it.data.inputStream().reader(), T::class.java)
         deserialized?.let { Pair(index, it) }


### PR DESCRIPTION
## :scroll: Description
ui tests now search the envelope among all the ones sent to the mock relay server and make assertion on them, instead of relying on the order the envelopes were created
added androidx test orchestrator to saucelabs configuration with "clearPackageData" option enabled 
updated androidx orchestrator dependency
renamed transactions in tests to be more useful

#skip-changelog


## :bulb: Motivation and Context
The ui tests were flaky, as sometimes (rarely) the envelopes were not sent in the creation order, causing https://github.com/getsentry/sentry-java/issues/2396


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [] I added tests to verify the changes
- [] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
