### PR TITLE
Renamed reportFullDisplayed to reportFullyDisplayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Renamed reportFullDisplayed to reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
+- Deprecate reportFullDisplayed in favor of reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
 
 ## 6.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## Unreleased
+
+### Fixes
+
+- Renamed reportFullDisplayed to reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
+
 ## 6.15.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -115,7 +115,7 @@ public final class ActivityLifecycleIntegration
             this.options.isEnableActivityLifecycleBreadcrumbs());
 
     performanceEnabled = isPerformanceEnabled(this.options);
-    fullyDisplayedReporter = this.options.getFullDisplayedReporter();
+    fullyDisplayedReporter = this.options.getFullyDisplayedReporter();
     timeToFullDisplaySpanEnabled = this.options.isEnableTimeToFullDisplayTracing();
 
     if (this.options.isEnableActivityLifecycleBreadcrumbs() || performanceEnabled) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -12,7 +12,7 @@ import android.os.Looper;
 import android.view.View;
 import androidx.annotation.NonNull;
 import io.sentry.Breadcrumb;
-import io.sentry.FullDisplayedReporter;
+import io.sentry.FullyDisplayedReporter;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -64,7 +64,7 @@ public final class ActivityLifecycleIntegration
   private boolean firstActivityCreated = false;
   private final boolean foregroundImportance;
 
-  private @Nullable FullDisplayedReporter fullDisplayedReporter = null;
+  private @Nullable FullyDisplayedReporter fullyDisplayedReporter = null;
   private @Nullable ISpan appStartSpan;
   private final @NotNull WeakHashMap<Activity, ISpan> ttidSpanMap = new WeakHashMap<>();
   private @NotNull SentryDate lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
@@ -115,7 +115,7 @@ public final class ActivityLifecycleIntegration
             this.options.isEnableActivityLifecycleBreadcrumbs());
 
     performanceEnabled = isPerformanceEnabled(this.options);
-    fullDisplayedReporter = this.options.getFullDisplayedReporter();
+    fullyDisplayedReporter = this.options.getFullDisplayedReporter();
     timeToFullDisplaySpanEnabled = this.options.isEnableTimeToFullDisplayTracing();
 
     if (this.options.isEnableActivityLifecycleBreadcrumbs() || performanceEnabled) {
@@ -239,7 +239,7 @@ public final class ActivityLifecycleIntegration
           transaction.startChild(
               TTID_OP, getTtidDesc(activityName), ttidStartTime, Instrumenter.SENTRY));
 
