### PR TITLE
Fix app start span end-time is wrong if SDK init is deferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix transaction performance collector oom ([#2505](https://github.com/getsentry/sentry-java/pull/2505))
 - Remove authority from URLs sent to Sentry ([#2366](https://github.com/getsentry/sentry-java/pull/2366))
 - Fix `sentry-bom` containing incorrect artifacts ([#2504](https://github.com/getsentry/sentry-java/pull/2504))
+- Fix app start span end-time is wrong if SDK init is deferred ([#2519](https://github.com/getsentry/sentry-java/pull/2519))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
 ## 6.13.1
+
+- Fix app start span end-time is wrong if SDK init is deferred ([#2519](https://github.com/getsentry/sentry-java/pull/2519))
 
 ### Fixes
 
 - Fix transaction performance collector oom ([#2505](https://github.com/getsentry/sentry-java/pull/2505))
 - Remove authority from URLs sent to Sentry ([#2366](https://github.com/getsentry/sentry-java/pull/2366))
 - Fix `sentry-bom` containing incorrect artifacts ([#2504](https://github.com/getsentry/sentry-java/pull/2504))
-- Fix app start span end-time is wrong if SDK init is deferred ([#2519](https://github.com/getsentry/sentry-java/pull/2519))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixes
 
-## 6.13.1
-
 - Fix app start span end-time is wrong if SDK init is deferred ([#2519](https://github.com/getsentry/sentry-java/pull/2519))
+
+## 6.13.1
 
 ### Fixes
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -71,6 +71,7 @@ public final class io/sentry/android/core/AppLifecycleIntegration : io/sentry/In
 }
 
 public final class io/sentry/android/core/AppStartState {
+	public fun getAppStartEndTime ()Lio/sentry/SentryDate;
 	public fun getAppStartInterval ()Ljava/lang/Long;
 	public fun getAppStartMillis ()Ljava/lang/Long;
 	public fun getAppStartTime ()Lio/sentry/SentryDate;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
@@ -1,7 +1,9 @@
 package io.sentry.android.core;
 
 import android.os.SystemClock;
+import io.sentry.DateUtils;
 import io.sentry.SentryDate;
+import io.sentry.SentryLongDate;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -82,6 +84,20 @@ public final class AppStartState {
   @Nullable
   public SentryDate getAppStartTime() {
     return appStartTime;
+  }
+
+  @Nullable
+  public SentryDate getAppStartEndTime() {
+    @Nullable final SentryDate start = getAppStartTime();
+    if (start != null) {
+      @Nullable final Long durationMillis = getAppStartInterval();
+      if (durationMillis != null) {
+        long startNanos = start.nanoTimestamp();
+        long endNanos = startNanos + DateUtils.millisToNanos(durationMillis);
+        return new SentryLongDate(endNanos);
+      }
+    }
+    return null;
   }
 
   @Nullable

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppStartState.java
@@ -92,8 +92,8 @@ public final class AppStartState {
     if (start != null) {
       @Nullable final Long durationMillis = getAppStartInterval();
       if (durationMillis != null) {
-        long startNanos = start.nanoTimestamp();
-        long endNanos = startNanos + DateUtils.millisToNanos(durationMillis);
+        final long startNanos = start.nanoTimestamp();
+        final long endNanos = startNanos + DateUtils.millisToNanos(durationMillis);
         return new SentryLongDate(endNanos);
       }
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -103,9 +103,8 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider
   @Override
   public void onActivityResumed(@NotNull Activity activity) {
     if (!firstActivityResumed) {
-      // we only finish the app start if the process is of foregroundImportance
-      firstActivityResumed = true;
       // sets App start as finished when the very first activity calls onResume
+      firstActivityResumed = true;
       AppStartState.getInstance().setAppStartEnd();
     }
     if (application != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -29,6 +29,8 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider
   private static long appStartMillis = SystemClock.uptimeMillis();
 
   private boolean firstActivityCreated = false;
+  private boolean firstActivityResumed = false;
+
   private @Nullable Application application;
 
   public SentryPerformanceProvider() {
@@ -91,9 +93,6 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider
       final boolean coldStart = savedInstanceState == null;
       AppStartState.getInstance().setColdStart(coldStart);
 
-      if (application != null) {
-        application.unregisterActivityLifecycleCallbacks(this);
-      }
       firstActivityCreated = true;
     }
   }
@@ -102,7 +101,17 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider
   public void onActivityStarted(@NotNull Activity activity) {}
 
   @Override
-  public void onActivityResumed(@NotNull Activity activity) {}
+  public void onActivityResumed(@NotNull Activity activity) {
+    if (!firstActivityResumed) {
+      // we only finish the app start if the process is of foregroundImportance
+      firstActivityResumed = true;
+      // sets App start as finished when the very first activity calls onResume
+      AppStartState.getInstance().setAppStartEnd();
+    }
+    if (application != null) {
+      application.unregisterActivityLifecycleCallbacks(this);
+    }
+  }
 
   @Override
   public void onActivityPaused(@NotNull Activity activity) {}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -650,37 +650,6 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `App start end time is set`() {
-        val sut = fixture.getSut(14)
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        setAppStartTime()
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, null)
-        sut.onActivityResumed(activity)
-
-        // SystemClock.uptimeMillis() always returns 0, can't assert real values
-        assertNotNull(AppStartState.getInstance().appStartInterval)
-    }
-
-    @Test
-    fun `App start end time isnt set if not foregroundImportance`() {
-        val sut = fixture.getSut(14, importance = RunningAppProcessInfo.IMPORTANCE_BACKGROUND)
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        setAppStartTime()
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, null)
-        sut.onActivityResumed(activity)
-
-        assertNull(AppStartState.getInstance().appStartInterval)
-    }
-
-    @Test
     fun `When firstActivityCreated is true, start transaction with given appStartTime`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
@@ -697,19 +666,46 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true, do not use appStartTime if not foregroundImportance`() {
+    fun `When firstActivityCreated is true, do not create app start span if not foregroundImportance`() {
         val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_BACKGROUND)
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
 
+        // usually set by SentryPerformanceProvider
         val date = SentryNanotimeDate(Date(0), 0)
         setAppStartTime(date)
+        AppStartState.getInstance().setAppStartEnd(1)
 
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, fixture.bundle)
 
         // call only once
         verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertNull(it.startTimestamp) })
+    }
+
+    @Test
+    fun `Create and finish app start span immediately in case SDK init is deferred`() {
+        val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
+        fixture.options.tracesSampleRate = 1.0
+        sut.register(fixture.hub, fixture.options)
+
+        // usually set by SentryPerformanceProvider
+        val startDate = SentryNanotimeDate(Date(0), 0)
+        setAppStartTime(startDate)
+        AppStartState.getInstance().setColdStart(false)
+        AppStartState.getInstance().setAppStartEnd(1)
+
+        val endDate = AppStartState.getInstance().appStartEndTime!!
+
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, fixture.bundle)
+
+        val appStartSpanCount = fixture.transaction.children.count {
+            it.spanContext.operation.startsWith("app.start.warm") &&
+                it.startDate.nanoTimestamp() == startDate.nanoTimestamp() &&
+                it.finishDate!!.nanoTimestamp() == endDate.nanoTimestamp()
+        }
+        assertEquals(1, appStartSpanCount)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -1,16 +1,20 @@
 package io.sentry.android.core
 
+import android.app.Application
 import android.content.pm.ProviderInfo
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.SentryNanotimeDate
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import java.util.Date
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -71,6 +75,26 @@ class SentryPerformanceProviderTest {
         provider.onActivityCreated(mock(), Bundle())
 
         assertFalse(AppStartState.getInstance().isColdStart!!)
+    }
+
+    @Test
+    fun `provider sets app start end on first activity resume, and unregisters afterwards`() {
+        val providerInfo = ProviderInfo()
+
+        val mockContext = ContextUtilsTest.createMockContext(true)
+        providerInfo.authority = AUTHORITY
+
+        val provider = SentryPerformanceProvider()
+        provider.attachInfo(mockContext, providerInfo)
+
+        provider.onActivityCreated(mock(), Bundle())
+        provider.onActivityResumed(mock())
+
+        assertNotNull(AppStartState.getInstance().appStartInterval)
+        assertNotNull(AppStartState.getInstance().appStartEndTime)
+
+        verify((mockContext.applicationContext as Application))
+            .unregisterActivityLifecycleCallbacks(any())
     }
 
     companion object {


### PR DESCRIPTION
This way the appstart start/end times are properly tracked, even if the
SDK is not initialized yet. In case of a deferred SDK init, the app
start span will be attached to the first tracked Activity after SDK
init.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2518


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
