### PR TITLE
Provide CPU count/frequency data as device context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Read integration list written by sentry gradle plugin from manifest ([#2598](https://github.com/getsentry/sentry-java/pull/2598))
+- Provide CPU count/frequency data as device context ([#2622](https://github.com/getsentry/sentry-java/pull/2622))
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -99,6 +99,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     // don't ref. to method reference, theres a bug on it
     //noinspection Convert2MethodRef
     contextData = executorService.submit(() -> loadContextData());
+    // reading CPU info performs disk I/O, but it's result is cached, let's pre-cache it
+    executorService.submit(() -> CpuInfoUtils.getInstance().readMaxFrequencies());
 
     executorService.shutdown();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -28,6 +28,7 @@ import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
 import io.sentry.android.core.internal.util.ConnectivityChecker;
+import io.sentry.android.core.internal.util.CpuInfoUtils;
 import io.sentry.android.core.internal.util.DeviceOrientations;
 import io.sentry.android.core.internal.util.RootChecker;
 import io.sentry.protocol.App;
@@ -43,8 +44,10 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -353,6 +356,12 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     }
     if (device.getLocale() == null) {
       device.setLocale(locale.toString()); // eg en_US
+    }
+
+    final @NotNull List<Integer> cpuFrequencies = CpuInfoUtils.getInstance().readMaxFrequencies();
+    if (!cpuFrequencies.isEmpty()) {
+      device.setProcessorFrequency(Collections.max(cpuFrequencies).doubleValue());
+      device.setProcessorCount(cpuFrequencies.size());
     }
 
     return device;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
@@ -34,7 +34,7 @@ public final class CpuInfoUtils {
    *
    * @return A list with the frequency of each core of the cpu in Mhz
    */
-  public @NotNull List<Integer> readMaxFrequencies() {
+  public synchronized @NotNull List<Integer> readMaxFrequencies() {
     if (!cpuMaxFrequenciesMhz.isEmpty()) {
       return cpuMaxFrequenciesMhz;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
@@ -71,6 +71,12 @@ public final class CpuInfoUtils {
   }
 
   @TestOnly
+  public void setCpuMaxFrequencies(List<Integer> frequencies) {
+    cpuMaxFrequenciesMhz.clear();
+    cpuMaxFrequenciesMhz.addAll(frequencies);
+  }
+
+  @TestOnly
   final void clear() {
     cpuMaxFrequenciesMhz.clear();
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -17,6 +17,7 @@ import io.sentry.android.core.DefaultAndroidEventProcessor.EMULATOR
 import io.sentry.android.core.DefaultAndroidEventProcessor.KERNEL_VERSION
 import io.sentry.android.core.DefaultAndroidEventProcessor.ROOTED
 import io.sentry.android.core.DefaultAndroidEventProcessor.SIDE_LOADED
+import io.sentry.android.core.internal.util.CpuInfoUtils
 import io.sentry.protocol.OperatingSystem
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryThread
@@ -523,6 +524,29 @@ class DefaultAndroidEventProcessorTest {
         assertNotNull(sut.process(SentryEvent(), Hint())) {
             val app = it.contexts.app!!
             assertFalse(app.inForeground!!)
+        }
+    }
+
+    @Test
+    fun `Event sets no device cpu info when there is none provided`() {
+        val sut = fixture.getSut(context)
+        CpuInfoUtils.getInstance().setCpuMaxFrequencies(emptyList())
+        assertNotNull(sut.process(SentryEvent(), Hint())) {
+            val device = it.contexts.device!!
+            assertNull(device.processorCount)
+            assertNull(device.processorFrequency)
+        }
+    }
+
+    @Test
+    fun `Event sets rights device cpu info when there is one provided`() {
+        val sut = fixture.getSut(context)
+        CpuInfoUtils.getInstance().setCpuMaxFrequencies(listOf(800, 900))
+
+        assertNotNull(sut.process(SentryEvent(), Hint())) {
+            val device = it.contexts.device!!
+            assertEquals(2, device.processorCount)
+            assertEquals(900.0, device.processorFrequency)
         }
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2747,6 +2747,7 @@ public final class io/sentry/protocol/Device : io/sentry/JsonSerializable, io/se
 	public fun getBootTime ()Ljava/util/Date;
 	public fun getBrand ()Ljava/lang/String;
 	public fun getConnectionType ()Ljava/lang/String;
+	public fun getCpuDescription ()Ljava/lang/String;
 	public fun getExternalFreeStorage ()Ljava/lang/Long;
 	public fun getExternalStorageSize ()Ljava/lang/Long;
 	public fun getFamily ()Ljava/lang/String;
@@ -2761,6 +2762,8 @@ public final class io/sentry/protocol/Device : io/sentry/JsonSerializable, io/se
 	public fun getModelId ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getOrientation ()Lio/sentry/protocol/Device$DeviceOrientation;
+	public fun getProcessorCount ()Ljava/lang/Integer;
+	public fun getProcessorFrequency ()Ljava/lang/Double;
 	public fun getScreenDensity ()Ljava/lang/Float;
 	public fun getScreenDpi ()Ljava/lang/Integer;
 	public fun getScreenHeightPixels ()Ljava/lang/Integer;
@@ -2781,6 +2784,7 @@ public final class io/sentry/protocol/Device : io/sentry/JsonSerializable, io/se
 	public fun setBrand (Ljava/lang/String;)V
 	public fun setCharging (Ljava/lang/Boolean;)V
 	public fun setConnectionType (Ljava/lang/String;)V
+	public fun setCpuDescription (Ljava/lang/String;)V
 	public fun setExternalFreeStorage (Ljava/lang/Long;)V
 	public fun setExternalStorageSize (Ljava/lang/Long;)V
 	public fun setFamily (Ljava/lang/String;)V
@@ -2797,6 +2801,8 @@ public final class io/sentry/protocol/Device : io/sentry/JsonSerializable, io/se
 	public fun setName (Ljava/lang/String;)V
 	public fun setOnline (Ljava/lang/Boolean;)V
 	public fun setOrientation (Lio/sentry/protocol/Device$DeviceOrientation;)V
+	public fun setProcessorCount (Ljava/lang/Integer;)V
+	public fun setProcessorFrequency (Ljava/lang/Double;)V
 	public fun setScreenDensity (Ljava/lang/Float;)V
 	public fun setScreenDpi (Ljava/lang/Integer;)V
 	public fun setScreenHeightPixels (Ljava/lang/Integer;)V
@@ -2836,6 +2842,7 @@ public final class io/sentry/protocol/Device$JsonKeys {
 	public static final field BRAND Ljava/lang/String;
 	public static final field CHARGING Ljava/lang/String;
 	public static final field CONNECTION_TYPE Ljava/lang/String;
+	public static final field CPU_DESCRIPTION Ljava/lang/String;
 	public static final field EXTERNAL_FREE_STORAGE Ljava/lang/String;
 	public static final field EXTERNAL_STORAGE_SIZE Ljava/lang/String;
 	public static final field FAMILY Ljava/lang/String;
@@ -2852,6 +2859,8 @@ public final class io/sentry/protocol/Device$JsonKeys {
 	public static final field NAME Ljava/lang/String;
 	public static final field ONLINE Ljava/lang/String;
 	public static final field ORIENTATION Ljava/lang/String;
+	public static final field PROCESSOR_COUNT Ljava/lang/String;
+	public static final field PROCESSOR_FREQUENCY Ljava/lang/String;
 	public static final field SCREEN_DENSITY Ljava/lang/String;
 	public static final field SCREEN_DPI Ljava/lang/String;
 	public static final field SCREEN_HEIGHT_PIXELS Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -117,6 +117,19 @@ public final class Device implements JsonUnknown, JsonSerializable {
   /** battery's temperature in celsius */
   private @Nullable Float batteryTemperature;
 
+  /** Optional. Number of "logical processors". For example, 8. */
+  private @Nullable Integer processorCount;
+
+  /**
+   * Optional. Processor frequency in MHz. Note that the actual CPU frequency might vary depending
+   * on current load and power conditions, especially on low-powered devices like phones and
+   * laptops.
+   */
+  private @Nullable Double processorFrequency;
+
+  /** Optional. CPU description. For example, Intel(R) Core(TM)2 Quad CPU Q6600 @ 2.40GHz. */
+  private @Nullable String cpuDescription;
+
   @SuppressWarnings("unused")
   private @Nullable Map<String, @NotNull Object> unknown;
 
@@ -157,6 +170,10 @@ public final class Device implements JsonUnknown, JsonSerializable {
 
     final TimeZone timezoneRef = device.timezone;
     this.timezone = timezoneRef != null ? (TimeZone) timezoneRef.clone() : null;
+
+    this.processorCount = device.processorCount;
+    this.processorFrequency = device.processorFrequency;
+    this.cpuDescription = device.cpuDescription;
 
     this.unknown = CollectionUtils.newConcurrentHashMap(device.unknown);
   }
@@ -403,6 +420,30 @@ public final class Device implements JsonUnknown, JsonSerializable {
     this.batteryTemperature = batteryTemperature;
   }
 
+  public @Nullable Integer getProcessorCount() {
+    return processorCount;
+  }
+
+  public void setProcessorCount(@Nullable Integer processorCount) {
+    this.processorCount = processorCount;
+  }
+
+  public @Nullable Double getProcessorFrequency() {
+    return processorFrequency;
+  }
+
+  public void setProcessorFrequency(@Nullable Double processorFrequency) {
+    this.processorFrequency = processorFrequency;
+  }
+
+  public @Nullable String getCpuDescription() {
+    return cpuDescription;
+  }
+
+  public void setCpuDescription(@Nullable String cpuDescription) {
+    this.cpuDescription = cpuDescription;
+  }
+
   public enum DeviceOrientation implements JsonSerializable {
     PORTRAIT,
     LANDSCAPE;
@@ -460,6 +501,9 @@ public final class Device implements JsonUnknown, JsonSerializable {
     public static final String CONNECTION_TYPE = "connection_type";
     public static final String BATTERY_TEMPERATURE = "battery_temperature";
     public static final String LOCALE = "locale";
+    public static final String PROCESSOR_COUNT = "processor_count";
+    public static final String CPU_DESCRIPTION = "cpu_description";
+    public static final String PROCESSOR_FREQUENCY = "processor_frequency";
   }
 
   @Override
@@ -558,6 +602,15 @@ public final class Device implements JsonUnknown, JsonSerializable {
     }
     if (locale != null) {
       writer.name(JsonKeys.LOCALE).value(locale);
+    }
+    if (processorCount != null) {
+      writer.name(JsonKeys.PROCESSOR_COUNT).value(processorCount);
+    }
+    if (processorFrequency != null) {
+      writer.name(JsonKeys.PROCESSOR_FREQUENCY).value(processorFrequency);
+    }
+    if (cpuDescription != null) {
+      writer.name(JsonKeys.CPU_DESCRIPTION).value(cpuDescription);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -697,6 +750,15 @@ public final class Device implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.LOCALE:
             device.locale = reader.nextStringOrNull();
+            break;
+          case JsonKeys.PROCESSOR_COUNT:
+            device.processorCount = reader.nextIntegerOrNull();
+            break;
+          case JsonKeys.PROCESSOR_FREQUENCY:
+            device.processorFrequency = reader.nextDoubleOrNull();
+            break;
+          case JsonKeys.CPU_DESCRIPTION:
+            device.cpuDescription = reader.nextStringOrNull();
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -424,7 +424,7 @@ public final class Device implements JsonUnknown, JsonSerializable {
     return processorCount;
   }
 
-  public void setProcessorCount(@Nullable Integer processorCount) {
+  public void setProcessorCount(@Nullable final Integer processorCount) {
     this.processorCount = processorCount;
   }
 
@@ -432,7 +432,7 @@ public final class Device implements JsonUnknown, JsonSerializable {
     return processorFrequency;
   }
 
-  public void setProcessorFrequency(@Nullable Double processorFrequency) {
+  public void setProcessorFrequency(@Nullable final Double processorFrequency) {
     this.processorFrequency = processorFrequency;
   }
 
@@ -440,7 +440,7 @@ public final class Device implements JsonUnknown, JsonSerializable {
     return cpuDescription;
   }
 
-  public void setCpuDescription(@Nullable String cpuDescription) {
+  public void setCpuDescription(@Nullable final String cpuDescription) {
     this.cpuDescription = cpuDescription;
   }
 

--- a/sentry/src/test/java/io/sentry/protocol/DeviceSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/DeviceSerializationTest.kt
@@ -56,6 +56,9 @@ class DeviceSerializationTest {
             language = "6dd45f60-111d-42d8-9204-0452cc836ad8"
             connectionType = "9ceb3a6c-5292-4ed9-8665-5732495e8ed4"
             batteryTemperature = 0.14775127f
+            cpuDescription = "cpu0"
+            processorCount = 4
+            processorFrequency = 800.0
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/java/io/sentry/protocol/DeviceTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/DeviceTest.kt
@@ -62,6 +62,9 @@ class DeviceTest {
         device.connectionType = "connection type"
         device.batteryTemperature = 30f
         device.locale = "en-US"
+        device.cpuDescription = "cpu0"
+        device.processorCount = 4
+        device.processorFrequency = 800.0
         val unknown = mapOf(Pair("unknown", "unknown"))
         device.setUnknown(unknown)
 
@@ -99,7 +102,10 @@ class DeviceTest {
         assertEquals("language", clone.language)
         assertEquals("connection type", clone.connectionType)
         assertEquals(30f, clone.batteryTemperature)
-        assertEquals("en-US", clone.locale)
+        assertEquals("cpu0", clone.cpuDescription)
+        assertEquals(4, clone.processorCount)
+        assertEquals(800.0, clone.processorFrequency)
+        device.processorFrequency = 800.0
         assertNotNull(clone.unknown) {
             assertEquals("unknown", it["unknown"])
         }

--- a/sentry/src/test/resources/json/contexts.json
+++ b/sentry/src/test/resources/json/contexts.json
@@ -59,7 +59,10 @@
     "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
     "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
     "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-    "battery_temperature": 0.14775127
+    "battery_temperature": 0.14775127,
+    "processor_count": 4,
+    "processor_frequency": 800.0,
+    "cpu_description": "cpu0"
   },
   "gpu":
   {

--- a/sentry/src/test/resources/json/device.json
+++ b/sentry/src/test/resources/json/device.json
@@ -36,5 +36,8 @@
     "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
     "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
     "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-    "battery_temperature": 0.14775127
+    "battery_temperature": 0.14775127,
+    "processor_count": 4,
+    "processor_frequency": 800.0,
+    "cpu_description": "cpu0"
 }

--- a/sentry/src/test/resources/json/sentry_base_event.json
+++ b/sentry/src/test/resources/json/sentry_base_event.json
@@ -62,7 +62,10 @@
       "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
       "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
       "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-      "battery_temperature": 0.14775127
+      "battery_temperature": 0.14775127,
+      "processor_count": 4,
+      "processor_frequency": 800.0,
+      "cpu_description": "cpu0"
     },
     "gpu":
     {

--- a/sentry/src/test/resources/json/sentry_event.json
+++ b/sentry/src/test/resources/json/sentry_event.json
@@ -186,7 +186,10 @@
             "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
             "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
             "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-            "battery_temperature": 0.14775127
+            "battery_temperature": 0.14775127,
+            "processor_count": 4,
+            "processor_frequency": 800.0,
+            "cpu_description": "cpu0"
         },
         "gpu":
         {

--- a/sentry/src/test/resources/json/sentry_transaction.json
+++ b/sentry/src/test/resources/json/sentry_transaction.json
@@ -105,7 +105,10 @@
             "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
             "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
             "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-            "battery_temperature": 0.14775127
+            "battery_temperature": 0.14775127,
+            "processor_count": 4,
+            "processor_frequency": 800.0,
+            "cpu_description": "cpu0"
         },
         "gpu":
         {

--- a/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
@@ -105,7 +105,10 @@
             "id": "e0fa5c8d-83f5-4e70-bc60-1e82ad30e196",
             "language": "6dd45f60-111d-42d8-9204-0452cc836ad8",
             "connection_type": "9ceb3a6c-5292-4ed9-8665-5732495e8ed4",
-            "battery_temperature": 0.14775127
+            "battery_temperature": 0.14775127,
+            "processor_count": 4,
+            "processor_frequency": 800.0,
+            "cpu_description": "cpu0"
         },
         "gpu":
         {


### PR DESCRIPTION
## :scroll: Description
Adds CPU description, processor count and frequency to the device context.


## :bulb: Motivation and Context

Implements required changes for https://github.com/getsentry/sentry-java/issues/2561

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
