### PR TITLE
Use `ThreadLocalAccessor` in Spring Boot 3 WebFlux sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
   - Enable the feature by setting `sentry.reactive.thread-local-accessor-enabled=true`
   - This is still considered experimental. Once we have enough feedback we may turn this on by default.
   - Checkout the sample here: https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-spring-boot-webflux-jakarta
+  - A new hub is now cloned from the main hub for every request
 
 ### Fixes
 
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
+- Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
 
 ## 6.14.0
 

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -19,14 +19,11 @@ repositories {
 
 dependencies {
     implementation(Config.Libs.springBoot3StarterWebflux)
+    implementation(Config.Libs.contextPropagation)
     implementation(Config.Libs.kotlinReflect)
     implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
     implementation(projects.sentrySpringBootStarterJakarta)
     implementation(projects.sentryLogback)
-
-    implementation("io.projectreactor:reactor-core:3.5.3")
-    implementation("io.projectreactor.netty:reactor-netty:1.1.3")
-    implementation("io.micrometer:context-propagation:1.0.2")
 
     testImplementation(Config.Libs.springBoot3StarterTest) {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -23,6 +23,11 @@ dependencies {
     implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
     implementation(projects.sentrySpringBootStarterJakarta)
     implementation(projects.sentryLogback)
+
+    implementation("io.projectreactor:reactor-core:3.5.3")
+    implementation("io.projectreactor.netty:reactor-netty:1.1.3")
+    implementation("io.micrometer:context-propagation:1.0.2")
+
     testImplementation(Config.Libs.springBoot3StarterTest) {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/Person.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/Person.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot;
+package io.sentry.samples.spring.boot.jakarta;
 
 public class Person {
   private final String firstName;

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonController.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonController.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot;
+package io.sentry.samples.spring.boot.jakarta;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonService.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonService.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot;
+package io.sentry.samples.spring.boot.jakarta;
 
 import io.sentry.Sentry;
 import java.time.Duration;

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/SentryDemoApplication.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/SentryDemoApplication.java
@@ -1,11 +1,18 @@
-package io.sentry.samples.spring.boot;
+package io.sentry.samples.spring.boot.jakarta;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
 public class SentryDemoApplication {
   public static void main(String[] args) {
     SpringApplication.run(SentryDemoApplication.class, args);
+  }
+
+  @Bean
+  WebClient webClient(WebClient.Builder builder) {
+    return builder.build();
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/Todo.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/Todo.java
@@ -1,0 +1,25 @@
+package io.sentry.samples.spring.boot.jakarta;
+
+public class Todo {
+  private final Long id;
+  private final String title;
+  private final boolean completed;
+
+  public Todo(Long id, String title, boolean completed) {
+    this.id = id;
+    this.title = title;
+    this.completed = completed;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public boolean isCompleted() {
+    return completed;
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/TodoController.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/TodoController.java
@@ -1,0 +1,26 @@
+package io.sentry.samples.spring.boot.jakarta;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class TodoController {
+  private final WebClient webClient;
+
+  public TodoController(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  @GetMapping("/todo-webclient/{id}")
+  Mono<Todo> todoWebClient(@PathVariable Long id) {
+    return webClient
+        .get()
+        .uri("https://jsonplaceholder.typicode.com/todos/{id}", id)
+        .retrieve()
+        .bodyToMono(Todo.class)
+        .map(response -> response);
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/main/resources/application.properties
@@ -7,3 +7,4 @@ sentry.max-breadcrumbs=150
 # Logback integration configuration options
 sentry.logging.minimum-event-level=info
 sentry.logging.minimum-breadcrumb-level=debug
+sentry.reactive.thread-local-accessor-enabled=true

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     testImplementation(Config.Libs.springBoot3StarterWebflux)
     testImplementation(Config.Libs.springBoot3StarterSecurity)
     testImplementation(Config.Libs.springBoot3StarterAop)
+    testImplementation(Config.Libs.contextPropagation)
     testImplementation(Config.TestLibs.awaitility)
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
@@ -13,48 +13,101 @@ import reactor.util.context.Context;
 public final class ReactorUtils {
 
   /**
-   * Writes the Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   * Writes the current Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Mono<T> withSentry(Mono<T> mono) {
+  public static <T> Mono<T> withSentry(final @NotNull Mono<T> mono) {
     final @NotNull IHub oldHub = Sentry.getCurrentHub();
     final @NotNull IHub clonedHub = oldHub.clone();
-
-    /**
-     * WARNING: Cannot set the clonedHub as current hub.
-     * It would be used by others to clone again causing shared hubs and scopes and thus
-     * leading to issues like unrelated breadcrumbs showing up in events.
-     */
-    // Sentry.setCurrentHub(clonedHub);
-
-    return Mono.deferContextual(ctx -> mono).contextWrite(Context.of(SentryReactorThreadLocalAccessor.KEY, clonedHub));
+    return withSentryHub(mono, clonedHub);
   }
 
   /**
-   * Writes the Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   * Writes a new Sentry {@link IHub} cloned from the main hub to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * This requires
    *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
-   *  - having `io.micrometer:context-propagation:1.0.2` or newer as dependency
-   *  - having `io.projectreactor:reactor-core:3.5.3` or newer as dependency
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Flux<T> withSentry(Flux<T> flux) {
-    final @NotNull IHub oldHub = Sentry.getCurrentHub();
-    final @NotNull IHub clonedHub = oldHub.clone();
+  public static <T> Mono<T> withSentryNewMainHubClone(final @NotNull Mono<T> mono) {
+    final @NotNull IHub hub = Sentry.cloneMainHub();
+    return withSentryHub(mono, hub);
+  }
 
+  /**
+   * Writes the given Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   *
+   * This requires
+   *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
+   */
+  @ApiStatus.Experimental
+  public static <T> Mono<T> withSentryHub(final @NotNull Mono<T> mono, final @NotNull IHub hub) {
     /**
-     * WARNING: Cannot set the clonedHub as current hub.
+     * WARNING: Cannot set the hub as current.
      * It would be used by others to clone again causing shared hubs and scopes and thus
      * leading to issues like unrelated breadcrumbs showing up in events.
      */
     // Sentry.setCurrentHub(clonedHub);
 
-    return Flux.deferContextual(ctx -> flux).contextWrite(Context.of(SentryReactorThreadLocalAccessor.KEY, clonedHub));
+    return Mono.deferContextual(ctx -> mono).contextWrite(Context.of(SentryReactorThreadLocalAccessor.KEY, hub));
+  }
+
+  /**
+   * Writes the current Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   *
+   * This requires
+   *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
+   */
+  @ApiStatus.Experimental
+  public static <T> Flux<T> withSentry(final @NotNull Flux<T> flux) {
+    final @NotNull IHub oldHub = Sentry.getCurrentHub();
+    final @NotNull IHub clonedHub = oldHub.clone();
+
+    return withSentryHub(flux, clonedHub);
+  }
+
+  /**
+   * Writes a new Sentry {@link IHub} cloned from the main hub to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   *
+   * This requires
+   *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
+   */
+  @ApiStatus.Experimental
+  public static <T> Flux<T> withSentryNewMainHubClone(final @NotNull Flux<T> flux) {
+    final @NotNull IHub hub = Sentry.cloneMainHub();
+    return withSentryHub(flux, hub);
+  }
+
+  /**
+   * Writes the given Sentry {@link IHub} to the {@link Context} and uses {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
+   *
+   * This requires
+   *  - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be enabled
+   *  - having `io.micrometer:context-propagation:1.0.2+` (provided by Spring Boot 3.0.3+)
+   *  - having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
+   */
+  @ApiStatus.Experimental
+  public static <T> Flux<T> withSentryHub(final @NotNull Flux<T> flux, final @NotNull IHub hub) {
+    /**
+     * WARNING: Cannot set the hub as current.
+     * It would be used by others to clone again causing shared hubs and scopes and thus
+     * leading to issues like unrelated breadcrumbs showing up in events.
+     */
+    // Sentry.setCurrentHub(clonedHub);
+
+    return Flux.deferContextual(ctx -> flux).contextWrite(Context.of(SentryReactorThreadLocalAccessor.KEY, hub));
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 public class SentryWebFilter implements WebFilter {
   private final @NotNull IHub hub;
   private final @NotNull SentryRequestResolver sentryRequestResolver;
+  public static final String SENTRY_HUB_KEY = "sentry-hub";
 
   public SentryWebFilter(final @NotNull IHub hub) {
     this.hub = Objects.requireNonNull(hub, "hub is required");
@@ -43,6 +44,7 @@ public class SentryWebFilter implements WebFilter {
             })
         .doFirst(
             () -> {
+              serverWebExchange.getAttributes().put(SENTRY_HUB_KEY, Sentry.getCurrentHub());
               hub.pushScope();
               final ServerHttpRequest request = serverWebExchange.getRequest();
               final ServerHttpResponse response = serverWebExchange.getResponse();

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -20,6 +20,6 @@ public final class SentryWebFilterWithThreadLocalAccessor extends SentryWebFilte
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
-    return ReactorUtils.withSentry(super.filter(serverWebExchange, webFilterChain));
+    return ReactorUtils.withSentryNewMainHubClone(super.filter(serverWebExchange, webFilterChain));
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
@@ -1,0 +1,116 @@
+package io.sentry.spring.jakarta.webflux
+
+import io.sentry.IHub
+import io.sentry.NoOpHub
+import io.sentry.Sentry
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Hooks
+
+class ReactorUtilsTest {
+
+    @BeforeTest
+    fun setup() {
+        Hooks.enableAutomaticContextPropagation()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Sentry.setCurrentHub(NoOpHub.getInstance());
+    }
+
+    @Test
+    fun `propagates hub inside mono`() {
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val mono = ReactorUtils.withSentryHub(
+            Mono.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                },
+            hubToUse
+        )
+
+        assertEquals("hello", mono.block())
+        assertSame(hubToUse, hubInside)
+    }
+    @Test
+    fun `propagates hub inside flux`() {
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val flux = ReactorUtils.withSentryHub(
+            Flux.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                },
+            hubToUse
+        )
+
+        assertEquals("hello", flux.blockFirst())
+        assertSame(hubToUse, hubInside)
+    }
+
+    @Test
+    fun `without reactive utils hub is not propagated to mono`() {
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val mono = Mono.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                }
+
+        assertEquals("hello", mono.block())
+        assertNotSame(hubToUse, hubInside)
+    }
+
+    @Test
+    fun `without reactive utils hub is not propagated to flux`() {
+        val hubToUse = mock<IHub>()
+        var hubInside: IHub? = null
+        val flux = Flux.just("hello")
+                .publishOn(Schedulers.boundedElastic())
+                .map { it ->
+                    hubInside = Sentry.getCurrentHub()
+                    it
+                }
+
+        assertEquals("hello", flux.blockFirst())
+        assertNotSame(hubToUse, hubInside)
+    }
+
+    @Test
+    fun `clones hub for mono`() {
+        val mockHub = mock<IHub>()
+        whenever(mockHub.clone()).thenReturn(mock<IHub>())
+        Sentry.setCurrentHub(mockHub)
+        ReactorUtils.withSentry(Mono.just("hello")).block()
+
+        verify(mockHub).clone()
+    }
+
+    @Test
+    fun `clones hub for flux`() {
+        val mockHub = mock<IHub>()
+        whenever(mockHub.clone()).thenReturn(mock<IHub>())
+        Sentry.setCurrentHub(mockHub)
+        ReactorUtils.withSentry(Flux.just("hello")).blockFirst()
+
+        verify(mockHub).clone()
+    }
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1161,6 +1161,7 @@ public final class io/sentry/Sentry {
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public static fun clearBreadcrumbs ()V
+	public static fun cloneMainHub ()Lio/sentry/IHub;
 	public static fun close ()V
 	public static fun configureScope (Lio/sentry/ScopeCallback;)V
 	public static fun endSession ()V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -58,6 +58,20 @@ public final class Sentry {
     return hub;
   }
 
+  /**
+   * Returns a new hub which is cloned from the mainHub.
+   *
+   * @return the hub
+   */
+  @ApiStatus.Internal
+  @ApiStatus.Experimental
+  public static @NotNull IHub cloneMainHub() {
+    if (globalHubMode) {
+      return mainHub;
+    }
+    return mainHub.clone();
+  }
+
   @ApiStatus.Internal // exposed for the coroutines integration in SentryContext
   public static void setCurrentHub(final @NotNull IHub hub) {
     currentHub.set(hub);


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Use `ThreadLocalAccessor` in Spring Boot 3 WebFlux sample

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To showcase how

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
