### PR TITLE
Add time-to-initial-display and time-to-full-display measurements to Activity transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add time-to-initial-display and time-to-full-display measurements to Activity transactions ([#2611](https://github.com/getsentry/sentry-java/pull/2611))
+
 ## 6.16.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -159,9 +159,9 @@ public final class ActivityFramesTracker {
     final MeasurementValue ffValues =
         new MeasurementValue(frameCounts.frozenFrames, MeasurementUnit.NONE);
     final Map<String, @NotNull MeasurementValue> measurements = new HashMap<>();
-    measurements.put("frames_total", tfValues);
-    measurements.put("frames_slow", sfValues);
-    measurements.put("frames_frozen", ffValues);
+    measurements.put(MeasurementValue.KEY_FRAMES_TOTAL, tfValues);
+    measurements.put(MeasurementValue.KEY_FRAMES_SLOW, sfValues);
+    measurements.put(MeasurementValue.KEY_FRAMES_FROZEN, ffValues);
 
     activityMeasurements.put(transactionId, measurements);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -1,6 +1,6 @@
 package io.sentry.android.core;
 
-import static io.sentry.MeasurementUnit.Duration.NANOSECOND;
+import static io.sentry.MeasurementUnit.Duration.MILLISECOND;
 import static io.sentry.TypeCheckHint.ANDROID_ACTIVITY;
 
 import android.annotation.SuppressLint;
@@ -28,6 +28,7 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
+import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.TransactionNameSource;
 import io.sentry.util.Objects;
 import java.io.Closeable;
@@ -36,6 +37,7 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -499,12 +501,15 @@ public final class ActivityLifecycleIntegration
     if (options != null && ttidSpan != null) {
       final SentryDate endDate = options.getDateProvider().now();
       final long durationNanos = endDate.diff(ttidSpan.getStartDate());
-      ttidSpan.setMeasurement("time-to-initial-display", durationNanos, NANOSECOND);
+      final long durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+      ttidSpan.setMeasurement(
+          MeasurementValue.KEY_TIME_TO_INITIAL_DISPLAY, durationMillis, MILLISECOND);
 
       if (ttfdSpan != null && ttfdSpan.isFinished()) {
         ttfdSpan.updateEndDate(endDate);
         // If the ttfd span was finished before the first frame we adjust the measurement, too
-        ttidSpan.setMeasurement("time-to-full-display", durationNanos, NANOSECOND);
+        ttidSpan.setMeasurement(
+            MeasurementValue.KEY_TIME_TO_FULL_DISPLAY, durationMillis, MILLISECOND);
       }
       finishSpan(ttidSpan, endDate);
     } else {
@@ -516,7 +521,9 @@ public final class ActivityLifecycleIntegration
     if (options != null && ttfdSpan != null) {
       final SentryDate endDate = options.getDateProvider().now();
       final long durationNanos = endDate.diff(ttfdSpan.getStartDate());
-      ttfdSpan.setMeasurement("time-to-full-display", durationNanos, NANOSECOND);
+      final long durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+      ttfdSpan.setMeasurement(
+          MeasurementValue.KEY_TIME_TO_FULL_DISPLAY, durationMillis, MILLISECOND);
       finishSpan(ttfdSpan, endDate);
     } else {
       finishSpan(ttfdSpan);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -24,7 +24,6 @@ import io.sentry.Scope;
 import io.sentry.SentryDate;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.Span;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
@@ -499,11 +498,12 @@ public final class ActivityLifecycleIntegration
   private void onFirstFrameDrawn(final @Nullable ISpan ttidSpan) {
     if (options != null && ttidSpan != null) {
       final SentryDate endDate = options.getDateProvider().now();
-      final long durationNanos = endDate.diff(((Span) ttidSpan).getStartDate());
+      final long durationNanos = endDate.diff(ttidSpan.getStartDate());
       ttidSpan.setMeasurement("time-to-initial-display", durationNanos, NANOSECOND);
 
       if (ttfdSpan != null && ttfdSpan.isFinished()) {
         ttfdSpan.updateEndDate(endDate);
+        // If the ttfd span was finished before the first frame we adjust the measurement, too
         ttidSpan.setMeasurement("time-to-full-display", durationNanos, NANOSECOND);
       }
       finishSpan(ttidSpan, endDate);
@@ -515,8 +515,7 @@ public final class ActivityLifecycleIntegration
   private void onFullFrameDrawn() {
     if (options != null && ttfdSpan != null) {
       final SentryDate endDate = options.getDateProvider().now();
-// todo      add to ISpan
-      final long durationNanos = endDate.diff(((Span) ttfdSpan).getStartDate());
+      final long durationNanos = endDate.diff(ttfdSpan.getStartDate());
       ttfdSpan.setMeasurement("time-to-full-display", durationNanos, NANOSECOND);
       finishSpan(ttfdSpan, endDate);
     } else {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -71,7 +71,9 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
                 (float) appStartUpInterval, MeasurementUnit.Duration.MILLISECOND.apiName());
 
         final String appStartKey =
-            AppStartState.getInstance().isColdStart() ? "app_start_cold" : "app_start_warm";
+            AppStartState.getInstance().isColdStart()
+                ? MeasurementValue.KEY_APP_START_COLD
+                : MeasurementValue.KEY_APP_START_WARM;
 
         transaction.getMeasurements().put(appStartKey, value);
         sentStartMeasurement = true;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -5,6 +5,7 @@ import android.util.SparseIntArray
 import androidx.core.app.FrameMetricsAggregator
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
+import io.sentry.protocol.MeasurementValue
 import io.sentry.protocol.SentryId
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -48,7 +49,7 @@ class ActivityFramesTrackerTest {
         sut.setMetrics(fixture.activity, fixture.sentryId)
 
         val metrics = sut.takeMetrics(fixture.sentryId)
-        val totalFrames = metrics!!["frames_total"]
+        val totalFrames = metrics!![MeasurementValue.KEY_FRAMES_TOTAL]
 
         assertEquals(totalFrames!!.value, 1)
         assertEquals(totalFrames.unit, "none")
@@ -66,7 +67,7 @@ class ActivityFramesTrackerTest {
         sut.setMetrics(fixture.activity, fixture.sentryId)
 
         val metrics = sut.takeMetrics(fixture.sentryId)
-        val frozenFrames = metrics!!["frames_frozen"]
+        val frozenFrames = metrics!![MeasurementValue.KEY_FRAMES_FROZEN]
 
         assertEquals(frozenFrames!!.value, 5)
         assertEquals(frozenFrames.unit, "none")
@@ -84,7 +85,7 @@ class ActivityFramesTrackerTest {
         sut.setMetrics(fixture.activity, fixture.sentryId)
 
         val metrics = sut.takeMetrics(fixture.sentryId)
-        val slowFrames = metrics!!["frames_slow"]
+        val slowFrames = metrics!![MeasurementValue.KEY_FRAMES_SLOW]
 
         assertEquals(slowFrames!!.value, 5)
         assertEquals(slowFrames.unit, "none")
@@ -106,13 +107,13 @@ class ActivityFramesTrackerTest {
 
         val metrics = sut.takeMetrics(fixture.sentryId)
 
-        val totalFrames = metrics!!["frames_total"]
+        val totalFrames = metrics!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFrames!!.value, 111)
 
-        val frozenFrames = metrics["frames_frozen"]
+        val frozenFrames = metrics[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFrames!!.value, 6)
 
-        val slowFrames = metrics["frames_slow"]
+        val slowFrames = metrics[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFrames!!.value, 5)
     }
 
@@ -132,13 +133,13 @@ class ActivityFramesTrackerTest {
 
         val metrics = sut.takeMetrics(fixture.sentryId)
 
-        val totalFrames = metrics!!["frames_total"]
+        val totalFrames = metrics!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFrames!!.value, 111)
 
-        val frozenFrames = metrics["frames_frozen"]
+        val frozenFrames = metrics[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFrames!!.value, 6)
 
-        val slowFrames = metrics["frames_slow"]
+        val slowFrames = metrics[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFrames!!.value, 5)
     }
 
@@ -185,22 +186,22 @@ class ActivityFramesTrackerTest {
         val metricsA = sut.takeMetrics(sentryIdA)!!
         val metricsB = sut.takeMetrics(sentryIdB)!!
 
-        val totalFramesA = metricsA!!["frames_total"]
+        val totalFramesA = metricsA!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFramesA!!.value, 21) // 15 + 3 + 3 (diff counts for activityA)
 
-        val frozenFramesA = metricsA["frames_frozen"]
+        val frozenFramesA = metricsA[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFramesA!!.value, 3)
 
-        val slowFramesA = metricsA["frames_slow"]
+        val slowFramesA = metricsA[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFramesA!!.value, 3)
 
-        val totalFramesB = metricsB!!["frames_total"]
+        val totalFramesB = metricsB!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFramesB!!.value, 35) // 25 + 5 + 5 (diff counts for activityB)
 
-        val frozenFramesB = metricsB["frames_frozen"]
+        val frozenFramesB = metricsB[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFramesB!!.value, 5)
 
-        val slowFramesB = metricsB["frames_slow"]
+        val slowFramesB = metricsB[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFramesB!!.value, 5)
     }
 
@@ -239,22 +240,22 @@ class ActivityFramesTrackerTest {
         val metrics = sut.takeMetrics(fixture.sentryId)
         val secondMetrics = sut.takeMetrics(secondSentryId)
 
-        val totalFrames = metrics!!["frames_total"]
+        val totalFrames = metrics!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFrames!!.value, 12) // 10 + 1 + 1 (diff counts for first invocation)
 
-        val frozenFrames = metrics["frames_frozen"]
+        val frozenFrames = metrics[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFrames!!.value, 1)
 
-        val slowFrames = metrics["frames_slow"]
+        val slowFrames = metrics[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFrames!!.value, 1)
 
-        val totalFramesSecond = secondMetrics!!["frames_total"]
+        val totalFramesSecond = secondMetrics!![MeasurementValue.KEY_FRAMES_TOTAL]
         assertEquals(totalFramesSecond!!.value, 26) // 20 + 3 + 3 (diff counts for second invocation)
 
-        val frozenFramesSecond = secondMetrics["frames_frozen"]
+        val frozenFramesSecond = secondMetrics[MeasurementValue.KEY_FRAMES_FROZEN]
         assertEquals(frozenFramesSecond!!.value, 3)
 
-        val slowFramesSecond = secondMetrics["frames_slow"]
+        val slowFramesSecond = secondMetrics[MeasurementValue.KEY_FRAMES_SLOW]
         assertEquals(slowFramesSecond!!.value, 3)
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -46,6 +46,7 @@ import java.util.Date
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -123,6 +124,11 @@ class ActivityLifecycleIntegrationTest {
     @BeforeTest
     fun `reset instance`() {
         AppStartState.getInstance().resetInstance()
+    }
+
+    @AfterTest
+    fun `clear instance`() {
+        fixture.transaction.finish()
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -28,6 +28,7 @@ import io.sentry.TraceContext
 import io.sentry.TransactionContext
 import io.sentry.TransactionFinishedCallback
 import io.sentry.TransactionOptions
+import io.sentry.protocol.MeasurementValue
 import io.sentry.protocol.TransactionNameSource
 import io.sentry.test.getProperty
 import org.junit.runner.RunWith
@@ -1126,7 +1127,7 @@ class ActivityLifecycleIntegrationTest {
         verify(fixture.hub).captureTransaction(
             check {
                 // ttfd timed out, so its measurement should not be set
-                val ttfdMeasurement = it.measurements["time-to-full-display"]
+                val ttfdMeasurement = it.measurements[MeasurementValue.KEY_TIME_TO_FULL_DISPLAY]
                 assertNull(ttfdMeasurement)
             },
             any(),
@@ -1165,7 +1166,7 @@ class ActivityLifecycleIntegrationTest {
         verify(fixture.hub).captureTransaction(
             check {
                 // ttfd was finished successfully, so its measurement should be set
-                val ttfdMeasurement = it.measurements["time-to-full-display"]
+                val ttfdMeasurement = it.measurements[MeasurementValue.KEY_TIME_TO_FULL_DISPLAY]
                 assertNotNull(ttfdMeasurement)
                 assertTrue(ttfdMeasurement.value.toLong() > 0)
             },
@@ -1235,7 +1236,7 @@ class ActivityLifecycleIntegrationTest {
         verify(fixture.hub).captureTransaction(
             check {
                 // ttid measurement should be set
-                val ttidMeasurement = it.measurements["time-to-initial-display"]
+                val ttidMeasurement = it.measurements[MeasurementValue.KEY_TIME_TO_INITIAL_DISPLAY]
                 assertNotNull(ttidMeasurement)
                 assertTrue(ttidMeasurement.value.toLong() > 0)
             },
@@ -1281,8 +1282,8 @@ class ActivityLifecycleIntegrationTest {
         verify(fixture.hub).captureTransaction(
             check {
                 // ttid and ttfd measurements should be the same
-                val ttidMeasurement = it.measurements["time-to-initial-display"]
-                val ttfdMeasurement = it.measurements["time-to-full-display"]
+                val ttidMeasurement = it.measurements[MeasurementValue.KEY_TIME_TO_INITIAL_DISPLAY]
+                val ttfdMeasurement = it.measurements[MeasurementValue.KEY_TIME_TO_FULL_DISPLAY]
                 assertNotNull(ttidMeasurement)
                 assertNotNull(ttfdMeasurement)
                 assertEquals(ttidMeasurement.value, ttfdMeasurement.value)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -52,7 +52,7 @@ class PerformanceAndroidEventProcessorTest {
 
         tr = sut.process(tr, Hint())
 
-        assertTrue(tr.measurements.containsKey("app_start_cold"))
+        assertTrue(tr.measurements.containsKey(MeasurementValue.KEY_APP_START_COLD))
     }
 
     @Test
@@ -64,7 +64,7 @@ class PerformanceAndroidEventProcessorTest {
 
         tr = sut.process(tr, Hint())
 
-        assertTrue(tr.measurements.containsKey("app_start_warm"))
+        assertTrue(tr.measurements.containsKey(MeasurementValue.KEY_APP_START_WARM))
     }
 
     @Test
@@ -76,7 +76,7 @@ class PerformanceAndroidEventProcessorTest {
 
         tr = sut.process(tr, Hint())
 
-        val measurement = tr.measurements["app_start_cold"]
+        val measurement = tr.measurements[MeasurementValue.KEY_APP_START_COLD]
         assertEquals("millisecond", measurement?.unit)
     }
 
@@ -92,7 +92,7 @@ class PerformanceAndroidEventProcessorTest {
         var tr2 = getTransaction()
         tr2 = sut.process(tr2, Hint())
 
-        assertTrue(tr1.measurements.containsKey("app_start_warm"))
+        assertTrue(tr1.measurements.containsKey(MeasurementValue.KEY_APP_START_WARM))
         assertTrue(tr2.measurements.isEmpty())
     }
 
@@ -156,12 +156,12 @@ class PerformanceAndroidEventProcessorTest {
         val tracer = SentryTracer(context, fixture.hub)
         var tr = SentryTransaction(tracer)
 
-        val metrics = mapOf("frames_total" to MeasurementValue(1f, MeasurementUnit.Duration.MILLISECOND.apiName()))
+        val metrics = mapOf(MeasurementValue.KEY_FRAMES_TOTAL to MeasurementValue(1f, MeasurementUnit.Duration.MILLISECOND.apiName()))
         whenever(fixture.activityFramesTracker.takeMetrics(any())).thenReturn(metrics)
 
         tr = sut.process(tr, Hint())
 
-        assertTrue(tr.measurements.containsKey("frames_total"))
+        assertTrue(tr.measurements.containsKey(MeasurementValue.KEY_FRAMES_TOTAL))
     }
 
     private fun setAppStart(coldStart: Boolean = true) {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -549,6 +549,7 @@ public abstract interface class io/sentry/ISpan {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getOperation ()Ljava/lang/String;
 	public abstract fun getSpanContext ()Lio/sentry/SpanContext;
+	public abstract fun getStartDate ()Lio/sentry/SentryDate;
 	public abstract fun getStatus ()Lio/sentry/SpanStatus;
 	public abstract fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun getThrowable ()Ljava/lang/Throwable;
@@ -820,6 +821,7 @@ public final class io/sentry/NoOpSpan : io/sentry/ISpan {
 	public static fun getInstance ()Lio/sentry/NoOpSpan;
 	public fun getOperation ()Ljava/lang/String;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
+	public fun getStartDate ()Lio/sentry/SentryDate;
 	public fun getStatus ()Lio/sentry/SpanStatus;
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getThrowable ()Ljava/lang/Throwable;
@@ -859,6 +861,7 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 	public fun getSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun getSpanContext ()Lio/sentry/SpanContext;
 	public fun getSpans ()Ljava/util/List;
+	public fun getStartDate ()Lio/sentry/SentryDate;
 	public fun getStatus ()Lio/sentry/SpanStatus;
 	public fun getTag (Ljava/lang/String;)Ljava/lang/String;
 	public fun getThrowable ()Ljava/lang/Throwable;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2912,6 +2912,13 @@ public final class io/sentry/protocol/Gpu$JsonKeys {
 }
 
 public final class io/sentry/protocol/MeasurementValue : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field KEY_APP_START_COLD Ljava/lang/String;
+	public static final field KEY_APP_START_WARM Ljava/lang/String;
+	public static final field KEY_FRAMES_FROZEN Ljava/lang/String;
+	public static final field KEY_FRAMES_SLOW Ljava/lang/String;
+	public static final field KEY_FRAMES_TOTAL Ljava/lang/String;
+	public static final field KEY_TIME_TO_FULL_DISPLAY Ljava/lang/String;
+	public static final field KEY_TIME_TO_INITIAL_DISPLAY Ljava/lang/String;
 	public fun <init> (Ljava/lang/Number;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/Number;Ljava/lang/String;Ljava/util/Map;)V
 	public fun getUnit ()Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/ISpan.java
+++ b/sentry/src/main/java/io/sentry/ISpan.java
@@ -230,6 +230,15 @@ public interface ISpan {
   boolean updateEndDate(@NotNull SentryDate date);
 
   /**
+   * Returns the start date of this span or transaction.
+   *
+   * @return the start date
+   */
+  @ApiStatus.Internal
+  @NotNull
+  SentryDate getStartDate();
+
+  /**
    * Whether this span instance is a NOOP that doesn't collect information
    *
    * @return true if NOOP

--- a/sentry/src/main/java/io/sentry/NoOpSpan.java
+++ b/sentry/src/main/java/io/sentry/NoOpSpan.java
@@ -146,6 +146,11 @@ public final class NoOpSpan implements ISpan {
   }
 
   @Override
+  public @NotNull SentryDate getStartDate() {
+    return new SentryNanotimeDate();
+  }
+
+  @Override
   public boolean isNoOp() {
     return true;
   }

--- a/sentry/src/main/java/io/sentry/NoOpTransaction.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransaction.java
@@ -210,6 +210,11 @@ public final class NoOpTransaction implements ITransaction {
   }
 
   @Override
+  public @NotNull SentryDate getStartDate() {
+    return new SentryNanotimeDate();
+  }
+
+  @Override
   public boolean isNoOp() {
     return true;
   }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -141,6 +141,7 @@ public final class SentryTracer implements ITransaction {
     return children;
   }
 
+  @Override
   public @NotNull SentryDate getStartDate() {
     return this.root.getStartDate();
   }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -92,6 +92,7 @@ public final class Span implements ISpan {
     this.options = options;
   }
 
+  @Override
   public @NotNull SentryDate getStartDate() {
     return startTimestamp;
   }

--- a/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
@@ -19,6 +19,14 @@ import org.jetbrains.annotations.TestOnly;
 @ApiStatus.Internal
 public final class MeasurementValue implements JsonUnknown, JsonSerializable {
 
+  public static final String KEY_APP_START_COLD = "app_start_cold";
+  public static final String KEY_APP_START_WARM = "app_start_warm";
+  public static final String KEY_FRAMES_TOTAL = "frames_total";
+  public static final String KEY_FRAMES_SLOW = "frames_slow";
+  public static final String KEY_FRAMES_FROZEN = "frames_frozen";
+  public static final String KEY_TIME_TO_INITIAL_DISPLAY = "time-to-initial-display";
+  public static final String KEY_TIME_TO_FULL_DISPLAY = "time-to-full-display";
+
   @SuppressWarnings("UnusedVariable")
   private final @NotNull Number value;
 

--- a/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
@@ -24,8 +24,8 @@ public final class MeasurementValue implements JsonUnknown, JsonSerializable {
   public static final String KEY_FRAMES_TOTAL = "frames_total";
   public static final String KEY_FRAMES_SLOW = "frames_slow";
   public static final String KEY_FRAMES_FROZEN = "frames_frozen";
-  public static final String KEY_TIME_TO_INITIAL_DISPLAY = "time-to-initial-display";
-  public static final String KEY_TIME_TO_FULL_DISPLAY = "time-to-full-display";
+  public static final String KEY_TIME_TO_INITIAL_DISPLAY = "time_to_initial_display";
+  public static final String KEY_TIME_TO_FULL_DISPLAY = "time_to_full_display";
 
   @SuppressWarnings("UnusedVariable")
   private final @NotNull Number value;

--- a/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSpanTest.kt
@@ -3,6 +3,7 @@ package io.sentry
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 class NoOpSpanTest {
@@ -28,5 +29,10 @@ class NoOpSpanTest {
     @Test
     fun `updateEndDate return false`() {
         assertFalse(span.updateEndDate(mock()))
+    }
+
+    @Test
+    fun `startDate return a NanotimeDate`() {
+        assertIs<SentryNanotimeDate>(span.startDate)
     }
 }

--- a/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionTest.kt
@@ -3,6 +3,7 @@ package io.sentry
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -34,5 +35,10 @@ class NoOpTransactionTest {
     @Test
     fun `updateEndDate return false`() {
         assertFalse(transaction.updateEndDate(mock()))
+    }
+
+    @Test
+    fun `startDate return a NanotimeDate`() {
+        assertIs<SentryNanotimeDate>(transaction.startDate)
     }
 }


### PR DESCRIPTION
## :scroll: Description
Added ttid and ttfd as measurements
Added getStartDate() to ISpan
Fixed ActivityLifecycleIntegration tests


## :bulb: Motivation and Context
Currently we track time-to-initial-display and time-to-full-display as spans on automatic activity transactions.
Now we add them as measurements, too.
More info [here](https://github.com/getsentry/sentry-java/issues/2587).


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
