### PR TITLE
Fix timestamps of PerformanceCollectionData in profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- Fix timestamps of PerformanceCollectionData in profiles ([#2632](https://github.com/getsentry/sentry-java/pull/2632))
 - Fix Automatic UI transactions having wrong durations ([#2623](https://github.com/getsentry/sentry-java/pull/2623))
 - Fix wrong default environment in Session ([#2610](https://github.com/getsentry/sentry-java/pull/2610))
 - Pass through unknown sentry baggage keys into SentryEnvelopeHeader ([#2618](https://github.com/getsentry/sentry-java/pull/2618))

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -109,7 +109,7 @@ class EnvelopeTests : BaseUiTest() {
                 assertTrue(cpuStats.values.isNotEmpty())
 
                 // We allow measurements to be added since the start up to the end of the profile, with a small tolerance due to threading
-                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(10)
+                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(50)
 
                 assertTrue((slowFrames?.values?.maxOf { it.relativeStartNs.toLong() } ?: 0) < maxTimestampAllowed)
                 assertTrue((slowFrames?.values?.minOf { it.relativeStartNs.toLong() } ?: 0) >= 0)

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -109,7 +109,7 @@ class EnvelopeTests : BaseUiTest() {
                 assertTrue(cpuStats.values.isNotEmpty())
 
                 // We allow measurements to be added since the start up to the end of the profile, with a small tolerance due to threading
-                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(100)
+                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.SECONDS.toNanos(1)
 
                 assertTrue((slowFrames?.values?.maxOf { it.relativeStartNs.toLong() } ?: 0) < maxTimestampAllowed)
                 assertTrue((slowFrames?.values?.minOf { it.relativeStartNs.toLong() } ?: 0) >= 0)

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -109,7 +109,7 @@ class EnvelopeTests : BaseUiTest() {
                 assertTrue(cpuStats.values.isNotEmpty())
 
                 // We allow measurements to be added since the start up to the end of the profile, with a small tolerance due to threading
-                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(50)
+                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(100)
 
                 assertTrue((slowFrames?.values?.maxOf { it.relativeStartNs.toLong() } ?: 0) < maxTimestampAllowed)
                 assertTrue((slowFrames?.values?.minOf { it.relativeStartNs.toLong() } ?: 0) >= 0)

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -88,9 +88,9 @@ class EnvelopeTests : BaseUiTest() {
                 val slowFrames = profilingTraceData.measurementsMap[ProfileMeasurement.ID_SLOW_FRAME_RENDERS]
                 val frozenFrames = profilingTraceData.measurementsMap[ProfileMeasurement.ID_FROZEN_FRAME_RENDERS]
                 val frameRates = profilingTraceData.measurementsMap[ProfileMeasurement.ID_SCREEN_FRAME_RATES]!!
-//                val memoryStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_MEMORY_FOOTPRINT]!!
-//                val memoryNativeStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_MEMORY_NATIVE_FOOTPRINT]!!
-//                val cpuStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_CPU_USAGE]!!
+                val memoryStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_MEMORY_FOOTPRINT]!!
+                val memoryNativeStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_MEMORY_NATIVE_FOOTPRINT]!!
+                val cpuStats = profilingTraceData.measurementsMap[ProfileMeasurement.ID_CPU_USAGE]!!
                 // Slow and frozen frames can be null (in case there were none)
                 if (slowFrames != null) {
                     assertEquals(ProfileMeasurement.UNIT_NANOSECONDS, slowFrames.unit)
@@ -101,12 +101,28 @@ class EnvelopeTests : BaseUiTest() {
                 // There could be no slow/frozen frames, but we expect at least one frame rate
                 assertEquals(ProfileMeasurement.UNIT_HZ, frameRates.unit)
                 assertTrue(frameRates.values.isNotEmpty())
-//                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryStats.unit)
-//                assertTrue(memoryStats.values.isNotEmpty())
-//                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryNativeStats.unit)
-//                assertTrue(memoryNativeStats.values.isNotEmpty())
-//                assertEquals(ProfileMeasurement.UNIT_PERCENT, cpuStats.unit)
-//                assertTrue(cpuStats.values.isNotEmpty())
+                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryStats.unit)
+                assertTrue(memoryStats.values.isNotEmpty())
+                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryNativeStats.unit)
+                assertTrue(memoryNativeStats.values.isNotEmpty())
+                assertEquals(ProfileMeasurement.UNIT_PERCENT, cpuStats.unit)
+                assertTrue(cpuStats.values.isNotEmpty())
+
+                // We allow measurements to be added since the start up to the end of the profile, with a small tolerance due to threading
+                val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.MILLISECONDS.toNanos(10)
+
+                assertTrue((slowFrames?.values?.maxOf { it.relativeStartNs.toLong() } ?: 0) < maxTimestampAllowed)
+                assertTrue((slowFrames?.values?.minOf { it.relativeStartNs.toLong() } ?: 0) >= 0)
+                assertTrue((frozenFrames?.values?.maxOf { it.relativeStartNs.toLong() } ?: 0) < maxTimestampAllowed)
+                assertTrue((frozenFrames?.values?.minOf { it.relativeStartNs.toLong() } ?: 0) >= 0)
+                assertTrue(frameRates.values.maxOf { it.relativeStartNs.toLong() } < maxTimestampAllowed)
+                assertTrue(frameRates.values.minOf { it.relativeStartNs.toLong() } > 0)
+                assertTrue(memoryStats.values.maxOf { it.relativeStartNs.toLong() } < maxTimestampAllowed)
+                assertTrue(memoryStats.values.minOf { it.relativeStartNs.toLong() } > 0)
+                assertTrue(memoryNativeStats.values.maxOf { it.relativeStartNs.toLong() } < maxTimestampAllowed)
+                assertTrue(memoryNativeStats.values.minOf { it.relativeStartNs.toLong() } > 0)
+                assertTrue(cpuStats.values.maxOf { it.relativeStartNs.toLong() } < maxTimestampAllowed)
+                assertTrue(cpuStats.values.minOf { it.relativeStartNs.toLong() } > 0)
 
                 // We should find the transaction id that started the profiling in the list of transactions
                 val transactionData = profilingTraceData.transactions

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2559,6 +2559,7 @@ public final class io/sentry/profilemeasurements/ProfileMeasurementValue : io/se
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Long;Ljava/lang/Number;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getRelativeStartNs ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getValue ()D
 	public fun hashCode ()I

--- a/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
@@ -35,6 +35,10 @@ public final class ProfileMeasurementValue implements JsonUnknown, JsonSerializa
     return value;
   }
 
+  public @NotNull String getRelativeStartNs() {
+    return relativeStartNs;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -814,6 +814,7 @@ class JsonSerializerTest {
         val expected = ProfileMeasurementValue(1, 60.1)
         assertEquals(expected, profileMeasurementValue)
         assertEquals(60.1, profileMeasurementValue?.value)
+        assertEquals("1", profileMeasurementValue?.relativeStartNs)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
PerformanceCollectionData timestamps in profiles have been adjusted to be relative to the profile start


## :bulb: Motivation and Context
PerformanceCollectionData timestamps were absolute values, but they were supposed to be relative to the profile start


## :green_heart: How did you test it?
Added a Ui test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
