### PR TITLE
Create timer in `TransactionPerformanceCollector` lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Create timer in `TransactionPerformanceCollector` lazily ([#2478](https://github.com/getsentry/sentry-java/pull/2478))
+
 ## 6.12.0
 
 ### Features

--- a/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionPerformanceCollectorTest.kt
@@ -32,7 +32,7 @@ class TransactionPerformanceCollectorTest {
         lateinit var transaction2: ITransaction
         val hub: IHub = mock()
         val options = SentryOptions()
-        lateinit var mockTimer: Timer
+        var mockTimer: Timer? = null
         var lastScheduledRunnable: Runnable? = null
 
         val mockExecutorService = object : ISentryExecutorService {
@@ -56,7 +56,7 @@ class TransactionPerformanceCollectorTest {
             transaction1 = SentryTracer(TransactionContext("", ""), hub)
             transaction2 = SentryTracer(TransactionContext("", ""), hub)
             val collector = TransactionPerformanceCollector(options)
-            val timer: Timer = collector.getProperty("timer")
+            val timer: Timer? = collector.getProperty("timer") ?: Timer(true)
             mockTimer = spy(timer)
             collector.injectForField("timer", mockTimer)
             return collector
@@ -77,14 +77,14 @@ class TransactionPerformanceCollectorTest {
         val collector = fixture.getSut(NoOpMemoryCollector.getInstance())
         assertIs<NoOpMemoryCollector>(fixture.options.memoryCollector)
         collector.start(fixture.transaction1)
-        verify(fixture.mockTimer, never()).scheduleAtFixedRate(any(), any<Long>(), any())
+        verify(fixture.mockTimer, never())!!.scheduleAtFixedRate(any(), any<Long>(), any())
     }
 
     @Test
     fun `when start, timer is scheduled every 100 milliseconds`() {
         val collector = fixture.getSut()
         collector.start(fixture.transaction1)
-        verify(fixture.mockTimer).scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
     }
 
     @Test
@@ -92,16 +92,16 @@ class TransactionPerformanceCollectorTest {
         val collector = fixture.getSut()
         collector.start(fixture.transaction1)
         collector.stop(fixture.transaction1)
-        verify(fixture.mockTimer).scheduleAtFixedRate(any(), any<Long>(), eq(100))
-        verify(fixture.mockTimer).cancel()
+        verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer)!!.cancel()
     }
 
     @Test
     fun `stopping a not collected transaction return null`() {
         val collector = fixture.getSut()
         val data = collector.stop(fixture.transaction1)
-        verify(fixture.mockTimer, never()).scheduleAtFixedRate(any(), any<Long>(), eq(100))
-        verify(fixture.mockTimer, never()).cancel()
+        verify(fixture.mockTimer, never())!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer, never())!!.cancel()
         assertNull(data)
     }
 
@@ -115,11 +115,11 @@ class TransactionPerformanceCollectorTest {
 
         val data1 = collector.stop(fixture.transaction1)
         // There is still a transaction running: the timer shouldn't stop now
-        verify(fixture.mockTimer, never()).cancel()
+        verify(fixture.mockTimer, never())!!.cancel()
 
         val data2 = collector.stop(fixture.transaction2)
         // There are no more transactions running: the time should stop now
-        verify(fixture.mockTimer).cancel()
+        verify(fixture.mockTimer)!!.cancel()
 
         // The data returned by the collector is not empty
         assertFalse(data1!!.isEmpty())
@@ -132,11 +132,11 @@ class TransactionPerformanceCollectorTest {
         collector.start(fixture.transaction1)
         // Let's sleep to make the collector get values
         Thread.sleep(200)
-        verify(fixture.mockTimer, never()).cancel()
+        verify(fixture.mockTimer, never())!!.cancel()
 
         // Let the timeout job stop the collector
         fixture.lastScheduledRunnable?.run()
-        verify(fixture.mockTimer).cancel()
+        verify(fixture.mockTimer)!!.cancel()
 
         // Data is returned even after the collector times out
         val data1 = collector.stop(fixture.transaction1)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Timer was created even if performance wasn't enabled. Also Timer prevented shutdown.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2477 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
- @stefanosiano can you please help test if this still works correctly