### PR TITLE
Ignore Shutdown in progress when closing ShutdownHookIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Ignore Shutdown in progress when closing ShutdownHookIntegration ([#2521](https://github.com/getsentry/sentry-java/pull/2521))
+
 ## 6.13.1
 
 ### Fixes

--- a/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
+++ b/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
@@ -41,7 +41,16 @@ public final class ShutdownHookIntegration implements Integration, Closeable {
   @Override
   public void close() throws IOException {
     if (thread != null) {
-      runtime.removeShutdownHook(thread);
+      try {
+        runtime.removeShutdownHook(thread);
+      } catch (IllegalStateException e) {
+        @Nullable final String message = e.getMessage();
+        if (message != null && message.equals("Shutdown in progress")) {
+          // ignore
+        } else {
+          throw e;
+        }
+      }
     }
   }
 

--- a/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
+++ b/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
@@ -45,6 +45,7 @@ public final class ShutdownHookIntegration implements Integration, Closeable {
         runtime.removeShutdownHook(thread);
       } catch (IllegalStateException e) {
         @Nullable final String message = e.getMessage();
+        // https://github.com/openjdk/jdk/blob/09b8a1959771213cb982d062f0a913285e4a0c6e/src/java.base/share/classes/java/lang/ApplicationShutdownHooks.java#L83
         if (message != null && message.equals("Shutdown in progress")) {
           // ignore
         } else {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Ignore "Shutdown in progress" `IllegalStateException` when removing the shutdown hook. This was also present in older versions of the SDK (https://github.com/getsentry/sentry-java/pull/550/files).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Came up again recently in #2465 and also happened in tests before #1574 and #1663

## :green_heart: How did you test it?
Unit Test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [-] I updated the docs if needed.
- [-] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
