### PR TITLE
Add version to sentryClientName used in auth header

### DIFF
--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -121,7 +121,8 @@ public class SentryAppender extends AbstractAppender {
               if (debug != null) {
                 options.setDebug(debug);
               }
-              options.setSentryClientName(BuildConfig.SENTRY_LOG4J2_SDK_NAME);
+              options.setSentryClientName(
+                  BuildConfig.SENTRY_LOG4J2_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
               options.setSdkVersion(createSdkVersion(options));
               if (contextTags != null) {
                 for (final String contextTag : contextTags) {

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -50,7 +50,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     if (!Sentry.isEnabled()) {
       if (options.getDsn() == null || !options.getDsn().endsWith("_IS_UNDEFINED")) {
         options.setEnableExternalConfiguration(true);
-        options.setSentryClientName(BuildConfig.SENTRY_LOGBACK_SDK_NAME);
+        options.setSentryClientName(
+            BuildConfig.SENTRY_LOGBACK_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
         options.setSdkVersion(createSdkVersion(options));
         Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
         try {

--- a/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -115,7 +115,8 @@ public class SentryAutoConfiguration {
             }
           });
 
-      options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_JAKARTA_SDK_NAME);
+      options.setSentryClientName(
+          BuildConfig.SENTRY_SPRING_BOOT_JAKARTA_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
       options.setSdkVersion(createSdkVersion(options));
       addPackageAndIntegrationInfo();
       if (options.getTracesSampleRate() == null && options.getEnableTracing() == null) {

--- a/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -244,7 +244,7 @@ class SentryAutoConfigurationTest {
     fun `sets sentryClientName property on SentryOptions`() {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
             .run {
-                assertThat(it.getBean(SentryOptions::class.java).sentryClientName).isEqualTo("sentry.java.spring-boot${optionalJakartaPrefix()}")
+                assertThat(it.getBean(SentryOptions::class.java).sentryClientName).isEqualTo("sentry.java.spring-boot.jakarta/${BuildConfig.VERSION_NAME}")
             }
     }
 
@@ -923,12 +923,5 @@ class SentryAutoConfigurationTest {
     private fun ApplicationContext.getSentryUserProviders(): List<SentryUserProvider> {
         val userFilter = this.getBean("sentryUserFilter", FilterRegistrationBean::class.java).filter as SentryUserFilter
         return userFilter.sentryUserProviders
-    }
-
-    private fun optionalJakartaPrefix(): String {
-        if (this.javaClass.packageName.endsWith("jakarta")) {
-            return ".jakarta"
-        }
-        return ""
     }
 }

--- a/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-starter/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -115,7 +115,8 @@ public class SentryAutoConfiguration {
             }
           });
 
-      options.setSentryClientName(BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME);
+      options.setSentryClientName(
+          BuildConfig.SENTRY_SPRING_BOOT_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
       options.setSdkVersion(createSdkVersion(options));
       addPackageAndIntegrationInfo();
       if (options.getTracesSampleRate() == null && options.getEnableTracing() == null) {

--- a/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-starter/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -244,7 +244,7 @@ class SentryAutoConfigurationTest {
     fun `sets sentryClientName property on SentryOptions`() {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
             .run {
-                assertThat(it.getBean(SentryOptions::class.java).sentryClientName).isEqualTo("sentry.java.spring-boot${optionalJakartaPrefix()}")
+                assertThat(it.getBean(SentryOptions::class.java).sentryClientName).isEqualTo("sentry.java.spring-boot/${BuildConfig.VERSION_NAME}")
             }
     }
 
@@ -923,12 +923,5 @@ class SentryAutoConfigurationTest {
     private fun ApplicationContext.getSentryUserProviders(): List<SentryUserProvider> {
         val userFilter = this.getBean("sentryUserFilter", FilterRegistrationBean::class.java).filter as SentryUserFilter
         return userFilter.sentryUserProviders
-    }
-
-    private fun optionalJakartaPrefix(): String {
-        if (this.javaClass.packageName.endsWith("jakarta")) {
-            return ".jakarta"
-        }
-        return ""
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add missing version number to `setSentryClientName()` invocations.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2528 

## :green_heart: How did you test it?
unit tests; debugger

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
