### PR TITLE
Adjust time-to-full-display span if reportFullDisplayed is called too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Adjust time-to-full-display span if reportFullDisplayed is called too early ([#2550](https://github.com/getsentry/sentry-java/pull/2550))
 - Add `enableTracing` option ([#2530](https://github.com/getsentry/sentry-java/pull/2530))
     - This change is backwards compatible. The default is `null` meaning existing behaviour remains unchanged (setting either `tracesSampleRate` or `tracesSampler` enables performance).
     - If set to `true`, performance is enabled, even if no `tracesSampleRate` or `tracesSampler` have been configured.

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -702,6 +702,24 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
+    fun `stop transaction on resumed does not finish ttfd if isEnableTimeToFullDisplayTracing`() {
+        val sut = fixture.getSut()
+        fixture.options.tracesSampleRate = 1.0
+        fixture.options.isEnableTimeToFullDisplayTracing = true
+        sut.register(fixture.hub, fixture.options)
+
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, mock())
+        val ttfd = sut.ttfdSpan
+        sut.ttidSpanMap.values.first().finish()
+        sut.onActivityResumed(activity)
+        sut.onActivityPostResumed(activity)
+
+        assertNotNull(ttfd)
+        assertFalse(ttfd.isFinished)
+    }
+
+    @Test
     fun `reportFullyDrawn finishes the ttfd`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -567,6 +567,7 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun toBaggageHeader (Ljava/util/List;)Lio/sentry/BaggageHeader;
 	public abstract fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 	public abstract fun traceContext ()Lio/sentry/TraceContext;
+	public abstract fun updateEndDate (Lio/sentry/SentryDate;)Z
 }
 
 public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
@@ -830,6 +831,7 @@ public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public fun toBaggageHeader (Ljava/util/List;)Lio/sentry/BaggageHeader;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 	public fun traceContext ()Lio/sentry/TraceContext;
+	public fun updateEndDate (Lio/sentry/SentryDate;)Z
 }
 
 public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
@@ -873,6 +875,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun toBaggageHeader (Ljava/util/List;)Lio/sentry/BaggageHeader;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 	public fun traceContext ()Lio/sentry/TraceContext;
+	public fun updateEndDate (Lio/sentry/SentryDate;)Z
 }
 
 public final class io/sentry/NoOpTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
