### PR TITLE
Add `traceOptionsRequests` option to disable tracing of OPTIONS requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Collect memory usage in transactions ([#2445](https://github.com/getsentry/sentry-java/pull/2445))
+- Add `traceOptionsRequests` option to disable tracing of OPTIONS requests ([#2453](https://github.com/getsentry/sentry-java/pull/2453))
 
 ### Fixes
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTracingFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTracingFilter.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
@@ -74,7 +75,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       final @NotNull FilterChain filterChain)
       throws ServletException, IOException {
 
-    if (hub.isEnabled()) {
+    if (hub.isEnabled() && shouldTraceRequest(httpRequest)) {
       final String sentryTraceHeader = httpRequest.getHeader(SentryTraceHeader.SENTRY_TRACE_HEADER);
       final List<String> baggageHeader =
           Collections.list(httpRequest.getHeaders(BaggageHeader.BAGGAGE_HEADER));
@@ -109,6 +110,10 @@ public class SentryTracingFilter extends OncePerRequestFilter {
     } else {
       filterChain.doFilter(httpRequest, httpResponse);
     }
+  }
+
+  private boolean shouldTraceRequest(final @NotNull HttpServletRequest request) {
+    return hub.getOptions().isTraceOptionsRequests() || !HttpMethod.OPTIONS.name().equals(request.getMethod());
   }
 
   private ITransaction startTransaction(

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTracingFilterTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import org.springframework.http.HttpMethod
 
 class SentryTracingFilterTest {
     private class Fixture {
@@ -37,13 +38,12 @@ class SentryTracingFilterTest {
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
         val transactionNameProvider = mock<TransactionNameProvider>()
+        val options = SentryOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+        }
 
         init {
-            whenever(hub.options).thenReturn(
-                SentryOptions().apply {
-                    dsn = "https://key@sentry.io/proj"
-                }
-            )
+            whenever(hub.options).thenReturn(options)
         }
 
         fun getSut(isEnabled: Boolean = true, status: Int = 200, sentryTraceHeader: String? = null): SentryTracingFilter {
@@ -187,6 +187,42 @@ class SentryTracingFilterTest {
         verify(fixture.hub).captureTransaction(
             check {
                 assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
+            },
+            anyOrNull<TraceContext>(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `does not track OPTIONS request with traceOptionsRequests=false`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.OPTIONS.name()
+        fixture.options.isTraceOptionsRequests = false
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).isEnabled
+        verify(fixture.hub).options
+        verifyNoMoreInteractions(fixture.hub)
+        verify(fixture.transactionNameProvider, never()).provideTransactionName(any())
+    }
+
+    @Test
+    fun `tracks OPTIONS request with traceOptionsRequests=true`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.OPTIONS.name()
+        fixture.options.isTraceOptionsRequests = true
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertThat(it.contexts.trace!!.parentSpanId).isNull()
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTracingFilterTest.kt
@@ -229,4 +229,24 @@ class SentryTracingFilterTest {
             anyOrNull()
         )
     }
+
+    @Test
+    fun `tracks POST request with traceOptionsRequests=false`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.POST.name()
+        fixture.options.isTraceOptionsRequests = false
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertThat(it.contexts.trace!!.parentSpanId).isNull()
+            },
+            anyOrNull<TraceContext>(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
@@ -74,7 +75,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       final @NotNull FilterChain filterChain)
       throws ServletException, IOException {
 
-    if (hub.isEnabled()) {
+    if (hub.isEnabled() && shouldTraceRequest(httpRequest)) {
       final String sentryTraceHeader = httpRequest.getHeader(SentryTraceHeader.SENTRY_TRACE_HEADER);
       final List<String> baggageHeader =
           Collections.list(httpRequest.getHeaders(BaggageHeader.BAGGAGE_HEADER));
@@ -109,6 +110,11 @@ public class SentryTracingFilter extends OncePerRequestFilter {
     } else {
       filterChain.doFilter(httpRequest, httpResponse);
     }
+  }
+
+  private boolean shouldTraceRequest(final @NotNull HttpServletRequest request) {
+    return hub.getOptions().isTraceOptionsRequests()
+        || !HttpMethod.OPTIONS.name().equals(request.getMethod());
   }
 
   private ITransaction startTransaction(

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpMethod
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.web.servlet.HandlerMapping
@@ -37,13 +38,12 @@ class SentryTracingFilterTest {
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
         val transactionNameProvider = mock<TransactionNameProvider>()
+        val options = SentryOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+        }
 
         init {
-            whenever(hub.options).thenReturn(
-                SentryOptions().apply {
-                    dsn = "https://key@sentry.io/proj"
-                }
-            )
+            whenever(hub.options).thenReturn(options)
         }
 
         fun getSut(isEnabled: Boolean = true, status: Int = 200, sentryTraceHeader: String? = null): SentryTracingFilter {
@@ -187,6 +187,42 @@ class SentryTracingFilterTest {
         verify(fixture.hub).captureTransaction(
             check {
                 assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
+            },
+            anyOrNull<TraceContext>(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `does not track OPTIONS request with traceOptionsRequests=false`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.OPTIONS.name
+        fixture.options.isTraceOptionsRequests = false
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).isEnabled
+        verify(fixture.hub).options
+        verifyNoMoreInteractions(fixture.hub)
+        verify(fixture.transactionNameProvider, never()).provideTransactionName(any())
+    }
+
+    @Test
+    fun `tracks OPTIONS request with traceOptionsRequests=true`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.OPTIONS.name
+        fixture.options.isTraceOptionsRequests = true
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertThat(it.contexts.trace!!.parentSpanId).isNull()
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -229,4 +229,24 @@ class SentryTracingFilterTest {
             anyOrNull()
         )
     }
+
+    @Test
+    fun `tracks POST request with traceOptionsRequests=false`() {
+        val filter = fixture.getSut()
+        fixture.request.method = HttpMethod.POST.name
+        fixture.options.isTraceOptionsRequests = false
+
+        filter.doFilter(fixture.request, fixture.response, fixture.chain)
+
+        verify(fixture.chain).doFilter(fixture.request, fixture.response)
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertThat(it.contexts.trace!!.parentSpanId).isNull()
+            },
+            anyOrNull<TraceContext>(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1479,6 +1479,7 @@ public class io/sentry/SentryOptions {
 	public fun isProfilingEnabled ()Z
 	public fun isSendClientReports ()Z
 	public fun isSendDefaultPii ()Z
+	public fun isTraceOptionsRequests ()Z
 	public fun isTraceSampling ()Z
 	public fun isTracingEnabled ()Z
 	public fun merge (Lio/sentry/ExternalOptions;)V
@@ -1545,6 +1546,7 @@ public class io/sentry/SentryOptions {
 	public fun setShutdownTimeoutMillis (J)V
 	public fun setSslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setTraceOptionsRequests (Z)V
 	public fun setTracePropagationTargets (Ljava/util/List;)V
 	public fun setTraceSampling (Z)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -387,6 +387,10 @@ public class SentryOptions {
 
   private @NotNull IMemoryCollector memoryCollector = NoOpMemoryCollector.getInstance();
 
+  // TODO this should default to false on the next major
+  /** Whether OPTIONS requests should be traced. */
+  private boolean traceOptionsRequests = true;
+
   /**
    * Adds an event processor
    *
@@ -1897,6 +1901,24 @@ public class SentryOptions {
   public void setMemoryCollector(final @Nullable IMemoryCollector memoryCollector) {
     this.memoryCollector =
         memoryCollector != null ? memoryCollector : NoOpMemoryCollector.getInstance();
+  }
+
+  /**
+   * Whether OPTIONS requests should be traced.
+   *
+   * @return true if OPTIONS requests should be traced
+   */
+  public boolean isTraceOptionsRequests() {
+    return traceOptionsRequests;
+  }
+
+  /**
+   * Whether OPTIONS requests should be traced.
+   *
+   * @param traceOptionsRequests true if OPTIONS requests should be traced
+   */
+  public void setTraceOptionsRequests(boolean traceOptionsRequests) {
+    this.traceOptionsRequests = traceOptionsRequests;
   }
 
   /** The BeforeSend callback */


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`traceOptionsRequests` defaults to `true` for now. I think we should change this to `false` only in the next major release.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows us to fix https://github.com/getsentry/sentry-java/issues/2231 in the next major by flipping the default to `false`.

## :green_heart: How did you test it?
Unit Tests, manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
