### PR TITLE
Add mechanism for logging integrations and update spring mechanism types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Deprecate reportFullDisplayed in favor of reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
+- Add mechanism for logging integrations and update spring mechanism types ([#2595](https://github.com/getsentry/sentry-java/pull/2595))
 
 ## 6.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix timestamps of slow and frozen frames for profiles ([#2584](https://github.com/getsentry/sentry-java/pull/2584))
 - Deprecate reportFullDisplayed in favor of reportFullyDisplayed ([#2585](https://github.com/getsentry/sentry-java/pull/2585))
 - Add mechanism for logging integrations and update spring mechanism types ([#2595](https://github.com/getsentry/sentry-java/pull/2595))
+	- NOTE: If you're using these mechanism types (`HandlerExceptionResolver`, `SentryWebExceptionHandler`) in your dashboards please update them to use the new types.
 - Filter out session cookies sent by Spring and Spring Boot integrations ([#2593](https://github.com/getsentry/sentry-java/pull/2593))
   - We filter out some common cookies like JSESSIONID
   - We also read the value from `server.servlet.session.cookie.name` and filter it out

--- a/sentry-jul/api/sentry-jul.api
+++ b/sentry-jul/api/sentry-jul.api
@@ -4,6 +4,7 @@ public final class io/sentry/jul/BuildConfig {
 }
 
 public class io/sentry/jul/SentryHandler : java/util/logging/Handler {
+	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public static final field THREAD_ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/SentryOptions;)V

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -197,6 +197,22 @@ class SentryHandlerTest {
     }
 
     @Test
+    fun `converts severe log level to Sentry level with exception`() {
+        fixture = Fixture(minimumEventLevel = Level.SEVERE)
+        fixture.logger.log(Level.SEVERE, "testing error level", RuntimeException("test exc"))
+
+        verify(fixture.transport).send(
+            checkEvent { event ->
+                assertEquals(SentryLevel.ERROR, event.level)
+                val exception = event.exceptions!!.first()
+                assertEquals(SentryHandler.MECHANISM_TYPE, exception.mechanism!!.type)
+                assertEquals("test exc", exception.value)
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
     fun `attaches thread information`() {
         fixture = Fixture(minimumEventLevel = Level.WARNING)
         fixture.logger.warning("testing thread information")

--- a/sentry-log4j2/api/sentry-log4j2.api
+++ b/sentry-log4j2/api/sentry-log4j2.api
@@ -4,6 +4,7 @@ public final class io/sentry/log4j2/BuildConfig {
 }
 
 public class io/sentry/log4j2/SentryAppender : org/apache/logging/log4j/core/appender/AbstractAppender {
+	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/Boolean;Lio/sentry/ITransportFactory;Lio/sentry/IHub;[Ljava/lang/String;)V
 	public fun append (Lorg/apache/logging/log4j/core/LogEvent;)V
 	public static fun createAppender (Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Level;Ljava/lang/String;Ljava/lang/Boolean;Lorg/apache/logging/log4j/core/Filter;Ljava/lang/String;)Lio/sentry/log4j2/SentryAppender;

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -202,6 +202,22 @@ class SentryAppenderTest {
     }
 
     @Test
+    fun `converts error log level to Sentry level with exception`() {
+        val logger = fixture.getSut(minimumEventLevel = Level.ERROR)
+        logger.error("testing error level", RuntimeException("test exc"))
+
+        verify(fixture.transport).send(
+            checkEvent { event ->
+                assertEquals(SentryLevel.ERROR, event.level)
+                val exception = event.exceptions!!.first()
+                assertEquals(SentryAppender.MECHANISM_TYPE, exception.mechanism!!.type)
+                assertEquals("test exc", exception.value)
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
     fun `converts fatal log level to Sentry level`() {
         val logger = fixture.getSut(minimumEventLevel = Level.FATAL)
         logger.fatal("testing fatal level")

--- a/sentry-logback/api/sentry-logback.api
+++ b/sentry-logback/api/sentry-logback.api
@@ -4,6 +4,7 @@ public final class io/sentry/logback/BuildConfig {
 }
 
 public class io/sentry/logback/SentryAppender : ch/qos/logback/core/UnsynchronizedAppenderBase {
+	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public fun <init> ()V
 	protected fun append (Lch/qos/logback/classic/spi/ILoggingEvent;)V
 	protected synthetic fun append (Ljava/lang/Object;)V

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -19,6 +19,8 @@ import io.sentry.SentryEvent;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.exception.ExceptionMechanismException;
+import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.util.CollectionUtils;
@@ -37,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 /** Appender for logback in charge of sending the logged events to a Sentry server. */
 @Open
 public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+  public static final String MECHANISM_TYPE = "LogbackSentryAppender";
   // WARNING: Do not use these options in here, they are only to be used for startup
   private @NotNull SentryOptions options = new SentryOptions();
   private @Nullable ITransportFactory transportFactory;
@@ -104,7 +107,12 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     final ThrowableProxy throwableInformation = (ThrowableProxy) loggingEvent.getThrowableProxy();
     if (throwableInformation != null) {
-      event.setThrowable(throwableInformation.getThrowable());
+      final Mechanism mechanism = new Mechanism();
+      mechanism.setType(MECHANISM_TYPE);
+      final Throwable mechanismException =
+          new ExceptionMechanismException(
+              mechanism, throwableInformation.getThrowable(), Thread.currentThread());
+      event.setThrowable(mechanismException);
     }
 
     if (loggingEvent.getThreadName() != null) {

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -252,6 +252,22 @@ class SentryAppenderTest {
     }
 
     @Test
+    fun `converts error log level to Sentry level with exception`() {
+        fixture = Fixture(minimumEventLevel = Level.ERROR)
+        fixture.logger.error("testing error level", RuntimeException("test exc"))
+
+        verify(fixture.transport).send(
+            checkEvent { event ->
+                assertEquals(SentryLevel.ERROR, event.level)
+                val exception = event.exceptions!!.first()
+                assertEquals(SentryAppender.MECHANISM_TYPE, exception.mechanism!!.type)
+                assertEquals("test exc", exception.value)
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
     fun `attaches thread information`() {
         fixture = Fixture(minimumEventLevel = Level.WARN)
         fixture.logger.warn("testing thread information")

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonController.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/PersonController.java
@@ -21,7 +21,7 @@ public class PersonController {
 
   @GetMapping("{id}")
   Person person(@PathVariable Long id) {
-    LOGGER.info("Loading person with id={}", id);
+    LOGGER.error("Trying person with id={}", id, new RuntimeException("error while loading"));
     throw new IllegalArgumentException("Something went wrong [id=" + id + "]");
   }
 

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -200,6 +200,7 @@ public final class io/sentry/spring/jakarta/webflux/SentryScheduleHook : java/ut
 }
 
 public final class io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler : org/springframework/web/server/WebExceptionHandler {
+	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public fun <init> (Lio/sentry/IHub;)V
 	public fun handle (Lorg/springframework/web/server/ServerWebExchange;Ljava/lang/Throwable;)Lreactor/core/publisher/Mono;
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @Open
 public class SentryExceptionResolver implements HandlerExceptionResolver, Ordered {
-  public static final String MECHANISM_TYPE = "HandlerExceptionResolver";
+  public static final String MECHANISM_TYPE = "Spring6ExceptionResolver";
 
   private final @NotNull IHub hub;
   private final @NotNull TransactionNameProvider transactionNameProvider;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 // at -1
 @ApiStatus.Experimental
 public final class SentryWebExceptionHandler implements WebExceptionHandler {
+  public static final String MECHANISM_TYPE = "Spring6WebFluxExceptionResolver";
   private final @NotNull IHub hub;
 
   public SentryWebExceptionHandler(final @NotNull IHub hub) {
@@ -44,7 +45,7 @@ public final class SentryWebExceptionHandler implements WebExceptionHandler {
                     it -> {
                       if (!(ex instanceof ResponseStatusException)) {
                         final Mechanism mechanism = new Mechanism();
-                        mechanism.setType("SentryWebExceptionHandler");
+                        mechanism.setType(MECHANISM_TYPE);
                         mechanism.setHandled(false);
                         final Throwable throwable =
                             new ExceptionMechanismException(mechanism, ex, Thread.currentThread());

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
@@ -36,7 +36,7 @@ class SentryExceptionResolverTest {
         assertThat(eventCaptor.firstValue.throwableMechanism).isInstanceOf(ExceptionMechanismException::class.java)
         with(eventCaptor.firstValue.throwableMechanism as ExceptionMechanismException) {
             assertThat(exceptionMechanism.isHandled).isFalse
-            assertThat(exceptionMechanism.type).isEqualTo("HandlerExceptionResolver")
+            assertThat(exceptionMechanism.type).isEqualTo(SentryExceptionResolver.MECHANISM_TYPE)
             assertThat(throwable).isEqualTo(expectedCause)
             assertThat(thread).isEqualTo(Thread.currentThread())
             assertThat(isSnapshot).isFalse

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
@@ -98,6 +98,7 @@ class SentryWebfluxIntegrationTest {
                     assertEquals("something went wrong", ex.value)
                     assertNotNull(ex.mechanism) {
                         assertThat(it.isHandled).isFalse()
+                        assertThat(it.type).isEqualTo(SentryWebExceptionHandler.MECHANISM_TYPE)
                     }
                 }
             },

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -172,6 +172,7 @@ public final class io/sentry/spring/webflux/SentryScheduleHook : java/util/funct
 }
 
 public final class io/sentry/spring/webflux/SentryWebExceptionHandler : org/springframework/web/server/WebExceptionHandler {
+	public static final field MECHANISM_TYPE Ljava/lang/String;
 	public fun <init> (Lio/sentry/IHub;)V
 	public fun handle (Lorg/springframework/web/server/ServerWebExchange;Ljava/lang/Throwable;)Lreactor/core/publisher/Mono;
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @Open
 public class SentryExceptionResolver implements HandlerExceptionResolver, Ordered {
-  public static final String MECHANISM_TYPE = "HandlerExceptionResolver";
+  public static final String MECHANISM_TYPE = "Spring5ExceptionResolver";
 
   private final @NotNull IHub hub;
   private final @NotNull TransactionNameProvider transactionNameProvider;

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 // at -1
 @ApiStatus.Experimental
 public final class SentryWebExceptionHandler implements WebExceptionHandler {
+  public static final String MECHANISM_TYPE = "Spring5WebFluxExceptionResolver";
   private final @NotNull IHub hub;
 
   public SentryWebExceptionHandler(final @NotNull IHub hub) {
@@ -35,7 +36,7 @@ public final class SentryWebExceptionHandler implements WebExceptionHandler {
       final @NotNull ServerWebExchange serverWebExchange, final @NotNull Throwable ex) {
     if (!(ex instanceof ResponseStatusException)) {
       final Mechanism mechanism = new Mechanism();
-      mechanism.setType("SentryWebExceptionHandler");
+      mechanism.setType(MECHANISM_TYPE);
       mechanism.setHandled(false);
       final Throwable throwable =
           new ExceptionMechanismException(mechanism, ex, Thread.currentThread());

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
@@ -36,7 +36,7 @@ class SentryExceptionResolverTest {
         assertThat(eventCaptor.firstValue.throwableMechanism).isInstanceOf(ExceptionMechanismException::class.java)
         with(eventCaptor.firstValue.throwableMechanism as ExceptionMechanismException) {
             assertThat(exceptionMechanism.isHandled).isFalse
-            assertThat(exceptionMechanism.type).isEqualTo("HandlerExceptionResolver")
+            assertThat(exceptionMechanism.type).isEqualTo(SentryExceptionResolver.MECHANISM_TYPE)
             assertThat(throwable).isEqualTo(expectedCause)
             assertThat(thread).isEqualTo(Thread.currentThread())
             assertThat(isSnapshot).isFalse

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
@@ -98,6 +98,7 @@ class SentryWebfluxIntegrationTest {
                     assertEquals("something went wrong", ex.value)
                     assertNotNull(ex.mechanism) {
                         assertThat(it.isHandled).isFalse()
+                        assertThat(it.type).isEqualTo(SentryWebExceptionHandler.MECHANISM_TYPE)
                     }
                 }
             },


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When capturing an exception via any of our logging integrations (logback, log4j2, jul) we now add the mechanism and set the mechanism type.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2555

## :green_heart: How did you test it?
Unit tests, manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
