### PR TITLE
Fix lazy initialization causing long startup times

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
 import io.sentry.DateUtils;
+import io.sentry.Sentry;
 import java.util.Date;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -130,6 +131,14 @@ public final class SentryPerformanceProvider extends ContentProvider
         application.unregisterActivityLifecycleCallbacks(this);
       }
       firstActivityCreated = true;
+
+      // When sentry initialization is manually initialized after the Activity is displayed,
+      // reset the appStartTime & appStartMillis
+      if (!Sentry.isEnabled()) {
+        AppStartState.getInstance().reset();
+        AppStartState.getInstance()
+          .setFirstActivityCreatedMillis(SystemClock.uptimeMillis() - appStartMillis);
+      }
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppStartStateTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppStartStateTest.kt
@@ -89,4 +89,23 @@ class AppStartStateTest {
 
         assertNull(sut.appStartInterval)
     }
+
+    @Test
+    fun `setFirstActivityCreatedMillis can make getAppStartInterval returns right interval even if more than 60s`() {
+        val sut = AppStartState.getInstance()
+
+        // performance provider init
+        val date = Date()
+        sut.setAppStartTime(100, date)
+        // first activity displayed cost 100ms
+        sut.setColdStart(true)
+        sut.reset()
+        sut.setFirstActivityCreatedMillis(100)
+        // sentry init after 60000ms
+        sut.setAppStartTime(60100, Date())
+        // next activity displayed cost 200ms
+        sut.setAppStartEnd(60300)
+
+        assertEquals(300, sut.appStartInterval)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The app needs a sentry to be initialized after the privacy confirmation pop-up box is confirmed, so as to avoid collecting user information in advance.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using performance monitoring, if the initialization is delayed for some reasons (such as the privacy confirmation popup), the startup time will no longer be accurate (although there is a 60s limit).

## :green_heart: How did you test it?
1. Open app
2. Show privacy confirmation dialog
3. Wait 30s
4. Click to confirm，init Sentry，jump to MainActivity

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
