### PR TITLE
fix(internal): Do not attach view hierarchy to hybrid sdks events

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -14,6 +14,7 @@ import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.gestures.ViewUtils;
 import io.sentry.protocol.ViewHierarchy;
 import io.sentry.protocol.ViewHierarchyNode;
+import io.sentry.util.HintUtils;
 import io.sentry.util.JsonSerializationUtils;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
@@ -40,6 +41,10 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
 
     if (!options.isAttachViewHierarchy()) {
       options.getLogger().log(SentryLevel.DEBUG, "attachViewHierarchy is disabled.");
+      return event;
+    }
+
+    if (HintUtils.isFromHybridSdk(hint)) {
       return event;
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The view hierarchy the same way as screenshots would appear twice if not checked for hybrid sdks.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/getsentry/sentry-react-native/pull/2708

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
#skip-changelog 