### PR TITLE
Fix inAppExcludes not returning true for non-excluded class names

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -92,9 +92,12 @@ public final class SentryStackTraceFactory {
     if (inAppExcludes != null) {
       for (String exclude : inAppExcludes) {
         if (className.startsWith(exclude)) {
+          // If the class name starts with an exclude, it's not inApp
           return false;
         }
       }
+      // else if it doesn't start with any of the excludes, it's inApp
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Previously, if you only used inAppExcludes, classes that prefix matched the excluded class name would `return false`, but there was no path for matching true, so the check would exit out of the inAppExclude loop and hit the default `return false`.

Now, isInApp will return true if inAppExcludes are provided, and the class doesn't match any of the excluded class names.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm trying to use inAppExcludes, but it doesn't work. Looking at the implementation I can see why it was never marking any stack frames as inApp.

After seeing this I was reminded of https://github.com/getsentry/sentry-java/issues/1879

> In the StackTraceFactory, isInApp appears that it should return false for everything if you haven't set any includes or excludes. Looking at the python version, I see that it inverts everything to "inApp" if nothing is set to inApp so maybe something similar happens somewhere down the line here?
> Anyway, does adding any inAppExcludes have any effect? Looking at the code, if it doesn't match an exclude it still returns false. So the only way to get any different behavior at all is to specify inAppIncludes, which has the effect of excluding everything outside of it.

## :green_heart: How did you test it?

I haven't got tests yet, I'm not quite sure how to run the tests locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
