### PR TITLE
Add breadcrumbs on network changes

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -151,6 +151,12 @@ public final class io/sentry/android/core/NdkIntegration : io/sentry/Integration
 	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 }
 
+public class io/sentry/android/core/NetworkBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {
+	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/BuildInfoProvider;Lio/sentry/ILogger;)V
+	public fun close ()V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+}
+
 public final class io/sentry/android/core/PhoneStateBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;)V
 	public fun close ()V
@@ -193,6 +199,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableAppLifecycleBreadcrumbs ()Z
 	public fun isEnableAutoActivityLifecycleTracing ()Z
 	public fun isEnableFramesTracking ()Z
+	public fun isEnableNetworkEventBreadcrumbs ()Z
 	public fun isEnableSystemEventBreadcrumbs ()Z
 	public fun setAnrEnabled (Z)V
 	public fun setAnrReportInDebug (Z)V
@@ -207,6 +214,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableAppLifecycleBreadcrumbs (Z)V
 	public fun setEnableAutoActivityLifecycleTracing (Z)V
 	public fun setEnableFramesTracking (Z)V
+	public fun setEnableNetworkEventBreadcrumbs (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V
 	public fun setProfilingTracesHz (I)V
 	public fun setProfilingTracesIntervalMillis (I)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -238,6 +238,8 @@ final class AndroidOptionsInitializer {
     }
     options.addIntegration(new AppComponentsBreadcrumbsIntegration(context));
     options.addIntegration(new SystemEventsBreadcrumbsIntegration(context));
+    options.addIntegration(
+        new NetworkBreadcrumbsIntegration(context, buildInfoProvider, options.getLogger()));
     options.addIntegration(new TempSensorBreadcrumbsIntegration(context));
     options.addIntegration(new PhoneStateBreadcrumbsIntegration(context));
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -47,6 +47,7 @@ final class ManifestMetadataReader {
       "io.sentry.breadcrumbs.activity-lifecycle";
   static final String BREADCRUMBS_APP_LIFECYCLE_ENABLE = "io.sentry.breadcrumbs.app-lifecycle";
   static final String BREADCRUMBS_SYSTEM_EVENTS_ENABLE = "io.sentry.breadcrumbs.system-events";
+  static final String BREADCRUMBS_NETWORK_EVENTS_ENABLE = "io.sentry.breadcrumbs.network-events";
   static final String BREADCRUMBS_APP_COMPONENTS_ENABLE = "io.sentry.breadcrumbs.app-components";
   static final String BREADCRUMBS_USER_INTERACTION_ENABLE =
       "io.sentry.breadcrumbs.user-interaction";
@@ -188,7 +189,7 @@ final class ManifestMetadataReader {
                 metadata,
                 logger,
                 BREADCRUMBS_APP_LIFECYCLE_ENABLE,
-                options.isEnableAppComponentBreadcrumbs()));
+                options.isEnableAppLifecycleBreadcrumbs()));
 
         options.setEnableSystemEventBreadcrumbs(
             readBool(
@@ -210,6 +211,13 @@ final class ManifestMetadataReader {
                 logger,
                 BREADCRUMBS_USER_INTERACTION_ENABLE,
                 options.isEnableUserInteractionBreadcrumbs()));
+
+        options.setEnableNetworkEventBreadcrumbs(
+            readBool(
+                metadata,
+                logger,
+                BREADCRUMBS_NETWORK_EVENTS_ENABLE,
+                options.isEnableNetworkEventBreadcrumbs()));
 
         options.setEnableUncaughtExceptionHandler(
             readBool(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NetworkBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NetworkBreadcrumbsIntegration.java
@@ -1,0 +1,223 @@
+package io.sentry.android.core;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import io.sentry.Breadcrumb;
+import io.sentry.Hint;
+import io.sentry.IHub;
+import io.sentry.ILogger;
+import io.sentry.Integration;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.android.core.internal.util.ConnectivityChecker;
+import io.sentry.util.Objects;
+import java.io.Closeable;
+import java.io.IOException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
+
+public class NetworkBreadcrumbsIntegration implements Integration, Closeable {
+
+  private final @NotNull Context context;
+
+  private final @NotNull BuildInfoProvider buildInfoProvider;
+
+  private final @NotNull ILogger logger;
+
+  @TestOnly @Nullable NetworkBreadcrumbsNetworkCallback networkCallback;
+
+  public NetworkBreadcrumbsIntegration(
+      final @NotNull Context context,
+      final @NotNull BuildInfoProvider buildInfoProvider,
+      final @NotNull ILogger logger) {
+    this.context = Objects.requireNonNull(context, "Context is required");
+    this.buildInfoProvider =
+        Objects.requireNonNull(buildInfoProvider, "BuildInfoProvider is required");
+    this.logger = Objects.requireNonNull(logger, "ILogger is required");
+  }
+
+  @SuppressLint("NewApi")
+  @Override
+  public void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
+    Objects.requireNonNull(hub, "Hub is required");
+    SentryAndroidOptions androidOptions =
+        Objects.requireNonNull(
+            (options instanceof SentryAndroidOptions) ? (SentryAndroidOptions) options : null,
+            "SentryAndroidOptions is required");
+
+    logger.log(
+        SentryLevel.DEBUG,
+        "NetworkBreadcrumbsIntegration enabled: %s",
+        androidOptions.isEnableNetworkEventBreadcrumbs());
+
+    if (androidOptions.isEnableNetworkEventBreadcrumbs()) {
+
+      // The specific error is logged in the ConnectivityChecker method
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) {
+        networkCallback = null;
+        logger.log(SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration requires Android 5+");
+        return;
+      }
+
+      networkCallback = new NetworkBreadcrumbsNetworkCallback(hub, buildInfoProvider);
+      final boolean registered =
+          ConnectivityChecker.registerNetworkCallback(
+              context, logger, buildInfoProvider, networkCallback);
+
+      // The specific error is logged in the ConnectivityChecker method
+      if (!registered) {
+        networkCallback = null;
+        logger.log(SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration not installed.");
+        return;
+      }
+      logger.log(SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration installed.");
+      addIntegrationToSdkVersion();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (networkCallback != null) {
+      ConnectivityChecker.unregisterNetworkCallback(
+          context, logger, buildInfoProvider, networkCallback);
+      logger.log(SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration remove.");
+    }
+    networkCallback = null;
+  }
+
+  @SuppressLint("ObsoleteSdkInt")
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  static final class NetworkBreadcrumbsNetworkCallback extends ConnectivityManager.NetworkCallback {
+    final @NotNull IHub hub;
+    final @NotNull BuildInfoProvider buildInfoProvider;
+
+    @Nullable Network currentNetwork = null;
+
+    @Nullable NetworkCapabilities lastCapabilities = null;
+
+    NetworkBreadcrumbsNetworkCallback(
+        final @NotNull IHub hub, final @NotNull BuildInfoProvider buildInfoProvider) {
+      this.hub = Objects.requireNonNull(hub, "Hub is required");
+      this.buildInfoProvider =
+          Objects.requireNonNull(buildInfoProvider, "BuildInfoProvider is required");
+    }
+
+    @Override
+    public void onAvailable(final @NonNull Network network) {
+      if (network.equals(currentNetwork)) {
+        return;
+      }
+      final Breadcrumb breadcrumb = createBreadcrumb("networkAvailable");
+      hub.addBreadcrumb(breadcrumb);
+      currentNetwork = network;
+      lastCapabilities = null;
+    }
+
+    @Override
+    public void onCapabilitiesChanged(
+        final @NonNull Network network, final @NonNull NetworkCapabilities networkCapabilities) {
+      if (!network.equals(currentNetwork)) {
+        return;
+      }
+      final @Nullable NetworkBreadcrumbConnectionDetail connectionDetail =
+          getNewConnectionDetails(lastCapabilities, networkCapabilities);
+      if (connectionDetail == null) {
+        return;
+      }
+      lastCapabilities = networkCapabilities;
+      final Breadcrumb breadcrumb = createBreadcrumb("networkCapabilitiesChanged");
+      Hint hint = new Hint();
+      hint.set("data", connectionDetail);
+      hub.addBreadcrumb(breadcrumb, hint);
+    }
+
+    @Override
+    public void onLost(final @NonNull Network network) {
+      if (!network.equals(currentNetwork)) {
+        return;
+      }
+      final Breadcrumb breadcrumb = createBreadcrumb("networkLost");
+      hub.addBreadcrumb(breadcrumb);
+      currentNetwork = null;
+      lastCapabilities = null;
+    }
+
+    private Breadcrumb createBreadcrumb(String action) {
+      final Breadcrumb breadcrumb = new Breadcrumb();
+      breadcrumb.setType("system");
+      breadcrumb.setCategory("network.event");
+      breadcrumb.setData("action", action);
+      breadcrumb.setLevel(SentryLevel.INFO);
+      return breadcrumb;
+    }
+
+    private @Nullable NetworkBreadcrumbConnectionDetail getNewConnectionDetails(
+        final @Nullable NetworkCapabilities oldCapabilities,
+        final @NotNull NetworkCapabilities newCapabilities) {
+      if (oldCapabilities == null) {
+        return new NetworkBreadcrumbConnectionDetail(newCapabilities, buildInfoProvider);
+      }
+      NetworkBreadcrumbConnectionDetail oldConnectionDetails =
+          new NetworkBreadcrumbConnectionDetail(oldCapabilities, buildInfoProvider);
+      NetworkBreadcrumbConnectionDetail newConnectionDetails =
+          new NetworkBreadcrumbConnectionDetail(newCapabilities, buildInfoProvider);
+
+      // We compare the details and if they are similar we return null, so that we don't spam the
+      // user with lots of breadcrumbs for e.g. an increase of signal strength of 1 point
+      if (newConnectionDetails.isSimilar(oldConnectionDetails)) {
+        return null;
+      }
+      return newConnectionDetails;
+    }
+  }
+
+  static class NetworkBreadcrumbConnectionDetail {
+    final int downBandwidth, upBandwidth, signalStrength;
+    final boolean isVpn;
+    final @NotNull String type;
+
+    @SuppressLint({"NewApi", "ObsoleteSdkInt"})
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    NetworkBreadcrumbConnectionDetail(
+        final @NotNull NetworkCapabilities networkCapabilities,
+        final @NotNull BuildInfoProvider buildInfoProvider) {
+      Objects.requireNonNull(networkCapabilities, "NetworkCapabilities is required");
+      Objects.requireNonNull(buildInfoProvider, "BuildInfoProvider is required");
+      this.downBandwidth = networkCapabilities.getLinkDownstreamBandwidthKbps();
+      this.upBandwidth = networkCapabilities.getLinkUpstreamBandwidthKbps();
+      int strength =
+          buildInfoProvider.getSdkInfoVersion() >= Build.VERSION_CODES.Q
+              ? networkCapabilities.getSignalStrength()
+              : 0;
+      // If the system reports a signalStrength of Integer.MIN_VALUE, we adjust it to be 0
+      this.signalStrength = strength > -100 ? strength : 0;
+      this.isVpn = networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN);
+      String connectionType =
+          ConnectivityChecker.getConnectionType(networkCapabilities, buildInfoProvider);
+      this.type = connectionType != null ? connectionType : "";
+    }
+
+    /**
+     * Compares this connection detail to another one.
+     *
+     * @param other The other NetworkBreadcrumbConnectionDetail to compare
+     * @return true if the details are similar enough, false otherwise
+     */
+    boolean isSimilar(final @NotNull NetworkBreadcrumbConnectionDetail other) {
+      return isVpn == other.isVpn
+          && type.equals(other.type)
+          && (-5 <= signalStrength - other.signalStrength
+              && signalStrength - other.signalStrength <= 5)
+          && (-1000 <= downBandwidth - other.downBandwidth
+              && downBandwidth - other.downBandwidth <= 1000)
+          && (-1000 <= upBandwidth - other.upBandwidth && upBandwidth - other.upBandwidth <= 1000);
+    }
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -39,6 +39,9 @@ public final class SentryAndroidOptions extends SentryOptions {
   /** Enable or disable automatic breadcrumbs for App Components Using ComponentCallbacks */
   private boolean enableAppComponentBreadcrumbs = true;
 
+  /** Enable or disable automatic breadcrumbs for Network Events Using NetworkCallback */
+  private boolean enableNetworkEventBreadcrumbs = true;
+
   /**
    * Enables the Auto instrumentation for Activity lifecycle tracing.
    *
@@ -238,6 +241,14 @@ public final class SentryAndroidOptions extends SentryOptions {
     this.enableAppComponentBreadcrumbs = enableAppComponentBreadcrumbs;
   }
 
+  public boolean isEnableNetworkEventBreadcrumbs() {
+    return enableNetworkEventBreadcrumbs;
+  }
+
+  public void setEnableNetworkEventBreadcrumbs(boolean enableNetworkEventBreadcrumbs) {
+    this.enableNetworkEventBreadcrumbs = enableNetworkEventBreadcrumbs;
+  }
+
   /**
    * Enable or disable all the automatic breadcrumbs
    *
@@ -248,6 +259,7 @@ public final class SentryAndroidOptions extends SentryOptions {
     enableAppComponentBreadcrumbs = enable;
     enableSystemEventBreadcrumbs = enable;
     enableAppLifecycleBreadcrumbs = enable;
+    enableNetworkEventBreadcrumbs = enable;
     setEnableUserInteractionBreadcrumbs(enable);
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -320,6 +320,31 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
+    fun `applyMetadata reads network events breadcrumbs to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.BREADCRUMBS_NETWORK_EVENTS_ENABLE to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.isEnableNetworkEventBreadcrumbs)
+    }
+
+    @Test
+    fun `applyMetadata reads network events breadcrumbs and keep default value if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.isEnableNetworkEventBreadcrumbs)
+    }
+
+    @Test
     fun `applyMetadata reads app components breadcrumbs to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.BREADCRUMBS_APP_COMPONENTS_ENABLE to false)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/NetworkBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/NetworkBreadcrumbsIntegrationTest.kt
@@ -1,0 +1,439 @@
+package io.sentry.android.core
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import io.sentry.Breadcrumb
+import io.sentry.IHub
+import io.sentry.SentryLevel
+import io.sentry.android.core.NetworkBreadcrumbsIntegration.NetworkBreadcrumbConnectionDetail
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class NetworkBreadcrumbsIntegrationTest {
+
+    private class Fixture {
+        val context = mock<Context>()
+        var options = SentryAndroidOptions()
+        val hub = mock<IHub>()
+        val mockBuildInfoProvider = mock<BuildInfoProvider>()
+        val connectivityManager = mock<ConnectivityManager>()
+
+        init {
+            whenever(mockBuildInfoProvider.sdkInfoVersion).thenReturn(Build.VERSION_CODES.N)
+            whenever(context.getSystemService(eq(Context.CONNECTIVITY_SERVICE))).thenReturn(connectivityManager)
+        }
+
+        fun getSut(enableNetworkEventBreadcrumbs: Boolean = true, buildInfo: BuildInfoProvider = mockBuildInfoProvider): NetworkBreadcrumbsIntegration {
+            options = SentryAndroidOptions().apply {
+                isEnableNetworkEventBreadcrumbs = enableNetworkEventBreadcrumbs
+            }
+            return NetworkBreadcrumbsIntegration(context, buildInfo, options.logger)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `When network events breadcrumb is enabled, it registers callback`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.hub, fixture.options)
+
+        verify(fixture.connectivityManager).registerDefaultNetworkCallback(any())
+        assertNotNull(sut.networkCallback)
+    }
+
+    @Test
+    fun `When system events breadcrumb is disabled, it doesn't register callback`() {
+        val sut = fixture.getSut(enableNetworkEventBreadcrumbs = false)
+
+        sut.register(fixture.hub, fixture.options)
+
+        verify(fixture.connectivityManager, never()).registerDefaultNetworkCallback(any())
+        assertNull(sut.networkCallback)
+    }
+
+    @Test
+    fun `It doesn't register callback if not on Android N+`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.M)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+
+        sut.register(fixture.hub, fixture.options)
+
+        verify(fixture.connectivityManager, never()).registerDefaultNetworkCallback(any())
+        assertNull(sut.networkCallback)
+    }
+
+    @Test
+    fun `When NetworkBreadcrumbsIntegration is closed, it should unregister the callback`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.hub, fixture.options)
+        sut.close()
+
+        verify(fixture.connectivityManager).unregisterNetworkCallback(any<NetworkCallback>())
+        assertNull(sut.networkCallback)
+    }
+
+    @Test
+    fun `When NetworkBreadcrumbsIntegration is closed, it's ignored if not on Android N+`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.M)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+        assertNull(sut.networkCallback)
+
+        sut.register(fixture.hub, fixture.options)
+        sut.close()
+
+        verify(fixture.connectivityManager, never()).unregisterNetworkCallback(any<NetworkCallback>())
+        assertNull(sut.networkCallback)
+    }
+
+    @Test
+    fun `When connected to a new network, a breadcrumb is captured`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        assertNotNull(callback)
+        callback.onAvailable(mock())
+
+        verify(fixture.hub).addBreadcrumb(
+            check<Breadcrumb> {
+                assertEquals("system", it.type)
+                assertEquals("network.event", it.category)
+                assertEquals(SentryLevel.INFO, it.level)
+                assertEquals("networkAvailable", it.data["action"])
+            }
+        )
+    }
+
+    @Test
+    fun `When connected to the same network without disconnecting from the previous one, only one breadcrumb is captured`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        assertNotNull(callback)
+        val network = mock<Network>()
+        callback.onAvailable(network)
+        callback.onAvailable(network)
+
+        verify(fixture.hub, times(1)).addBreadcrumb(any<Breadcrumb>())
+    }
+
+    @Test
+    fun `When disconnected from a network, a breadcrumb is captured`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        assertNotNull(callback)
+        val network = mock<Network>()
+
+        callback.onAvailable(network)
+        verify(fixture.hub).addBreadcrumb(any<Breadcrumb>())
+
+        callback.onLost(network)
+        verify(fixture.hub).addBreadcrumb(
+            check<Breadcrumb> {
+                assertEquals("system", it.type)
+                assertEquals("network.event", it.category)
+                assertEquals(SentryLevel.INFO, it.level)
+                assertEquals("networkLost", it.data["action"])
+            }
+        )
+    }
+
+    @Test
+    fun `When disconnected from a network, a breadcrumb is captured only if previously connected to that network`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        assertNotNull(callback)
+        // callback.onAvailable(network) was not called, so no breadcrumb should be captured
+        callback.onLost(mock())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
+    }
+
+    @Test
+    fun `When a network connection detail changes, a breadcrumb is captured`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        callback.onCapabilitiesChanged(network, mock())
+        verify(fixture.hub).addBreadcrumb(
+            check<Breadcrumb> {
+                assertEquals("system", it.type)
+                assertEquals("network.event", it.category)
+                assertEquals(SentryLevel.INFO, it.level)
+                assertEquals("networkCapabilitiesChanged", it.data["action"])
+            },
+            any()
+        )
+    }
+
+    @Test
+    fun `When a network connection detail changes, a breadcrumb is captured only if previously connected to that network`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        assertNotNull(callback)
+        // callback.onAvailable(network) was not called, so no breadcrumb should be captured
+        callback.onCapabilitiesChanged(mock(), mock())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), anyOrNull())
+    }
+
+    @Test
+    fun `When a network connection detail changes, a new breadcrumb is captured if vpn flag changes`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(isVpn = false)
+        // Not changing the vpn flag doesn't trigger a new breadcrumb
+        val details2 = createConnectionDetail(isVpn = false)
+        val details3 = createConnectionDetail(isVpn = true)
+        callback.onCapabilitiesChanged(network, details1)
+        callback.onCapabilitiesChanged(network, details2)
+        callback.onCapabilitiesChanged(network, details3)
+        inOrder(fixture.hub) {
+            verify(fixture.hub).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(false, connectionDetail.isVpn)
+                }
+            )
+            verify(fixture.hub).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(true, connectionDetail.isVpn)
+                }
+            )
+            verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), any())
+        }
+    }
+
+    @Test
+    fun `When a network connection detail changes, a new breadcrumb is captured if type changes`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(isWifi = true, isCellular = false)
+        // Not changing the connection doesn't trigger a new breadcrumb
+        val details2 = createConnectionDetail(isWifi = true, isCellular = false)
+        val details3 = createConnectionDetail(isWifi = false, isCellular = true)
+        callback.onCapabilitiesChanged(network, details1)
+        callback.onCapabilitiesChanged(network, details2)
+        callback.onCapabilitiesChanged(network, details3)
+        inOrder(fixture.hub) {
+            verify(fixture.hub).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals("wifi", connectionDetail.type)
+                }
+            )
+            verify(fixture.hub).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals("cellular", connectionDetail.type)
+                }
+            )
+            verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), any())
+        }
+    }
+
+    @Test
+    fun `When a network connection detail changes, a new breadcrumb is captured if signal strength changes by 5+`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.Q)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(signalStrength = 50)
+        val details2 = createConnectionDetail(signalStrength = 55)
+        val details3 = createConnectionDetail(signalStrength = 56)
+        callback.onCapabilitiesChanged(network, details1)
+        // A change of signal strength of 5 doesn't trigger a new breadcrumb
+        callback.onCapabilitiesChanged(network, details2)
+        callback.onCapabilitiesChanged(network, details3)
+        inOrder(fixture.hub) {
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(50, connectionDetail.signalStrength)
+                }
+            )
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(56, connectionDetail.signalStrength)
+                }
+            )
+            verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), any())
+        }
+    }
+
+    @Test
+    fun `When a network connection detail changes, a new breadcrumb is captured if downBandwidth changes by 1000+ kbps`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.Q)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(downstreamBandwidthKbps = 1000)
+        val details2 = createConnectionDetail(downstreamBandwidthKbps = 2000)
+        val details3 = createConnectionDetail(downstreamBandwidthKbps = 2001)
+        callback.onCapabilitiesChanged(network, details1)
+        // A change of signal strength of 5 doesn't trigger a new breadcrumb
+        callback.onCapabilitiesChanged(network, details2)
+        callback.onCapabilitiesChanged(network, details3)
+        inOrder(fixture.hub) {
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(1000, connectionDetail.downBandwidth)
+                }
+            )
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(2001, connectionDetail.downBandwidth)
+                }
+            )
+            verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), any())
+        }
+    }
+
+    @Test
+    fun `When a network connection detail changes, a new breadcrumb is captured if upBandwidth changes by 1000+ kbps`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.Q)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(upstreamBandwidthKbps = 1000)
+        val details2 = createConnectionDetail(upstreamBandwidthKbps = 2000)
+        val details3 = createConnectionDetail(upstreamBandwidthKbps = 2001)
+        callback.onCapabilitiesChanged(network, details1)
+        // A change of signal strength of 5 doesn't trigger a new breadcrumb
+        callback.onCapabilitiesChanged(network, details2)
+        callback.onCapabilitiesChanged(network, details3)
+        inOrder(fixture.hub) {
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(1000, connectionDetail.upBandwidth)
+                }
+            )
+            verify(fixture.hub, times(1)).addBreadcrumb(
+                any<Breadcrumb>(),
+                check {
+                    val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                    assertEquals(2001, connectionDetail.upBandwidth)
+                }
+            )
+            verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), any())
+        }
+    }
+
+    @Test
+    fun `signal strength is 0 if not on Android Q+`() {
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(signalStrength = 10)
+        callback.onCapabilitiesChanged(network, details1)
+        verify(fixture.hub).addBreadcrumb(
+            any<Breadcrumb>(),
+            check {
+                val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                assertEquals(0, connectionDetail.signalStrength)
+            }
+        )
+    }
+
+    @Test
+    fun `signal strength is 0 if system reports less than -100`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.Q)
+        val sut = fixture.getSut(buildInfo = buildInfo)
+        sut.register(fixture.hub, fixture.options)
+        val callback = sut.networkCallback
+        val network = mock<Network>()
+        assertNotNull(callback)
+        callback.onAvailable(network)
+        val details1 = createConnectionDetail(signalStrength = Int.MIN_VALUE)
+        callback.onCapabilitiesChanged(network, details1)
+        verify(fixture.hub).addBreadcrumb(
+            any<Breadcrumb>(),
+            check {
+                val connectionDetail = it["data"] as NetworkBreadcrumbConnectionDetail
+                assertEquals(0, connectionDetail.signalStrength)
+            }
+        )
+    }
+
+    private fun createConnectionDetail(
+        downstreamBandwidthKbps: Int = 1000,
+        upstreamBandwidthKbps: Int = 1000,
+        signalStrength: Int = -50,
+        isVpn: Boolean = false,
+        isEthernet: Boolean = false,
+        isWifi: Boolean = false,
+        isCellular: Boolean = false
+    ): NetworkCapabilities {
+        val capabilities = mock<NetworkCapabilities>()
+        whenever(capabilities.linkDownstreamBandwidthKbps).thenReturn(downstreamBandwidthKbps)
+        whenever(capabilities.linkUpstreamBandwidthKbps).thenReturn(upstreamBandwidthKbps)
+        whenever(capabilities.signalStrength).thenReturn(signalStrength)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)).thenReturn(isVpn)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)).thenReturn(isEthernet)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(isWifi)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(isCellular)
+        return capabilities
+    }
+}


### PR DESCRIPTION
## :scroll: Description
added NetworkBreadcrumbsIntegration
added registerNetworkCallback and unregisterNetworkCallback to ConnectivityChecker
added io.sentry.breadcrumbs.network-events manifest option 
added enableNetworkEventBreadcrumbs manual option


## :bulb: Motivation and Context
In order to provide more context to the user when an error occurs or during a transaction, we are adding breadcrumbs on network changes, like when a vpn is enabled or disabled or the device connects/disconnects to/from a network.


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
Connection details (vpn status, up/down bandwidth and signal strength) is collected correctly and set as a Hint of the breadcrumbs. I should add these details to the breadcrumb data, too