### PR TITLE
Extend list of HTTP headers considered sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Collect memory usage in transactions ([#2445](https://github.com/getsentry/sentry-java/pull/2445))
 - Add `traceOptionsRequests` option to disable tracing of OPTIONS requests ([#2453](https://github.com/getsentry/sentry-java/pull/2453))
+- Extend list of HTTP headers considered sensitive ([#2455](https://github.com/getsentry/sentry-java/pull/2455))
 
 ### Fixes
 

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -4,13 +4,12 @@ import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
 import io.sentry.protocol.Request;
+import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -18,8 +17,6 @@ import org.jetbrains.annotations.Nullable;
 
 /** Attaches information about HTTP request to {@link SentryEvent}. */
 final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
-  private static final List<String> SENSITIVE_HEADERS =
-      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE");
 
   private final @NotNull HttpServletRequest httpRequest;
 
@@ -46,7 +43,7 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
-      if (!SENSITIVE_HEADERS.contains(headerName.toUpperCase(Locale.ROOT))) {
+      if (!HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
         headersMap.put(headerName, toString(request.getHeaders(headerName)));
       }
     }

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
@@ -4,12 +4,11 @@ import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.SentryEvent;
 import io.sentry.protocol.Request;
+import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -18,8 +17,6 @@ import org.jetbrains.annotations.Nullable;
 
 /** Attaches information about HTTP request to {@link SentryEvent}. */
 final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
-  private static final List<String> SENSITIVE_HEADERS =
-      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE");
 
   private final @NotNull HttpServletRequest httpRequest;
 
@@ -46,7 +43,7 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
-      if (!SENSITIVE_HEADERS.contains(headerName.toUpperCase(Locale.ROOT))) {
+      if (!HttpUtils.containsSensitiveHeader(headerName.toUpperCase(Locale.ROOT))) {
         headersMap.put(headerName, toString(request.getHeaders(headerName)));
       }
     }

--- a/sentry/src/main/java/io/sentry/util/HttpUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HttpUtils.java
@@ -9,7 +9,19 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public final class HttpUtils {
   private static final List<String> SENSITIVE_HEADERS =
-      Arrays.asList("X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE");
+      Arrays.asList(
+          "X-FORWARDED-FOR",
+          "AUTHORIZATION",
+          "COOKIE",
+          "SET-COOKIE",
+          "X-API-KEY",
+          "X-REAL-IP",
+          "REMOTE-ADDR",
+          "FORWARDED",
+          "PROXY-AUTHORIZATION",
+          "X-CSRF-TOKEN",
+          "X-CSRFTOKEN",
+          "X-XSRF-TOKEN");
 
   public static boolean containsSensitiveHeader(final @NotNull String header) {
     return SENSITIVE_HEADERS.contains(header.toUpperCase(Locale.ROOT));


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use `HttpUtils` where it wasn't before and add more headers that are considered sensitive.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2454 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
