### PR TITLE
Add `enableTracing` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
 - Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
+  - This change is backwards compatible.  The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
+  - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.
+  - If set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
+- Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
+    - This change is backwards compatible. The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
+    - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.
+    - If set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options.
+
 ## 6.14.0
 
 ### Features
 
 - Add time-to-full-display span to Activity auto-instrumentation ([#2432](https://github.com/getsentry/sentry-java/pull/2432))
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
-- Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
-  - This change is backwards compatible. The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
-  - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.
-  - If set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
 - Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
-  - This change is backwards compatible.  The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
+  - This change is backwards compatible. The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
   - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.
   - If set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options.
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -235,7 +235,7 @@ final class ManifestMetadataReader {
                 COLLECT_ADDITIONAL_CONTEXT,
                 options.isCollectAdditionalContext()));
 
-        if (options.isEnableTracing() == null) {
+        if (options.getEnableTracing() == null) {
           options.setEnableTracing(readBoolNullable(metadata, logger, TRACING_ENABLE, null));
         }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -43,8 +43,8 @@ public final class SentryAndroidOptions extends SentryOptions {
    * Enables the Auto instrumentation for Activity lifecycle tracing.
    *
    * <ul>
-   *   <li>It also requires setting {@link SentryOptions#getTracesSampleRate()} or {@link
-   *       SentryOptions#getTracesSampler()}.
+   *   <li>It also requires setting any of {@link SentryOptions#isEnableTracing()}, {@link
+   *       SentryOptions#getTracesSampleRate()} or {@link SentryOptions#getTracesSampler()}.
    * </ul>
    *
    * <ul>

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -43,7 +43,7 @@ public final class SentryAndroidOptions extends SentryOptions {
    * Enables the Auto instrumentation for Activity lifecycle tracing.
    *
    * <ul>
-   *   <li>It also requires setting any of {@link SentryOptions#isEnableTracing()}, {@link
+   *   <li>It also requires setting any of {@link SentryOptions#getEnableTracing()}, {@link
    *       SentryOptions#getTracesSampleRate()} or {@link SentryOptions#getTracesSampler()}.
    * </ul>
    *

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -99,6 +99,29 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
+    fun `When activity lifecycle breadcrumb is disabled but tracing is enabled, it registers callback`() {
+        val sut = fixture.getSut()
+        fixture.options.isEnableActivityLifecycleBreadcrumbs = false
+        fixture.options.isEnableTracing = true
+
+        sut.register(fixture.hub, fixture.options)
+
+        verify(fixture.application).registerActivityLifecycleCallbacks(any())
+    }
+
+    @Test
+    fun `When activity lifecycle breadcrumb is disabled and tracesSampleRate is set but tracing is disabled, it does not register callback`() {
+        val sut = fixture.getSut()
+        fixture.options.isEnableActivityLifecycleBreadcrumbs = false
+        fixture.options.tracesSampleRate = 1.0
+        fixture.options.isEnableTracing = false
+
+        sut.register(fixture.hub, fixture.options)
+
+        verify(fixture.application, never()).registerActivityLifecycleCallbacks(any())
+    }
+
+    @Test
     fun `When activity lifecycle breadcrumb is disabled but tracing sample rate is enabled, it registers callback`() {
         val sut = fixture.getSut()
         fixture.options.isEnableActivityLifecycleBreadcrumbs = false

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -102,7 +102,7 @@ class ActivityLifecycleIntegrationTest {
     fun `When activity lifecycle breadcrumb is disabled but tracing is enabled, it registers callback`() {
         val sut = fixture.getSut()
         fixture.options.isEnableActivityLifecycleBreadcrumbs = false
-        fixture.options.isEnableTracing = true
+        fixture.options.enableTracing = true
 
         sut.register(fixture.hub, fixture.options)
 
@@ -114,7 +114,7 @@ class ActivityLifecycleIntegrationTest {
         val sut = fixture.getSut()
         fixture.options.isEnableActivityLifecycleBreadcrumbs = false
         fixture.options.tracesSampleRate = 1.0
-        fixture.options.isEnableTracing = false
+        fixture.options.enableTracing = false
 
         sut.register(fixture.hub, fixture.options)
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -646,6 +646,45 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
+    fun `applyMetadata reads enableTracing from metadata`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.TRACING_ENABLE to true)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(true, fixture.options.isEnableTracing)
+    }
+
+    @Test
+    fun `applyMetadata does not override enableTracing from options`() {
+        // Arrange
+        fixture.options.isEnableTracing = true
+        val bundle = bundleOf(ManifestMetadataReader.TRACING_ENABLE to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(true, fixture.options.isEnableTracing)
+    }
+
+    @Test
+    fun `applyMetadata without specifying enableTracing, stays null`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertNull(fixture.options.isEnableTracing)
+    }
+
+    @Test
     fun `applyMetadata reads enableAutoActivityLifecycleTracing to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.TRACES_ACTIVITY_ENABLE to false)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -655,13 +655,13 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(true, fixture.options.isEnableTracing)
+        assertEquals(true, fixture.options.enableTracing)
     }
 
     @Test
     fun `applyMetadata does not override enableTracing from options`() {
         // Arrange
-        fixture.options.isEnableTracing = true
+        fixture.options.enableTracing = true
         val bundle = bundleOf(ManifestMetadataReader.TRACING_ENABLE to false)
         val context = fixture.getContext(metaData = bundle)
 
@@ -669,7 +669,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(true, fixture.options.isEnableTracing)
+        assertEquals(true, fixture.options.enableTracing)
     }
 
     @Test
@@ -681,7 +681,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertNull(fixture.options.isEnableTracing)
+        assertNull(fixture.options.enableTracing)
     }
 
     @Test

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -101,7 +101,8 @@
 
         <!--    how to enable the performance API by either enabling tracing or setting a sample-rate-->
         <meta-data android:name="io.sentry.traces.enable" android:value="true" />
-        <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+<!-- how to set custom sample rate different from the default 1.0 -->
+<!--        <meta-data android:name="io.sentry.traces.sample-rate" android:value="0.8" /> -->
 
         <!--    how to enable profiling when starting transactions -->
         <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -99,7 +99,8 @@
         <!--    how to change the session tracking interval-->
         <meta-data android:name="io.sentry.session-tracking.timeout-interval-millis" android:value="10000" />
 
-        <!--    how to enable the performance API by setting a sample-rate-->
+        <!--    how to enable the performance API by either enabling tracing or setting a sample-rate-->
+        <meta-data android:name="io.sentry.traces.enable" android:value="true" />
         <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
 
         <!--    how to enable profiling when starting transactions -->

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -9,6 +9,7 @@ sentry.logging.minimum-event-level=info
 sentry.logging.minimum-breadcrumb-level=debug
 # Performance configuration
 sentry.traces-sample-rate=1.0
+sentry.enable-tracing=true
 sentry.debug=true
 in-app-includes="io.sentry.samples"
 

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -9,6 +9,7 @@ sentry.logging.minimum-event-level=info
 sentry.logging.minimum-breadcrumb-level=debug
 # Performance configuration
 sentry.traces-sample-rate=1.0
+sentry.enable-tracing=true
 sentry.debug=true
 in-app-includes="io.sentry.samples"
 

--- a/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -115,7 +115,7 @@ public class SentryAutoConfiguration {
 
       options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME);
       options.setSdkVersion(createSdkVersion(options));
-      if (options.getTracesSampleRate() == null && options.isEnableTracing() == null) {
+      if (options.getTracesSampleRate() == null && options.getEnableTracing() == null) {
         options.setTracesSampleRate(0.0);
       }
       // Spring Boot sets ignored exceptions in runtime using reflection - where the generic

--- a/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -115,7 +115,7 @@ public class SentryAutoConfiguration {
 
       options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME);
       options.setSdkVersion(createSdkVersion(options));
-      if (options.getTracesSampleRate() == null) {
+      if (options.getTracesSampleRate() == null && options.isEnableTracing() == null) {
         options.setTracesSampleRate(0.0);
       }
       // Spring Boot sets ignored exceptions in runtime using reflection - where the generic
@@ -331,6 +331,10 @@ public class SentryAutoConfiguration {
     public SentryTracingCondition() {
       super(ConfigurationPhase.REGISTER_BEAN);
     }
+
+    @ConditionalOnProperty(name = "sentry.enable-tracing")
+    @SuppressWarnings("UnusedNestedClass")
+    private static class SentryEnableTracingCondition {}
 
     @ConditionalOnProperty(name = "sentry.traces-sample-rate")
     @SuppressWarnings("UnusedNestedClass")

--- a/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -150,6 +150,7 @@ class SentryAutoConfigurationTest {
             "sentry.proxy.port=8090",
             "sentry.proxy.user=proxy-user",
             "sentry.proxy.pass=proxy-pass",
+            "sentry.enable-tracing=true",
             "sentry.traces-sample-rate=0.3",
             "sentry.tags.tag1=tag1-value",
             "sentry.tags.tag2=tag2-value",
@@ -178,6 +179,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.proxy!!.port).isEqualTo("8090")
             assertThat(options.proxy!!.user).isEqualTo("proxy-user")
             assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
+            assertThat(options.isEnableTracing).isEqualTo(true)
             assertThat(options.tracesSampleRate).isEqualTo(0.3)
             assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)

--- a/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -179,7 +179,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.proxy!!.port).isEqualTo("8090")
             assertThat(options.proxy!!.user).isEqualTo("proxy-user")
             assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
-            assertThat(options.isEnableTracing).isEqualTo(true)
+            assertThat(options.enableTracing).isEqualTo(true)
             assertThat(options.tracesSampleRate).isEqualTo(0.3)
             assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -116,7 +116,7 @@ public class SentryAutoConfiguration {
 
       options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME);
       options.setSdkVersion(createSdkVersion(options));
-      if (options.getTracesSampleRate() == null) {
+      if (options.getTracesSampleRate() == null && options.isEnableTracing() == null) {
         options.setTracesSampleRate(0.0);
       }
       // Spring Boot sets ignored exceptions in runtime using reflection - where the generic
@@ -332,6 +332,10 @@ public class SentryAutoConfiguration {
     public SentryTracingCondition() {
       super(ConfigurationPhase.REGISTER_BEAN);
     }
+
+    @ConditionalOnProperty(name = "sentry.enable-tracing")
+    @SuppressWarnings("UnusedNestedClass")
+    private static class SentryEnableTracingCondition {}
 
     @ConditionalOnProperty(name = "sentry.traces-sample-rate")
     @SuppressWarnings("UnusedNestedClass")

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -116,7 +116,7 @@ public class SentryAutoConfiguration {
 
       options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME);
       options.setSdkVersion(createSdkVersion(options));
-      if (options.getTracesSampleRate() == null && options.isEnableTracing() == null) {
+      if (options.getTracesSampleRate() == null && options.getEnableTracing() == null) {
         options.setTracesSampleRate(0.0);
       }
       // Spring Boot sets ignored exceptions in runtime using reflection - where the generic

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -150,6 +150,7 @@ class SentryAutoConfigurationTest {
             "sentry.proxy.port=8090",
             "sentry.proxy.user=proxy-user",
             "sentry.proxy.pass=proxy-pass",
+            "sentry.enable-tracing=true",
             "sentry.traces-sample-rate=0.3",
             "sentry.tags.tag1=tag1-value",
             "sentry.tags.tag2=tag2-value",
@@ -178,6 +179,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.proxy!!.port).isEqualTo("8090")
             assertThat(options.proxy!!.user).isEqualTo("proxy-user")
             assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
+            assertThat(options.isEnableTracing).isEqualTo(true)
             assertThat(options.tracesSampleRate).isEqualTo(0.3)
             assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -179,7 +179,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.proxy!!.port).isEqualTo("8090")
             assertThat(options.proxy!!.user).isEqualTo("proxy-user")
             assertThat(options.proxy!!.pass).isEqualTo("proxy-pass")
-            assertThat(options.isEnableTracing).isEqualTo(true)
+            assertThat(options.enableTracing).isEqualTo(true)
             assertThat(options.tracesSampleRate).isEqualTo(0.3)
             assertThat(options.tags).containsEntry("tag1", "tag1-value").containsEntry("tag2", "tag2-value")
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1506,6 +1506,7 @@ public class io/sentry/SentryOptions {
 	public fun getDist ()Ljava/lang/String;
 	public fun getDistinctId ()Ljava/lang/String;
 	public fun getDsn ()Ljava/lang/String;
+	public fun getEnableTracing ()Ljava/lang/Boolean;
 	public fun getEnvelopeDiskCache ()Lio/sentry/cache/IEnvelopeCache;
 	public fun getEnvelopeReader ()Lio/sentry/IEnvelopeReader;
 	public fun getEnvironment ()Ljava/lang/String;
@@ -1567,7 +1568,6 @@ public class io/sentry/SentryOptions {
 	public fun isEnableNdk ()Z
 	public fun isEnableScopeSync ()Z
 	public fun isEnableShutdownHook ()Z
-	public fun isEnableTracing ()Ljava/lang/Boolean;
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isEnableUserInteractionBreadcrumbs ()Z
 	public fun isEnableUserInteractionTracing ()Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -238,6 +238,7 @@ public final class io/sentry/ExternalOptions {
 	public fun getDist ()Ljava/lang/String;
 	public fun getDsn ()Ljava/lang/String;
 	public fun getEnableDeduplication ()Ljava/lang/Boolean;
+	public fun getEnableTracing ()Ljava/lang/Boolean;
 	public fun getEnableUncaughtExceptionHandler ()Ljava/lang/Boolean;
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getIdleTimeout ()Ljava/lang/Long;
@@ -260,6 +261,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
+	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
@@ -1565,6 +1567,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableNdk ()Z
 	public fun isEnableScopeSync ()Z
 	public fun isEnableShutdownHook ()Z
+	public fun isEnableTracing ()Ljava/lang/Boolean;
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isEnableUserInteractionBreadcrumbs ()Z
 	public fun isEnableUserInteractionTracing ()Z
@@ -1596,6 +1599,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableNdk (Z)V
 	public fun setEnableScopeSync (Z)V
 	public fun setEnableShutdownHook (Z)V
+	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Z)V
 	public fun setEnableUserInteractionBreadcrumbs (Z)V
 	public fun setEnableUserInteractionTracing (Z)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -25,6 +25,7 @@ public final class ExternalOptions {
   private @Nullable Boolean enableUncaughtExceptionHandler;
   private @Nullable Boolean debug;
   private @Nullable Boolean enableDeduplication;
+  private @Nullable Boolean enableTracing;
   private @Nullable Double tracesSampleRate;
   private @Nullable Double profilesSampleRate;
   private @Nullable SentryOptions.RequestSize maxRequestBodySize;
@@ -54,6 +55,7 @@ public final class ExternalOptions {
         propertiesProvider.getBooleanProperty("uncaught.handler.enabled"));
     options.setPrintUncaughtStackTrace(
         propertiesProvider.getBooleanProperty("uncaught.handler.print-stacktrace"));
+    options.setEnableTracing(propertiesProvider.getBooleanProperty("enable-tracing"));
     options.setTracesSampleRate(propertiesProvider.getDoubleProperty("traces-sample-rate"));
     options.setProfilesSampleRate(propertiesProvider.getDoubleProperty("profiles-sample-rate"));
     options.setDebug(propertiesProvider.getBooleanProperty("debug"));
@@ -205,6 +207,14 @@ public final class ExternalOptions {
 
   public void setEnableDeduplication(final @Nullable Boolean enableDeduplication) {
     this.enableDeduplication = enableDeduplication;
+  }
+
+  public @Nullable Boolean getEnableTracing() {
+    return enableTracing;
+  }
+
+  public void setEnableTracing(final @Nullable Boolean enableTracing) {
+    this.enableTracing = enableTracing;
   }
 
   public @Nullable Double getTracesSampleRate() {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -830,7 +830,7 @@ public class SentryOptions {
    * @return true if enabled, false if disabled, null can mean enabled if {@link
    *     SentryOptions#getTracesSampleRate()} or {@link SentryOptions#getTracesSampler()} are set.
    */
-  public @Nullable Boolean isEnableTracing() {
+  public @Nullable Boolean getEnableTracing() {
     return enableTracing;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -167,6 +167,9 @@ public class SentryOptions {
    */
   private @Nullable Double sampleRate;
 
+  /** Enables generation of transactions and propagation of trace data. */
+  private @Nullable Boolean enableTracing;
+
   /**
    * Configures the sample rate as a percentage of transactions to be sent in the range of 0.0 to
    * 1.0. if 1.0 is set it means that 100% of transactions are sent. If set to 0.1 only 10% of
@@ -819,6 +822,24 @@ public class SentryOptions {
   }
 
   /**
+   * Whether generation of transactions and propagation of trace data is enabled.
+   *
+   * <p>NOTE: There is also {@link SentryOptions#isTracingEnabled()} which checks other options as
+   * well.
+   *
+   * @return true if enabled, false if disabled, null can mean enabled if {@link
+   *     SentryOptions#getTracesSampleRate()} or {@link SentryOptions#getTracesSampler()} are set.
+   */
+  public @Nullable Boolean isEnableTracing() {
+    return enableTracing;
+  }
+
+  /** Enables generation of transactions and propagation of trace data. */
+  public void setEnableTracing(@Nullable Boolean enableTracing) {
+    this.enableTracing = enableTracing;
+  }
+
+  /**
    * Returns the traces sample rate Default is null (disabled)
    *
    * @return the sample rate
@@ -1415,6 +1436,10 @@ public class SentryOptions {
    * @return if tracing is enabled.
    */
   public boolean isTracingEnabled() {
+    if (enableTracing != null) {
+      return enableTracing;
+    }
+
     return getTracesSampleRate() != null || getTracesSampler() != null;
   }
 
@@ -2112,6 +2137,9 @@ public class SentryOptions {
     }
     if (options.getPrintUncaughtStackTrace() != null) {
       setPrintUncaughtStackTrace(options.getPrintUncaughtStackTrace());
+    }
+    if (options.getEnableTracing() != null) {
+      setEnableTracing(options.getEnableTracing());
     }
     if (options.getTracesSampleRate() != null) {
       setTracesSampleRate(options.getTracesSampleRate());

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -3,9 +3,12 @@ package io.sentry;
 import io.sentry.util.Objects;
 import java.security.SecureRandom;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 final class TracesSampler {
+  private static final @NotNull Double DEFAULT_TRACES_SAMPLE_RATE = 1.0;
+
   private final @NotNull SentryOptions options;
   private final @NotNull SecureRandom random;
 
@@ -63,11 +66,17 @@ final class TracesSampler {
       return parentSamplingDecision;
     }
 
-    final Double tracesSampleRateFromOptions = options.getTracesSampleRate();
-    if (tracesSampleRateFromOptions != null) {
+    final @Nullable Double tracesSampleRateFromOptions = options.getTracesSampleRate();
+    final @Nullable Boolean isEnableTracing = options.isEnableTracing();
+    final @Nullable Double defaultSampleRate =
+        Boolean.TRUE.equals(isEnableTracing) ? DEFAULT_TRACES_SAMPLE_RATE : null;
+    final @Nullable Double tracesSampleRateOrDefault =
+        tracesSampleRateFromOptions == null ? defaultSampleRate : tracesSampleRateFromOptions;
+
+    if (tracesSampleRateOrDefault != null) {
       return new TracesSamplingDecision(
-          sample(tracesSampleRateFromOptions),
-          tracesSampleRateFromOptions,
+          sample(tracesSampleRateOrDefault),
+          tracesSampleRateOrDefault,
           profilesSampled,
           profilesSampleRate);
     }

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -67,7 +67,7 @@ final class TracesSampler {
     }
 
     final @Nullable Double tracesSampleRateFromOptions = options.getTracesSampleRate();
-    final @Nullable Boolean isEnableTracing = options.isEnableTracing();
+    final @Nullable Boolean isEnableTracing = options.getEnableTracing();
     final @Nullable Double defaultSampleRate =
         Boolean.TRUE.equals(isEnableTracing) ? DEFAULT_TRACES_SAMPLE_RATE : null;
     final @Nullable Double tracesSampleRateOrDefault =

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -107,6 +107,13 @@ class ExternalOptionsTest {
     }
 
     @Test
+    fun `creates options with enableTracing using external properties`() {
+        withPropertiesFile("enable-tracing=true") {
+            assertEquals(true, it.enableTracing)
+        }
+    }
+
+    @Test
     fun `creates options with tracesSampleRate using external properties`() {
         withPropertiesFile("traces-sample-rate=0.2") {
             assertEquals(0.2, it.tracesSampleRate)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -135,7 +135,7 @@ class SentryOptionsTest {
     @Test
     fun `when enableTracing is set to true tracing is considered enabled`() {
         val options = SentryOptions().apply {
-            this.isEnableTracing = true
+            this.enableTracing = true
         }
 
         assertTrue(options.isTracingEnabled)
@@ -151,7 +151,7 @@ class SentryOptionsTest {
     @Test
     fun `when enableTracing is set to false tracing is considered disabled`() {
         val options = SentryOptions().apply {
-            this.isEnableTracing = false
+            this.enableTracing = false
             this.tracesSampleRate = 1.0
             this.tracesSampler = SentryOptions.TracesSamplerCallback { _ -> 1.0 }
         }
@@ -362,7 +362,7 @@ class SentryOptionsTest {
         assertEquals("8090", options.proxy!!.port)
         assertEquals(mapOf("tag1" to "value1", "tag2" to "value2"), options.tags)
         assertFalse(options.isEnableUncaughtExceptionHandler)
-        assertEquals(true, options.isEnableTracing)
+        assertEquals(true, options.enableTracing)
         assertEquals(0.5, options.tracesSampleRate)
         assertEquals(0.5, options.profilesSampleRate)
         assertEquals(listOf("com.app"), options.inAppIncludes)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -292,6 +292,7 @@ class SentryOptionsTest {
         externalOptions.setTag("tag1", "value1")
         externalOptions.setTag("tag2", "value2")
         externalOptions.enableUncaughtExceptionHandler = false
+        externalOptions.enableTracing = true
         externalOptions.tracesSampleRate = 0.5
         externalOptions.profilesSampleRate = 0.5
         externalOptions.addInAppInclude("com.app")
@@ -316,6 +317,7 @@ class SentryOptionsTest {
         assertEquals("8090", options.proxy!!.port)
         assertEquals(mapOf("tag1" to "value1", "tag2" to "value2"), options.tags)
         assertFalse(options.isEnableUncaughtExceptionHandler)
+        assertEquals(true, options.isEnableTracing)
         assertEquals(0.5, options.tracesSampleRate)
         assertEquals(0.5, options.profilesSampleRate)
         assertEquals(listOf("com.app"), options.inAppIncludes)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -115,6 +115,51 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `when tracesSampleRate is set tracing is considered enabled`() {
+        val options = SentryOptions().apply {
+            this.tracesSampleRate = 1.0
+        }
+
+        assertTrue(options.isTracingEnabled)
+    }
+
+    @Test
+    fun `when tracesSampler is set tracing is considered enabled`() {
+        val options = SentryOptions().apply {
+            this.tracesSampler = SentryOptions.TracesSamplerCallback { samplingContext -> 1.0 }
+        }
+
+        assertTrue(options.isTracingEnabled)
+    }
+
+    @Test
+    fun `when enableTracing is set to true tracing is considered enabled`() {
+        val options = SentryOptions().apply {
+            this.isEnableTracing = true
+        }
+
+        assertTrue(options.isTracingEnabled)
+    }
+
+    @Test
+    fun `by default tracing is considered disabled`() {
+        val options = SentryOptions()
+
+        assertFalse(options.isTracingEnabled)
+    }
+
+    @Test
+    fun `when enableTracing is set to false tracing is considered disabled`() {
+        val options = SentryOptions().apply {
+            this.isEnableTracing = false
+            this.tracesSampleRate = 1.0
+            this.tracesSampler = SentryOptions.TracesSamplerCallback { _ -> 1.0 }
+        }
+
+        assertFalse(options.isTracingEnabled)
+    }
+
+    @Test
     fun `when there's no cacheDirPath, outboxPath returns null`() {
         val options = SentryOptions()
         assertNull(options.outboxPath)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTracingTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTracingTest.kt
@@ -1,0 +1,56 @@
+package io.sentry
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.assertEquals
+
+data class TracingEnabledTestData(val enableTracing: Boolean?, val tracesSampleRate: Double?, val tracesSamplerPresent: Boolean, val isTracingEnabled: Boolean)
+
+/**
+ * Test @link{SentryOptions#isTracingEnabled()} with combination of other options.
+ */
+@RunWith(Parameterized::class)
+class SentryOptionsTracingTest(private val testData: TracingEnabledTestData) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> {
+            return listOf(
+                TracingEnabledTestData(null, null, false, false),
+                TracingEnabledTestData(null, 1.0, false, true),
+                TracingEnabledTestData(false, 1.0, false, false),
+                TracingEnabledTestData(true, 1.0, false, true),
+                TracingEnabledTestData(null, 0.0, false, true),
+                TracingEnabledTestData(false, 0.0, false, false),
+                TracingEnabledTestData(true, 0.0, false, true),
+                TracingEnabledTestData(true, null, false, true),
+                TracingEnabledTestData(false, null, false, false),
+
+                TracingEnabledTestData(null, null, true, true),
+                TracingEnabledTestData(null, 1.0, true, true),
+                TracingEnabledTestData(false, 1.0, true, false),
+                TracingEnabledTestData(true, 1.0, true, true),
+                TracingEnabledTestData(null, 0.0, true, true),
+                TracingEnabledTestData(false, 0.0, true, false),
+                TracingEnabledTestData(true, 0.0, true, true),
+                TracingEnabledTestData(true, null, true, true),
+                TracingEnabledTestData(false, null, true, false)
+            ).map { arrayOf(it) }
+        }
+    }
+
+    @Test
+    fun `test isTracingEnabled`() {
+        val options = SentryOptions().apply {
+            testData.enableTracing?.let { this.enableTracing = it }
+            testData.tracesSampleRate?.let { this.tracesSampleRate = it }
+            if (testData.tracesSamplerPresent) {
+                this.tracesSampler = SentryOptions.TracesSamplerCallback { samplingContext -> 1.0 }
+            }
+        }
+
+        assertEquals(testData.isTracingEnabled, options.isTracingEnabled, "combination failed: $testData")
+    }
+}

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -16,6 +16,7 @@ class TracesSamplerTest {
     class Fixture {
         internal fun getSut(
             randomResult: Double? = null,
+            enableTracing: Boolean? = null,
             tracesSampleRate: Double? = null,
             profilesSampleRate: Double? = null,
             tracesSamplerCallback: SentryOptions.TracesSamplerCallback? = null,
@@ -27,6 +28,9 @@ class TracesSamplerTest {
                 whenever(random.nextDouble()).thenReturn(randomResult)
             }
             val options = SentryOptions()
+            if (enableTracing != null) {
+                options.isEnableTracing = enableTracing
+            }
             if (tracesSampleRate != null) {
                 options.tracesSampleRate = tracesSampleRate
             }
@@ -48,6 +52,14 @@ class TracesSamplerTest {
     }
 
     private val fixture = Fixture()
+
+    @Test
+    fun `when no tracesSampleRate is set, uses default rate`() {
+        val sampler = fixture.getSut(randomResult = 0.9, enableTracing = true)
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null))
+        assertTrue(samplingDecision.sampled)
+        assertEquals(1.0, samplingDecision.sampleRate)
+    }
 
     @Test
     fun `when tracesSampleRate is set and random returns greater number returns false`() {

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -29,7 +29,7 @@ class TracesSamplerTest {
             }
             val options = SentryOptions()
             if (enableTracing != null) {
-                options.isEnableTracing = enableTracing
+                options.enableTracing = enableTracing
             }
             if (tracesSampleRate != null) {
                 options.tracesSampleRate = tracesSampleRate


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adds a new `enableTracing` option. If set to true, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured. For now we set a default `tracesSampleRate` of `1.0` if none has been configured explicitly. If `enableTracing` is set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options. The default for `enableTracing` is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2522

## :green_heart: How did you test it?
Unit tests, manually using Android and Spring Boot (Jakarta)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed. - Will be done for all SDKs at once.
- [-] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [?] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
	- 	Shouldn't break anything, existing behaviour should still work


## :crystal_ball: Next steps
