### PR TITLE
Clone hub from main hub for every WebFlux request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Enable the feature by setting `sentry.reactive.thread-local-accessor-enabled=true`
   - This is still considered experimental. Once we have enough feedback we may turn this on by default.
   - Checkout the sample here: https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-spring-boot-webflux-jakarta
+  - A new hub is now cloned from the main hub for every request
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixes
 
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
+- Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
 
 ## 6.14.0
 

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     testImplementation(Config.Libs.springBoot3StarterWebflux)
     testImplementation(Config.Libs.springBoot3StarterSecurity)
     testImplementation(Config.Libs.springBoot3StarterAop)
+    testImplementation(Config.Libs.contextPropagation)
     testImplementation(Config.TestLibs.awaitility)
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
@@ -36,7 +36,7 @@ public final class ReactorUtils {
    *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Mono<T> withFreshSentry(final @NotNull Mono<T> mono) {
+  public static <T> Mono<T> withSentryNewMainHubClone(final @NotNull Mono<T> mono) {
     final @NotNull IHub hub = Sentry.cloneMainHub();
     return withSentryHub(mono, hub);
   }
@@ -86,7 +86,7 @@ public final class ReactorUtils {
    *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Flux<T> withFreshSentry(final @NotNull Flux<T> flux) {
+  public static <T> Flux<T> withSentryNewMainHubClone(final @NotNull Flux<T> flux) {
     final @NotNull IHub hub = Sentry.cloneMainHub();
     return withSentryHub(flux, hub);
   }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
@@ -37,7 +37,7 @@ public final class ReactorUtils {
    */
   @ApiStatus.Experimental
   public static <T> Mono<T> withFreshSentry(final @NotNull Mono<T> mono) {
-    final @NotNull IHub hub = Sentry.getNewHub();
+    final @NotNull IHub hub = Sentry.cloneMainHub();
     return withSentryHub(mono, hub);
   }
 
@@ -87,7 +87,7 @@ public final class ReactorUtils {
    */
   @ApiStatus.Experimental
   public static <T> Flux<T> withFreshSentry(final @NotNull Flux<T> flux) {
-    final @NotNull IHub hub = Sentry.getNewHub();
+    final @NotNull IHub hub = Sentry.cloneMainHub();
     return withSentryHub(flux, hub);
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
@@ -17,8 +17,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Mono<T> withSentry(final @NotNull Mono<T> mono) {
@@ -32,8 +32,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Mono<T> withFreshSentry(final @NotNull Mono<T> mono) {
@@ -46,8 +46,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Mono<T> withSentryHub(final @NotNull Mono<T> mono, final @NotNull IHub hub) {
@@ -66,8 +66,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Flux<T> withSentry(final @NotNull Flux<T> flux) {
@@ -82,8 +82,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Flux<T> withFreshSentry(final @NotNull Flux<T> flux) {
@@ -96,8 +96,8 @@ public final class ReactorUtils {
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
   public static <T> Flux<T> withSentryHub(final @NotNull Flux<T> flux, final @NotNull IHub hub) {

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 public class SentryWebFilter implements WebFilter {
   private final @NotNull IHub hub;
   private final @NotNull SentryRequestResolver sentryRequestResolver;
+  public static final String SENTRY_HUB_KEY = "sentry-hub";
 
   public SentryWebFilter(final @NotNull IHub hub) {
     this.hub = Objects.requireNonNull(hub, "hub is required");
@@ -43,6 +44,7 @@ public class SentryWebFilter implements WebFilter {
             })
         .doFirst(
             () -> {
+              serverWebExchange.getAttributes().put(SENTRY_HUB_KEY, Sentry.getCurrentHub());
               hub.pushScope();
               final ServerHttpRequest request = serverWebExchange.getRequest();
               final ServerHttpResponse response = serverWebExchange.getResponse();

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -20,6 +20,6 @@ public final class SentryWebFilterWithThreadLocalAccessor extends SentryWebFilte
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
-    return ReactorUtils.withSentry(super.filter(serverWebExchange, webFilterChain));
+    return ReactorUtils.withFreshSentry(super.filter(serverWebExchange, webFilterChain));
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -20,6 +20,6 @@ public final class SentryWebFilterWithThreadLocalAccessor extends SentryWebFilte
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
-    return ReactorUtils.withFreshSentry(super.filter(serverWebExchange, webFilterChain));
+    return ReactorUtils.withSentryNewMainHubClone(super.filter(serverWebExchange, webFilterChain));
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
@@ -1,0 +1,85 @@
+package io.sentry.spring.jakarta.webflux
+
+import io.sentry.IHub
+import io.sentry.Sentry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import org.mockito.kotlin.mock
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Hooks
+
+class ReactorUtilsTest {
+
+    @Test
+    fun `propagates hub inside mono`() {
+        Hooks.enableAutomaticContextPropagation()
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val mono = ReactorUtils.withSentryHub(
+            Mono.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                },
+            hubToUse
+        )
+
+        assertEquals("hello", mono.block())
+        assertSame(hubToUse, hubInside)
+    }
+    @Test
+    fun `propagates hub inside flux`() {
+        Hooks.enableAutomaticContextPropagation()
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val flux = ReactorUtils.withSentryHub(
+            Flux.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                },
+            hubToUse
+        )
+
+        assertEquals("hello", flux.blockFirst())
+        assertSame(hubToUse, hubInside)
+    }
+
+    @Test
+    fun `without reactive utils hub is not propagated to mono`() {
+        Hooks.enableAutomaticContextPropagation()
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val mono = Mono.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                }
+
+        assertEquals("hello", mono.block())
+        assertNotSame(hubToUse, hubInside)
+    }
+
+    @Test
+    fun `without reactive utils hub is not propagated to flux`() {
+        Hooks.enableAutomaticContextPropagation()
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val flux = Flux.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                }
+
+        assertEquals("hello", flux.blockFirst())
+        assertNotSame(hubToUse, hubInside)
+    }
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1167,6 +1167,7 @@ public final class io/sentry/Sentry {
 	public static fun flush (J)V
 	public static fun getCurrentHub ()Lio/sentry/IHub;
 	public static fun getLastEventId ()Lio/sentry/protocol/SentryId;
+	public static fun getNewHub ()Lio/sentry/IHub;
 	public static fun getSpan ()Lio/sentry/ISpan;
 	public static fun init ()V
 	public static fun init (Lio/sentry/OptionsContainer;Lio/sentry/Sentry$OptionsConfiguration;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1161,13 +1161,13 @@ public final class io/sentry/Sentry {
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public static fun clearBreadcrumbs ()V
+	public static fun cloneMainHub ()Lio/sentry/IHub;
 	public static fun close ()V
 	public static fun configureScope (Lio/sentry/ScopeCallback;)V
 	public static fun endSession ()V
 	public static fun flush (J)V
 	public static fun getCurrentHub ()Lio/sentry/IHub;
 	public static fun getLastEventId ()Lio/sentry/protocol/SentryId;
-	public static fun getNewHub ()Lio/sentry/IHub;
 	public static fun getSpan ()Lio/sentry/ISpan;
 	public static fun init ()V
 	public static fun init (Lio/sentry/OptionsContainer;Lio/sentry/Sentry$OptionsConfiguration;)V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -65,7 +65,10 @@ public final class Sentry {
    */
   @ApiStatus.Internal
   @ApiStatus.Experimental
-  public static @NotNull IHub getNewHub() {
+  public static @NotNull IHub cloneMainHub() {
+    if (globalHubMode) {
+      return mainHub;
+    }
     return mainHub.clone();
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -58,6 +58,17 @@ public final class Sentry {
     return hub;
   }
 
+  /**
+   * Returns a new hub which is cloned from the mainHub.
+   *
+   * @return the hub
+   */
+  @ApiStatus.Internal
+  @ApiStatus.Experimental
+  public static @NotNull IHub getNewHub() {
+    return mainHub.clone();
+  }
+
   @ApiStatus.Internal // exposed for the coroutines integration in SentryContext
   public static void setCurrentHub(final @NotNull IHub hub) {
     currentHub.set(hub);


### PR DESCRIPTION
#skip-changelog
(modified changelog entry for this chain of PRs instead of having a separate one)

## :scroll: Description
<!--- Describe your changes in detail -->
Clone hub from main hub for every WebFlux request

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we just use whatever hub is there on the thread, we could leak between requests.

## :green_heart: How did you test it?
manually using debugger

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
