### PR TITLE
Leave inApp flag for stack frames undecided in SDK if unsure and let ingestion decide instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Ignore Shutdown in progress when closing ShutdownHookIntegration ([#2521](https://github.com/getsentry/sentry-java/pull/2521))
 - Fix app start span end-time is wrong if SDK init is deferred ([#2519](https://github.com/getsentry/sentry-java/pull/2519))
+- Leave inApp undecided if unsure ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
 
 ## 6.13.1
 

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -77,7 +77,8 @@ public final class SentryStackTraceFactory {
    * @return true if it is or false otherwise
    */
   @TestOnly
-  boolean isInApp(final @Nullable String className) {
+  @Nullable
+  Boolean isInApp(final @Nullable String className) {
     if (className == null || className.isEmpty()) {
       return true;
     }
@@ -96,7 +97,7 @@ public final class SentryStackTraceFactory {
         }
       }
     }
-    return false;
+    return null;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
@@ -67,23 +67,23 @@ class SentryStackTraceFactoryTest {
     }
 
     @Test
-    fun `when getStackFrames is called passing a valid inAppExcludes, inApp should be false if prefix doesnt matches it`() {
+    fun `when getStackFrames is called passing a valid inAppExcludes, inApp should be undecided if prefix doesnt matches it`() {
         val element = generateStackTrace("io.myapp.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.mysentry"), null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertFalse(sentryElements!!.first().isInApp!!)
+        assertNull(sentryElements!!.first().isInApp)
     }
 
     @Test
-    fun `when getStackFrames is called passing an invalid inAppExcludes, inApp should be false`() {
+    fun `when getStackFrames is called passing an invalid inAppExcludes, inApp should undecided`() {
         val element = generateStackTrace("io.mysentry.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertFalse(sentryElements!!.first().isInApp!!)
+        assertNull(sentryElements!!.first().isInApp)
     }
     //endregion
 
@@ -99,23 +99,23 @@ class SentryStackTraceFactoryTest {
     }
 
     @Test
-    fun `when getStackFrames is called passing a valid inAppIncludes, inApp should be false if prefix doesnt matches it`() {
+    fun `when getStackFrames is called passing a valid inAppIncludes, inApp should be undecided if prefix doesnt matches it`() {
         val element = generateStackTrace("io.myapp.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(null, listOf("io.mysentry"))
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertFalse(sentryElements!!.first().isInApp!!)
+        assertNull(sentryElements!!.first().isInApp)
     }
 
     @Test
-    fun `when getStackFrames is called passing an invalid inAppIncludes, inApp should be false`() {
+    fun `when getStackFrames is called passing an invalid inAppIncludes, inApp should be undecided`() {
         val element = generateStackTrace("io.mysentry.MyActivity")
         val elements = arrayOf(element)
         val sentryStackTraceFactory = SentryStackTraceFactory(null, null)
         val sentryElements = sentryStackTraceFactory.getStackFrames(elements)
 
-        assertFalse(sentryElements!!.first().isInApp!!)
+        assertNull(sentryElements!!.first().isInApp)
     }
     //endregion
 
@@ -132,16 +132,16 @@ class SentryStackTraceFactoryTest {
     @Test
     fun `when class is defined in the app, inApp is true`() {
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf("io.mysentry.not"), listOf("io.mysentry.inApp"))
-        assertTrue(sentryStackTraceFactory.isInApp("io.mysentry.inApp.ClassName"))
-        assertTrue(sentryStackTraceFactory.isInApp("io.mysentry.inApp.somePackage.ClassName"))
-        assertFalse(sentryStackTraceFactory.isInApp("io.mysentry.not.ClassName"))
-        assertFalse(sentryStackTraceFactory.isInApp("io.mysentry.not.somePackage.ClassName"))
+        assertTrue(sentryStackTraceFactory.isInApp("io.mysentry.inApp.ClassName")!!)
+        assertTrue(sentryStackTraceFactory.isInApp("io.mysentry.inApp.somePackage.ClassName")!!)
+        assertFalse(sentryStackTraceFactory.isInApp("io.mysentry.not.ClassName")!!)
+        assertFalse(sentryStackTraceFactory.isInApp("io.mysentry.not.somePackage.ClassName")!!)
     }
 
     @Test
-    fun `when class is not in the list, is not inApp`() {
+    fun `when class is not in the list, is left undecided`() {
         val sentryStackTraceFactory = SentryStackTraceFactory(listOf(), listOf("io.mysentry"))
-        assertFalse(sentryStackTraceFactory.isInApp("com.getsentry"))
+        assertNull(sentryStackTraceFactory.isInApp("com.getsentry"))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
If a stack frame neither matches any `inAppIncludes` nor `inAppExcludes`, we now treat it as undecided by setting `null` and leaving the decision to the backend / ingestion.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As discussed internally SDKs should only set `true` / `false` if they're certain.

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [-] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
