### PR TITLE
Change log level from INFO to WARN for error message indicating a failed Log4j2 Sentry.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - No longer send event / transaction to Sentry if `beforeSend` / `beforeSendTransaction` throws ([#2591](https://github.com/getsentry/sentry-java/pull/2591))
 - Add version to sentryClientName used in auth header ([#2596](https://github.com/getsentry/sentry-java/pull/2596))
 - Keep integration names from being obfuscated ([#2599](https://github.com/getsentry/sentry-java/pull/2599))
+- Change log level from INFO to WARN for error message indicating a failed Log4j2 Sentry.init ([#2606](https://github.com/getsentry/sentry-java/pull/2606))
+  - The log message was often not visible as our docs suggest a minimum log level of WARN 
 
 ### Dependencies
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -136,7 +136,7 @@ public class SentryAppender extends AbstractAppender {
               Optional.ofNullable(transportFactory).ifPresent(options::setTransportFactory);
             });
       } catch (IllegalArgumentException e) {
-        LOGGER.info("Failed to init Sentry during appender initialization: " + e.getMessage());
+        LOGGER.warn("Failed to init Sentry during appender initialization: " + e.getMessage());
       }
     }
     addPackageAndIntegrationInfo();


### PR DESCRIPTION
## :scroll: Description
Changed INFO level logging to WARN when failing to initialise

## :bulb: Motivation and Context
Normally log4j appenders are configured to show only warnings, and is also the example on the official page
https://docs.sentry.io/platforms/java/guides/log4j2/.

With that, if Sentry fails to initialise due to e.g missing DSN, the user has no useful feedback.

## :green_heart: How did you test it?
I didn't find necessary to add a test for the logging

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
