### PR TITLE
Fix transaction performance collector oom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix transaction performance collector oom ([#2505](https://github.com/getsentry/sentry-java/pull/2505))
 - Remove authority from URLs sent to Sentry ([#2366](https://github.com/getsentry/sentry-java/pull/2366))
 - Fix `sentry-bom` containing incorrect artifacts ([#2504](https://github.com/getsentry/sentry-java/pull/2504))
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -25,7 +25,7 @@ public final class io/sentry/android/core/ActivityLifecycleIntegration : android
 
 public final class io/sentry/android/core/AndroidCpuCollector : io/sentry/ICollector {
 	public fun <init> (Lio/sentry/ILogger;Lio/sentry/android/core/BuildInfoProvider;)V
-	public fun collect (Ljava/lang/Iterable;)V
+	public fun collect (Lio/sentry/PerformanceCollectionData;)V
 	public fun setup ()V
 }
 
@@ -45,7 +45,7 @@ public final class io/sentry/android/core/AndroidLogger : io/sentry/ILogger {
 
 public class io/sentry/android/core/AndroidMemoryCollector : io/sentry/ICollector {
 	public fun <init> ()V
-	public fun collect (Ljava/lang/Iterable;)V
+	public fun collect (Lio/sentry/PerformanceCollectionData;)V
 	public fun setup ()V
 }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -66,8 +66,7 @@ public final class AndroidCpuCollector implements ICollector {
 
   @SuppressLint("NewApi")
   @Override
-  public void collect(
-      @NotNull final Iterable<PerformanceCollectionData> performanceCollectionData) {
+  public void collect(final @NotNull PerformanceCollectionData performanceCollectionData) {
     if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP || !isEnabled) {
       return;
     }
@@ -86,9 +85,7 @@ public final class AndroidCpuCollector implements ICollector {
         new CpuCollectionData(
             System.currentTimeMillis(), (cpuUsagePercentage / (double) numCores) * 100.0);
 
-    for (PerformanceCollectionData data : performanceCollectionData) {
-      data.addCpuData(cpuData);
-    }
+    performanceCollectionData.addCpuData(cpuData);
   }
 
   /** Read the /proc/self/stat file and parses the result. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidMemoryCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidMemoryCollector.java
@@ -14,13 +14,11 @@ public class AndroidMemoryCollector implements ICollector {
   public void setup() {}
 
   @Override
-  public void collect(@NotNull Iterable<PerformanceCollectionData> performanceCollectionData) {
+  public void collect(final @NotNull PerformanceCollectionData performanceCollectionData) {
     long now = System.currentTimeMillis();
     long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
     long usedNativeMemory = Debug.getNativeHeapSize() - Debug.getNativeHeapFreeSize();
     MemoryCollectionData memoryData = new MemoryCollectionData(now, usedMemory, usedNativeMemory);
-    for (PerformanceCollectionData data : performanceCollectionData) {
-      data.addMemoryData(memoryData);
-    }
+    performanceCollectionData.addMemoryData(memoryData);
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.res.AssetManager;
 import android.os.Build;
+import io.sentry.DefaultTransactionPerformanceCollector;
 import io.sentry.ILogger;
 import io.sentry.SendFireAndForgetEnvelopeSender;
 import io.sentry.SendFireAndForgetOutboxSender;
@@ -168,6 +169,7 @@ final class AndroidOptionsInitializer {
       options.addCollector(new AndroidMemoryCollector());
       options.addCollector(new AndroidCpuCollector(options.getLogger(), buildInfoProvider));
     }
+    options.setTransactionPerformanceCollector(new DefaultTransactionPerformanceCollector(options));
   }
 
   private static void installDefaultIntegrations(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidCpuCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidCpuCollectorTest.kt
@@ -43,7 +43,6 @@ class AndroidCpuCollectorTest {
     fun `collect works only after setup`() {
         val data = PerformanceCollectionData()
         fixture.getSut().collect(data)
-        data.commitData()
         assertNull(data.cpuData)
     }
 
@@ -53,7 +52,6 @@ class AndroidCpuCollectorTest {
         val collector = fixture.getSut()
         collector.setup()
         collector.collect(data)
-        data.commitData()
         val cpuData = data.cpuData
         assertNotNull(cpuData)
         assertNotEquals(0.0, cpuData.cpuUsagePercentage)
@@ -68,7 +66,6 @@ class AndroidCpuCollectorTest {
         val collector = fixture.getSut(mockBuildInfoProvider)
         collector.setup()
         collector.collect(data)
-        data.commitData()
         assertNull(data.cpuData)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidCpuCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidCpuCollectorTest.kt
@@ -8,10 +8,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 
 class AndroidCpuCollectorTest {
 
@@ -43,9 +42,9 @@ class AndroidCpuCollectorTest {
     @Test
     fun `collect works only after setup`() {
         val data = PerformanceCollectionData()
-        fixture.getSut().collect(listOf(data))
+        fixture.getSut().collect(data)
         data.commitData()
-        assertTrue(data.cpuData.isEmpty())
+        assertNull(data.cpuData)
     }
 
     @Test
@@ -53,13 +52,12 @@ class AndroidCpuCollectorTest {
         val data = PerformanceCollectionData()
         val collector = fixture.getSut()
         collector.setup()
-        collector.collect(listOf(data))
+        collector.collect(data)
         data.commitData()
         val cpuData = data.cpuData
-        assertNotNull(data.cpuData)
-        assertFalse(data.cpuData.isEmpty())
-        assertNotEquals(0.0, cpuData[0].cpuUsagePercentage)
-        assertNotEquals(0, cpuData[0].timestampMillis)
+        assertNotNull(cpuData)
+        assertNotEquals(0.0, cpuData.cpuUsagePercentage)
+        assertNotEquals(0, cpuData.timestampMillis)
     }
 
     @Test
@@ -69,8 +67,8 @@ class AndroidCpuCollectorTest {
         whenever(mockBuildInfoProvider.sdkInfoVersion).thenReturn(Build.VERSION_CODES.KITKAT)
         val collector = fixture.getSut(mockBuildInfoProvider)
         collector.setup()
-        collector.collect(listOf(data))
+        collector.collect(data)
         data.commitData()
-        assertTrue(data.cpuData.isEmpty())
+        assertNull(data.cpuData)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
@@ -22,7 +22,6 @@ class AndroidMemoryCollectorTest {
         val usedNativeMemory = Debug.getNativeHeapSize() - Debug.getNativeHeapFreeSize()
         val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
         fixture.collector.collect(data)
-        data.commitData()
         val memoryData = data.memoryData
         assertNotNull(memoryData)
         assertNotEquals(-1, memoryData.usedNativeMemory)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidMemoryCollectorTest.kt
@@ -18,13 +18,12 @@ class AndroidMemoryCollectorTest {
 
     @Test
     fun `when collect, both native and heap memory are collected`() {
-        val performanceCollectionData = PerformanceCollectionData()
-        val data = listOf(performanceCollectionData)
+        val data = PerformanceCollectionData()
         val usedNativeMemory = Debug.getNativeHeapSize() - Debug.getNativeHeapFreeSize()
         val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
         fixture.collector.collect(data)
-        performanceCollectionData.commitData()
-        val memoryData = performanceCollectionData.memoryData.firstOrNull()
+        data.commitData()
+        val memoryData = data.memoryData
         assertNotNull(memoryData)
         assertNotEquals(-1, memoryData.usedNativeMemory)
         assertEquals(usedNativeMemory, memoryData.usedNativeMemory)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.DefaultTransactionPerformanceCollector
 import io.sentry.ILogger
 import io.sentry.MainEventProcessor
 import io.sentry.SentryOptions
@@ -24,6 +25,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -524,5 +526,12 @@ class AndroidOptionsInitializerTest {
         fixture.initSut()
 
         assertTrue { fixture.sentryOptions.collectors.any { it is AndroidCpuCollector } }
+    }
+
+    @Test
+    fun `DefaultTransactionPerformanceCollector is set to options`() {
+        fixture.initSut()
+
+        assertIs<DefaultTransactionPerformanceCollector>(fixture.sentryOptions.transactionPerformanceCollector)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -380,12 +380,10 @@ class AndroidTransactionProfilerTest {
         var singleData = PerformanceCollectionData()
         singleData.addMemoryData(MemoryCollectionData(1, 2, 3))
         singleData.addCpuData(CpuCollectionData(1, 1.4))
-        singleData.commitData()
         performanceCollectionData.add(singleData)
 
         singleData = PerformanceCollectionData()
         singleData.addMemoryData(MemoryCollectionData(2, 3, 4))
-        singleData.commitData()
         performanceCollectionData.add(singleData)
 
         profiler.onTransactionStart(fixture.transaction1)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -376,14 +376,20 @@ class AndroidTransactionProfilerTest {
     @Test
     fun `profiler includes performance measurements when passed on transaction finish`() {
         val profiler = fixture.getSut(context)
-        val memoryCollectionData = PerformanceCollectionData()
-        memoryCollectionData.addMemoryData(MemoryCollectionData(1, 2, 3))
-        memoryCollectionData.addCpuData(CpuCollectionData(1, 1.4))
-        memoryCollectionData.commitData()
-        memoryCollectionData.addMemoryData(MemoryCollectionData(2, 3, 4))
-        memoryCollectionData.commitData()
+        val performanceCollectionData = ArrayList<PerformanceCollectionData>()
+        var singleData = PerformanceCollectionData()
+        singleData.addMemoryData(MemoryCollectionData(1, 2, 3))
+        singleData.addCpuData(CpuCollectionData(1, 1.4))
+        singleData.commitData()
+        performanceCollectionData.add(singleData)
+
+        singleData = PerformanceCollectionData()
+        singleData.addMemoryData(MemoryCollectionData(2, 3, 4))
+        singleData.commitData()
+        performanceCollectionData.add(singleData)
+
         profiler.onTransactionStart(fixture.transaction1)
-        val data = profiler.onTransactionFinish(fixture.transaction1, memoryCollectionData)
+        val data = profiler.onTransactionFinish(fixture.transaction1, performanceCollectionData)
         assertContentEquals(
             listOf(1.4),
             data!!.measurementsMap[ProfileMeasurement.ID_CPU_USAGE]!!.values.map { it.value }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -113,7 +113,7 @@ class SentryAndroidOptionsTest {
         override fun onTransactionStart(transaction: ITransaction) {}
         override fun onTransactionFinish(
             transaction: ITransaction,
-            memoryCollectionData: PerformanceCollectionData?
+            performanceCollectionData: List<PerformanceCollectionData>?
         ): ProfilingTraceData? = null
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -891,7 +891,6 @@ public final class io/sentry/PerformanceCollectionData {
 	public fun <init> ()V
 	public fun addCpuData (Lio/sentry/CpuCollectionData;)V
 	public fun addMemoryData (Lio/sentry/MemoryCollectionData;)V
-	public fun commitData ()V
 	public fun getCpuData ()Lio/sentry/CpuCollectionData;
 	public fun getMemoryData ()Lio/sentry/MemoryCollectionData;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -186,7 +186,7 @@ public final class io/sentry/DateUtils {
 public final class io/sentry/DefaultTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun start (Lio/sentry/ITransaction;)V
-	public fun stop (Lio/sentry/ITransaction;)Lio/sentry/PerformanceCollectionData;
+	public fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
 
 public final class io/sentry/DiagnosticLogger : io/sentry/ILogger {
@@ -391,7 +391,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 }
 
 public abstract interface class io/sentry/ICollector {
-	public abstract fun collect (Ljava/lang/Iterable;)V
+	public abstract fun collect (Lio/sentry/PerformanceCollectionData;)V
 	public abstract fun setup ()V
 }
 
@@ -571,7 +571,7 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 }
 
 public abstract interface class io/sentry/ITransactionProfiler {
-	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;Lio/sentry/PerformanceCollectionData;)Lio/sentry/ProfilingTraceData;
+	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;)Lio/sentry/ProfilingTraceData;
 	public abstract fun onTransactionStart (Lio/sentry/ITransaction;)V
 }
 
@@ -596,7 +596,7 @@ public final class io/sentry/IpAddressUtils {
 
 public final class io/sentry/JavaMemoryCollector : io/sentry/ICollector {
 	public fun <init> ()V
-	public fun collect (Ljava/lang/Iterable;)V
+	public fun collect (Lio/sentry/PerformanceCollectionData;)V
 	public fun setup ()V
 }
 
@@ -862,12 +862,12 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 public final class io/sentry/NoOpTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
 	public static fun getInstance ()Lio/sentry/NoOpTransactionPerformanceCollector;
 	public fun start (Lio/sentry/ITransaction;)V
-	public fun stop (Lio/sentry/ITransaction;)Lio/sentry/PerformanceCollectionData;
+	public fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
 
 public final class io/sentry/NoOpTransactionProfiler : io/sentry/ITransactionProfiler {
 	public static fun getInstance ()Lio/sentry/NoOpTransactionProfiler;
-	public fun onTransactionFinish (Lio/sentry/ITransaction;Lio/sentry/PerformanceCollectionData;)Lio/sentry/ProfilingTraceData;
+	public fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;)Lio/sentry/ProfilingTraceData;
 	public fun onTransactionStart (Lio/sentry/ITransaction;)V
 }
 
@@ -892,8 +892,8 @@ public final class io/sentry/PerformanceCollectionData {
 	public fun addCpuData (Lio/sentry/CpuCollectionData;)V
 	public fun addMemoryData (Lio/sentry/MemoryCollectionData;)V
 	public fun commitData ()V
-	public fun getCpuData ()Ljava/util/List;
-	public fun getMemoryData ()Ljava/util/List;
+	public fun getCpuData ()Lio/sentry/CpuCollectionData;
+	public fun getMemoryData ()Lio/sentry/MemoryCollectionData;
 }
 
 public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -1646,6 +1646,7 @@ public class io/sentry/SentryOptions {
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 	public fun setTracesSampler (Lio/sentry/SentryOptions$TracesSamplerCallback;)V
 	public fun setTracingOrigins (Ljava/util/List;)V
+	public fun setTransactionPerformanceCollector (Lio/sentry/TransactionPerformanceCollector;)V
 	public fun setTransactionProfiler (Lio/sentry/ITransactionProfiler;)V
 	public fun setTransportFactory (Lio/sentry/ITransportFactory;)V
 	public fun setTransportGate (Lio/sentry/transport/ITransportGate;)V
@@ -2069,7 +2070,7 @@ public final class io/sentry/TransactionOptions {
 
 public abstract interface class io/sentry/TransactionPerformanceCollector {
 	public abstract fun start (Lio/sentry/ITransaction;)V
-	public abstract fun stop (Lio/sentry/ITransaction;)Lio/sentry/PerformanceCollectionData;
+	public abstract fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
 
 public final class io/sentry/TypeCheckHint {

--- a/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import io.sentry.util.Objects;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
@@ -18,7 +19,7 @@ public final class DefaultTransactionPerformanceCollector
   private static final long TRANSACTION_COLLECTION_TIMEOUT_MILLIS = 30000;
   private final @NotNull Object timerLock = new Object();
   private volatile @Nullable Timer timer = null;
-  private final @NotNull Map<String, PerformanceCollectionData> performanceDataMap =
+  private final @NotNull Map<String, List<PerformanceCollectionData>> performanceDataMap =
       new ConcurrentHashMap<>();
   private final @NotNull List<ICollector> collectors;
   private final @NotNull SentryOptions options;
@@ -42,17 +43,11 @@ public final class DefaultTransactionPerformanceCollector
     }
 
     if (!performanceDataMap.containsKey(transaction.getEventId().toString())) {
-      performanceDataMap.put(transaction.getEventId().toString(), new PerformanceCollectionData());
+      performanceDataMap.put(transaction.getEventId().toString(), new ArrayList<>());
+      // We schedule deletion of collected performance data after a timeout
       options
           .getExecutorService()
-          .schedule(
-              () -> {
-                PerformanceCollectionData data = stop(transaction);
-                if (data != null) {
-                  performanceDataMap.put(transaction.getEventId().toString(), data);
-                }
-              },
-              TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
+          .schedule(() -> stop(transaction), TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
     }
     if (!isStarted.getAndSet(true)) {
       synchronized (timerLock) {
@@ -74,22 +69,26 @@ public final class DefaultTransactionPerformanceCollector
         // and collect() calls.
         // This way ICollectors that collect average stats based on time intervals, like
         // AndroidCpuCollector, can have an actual time interval to evaluate.
-        timer.scheduleAtFixedRate(
+        TimerTask timerTask =
             new TimerTask() {
               @Override
               public void run() {
-                synchronized (timerLock) {
-                  for (ICollector collector : collectors) {
-                    collector.collect(performanceDataMap.values());
-                  }
-                  // We commit data after calling all collectors.
-                  // This way we avoid issues caused by having multiple cpu or memory collectors.
-                  for (PerformanceCollectionData data : performanceDataMap.values()) {
-                    data.commitData();
-                  }
+                final @NotNull PerformanceCollectionData tempData = new PerformanceCollectionData();
+
+                for (ICollector collector : collectors) {
+                  collector.collect(tempData);
+                }
+                // We commit data after calling all collectors.
+                // This way we avoid issues caused by having multiple cpu or memory collectors.
+                tempData.commitData();
+
+                for (List<PerformanceCollectionData> data : performanceDataMap.values()) {
+                  data.add(tempData);
                 }
               }
-            },
+            };
+        timer.scheduleAtFixedRate(
+            timerTask,
             TRANSACTION_COLLECTION_INTERVAL_MILLIS,
             TRANSACTION_COLLECTION_INTERVAL_MILLIS);
       }
@@ -97,9 +96,16 @@ public final class DefaultTransactionPerformanceCollector
   }
 
   @Override
-  public @Nullable PerformanceCollectionData stop(final @NotNull ITransaction transaction) {
-    PerformanceCollectionData data =
-      performanceDataMap.remove(transaction.getEventId().toString());
+  public @Nullable List<PerformanceCollectionData> stop(final @NotNull ITransaction transaction) {
+    List<PerformanceCollectionData> data =
+        performanceDataMap.remove(transaction.getEventId().toString());
+    options
+        .getLogger()
+        .log(
+            SentryLevel.DEBUG,
+            "stop collecting performance info for transactions %s (%s)",
+            transaction.getName(),
+            transaction.getSpanContext().getTraceId().toString());
     if (performanceDataMap.isEmpty() && isStarted.getAndSet(false)) {
       synchronized (timerLock) {
         if (timer != null) {

--- a/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
@@ -78,9 +78,6 @@ public final class DefaultTransactionPerformanceCollector
                 for (ICollector collector : collectors) {
                   collector.collect(tempData);
                 }
-                // We commit data after calling all collectors.
-                // This way we avoid issues caused by having multiple cpu or memory collectors.
-                tempData.commitData();
 
                 for (List<PerformanceCollectionData> data : performanceDataMap.values()) {
                   data.add(tempData);

--- a/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
@@ -98,16 +98,16 @@ public final class DefaultTransactionPerformanceCollector
 
   @Override
   public @Nullable PerformanceCollectionData stop(final @NotNull ITransaction transaction) {
-    synchronized (timerLock) {
-      PerformanceCollectionData data =
-          performanceDataMap.remove(transaction.getEventId().toString());
-      if (performanceDataMap.isEmpty() && isStarted.getAndSet(false)) {
+    PerformanceCollectionData data =
+      performanceDataMap.remove(transaction.getEventId().toString());
+    if (performanceDataMap.isEmpty() && isStarted.getAndSet(false)) {
+      synchronized (timerLock) {
         if (timer != null) {
           timer.cancel();
           timer = null;
         }
       }
-      return data;
     }
+    return data;
   }
 }

--- a/sentry/src/main/java/io/sentry/ICollector.java
+++ b/sentry/src/main/java/io/sentry/ICollector.java
@@ -9,5 +9,5 @@ public interface ICollector {
 
   void setup();
 
-  void collect(@NotNull final Iterable<PerformanceCollectionData> performanceCollectionData);
+  void collect(final @NotNull PerformanceCollectionData performanceCollectionData);
 }

--- a/sentry/src/main/java/io/sentry/ITransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/ITransactionProfiler.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,5 +12,6 @@ public interface ITransactionProfiler {
 
   @Nullable
   ProfilingTraceData onTransactionFinish(
-      @NotNull ITransaction transaction, @Nullable PerformanceCollectionData memoryCollectionData);
+      @NotNull ITransaction transaction,
+      @Nullable List<PerformanceCollectionData> performanceCollectionData);
 }

--- a/sentry/src/main/java/io/sentry/JavaMemoryCollector.java
+++ b/sentry/src/main/java/io/sentry/JavaMemoryCollector.java
@@ -12,12 +12,10 @@ public final class JavaMemoryCollector implements ICollector {
   public void setup() {}
 
   @Override
-  public void collect(@NotNull Iterable<PerformanceCollectionData> performanceCollectionData) {
+  public void collect(final @NotNull PerformanceCollectionData performanceCollectionData) {
     final long now = System.currentTimeMillis();
     final long usedMemory = runtime.totalMemory() - runtime.freeMemory();
     MemoryCollectionData memoryData = new MemoryCollectionData(now, usedMemory);
-    for (PerformanceCollectionData data : performanceCollectionData) {
-      data.addMemoryData(memoryData);
-    }
+    performanceCollectionData.addMemoryData(memoryData);
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionPerformanceCollector.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,7 +19,7 @@ public final class NoOpTransactionPerformanceCollector implements TransactionPer
   public void start(@NotNull ITransaction transaction) {}
 
   @Override
-  public @Nullable PerformanceCollectionData stop(@NotNull ITransaction transaction) {
+  public @Nullable List<PerformanceCollectionData> stop(@NotNull ITransaction transaction) {
     return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,7 +19,8 @@ public final class NoOpTransactionProfiler implements ITransactionProfiler {
 
   @Override
   public @Nullable ProfilingTraceData onTransactionFinish(
-      @NotNull ITransaction transaction, @Nullable PerformanceCollectionData memoryCollectionData) {
+      @NotNull ITransaction transaction,
+      @Nullable List<PerformanceCollectionData> performanceCollectionData) {
     return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/PerformanceCollectionData.java
+++ b/sentry/src/main/java/io/sentry/PerformanceCollectionData.java
@@ -7,38 +7,18 @@ import org.jetbrains.annotations.Nullable;
 public final class PerformanceCollectionData {
   private @Nullable MemoryCollectionData memoryData = null;
   private @Nullable CpuCollectionData cpuData = null;
-  private @Nullable MemoryCollectionData uncommittedMemoryData = null;
-  private @Nullable CpuCollectionData uncommittedCpuData = null;
 
-  /**
-   * Add a {@link io.sentry.MemoryCollectionData} to internal uncommitted data. To save the data
-   * call {@code commitData}. Only the last uncommitted memory data will be retained.
-   */
+  /** Store a {@link io.sentry.MemoryCollectionData}, if not null. */
   public void addMemoryData(final @Nullable MemoryCollectionData memoryCollectionData) {
     if (memoryCollectionData != null) {
-      uncommittedMemoryData = memoryCollectionData;
+      memoryData = memoryCollectionData;
     }
   }
 
-  /**
-   * Add a {@link io.sentry.CpuCollectionData} to internal uncommitted data. To save the data call
-   * {@code commitData()}. Only the last uncommitted cpu data will be retained.
-   */
+  /** Store a {@link io.sentry.CpuCollectionData}, if not null. */
   public void addCpuData(final @Nullable CpuCollectionData cpuCollectionData) {
     if (cpuCollectionData != null) {
-      uncommittedCpuData = cpuCollectionData;
-    }
-  }
-
-  /** Save any uncommitted data. */
-  public void commitData() {
-    if (uncommittedMemoryData != null) {
-      memoryData = uncommittedMemoryData;
-      uncommittedMemoryData = null;
-    }
-    if (uncommittedCpuData != null) {
-      cpuData = uncommittedCpuData;
-      uncommittedCpuData = null;
+      cpuData = cpuCollectionData;
     }
   }
 

--- a/sentry/src/main/java/io/sentry/PerformanceCollectionData.java
+++ b/sentry/src/main/java/io/sentry/PerformanceCollectionData.java
@@ -1,15 +1,12 @@
 package io.sentry;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class PerformanceCollectionData {
-  private final @NotNull List<MemoryCollectionData> memoryData = new ArrayList<>();
-  private final @NotNull List<CpuCollectionData> cpuData = new ArrayList<>();
+  private @Nullable MemoryCollectionData memoryData = null;
+  private @Nullable CpuCollectionData cpuData = null;
   private @Nullable MemoryCollectionData uncommittedMemoryData = null;
   private @Nullable CpuCollectionData uncommittedCpuData = null;
 
@@ -36,20 +33,20 @@ public final class PerformanceCollectionData {
   /** Save any uncommitted data. */
   public void commitData() {
     if (uncommittedMemoryData != null) {
-      memoryData.add(uncommittedMemoryData);
+      memoryData = uncommittedMemoryData;
       uncommittedMemoryData = null;
     }
     if (uncommittedCpuData != null) {
-      cpuData.add(uncommittedCpuData);
+      cpuData = uncommittedCpuData;
       uncommittedCpuData = null;
     }
   }
 
-  public @NotNull List<CpuCollectionData> getCpuData() {
+  public @Nullable CpuCollectionData getCpuData() {
     return cpuData;
   }
 
-  public @NotNull List<MemoryCollectionData> getMemoryData() {
+  public @Nullable MemoryCollectionData getMemoryData() {
     return memoryData;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -396,8 +396,8 @@ public class SentryOptions {
   private final @NotNull List<ICollector> collectors = new ArrayList<>();
 
   /** Performance collector that collect performance stats while transactions run. */
-  private final @NotNull TransactionPerformanceCollector transactionPerformanceCollector =
-      new DefaultTransactionPerformanceCollector(this);
+  private @NotNull TransactionPerformanceCollector transactionPerformanceCollector =
+      NoOpTransactionPerformanceCollector.getInstance();
 
   /**
    * Adds an event processor
@@ -1898,6 +1898,17 @@ public class SentryOptions {
   @ApiStatus.Internal
   public @NotNull TransactionPerformanceCollector getTransactionPerformanceCollector() {
     return transactionPerformanceCollector;
+  }
+
+  /**
+   * Sets the performance collector used to collect performance stats while transactions run.
+   *
+   * @param transactionPerformanceCollector the performance collector.
+   */
+  @ApiStatus.Internal
+  public void setTransactionPerformanceCollector(
+      final @NotNull TransactionPerformanceCollector transactionPerformanceCollector) {
+    this.transactionPerformanceCollector = transactionPerformanceCollector;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -397,7 +397,7 @@ public class SentryOptions {
 
   /** Performance collector that collect performance stats while transactions run. */
   private final @NotNull TransactionPerformanceCollector transactionPerformanceCollector =
-      NoOpTransactionPerformanceCollector.getInstance();
+      new DefaultTransactionPerformanceCollector(this);
 
   /**
    * Adds an event processor

--- a/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -8,5 +9,5 @@ public interface TransactionPerformanceCollector {
   void start(@NotNull ITransaction transaction);
 
   @Nullable
-  PerformanceCollectionData stop(@NotNull ITransaction transaction);
+  List<PerformanceCollectionData> stop(@NotNull ITransaction transaction);
 }

--- a/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
@@ -2,8 +2,8 @@ package io.sentry
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 
 class JavaMemoryCollectorTest {
 
@@ -16,15 +16,14 @@ class JavaMemoryCollectorTest {
 
     @Test
     fun `when collect, only heap memory is collected`() {
-        val performanceCollectionData = PerformanceCollectionData()
-        val data = listOf(performanceCollectionData)
+        val data = PerformanceCollectionData()
         val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
         fixture.collector.collect(data)
-        performanceCollectionData.commitData()
-        val memoryData = performanceCollectionData.memoryData
-        assertFalse(memoryData.isEmpty())
-        assertEquals(-1, memoryData.first().usedNativeMemory)
-        assertEquals(usedMemory, memoryData.first().usedHeapMemory)
-        assertNotEquals(0, memoryData.first().timestampMillis)
+        data.commitData()
+        val memoryData = data.memoryData
+        assertNotNull(memoryData)
+        assertEquals(-1, memoryData.usedNativeMemory)
+        assertEquals(usedMemory, memoryData.usedHeapMemory)
+        assertNotEquals(0, memoryData.timestampMillis)
     }
 }

--- a/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/JavaMemoryCollectorTest.kt
@@ -19,7 +19,6 @@ class JavaMemoryCollectorTest {
         val data = PerformanceCollectionData()
         val usedMemory = fixture.runtime.totalMemory() - fixture.runtime.freeMemory()
         fixture.collector.collect(data)
-        data.commitData()
         val memoryData = data.memoryData
         assertNotNull(memoryData)
         assertEquals(-1, memoryData.usedNativeMemory)

--- a/sentry/src/test/java/io/sentry/PerformanceCollectionDataTest.kt
+++ b/sentry/src/test/java/io/sentry/PerformanceCollectionDataTest.kt
@@ -3,9 +3,9 @@ package io.sentry
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class PerformanceCollectionDataTest {
 
@@ -19,18 +19,18 @@ class PerformanceCollectionDataTest {
     fun `memory data is saved only after commitData`() {
         val data = fixture.getSut()
         data.addMemoryData(mock())
-        assertTrue(data.memoryData.isEmpty())
+        assertNull(data.memoryData)
         data.commitData()
-        assertFalse(data.memoryData.isEmpty())
+        assertNotNull(data.memoryData)
     }
 
     @Test
     fun `cpu data is saved only after commitData`() {
         val data = fixture.getSut()
         data.addCpuData(mock())
-        assertTrue(data.cpuData.isEmpty())
+        assertNull(data.cpuData)
         data.commitData()
-        assertFalse(data.cpuData.isEmpty())
+        assertNotNull(data.cpuData)
     }
 
     @Test
@@ -41,7 +41,7 @@ class PerformanceCollectionDataTest {
         data.addMemoryData(memData1)
         data.addMemoryData(memData2)
         data.commitData()
-        val savedMemoryData = data.memoryData.first()
+        val savedMemoryData = data.memoryData
         assertNotEquals(memData1, savedMemoryData)
         assertEquals(memData2, savedMemoryData)
     }
@@ -54,7 +54,7 @@ class PerformanceCollectionDataTest {
         data.addCpuData(cpuData1)
         data.addCpuData(cpuData2)
         data.commitData()
-        val savedCpuData = data.cpuData.first()
+        val savedCpuData = data.cpuData
         assertNotEquals(cpuData1, savedCpuData)
         assertEquals(cpuData2, savedCpuData)
     }
@@ -67,22 +67,8 @@ class PerformanceCollectionDataTest {
         data.addCpuData(null)
         data.addMemoryData(null)
         data.commitData()
-        assertEquals(1, data.cpuData.size)
-        assertTrue(data.memoryData.isEmpty())
-        val savedCpuData = data.cpuData.first()
+        assertNull(data.memoryData)
+        val savedCpuData = data.cpuData
         assertEquals(cpuData1, savedCpuData)
-    }
-
-    @Test
-    fun `committing multiple times does not duplicate values`() {
-        val data = fixture.getSut()
-        data.addCpuData(mock())
-        data.addMemoryData(mock())
-        data.commitData()
-        assertEquals(1, data.cpuData.size)
-        assertEquals(1, data.memoryData.size)
-        data.commitData()
-        assertEquals(1, data.cpuData.size)
-        assertEquals(1, data.memoryData.size)
     }
 }

--- a/sentry/src/test/java/io/sentry/PerformanceCollectionDataTest.kt
+++ b/sentry/src/test/java/io/sentry/PerformanceCollectionDataTest.kt
@@ -1,10 +1,8 @@
 package io.sentry
 
-import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class PerformanceCollectionDataTest {
@@ -16,44 +14,24 @@ class PerformanceCollectionDataTest {
     }
 
     @Test
-    fun `memory data is saved only after commitData`() {
-        val data = fixture.getSut()
-        data.addMemoryData(mock())
-        assertNull(data.memoryData)
-        data.commitData()
-        assertNotNull(data.memoryData)
-    }
-
-    @Test
-    fun `cpu data is saved only after commitData`() {
-        val data = fixture.getSut()
-        data.addCpuData(mock())
-        assertNull(data.cpuData)
-        data.commitData()
-        assertNotNull(data.cpuData)
-    }
-
-    @Test
-    fun `only the last of multiple memory data is saved on commit`() {
+    fun `only the last of multiple memory data is saved`() {
         val data = fixture.getSut()
         val memData1 = MemoryCollectionData(0, 0, 0)
         val memData2 = MemoryCollectionData(1, 1, 1)
         data.addMemoryData(memData1)
         data.addMemoryData(memData2)
-        data.commitData()
         val savedMemoryData = data.memoryData
         assertNotEquals(memData1, savedMemoryData)
         assertEquals(memData2, savedMemoryData)
     }
 
     @Test
-    fun `only the last of multiple cpu data is saved on commit`() {
+    fun `only the last of multiple cpu data is saved`() {
         val data = fixture.getSut()
         val cpuData1 = CpuCollectionData(0, 0.0)
         val cpuData2 = CpuCollectionData(1, 1.0)
         data.addCpuData(cpuData1)
         data.addCpuData(cpuData2)
-        data.commitData()
         val savedCpuData = data.cpuData
         assertNotEquals(cpuData1, savedCpuData)
         assertEquals(cpuData2, savedCpuData)
@@ -66,7 +44,6 @@ class PerformanceCollectionDataTest {
         data.addCpuData(cpuData1)
         data.addCpuData(null)
         data.addMemoryData(null)
-        data.commitData()
         assertNull(data.memoryData)
         val savedCpuData = data.cpuData
         assertEquals(cpuData1, savedCpuData)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -388,7 +388,13 @@ class SentryOptionsTest {
         assertEquals("${File.separator}test${File.separator}${hash}${File.separator}profiling_traces", options.profilingTracesDirPath)
     }
 
+    @Test
     fun `when options are initialized, idleTimeout is 3000`() {
         assertEquals(3000L, SentryOptions().idleTimeout)
+    }
+
+    @Test
+    fun `when options are initialized, TransactionPerformanceCollector is a NoOp`() {
+        assertEquals(SentryOptions().transactionPerformanceCollector, NoOpTransactionPerformanceCollector.getInstance())
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -397,4 +397,12 @@ class SentryOptionsTest {
     fun `when options are initialized, TransactionPerformanceCollector is a NoOp`() {
         assertEquals(SentryOptions().transactionPerformanceCollector, NoOpTransactionPerformanceCollector.getInstance())
     }
+
+    @Test
+    fun `when setTransactionPerformanceCollector is called, overrides default`() {
+        val performanceCollector = mock<TransactionPerformanceCollector>()
+        val options = SentryOptions()
+        options.transactionPerformanceCollector = performanceCollector
+        assertEquals(performanceCollector, options.transactionPerformanceCollector)
+    }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -381,7 +381,7 @@ class SentryTest {
 
     private class CustomMemoryCollector : ICollector {
         override fun setup() {}
-        override fun collect(performanceCollectionData: MutableIterable<PerformanceCollectionData>) {}
+        override fun collect(performanceCollectionData: PerformanceCollectionData) {}
     }
 
     private class CustomModulesLoader : IModulesLoader {

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -888,8 +888,16 @@ class SentryTracerTest {
     }
 
     @Test
-    fun `when transaction is created, transactionPerformanceCollector is started`() {
+    fun `when transaction is created, but not profiled, transactionPerformanceCollector is not started`() {
         val transaction = fixture.getSut()
+        verify(fixture.transactionPerformanceCollector, never()).start(anyOrNull())
+    }
+
+    @Test
+    fun `when transaction is created and profiled transactionPerformanceCollector is started`() {
+        val transaction = fixture.getSut(optionsConfiguration = {
+            it.profilesSampleRate = 1.0
+        }, samplingDecision = TracesSamplingDecision(true, null, true, null))
         verify(fixture.transactionPerformanceCollector).start(check { assertEquals(transaction, it) })
     }
 


### PR DESCRIPTION
## :scroll: Description
PerformanceCollectionData now contains single values instead of lists
ICollectors now work on a single instance of PerformanceCollectionData instead than a list
TransactionPerformanceCollector:
* is now set in Android options
* a NoOpTransactionPerformanceCollector is set in Java options
* deletes data after 30 seconds
* collect data only if a profile is sampled


## :bulb: Motivation and Context
We collect data about cpu and memory usage during transactions. This caused [oom error in java backend](https://github.com/getsentry/sentry-java/issues/2496).  
As a workaround, the data collection [was disabled](https://github.com/getsentry/sentry-java/pull/2498).   
We are now enabling the data collection only on the Android SDK, and only if a profile is sampled, since we send this data only in profiles, at the moment.
Several updates were put to reduce the memory footprint of the collected data


## :green_heart: How did you test it?
Unit test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
