### PR TITLE
Fix potential SecurityException thrown by ConnectivityManager on Android 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix timestamp intervals of PerformanceCollectionData in profiles ([#2648](https://github.com/getsentry/sentry-java/pull/2648))
 - Fix timestamps of PerformanceCollectionData in profiles ([#2632](https://github.com/getsentry/sentry-java/pull/2632))
 - Fix missing propagateMinConstraints flag for SentryTraced ([#2637](https://github.com/getsentry/sentry-java/pull/2637))
+- Fix potential SecurityException thrown by ConnectivityManager on Android 11 ([#2653](https://github.com/getsentry/sentry-java/pull/2653))
 
 ### Dependencies
 - Bump Kotlin compile version from v1.6.10 to 1.8.0 ([#2563](https://github.com/getsentry/sentry-java/pull/2563))

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ConnectivityCheckerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ConnectivityCheckerTest.kt
@@ -276,7 +276,7 @@ class ConnectivityCheckerTest {
     }
 
     @Test
-    fun `When connectivityManager unregisterDefaultCallback throws an exception, false is returned`() {
+    fun `When connectivityManager unregisterDefaultCallback throws an exception, it gets swallowed`() {
         whenever(connectivityManager.registerDefaultNetworkCallback(any())).thenThrow(
             SecurityException("Android OS Bug")
         )


### PR DESCRIPTION
## :scroll: Description
Retrieving Network info via ConnectivityManager seems to cause crashes on Android 11. See https://issuetracker.google.com/issues/175055271 for more details.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2646


## :green_heart: How did you test it?
Added new unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
