### PR TITLE
Fix Sentry BOM containing wrong artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix `sentry-bom` containing incorrect artifacts ([#2504](https://github.com/getsentry/sentry-java/pull/2504))
+
 ### Dependencies
 
 - Bump Native SDK from v0.5.3 to v0.5.4 ([#2500](https://github.com/getsentry/sentry-java/pull/2500))

--- a/sentry-bom/build.gradle.kts
+++ b/sentry-bom/build.gradle.kts
@@ -9,10 +9,21 @@ dependencies {
             .filter {
                 !it.name.startsWith("sentry-samples") &&
                     it.name != project.name &&
-                    it.name != "sentry-test-support"
+                    !it.name.contains("test", ignoreCase = true) &&
+                    it.name != "sentry-compose-helper"
             }
-            .forEach {
-                api(it)
+            .forEach { project ->
+                evaluationDependsOn(project.path)
+                project.publishing.publications
+                    .mapNotNull { it as? MavenPublication }
+                    .filter {
+                        !it.artifactId.endsWith("-kotlinMultiplatform") &&
+                            !it.artifactId.endsWith("-metadata")
+                    }
+                    .forEach {
+                        val dependency = "${it.groupId}:${it.artifactId}:${it.version}"
+                        api(dependency)
+                    }
             }
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
sentry-bom was containing [wrong artifacts](https://repo.maven.apache.org/maven2/io/sentry/sentry-bom/6.13.0/sentry-bom-6.13.0.pom) (e.g. test dependencies, test apps, missing compose artifacts, etc.). This PR fixes it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/discussions/2503


## :green_heart: How did you test it?
Manually `./gradlew publishToMavenLocal`. The result can be checked here 
[sentry-bom-6.13.0.txt](https://github.com/getsentry/sentry-java/files/10544041/sentry-bom-6.13.0.txt)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed
- [x] No breaking changes

