### PR TITLE
Fix memory leak in Webflux related to an ever growing stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Leave `inApp` flag for stack frames undecided in SDK if unsure and let ingestion decide instead ([#2547](https://github.com/getsentry/sentry-java/pull/2547))
 - Allow `0.0` error sample rate ([#2573](https://github.com/getsentry/sentry-java/pull/2573))
+- Fix memory leak in WebFlux related to an ever growing stack ([#2580](https://github.com/getsentry/sentry-java/pull/2580))
 - Use the same hub in WebFlux exception handler as we do in WebFilter ([#2566](https://github.com/getsentry/sentry-java/pull/2566))
 
 ## 6.14.0

--- a/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/SentryDemoApplication.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/SentryDemoApplication.java
@@ -2,10 +2,17 @@ package io.sentry.samples.spring.boot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
 public class SentryDemoApplication {
   public static void main(String[] args) {
     SpringApplication.run(SentryDemoApplication.class, args);
+  }
+
+  @Bean
+  WebClient webClient(WebClient.Builder builder) {
+    return builder.build();
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/Todo.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/Todo.java
@@ -1,0 +1,25 @@
+package io.sentry.samples.spring.boot;
+
+public class Todo {
+  private final Long id;
+  private final String title;
+  private final boolean completed;
+
+  public Todo(Long id, String title, boolean completed) {
+    this.id = id;
+    this.title = title;
+    this.completed = completed;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public boolean isCompleted() {
+    return completed;
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/TodoController.java
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/src/main/java/io/sentry/samples/spring/boot/TodoController.java
@@ -1,0 +1,26 @@
+package io.sentry.samples.spring.boot;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class TodoController {
+  private final WebClient webClient;
+
+  public TodoController(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  @GetMapping("/todo-webclient/{id}")
+  Mono<Todo> todoWebClient(@PathVariable Long id) {
+    return webClient
+        .get()
+        .uri("https://jsonplaceholder.typicode.com/todos/{id}", id)
+        .retrieve()
+        .bodyToMono(Todo.class)
+        .map(response -> response);
+  }
+}

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/AbstractSentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/AbstractSentryWebFilter.java
@@ -1,0 +1,52 @@
+package io.sentry.spring.jakarta.webflux;
+
+import com.jakewharton.nopen.annotation.Open;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import io.sentry.Breadcrumb;
+import io.sentry.Hint;
+import io.sentry.IHub;
+import io.sentry.Sentry;
+import static io.sentry.TypeCheckHint.WEBFLUX_FILTER_REQUEST;
+import static io.sentry.TypeCheckHint.WEBFLUX_FILTER_RESPONSE;
+import io.sentry.util.Objects;
+import reactor.core.publisher.Mono;
+
+/** Manages {@link io.sentry.Scope} in Webflux request processing. */
+@ApiStatus.Experimental
+public abstract class AbstractSentryWebFilter implements WebFilter {
+  private final @NotNull SentryRequestResolver sentryRequestResolver;
+  public static final String SENTRY_HUB_KEY = "sentry-hub";
+
+  public AbstractSentryWebFilter(final @NotNull IHub hub) {
+    Objects.requireNonNull(hub, "hub is required");
+    this.sentryRequestResolver = new SentryRequestResolver(hub);
+  }
+
+  protected void doFinally(final @NotNull IHub requestHub) {
+    requestHub.popScope();
+  }
+
+  protected void doFirst(final @NotNull ServerWebExchange serverWebExchange, final @NotNull IHub requestHub) {
+    serverWebExchange.getAttributes().put(SENTRY_HUB_KEY, requestHub);
+    requestHub.pushScope();
+    final ServerHttpRequest request = serverWebExchange.getRequest();
+    final ServerHttpResponse response = serverWebExchange.getResponse();
+
+    final Hint hint = new Hint();
+    hint.set(WEBFLUX_FILTER_REQUEST, request);
+    hint.set(WEBFLUX_FILTER_RESPONSE, response);
+    final String methodName =
+      request.getMethod() != null ? request.getMethod().name() : "unknown";
+    requestHub.addBreadcrumb(Breadcrumb.http(request.getURI().toString(), methodName), hint);
+    requestHub.configureScope(
+      scope -> scope.setRequest(sentryRequestResolver.resolveSentryRequest(request)));
+  }
+}

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
@@ -2,6 +2,7 @@ package io.sentry.spring.jakarta.webflux;
 
 import com.jakewharton.nopen.annotation.Open;
 
+import io.sentry.NoOpHub;
 import io.sentry.Sentry;
 import static io.sentry.TypeCheckHint.WEBFLUX_FILTER_REQUEST;
 import static io.sentry.TypeCheckHint.WEBFLUX_FILTER_RESPONSE;
@@ -22,41 +23,28 @@ import reactor.core.publisher.Mono;
 /** Manages {@link io.sentry.Scope} in Webflux request processing. */
 @ApiStatus.Experimental
 @Open
-public class SentryWebFilter implements WebFilter {
-  private final @NotNull IHub hub;
-  private final @NotNull SentryRequestResolver sentryRequestResolver;
-  public static final String SENTRY_HUB_KEY = "sentry-hub";
+public class SentryWebFilter extends AbstractSentryWebFilter {
 
   public SentryWebFilter(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
-    this.sentryRequestResolver = new SentryRequestResolver(hub);
+    super(hub);
   }
 
   @Override
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
+    @NotNull IHub requestHub = Sentry.cloneMainHub();
     return webFilterChain
         .filter(serverWebExchange)
         .doFinally(
             __ -> {
-              hub.popScope();
+              doFinally(requestHub);
+              Sentry.setCurrentHub(NoOpHub.getInstance());
             })
         .doFirst(
             () -> {
-              serverWebExchange.getAttributes().put(SENTRY_HUB_KEY, Sentry.getCurrentHub());
-              hub.pushScope();
-              final ServerHttpRequest request = serverWebExchange.getRequest();
-              final ServerHttpResponse response = serverWebExchange.getResponse();
-
-              final Hint hint = new Hint();
-              hint.set(WEBFLUX_FILTER_REQUEST, request);
-              hint.set(WEBFLUX_FILTER_RESPONSE, response);
-              final String methodName =
-                  request.getMethod() != null ? request.getMethod().name() : "unknown";
-              hub.addBreadcrumb(Breadcrumb.http(request.getURI().toString(), methodName), hint);
-              hub.configureScope(
-                  scope -> scope.setRequest(sentryRequestResolver.resolveSentryRequest(request)));
+              Sentry.setCurrentHub(requestHub);
+              doFirst(serverWebExchange, requestHub);
             });
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -6,11 +6,13 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilterChain;
 
 import io.sentry.IHub;
+import io.sentry.NoOpHub;
+import io.sentry.Sentry;
 import reactor.core.publisher.Mono;
 
 /** Manages {@link io.sentry.Scope} in Webflux request processing. */
 @ApiStatus.Experimental
-public final class SentryWebFilterWithThreadLocalAccessor extends SentryWebFilter {
+public final class SentryWebFilterWithThreadLocalAccessor extends AbstractSentryWebFilter {
 
   public SentryWebFilterWithThreadLocalAccessor(final @NotNull IHub hub) {
     super(hub);
@@ -20,6 +22,16 @@ public final class SentryWebFilterWithThreadLocalAccessor extends SentryWebFilte
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
-    return ReactorUtils.withSentryNewMainHubClone(super.filter(serverWebExchange, webFilterChain));
+    return ReactorUtils.withSentryNewMainHubClone(webFilterChain
+      .filter(serverWebExchange)
+      .doFinally(
+        __ -> {
+          doFinally(Sentry.getCurrentHub());
+          Sentry.setCurrentHub(NoOpHub.getInstance());
+        })
+      .doFirst(
+        () -> {
+          doFirst(serverWebExchange, Sentry.getCurrentHub());
+        }));
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use a new hub cloned from main hub for WebFlux requests instead of cloning the current one on the thread. This allows the hub, used for the request, to be garbage collected eventually. Previously we were using the current hub on the thread to call `.pushScope()`, then cloned that hub including the stack and the call to `.popScope()` would go to the clone instead of the hub we called `.pushScope()` on. This means we were popping the copied stack of the cloned hub leaving the stack of the original hub untouched. This lead to an ever growing stack on the original hub, causing a memory leak and also scope bleed because the original hub survives across requests and is never cleaned up.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves #2557 but still holds on to one hub per thread + stack and scope etc.
I have some ideas for further improving this which I'll try later. I'd like to first ship this as it already makes the situation a lot better.

## :green_heart: How did you test it?
Manually running our sample and looking at `visualvm` as well as debugging thread locals.

```
  @GetMapping("{id}")
  Mono<Person> person(@PathVariable Long id) {
//    LOGGER.info("Loading person with id={}", id);
//    throw new IllegalArgumentException("Something went wrong [id=" + id + "]");
    return personService.create(new Person("f", "l")).flatMap(it -> Mono.error(new RuntimeException("oopsie from webflux")));
  }
```

`wrk -t2 -c100 -d30s http://user:password@localhost:8080/person/91`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
