### PR TITLE
Detect dependencies by listing MANIFEST.MF files at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - This change is backwards compatible. The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
     - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.
     - If set to `false` performance is disabled, regardless of `tracesSampleRate` and `tracesSampler` options.
+- Detect dependencies by listing MANIFEST.MF files at runtime ([#2538](https://github.com/getsentry/sentry-java/pull/2538))
 
 ## 6.14.0
 
@@ -15,7 +16,6 @@
 
 - Add time-to-full-display span to Activity auto-instrumentation ([#2432](https://github.com/getsentry/sentry-java/pull/2432))
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
-- Detect dependencies by listing MANIFEST.MF files at runtime ([#2538](https://github.com/getsentry/sentry-java/pull/2538))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `main` flag to threads and `in_foreground` flag for app contexts  ([#2516](https://github.com/getsentry/sentry-java/pull/2516))
+- Detect dependencies by listing MANIFEST.MF files at runtime ([#2538](https://github.com/getsentry/sentry-java/pull/2538))
 
 ### Fixes
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2417,8 +2417,16 @@ public final class io/sentry/internal/gestures/UiElement$Type : java/lang/Enum {
 	public static fun values ()[Lio/sentry/internal/gestures/UiElement$Type;
 }
 
+public final class io/sentry/internal/modules/CompositeModulesLoader : io/sentry/internal/modules/ModulesLoader {
+	public fun <init> (Ljava/util/List;Lio/sentry/ILogger;)V
+}
+
 public abstract interface class io/sentry/internal/modules/IModulesLoader {
 	public abstract fun getOrLoadModules ()Ljava/util/Map;
+}
+
+public final class io/sentry/internal/modules/ManifestModulesLoader : io/sentry/internal/modules/ModulesLoader {
+	public fun <init> (Lio/sentry/ILogger;)V
 }
 
 public abstract class io/sentry/internal/modules/ModulesLoader : io/sentry/internal/modules/IModulesLoader {
@@ -3632,6 +3640,11 @@ public abstract class io/sentry/transport/TransportResult {
 	public abstract fun getResponseCode ()I
 	public abstract fun isSuccess ()Z
 	public static fun success ()Lio/sentry/transport/TransportResult;
+}
+
+public final class io/sentry/util/ClassLoaderUtils {
+	public fun <init> ()V
+	public static fun classLoaderOrDefault (Ljava/lang/ClassLoader;)Ljava/lang/ClassLoader;
 }
 
 public final class io/sentry/util/CollectionUtils {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -12,7 +12,6 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.util.FileUtils;
-import io.sentry.util.Platform;
 import io.sentry.util.thread.IMainThreadChecker;
 import io.sentry.util.thread.MainThreadChecker;
 import io.sentry.util.thread.NoOpMainThreadChecker;
@@ -282,16 +281,12 @@ public final class Sentry {
 
     final @NotNull IModulesLoader modulesLoader = options.getModulesLoader();
     if (modulesLoader instanceof NoOpModulesLoader) {
-      if (Platform.isJvm()) {
-        options.setModulesLoader(
-            new CompositeModulesLoader(
-                Arrays.asList(
-                    new ManifestModulesLoader(options.getLogger()),
-                    new ResourcesModulesLoader(options.getLogger())),
-                options.getLogger()));
-      } else {
-        options.setModulesLoader(new ResourcesModulesLoader(options.getLogger()));
-      }
+      options.setModulesLoader(
+          new CompositeModulesLoader(
+              Arrays.asList(
+                  new ManifestModulesLoader(options.getLogger()),
+                  new ResourcesModulesLoader(options.getLogger())),
+              options.getLogger()));
     }
 
     final IMainThreadChecker mainThreadChecker = options.getMainThreadChecker();

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -3,18 +3,22 @@ package io.sentry;
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.cache.IEnvelopeCache;
 import io.sentry.config.PropertiesProviderFactory;
+import io.sentry.internal.modules.CompositeModulesLoader;
 import io.sentry.internal.modules.IModulesLoader;
+import io.sentry.internal.modules.ManifestModulesLoader;
 import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.internal.modules.ResourcesModulesLoader;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.util.FileUtils;
+import io.sentry.util.Platform;
 import io.sentry.util.thread.IMainThreadChecker;
 import io.sentry.util.thread.MainThreadChecker;
 import io.sentry.util.thread.NoOpMainThreadChecker;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -276,10 +280,18 @@ public final class Sentry {
               });
     }
 
-    final IModulesLoader modulesLoader = options.getModulesLoader();
-    // only override the ModulesLoader if it's not already set by Android
+    final @NotNull IModulesLoader modulesLoader = options.getModulesLoader();
     if (modulesLoader instanceof NoOpModulesLoader) {
-      options.setModulesLoader(new ResourcesModulesLoader(options.getLogger()));
+      if (Platform.isJvm()) {
+        options.setModulesLoader(
+            new CompositeModulesLoader(
+                Arrays.asList(
+                    new ManifestModulesLoader(options.getLogger()),
+                    new ResourcesModulesLoader(options.getLogger())),
+                options.getLogger()));
+      } else {
+        options.setModulesLoader(new ResourcesModulesLoader(options.getLogger()));
+      }
     }
 
     final IMainThreadChecker mainThreadChecker = options.getMainThreadChecker();

--- a/sentry/src/main/java/io/sentry/config/ClasspathPropertiesLoader.java
+++ b/sentry/src/main/java/io/sentry/config/ClasspathPropertiesLoader.java
@@ -1,5 +1,7 @@
 package io.sentry.config;
 
+import static io.sentry.util.ClassLoaderUtils.classLoaderOrDefault;
+
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import java.io.BufferedInputStream;
@@ -18,12 +20,7 @@ final class ClasspathPropertiesLoader implements PropertiesLoader {
   public ClasspathPropertiesLoader(
       @NotNull String fileName, @Nullable ClassLoader classLoader, @NotNull ILogger logger) {
     this.fileName = fileName;
-    // bootstrap classloader is represented as null, so using system classloader instead
-    if (classLoader == null) {
-      this.classLoader = ClassLoader.getSystemClassLoader();
-    } else {
-      this.classLoader = classLoader;
-    }
+    this.classLoader = classLoaderOrDefault(classLoader);
     this.logger = logger;
   }
 

--- a/sentry/src/main/java/io/sentry/internal/modules/CompositeModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/CompositeModulesLoader.java
@@ -1,0 +1,36 @@
+package io.sentry.internal.modules;
+
+import io.sentry.ILogger;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Experimental
+@ApiStatus.Internal
+public final class CompositeModulesLoader extends ModulesLoader {
+
+  private final List<IModulesLoader> loaders;
+
+  public CompositeModulesLoader(
+      final @NotNull List<IModulesLoader> loaders, final @NotNull ILogger logger) {
+    super(logger);
+    this.loaders = loaders;
+  }
+
+  @Override
+  protected Map<String, String> loadModules() {
+    final @NotNull TreeMap<String, String> allModules = new TreeMap<>();
+
+    for (IModulesLoader loader : this.loaders) {
+      final @Nullable Map<String, String> modules = loader.getOrLoadModules();
+      if (modules != null) {
+        allModules.putAll(modules);
+      }
+    }
+
+    return allModules;
+  }
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
@@ -4,7 +4,6 @@ import static io.sentry.util.ClassLoaderUtils.classLoaderOrDefault;
 
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
-import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;

--- a/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
@@ -1,0 +1,102 @@
+package io.sentry.internal.modules;
+
+import static io.sentry.util.ClassLoaderUtils.classLoaderOrDefault;
+
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Experimental
+@ApiStatus.Internal
+public final class ManifestModulesLoader extends ModulesLoader {
+  private final Pattern URL_LIB_PATTERN = Pattern.compile(".*/(.+)!/META-INF/MANIFEST.MF");
+  private final Pattern NAME_AND_VERSION = Pattern.compile("(.*?)-(\\d+\\.\\d+.*).jar");
+  private final ClassLoader classLoader;
+
+  public ManifestModulesLoader(final @NotNull ILogger logger) {
+    this(ManifestModulesLoader.class.getClassLoader(), logger);
+  }
+
+  ManifestModulesLoader(final @Nullable ClassLoader classLoader, final @NotNull ILogger logger) {
+    super(logger);
+    this.classLoader = classLoaderOrDefault(classLoader);
+  }
+
+  @Override
+  protected Map<String, String> loadModules() {
+    final @NotNull Map<String, String> modules = new HashMap<>();
+    List<Module> detectedModules = detectModulesViaManifestFiles();
+
+    for (Module module : detectedModules) {
+      modules.put(module.name, module.version);
+    }
+
+    return modules;
+  }
+
+  private @NotNull List<Module> detectModulesViaManifestFiles() {
+    final @NotNull List<Module> modules = new ArrayList<>();
+    try {
+      final @NotNull Enumeration<URL> manifestUrls =
+          classLoader.getResources("META-INF/MANIFEST.MF");
+      while (manifestUrls.hasMoreElements()) {
+        final @NotNull URL manifestUrl = manifestUrls.nextElement();
+        final @Nullable String originalName = extractDependencyNameFromUrl(manifestUrl);
+        final @Nullable Module module = convertOriginalNameToModule(originalName);
+        if (module != null) {
+          modules.add(module);
+        }
+      }
+    } catch (IOException e) {
+      logger.log(SentryLevel.ERROR, "Unable to detect modules via manifest files.", e);
+    }
+
+    return modules;
+  }
+
+  private @Nullable Module convertOriginalNameToModule(@Nullable String originalName) {
+    if (originalName == null) {
+      return null;
+    }
+
+    final @NotNull Matcher matcher = NAME_AND_VERSION.matcher(originalName);
+    if (matcher.matches() && matcher.groupCount() == 2) {
+      @NotNull String moduleName = matcher.group(1);
+      @NotNull String moduleVersion = matcher.group(2);
+      return new Module(moduleName, moduleVersion);
+    }
+
+    return null;
+  }
+
+  private @Nullable String extractDependencyNameFromUrl(final @NotNull URL url) {
+    final @NotNull String urlString = url.toString();
+    final @NotNull Matcher matcher = URL_LIB_PATTERN.matcher(urlString);
+    if (matcher.matches() && matcher.groupCount() == 1) {
+      return matcher.group(1);
+    }
+
+    return null;
+  }
+
+  private static final class Module {
+    private final @NotNull String name;
+    private final @NotNull String version;
+
+    public Module(final @NotNull String name, final @NotNull String version) {
+      this.name = name;
+      this.version = version;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
@@ -58,7 +58,7 @@ public final class ManifestModulesLoader extends ModulesLoader {
           modules.add(module);
         }
       }
-    } catch (IOException e) {
+    } catch (Thowable e) {
       logger.log(SentryLevel.ERROR, "Unable to detect modules via manifest files.", e);
     }
 

--- a/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ManifestModulesLoader.java
@@ -57,7 +57,7 @@ public final class ManifestModulesLoader extends ModulesLoader {
           modules.add(module);
         }
       }
-    } catch (Thowable e) {
+    } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Unable to detect modules via manifest files.", e);
     }
 

--- a/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
+++ b/sentry/src/main/java/io/sentry/internal/modules/ResourcesModulesLoader.java
@@ -1,5 +1,7 @@
 package io.sentry.internal.modules;
 
+import static io.sentry.util.ClassLoaderUtils.classLoaderOrDefault;
+
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import java.io.InputStream;
@@ -20,12 +22,7 @@ public final class ResourcesModulesLoader extends ModulesLoader {
 
   ResourcesModulesLoader(final @NotNull ILogger logger, final @Nullable ClassLoader classLoader) {
     super(logger);
-    // bootstrap classloader is represented as null, so using system classloader instead
-    if (classLoader == null) {
-      this.classLoader = ClassLoader.getSystemClassLoader();
-    } else {
-      this.classLoader = classLoader;
-    }
+    this.classLoader = classLoaderOrDefault(classLoader);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
@@ -1,0 +1,16 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class ClassLoaderUtils {
+
+  public static @NotNull ClassLoader classLoaderOrDefault(final @Nullable ClassLoader classLoader) {
+    // bootstrap classloader is represented as null, so using system classloader instead
+    if (classLoader == null) {
+      return ClassLoader.getSystemClassLoader();
+    } else {
+      return classLoader;
+    }
+  }
+}

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -2,8 +2,8 @@ package io.sentry
 
 import io.sentry.cache.EnvelopeCache
 import io.sentry.cache.IEnvelopeCache
+import io.sentry.internal.modules.CompositeModulesLoader
 import io.sentry.internal.modules.IModulesLoader
-import io.sentry.internal.modules.ResourcesModulesLoader
 import io.sentry.protocol.SentryId
 import io.sentry.util.thread.IMainThreadChecker
 import io.sentry.util.thread.MainThreadChecker
@@ -309,7 +309,7 @@ class SentryTest {
             sentryOptions = it
         }
 
-        assertTrue { sentryOptions!!.modulesLoader is ResourcesModulesLoader }
+        assertTrue { sentryOptions!!.modulesLoader is CompositeModulesLoader }
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/internal/modules/CompositeModulesLoaderTest.kt
+++ b/sentry/src/test/java/io/sentry/internal/modules/CompositeModulesLoaderTest.kt
@@ -1,0 +1,45 @@
+package io.sentry.internal.modules
+
+import io.sentry.ILogger
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CompositeModulesLoaderTest {
+
+    @Test
+    fun `reads modules from multiple loaders and caches result`() {
+        val logger = mock<ILogger>()
+        val loader1 = mock<IModulesLoader>()
+        val loader2 = mock<IModulesLoader>()
+
+        whenever(loader1.orLoadModules).thenReturn(mapOf("spring-core" to "6.0.0"))
+        whenever(loader2.orLoadModules).thenReturn(mapOf("spring-webmvc" to "6.0.2"))
+
+        val sut = CompositeModulesLoader(listOf(loader1, loader2), logger)
+
+        assertEquals(
+            mapOf(
+                "spring-core" to "6.0.0",
+                "spring-webmvc" to "6.0.2"
+            ),
+            sut.orLoadModules
+        )
+
+        verify(loader1).orLoadModules
+        verify(loader2).orLoadModules
+
+        assertEquals(
+            mapOf(
+                "spring-core" to "6.0.0",
+                "spring-webmvc" to "6.0.2"
+            ),
+            sut.orLoadModules
+        )
+
+        verifyNoMoreInteractions(loader1, loader2)
+    }
+}

--- a/sentry/src/test/java/io/sentry/internal/modules/ManifestModulesLoaderTest.kt
+++ b/sentry/src/test/java/io/sentry/internal/modules/ManifestModulesLoaderTest.kt
@@ -1,0 +1,85 @@
+package io.sentry.internal.modules
+
+import io.sentry.ILogger
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.net.URL
+import java.util.Collections
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ManifestModulesLoaderTest {
+
+    @Test
+    fun `reads modules from manifest urls caches result`() {
+        val logger = mock<ILogger>()
+        val classLoader = mock<ClassLoader>()
+
+        whenever(classLoader.getResources(any())).thenReturn(
+            Collections.enumeration(
+                listOf(
+                    URL("jar:file:/Users/sentry/.gradle/caches/modules-2/files-2.1/org.springframework.boot/spring-boot-starter-security/3.0.0/efe7ffae5c9875e2019c6a701759ea524cb331ee/spring-boot-starter-security-3.0.0.jar!/META-INF/MANIFEST.MF"),
+                    URL("jar:file:/Users/sentry/.gradle/caches/modules-2/files-2.1/org.yaml/snakeyaml/1.33/2cd0a87ff7df953f810c344bdf2fe3340b954c69/snakeyaml-1.33.jar!/META-INF/MANIFEST.MF"),
+                    URL("jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/aspectjweaver-1.9.9.1.jar!/META-INF/MANIFEST.MF"),
+                    URL("jar:file:/Users/sentry/repos/sentry-java/sentry-samples/sentry-samples-spring-boot-jakarta/build/libs/sentry-samples-spring-boot-jakarta-0.0.1-SNAPSHOT.jar!/BOOT-INF/lib/kotlin-stdlib-jdk8-1.6.10.jar!/META-INF/MANIFEST.MF"),
+                    URL("http://sentry.io"),
+                    URL("jar:file:/Users/sentry/repos/sentry-java/sentry-samples/sentry-samples-spring-boot-jakarta/build/libs/sentry-samples-spring-boot-jakarta-0.0.1-SNAPSHOT.jar!/BOOT-INF/lib/hello-world.jar!/META-INF/MANIFEST.MF")
+                )
+            )
+        )
+
+        val sut = ManifestModulesLoader(classLoader, logger)
+
+        assertEquals(
+            mapOf(
+                "spring-boot-starter-security" to "3.0.0",
+                "snakeyaml" to "1.33",
+                "aspectjweaver" to "1.9.9.1",
+                "kotlin-stdlib-jdk8" to "1.6.10"
+            ),
+            sut.orLoadModules
+        )
+
+        verify(classLoader).getResources(any())
+
+        assertEquals(
+            mapOf(
+                "spring-boot-starter-security" to "3.0.0",
+                "snakeyaml" to "1.33",
+                "aspectjweaver" to "1.9.9.1",
+                "kotlin-stdlib-jdk8" to "1.6.10"
+            ),
+            sut.orLoadModules
+        )
+
+        verifyNoMoreInteractions(classLoader)
+    }
+
+    @Test
+    fun `reading modules from manifest returns empty map on IOException`() {
+        val logger = mock<ILogger>()
+        val classLoader = mock<ClassLoader>()
+
+        whenever(classLoader.getResources(any())).thenThrow(IOException("thrown on purpose"))
+
+        val sut = ManifestModulesLoader(classLoader, logger)
+
+        assertEquals(
+            emptyMap(),
+            sut.orLoadModules
+        )
+
+        verify(classLoader).getResources(any())
+
+        assertEquals(
+            emptyMap(),
+            sut.orLoadModules
+        )
+
+        verifyNoMoreInteractions(classLoader)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This allows us to collect dependencies at runtime by looking at all available `MANIFEST.MF` resources and extracting the dependency name and version from the URL. This does not actually look at the contents of the manifest files but only at the URLs which usually takes a low single digit amount of `ms` to collect all dependencies.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows us to show `modules` in UI for JVM applications that aren't using our plugin to provide `sentry-external-modules.txt`. A workaround for #2474 until we can provide a non Android focused build plugin that users can use.

## :green_heart: How did you test it?
Running Spring Boot from IDE, from runnable JAR and WAR deployed to Tomcat. Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [-] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
