### PR TITLE
Revert sourcesets config to produce same modules as before

### DIFF
--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
     android {
         publishLibraryVariants("release")
     }
-    jvm() {
+    jvm("desktop") {
         compilations.all {
             kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
@@ -42,21 +42,12 @@ kotlin {
                 api(compose.ui)
 
                 implementation(Config.Libs.kotlinStdLib)
-            }
-        }
-
-        val jvmMain by getting {
-            dependencies {
-                api(projects.sentry)
-                implementation(Config.Libs.kotlinStdLib)
                 api(projects.sentryComposeHelper)
             }
         }
-
         val androidMain by getting {
-            dependsOn(jvmMain)
-
             dependencies {
+                api(projects.sentry)
                 api(projects.sentryAndroidNavigation)
 
                 api(Config.Libs.composeNavigation)


### PR DESCRIPTION
## :scroll: Description
This will produce artifacts for `sentry-compose`, `sentry-compose-android`, `sentry-compose-desktop`


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

#skip-changelog
