### PR TITLE
Fix sentry-native changelog message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
 
 ### Dependencies
 
-- Bump Native SDK from v0.5.4 to v0.6.1 ([#2629](https://github.com/getsentry/sentry-java/pull/2629))
+- Bump Native SDK from v0.6.0 to v0.6.1 ([#2629](https://github.com/getsentry/sentry-java/pull/2629))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#061)
-  - [diff](https://github.com/getsentry/sentry-native/compare/0.5.4...0.6.1)
+  - [diff](https://github.com/getsentry/sentry-native/compare/0.6.0...0.6.1)
 
 ## 6.16.0
 


### PR DESCRIPTION
#skip-changelog
#skip-ci

## :scroll: Description
Some git submodule refs for `sentry-native` where incorrectly pushed. The newest release will bump `0.6.0` to `0.6.1`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
