### PR TITLE
Use the same hub in WebFlux exception handler as we do in WebFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixes
 
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
+- Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
 
 ## 6.14.0
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 public class SentryWebFilter implements WebFilter {
   private final @NotNull IHub hub;
   private final @NotNull SentryRequestResolver sentryRequestResolver;
+  public static final String SENTRY_HUB_KEY = "sentry-hub";
 
   public SentryWebFilter(final @NotNull IHub hub) {
     this.hub = Objects.requireNonNull(hub, "hub is required");
@@ -43,6 +44,7 @@ public class SentryWebFilter implements WebFilter {
             })
         .doFirst(
             () -> {
+              serverWebExchange.getAttributes().put(SENTRY_HUB_KEY, Sentry.getCurrentHub());
               hub.pushScope();
               final ServerHttpRequest request = serverWebExchange.getRequest();
               final ServerHttpResponse response = serverWebExchange.getResponse();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Pass hub from `WebFilter` to `SentryWebExceptionHandler` via `ServerWebExchange` `attributes`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We just used whatever hub is there which could possibly bleed into other requests.

## :green_heart: How did you test it?
Manually with debugger

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
