### PR TITLE
ci: specify explicit java version in update-gradle.sh

### DIFF
--- a/scripts/update-gradle.sh
+++ b/scripts/update-gradle.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 cd $(dirname "$0")/../
 
+if [[ -n ${CI+x} ]]; then
+    export JAVA_HOME=$JAVA_HOME_17_X64
+fi
+
 case $1 in
 get-version)
     # `./gradlew` shows some info on the first run, breaking the parsing in the next step.


### PR DESCRIPTION
Should fix https://github.com/getsentry/sentry-java/actions/runs/3730123923/jobs/6326807766