### PR TITLE
Switch to compileOnly dependencies in sentry-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
 - Allow `0.0` error sample rate ([#2573](https://github.com/getsentry/sentry-java/pull/2573))
 - Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
-- Switch upstream Jetpack Compose dependencies to `compileOnly` ([#2578](https://github.com/getsentry/sentry-java/pull/2578))
+- Switch upstream Jetpack Compose dependencies to `compileOnly` in `sentry-compose-android` ([#2578](https://github.com/getsentry/sentry-java/pull/2578))
   - NOTE: If you're using Compose Navigation/User Interaction integrations, make sure to have the following dependencies on the classpath as we do not bring them in transitively anymore:
     - `androidx.navigation:navigation-compose:`
     - `androidx.compose.runtime:runtime:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
 - Allow `0.0` error sample rate ([#2573](https://github.com/getsentry/sentry-java/pull/2573))
 - Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
+- Switch upstream Jetpack Compose dependencies to `compileOnly` ([#2578](https://github.com/getsentry/sentry-java/pull/2578))
+  - NOTE: If you're using Compose Navigation/User Interaction integrations, make sure to have the following dependencies on the classpath as we do not bring them in transitively anymore:
+    - `androidx.navigation:navigation-compose:`
+    - `androidx.compose.runtime:runtime:`
+    - `androidx.compose.ui:ui:`
 
 ## 6.14.0
 

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -38,10 +38,9 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(compose.runtime)
-                api(compose.ui)
+                compileOnly(compose.runtime)
+                compileOnly(compose.ui)
 
-                implementation(Config.Libs.kotlinStdLib)
                 api(projects.sentryComposeHelper)
             }
         }
@@ -50,7 +49,7 @@ kotlin {
                 api(projects.sentry)
                 api(projects.sentryAndroidNavigation)
 
-                api(Config.Libs.composeNavigation)
+                compileOnly(Config.Libs.composeNavigation)
                 implementation(Config.Libs.lifecycleCommonJava8)
             }
         }
@@ -59,6 +58,7 @@ kotlin {
                 implementation(Config.TestLibs.kotlinTestJunit)
                 implementation(Config.TestLibs.mockitoKotlin)
                 implementation(Config.TestLibs.mockitoInline)
+                implementation(Config.Libs.composeNavigation)
             }
         }
     }

--- a/sentry-compose/proguard-rules.pro
+++ b/sentry-compose/proguard-rules.pro
@@ -4,6 +4,13 @@
 -keep class io.sentry.compose.gestures.ComposeGestureTargetLocator { <init>(...); }
 -keepnames interface androidx.compose.ui.node.Owner
 
+# R8 will warn about missing classes if people don't have androidx.compose-navigation on their
+# classpath, but this is fine, these classes are used in an internal class which is only used when
+# someone is using withSentryObservableEffect extension function (which, in turn, cannot be used
+# without having androidx.compose-navigation on the classpath)
+-dontwarn androidx.navigation.NavController$OnDestinationChangedListener
+-dontwarn androidx.navigation.NavController
+
 # To ensure that stack traces is unambiguous
 # https://developer.android.com/studio/build/shrink-code#decode-stack-trace
 -keepattributes LineNumberTable,SourceFile

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1660,7 +1660,7 @@ public class SentryOptions {
 
   /**
    * Sets the profilesSampleRate. Can be anything between 0.0 and 1.0 or null (default), to disable
-   * it. It’s dependent on the {{@link SentryOptions#setTracesSampleRate(Double)} } If a transaction
+   * it. It's dependent on the {{@link SentryOptions#setTracesSampleRate(Double)} } If a transaction
    * is sampled, then a profile could be sampled with a probability given by profilesSampleRate.
    *
    * @param profilesSampleRate the sample rate


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Since our Gradle Plugin is modifying the `.pom` of the dependencies to auto-install integrations, sentry-compose itself was depending on `androidx.compose:runtime`, therefore after auto-installing it was creating a circular dependency. This PR fixes that, so the users will have to have compose/compose-navigation on their classpath for our integration to kick in.

It's also fine if they don't have them on the classpath, because our Navigation instrumentation will not be called/installed if there's no `NavHostController` on the classpath.

Similar to https://github.com/getsentry/sentry-java/pull/2175

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2364 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
2 more PRs:
* https://github.com/getsentry/sentry-android-gradle-plugin/pull/442
* https://github.com/getsentry/sentry-docs/pull/6390