### PR TITLE
Fix Automatic UI transactions having wrong durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Fix Automatic UI transactions having wrong durations ([#2623](https://github.com/getsentry/sentry-java/pull/2623))
 - Fix wrong default environment in Session ([#2610](https://github.com/getsentry/sentry-java/pull/2610))
 
 ## 6.16.0

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -193,7 +193,12 @@ public final class Span implements ISpan {
       @Nullable SentryDate minChildStart = null;
       @Nullable SentryDate maxChildEnd = null;
 
-      final @NotNull List<Span> children = getChildren();
+      // The root span should be trimmed based on all children, but the other spans, like the
+      // jetpack composition should be trimmed based on its direct children only
+      final @NotNull List<Span> children =
+          transaction.getRoot().getSpanId().equals(getSpanId())
+              ? transaction.getChildren()
+              : getDirectChildren();
       for (final Span child : children) {
         if (minChildStart == null || child.getStartDate().isBefore(minChildStart)) {
           minChildStart = child.getStartDate();
@@ -389,7 +394,7 @@ public final class Span implements ISpan {
   }
 
   @NotNull
-  private List<Span> getChildren() {
+  private List<Span> getDirectChildren() {
     final List<Span> children = new ArrayList<>();
     final Iterator<Span> iterator = transaction.getSpans().iterator();
 


### PR DESCRIPTION
## :scroll: Description
Automatic Activity transactions now have the ttid start timestamp if appStart span is not present
Span now trims for all transaction children if it's the root span of the transaction


## :bulb: Motivation and Context
The reported duration of the transaction [is wrong](https://github.com/getsentry/sentry-java/issues/2615).


## :green_heart: How did you test it?
Added Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