@@ -1786,6 +1789,7 @@ public final class io/sentry/SentryTracer : io/sentry/ITransaction {
 	public fun toBaggageHeader (Ljava/util/List;)Lio/sentry/BaggageHeader;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 	public fun traceContext ()Lio/sentry/TraceContext;
+	public fun updateEndDate (Lio/sentry/SentryDate;)Z
 }
 
 public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -1896,6 +1900,7 @@ public final class io/sentry/Span : io/sentry/ISpan {
 	public fun toBaggageHeader (Ljava/util/List;)Lio/sentry/BaggageHeader;
 	public fun toSentryTrace ()Lio/sentry/SentryTraceHeader;
 	public fun traceContext ()Lio/sentry/TraceContext;
+	public fun updateEndDate (Lio/sentry/SentryDate;)Z
 }
 
 public class io/sentry/SpanContext : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -206,6 +206,16 @@ public interface ISpan {
   void setMeasurement(@NotNull String name, @NotNull Number value, @NotNull MeasurementUnit unit);
 
   /**
+   * Updates the end date of the span. Note: This will only update the end date if the span is
+   * already finished.
+   *
+   * @param date the end date to set
+   * @return true if the end date was updated, false otherwise
+   */
+  @ApiStatus.Internal
+  boolean updateEndDate(@NotNull SentryDate date);
+
+  /**
    * Whether this span instance is a NOOP that doesn't collect information
    *
    * @return true if NOOP

--- a/sentry/src/main/java/io/sentry/NoOpSpan.java
+++ b/sentry/src/main/java/io/sentry/NoOpSpan.java
@@ -125,6 +125,11 @@ public final class NoOpSpan implements ISpan {
       @NotNull String name, @NotNull Number value, @NotNull MeasurementUnit unit) {}
 
   @Override
+  public boolean updateEndDate(final @NotNull SentryDate date) {
+    return false;
+  }
+
+  @Override
   public boolean isNoOp() {
     return true;
   }

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -189,6 +189,11 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
+  public boolean updateEndDate(final @NotNull SentryDate date) {
+    return false;
+  }
+
+  @Override
   public boolean isNoOp() {
     return true;
   }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -701,6 +701,11 @@ public final class SentryTracer implements ITransaction {
   }
 
   @Override
+  public boolean updateEndDate(final @NotNull SentryDate date) {
+    return root.updateEndDate(date);
+  }
+
+  @Override
   public boolean isNoOp() {
     return false;
   }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -310,6 +310,15 @@ public final class Span implements ISpan {
   }
 
   @Override
+  public boolean updateEndDate(final @NotNull SentryDate date) {
+    if (this.timestamp != null) {
+      this.timestamp = date;
+      return true;
+    }
+    return false;
+  }
+
+  @Override
   public boolean isNoOp() {
     return false;
   }

--- a/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
@@ -1,6 +1,8 @@
 package io.sentry
 
+import org.mockito.kotlin.mock
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class NoOpSpanTest {
@@ -21,5 +23,10 @@ class NoOpSpanTest {
     @Test
     fun `getOperation does not return null`() {
         assertNotNull(span.operation)
+    }
+
+    @Test
+    fun `updateEndDate return false`() {
+        assertFalse(span.updateEndDate(mock()))
     }
 }

--- a/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
@@ -1,6 +1,8 @@
 package io.sentry
 
+import org.mockito.kotlin.mock
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -27,5 +29,10 @@ class NoOpTransactionTest {
     @Test
     fun `isProfileSampled returns null`() {
         assertNull(transaction.isProfileSampled)
+    }
+
+    @Test
+    fun `updateEndDate return false`() {
+        assertFalse(transaction.updateEndDate(mock()))
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -932,4 +932,24 @@ class SentryTracerTest {
         transaction.finish()
         assertTrue(data.isEmpty())
     }
+
+    @Test
+    fun `updateEndDate is ignored and returns false if span is not finished`() {
+        val transaction = fixture.getSut()
+        assertFalse(transaction.isFinished)
+        assertNull(transaction.finishDate)
+        assertFalse(transaction.updateEndDate(mock()))
+        assertNull(transaction.finishDate)
+    }
+
+    @Test
+    fun `updateEndDate updates finishDate and returns true if span is finished`() {
+        val transaction = fixture.getSut()
+        val endDate: SentryDate = mock()
+        transaction.finish()
+        assertTrue(transaction.isFinished)
+        assertNotNull(transaction.finishDate)
+        assertTrue(transaction.updateEndDate(endDate))
+        assertEquals(endDate, transaction.finishDate)
+    }
 }

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SpanTest {
@@ -237,6 +238,26 @@ class SpanTest {
         assertNotNull(transaction.toBaggageHeader(null)) {
             assertEquals(it.value, span.toBaggageHeader(null)!!.value)
         }
+    }
+
+    @Test
+    fun `updateEndDate is ignored and returns false if span is not finished`() {
+        val span = fixture.getSut()
+        assertFalse(span.isFinished)
+        assertNull(span.finishDate)
+        assertFalse(span.updateEndDate(mock()))
+        assertNull(span.finishDate)
+    }
+
+    @Test
+    fun `updateEndDate updates finishDate and returns true if span is finished`() {
+        val span = fixture.getSut()
+        val endDate: SentryDate = mock()
+        span.finish()
+        assertTrue(span.isFinished)
+        assertNotNull(span.finishDate)
+        assertTrue(span.updateEndDate(endDate))
+        assertEquals(endDate, span.finishDate)
     }
 
     private fun getTransaction(transactionContext: TransactionContext = TransactionContext("name", "op")): SentryTracer {


### PR DESCRIPTION
## :scroll: Description
`time-to-full-display` end timestamp is now adjusted to the `time-to-initial-display` end timestamp if called too early
added updateEndDate method to ISpan


## :bulb: Motivation and Context
If the user calls the manual API `Sentry.reportFullDisplayed` too early, we would show the `time-to-full-display` span to be shorter than our automatically calculated `time-to-initial-display`, which would be pretty confusing.
This adjustment is done also by the [Android system](https://developer.android.com/reference/android/app/Activity#reportFullyDrawn()): `If this method is called before the activity's window is first drawn and displayed as measured by the system, the reported time here will be shifted to the system measured time.`
It's also done by the Firebase SDK.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
