### PR TITLE
Improve versatility of exception resolver component for Spring with more flexible API for consumers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - This is still considered experimental. Once we have enough feedback we may turn this on by default.
   - Checkout the sample here: https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-spring-boot-webflux-jakarta
   - A new hub is now cloned from the main hub for every request
-- Improve versatility of exception resolver component for Spring with more flexible API for consumers.
+- Improve versatility of exception resolver component for Spring with more flexible API for consumers. ([#2577](https://github.com/getsentry/sentry-java/pull/2577))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - This is still considered experimental. Once we have enough feedback we may turn this on by default.
   - Checkout the sample here: https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-spring-boot-webflux-jakarta
   - A new hub is now cloned from the main hub for every request
+- Improve versatility of exception resolver component for Spring with more flexible API for consumers.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Improve versatility of exception resolver component for Spring with more flexible API for consumers. ([#2577](https://github.com/getsentry/sentry-java/pull/2577))
+
 ## 6.15.0
 
 ### Features
@@ -17,7 +23,6 @@
   - This is still considered experimental. Once we have enough feedback we may turn this on by default.
   - Checkout the sample here: https://github.com/getsentry/sentry-java/tree/main/sentry-samples/sentry-samples-spring-boot-webflux-jakarta
   - A new hub is now cloned from the main hub for every request
-- Improve versatility of exception resolver component for Spring with more flexible API for consumers. ([#2577](https://github.com/getsentry/sentry-java/pull/2577))
 
 ### Fixes
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
@@ -50,18 +50,8 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
       final @Nullable Object handler,
       final @NotNull Exception ex) {
 
-    final Mechanism mechanism = new Mechanism();
-    mechanism.setHandled(false);
-    mechanism.setType(MECHANISM_TYPE);
-    final Throwable throwable =
-        new ExceptionMechanismException(mechanism, ex, Thread.currentThread());
-    final SentryEvent event = new SentryEvent(throwable);
-    event.setLevel(SentryLevel.FATAL);
-    event.setTransaction(transactionNameProvider.provideTransactionName(request));
-
-    final Hint hint = new Hint();
-    hint.set(SPRING_RESOLVER_REQUEST, request);
-    hint.set(SPRING_RESOLVER_RESPONSE, response);
+    final SentryEvent event = createEvent(request, ex);
+    final Hint hint = createHint(request, response);
 
     hub.captureEvent(event, hint);
 
@@ -72,5 +62,34 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
   @Override
   public int getOrder() {
     return order;
+  }
+
+  @NotNull
+  protected SentryEvent createEvent(
+      final @NotNull HttpServletRequest request,
+      final @NotNull Exception ex) {
+
+    final Mechanism mechanism = new Mechanism();
+    mechanism.setHandled(false);
+    mechanism.setType(MECHANISM_TYPE);
+    final Throwable throwable =
+        new ExceptionMechanismException(mechanism, ex, Thread.currentThread());
+    final SentryEvent event = new SentryEvent(throwable);
+    event.setLevel(SentryLevel.FATAL);
+    event.setTransaction(transactionNameProvider.provideTransactionName(request));
+
+    return event;
+  }
+
+  @Nullable
+  protected Hint createHint(
+      final @NotNull HttpServletRequest request,
+      final @NotNull HttpServletResponse response) {
+
+    final Hint hint = new Hint();
+    hint.set(SPRING_RESOLVER_REQUEST, request);
+    hint.set(SPRING_RESOLVER_RESPONSE, response);
+
+    return hint;
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
@@ -1,13 +1,13 @@
-package io.sentry.spring
+package io.sentry.spring.jakarta
 
 import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.exception.ExceptionMechanismException
-import io.sentry.spring.tracing.TransactionNameProvider
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import io.sentry.spring.jakarta.tracing.TransactionNameProvider
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -23,6 +23,8 @@ public final class io/sentry/spring/HttpServletRequestSentryUserProvider : io/se
 public class io/sentry/spring/SentryExceptionResolver : org/springframework/core/Ordered, org/springframework/web/servlet/HandlerExceptionResolver {
 	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/tracing/TransactionNameProvider;I)V
+	protected fun createEvent (Ljavax/servlet/http/HttpServletRequest;Ljava/lang/Exception;)Lio/sentry/SentryEvent;
+	protected fun createHint (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)Lio/sentry/Hint;
 	public fun getOrder ()I
 	public fun resolveException (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljava/lang/Object;Ljava/lang/Exception;)Lorg/springframework/web/servlet/ModelAndView;
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -66,8 +66,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
 
   @NotNull
   protected SentryEvent createEvent(
-      final @NotNull HttpServletRequest request,
-      final @NotNull Exception ex) {
+      final @NotNull HttpServletRequest request, final @NotNull Exception ex) {
 
     final Mechanism mechanism = new Mechanism();
     mechanism.setHandled(false);
@@ -83,8 +82,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
 
   @Nullable
   protected Hint createHint(
-      final @NotNull HttpServletRequest request,
-      final @NotNull HttpServletResponse response) {
+      final @NotNull HttpServletRequest request, final @NotNull HttpServletResponse response) {
 
     final Hint hint = new Hint();
     hint.set(SPRING_RESOLVER_REQUEST, request);

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -50,18 +50,8 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
       final @Nullable Object handler,
       final @NotNull Exception ex) {
 
-    final Mechanism mechanism = new Mechanism();
-    mechanism.setHandled(false);
-    mechanism.setType(MECHANISM_TYPE);
-    final Throwable throwable =
-        new ExceptionMechanismException(mechanism, ex, Thread.currentThread());
-    final SentryEvent event = new SentryEvent(throwable);
-    event.setLevel(SentryLevel.FATAL);
-    event.setTransaction(transactionNameProvider.provideTransactionName(request));
-
-    final Hint hint = new Hint();
-    hint.set(SPRING_RESOLVER_REQUEST, request);
-    hint.set(SPRING_RESOLVER_RESPONSE, response);
+    final SentryEvent event = createEvent(request, ex);
+    final Hint hint = createHint(request, response);
 
     hub.captureEvent(event, hint);
 
@@ -72,5 +62,32 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
   @Override
   public int getOrder() {
     return order;
+  }
+
+  protected SentryEvent createEvent(
+      final @NotNull HttpServletRequest request,
+      final @NotNull Exception ex) {
+
+    final Mechanism mechanism = new Mechanism();
+    mechanism.setHandled(false);
+    mechanism.setType(MECHANISM_TYPE);
+    final Throwable throwable =
+        new ExceptionMechanismException(mechanism, ex, Thread.currentThread());
+    final SentryEvent event = new SentryEvent(throwable);
+    event.setLevel(SentryLevel.FATAL);
+    event.setTransaction(transactionNameProvider.provideTransactionName(request));
+
+    return event;
+  }
+
+  protected Hint createHint(
+      final @NotNull HttpServletRequest request,
+      final @NotNull HttpServletResponse response) {
+
+    final Hint hint = new Hint();
+    hint.set(SPRING_RESOLVER_REQUEST, request);
+    hint.set(SPRING_RESOLVER_RESPONSE, response);
+
+    return hint;
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -64,6 +64,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
     return order;
   }
 
+  @NotNull
   protected SentryEvent createEvent(
       final @NotNull HttpServletRequest request,
       final @NotNull Exception ex) {
@@ -80,6 +81,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
     return event;
   }
 
+  @Nullable
   protected Hint createHint(
       final @NotNull HttpServletRequest request,
       final @NotNull HttpServletResponse response) {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
@@ -6,14 +6,14 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.spring.tracing.TransactionNameProvider
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 import kotlin.test.Test
 
 class SentryExceptionResolverTest {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
@@ -1,0 +1,112 @@
+package io.sentry.spring;
+
+import io.sentry.Hint
+import io.sentry.IHub
+import io.sentry.SentryEvent
+import io.sentry.SentryLevel
+import io.sentry.exception.ExceptionMechanismException
+import io.sentry.spring.tracing.TransactionNameProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import kotlin.test.Test
+
+class SentryExceptionResolverTest {
+    private val hub = mock<IHub>()
+    private val transactionNameProvider = mock<TransactionNameProvider>()
+
+    private val request = mock<HttpServletRequest>()
+    private val response = mock<HttpServletResponse>()
+
+    @Test
+    fun `when handles exception, sets wrapped exception for event`() {
+        val eventCaptor = argumentCaptor<SentryEvent>()
+        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        val expectedCause = RuntimeException("test")
+
+        SentryExceptionResolver(hub, transactionNameProvider, 1)
+            .resolveException(request, response, null, expectedCause)
+
+        assertThat(eventCaptor.firstValue.throwable).isEqualTo(expectedCause)
+        assertThat(eventCaptor.firstValue.throwableMechanism).isInstanceOf(ExceptionMechanismException::class.java)
+        with(eventCaptor.firstValue.throwableMechanism as ExceptionMechanismException) {
+            assertThat(exceptionMechanism.isHandled).isFalse
+            assertThat(exceptionMechanism.type).isEqualTo("HandlerExceptionResolver")
+            assertThat(throwable).isEqualTo(expectedCause)
+            assertThat(thread).isEqualTo(Thread.currentThread())
+            assertThat(isSnapshot).isFalse
+        }
+    }
+
+    @Test
+    fun `when handles exception, sets fatal level for event`() {
+        val eventCaptor = argumentCaptor<SentryEvent>()
+        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+
+        SentryExceptionResolver(hub, transactionNameProvider, 1)
+            .resolveException(request, response, null, RuntimeException("test"))
+
+        assertThat(eventCaptor.firstValue.level).isEqualTo(SentryLevel.FATAL)
+    }
+
+    @Test
+    fun `when handles exception, sets transaction name for event`() {
+        val expectedTransactionName = "test-transaction"
+        whenever(transactionNameProvider.provideTransactionName(any())).thenReturn(expectedTransactionName)
+        val eventCaptor = argumentCaptor<SentryEvent>()
+        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+
+        SentryExceptionResolver(hub, transactionNameProvider, 1)
+            .resolveException(request, response, null, RuntimeException("test"))
+
+        assertThat(eventCaptor.firstValue.transaction).isEqualTo(expectedTransactionName)
+        verify(transactionNameProvider).provideTransactionName(request)
+    }
+
+    @Test
+    fun `when handles exception, provides spring resolver hint`() {
+        val hintCaptor = argumentCaptor<Hint>()
+        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+
+        SentryExceptionResolver(hub, transactionNameProvider, 1)
+            .resolveException(request, response, null, RuntimeException("test"))
+
+        with(hintCaptor.firstValue) {
+            assertThat(get("springResolver:request")).isEqualTo(request)
+            assertThat(get("springResolver:response")).isEqualTo(response)
+        }
+    }
+
+    @Test
+    fun `when custom create event method provided, uses it to capture event`() {
+        val expectedEvent = mock<SentryEvent>()
+        val eventCaptor = argumentCaptor<SentryEvent>()
+        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+            override fun createEvent(request: HttpServletRequest, ex: Exception) = expectedEvent
+        }
+
+        resolver.resolveException(request, response, null, RuntimeException("test"))
+
+        assertThat(eventCaptor.firstValue).isEqualTo(expectedEvent)
+    }
+
+    @Test
+    fun `when custom create hint method provided, uses it to capture event`() {
+        val expectedHint = mock<Hint>()
+        val hintCaptor = argumentCaptor<Hint>()
+        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+            override fun createHint(request: HttpServletRequest, response: HttpServletResponse) = expectedHint
+        }
+
+        resolver.resolveException(request, response, null, RuntimeException("test"))
+
+        assertThat(hintCaptor.firstValue).isEqualTo(expectedHint)
+    }
+}


### PR DESCRIPTION
## :scroll: Description

Refactor `SentryExceptionResolver` to improve its API: extract Sentry event and hint creation from `resolveException` method into protected methods to allow easier and more flexible override of any of these pieces by the consumers of the Spring integration module.

## :bulb: Motivation and Context

A very common scenario for the apps I work on is to return the Sentry ID in the `ModelAndView` back to the client who faced a problem so that they could then reach out to me providing that ID which makes it significantly quicker and easier to locate the relevant report and hence trace down the root cause.

The existing implementation of `SentryExceptionResolver` didn't care about the Sentry ID returned from `IHub.captureEvent(event, hint)` and didn't provide a simple way to override this behavior. This change allows a subclass to override just the right bit of code and reuse event an hint creation methods in order to implement the aforementioned scenario. Similarly, it allows to override event and/or hint creation logic without requiring to modify the capture call to the `IHub`.

## :green_heart: How did you test it?

The `SentryExceptionResolver` didn't have any unit tests at all. I added the tests for the existing logic (verifying the shape of the event and the hint passed to the `IHub`), and for the introduced refactoring (ensuring that an override of event and hint creation methods is applied correctly).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
