### PR TITLE
Don't override sdk version with timber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Don't override sdk name with Timber ([#2450](https://github.com/getsentry/sentry-java/pull/2450))
+
 ## 6.11.0
 
 ### Features

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
@@ -22,7 +22,8 @@ class SentryTimberIntegration(
     private lateinit var logger: ILogger
 
     override fun register(hub: IHub, options: SentryOptions) {
-        createSdkVersion(options)
+        options.sdkVersion?.addPackage("maven:io.sentry:sentry-android-timber", VERSION_NAME)
+
         logger = options.logger
 
         tree = SentryTimberTree(hub, minEventLevel, minBreadcrumbLevel)
@@ -39,17 +40,5 @@ class SentryTimberIntegration(
                 logger.log(SentryLevel.DEBUG, "SentryTimberIntegration removed.")
             }
         }
-    }
-
-    private fun createSdkVersion(options: SentryOptions): SdkVersion {
-        var sdkVersion = options.sdkVersion
-
-        val name = SENTRY_TIMBER_SDK_NAME
-        val version = VERSION_NAME
-        sdkVersion = SdkVersion.updateSdkVersion(sdkVersion, name, version)
-
-        sdkVersion.addPackage("maven:io.sentry:sentry-android-timber", VERSION_NAME)
-
-        return sdkVersion
     }
 }

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
@@ -5,9 +5,7 @@ import io.sentry.ILogger
 import io.sentry.Integration
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
-import io.sentry.android.timber.BuildConfig.SENTRY_TIMBER_SDK_NAME
 import io.sentry.android.timber.BuildConfig.VERSION_NAME
-import io.sentry.protocol.SdkVersion
 import timber.log.Timber
 import java.io.Closeable
 

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
@@ -97,20 +97,9 @@ class SentryTimberIntegrationTest {
 
         assertTrue(
             fixture.options.sdkVersion!!.packages!!.any {
-                it.name == "maven:io.sentry:sentry-android-timber"
-                it.version == BuildConfig.VERSION_NAME
+                it.name == "maven:io.sentry:sentry-android-timber" &&
+                    it.version == BuildConfig.VERSION_NAME
             }
         )
-    }
-
-    @Test
-    fun `Integration sets SDK name and version to options`() {
-        val sut = fixture.getSut()
-        sut.register(fixture.hub, fixture.options)
-
-        val sdkVersion = fixture.options.sdkVersion!!
-
-        assertEquals(sdkVersion.name, "sentry.java.android.timber")
-        assertEquals(sdkVersion.version, BuildConfig.VERSION_NAME)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We should not override the sdk version/name, because Timber is just an integration as opposed to other "sdk-like" things, like spring-boot or log4j. We can still query the `packages` and see who's using timber (and soon, `integrations`). 

This way we avoid the weird `sentry.java.android.timber` name in the SDK description (should be `sentry.java.android`)
<img width="711" alt="image" src="https://user-images.githubusercontent.com/4999776/210387228-7c05a52b-950a-499a-811c-0ae1629bef7c.png">


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1893 


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes

