### PR TITLE
Filter out session cookies sent by Spring and Spring Boot integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixes
 
 - Deprecate reportFullDisplayed in favor of reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
+- Filter out session cookies sent by Spring and Spring Boot integrations ([#2593](https://github.com/getsentry/sentry-java/pull/2593))
+  - We filter out some common cookies like JSESSIONID
+  - We also read the value from `server.servlet.session.cookie.name` and filter it out
 
 ## 6.15.0
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
@@ -2,14 +2,18 @@ package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IHub;
+import io.sentry.SentryLevel;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.UrlUtils;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.SessionCookieConfig;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,27 +35,60 @@ public class SentryRequestResolver {
         UrlUtils.parse(httpRequest.getRequestURL().toString());
     urlDetails.applyToRequest(sentryRequest);
     sentryRequest.setQueryString(httpRequest.getQueryString());
-    sentryRequest.setHeaders(resolveHeadersMap(httpRequest));
+    final @NotNull List<String> additionalSecurityCookieNames =
+        extractSecurityCookieNames(httpRequest);
+    sentryRequest.setHeaders(resolveHeadersMap(httpRequest, additionalSecurityCookieNames));
 
     if (hub.getOptions().isSendDefaultPii()) {
-      sentryRequest.setCookies(toString(httpRequest.getHeaders("Cookie")));
+      String cookieName = HttpUtils.COOKIE_HEADER_NAME;
+      final @Nullable List<String> filteredHeaders =
+          HttpUtils.filterOutSecurityCookiesFromHeader(
+              httpRequest.getHeaders(cookieName), cookieName, additionalSecurityCookieNames);
+      sentryRequest.setCookies(toString(filteredHeaders));
     }
     return sentryRequest;
   }
 
   @NotNull
-  Map<String, String> resolveHeadersMap(final @NotNull HttpServletRequest request) {
+  Map<String, String> resolveHeadersMap(
+      final @NotNull HttpServletRequest request,
+      final @NotNull List<String> additionalSecurityCookieNames) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
       if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
-        headersMap.put(headerName, toString(request.getHeaders(headerName)));
+        final @Nullable List<String> filteredHeaders =
+            HttpUtils.filterOutSecurityCookiesFromHeader(
+                request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
+        headersMap.put(headerName, toString(filteredHeaders));
       }
     }
     return headersMap;
   }
 
-  private static @Nullable String toString(final @Nullable Enumeration<String> enumeration) {
-    return enumeration != null ? String.join(",", Collections.list(enumeration)) : null;
+  private List<String> extractSecurityCookieNames(final @NotNull HttpServletRequest httpRequest) {
+    try {
+      final @Nullable ServletContext servletContext = httpRequest.getServletContext();
+      if (servletContext != null) {
+        final @Nullable SessionCookieConfig sessionCookieConfig =
+            servletContext.getSessionCookieConfig();
+        if (sessionCookieConfig != null) {
+          final @Nullable String cookieName = sessionCookieConfig.getName();
+          if (cookieName != null) {
+            return Arrays.asList(cookieName);
+          }
+        }
+      }
+    } catch (Throwable t) {
+      hub.getOptions()
+          .getLogger()
+          .log(SentryLevel.WARNING, "Failed to extract session cookie name from request.", t);
+    }
+
+    return Collections.emptyList();
+  }
+
+  private static @Nullable String toString(final @Nullable List<String> list) {
+    return list != null ? String.join(",", list) : null;
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
@@ -2,14 +2,18 @@ package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IHub;
+import io.sentry.SentryLevel;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.UrlUtils;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import javax.servlet.ServletContext;
+import javax.servlet.SessionCookieConfig;
 import javax.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,27 +35,60 @@ public class SentryRequestResolver {
         UrlUtils.parse(httpRequest.getRequestURL().toString());
     urlDetails.applyToRequest(sentryRequest);
     sentryRequest.setQueryString(httpRequest.getQueryString());
-    sentryRequest.setHeaders(resolveHeadersMap(httpRequest));
+    final @NotNull List<String> additionalSecurityCookieNames =
+        extractSecurityCookieNames(httpRequest);
+    sentryRequest.setHeaders(resolveHeadersMap(httpRequest, additionalSecurityCookieNames));
 
     if (hub.getOptions().isSendDefaultPii()) {
-      sentryRequest.setCookies(toString(httpRequest.getHeaders("Cookie")));
+      String cookieName = HttpUtils.COOKIE_HEADER_NAME;
+      final @Nullable List<String> filteredHeaders =
+          HttpUtils.filterOutSecurityCookiesFromHeader(
+              httpRequest.getHeaders(cookieName), cookieName, additionalSecurityCookieNames);
+      sentryRequest.setCookies(toString(filteredHeaders));
     }
     return sentryRequest;
   }
 
   @NotNull
-  Map<String, String> resolveHeadersMap(final @NotNull HttpServletRequest request) {
+  Map<String, String> resolveHeadersMap(
+      final @NotNull HttpServletRequest request,
+      final @NotNull List<String> additionalSecurityCookieNames) {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
       if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
-        headersMap.put(headerName, toString(request.getHeaders(headerName)));
+        final @Nullable List<String> filteredHeaders =
+            HttpUtils.filterOutSecurityCookiesFromHeader(
+                request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
+        headersMap.put(headerName, toString(filteredHeaders));
       }
     }
     return headersMap;
   }
 
-  private static @Nullable String toString(final @Nullable Enumeration<String> enumeration) {
-    return enumeration != null ? String.join(",", Collections.list(enumeration)) : null;
+  private List<String> extractSecurityCookieNames(final @NotNull HttpServletRequest httpRequest) {
+    try {
+      final @Nullable ServletContext servletContext = httpRequest.getServletContext();
+      if (servletContext != null) {
+        final @Nullable SessionCookieConfig sessionCookieConfig =
+            servletContext.getSessionCookieConfig();
+        if (sessionCookieConfig != null) {
+          final @Nullable String cookieName = sessionCookieConfig.getName();
+          if (cookieName != null) {
+            return Arrays.asList(cookieName);
+          }
+        }
+      }
+    } catch (Throwable t) {
+      hub.getOptions()
+          .getLogger()
+          .log(SentryLevel.WARNING, "Failed to extract session cookie name from request.", t);
+    }
+
+    return Collections.emptyList();
+  }
+
+  private static @Nullable String toString(final @Nullable List<String> list) {
+    return list != null ? String.join(",", list) : null;
   }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
@@ -24,6 +24,7 @@ import org.springframework.mock.web.MockServletContext
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import java.net.URI
 import javax.servlet.FilterChain
+import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -150,7 +151,7 @@ class SentrySpringFilterTest {
     }
 
     @Test
-    fun `when sendDefaultPii is set to true, attaches cookies information to Scope request`() {
+    fun `when sendDefaultPii is set to true, attaches filtered cookies to Scope request`() {
         val sentryOptions = SentryOptions().apply {
             isSendDefaultPii = true
         }
@@ -158,16 +159,19 @@ class SentrySpringFilterTest {
         val listener = fixture.getSut(
             request = MockMvcRequestBuilders
                 .get(URI.create("http://example.com?param1=xyz"))
-                .header("Cookie", "name=value")
-                .header("Cookie", "name2=value2")
-                .buildRequest(MockServletContext()),
+                .header("Cookie", "name=value; JSESSIONID=123; mysessioncookiename=789")
+                .header("Cookie", "name2=value2; SID=456")
+                .buildRequest(servletContextWithCustomCookieName("mysessioncookiename")),
             options = sentryOptions
         )
 
         listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
         assertNotNull(fixture.scope.request) {
-            assertEquals("name=value,name2=value2", it.cookies)
+            val expectedCookieString =
+                "name=value; JSESSIONID=[Filtered]; mysessioncookiename=[Filtered],name2=value2; SID=[Filtered]"
+            assertEquals(expectedCookieString, it.cookies)
+            assertEquals(expectedCookieString, it.headers!!["Cookie"])
         }
     }
 
@@ -268,5 +272,9 @@ class SentrySpringFilterTest {
                 throw e
             }
         }
+    }
+
+    private fun servletContextWithCustomCookieName(name: String): ServletContext {
+        return MockServletContext().also { it.sessionCookieConfig.name = name }
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3751,8 +3751,13 @@ public abstract interface class io/sentry/util/HintUtils$SentryNullableConsumer 
 }
 
 public final class io/sentry/util/HttpUtils {
+	public static final field COOKIE_HEADER_NAME Ljava/lang/String;
 	public fun <init> ()V
 	public static fun containsSensitiveHeader (Ljava/lang/String;)Z
+	public static fun filterOutSecurityCookies (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+	public static fun filterOutSecurityCookiesFromHeader (Ljava/util/Enumeration;Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public static fun filterOutSecurityCookiesFromHeader (Ljava/util/List;Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public static fun isSecurityCookie (Ljava/lang/String;Ljava/util/List;)Z
 }
 
 public final class io/sentry/util/JsonSerializationUtils {
@@ -3811,6 +3816,7 @@ public final class io/sentry/util/StringUtils {
 }
 
 public final class io/sentry/util/UrlUtils {
+	public static final field SENSITIVE_DATA_SUBSTITUTE Ljava/lang/String;
 	public fun <init> ()V
 	public static fun parse (Ljava/lang/String;)Lio/sentry/util/UrlUtils$UrlDetails;
 	public static fun parseNullable (Ljava/lang/String;)Lio/sentry/util/UrlUtils$UrlDetails;

--- a/sentry/src/main/java/io/sentry/util/UrlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/UrlUtils.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class UrlUtils {
 
+  public static final @NotNull String SENSITIVE_DATA_SUBSTITUTE = "[Filtered]";
   private static final @NotNull Pattern AUTH_REGEX = Pattern.compile("(.+://)(.*@)(.*)");
 
   public static @Nullable UrlDetails parseNullable(final @Nullable String url) {
@@ -108,7 +109,9 @@ public final class UrlUtils {
     if (userInfoMatcher.matches() && userInfoMatcher.groupCount() == 3) {
       final @NotNull String userInfoString = userInfoMatcher.group(2);
       final @NotNull String replacementString =
-          userInfoString.contains(":") ? "[Filtered]:[Filtered]@" : "[Filtered]@";
+          userInfoString.contains(":")
+              ? (SENSITIVE_DATA_SUBSTITUTE + ":" + SENSITIVE_DATA_SUBSTITUTE + "@")
+              : (SENSITIVE_DATA_SUBSTITUTE + "@");
       return userInfoMatcher.group(1) + replacementString + userInfoMatcher.group(3);
     } else {
       return url;

--- a/sentry/src/test/java/io/sentry/util/HttpUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/HttpUtilsTest.kt
@@ -1,0 +1,74 @@
+package io.sentry.util
+
+import java.util.Enumeration
+import java.util.StringTokenizer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class HttpUtilsTest {
+    @Test
+    fun `null enumeration returns null when filtering security cookies from headers`() {
+        val enumeration: Enumeration<String>? = null
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(enumeration, "Cookie", emptyList())
+
+        assertNull(headers)
+    }
+
+    @Test
+    fun `null list returns null when filtering security cookies from headers`() {
+        val list: List<String>? = null
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(list, "Cookie", emptyList())
+
+        assertNull(headers)
+    }
+
+    @Test
+    fun `enumeration works when filtering security cookies from headers`() {
+        val enumeration: Enumeration<String>? = StringTokenizer("Cookie_2=value2; Cookie_3=value3; JSESSIONID=123456789; mysessioncookiename=1F54D793F432FEE4CFC6A3FAED6D062F|Cookie_1=value1; SID=987654312", "|") as Enumeration<String>
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(enumeration, "Cookie", listOf("mysessioncookiename"))
+
+        assertNotNull(headers)
+        assertEquals(2, headers.size)
+        assertEquals("Cookie_2=value2; Cookie_3=value3; JSESSIONID=[Filtered]; mysessioncookiename=[Filtered]", headers!![0])
+        assertEquals("Cookie_1=value1; SID=[Filtered]", headers!![1])
+    }
+
+    @Test
+    fun `list works when filtering security cookies from headers`() {
+        val list: List<String>? = listOf("Cookie_2=value2; Cookie_3=value3; JSESSIONID=123456789; mysessioncookiename=1F54D793F432FEE4CFC6A3FAED6D062F", "Cookie_1=value1; SID=987654312")
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(list, "Cookie", listOf("mysessioncookiename"))
+
+        assertNotNull(headers)
+        assertEquals(2, headers.size)
+        assertEquals("Cookie_2=value2; Cookie_3=value3; JSESSIONID=[Filtered]; mysessioncookiename=[Filtered]", headers!![0])
+        assertEquals("Cookie_1=value1; SID=[Filtered]", headers!![1])
+    }
+
+    @Test
+    fun `filtering security cookies from header works for corrupted string`() {
+        val list: List<String>? = listOf("Cookie_1=value1;; SID=; JSESSIONID; =")
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(list, "Cookie", listOf("mysessioncookiename"))
+
+        assertNotNull(headers)
+        assertEquals(1, headers.size)
+        assertEquals("Cookie_1=value1;; SID=[Filtered]; JSESSIONID=[Filtered]; =", headers!![0])
+    }
+
+    @Test
+    fun `filtering security cookies from header works for null string`() {
+        val list: List<String?>? = listOf(null)
+        val headers =
+            HttpUtils.filterOutSecurityCookiesFromHeader(list, "Cookie", listOf("mysessioncookiename"))
+
+        assertNotNull(headers)
+        assertEquals(1, headers.size)
+        assertEquals(null, headers!![0])
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Replace values of certain cookies that could allow impersonation with `[Filtered]` and do not send the value to Sentry.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2562 


## :green_heart: How did you test it?
Unit Tests, manually using samples

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
