### PR TITLE
Expand fix for potential Privilege Escalation via Content Provider (CVE-2018-9492)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Expand guard against CVE-2018-9492 "Privilege Escalation via Content Provider" ([#2482](https://github.com/getsentry/sentry-java/pull/2482))
+
 ## 6.12.1
 
 ### Fixes

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -189,24 +189,18 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setProfilingTracesIntervalMillis (I)V
 }
 
-public final class io/sentry/android/core/SentryInitProvider : android/content/ContentProvider {
+public final class io/sentry/android/core/SentryInitProvider {
 	public fun <init> ()V
 	public fun attachInfo (Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V
-	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
 	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
-	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;
 	public fun onCreate ()Z
-	public fun query (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
 	public fun shutdown ()V
-	public fun update (Landroid/net/Uri;Landroid/content/ContentValues;Ljava/lang/String;[Ljava/lang/String;)I
 }
 
-public final class io/sentry/android/core/SentryPerformanceProvider : android/content/ContentProvider, android/app/Application$ActivityLifecycleCallbacks {
+public final class io/sentry/android/core/SentryPerformanceProvider : android/app/Application$ActivityLifecycleCallbacks {
 	public fun <init> ()V
 	public fun attachInfo (Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V
-	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
 	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
-	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityDestroyed (Landroid/app/Activity;)V
 	public fun onActivityPaused (Landroid/app/Activity;)V
@@ -215,8 +209,6 @@ public final class io/sentry/android/core/SentryPerformanceProvider : android/co
 	public fun onActivityStarted (Landroid/app/Activity;)V
 	public fun onActivityStopped (Landroid/app/Activity;)V
 	public fun onCreate ()Z
-	public fun query (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
-	public fun update (Landroid/net/Uri;Landroid/content/ContentValues;Ljava/lang/String;[Ljava/lang/String;)I
 }
 
 public final class io/sentry/android/core/SystemEventsBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EmptySecureContentProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EmptySecureContentProvider.java
@@ -1,0 +1,56 @@
+package io.sentry.android.core;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import io.sentry.android.core.internal.util.ContentProviderSecurityChecker;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A ContentProvider that does NOT store or provide any data for read or write operations.
+ *
+ * <p>This does not allow for overriding the abstract query, insert, update, and delete operations
+ * of the {@link ContentProvider}. Additionally, those functions are secure.
+ */
+@ApiStatus.Internal
+abstract class EmptySecureContentProvider extends ContentProvider {
+
+  private final ContentProviderSecurityChecker securityChecker =
+      new ContentProviderSecurityChecker();
+
+  @Override
+  public final @Nullable Cursor query(
+      @NotNull Uri uri,
+      @Nullable String[] strings,
+      @Nullable String s,
+      @Nullable String[] strings1,
+      @Nullable String s1) {
+    securityChecker.checkPrivilegeEscalation(this);
+    return null;
+  }
+
+  @Override
+  public final @Nullable Uri insert(@NotNull Uri uri, @Nullable ContentValues contentValues) {
+    securityChecker.checkPrivilegeEscalation(this);
+    return null;
+  }
+
+  @Override
+  public final int delete(@NotNull Uri uri, @Nullable String s, @Nullable String[] strings) {
+    securityChecker.checkPrivilegeEscalation(this);
+    return 0;
+  }
+
+  @Override
+  public final int update(
+      @NotNull Uri uri,
+      @Nullable ContentValues contentValues,
+      @Nullable String s,
+      @Nullable String[] strings) {
+    securityChecker.checkPrivilegeEscalation(this);
+    return 0;
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -1,20 +1,16 @@
 package io.sentry.android.core;
 
-import android.content.ContentProvider;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.pm.ProviderInfo;
-import android.database.Cursor;
 import android.net.Uri;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
-import io.sentry.android.core.internal.util.ContentProviderSecurityChecker;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class SentryInitProvider extends ContentProvider {
+public final class SentryInitProvider extends EmptySecureContentProvider {
 
   @Override
   public boolean onCreate() {
@@ -46,37 +42,7 @@ public final class SentryInitProvider extends ContentProvider {
   }
 
   @Override
-  public @Nullable Cursor query(
-      @NotNull Uri uri,
-      @Nullable String[] strings,
-      @Nullable String s,
-      @Nullable String[] strings1,
-      @Nullable String s1) {
-    new ContentProviderSecurityChecker().checkPrivilegeEscalation(this);
-    return null;
-  }
-
-  @Override
   public @Nullable String getType(@NotNull Uri uri) {
     return null;
-  }
-
-  @Override
-  public @Nullable Uri insert(@NotNull Uri uri, @Nullable ContentValues contentValues) {
-    return null;
-  }
-
-  @Override
-  public int delete(@NotNull Uri uri, @Nullable String s, @Nullable String[] strings) {
-    return 0;
-  }
-
-  @Override
-  public int update(
-      @NotNull Uri uri,
-      @Nullable ContentValues contentValues,
-      @Nullable String s,
-      @Nullable String[] strings) {
-    return 0;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -2,16 +2,12 @@ package io.sentry.android.core;
 
 import android.app.Activity;
 import android.app.Application;
-import android.content.ContentProvider;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.pm.ProviderInfo;
-import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
 import io.sentry.DateUtils;
-import io.sentry.android.core.internal.util.ContentProviderSecurityChecker;
 import java.util.Date;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +21,7 @@ import org.jetbrains.annotations.TestOnly;
  * AppComponentFactory but it depends on androidx.core.app.AppComponentFactory
  */
 @ApiStatus.Internal
-public final class SentryPerformanceProvider extends ContentProvider
+public final class SentryPerformanceProvider extends EmptySecureContentProvider
     implements Application.ActivityLifecycleCallbacks {
 
   // static to rely on Class load
@@ -73,41 +69,8 @@ public final class SentryPerformanceProvider extends ContentProvider
 
   @Nullable
   @Override
-  public Cursor query(
-      @NotNull Uri uri,
-      @Nullable String[] projection,
-      @Nullable String selection,
-      @Nullable String[] selectionArgs,
-      @Nullable String sortOrder) {
-    new ContentProviderSecurityChecker().checkPrivilegeEscalation(this);
-    return null;
-  }
-
-  @Nullable
-  @Override
   public String getType(@NotNull Uri uri) {
     return null;
-  }
-
-  @Nullable
-  @Override
-  public Uri insert(@NotNull Uri uri, @Nullable ContentValues values) {
-    return null;
-  }
-
-  @Override
-  public int delete(
-      @NotNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
-    return 0;
-  }
-
-  @Override
-  public int update(
-      @NotNull Uri uri,
-      @Nullable ContentValues values,
-      @Nullable String selection,
-      @Nullable String[] selectionArgs) {
-    return 0;
   }
 
   @TestOnly

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/ContentProviderSecurityChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/ContentProviderSecurityChecker.java
@@ -2,7 +2,6 @@ package io.sentry.android.core.internal.util;
 
 import android.annotation.SuppressLint;
 import android.content.ContentProvider;
-import android.net.Uri;
 import android.os.Build;
 import io.sentry.NoOpLogger;
 import io.sentry.android.core.BuildInfoProvider;
@@ -30,20 +29,21 @@ public final class ContentProviderSecurityChecker {
    * <p>See https://www.cvedetails.com/cve/CVE-2018-9492/ and
    * https://github.com/getsentry/sentry-java/issues/2460
    *
-   * <p>Call this function in the {@link ContentProvider#query(Uri, String[], String, String[],
-   * String)} function.
+   * <p>Call this function in the {@link ContentProvider}'s implementations of the abstract
+   * functions; query, insert, update, and delete.
    *
-   * <p>This should be invoked regardless of whether there is data to query or not. The attack is
-   * not contained to the specific provider but rather the entire system.
+   * <p>This should be invoked regardless of whether there is data to read/write or not. The attack
+   * is not contained to the specific provider but rather the entire system.
    *
-   * <p>This blocks the attacker by only allowing the app itself (not other apps) to "query" the
-   * provider.
+   * <p>This blocks the attacker by only allowing the app itself (not other apps) to interact with
+   * the ContentProvider. If the ContentProvider needs to be able to interact with other trusted
+   * apps, then this function or class should be refactored to accommodate that.
    *
    * <p>The vulnerability is specific to un-patched versions of Android 8 and 9 (API 26 to 28).
    * Therefore, this security check is limited to those versions to mitigate risk of regression.
    */
   @SuppressLint("NewApi")
-  public void checkPrivilegeEscalation(ContentProvider contentProvider) {
+  public void checkPrivilegeEscalation(@NotNull ContentProvider contentProvider) {
     final int sdkVersion = buildInfoProvider.getSdkInfoVersion();
     if (sdkVersion >= Build.VERSION_CODES.O && sdkVersion <= Build.VERSION_CODES.P) {
 


### PR DESCRIPTION
## :exclamation: Problem

The changes contained in https://github.com/getsentry/sentry-java/pull/2466 that were merged and released in [6.12.0](https://github.com/getsentry/sentry-java/releases/tag/6.12.0) were not enough to pass [Data/Secure theorem](https://www.securetheorem.com/) security scans.

This is either due to...

- The security scans expecting exact copy-paste of their suggested code 
- OR it expects the security checks to also be applied to `insert`, `update`, and `delete` ContentProvider functions
    - The security check was, and is currently, only applied to the `query` function.

## :bulb: Solution

In order to completely fix the **potential** security vulnerability described in https://github.com/getsentry/sentry-java/issues/2460, we should also apply the security checks to the `insert`, `update`, and `delete` functions of `SentryInitProvider` and `SentryPerformanceProvider`.

This may not result in passing [Data/Secure theorem](https://www.securetheorem.com/) security scans in case it is expecting copy-paste code of the suggest code. However, we will be 100% sure that we are protected no matter what scanners say 😎 

Thanks to my colleague @artour-bakiev for being [diligent in making sure that I do the right thing](https://github.com/getsentry/sentry-java/pull/2466#discussion_r1071721924) for everyone ❤️ 

## :green_heart: How did you test it?

I smoke tested the Android sample to make sure that it still works and is not just crashing (lol).

I do not actually know how to perform the attack, so I'm not able to verify that this works against attackers. However, it is safe to assume that it will work given that the attacker will have a different package than the app package.

## :pencil: Checklist

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps

There are no next steps after this. If the next Sentry version that contains these changes still do no pass the [Data/Secure theorem](https://www.securetheorem.com/) security scans, then we know that they are expecting copy-paste of their suggested code, which we are just not going to do 😁 

Note that there is no urgency in getting this change out in a new Sentry version. We can wait a whole month. No rush. Whenever the next Sentry version is released is kewl!