### PR TITLE
Fix missing propagateMinConstraints flag for SentryTraced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix missing propagateMinConstraints flag for SentryTraced ([#2637](https://github.com/getsentry/sentry-java/pull/2637))
+
 ## 6.17.0
 
 ### Features

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -90,7 +90,8 @@ public fun SentryTraced(
                 drawContent()
                 firstRendered.item = true
                 renderSpan?.finish()
-            }
+            },
+        propagateMinConstraints = true
     ) {
         content()
     }


### PR DESCRIPTION
## :scroll: Description
Our `SentryTraced` wrapper is using a `Box` right now to capture composition time. We should set the `propagateMinConstraints = true` flag to ensure `SentryTraced` is not modifying any layouting behavior.


## :bulb: Motivation and Context
As commented here: https://github.com/getsentry/sentry-java/commit/1d79c717cd52a26258ad3ff61df044c9ce6f03a9#r105548701


## :green_heart: How did you test it?
Manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
