### PR TITLE
Add 6.0.0 requirements for hosted Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This directory is also included in `.gitignore` not to be shown as pending chang
 
 Since version 3.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to self-hosted Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
 
-Since version 6.0.0 of this SDK, Sentry version >= v21.9.0 is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry.
+Since version 6.0.0 of this SDK, Sentry version >= v21.9.0 is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
 
 # Resources
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ This directory is also included in `.gitignore` not to be shown as pending chang
 
 Since version 3.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to on-premise Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
 
+Since version 6.0.0 of this SDK, Sentry version >= v21.9.0 is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry.
+
 # Resources
 
 * [![Java Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg?label=java%20docs)](https://docs.sentry.io/platforms/java/)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This directory is also included in `.gitignore` not to be shown as pending chang
 
 # Sentry Self Hosted Compatibility
 
-Since version 3.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to on-premise Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
+Since version 3.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to self-hosted Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
 
 Since version 6.0.0 of this SDK, Sentry version >= v21.9.0 is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry.
 


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description

<!--- Describe your changes in detail -->

Before bumping the Sentry SDK of my Android app, I had a hard time figuring out if the SDK version was compatible with the hosted Sentry version I was going to use.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After digging through release notes, I stumbled on [this note](https://github.com/getsentry/sentry-java/releases/tag/6.0.0):

> Starting with version `6.0.0` of the `sentry` package, [Sentry's self hosted version >= v21.9.0](https://github.com/getsentry/self-hosted/releases) is required or you have to manually disable sending client reports via the `sendClientReports` option. This only applies to self-hosted Sentry.

I assume this is information that should belong to the main README, shouldn't it?

## :green_heart: How did you test it?

I proofread the MD 😉

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

This PR only contains what I actually found reading release notes but I can't be sure I haven't missed other similar notes for other versions of the SDK.
