### PR TITLE
Fix timestamp intervals of PerformanceCollectionData in profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fix timestamp intervals of PerformanceCollectionData in profiles ([#2648](https://github.com/getsentry/sentry-java/pull/2648))
 - Fix timestamps of PerformanceCollectionData in profiles ([#2632](https://github.com/getsentry/sentry-java/pull/2632))
 - Fix missing propagateMinConstraints flag for SentryTraced ([#2637](https://github.com/getsentry/sentry-java/pull/2637))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -433,7 +433,9 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     // terms of System.currentTimeMillis() and measurements timestamps require the nanoseconds since
     // the beginning, expressed with SystemClock.elapsedRealtimeNanos()
     long timestampDiff =
-        SystemClock.elapsedRealtimeNanos() - transactionStartNanos - System.currentTimeMillis();
+        SystemClock.elapsedRealtimeNanos()
+            - transactionStartNanos
+            - TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
     if (performanceCollectionData != null) {
       final @NotNull ArrayDeque<ProfileMeasurementValue> memoryUsageMeasurements =
           new ArrayDeque<>(performanceCollectionData.size());
@@ -447,17 +449,19 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
         if (cpuData != null) {
           cpuUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  cpuData.getTimestampMillis() + timestampDiff, cpuData.getCpuUsagePercentage()));
+                  TimeUnit.MILLISECONDS.toNanos(cpuData.getTimestampMillis()) + timestampDiff,
+                  cpuData.getCpuUsagePercentage()));
         }
         if (memoryData != null && memoryData.getUsedHeapMemory() > -1) {
           memoryUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  memoryData.getTimestampMillis() + timestampDiff, memoryData.getUsedHeapMemory()));
+                  TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
+                  memoryData.getUsedHeapMemory()));
         }
         if (memoryData != null && memoryData.getUsedNativeMemory() > -1) {
           nativeMemoryUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  memoryData.getTimestampMillis() + timestampDiff,
+                  TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
                   memoryData.getUsedNativeMemory()));
         }
       }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -101,12 +101,18 @@ class EnvelopeTests : BaseUiTest() {
                 // There could be no slow/frozen frames, but we expect at least one frame rate
                 assertEquals(ProfileMeasurement.UNIT_HZ, frameRates.unit)
                 assertTrue(frameRates.values.isNotEmpty())
-                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryStats?.unit)
-                assertEquals(true, memoryStats?.values?.isNotEmpty())
-                assertEquals(ProfileMeasurement.UNIT_BYTES, memoryNativeStats?.unit)
-                assertEquals(true, memoryNativeStats?.values?.isNotEmpty())
-                assertEquals(ProfileMeasurement.UNIT_PERCENT, cpuStats?.unit)
-                assertEquals(true, cpuStats?.values?.isNotEmpty())
+                memoryStats?.let {
+                    assertEquals(ProfileMeasurement.UNIT_BYTES, it.unit)
+                    assertEquals(true, it.values.isNotEmpty())
+                }
+                memoryNativeStats?.let {
+                    assertEquals(ProfileMeasurement.UNIT_BYTES, it.unit)
+                    assertEquals(true, it.values.isNotEmpty())
+                }
+                cpuStats?.let {
+                    assertEquals(ProfileMeasurement.UNIT_PERCENT, it.unit)
+                    assertEquals(true, it.values.isNotEmpty())
+                }
 
                 // We allow measurements to be added since the start up to the end of the profile, with a small tolerance due to threading
                 val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.SECONDS.toNanos(2)

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
     <!-- Just some random permissions to showcase the permission context sent to Sentry -->
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Needed by leakcanary.NotificationEventListener -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!--  if your minSdkVersion < 16, this would make usable on minSdkVersion >= 14-->
     <uses-sdk


### PR DESCRIPTION
## :scroll: Description
fixed timestamps of PerformanceCollectionData in profiles
updated ui test to cover all measurements cases


## :bulb: Motivation and Context
The PerformanceCollectionData measurements in the profiles were not converted to nanoseconds, generating problems with their intervals


## :green_heart: How did you test it?
Updated ui test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
