### PR TITLE
Collect memory usage in transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Features
-
-- Disable Android concurrent profiling ([#2434](https://github.com/getsentry/sentry-java/pull/2434))
-
 ### Fixes
 
 - Use minSdk compatible `Objects` class ([#2436](https://github.com/getsentry/sentry-java/pull/2436))
@@ -13,6 +9,8 @@
 
 ### Features
 
+- Collect memory usage in transactions ([#2445](https://github.com/getsentry/sentry-java/pull/2445))
+- Disable Android concurrent profiling ([#2434](https://github.com/getsentry/sentry-java/pull/2434))
 - Add logging for OpenTelemetry integration ([#2425](https://github.com/getsentry/sentry-java/pull/2425))
 - Auto add `OpenTelemetryLinkErrorEventProcessor` for Spring Boot ([#2429](https://github.com/getsentry/sentry-java/pull/2429))
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -32,6 +32,11 @@ public final class io/sentry/android/core/AndroidLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public class io/sentry/android/core/AndroidMemoryCollector : io/sentry/IMemoryCollector {
+	public fun <init> ()V
+	public fun collect ()Lio/sentry/MemoryCollectionData;
+}
+
 public final class io/sentry/android/core/AnrIntegration : io/sentry/Integration, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;)V
 	public fun close ()V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidMemoryCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidMemoryCollector.java
@@ -1,0 +1,17 @@
+package io.sentry.android.core;
+
+import android.os.Debug;
+import io.sentry.IMemoryCollector;
+import io.sentry.MemoryCollectionData;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class AndroidMemoryCollector implements IMemoryCollector {
+  @Override
+  public MemoryCollectionData collect() {
+    long now = System.currentTimeMillis();
+    long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+    long usedNativeMemory = Debug.getNativeHeapSize() - Debug.getNativeHeapFreeSize();
+    return new MemoryCollectionData(now, usedMemory, usedNativeMemory);
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -161,6 +161,7 @@ final class AndroidOptionsInitializer {
       options.setGestureTargetLocators(gestureTargetLocators);
     }
     options.setMainThreadChecker(AndroidMainThreadChecker.getInstance());
+    options.setMemoryCollector(new AndroidMemoryCollector());
   }
 
   private static void installDefaultIntegrations(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
@@ -1,0 +1,29 @@
+package io.sentry.android.core
+
+import android.os.Debug
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+class AndroidMemoryCollectorTest {
+
+    private val fixture = Fixture()
+
+    private class Fixture {
+        val runtime: Runtime = Runtime.getRuntime()
+        val collector = AndroidMemoryCollector()
+    }
+
+    @Test
+    fun `when collect, both native and heap memory are collected`() {
+        val usedNativeMemory = Debug.getNativeHeapSize() - Debug.getNativeHeapFreeSize()
+        val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
+        val data = fixture.collector.collect()
+        assertNotNull(data)
+        assertNotEquals(-1, data.usedNativeMemory)
+        assertEquals(usedNativeMemory, data.usedNativeMemory)
+        assertEquals(usedMemory, data.usedHeapMemory)
+        assertNotEquals(0, data.timestamp)
+    }
+}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -484,4 +484,11 @@ class AndroidOptionsInitializerTest {
         assertTrue { fixture.sentryOptions.gestureTargetLocators[0] is AndroidViewGestureTargetLocator }
         assertTrue { fixture.sentryOptions.gestureTargetLocators[1] is ComposeGestureTargetLocator }
     }
+
+    @Test
+    fun `AndroidMemoryCollector is set to options`() {
+        fixture.initSut()
+
+        assertTrue { fixture.sentryOptions.memoryCollector is AndroidMemoryCollector }
+    }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -441,6 +441,10 @@ public abstract interface class io/sentry/ILogger {
 	public abstract fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public abstract interface class io/sentry/IMemoryCollector {
+	public abstract fun collect ()Lio/sentry/MemoryCollectionData;
+}
+
 public abstract interface class io/sentry/IScopeObserver {
 	public abstract fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
 	public abstract fun removeExtra (Ljava/lang/String;)V
@@ -558,6 +562,11 @@ public abstract interface class io/sentry/Integration {
 
 public final class io/sentry/IpAddressUtils {
 	public static fun isDefault (Ljava/lang/String;)Z
+}
+
+public final class io/sentry/JavaMemoryCollector : io/sentry/IMemoryCollector {
+	public fun <init> ()V
+	public fun collect ()Lio/sentry/MemoryCollectionData;
 }
 
 public abstract interface class io/sentry/JsonDeserializer {
@@ -681,6 +690,14 @@ public final class io/sentry/MeasurementUnit$Information : java/lang/Enum, io/se
 	public static fun values ()[Lio/sentry/MeasurementUnit$Information;
 }
 
+public final class io/sentry/MemoryCollectionData {
+	public fun <init> (JJ)V
+	public fun <init> (JJJ)V
+	public fun getTimestamp ()J
+	public fun getUsedHeapMemory ()J
+	public fun getUsedNativeMemory ()J
+}
+
 public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
 	public static fun getInstance ()Lio/sentry/NoOpEnvelopeReader;
 	public fun read (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
@@ -736,6 +753,11 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;Ljava/lang/Throwable;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/NoOpMemoryCollector : io/sentry/IMemoryCollector {
+	public fun collect ()Lio/sentry/MemoryCollectionData;
+	public static fun getInstance ()Lio/sentry/NoOpMemoryCollector;
 }
 
 public final class io/sentry/NoOpSpan : io/sentry/ISpan {
@@ -1411,6 +1433,7 @@ public class io/sentry/SentryOptions {
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
 	public fun getMaxSpans ()I
 	public fun getMaxTraceFileSize ()J
+	public fun getMemoryCollector ()Lio/sentry/IMemoryCollector;
 	public fun getModulesLoader ()Lio/sentry/internal/modules/IModulesLoader;
 	public fun getOutboxPath ()Ljava/lang/String;
 	public fun getProfilesSampleRate ()Ljava/lang/Double;
@@ -1498,6 +1521,7 @@ public class io/sentry/SentryOptions {
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setMaxSpans (I)V
 	public fun setMaxTraceFileSize (J)V
+	public fun setMemoryCollector (Lio/sentry/IMemoryCollector;)V
 	public fun setModulesLoader (Lio/sentry/internal/modules/IModulesLoader;)V
 	public fun setPrintUncaughtStackTrace (Z)V
 	public fun setProfilesSampleRate (Ljava/lang/Double;)V
@@ -1942,6 +1966,12 @@ public final class io/sentry/TransactionOptions {
 	public fun setTransactionFinishedCallback (Lio/sentry/TransactionFinishedCallback;)V
 	public fun setTrimEnd (Z)V
 	public fun setWaitForChildren (Z)V
+}
+
+public final class io/sentry/TransactionPerformanceCollector {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun start (Lio/sentry/ITransaction;)V
+	public fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
 
 public final class io/sentry/TypeCheckHint {

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -30,6 +30,7 @@ public final class Hub implements IHub {
   private final @NotNull TracesSampler tracesSampler;
   private final @NotNull Map<Throwable, Pair<WeakReference<ISpan>, String>> throwableToSpan =
       Collections.synchronizedMap(new WeakHashMap<>());
+  private final @NotNull TransactionPerformanceCollector transactionPerformanceCollector;
 
   public Hub(final @NotNull SentryOptions options) {
     this(options, createRootStackItem(options));
@@ -44,6 +45,7 @@ public final class Hub implements IHub {
     this.tracesSampler = new TracesSampler(options);
     this.stack = stack;
     this.lastEventId = SentryId.EMPTY_ID;
+    this.transactionPerformanceCollector = new TransactionPerformanceCollector(options);
 
     // Integrations will use this Hub instance once registered.
     // Make sure Hub ready to be used then.
@@ -730,7 +732,8 @@ public final class Hub implements IHub {
               waitForChildren,
               idleTimeout,
               trimEnd,
-              transactionFinishedCallback);
+              transactionFinishedCallback,
+              transactionPerformanceCollector);
 
       // The listener is called only if the transaction exists, as the transaction is needed to
       // stop it

--- a/sentry/src/main/java/io/sentry/IMemoryCollector.java
+++ b/sentry/src/main/java/io/sentry/IMemoryCollector.java
@@ -1,0 +1,12 @@
+package io.sentry;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/** Used for collecting data about memory load when a transaction is active. */
+@ApiStatus.Internal
+public interface IMemoryCollector {
+  /** Used for collecting data about memory load when a transaction is active. */
+  @Nullable
+  MemoryCollectionData collect();
+}

--- a/sentry/src/main/java/io/sentry/JavaMemoryCollector.java
+++ b/sentry/src/main/java/io/sentry/JavaMemoryCollector.java
@@ -1,0 +1,18 @@
+package io.sentry;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class JavaMemoryCollector implements IMemoryCollector {
+
+  private final @NotNull Runtime runtime = Runtime.getRuntime();
+
+  @Override
+  public @Nullable MemoryCollectionData collect() {
+    final long now = System.currentTimeMillis();
+    final long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+    return new MemoryCollectionData(now, usedMemory);
+  }
+}

--- a/sentry/src/main/java/io/sentry/MemoryCollectionData.java
+++ b/sentry/src/main/java/io/sentry/MemoryCollectionData.java
@@ -1,0 +1,33 @@
+package io.sentry;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class MemoryCollectionData {
+  final long timestamp;
+  final long usedHeapMemory;
+  final long usedNativeMemory;
+
+  public MemoryCollectionData(
+      final long timestamp, final long usedHeapMemory, final long usedNativeMemory) {
+    this.timestamp = timestamp;
+    this.usedHeapMemory = usedHeapMemory;
+    this.usedNativeMemory = usedNativeMemory;
+  }
+
+  public MemoryCollectionData(final long timestamp, final long usedHeapMemory) {
+    this(timestamp, usedHeapMemory, -1);
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public long getUsedHeapMemory() {
+    return usedHeapMemory;
+  }
+
+  public long getUsedNativeMemory() {
+    return usedNativeMemory;
+  }
+}

--- a/sentry/src/main/java/io/sentry/NoOpMemoryCollector.java
+++ b/sentry/src/main/java/io/sentry/NoOpMemoryCollector.java
@@ -1,0 +1,21 @@
+package io.sentry;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class NoOpMemoryCollector implements IMemoryCollector {
+
+  private static final NoOpMemoryCollector instance = new NoOpMemoryCollector();
+
+  public static NoOpMemoryCollector getInstance() {
+    return instance;
+  }
+
+  private NoOpMemoryCollector() {}
+
+  @Override
+  public @Nullable MemoryCollectionData collect() {
+    return null;
+  }
+}

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -288,6 +288,10 @@ public final class Sentry {
       options.setMainThreadChecker(MainThreadChecker.getInstance());
     }
 
+    if (options.getMemoryCollector() instanceof NoOpMemoryCollector) {
+      options.setMemoryCollector(new JavaMemoryCollector());
+    }
+
     return true;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -385,6 +385,8 @@ public class SentryOptions {
 
   private @NotNull IMainThreadChecker mainThreadChecker = NoOpMainThreadChecker.getInstance();
 
+  private @NotNull IMemoryCollector memoryCollector = NoOpMemoryCollector.getInstance();
+
   /**
    * Adds an event processor
    *
@@ -1874,6 +1876,25 @@ public class SentryOptions {
 
   public void setMainThreadChecker(final @NotNull IMainThreadChecker mainThreadChecker) {
     this.mainThreadChecker = mainThreadChecker;
+  }
+
+  /**
+   * Gets the memory collector used to collect memory usage during while transaction runs.
+   *
+   * @return the memory collector.
+   */
+  public @NotNull IMemoryCollector getMemoryCollector() {
+    return memoryCollector;
+  }
+
+  /**
+   * Sets the memory collector to collect memory usage during while transaction runs.
+   *
+   * @param memoryCollector - the memory collector. If null, a no op collector will be set.
+   */
+  public void setMemoryCollector(final @Nullable IMemoryCollector memoryCollector) {
+    this.memoryCollector =
+        memoryCollector != null ? memoryCollector : NoOpMemoryCollector.getInstance();
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1883,6 +1883,7 @@ public class SentryOptions {
    *
    * @return the memory collector.
    */
+  @ApiStatus.Internal
   public @NotNull IMemoryCollector getMemoryCollector() {
     return memoryCollector;
   }
@@ -1892,6 +1893,7 @@ public class SentryOptions {
    *
    * @param memoryCollector - the memory collector. If null, a no op collector will be set.
    */
+  @ApiStatus.Internal
   public void setMemoryCollector(final @Nullable IMemoryCollector memoryCollector) {
     this.memoryCollector =
         memoryCollector != null ? memoryCollector : NoOpMemoryCollector.getInstance();

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -80,9 +80,10 @@ public final class SentryTracer implements ITransaction {
   private final @NotNull Map<String, MeasurementValue> measurements;
   private final @NotNull Instrumenter instrumenter;
   private final @NotNull Contexts contexts = new Contexts();
+  private final @Nullable TransactionPerformanceCollector transactionPerformanceCollector;
 
   public SentryTracer(final @NotNull TransactionContext context, final @NotNull IHub hub) {
-    this(context, hub, null);
+    this(context, hub, null, false, null, false, null);
   }
 
   public SentryTracer(
@@ -96,8 +97,20 @@ public final class SentryTracer implements ITransaction {
   SentryTracer(
       final @NotNull TransactionContext context,
       final @NotNull IHub hub,
-      final @Nullable Date startTimestamp) {
-    this(context, hub, startTimestamp, false, null, false, null);
+      final @Nullable Date startTimestamp,
+      final boolean waitForChildren,
+      final @Nullable Long idleTimeout,
+      final boolean trimEnd,
+      final @Nullable TransactionFinishedCallback transactionFinishedCallback) {
+    this(
+        context,
+        hub,
+        startTimestamp,
+        waitForChildren,
+        idleTimeout,
+        trimEnd,
+        transactionFinishedCallback,
+        null);
   }
 
   SentryTracer(
@@ -107,7 +120,8 @@ public final class SentryTracer implements ITransaction {
       final boolean waitForChildren,
       final @Nullable Long idleTimeout,
       final boolean trimEnd,
-      final @Nullable TransactionFinishedCallback transactionFinishedCallback) {
+      final @Nullable TransactionFinishedCallback transactionFinishedCallback,
+      final @Nullable TransactionPerformanceCollector transactionPerformanceCollector) {
     Objects.requireNonNull(context, "context is required");
     Objects.requireNonNull(hub, "hub is required");
     this.measurements = new ConcurrentHashMap<>();
@@ -119,12 +133,17 @@ public final class SentryTracer implements ITransaction {
     this.idleTimeout = idleTimeout;
     this.trimEnd = trimEnd;
     this.transactionFinishedCallback = transactionFinishedCallback;
+    this.transactionPerformanceCollector = transactionPerformanceCollector;
     this.transactionNameSource = context.getTransactionNameSource();
 
     if (context.getBaggage() != null) {
       this.baggage = context.getBaggage();
     } else {
       this.baggage = new Baggage(hub.getOptions().getLogger());
+    }
+
+    if (transactionPerformanceCollector != null) {
+      transactionPerformanceCollector.start(this);
     }
 
     if (idleTimeout != null) {
@@ -327,6 +346,10 @@ public final class SentryTracer implements ITransaction {
   public void finish(@Nullable SpanStatus status, @Nullable Date finishDate) {
     this.finishStatus = FinishStatus.finishing(status);
     if (!root.isFinished() && (!waitForChildren || hasAllChildrenFinished())) {
+      if (transactionPerformanceCollector != null) {
+        transactionPerformanceCollector.stop(this);
+      }
+
       ProfilingTraceData profilingTraceData = null;
       if (Boolean.TRUE.equals(isSampled()) && Boolean.TRUE.equals(isProfileSampled())) {
         profilingTraceData = hub.getOptions().getTransactionProfiler().onTransactionFinish(this);

--- a/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
@@ -1,0 +1,84 @@
+package io.sentry;
+
+import io.sentry.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+@ApiStatus.Internal
+public final class TransactionPerformanceCollector {
+  private static final long TRANSACTION_COLLECTION_INTERVAL_MILLIS = 100;
+  private static final long TRANSACTION_COLLECTION_TIMEOUT_MILLIS = 30000;
+  private @NotNull Timer timer = new Timer();
+  private final @NotNull Map<String, ArrayList<MemoryCollectionData>> memoryMap =
+      new ConcurrentHashMap<>();
+  private final @NotNull IMemoryCollector memoryCollector;
+  private final @NotNull SentryOptions options;
+  private final @NotNull AtomicBoolean isStarted = new AtomicBoolean(false);
+
+  public TransactionPerformanceCollector(final @NotNull SentryOptions options) {
+    this.options = Objects.requireNonNull(options, "The options object is required.");
+    this.memoryCollector = options.getMemoryCollector();
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void start(final @NotNull ITransaction transaction) {
+    if (memoryCollector instanceof NoOpMemoryCollector) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.INFO,
+              "Memory collector is a NoOpMemoryCollector. Memory stats will not be captured during transactions.");
+      return;
+    }
+    if (!memoryMap.containsKey(transaction.getEventId().toString())) {
+      memoryMap.put(transaction.getEventId().toString(), new ArrayList<>());
+      options
+          .getExecutorService()
+          .schedule(
+              () -> {
+                ArrayList<MemoryCollectionData> memoryCollectionData =
+                    (ArrayList<MemoryCollectionData>) stop(transaction);
+                memoryMap.put(transaction.getEventId().toString(), memoryCollectionData);
+              },
+              TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
+    }
+    if (!isStarted.getAndSet(true)) {
+      timer.scheduleAtFixedRate(
+          new TimerTask() {
+            @Override
+            public void run() {
+              MemoryCollectionData memoryData = memoryCollector.collect();
+              if (memoryData != null) {
+                synchronized (memoryMap) {
+                  for (ArrayList<MemoryCollectionData> list : memoryMap.values()) {
+                    list.add(memoryData);
+                  }
+                }
+              }
+            }
+          },
+          0,
+          TRANSACTION_COLLECTION_INTERVAL_MILLIS);
+    }
+  }
+
+  public @Unmodifiable List<MemoryCollectionData> stop(final @NotNull ITransaction transaction) {
+    synchronized (memoryMap) {
+      List<MemoryCollectionData> memoryData = memoryMap.remove(transaction.getEventId().toString());
+      if (memoryMap.isEmpty() && isStarted.get()) {
+        timer.cancel();
+        timer = new Timer();
+        isStarted.set(false);
+      }
+      return memoryData;
+    }
+  }
+}

--- a/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
@@ -1,0 +1,26 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+class JavaMemoryCollectorTest {
+
+    private val fixture = Fixture()
+
+    private class Fixture {
+        val runtime: Runtime = Runtime.getRuntime()
+        val collector = JavaMemoryCollector()
+    }
+
+    @Test
+    fun `when collect, only heap memory is collected`() {
+        val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
+        val data = fixture.collector.collect()
+        assertNotNull(data)
+        assertEquals(-1, data.usedNativeMemory)
+        assertEquals(usedMemory, data.usedHeapMemory)
+        assertNotEquals(0, data.timestamp)
+    }
+}

--- a/sentry/src/test/java/io/sentry/NoOpMemoryCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpMemoryCollectorTest.kt
@@ -1,0 +1,13 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class NoOpMemoryCollectorTest {
+    private var collector = NoOpMemoryCollector.getInstance()
+
+    @Test
+    fun `collect returns null`() {
+        assertNull(collector.collect())
+    }
+}

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -260,6 +260,18 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `when options is initialized, memoryCollector is noop`() {
+        assert(SentryOptions().memoryCollector == NoOpMemoryCollector.getInstance())
+    }
+
+    @Test
+    fun `when a null memoryCollector is set, memoryCollector is noop`() {
+        val options = SentryOptions()
+        options.setMemoryCollector(null)
+        assert(SentryOptions().memoryCollector == NoOpMemoryCollector.getInstance())
+    }
+
+    @Test
     fun `when adds scope observer, observer list has it`() {
         val observer = mock<IScopeObserver>()
         val options = SentryOptions().apply {

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -350,8 +350,37 @@ class SentryTest {
         assertTrue { sentryOptions!!.mainThreadChecker is CustomMainThreadChecker }
     }
 
+    @Test
+    fun `overrides memory collector if it's not set`() {
+        var sentryOptions: SentryOptions? = null
+
+        Sentry.init {
+            it.dsn = dsn
+            sentryOptions = it
+        }
+
+        assertTrue { sentryOptions!!.memoryCollector is JavaMemoryCollector }
+    }
+
+    @Test
+    fun `does not override memory collector if it's already set`() {
+        var sentryOptions: SentryOptions? = null
+
+        Sentry.init {
+            it.dsn = dsn
+            it.setMemoryCollector(CustomMemoryCollector())
+            sentryOptions = it
+        }
+
+        assertTrue { sentryOptions!!.memoryCollector is CustomMemoryCollector }
+    }
+
     private class CustomMainThreadChecker : IMainThreadChecker {
         override fun isMainThread(threadId: Long): Boolean = false
+    }
+
+    private class CustomMemoryCollector : IMemoryCollector {
+        override fun collect(): MemoryCollectionData? = null
     }
 
     private class CustomModulesLoader : IModulesLoader {

--- a/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
@@ -1,0 +1,144 @@
+package io.sentry
+
+import io.sentry.test.getCtor
+import io.sentry.test.getProperty
+import io.sentry.test.injectForField
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Timer
+import java.util.concurrent.Callable
+import java.util.concurrent.Future
+import java.util.concurrent.FutureTask
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class TransactionPerformanceCollectorTest {
+
+    private val className = "io.sentry.TransactionPerformanceCollector"
+    private val ctorTypes: Array<Class<*>> = arrayOf(SentryOptions::class.java)
+    private val fixture = Fixture()
+
+    private class Fixture {
+        lateinit var transaction1: ITransaction
+        lateinit var transaction2: ITransaction
+        val hub: IHub = mock()
+        val options = SentryOptions()
+        lateinit var mockTimer: Timer
+        var lastScheduledRunnable: Runnable? = null
+
+        val mockExecutorService = object : ISentryExecutorService {
+            override fun submit(runnable: Runnable): Future<*> = mock()
+            override fun <T> submit(callable: Callable<T>): Future<T> = mock()
+            override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> {
+                lastScheduledRunnable = runnable
+                return FutureTask {}
+            }
+            override fun close(timeoutMillis: Long) {}
+        }
+
+        init {
+            whenever(hub.options).thenReturn(options)
+        }
+
+        fun getSut(memoryCollector: IMemoryCollector? = null): TransactionPerformanceCollector {
+            options.dsn = "https://key@sentry.io/proj"
+            options.executorService = mockExecutorService
+            options.setMemoryCollector(memoryCollector ?: JavaMemoryCollector())
+            transaction1 = SentryTracer(TransactionContext("", ""), hub)
+            transaction2 = SentryTracer(TransactionContext("", ""), hub)
+            val collector = TransactionPerformanceCollector(options)
+            val timer: Timer = collector.getProperty("timer")
+            mockTimer = spy(timer)
+            collector.injectForField("timer", mockTimer)
+            return collector
+        }
+    }
+
+    @Test
+    fun `when null param is provided, invalid argument is thrown`() {
+        val ctor = className.getCtor(ctorTypes)
+
+        assertFailsWith<IllegalArgumentException> {
+            ctor.newInstance(arrayOf<Any?>(null))
+        }
+    }
+
+    @Test
+    fun `when NoOpMemoryCollector is set in options, collect is ignored`() {
+        val collector = fixture.getSut(NoOpMemoryCollector.getInstance())
+        assertIs<NoOpMemoryCollector>(fixture.options.memoryCollector)
+        collector.start(fixture.transaction1)
+        verify(fixture.mockTimer, never()).scheduleAtFixedRate(any(), any<Long>(), any())
+    }
+
+    @Test
+    fun `when start, timer is scheduled every 100 milliseconds`() {
+        val collector = fixture.getSut()
+        collector.start(fixture.transaction1)
+        verify(fixture.mockTimer).scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    }
+
+    @Test
+    fun `when stop, timer is stopped`() {
+        val collector = fixture.getSut()
+        collector.start(fixture.transaction1)
+        collector.stop(fixture.transaction1)
+        verify(fixture.mockTimer).scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer).cancel()
+    }
+
+    @Test
+    fun `stopping a not collected transaction return null`() {
+        val collector = fixture.getSut()
+        val data = collector.stop(fixture.transaction1)
+        verify(fixture.mockTimer, never()).scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer, never()).cancel()
+        assertNull(data)
+    }
+
+    @Test
+    fun `collector collect memory for multiple transactions`() {
+        val collector = fixture.getSut()
+        collector.start(fixture.transaction1)
+        collector.start(fixture.transaction2)
+        // Let's sleep to make the collector get values
+        Thread.sleep(200)
+
+        val data1 = collector.stop(fixture.transaction1)
+        // There is still a transaction running: the timer shouldn't stop now
+        verify(fixture.mockTimer, never()).cancel()
+
+        val data2 = collector.stop(fixture.transaction2)
+        // There are no more transactions running: the time should stop now
+        verify(fixture.mockTimer).cancel()
+
+        // The data returned by the collector is
+        assertFalse(data1.isEmpty())
+        assertFalse(data2.isEmpty())
+    }
+
+    @Test
+    fun `collector times out after 30 seconds`() {
+        val collector = fixture.getSut()
+        collector.start(fixture.transaction1)
+        // Let's sleep to make the collector get values
+        Thread.sleep(200)
+        verify(fixture.mockTimer, never()).cancel()
+
+        // Let the timeout job stop the collector
+        fixture.lastScheduledRunnable?.run()
+        verify(fixture.mockTimer).cancel()
+
+        // Data is returned even after the collector times out
+        val data1 = collector.stop(fixture.transaction1)
+        assertFalse(data1.isEmpty())
+    }
+}

--- a/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
@@ -120,9 +120,9 @@ class TransactionPerformanceCollectorTest {
         // There are no more transactions running: the time should stop now
         verify(fixture.mockTimer).cancel()
 
-        // The data returned by the collector is
-        assertFalse(data1.isEmpty())
-        assertFalse(data2.isEmpty())
+        // The data returned by the collector is not empty
+        assertFalse(data1!!.isEmpty())
+        assertFalse(data2!!.isEmpty())
     }
 
     @Test
@@ -139,6 +139,6 @@ class TransactionPerformanceCollectorTest {
 
         // Data is returned even after the collector times out
         val data1 = collector.stop(fixture.transaction1)
-        assertFalse(data1.isEmpty())
+        assertFalse(data1!!.isEmpty())
     }
 }


### PR DESCRIPTION
## :scroll: Description
Added a MemoryCollector, with different implementations for Java and Android, set in SentryOptions
Added TransactionPerformanceCollector, that uses the MemoryCollector, to collect performance data while a transaction is running.
Collected data is a list of objects containing a timestamp, java heap memory usage and native memory usage (only on Android)


## :bulb: Motivation and Context
We want to build a POC to get the memory usage data as a time series while a transaction runs.


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
