### PR TITLE
Pass through unknown sentry baggage keys into SentryEnvelopeHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Pass through unknown sentry baggage keys into SentryEnvelopeHeader ([#2618](https://github.com/getsentry/sentry-java/pull/2618))
+
 ## 6.16.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -44,6 +44,7 @@ public final class io/sentry/Baggage {
 	public fun getThirdPartyHeader ()Ljava/lang/String;
 	public fun getTraceId ()Ljava/lang/String;
 	public fun getTransaction ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
 	public fun getUserId ()Ljava/lang/String;
 	public fun getUserSegment ()Ljava/lang/String;
 	public fun isMutable ()Z
@@ -62,6 +63,7 @@ public final class io/sentry/Baggage {
 }
 
 public final class io/sentry/Baggage$DSCKeys {
+	public static final field ALL Ljava/util/List;
 	public static final field ENVIRONMENT Ljava/lang/String;
 	public static final field PUBLIC_KEY Ljava/lang/String;
 	public static final field RELEASE Ljava/lang/String;

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -524,6 +524,20 @@ class BaggageTest {
         assertEquals("sentry-trace_id=a,sentry-transaction=sentryTransaction", baggage.toHeaderString(null))
     }
 
+    @Test
+    fun `unknown returns sentry- prefixed keys that are not known and passes them on to TraceContext`() {
+        val baggage = Baggage.fromHeader(listOf("sentry-trace_id=${SentryId()},sentry-public_key=b, sentry-replay_id=def", "sentry-transaction=sentryTransaction, sentry-anewkey=abc"))
+        val unknown = baggage.unknown
+        assertEquals(2, unknown.size)
+        assertEquals("def", unknown["replay_id"])
+        assertEquals("abc", unknown["anewkey"])
+
+        val traceContext = baggage.toTraceContext()!!
+        assertEquals(2, traceContext.unknown!!.size)
+        assertEquals("def", traceContext.unknown!!["replay_id"])
+        assertEquals("abc", traceContext.unknown!!["anewkey"])
+    }
+
     /**
      * token          = 1*tchar
      * tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When converting `Baggage` to `TraceContext` also keep unknown keys prefixed with `sentry-` and send them to Sentry via `SentryEnvelopeHeader`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So we don't have to add every new key explicitly and instead simply pass through all unknown keys.

## :green_heart: How did you test it?
Unit Tests, manually using Sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
