### PR TITLE
Make log4j2 integration compatible with log4j 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - Make log4j2 integration compatible with log4j 3.0 ([#2634](https://github.com/getsentry/sentry-java/pull/2634))
+	- Instead of relying on package scanning, we now use an annotation processor to generate `Log4j2Plugins.dat`
 
 ## 6.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Features
+
+- Make log4j2 integration compatible with log4j 3.0 ([#2634](https://github.com/getsentry/sentry-java/pull/2634))
+
 ## 6.17.0
 
 ### Features

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -65,7 +65,7 @@ object Config {
         val logbackVersion = "1.2.9"
         val logbackClassic = "ch.qos.logback:logback-classic:$logbackVersion"
 
-        val log4j2Version = "2.17.0"
+        val log4j2Version = "2.20.0"
         val log4j2Api = "org.apache.logging.log4j:log4j-api:$log4j2Version"
         val log4j2Core = "org.apache.logging.log4j:log4j-core:$log4j2Version"
 

--- a/sentry-log4j2/build.gradle.kts
+++ b/sentry-log4j2/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(projects.sentry)
     implementation(Config.Libs.log4j2Api)
     implementation(Config.Libs.log4j2Core)
+    annotationProcessor(Config.Libs.log4j2Core)
 
     compileOnly(Config.CompileOnly.nopen)
     errorprone(Config.CompileOnly.nopenChecker)

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="io.sentry.log4j2">
+<Configuration status="WARN">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>


### PR DESCRIPTION
## :scroll: Description
Bump log4j2 version to 2.20.0
Use AnnotationProcessor instead of package scanning to find Plugin.


## :bulb: Motivation and Context
Fixes #2616 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
