### PR TITLE
Make 0 sample rate a valid rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
+- Allow `0.0` error sample rate ([#2573](https://github.com/getsentry/sentry-java/pull/2573))
 
 ## 6.14.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3793,7 +3793,6 @@ public final class io/sentry/util/SampleRateUtils {
 	public fun <init> ()V
 	public static fun isValidProfilesSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidSampleRate (Ljava/lang/Double;)Z
-	public static fun isValidSampleRate (Ljava/lang/Double;Z)Z
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;Z)Z
 }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -814,7 +814,7 @@ public class SentryOptions {
   }
 
   /**
-   * Sets the sampleRate Can be anything between 0.01 and 1.0 or null (default), to disable it.
+   * Sets the sampleRate Can be anything between 0.0 and 1.0 or null (default), to disable it.
    *
    * @param sampleRate the sample rate
    */
@@ -823,7 +823,7 @@ public class SentryOptions {
       throw new IllegalArgumentException(
           "The value "
               + sampleRate
-              + " is not valid. Use null to disable or values > 0.0 and <= 1.0.");
+              + " is not valid. Use null to disable or values >= 0.0 and <= 1.0.");
     }
     this.sampleRate = sampleRate;
   }

--- a/sentry/src/main/java/io/sentry/util/SampleRateUtils.java
+++ b/sentry/src/main/java/io/sentry/util/SampleRateUtils.java
@@ -7,15 +7,7 @@ import org.jetbrains.annotations.Nullable;
 public final class SampleRateUtils {
 
   public static boolean isValidSampleRate(@Nullable Double sampleRate) {
-    return isValidSampleRate(sampleRate, true);
-  }
-
-  public static boolean isValidSampleRate(@Nullable Double sampleRate, boolean allowNull) {
-    if (sampleRate == null) {
-      return allowNull;
-    }
-
-    return !(sampleRate.isNaN() || sampleRate > 1.0 || sampleRate <= 0.0);
+    return isValidRate(sampleRate, true);
   }
 
   public static boolean isValidTracesSampleRate(@Nullable Double tracesSampleRate) {

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -92,11 +92,6 @@ class SentryOptionsTest {
     }
 
     @Test
-    fun `when setSampling is set to exactly 0, setter throws`() {
-        assertFailsWith<IllegalArgumentException> { SentryOptions().sampleRate = 0.0 }
-    }
-
-    @Test
     fun `when setTracesSampleRate is set to exactly 0, value is set`() {
         val options = SentryOptions().apply {
             this.tracesSampleRate = 0.0

--- a/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
+++ b/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
@@ -17,8 +17,8 @@ class SampleRateUtilTest {
     }
 
     @Test
-    fun `rejects 0 for sample rate`() {
-        assertFalse(SampleRateUtils.isValidSampleRate(0.0))
+    fun `accepts 0 for sample rate`() {
+        assertTrue(SampleRateUtils.isValidSampleRate(0.0))
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
+++ b/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
@@ -47,16 +47,6 @@ class SampleRateUtilTest {
     }
 
     @Test
-    fun `accepts null sample rate if told so`() {
-        assertTrue(SampleRateUtils.isValidSampleRate(null, true))
-    }
-
-    @Test
-    fun `rejects null sample rate if told so`() {
-        assertFalse(SampleRateUtils.isValidSampleRate(null, false))
-    }
-
-    @Test
     fun `accepts 0 for traces sample rate`() {
         assertTrue(SampleRateUtils.isValidTracesSampleRate(0.0))
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allow 0.0 sample rate to be set (though the effect would be as setting sample rate to null).


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To align with other SDKs (RN, Cocoa, Flutter)

## :green_heart: How did you test it?
Automated tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
