### PR TITLE
Fix missing null check when removing lifecycle observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Fix wrong default environment in Session ([#2610](https://github.com/getsentry/sentry-java/pull/2610))
+- Fix missing null check when removing lifecycle observer ([#2625](https://github.com/getsentry/sentry-java/pull/2625))
 
 ## 6.16.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -130,7 +130,7 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
     } else {
       // some versions of the androidx lifecycle-process require this to be executed on the main
       // thread.
-      handler.post(this::removeObserver);
+      handler.post(() -> removeObserver());
     }
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppLifecycleIntegrationTest.kt
@@ -1,12 +1,13 @@
 package io.sentry.android.core
 
+import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import io.sentry.IHub
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.robolectric.Shadows.shadowOf
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -112,7 +113,10 @@ class AppLifecycleIntegrationTest {
         }.start()
 
         latch.await()
-        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        // ensure all messages on main looper got processed
+        shadowOf(Looper.getMainLooper()).idle()
+
         assertNull(sut.watcher)
     }
 }


### PR DESCRIPTION
## :scroll: Description
If `Sentry.close` is called off the main thread, the lifecycle watcher field is set to `null`, while de-registering is posted on the main thread, leading to a NPE in combination with some versions of android x lifecycle lib.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2601

## :green_heart: How did you test it?
Manual testing, the overhead of running a single test against different version of the androidx lifecycle library didn't seem to justify the efforts.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