-      if (timeToFullDisplaySpanEnabled && fullDisplayedReporter != null && options != null) {
+      if (timeToFullDisplaySpanEnabled && fullyDisplayedReporter != null && options != null) {
         ttfdSpan =
             transaction.startChild(
                 TTFD_OP, getTtfdDesc(activityName), ttidStartTime, Instrumenter.SENTRY);
@@ -344,8 +344,8 @@ public final class ActivityLifecycleIntegration
 
     firstActivityCreated = true;
 
-    if (fullDisplayedReporter != null) {
-      fullDisplayedReporter.registerFullyDrawnListener(
+    if (fullyDisplayedReporter != null) {
+      fullyDisplayedReporter.registerFullyDrawnListener(
           () -> {
             finishSpan(ttfdSpan);
             cancelTtfdAutoClose();

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -12,7 +12,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.Breadcrumb
 import io.sentry.DateUtils
-import io.sentry.FullDisplayedReporter
+import io.sentry.FullyDisplayedReporter
 import io.sentry.Hub
 import io.sentry.ISentryExecutorService
 import io.sentry.Scope
@@ -66,7 +66,7 @@ class ActivityLifecycleIntegrationTest {
         val bundle = mock<Bundle>()
         val context = TransactionContext("name", "op")
         val activityFramesTracker = mock<ActivityFramesTracker>()
-        val fullDisplayedReporter = FullDisplayedReporter.getInstance()
+        val fullyDisplayedReporter = FullyDisplayedReporter.getInstance()
         val transactionFinishedCallback = mock<TransactionFinishedCallback>()
         lateinit var transaction: SentryTracer
         val buildInfo = mock<BuildInfoProvider>()
@@ -729,7 +729,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, mock())
         sut.ttidSpanMap.values.first().finish()
-        fixture.fullDisplayedReporter.reportFullyDrawn()
+        fixture.fullyDisplayedReporter.reportFullyDrawn()
         assertTrue(sut.ttfdSpan!!.isFinished)
         assertNotEquals(SpanStatus.CANCELLED, sut.ttfdSpan?.status)
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -1103,7 +1103,7 @@ class ActivityLifecycleIntegrationTest {
         assertNotNull(autoCloseFuture)
 
         // ReportFullyDrawn should finish the ttfd span and cancel the future
-        fixture.options.fullDisplayedReporter.reportFullyDrawn()
+        fixture.options.fullyDisplayedReporter.reportFullyDrawn()
         assertTrue(ttfdSpan.isFinished)
         assertNotEquals(SpanStatus.DEADLINE_EXCEEDED, ttfdSpan.status)
         assertTrue(autoCloseFuture.isCancelled)

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -207,6 +207,6 @@ public class MainActivity extends AppCompatActivity {
     if (span != null) {
       span.setMeasurement("screen_load_count", screenLoadCount, new MeasurementUnit.Custom("test"));
     }
-    Sentry.reportFullDisplayed();
+    Sentry.reportFullyDisplayed();
   }
 }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/PermissionsActivity.kt
@@ -38,6 +38,6 @@ class PermissionsActivity : AppCompatActivity() {
         }
 
         setContentView(binding.root)
-        Sentry.reportFullDisplayed()
+        Sentry.reportFullyDisplayed()
     }
 }

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/ProfilingActivity.kt
@@ -69,7 +69,7 @@ class ProfilingActivity : AppCompatActivity() {
             }.start()
         }
         setContentView(binding.root)
-        Sentry.reportFullDisplayed()
+        Sentry.reportFullyDisplayed()
     }
 
     private fun finishTransactionAndPrintResults(t: ITransaction) {

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/SecondActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/SecondActivity.kt
@@ -76,7 +76,7 @@ class SecondActivity : AppCompatActivity() {
 
                 showText(true, "error: ${t.message}")
 
-                Sentry.reportFullDisplayed()
+                Sentry.reportFullyDisplayed()
             }
 
             override fun onResponse(call: Call<List<Repo>>, response: Response<List<Repo>>) {
@@ -86,7 +86,7 @@ class SecondActivity : AppCompatActivity() {
 
                 showText(text = "items: ${repos.size}")
 
-                Sentry.reportFullDisplayed()
+                Sentry.reportFullyDisplayed()
             }
         })
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1548,7 +1548,7 @@ public class io/sentry/SentryOptions {
 	public fun getEventProcessors ()Ljava/util/List;
 	public fun getExecutorService ()Lio/sentry/ISentryExecutorService;
 	public fun getFlushTimeoutMillis ()J
-	public fun getFullDisplayedReporter ()Lio/sentry/FullyDisplayedReporter;
+	public fun getFullyDisplayedReporter ()Lio/sentry/FullyDisplayedReporter;
 	public fun getGestureTargetLocators ()Ljava/util/List;
 	public fun getHostnameVerifier ()Ljavax/net/ssl/HostnameVerifier;
 	public fun getIdleTimeout ()Ljava/lang/Long;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -277,13 +277,13 @@ public final class io/sentry/ExternalOptions {
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 }
 
-public final class io/sentry/FullDisplayedReporter {
-	public static fun getInstance ()Lio/sentry/FullDisplayedReporter;
-	public fun registerFullyDrawnListener (Lio/sentry/FullDisplayedReporter$FullDisplayedReporterListener;)V
+public final class io/sentry/FullyDisplayedReporter {
+	public static fun getInstance ()Lio/sentry/FullyDisplayedReporter;
+	public fun registerFullyDrawnListener (Lio/sentry/FullyDisplayedReporter$FullyDisplayedReporterListener;)V
 	public fun reportFullyDrawn ()V
 }
 
-public abstract interface class io/sentry/FullDisplayedReporter$FullDisplayedReporterListener {
+public abstract interface class io/sentry/FullyDisplayedReporter$FullyDisplayedReporterListener {
 	public abstract fun onFullyDrawn ()V
 }
 
@@ -344,7 +344,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun pushScope ()V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
-	public fun reportFullDisplayed ()V
+	public fun reportFullyDisplayed ()V
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
@@ -388,7 +388,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun pushScope ()V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
-	public fun reportFullDisplayed ()V
+	public fun reportFullyDisplayed ()V
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
@@ -457,7 +457,8 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun pushScope ()V
 	public abstract fun removeExtra (Ljava/lang/String;)V
 	public abstract fun removeTag (Ljava/lang/String;)V
-	public abstract fun reportFullDisplayed ()V
+	public fun reportFullDisplayed ()V
+	public abstract fun reportFullyDisplayed ()V
 	public abstract fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setFingerprint (Ljava/util/List;)V
 	public abstract fun setLevel (Lio/sentry/SentryLevel;)V
@@ -784,7 +785,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun pushScope ()V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
-	public fun reportFullDisplayed ()V
+	public fun reportFullyDisplayed ()V
 	public fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setFingerprint (Ljava/util/List;)V
 	public fun setLevel (Lio/sentry/SentryLevel;)V
@@ -1183,6 +1184,7 @@ public final class io/sentry/Sentry {
 	public static fun removeExtra (Ljava/lang/String;)V
 	public static fun removeTag (Ljava/lang/String;)V
 	public static fun reportFullDisplayed ()V
+	public static fun reportFullyDisplayed ()V
 	public static fun setCurrentHub (Lio/sentry/IHub;)V
 	public static fun setExtra (Ljava/lang/String;Ljava/lang/String;)V
 	public static fun setFingerprint (Ljava/util/List;)V
@@ -1546,7 +1548,7 @@ public class io/sentry/SentryOptions {
 	public fun getEventProcessors ()Ljava/util/List;
 	public fun getExecutorService ()Lio/sentry/ISentryExecutorService;
 	public fun getFlushTimeoutMillis ()J
-	public fun getFullDisplayedReporter ()Lio/sentry/FullDisplayedReporter;
+	public fun getFullDisplayedReporter ()Lio/sentry/FullyDisplayedReporter;
 	public fun getGestureTargetLocators ()Ljava/util/List;
 	public fun getHostnameVerifier ()Ljavax/net/ssl/HostnameVerifier;
 	public fun getIdleTimeout ()Ljava/lang/Long;

--- a/sentry/src/main/java/io/sentry/FullyDisplayedReporter.java
+++ b/sentry/src/main/java/io/sentry/FullyDisplayedReporter.java
@@ -7,26 +7,26 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
-public final class FullDisplayedReporter {
+public final class FullyDisplayedReporter {
 
-  private static final @NotNull FullDisplayedReporter instance = new FullDisplayedReporter();
+  private static final @NotNull FullyDisplayedReporter instance = new FullyDisplayedReporter();
 
-  private final @NotNull List<FullDisplayedReporterListener> listeners =
+  private final @NotNull List<FullyDisplayedReporterListener> listeners =
       new CopyOnWriteArrayList<>();
 
-  private FullDisplayedReporter() {}
+  private FullyDisplayedReporter() {}
 
-  public static @NotNull FullDisplayedReporter getInstance() {
+  public static @NotNull FullyDisplayedReporter getInstance() {
     return instance;
   }
 
   public void registerFullyDrawnListener(
-      final @NotNull FullDisplayedReporter.FullDisplayedReporterListener listener) {
+      final @NotNull FullyDisplayedReporter.FullyDisplayedReporterListener listener) {
     listeners.add(listener);
   }
 
   public void reportFullyDrawn() {
-    final @NotNull Iterator<FullDisplayedReporterListener> listenerIterator = listeners.iterator();
+    final @NotNull Iterator<FullyDisplayedReporterListener> listenerIterator = listeners.iterator();
     listeners.clear();
     while (listenerIterator.hasNext()) {
       listenerIterator.next().onFullyDrawn();
@@ -34,7 +34,7 @@ public final class FullDisplayedReporter {
   }
 
   @ApiStatus.Internal
-  public interface FullDisplayedReporterListener {
+  public interface FullyDisplayedReporterListener {
     void onFullyDrawn();
   }
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -517,7 +517,7 @@ public final class Hub implements IHub {
   @Override
   public void reportFullyDisplayed() {
     if (options.isEnableTimeToFullDisplayTracing()) {
-      options.getFullDisplayedReporter().reportFullyDrawn();
+      options.getFullyDisplayedReporter().reportFullyDrawn();
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -515,7 +515,7 @@ public final class Hub implements IHub {
   }
 
   @Override
-  public void reportFullDisplayed() {
+  public void reportFullyDisplayed() {
     if (options.isEnableTimeToFullDisplayTracing()) {
       options.getFullDisplayedReporter().reportFullyDrawn();
     }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -231,7 +231,7 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void reportFullDisplayed() {
-    Sentry.reportFullDisplayed();
+  public void reportFullyDisplayed() {
+    Sentry.reportFullyDisplayed();
   }
 }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -572,5 +572,13 @@ public interface IHub {
    * <p>This method is safe to be called multiple times. If the time-to-full-display span is already
    * finished, this call will be ignored.
    */
-  void reportFullDisplayed();
+  void reportFullyDisplayed();
+
+  /**
+   * @deprecated See {@link IHub#reportFullyDisplayed()}.
+   */
+  @Deprecated
+  default void reportFullDisplayed() {
+    reportFullyDisplayed();
+  }
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -188,5 +188,5 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public void reportFullDisplayed() {}
+  public void reportFullyDisplayed() {}
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -873,8 +873,17 @@ public final class Sentry {
    * <p>This method is safe to be called multiple times. If the time-to-full-display span is already
    * finished, this call will be ignored.
    */
+  public static void reportFullyDisplayed() {
+    getCurrentHub().reportFullyDisplayed();
+  }
+
+  /**
+   * @deprecated See {@link Sentry#reportFullyDisplayed()}.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static void reportFullDisplayed() {
-    getCurrentHub().reportFullDisplayed();
+    reportFullyDisplayed();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1967,7 +1967,7 @@ public class SentryOptions {
    * @return The reporter to call when a screen is fully loaded.
    */
   @ApiStatus.Internal
-  public @NotNull FullyDisplayedReporter getFullDisplayedReporter() {
+  public @NotNull FullyDisplayedReporter getFullyDisplayedReporter() {
     return fullyDisplayedReporter;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -406,8 +406,8 @@ public class SentryOptions {
   private boolean enableTimeToFullDisplayTracing = false;
 
   /** Screen fully displayed reporter, used for time-to-full-display spans. */
-  private final @NotNull FullDisplayedReporter fullDisplayedReporter =
-      FullDisplayedReporter.getInstance();
+  private final @NotNull FullyDisplayedReporter fullyDisplayedReporter =
+      FullyDisplayedReporter.getInstance();
 
   /**
    * Adds an event processor
@@ -1967,8 +1967,8 @@ public class SentryOptions {
    * @return The reporter to call when a screen is fully loaded.
    */
   @ApiStatus.Internal
-  public @NotNull FullDisplayedReporter getFullDisplayedReporter() {
-    return fullDisplayedReporter;
+  public @NotNull FullyDisplayedReporter getFullDisplayedReporter() {
+    return fullyDisplayedReporter;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/FullyDisplayedReporterTest.kt
+++ b/sentry/src/test/java/io/sentry/FullyDisplayedReporterTest.kt
@@ -1,6 +1,6 @@
 package io.sentry
 
-import io.sentry.FullDisplayedReporter.FullDisplayedReporterListener
+import io.sentry.FullyDisplayedReporter.FullyDisplayedReporterListener
 import io.sentry.test.getProperty
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -9,14 +9,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class FullDisplayedReporterTest {
+class FullyDisplayedReporterTest {
 
-    private val reporter = FullDisplayedReporter.getInstance()
-    private val listeners = reporter.getProperty<MutableList<FullDisplayedReporterListener>>("listeners")
-    private val listener1 = FullDisplayedReporterListener {}
-    private val listener2 = FullDisplayedReporterListener {}
-    private val mockListener1 = mock<FullDisplayedReporterListener>()
-    private val mockListener2 = mock<FullDisplayedReporterListener>()
+    private val reporter = FullyDisplayedReporter.getInstance()
+    private val listeners = reporter.getProperty<MutableList<FullyDisplayedReporterListener>>("listeners")
+    private val listener1 = FullyDisplayedReporterListener {}
+    private val listener2 = FullyDisplayedReporterListener {}
+    private val mockListener1 = mock<FullyDisplayedReporterListener>()
+    private val mockListener2 = mock<FullyDisplayedReporterListener>()
 
     @AfterTest
     fun shutdown() {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1652,9 +1652,8 @@ class HubTest {
     fun `reportFullyDisplayed is ignored if TimeToFullDisplayTracing is disabled`() {
         var called = false
         val hub = generateHub {
-            it.fullDisplayedReporter.registerFullyDrawnListener {
+            it.fullyDisplayedReporter.registerFullyDrawnListener {
                 called = !called
-                true
             }
         }
         hub.reportFullyDisplayed()
@@ -1662,13 +1661,12 @@ class HubTest {
     }
 
     @Test
-    fun `reportFullyDisplayed calls FullDisplayedReporter if TimeToFullDisplayTracing is enabled`() {
+    fun `reportFullyDisplayed calls FullyDisplayedReporter if TimeToFullDisplayTracing is enabled`() {
         var called = false
         val hub = generateHub {
             it.isEnableTimeToFullDisplayTracing = true
-            it.fullDisplayedReporter.registerFullyDrawnListener {
+            it.fullyDisplayedReporter.registerFullyDrawnListener {
                 called = !called
-                true
             }
         }
         hub.reportFullyDisplayed()
@@ -1676,13 +1674,12 @@ class HubTest {
     }
 
     @Test
-    fun `reportFullyDisplayed calls FullDisplayedReporter only once`() {
+    fun `reportFullyDisplayed calls FullyDisplayedReporter only once`() {
         var called = false
         val hub = generateHub {
             it.isEnableTimeToFullDisplayTracing = true
-            it.fullDisplayedReporter.registerFullyDrawnListener {
+            it.fullyDisplayedReporter.registerFullyDrawnListener {
                 called = !called
-                true
             }
         }
         hub.reportFullyDisplayed()

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1648,7 +1648,7 @@ class HubTest {
     }
 
     @Test
-    fun `reportFullDisplayed is ignored if TimeToFullDisplayTracing is disabled`() {
+    fun `reportFullyDisplayed is ignored if TimeToFullDisplayTracing is disabled`() {
         var called = false
         val hub = generateHub {
             it.fullDisplayedReporter.registerFullyDrawnListener {
@@ -1656,12 +1656,12 @@ class HubTest {
                 true
             }
         }
-        hub.reportFullDisplayed()
+        hub.reportFullyDisplayed()
         assertFalse(called)
     }
 
     @Test
-    fun `reportFullDisplayed calls FullDisplayedReporter if TimeToFullDisplayTracing is enabled`() {
+    fun `reportFullyDisplayed calls FullDisplayedReporter if TimeToFullDisplayTracing is enabled`() {
         var called = false
         val hub = generateHub {
             it.isEnableTimeToFullDisplayTracing = true
@@ -1670,12 +1670,12 @@ class HubTest {
                 true
             }
         }
-        hub.reportFullDisplayed()
+        hub.reportFullyDisplayed()
         assertTrue(called)
     }
 
     @Test
-    fun `reportFullDisplayed calls FullDisplayedReporter only once`() {
+    fun `reportFullyDisplayed calls FullDisplayedReporter only once`() {
         var called = false
         val hub = generateHub {
             it.isEnableTimeToFullDisplayTracing = true
@@ -1684,9 +1684,9 @@ class HubTest {
                 true
             }
         }
-        hub.reportFullDisplayed()
+        hub.reportFullyDisplayed()
         assertTrue(called)
-        hub.reportFullDisplayed()
+        hub.reportFullyDisplayed()
         assertTrue(called)
     }
 

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -1688,6 +1689,13 @@ class HubTest {
         assertTrue(called)
         hub.reportFullyDisplayed()
         assertTrue(called)
+    }
+
+    @Test
+    fun `reportFullDisplayed calls reportFullyDisplayed`() {
+        val hub = spy(generateHub())
+        hub.reportFullDisplayed()
+        verify(hub).reportFullyDisplayed()
     }
 
     private val dsnTest = "https://key@sentry.io/proj"

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -83,5 +83,5 @@ class NoOpHubTest {
     fun `setSpanContext doesnt throw`() = sut.setSpanContext(RuntimeException(), mock(), "")
 
     @Test
-    fun `reportFullyDrawn doesnt throw`() = sut.reportFullDisplayed()
+    fun `reportFullyDrawn doesnt throw`() = sut.reportFullyDisplayed()
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -455,6 +455,6 @@ class SentryOptionsTest {
 
     @Test
     fun `when options are initialized, FullyDrawnReporter is set`() {
-        assertEquals(FullDisplayedReporter.getInstance(), SentryOptions().fullDisplayedReporter)
+        assertEquals(FullyDisplayedReporter.getInstance(), SentryOptions().fullDisplayedReporter)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -455,6 +455,6 @@ class SentryOptionsTest {
 
     @Test
     fun `when options are initialized, FullyDrawnReporter is set`() {
-        assertEquals(FullyDisplayedReporter.getInstance(), SentryOptions().fullDisplayedReporter)
+        assertEquals(FullyDisplayedReporter.getInstance(), SentryOptions().fullyDisplayedReporter)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -478,6 +478,28 @@ class SentryTest {
         assertTrue { sentryOptions!!.collectors.any { it is CustomMemoryCollector } }
     }
 
+    @Test
+    fun `reportFullyDisplayed calls hub reportFullyDisplayed`() {
+        val hub = mock<IHub>()
+        Sentry.init {
+            it.dsn = dsn
+        }
+        Sentry.setCurrentHub(hub)
+        Sentry.reportFullyDisplayed()
+        verify(hub).reportFullyDisplayed()
+    }
+
+    @Test
+    fun `reportFullDisplayed calls reportFullyDisplayed`() {
+        val hub = mock<IHub>()
+        Sentry.init {
+            it.dsn = dsn
+        }
+        Sentry.setCurrentHub(hub)
+        Sentry.reportFullDisplayed()
+        verify(hub).reportFullyDisplayed()
+    }
+
     private class CustomMainThreadChecker : IMainThreadChecker {
         override fun isMainThread(threadId: Long): Boolean = false
     }


### PR DESCRIPTION
## :scroll: Description
Rename all occurrences of FullDisplayed with FullyDisplayed
Deprecated old Sentry.reportFullDisplayed() method

## :bulb: Motivation and Context
reportFullDisplayed is not correct english
It fixes https://github.com/getsentry/sentry-java/issues/2575


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
