### PR TITLE
Parse ANRv2 thread dump into threads interface

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,6 @@
 import com.diffplug.spotless.LineEnding
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.MavenPublishPlugin
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
-import groovy.util.Node
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ allprojects {
             dependsOn("cleanTest")
         }
         withType<JavaCompile> {
-            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Xlint:-classfile", "-Xlint:-processing"))
+            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import com.diffplug.spotless.LineEnding
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.MavenPublishPlugin
 import com.vanniktech.maven.publish.MavenPublishPluginExtension
+import groovy.util.Node
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
@@ -89,7 +91,7 @@ allprojects {
             dependsOn("cleanTest")
         }
         withType<JavaCompile> {
-            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing"))
+            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Xlint:-classfile", "-Xlint:-processing"))
         }
     }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -454,7 +454,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
     // AnrV2 threads contain a thread dump from the OS, so we just search for the main thread dump
     // and make an exception out of its stacktrace
     final Mechanism mechanism = new Mechanism();
-    mechanism.setType("ANRv2");
+    mechanism.setType("AppExitInfo");
 
     final boolean isBackgroundAnr = isBackgroundAnr(hint);
     String message = "ANR";

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -437,15 +437,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
   private boolean isBackgroundAnr(final @NotNull Object hint) {
     if (hint instanceof AbnormalExit) {
       final String abnormalMechanism = ((AbnormalExit) hint).mechanism();
-      if (abnormalMechanism == null) {
-        return false;
-      }
-
-      if (abnormalMechanism.equals("anr_foreground")) {
-        return false;
-      }
-
-      return abnormalMechanism.equals("anr_background");
+      return "anr_background".equals(abnormalMechanism);
     }
     return false;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -88,8 +88,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
     this.buildInfoProvider = buildInfoProvider;
 
     final SentryStackTraceFactory sentryStackTraceFactory =
-        new SentryStackTraceFactory(
-            this.options.getInAppExcludes(), this.options.getInAppIncludes());
+        new SentryStackTraceFactory(this.options);
 
     sentryExceptionFactory = new SentryExceptionFactory(sentryStackTraceFactory);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -458,10 +458,9 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
         message = "Background " + message;
       }
       final ApplicationNotResponding anr =
-        new ApplicationNotResponding(message, Thread.currentThread());
+          new ApplicationNotResponding(message, Thread.currentThread());
       event.setExceptions(
-        sentryExceptionFactory.getSentryExceptionsFromThread(mainThread, mechanism, anr)
-      );
+          sentryExceptionFactory.getSentryExceptionsFromThread(mainThread, mechanism, anr));
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.ApplicationExitInfo;
 import android.content.Context;
-import android.os.Looper;
 import io.sentry.DateUtils;
 import io.sentry.Hint;
 import io.sentry.IHub;
@@ -18,11 +17,9 @@ import io.sentry.android.core.internal.threaddump.Lines;
 import io.sentry.android.core.internal.threaddump.ThreadDumpParser;
 import io.sentry.cache.EnvelopeCache;
 import io.sentry.cache.IEnvelopeCache;
-import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.BlockingFlushHint;
-import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryThread;
 import io.sentry.transport.CurrentDateProvider;
@@ -262,7 +259,7 @@ public class AnrV2Integration implements Integration, Closeable {
         final @NotNull ApplicationExitInfo exitInfo, final boolean isBackground) {
       List<SentryThread> threads = null;
       try (final BufferedReader reader =
-             new BufferedReader(new InputStreamReader(exitInfo.getTraceInputStream()))) {
+          new BufferedReader(new InputStreamReader(exitInfo.getTraceInputStream()))) {
         final Lines lines = Lines.readLines(reader);
 
         final ThreadDumpParser threadDumpParser = new ThreadDumpParser(options, isBackground);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
@@ -1,0 +1,14 @@
+package io.sentry.android.core.internal.threaddump;
+
+public class Line {
+  public int lineno;
+  public String text;
+
+  public Line() {
+  }
+
+  public Line(int lineno, String text) {
+    this.lineno = lineno;
+    this.text = text;
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
@@ -1,4 +1,6 @@
 /*
+ * Adapted from https://cs.android.com/android/platform/superproject/+/master:development/tools/bugreport/src/com/android/bugreport/util/Line.java
+ *
  * Copyright (C) 2016 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Line.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sentry.android.core.internal.threaddump;
 
-public class Line {
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+public final class Line {
   public int lineno;
-  public String text;
+  public @NotNull String text;
 
-  public Line() {
-  }
-
-  public Line(int lineno, String text) {
+  public Line(final int lineno, final @NotNull String text) {
     this.lineno = lineno;
     this.text = text;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
@@ -1,4 +1,6 @@
 /*
+ * Adapted from https://cs.android.com/android/platform/superproject/+/master:development/tools/bugreport/src/com/android/bugreport/util/Lines.java
+ *
  * Copyright (C) 2016 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
@@ -26,8 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A stream of parsed lines.  Can be rewound, and sub-regions cloned for
- * recursive descent parsing.
+ * A stream of parsed lines. Can be rewound, and sub-regions cloned for recursive descent parsing.
  */
 @ApiStatus.Internal
 public final class Lines {
@@ -35,23 +34,17 @@ public final class Lines {
   private final int mMin;
   private final int mMax;
 
-  /**
-   * The read position inside the list.
-   */
+  /** The read position inside the list. */
   public int pos;
 
-  /**
-   * Read the whole file into a Lines object.
-   */
+  /** Read the whole file into a Lines object. */
   public static Lines readLines(final @NotNull File file) throws IOException {
     try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
       return Lines.readLines(reader);
     }
   }
 
-  /**
-   * Read the whole file into a Lines object.
-   */
+  /** Read the whole file into a Lines object. */
   public static Lines readLines(final @NotNull BufferedReader in) throws IOException {
     final ArrayList<Line> list = new ArrayList<>();
 
@@ -65,25 +58,21 @@ public final class Lines {
     return new Lines(list);
   }
 
-  /**
-   * Construct with a list of lines.
-   */
+  /** Construct with a list of lines. */
   public Lines(final @NotNull ArrayList<? extends Line> list) {
     this.mList = list;
     mMin = 0;
     mMax = mList.size();
   }
 
-  /**
-   * If there are more lines to read within the current range.
-   */
+  /** If there are more lines to read within the current range. */
   public boolean hasNext() {
     return pos < mMax;
   }
 
   /**
-   * Return the next line, or null if there are no more lines to read. Also
-   * returns null in the error condition where pos is before the beginning.
+   * Return the next line, or null if there are no more lines to read. Also returns null in the
+   * error condition where pos is before the beginning.
    */
   @Nullable
   public Line next() {
@@ -94,9 +83,7 @@ public final class Lines {
     }
   }
 
-  /**
-   * Move the read position back by one line.
-   */
+  /** Move the read position back by one line. */
   public void rewind() {
     pos--;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
@@ -1,0 +1,123 @@
+package io.sentry.android.core.internal.threaddump;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * A stream of parsed lines.  Can be rewound, and sub-regions cloned for
+ * recursive descent parsing.
+ */
+public class Lines<T extends Line> {
+  private final ArrayList<? extends Line> mList;
+  private final int mMin;
+  private final int mMax;
+
+  /**
+   * The read position inside the list.
+   */
+  public int pos;
+
+  /**
+   * Read the whole file into a Lines object.
+   */
+  public static Lines<Line> readLines(File file) throws IOException {
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new FileReader(file));
+      return Lines.readLines(reader);
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+
+  /**
+   * Read the whole file into a Lines object.
+   */
+  public static Lines<Line> readLines(BufferedReader in) throws IOException {
+    final ArrayList<Line> list = new ArrayList<Line>();
+
+    int lineno = 0;
+    String text;
+    while ((text = in.readLine()) != null) {
+      lineno++;
+      list.add(new Line(lineno, text));
+    }
+
+    return new Lines<Line>(list);
+  }
+
+  /**
+   * Construct with a list of lines.
+   */
+  public Lines(ArrayList<? extends Line> list) {
+    this.mList = list;
+    mMin = 0;
+    mMax = mList.size();
+  }
+
+  /**
+   * Construct with a list of lines, and a range inside that list.  The
+   * read position will be set to min, so the new Lines can be read from
+   * the beginning.
+   */
+  private Lines(ArrayList<? extends Line> list, int min, int max) {
+    mList = list;
+    mMin = min;
+    mMax = max;
+    this.pos = min;
+  }
+
+  /**
+   * If there are more lines to read within the current range.
+   */
+  public boolean hasNext() {
+    return pos < mMax;
+  }
+
+  /**
+   * Return the next line, or null if there are no more lines to read. Also
+   * returns null in the error condition where pos is before the beginning.
+   */
+  public Line next() {
+    if (pos >= mMin && pos < mMax) {
+      return this.mList.get(pos++);
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Move the read position back by one line.
+   */
+  public void rewind() {
+    pos--;
+  }
+
+  /**
+   * Move th read position to the given pos.
+   */
+  public void rewind(int pos) {
+    this.pos = pos;
+  }
+
+  /**
+   * Return the number of lines.
+   */
+  public int size() {
+    return mMax - mMin;
+  }
+
+  /**
+   * Return a new Lines object restricted to the [from,to) range.
+   * The array list and Lines objects are shared, so be careful
+   * if you modify the lines themselves.
+   */
+  public Lines<T> copy(int from, int to) {
+    return new Lines<T>(mList, Math.max(mMin, from), Math.min(mMax, to));
+  }
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/Lines.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sentry.android.core.internal.threaddump;
 
 import java.io.BufferedReader;
@@ -5,13 +21,17 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A stream of parsed lines.  Can be rewound, and sub-regions cloned for
  * recursive descent parsing.
  */
-public class Lines<T extends Line> {
-  private final ArrayList<? extends Line> mList;
+@ApiStatus.Internal
+public final class Lines {
+  private final @NotNull ArrayList<? extends Line> mList;
   private final int mMin;
   private final int mMax;
 
@@ -23,23 +43,17 @@ public class Lines<T extends Line> {
   /**
    * Read the whole file into a Lines object.
    */
-  public static Lines<Line> readLines(File file) throws IOException {
-    BufferedReader reader = null;
-    try {
-      reader = new BufferedReader(new FileReader(file));
+  public static Lines readLines(final @NotNull File file) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
       return Lines.readLines(reader);
-    } finally {
-      if (reader != null) {
-        reader.close();
-      }
     }
   }
 
   /**
    * Read the whole file into a Lines object.
    */
-  public static Lines<Line> readLines(BufferedReader in) throws IOException {
-    final ArrayList<Line> list = new ArrayList<Line>();
+  public static Lines readLines(final @NotNull BufferedReader in) throws IOException {
+    final ArrayList<Line> list = new ArrayList<>();
 
     int lineno = 0;
     String text;
@@ -48,28 +62,16 @@ public class Lines<T extends Line> {
       list.add(new Line(lineno, text));
     }
 
-    return new Lines<Line>(list);
+    return new Lines(list);
   }
 
   /**
    * Construct with a list of lines.
    */
-  public Lines(ArrayList<? extends Line> list) {
+  public Lines(final @NotNull ArrayList<? extends Line> list) {
     this.mList = list;
     mMin = 0;
     mMax = mList.size();
-  }
-
-  /**
-   * Construct with a list of lines, and a range inside that list.  The
-   * read position will be set to min, so the new Lines can be read from
-   * the beginning.
-   */
-  private Lines(ArrayList<? extends Line> list, int min, int max) {
-    mList = list;
-    mMin = min;
-    mMax = max;
-    this.pos = min;
   }
 
   /**
@@ -83,6 +85,7 @@ public class Lines<T extends Line> {
    * Return the next line, or null if there are no more lines to read. Also
    * returns null in the error condition where pos is before the beginning.
    */
+  @Nullable
   public Line next() {
     if (pos >= mMin && pos < mMax) {
       return this.mList.get(pos++);
@@ -96,28 +99,5 @@ public class Lines<T extends Line> {
    */
   public void rewind() {
     pos--;
-  }
-
-  /**
-   * Move th read position to the given pos.
-   */
-  public void rewind(int pos) {
-    this.pos = pos;
-  }
-
-  /**
-   * Return the number of lines.
-   */
-  public int size() {
-    return mMax - mMin;
-  }
-
-  /**
-   * Return a new Lines object restricted to the [from,to) range.
-   * The array list and Lines objects are shared, so be careful
-   * if you modify the lines themselves.
-   */
-  public Lines<T> copy(int from, int to) {
-    return new Lines<T>(mList, Math.max(mMin, from), Math.min(mMax, to));
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -1,6 +1,14 @@
 package io.sentry.android.core.internal.threaddump;
 
+import io.sentry.protocol.SentryStackFrame;
+import io.sentry.protocol.SentryStackTrace;
+import io.sentry.protocol.SentryThread;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ThreadDumpParser {
   public static final Pattern BEGIN_UNMANAGED_THREAD_RE = Pattern.compile(
@@ -52,5 +60,180 @@ public class ThreadDumpParser {
   public ThreadDumpParser() {
   }
 
+  @NotNull
+  public List<SentryThread> parse(Lines<? extends Line> lines) {
+    final List<SentryThread> result = new ArrayList<>();
 
+    final Matcher beginManagedThreadRe = BEGIN_MANAGED_THREAD_RE.matcher("");
+
+    while (lines.hasNext()) {
+      final Line line = lines.next();
+      final String text = line.text;
+      // we only handle managed threads, as unmanaged/not attached do not have the thread id and
+      // our protocol does not support this case
+      if (matches(beginManagedThreadRe, text)) {
+        lines.rewind();
+
+        final SentryThread thread = parseThread(lines);
+        if (thread != null) {
+          result.add(thread);
+        }
+      }
+    }
+    return result;
+  }
+
+  private SentryThread parseThread(Lines<? extends Line> lines) {
+    final SentryThread result = new SentryThread();
+
+    final Matcher beginManagedThreadRe = BEGIN_MANAGED_THREAD_RE.matcher("");
+
+    // thread attributes
+    if (!lines.hasNext()) {
+      return null;
+    }
+    final Line line = lines.next();
+    if (matches(beginManagedThreadRe, line.text)) {
+      Long tid = getLong(beginManagedThreadRe, 4, null);
+      if (tid == null) {
+        // tid is required by our protocol
+        return null;
+      }
+      result.setId(tid);
+      result.setName(beginManagedThreadRe.group(1));
+      result.setState(beginManagedThreadRe.group(5));
+      final String threadName = result.getName();
+      if (threadName != null) {
+        final boolean isMain = threadName.equals("main");
+        result.setMain(isMain);
+        // TODO: figure out crashed and current, most likely it's the main thread for both? Worth
+        // checking if it's a foreground ANR here, and if not we don't set these as we don't know
+        // which thread exactly triggered the ANR?
+        //result.setCrashed();
+        result.setCurrent(isMain);
+      }
+    }
+
+    // thread stacktrace
+    final SentryStackTrace stackTrace = parseStacktrace(lines);
+    if (stackTrace != null) {
+      result.setStacktrace(stackTrace);
+    }
+    return result;
+  }
+
+  @Nullable
+  private SentryStackTrace parseStacktrace(Lines<? extends Line> lines) {
+    final List<SentryStackFrame> frames = new ArrayList<>();
+    SentryStackFrame lastJavaFrame = null;
+
+    final Matcher nativeRe = NATIVE_RE.matcher("");
+    final Matcher nativeNoLocRe = NATIVE_NO_LOC_RE.matcher("");
+    final Matcher javaRe = JAVA_RE.matcher("");
+    final Matcher jniRe = JNI_RE.matcher("");
+    final Matcher lockedRe = LOCKED_RE.matcher("");
+    final Matcher waitingOnRe = WAITING_ON_RE.matcher("");
+    final Matcher sleepingOnRe = SLEEPING_ON_RE.matcher("");
+    final Matcher waitingToLockHeldRe = WAITING_TO_LOCK_HELD_RE.matcher("");
+    final Matcher waitingToLockRe = WAITING_TO_LOCK_RE.matcher("");
+    final Matcher waitingToLockUnknownRe = WAITING_TO_LOCK_UNKNOWN_RE.matcher("");
+    final Matcher noManagedStackFrameRe = NO_MANAGED_STACK_FRAME_RE.matcher("");
+    final Matcher blankRe = BLANK_RE.matcher("");
+
+    while (lines.hasNext()) {
+      final Line line = lines.next();
+      final String text = line.text;
+      if (matches(nativeRe, text)) {
+        final SentryStackFrame frame = new SentryStackFrame();
+        frame.setPackage(nativeRe.group(1));
+        frame.setSymbol(nativeRe.group(2));
+        frame.setLineno(getInteger(nativeRe, 3, null));
+        frames.add(frame);
+        lastJavaFrame = null;
+      } else if (matches(nativeNoLocRe, text)) {
+        final SentryStackFrame frame = new SentryStackFrame();
+        frame.setPackage(nativeNoLocRe.group(1));
+        frame.setSymbol(nativeNoLocRe.group(2));
+        frames.add(frame);
+        lastJavaFrame = null;
+      } else if (matches(javaRe, text)) {
+        final SentryStackFrame frame = new SentryStackFrame();
+        final String packageName = javaRe.group(1);
+        final String className = javaRe.group(2);
+        final String module = String.format("%s.%s", packageName, className);
+        frame.setModule(module);
+        frame.setFunction(javaRe.group(3));
+        frame.setFilename(javaRe.group(4));
+        frame.setLineno(getUInteger(javaRe, 5, null));
+        frames.add(frame);
+        lastJavaFrame = frame;
+      } else if (matches(jniRe, text)) {
+        final SentryStackFrame frame = new SentryStackFrame();
+        final String packageName = jniRe.group(1);
+        final String className = jniRe.group(2);
+        final String module = String.format("%s.%s", packageName, className);
+        frame.setModule(module);
+        frame.setFunction(jniRe.group(3));
+        frames.add(frame);
+        lastJavaFrame = frame;
+      } else if (matches(lockedRe, text)
+        || matches(waitingOnRe, text)
+        || matches(sleepingOnRe, text)
+        || matches(waitingToLockHeldRe, text)
+        || matches(waitingToLockRe, text)
+        || matches(waitingToLockUnknownRe, text)) {
+      } else if (text.length() == 0 || matches(blankRe, text)) {
+        break;
+      }
+    }
+
+    final SentryStackTrace stackTrace = new SentryStackTrace(frames);
+    // it's a thread dump
+    stackTrace.setSnapshot(true);
+    return stackTrace;
+  }
+
+  @NotNull
+  private void parseAndAssignLockReason(final @NotNull SentryStackFrame lastJavaFrame) {
+    //lastJavaFrame.
+  }
+
+  private boolean matches(Matcher matcher, String text) {
+    matcher.reset(text);
+    return matcher.matches();
+  }
+
+  @Nullable
+  private Long getLong(final @NotNull Matcher matcher, final int group,
+    final @Nullable Long defaultValue) {
+    final String str = matcher.group(group);
+    if (str == null || str.length() == 0) {
+      return defaultValue;
+    } else {
+      return Long.parseLong(str);
+    }
+  }
+
+  @Nullable
+  private Integer getInteger(final @NotNull Matcher matcher, final int group,
+    final @Nullable Integer defaultValue) {
+    final String str = matcher.group(group);
+    if (str == null || str.length() == 0) {
+      return defaultValue;
+    } else {
+      return Integer.parseInt(str);
+    }
+  }
+
+  @Nullable
+  private Integer getUInteger(final @NotNull Matcher matcher, final int group,
+    final @Nullable Integer defaultValue) {
+    final String str = matcher.group(group);
+    if (str == null || str.length() == 0) {
+      return defaultValue;
+    } else {
+      final Integer parsed = Integer.parseInt(str);
+      return parsed >= 0 ? parsed : defaultValue;
+    }
+  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -18,31 +18,32 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ThreadDumpParser {
-  private static final Pattern BEGIN_MANAGED_THREAD_RE = Pattern.compile(
-    "\"(.*)\" (.*) ?prio=(\\d+)\\s+tid=(\\d+)\\s*(.*)");
-  private static final Pattern NATIVE_RE = Pattern.compile(
-    "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s+\\((.*)\\+(\\d+)\\)");
-  private static final Pattern NATIVE_NO_LOC_RE = Pattern.compile(
-    "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?");
-  private static final Pattern JAVA_RE = Pattern.compile(
-    "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\((.*):([\\d-]+)\\)");
-  private static final Pattern JNI_RE = Pattern.compile(
-    "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\(Native method\\)");
-  private static final Pattern LOCKED_RE = Pattern.compile(
-    "  - locked \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  private static final Pattern SLEEPING_ON_RE = Pattern.compile(
-    "  - sleeping on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  private static final Pattern WAITING_ON_RE = Pattern.compile(
-    "  - waiting on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  private static final Pattern WAITING_TO_LOCK_RE = Pattern.compile(
-    "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  private static final Pattern WAITING_TO_LOCK_HELD_RE = Pattern.compile(
-    "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)"
-      + "(?: held by thread (\\d+))");
-  private static final Pattern WAITING_TO_LOCK_UNKNOWN_RE = Pattern.compile(
-    "  - waiting to lock an unknown object");
-  private static final Pattern BLANK_RE
-    = Pattern.compile("\\s+");
+  private static final Pattern BEGIN_MANAGED_THREAD_RE =
+      Pattern.compile("\"(.*)\" (.*) ?prio=(\\d+)\\s+tid=(\\d+)\\s*(.*)");
+  private static final Pattern NATIVE_RE =
+      Pattern.compile("  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s+\\((.*)\\+(\\d+)\\)");
+  private static final Pattern NATIVE_NO_LOC_RE =
+      Pattern.compile("  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?");
+  private static final Pattern JAVA_RE =
+      Pattern.compile("  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\((.*):([\\d-]+)\\)");
+  private static final Pattern JNI_RE =
+      Pattern.compile("  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\(Native method\\)");
+  private static final Pattern LOCKED_RE =
+      Pattern.compile("  - locked \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern SLEEPING_ON_RE =
+      Pattern.compile("  - sleeping on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_ON_RE =
+      Pattern.compile("  - waiting on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_TO_LOCK_RE =
+      Pattern.compile(
+          "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_TO_LOCK_HELD_RE =
+      Pattern.compile(
+          "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)"
+              + "(?: held by thread (\\d+))");
+  private static final Pattern WAITING_TO_LOCK_UNKNOWN_RE =
+      Pattern.compile("  - waiting to lock an unknown object");
+  private static final Pattern BLANK_RE = Pattern.compile("\\s+");
 
   private final @NotNull SentryOptions options;
 
@@ -50,10 +51,7 @@ public class ThreadDumpParser {
 
   private final @NotNull SentryStackTraceFactory stackTraceFactory;
 
-  public ThreadDumpParser(
-    final @NotNull SentryOptions options,
-    final boolean isBackground
-  ) {
+  public ThreadDumpParser(final @NotNull SentryOptions options, final boolean isBackground) {
     this.options = options;
     this.isBackground = isBackground;
     this.stackTraceFactory = new SentryStackTraceFactory(options);
@@ -128,9 +126,7 @@ public class ThreadDumpParser {
 
   @NotNull
   private SentryStackTrace parseStacktrace(
-    final @NotNull Lines lines,
-    final @NotNull SentryThread thread
-  ) {
+      final @NotNull Lines lines, final @NotNull SentryThread thread) {
     final List<SentryStackFrame> frames = new ArrayList<>();
     boolean isLastFrameJava = false;
 
@@ -259,9 +255,7 @@ public class ThreadDumpParser {
   }
 
   private void combineThreadLocks(
-    final @NotNull SentryThread thread,
-    final @NotNull SentryLockReason lockReason
-  ) {
+      final @NotNull SentryThread thread, final @NotNull SentryLockReason lockReason) {
     Map<String, SentryLockReason> heldLocks = thread.getHeldLocks();
     if (heldLocks == null) {
       heldLocks = new HashMap<>();
@@ -277,8 +271,8 @@ public class ThreadDumpParser {
   }
 
   @Nullable
-  private Long getLong(final @NotNull Matcher matcher, final int group,
-    final @Nullable Long defaultValue) {
+  private Long getLong(
+      final @NotNull Matcher matcher, final int group, final @Nullable Long defaultValue) {
     final String str = matcher.group(group);
     if (str == null || str.length() == 0) {
       return defaultValue;
@@ -288,8 +282,8 @@ public class ThreadDumpParser {
   }
 
   @Nullable
-  private Integer getInteger(final @NotNull Matcher matcher, final int group,
-    final @Nullable Integer defaultValue) {
+  private Integer getInteger(
+      final @NotNull Matcher matcher, final int group, final @Nullable Integer defaultValue) {
     final String str = matcher.group(group);
     if (str == null || str.length() == 0) {
       return defaultValue;
@@ -299,8 +293,8 @@ public class ThreadDumpParser {
   }
 
   @Nullable
-  private Integer getUInteger(final @NotNull Matcher matcher, final int group,
-    final @Nullable Integer defaultValue) {
+  private Integer getUInteger(
+      final @NotNull Matcher matcher, final int group, final @Nullable Integer defaultValue) {
     final String str = matcher.group(group);
     if (str == null || str.length() == 0) {
       return defaultValue;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -8,6 +8,7 @@ import io.sentry.protocol.SentryStackFrame;
 import io.sentry.protocol.SentryStackTrace;
 import io.sentry.protocol.SentryThread;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +245,8 @@ public class ThreadDumpParser {
       }
     }
 
+    // Sentry expects frames to be in reverse order
+    Collections.reverse(frames);
     final SentryStackTrace stackTrace = new SentryStackTrace(frames);
     // it's a thread dump
     stackTrace.setSnapshot(true);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -1,73 +1,75 @@
 package io.sentry.android.core.internal.threaddump;
 
+import io.sentry.SentryLevel;
+import io.sentry.SentryLockReason;
+import io.sentry.SentryOptions;
+import io.sentry.SentryStackTraceFactory;
 import io.sentry.protocol.SentryStackFrame;
 import io.sentry.protocol.SentryStackTrace;
 import io.sentry.protocol.SentryThread;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ThreadDumpParser {
-  public static final Pattern BEGIN_UNMANAGED_THREAD_RE = Pattern.compile(
-    "\"(.*)\" sysTid=(\\d+)(.*)");
-  public static final Pattern BEGIN_MANAGED_THREAD_RE = Pattern.compile(
+  private static final Pattern BEGIN_MANAGED_THREAD_RE = Pattern.compile(
     "\"(.*)\" (.*) ?prio=(\\d+)\\s+tid=(\\d+)\\s*(.*)");
-  public static final Pattern BEGIN_NOT_ATTACHED_THREAD_RE = Pattern.compile(
-    "\"(.*)\" (.*) ?prio=(\\d+)\\s+(\\(not attached\\))");
-
-  public static final Pattern ATTR_RE = Pattern.compile(
-    "  \\| (.*)");
-  public static final Pattern HELD_MUTEXES_RE = Pattern.compile(
-    "  \\| (held mutexes=\\s*(.*))");
-  public static final Pattern NATIVE_RE = Pattern.compile(
+  private static final Pattern NATIVE_RE = Pattern.compile(
     "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s+\\((.*)\\+(\\d+)\\)");
-  public static final Pattern NATIVE_NO_LOC_RE = Pattern.compile(
+  private static final Pattern NATIVE_NO_LOC_RE = Pattern.compile(
     "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?");
-  public static final Pattern KERNEL_RE = Pattern.compile(
-    "  kernel: (.*)\\+0x([0-9a-fA-F]+)/0x([0-9a-fA-F]+)");
-  public static final Pattern KERNEL_UNKNOWN_RE = Pattern.compile(
-    "  kernel: \\(couldn't read /proc/self/task/\\d+/stack\\)");
-  public static final Pattern JAVA_RE = Pattern.compile(
+  private static final Pattern JAVA_RE = Pattern.compile(
     "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\((.*):([\\d-]+)\\)");
-  public static final Pattern JNI_RE = Pattern.compile(
+  private static final Pattern JNI_RE = Pattern.compile(
     "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\(Native method\\)");
-  public static final Pattern LOCKED_RE = Pattern.compile(
-    "  - locked \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  public static final Pattern SLEEPING_ON_RE = Pattern.compile(
-    "  - sleeping on \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  public static final Pattern WAITING_ON_RE = Pattern.compile(
-    "  - waiting on \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  public static final Pattern WAITING_TO_LOCK_RE = Pattern.compile(
-    "  - waiting to lock \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
-  public static final Pattern WAITING_TO_LOCK_HELD_RE = Pattern.compile(
-    "  - waiting to lock \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)"
+  private static final Pattern LOCKED_RE = Pattern.compile(
+    "  - locked \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern SLEEPING_ON_RE = Pattern.compile(
+    "  - sleeping on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_ON_RE = Pattern.compile(
+    "  - waiting on \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_TO_LOCK_RE = Pattern.compile(
+    "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  private static final Pattern WAITING_TO_LOCK_HELD_RE = Pattern.compile(
+    "  - waiting to lock \\<([0x0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)"
       + "(?: held by thread (\\d+))");
-  public static final Pattern WAITING_TO_LOCK_UNKNOWN_RE = Pattern.compile(
+  private static final Pattern WAITING_TO_LOCK_UNKNOWN_RE = Pattern.compile(
     "  - waiting to lock an unknown object");
-  public static final Pattern NO_MANAGED_STACK_FRAME_RE = Pattern.compile(
-    "  (\\(no managed stack frames\\))");
   private static final Pattern BLANK_RE
     = Pattern.compile("\\s+");
 
-  public static final Pattern SYS_TID_ATTR_RE = Pattern.compile(
-    "  \\| sysTid=(\\d+) .*");
-  public static final Pattern STATE_ATTR_RE = Pattern.compile(
-    "  \\| state=R .*");
+  private final @NotNull SentryOptions options;
 
-  public ThreadDumpParser() {
+  private final boolean isBackground;
+
+  private final @NotNull SentryStackTraceFactory stackTraceFactory;
+
+  public ThreadDumpParser(
+    final @NotNull SentryOptions options,
+    final boolean isBackground
+  ) {
+    this.options = options;
+    this.isBackground = isBackground;
+    this.stackTraceFactory = new SentryStackTraceFactory(options);
   }
 
   @NotNull
-  public List<SentryThread> parse(Lines<? extends Line> lines) {
-    final List<SentryThread> result = new ArrayList<>();
+  public List<SentryThread> parse(final @NotNull Lines lines) {
+    final List<SentryThread> sentryThreads = new ArrayList<>();
 
     final Matcher beginManagedThreadRe = BEGIN_MANAGED_THREAD_RE.matcher("");
 
     while (lines.hasNext()) {
       final Line line = lines.next();
+      if (line == null) {
+        options.getLogger().log(SentryLevel.WARNING, "Internal error while parsing thread dump.");
+        return sentryThreads;
+      }
       final String text = line.text;
       // we only handle managed threads, as unmanaged/not attached do not have the thread id and
       // our protocol does not support this case
@@ -76,15 +78,15 @@ public class ThreadDumpParser {
 
         final SentryThread thread = parseThread(lines);
         if (thread != null) {
-          result.add(thread);
+          sentryThreads.add(thread);
         }
       }
     }
-    return result;
+    return sentryThreads;
   }
 
-  private SentryThread parseThread(Lines<? extends Line> lines) {
-    final SentryThread result = new SentryThread();
+  private SentryThread parseThread(final @NotNull Lines lines) {
+    final SentryThread sentryThread = new SentryThread();
 
     final Matcher beginManagedThreadRe = BEGIN_MANAGED_THREAD_RE.matcher("");
 
@@ -93,39 +95,43 @@ public class ThreadDumpParser {
       return null;
     }
     final Line line = lines.next();
+    if (line == null) {
+      options.getLogger().log(SentryLevel.WARNING, "Internal error while parsing thread dump.");
+      return null;
+    }
     if (matches(beginManagedThreadRe, line.text)) {
-      Long tid = getLong(beginManagedThreadRe, 4, null);
+      final Long tid = getLong(beginManagedThreadRe, 4, null);
       if (tid == null) {
+        options.getLogger().log(SentryLevel.DEBUG, "No thread id in the dump, skipping thread.");
         // tid is required by our protocol
         return null;
       }
-      result.setId(tid);
-      result.setName(beginManagedThreadRe.group(1));
-      result.setState(beginManagedThreadRe.group(5));
-      final String threadName = result.getName();
+      sentryThread.setId(tid);
+      sentryThread.setName(beginManagedThreadRe.group(1));
+      sentryThread.setState(beginManagedThreadRe.group(5));
+      final String threadName = sentryThread.getName();
       if (threadName != null) {
         final boolean isMain = threadName.equals("main");
-        result.setMain(isMain);
-        // TODO: figure out crashed and current, most likely it's the main thread for both? Worth
-        // checking if it's a foreground ANR here, and if not we don't set these as we don't know
-        // which thread exactly triggered the ANR?
-        //result.setCrashed();
-        result.setCurrent(isMain);
+        sentryThread.setMain(isMain);
+        // since it's an ANR, the crashed thread will always be main
+        sentryThread.setCrashed(isMain);
+        sentryThread.setCurrent(isMain && !isBackground);
       }
     }
 
     // thread stacktrace
-    final SentryStackTrace stackTrace = parseStacktrace(lines);
-    if (stackTrace != null) {
-      result.setStacktrace(stackTrace);
-    }
-    return result;
+    final SentryStackTrace stackTrace = parseStacktrace(lines, sentryThread);
+    sentryThread.setStacktrace(stackTrace);
+    return sentryThread;
   }
 
-  @Nullable
-  private SentryStackTrace parseStacktrace(Lines<? extends Line> lines) {
+  @NotNull
+  private SentryStackTrace parseStacktrace(
+    final @NotNull Lines lines,
+    final @NotNull SentryThread thread
+  ) {
     final List<SentryStackFrame> frames = new ArrayList<>();
-    SentryStackFrame lastJavaFrame = null;
+    boolean isLastFrameJava = false;
 
     final Matcher nativeRe = NATIVE_RE.matcher("");
     final Matcher nativeNoLocRe = NATIVE_NO_LOC_RE.matcher("");
@@ -137,11 +143,14 @@ public class ThreadDumpParser {
     final Matcher waitingToLockHeldRe = WAITING_TO_LOCK_HELD_RE.matcher("");
     final Matcher waitingToLockRe = WAITING_TO_LOCK_RE.matcher("");
     final Matcher waitingToLockUnknownRe = WAITING_TO_LOCK_UNKNOWN_RE.matcher("");
-    final Matcher noManagedStackFrameRe = NO_MANAGED_STACK_FRAME_RE.matcher("");
     final Matcher blankRe = BLANK_RE.matcher("");
 
     while (lines.hasNext()) {
       final Line line = lines.next();
+      if (line == null) {
+        options.getLogger().log(SentryLevel.WARNING, "Internal error while parsing thread dump.");
+        break;
+      }
       final String text = line.text;
       if (matches(nativeRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
@@ -149,13 +158,13 @@ public class ThreadDumpParser {
         frame.setSymbol(nativeRe.group(2));
         frame.setLineno(getInteger(nativeRe, 3, null));
         frames.add(frame);
-        lastJavaFrame = null;
+        isLastFrameJava = false;
       } else if (matches(nativeNoLocRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         frame.setPackage(nativeNoLocRe.group(1));
         frame.setSymbol(nativeNoLocRe.group(2));
         frames.add(frame);
-        lastJavaFrame = null;
+        isLastFrameJava = false;
       } else if (matches(javaRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         final String packageName = javaRe.group(1);
@@ -165,8 +174,9 @@ public class ThreadDumpParser {
         frame.setFunction(javaRe.group(3));
         frame.setFilename(javaRe.group(4));
         frame.setLineno(getUInteger(javaRe, 5, null));
+        frame.setInApp(stackTraceFactory.isInApp(module));
         frames.add(frame);
-        lastJavaFrame = frame;
+        isLastFrameJava = true;
       } else if (matches(jniRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         final String packageName = jniRe.group(1);
@@ -174,14 +184,61 @@ public class ThreadDumpParser {
         final String module = String.format("%s.%s", packageName, className);
         frame.setModule(module);
         frame.setFunction(jniRe.group(3));
+        frame.setInApp(stackTraceFactory.isInApp(module));
         frames.add(frame);
-        lastJavaFrame = frame;
-      } else if (matches(lockedRe, text)
-        || matches(waitingOnRe, text)
-        || matches(sleepingOnRe, text)
-        || matches(waitingToLockHeldRe, text)
-        || matches(waitingToLockRe, text)
-        || matches(waitingToLockUnknownRe, text)) {
+        isLastFrameJava = true;
+      } else if (matches(lockedRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.LOCKED);
+          lock.setAddress(lockedRe.group(1));
+          lock.setPackageName(lockedRe.group(2));
+          lock.setClassName(lockedRe.group(3));
+          combineThreadLocks(thread, lock);
+        }
+      } else if (matches(waitingOnRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.WAITING);
+          lock.setAddress(waitingOnRe.group(1));
+          lock.setPackageName(waitingOnRe.group(2));
+          lock.setClassName(waitingOnRe.group(3));
+          combineThreadLocks(thread, lock);
+        }
+      } else if (matches(sleepingOnRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.SLEEPING);
+          lock.setAddress(sleepingOnRe.group(1));
+          lock.setPackageName(sleepingOnRe.group(2));
+          lock.setClassName(sleepingOnRe.group(3));
+          combineThreadLocks(thread, lock);
+        }
+      } else if (matches(waitingToLockHeldRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.BLOCKED);
+          lock.setAddress(waitingToLockHeldRe.group(1));
+          lock.setPackageName(waitingToLockHeldRe.group(2));
+          lock.setClassName(waitingToLockHeldRe.group(3));
+          lock.setThreadId(getLong(waitingToLockHeldRe, 4, null));
+          combineThreadLocks(thread, lock);
+        }
+      } else if (matches(waitingToLockRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.BLOCKED);
+          lock.setAddress(waitingToLockRe.group(1));
+          lock.setPackageName(waitingToLockRe.group(2));
+          lock.setClassName(waitingToLockRe.group(3));
+          combineThreadLocks(thread, lock);
+        }
+      } else if (matches(waitingToLockUnknownRe, text)) {
+        if (isLastFrameJava) {
+          final SentryLockReason lock = new SentryLockReason();
+          lock.setType(SentryLockReason.BLOCKED);
+          combineThreadLocks(thread, lock);
+        }
       } else if (text.length() == 0 || matches(blankRe, text)) {
         break;
       }
@@ -193,14 +250,27 @@ public class ThreadDumpParser {
     return stackTrace;
   }
 
-  @NotNull
-  private void parseAndAssignLockReason(final @NotNull SentryStackFrame lastJavaFrame) {
-    //lastJavaFrame.
-  }
-
-  private boolean matches(Matcher matcher, String text) {
+  private boolean matches(final @NotNull Matcher matcher, final @NotNull String text) {
     matcher.reset(text);
     return matcher.matches();
+  }
+
+  private void combineThreadLocks(
+    final @NotNull SentryThread thread,
+    final @NotNull SentryLockReason lockReason
+  ) {
+    Map<String, SentryLockReason> heldLocks = thread.getHeldLocks();
+    if (heldLocks == null) {
+      heldLocks = new HashMap<>();
+    }
+    final SentryLockReason prev = heldLocks.get(lockReason.getAddress());
+    if (prev != null) {
+      // higher type prevails as we are tagging thread with the most severe lock reason
+      prev.setType(Math.max(prev.getType(), lockReason.getType()));
+    } else {
+      heldLocks.put(lockReason.getAddress(), new SentryLockReason(lockReason));
+    }
+    thread.setHeldLocks(heldLocks);
   }
 
   @Nullable

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -125,7 +125,16 @@ public class ThreadDumpParser {
       }
       sentryThread.setId(tid);
       sentryThread.setName(beginManagedThreadRe.group(1));
-      sentryThread.setState(beginManagedThreadRe.group(5));
+      final String state = beginManagedThreadRe.group(5);
+      // sanitizing thread that have more details after their actual state, e.g.
+      // "Native (still starting up)" <- we just need "Native" here
+      if (state != null) {
+        if (state.contains(" ")) {
+          sentryThread.setState(state.substring(0, state.indexOf(' ')));
+        } else {
+          sentryThread.setState(state);
+        }
+      }
       final String threadName = sentryThread.getName();
       if (threadName != null) {
         final boolean isMain = threadName.equals("main");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -1,0 +1,56 @@
+package io.sentry.android.core.internal.threaddump;
+
+import java.util.regex.Pattern;
+
+public class ThreadDumpParser {
+  public static final Pattern BEGIN_UNMANAGED_THREAD_RE = Pattern.compile(
+    "\"(.*)\" sysTid=(\\d+)(.*)");
+  public static final Pattern BEGIN_MANAGED_THREAD_RE = Pattern.compile(
+    "\"(.*)\" (.*) ?prio=(\\d+)\\s+tid=(\\d+)\\s*(.*)");
+  public static final Pattern BEGIN_NOT_ATTACHED_THREAD_RE = Pattern.compile(
+    "\"(.*)\" (.*) ?prio=(\\d+)\\s+(\\(not attached\\))");
+
+  public static final Pattern ATTR_RE = Pattern.compile(
+    "  \\| (.*)");
+  public static final Pattern HELD_MUTEXES_RE = Pattern.compile(
+    "  \\| (held mutexes=\\s*(.*))");
+  public static final Pattern NATIVE_RE = Pattern.compile(
+    "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s+\\((.*)\\+(\\d+)\\)");
+  public static final Pattern NATIVE_NO_LOC_RE = Pattern.compile(
+    "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?");
+  public static final Pattern KERNEL_RE = Pattern.compile(
+    "  kernel: (.*)\\+0x([0-9a-fA-F]+)/0x([0-9a-fA-F]+)");
+  public static final Pattern KERNEL_UNKNOWN_RE = Pattern.compile(
+    "  kernel: \\(couldn't read /proc/self/task/\\d+/stack\\)");
+  public static final Pattern JAVA_RE = Pattern.compile(
+    "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\((.*):([\\d-]+)\\)");
+  public static final Pattern JNI_RE = Pattern.compile(
+    "  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\(Native method\\)");
+  public static final Pattern LOCKED_RE = Pattern.compile(
+    "  - locked \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  public static final Pattern SLEEPING_ON_RE = Pattern.compile(
+    "  - sleeping on \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  public static final Pattern WAITING_ON_RE = Pattern.compile(
+    "  - waiting on \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  public static final Pattern WAITING_TO_LOCK_RE = Pattern.compile(
+    "  - waiting to lock \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)");
+  public static final Pattern WAITING_TO_LOCK_HELD_RE = Pattern.compile(
+    "  - waiting to lock \\<0x([0-9a-fA-F]{1,16})\\> \\(a (?:(.+)\\.)?([^.]+)\\)"
+      + "(?: held by thread (\\d+))");
+  public static final Pattern WAITING_TO_LOCK_UNKNOWN_RE = Pattern.compile(
+    "  - waiting to lock an unknown object");
+  public static final Pattern NO_MANAGED_STACK_FRAME_RE = Pattern.compile(
+    "  (\\(no managed stack frames\\))");
+  private static final Pattern BLANK_RE
+    = Pattern.compile("\\s+");
+
+  public static final Pattern SYS_TID_ATTR_RE = Pattern.compile(
+    "  \\| sysTid=(\\d+) .*");
+  public static final Pattern STATE_ATTR_RE = Pattern.compile(
+    "  \\| state=R .*");
+
+  public ThreadDumpParser() {
+  }
+
+
+}

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -1,3 +1,21 @@
+/*
+ * Adapted from https://cs.android.com/android/platform/superproject/+/master:development/tools/bugreport/src/com/android/bugreport/stacks/ThreadSnapshotParser.java
+ *
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sentry.android.core.internal.threaddump;
 
 import io.sentry.SentryLevel;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -465,14 +465,19 @@ class AnrV2EventProcessorTest {
     }
 
     @Test
-    fun `does not populate exception when there is no main thread in threads`() {
+    fun `populates exception without stacktrace when there is no main thread in threads`() {
         val hint = HintUtils.createWithTypeCheckHint(AbnormalExitHint())
 
         val processed = processEvent(hint) {
             threads = listOf(SentryThread())
         }
 
-        assertNull(processed.exceptions)
+        val exception = processed.exceptions!!.first()
+        assertEquals("ANRv2", exception.mechanism!!.type)
+        assertEquals("ANR", exception.value)
+        assertEquals("ApplicationNotResponding", exception.type)
+        assertEquals("io.sentry.android.core", exception.module)
+        assertNull(exception.stacktrace)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -453,7 +453,7 @@ class AnrV2EventProcessorTest {
 
         val exception = processed.exceptions!!.first()
         assertEquals(13, exception.threadId)
-        assertEquals("ANRv2", exception.mechanism!!.type)
+        assertEquals("AppExitInfo", exception.mechanism!!.type)
         assertEquals("ANR", exception.value)
         assertEquals("ApplicationNotResponding", exception.type)
         assertEquals("io.sentry.android.core", exception.module)
@@ -473,7 +473,7 @@ class AnrV2EventProcessorTest {
         }
 
         val exception = processed.exceptions!!.first()
-        assertEquals("ANRv2", exception.mechanism!!.type)
+        assertEquals("AppExitInfo", exception.mechanism!!.type)
         assertEquals("ANR", exception.value)
         assertEquals("ApplicationNotResponding", exception.type)
         assertEquals("io.sentry.android.core", exception.module)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -432,19 +432,23 @@ class AnrV2EventProcessorTest {
     fun `populates exception from main thread`() {
         val hint = HintUtils.createWithTypeCheckHint(AbnormalExitHint())
         val stacktrace = SentryStackTrace().apply {
-            frames = listOf(SentryStackFrame().apply {
-                lineno = 777
-                module = "io.sentry.samples.MainActivity"
-                function = "run"
-            })
+            frames = listOf(
+                SentryStackFrame().apply {
+                    lineno = 777
+                    module = "io.sentry.samples.MainActivity"
+                    function = "run"
+                }
+            )
         }
 
         val processed = processEvent(hint) {
-            threads = listOf(SentryThread().apply {
-                name = "main"
-                id = 13
-                this.stacktrace = stacktrace
-            })
+            threads = listOf(
+                SentryThread().apply {
+                    name = "main"
+                    id = 13
+                    this.stacktrace = stacktrace
+                }
+            )
         }
 
         val exception = processed.exceptions!!.first()
@@ -476,10 +480,12 @@ class AnrV2EventProcessorTest {
         val hint = HintUtils.createWithTypeCheckHint(AbnormalExitHint(mechanism = "anr_background"))
 
         val processed = processEvent(hint) {
-            threads = listOf(SentryThread().apply {
-                name = "main"
-                stacktrace = SentryStackTrace()
-            })
+            threads = listOf(
+                SentryThread().apply {
+                    name = "main"
+                    stacktrace = SentryStackTrace()
+                }
+            )
         }
 
         val exception = processed.exceptions!!.first()
@@ -491,10 +497,12 @@ class AnrV2EventProcessorTest {
         val hint = HintUtils.createWithTypeCheckHint(AbnormalExitHint(mechanism = "anr_foreground"))
 
         val processed = processEvent(hint) {
-            threads = listOf(SentryThread().apply {
-                name = "main"
-                stacktrace = SentryStackTrace()
-            })
+            threads = listOf(
+                SentryThread().apply {
+                    name = "main"
+                    stacktrace = SentryStackTrace()
+                }
+            )
         }
 
         val exception = processed.exceptions!!.first()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
@@ -13,7 +13,6 @@ import io.sentry.SentryLevel
 import io.sentry.android.core.AnrV2Integration.AnrV2Hint
 import io.sentry.android.core.cache.AndroidEnvelopeCache
 import io.sentry.cache.EnvelopeCache
-import io.sentry.exception.ExceptionMechanismException
 import io.sentry.hints.DiskFlushNotification
 import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
@@ -107,7 +106,8 @@ class AnrV2IntegrationTest {
                 builder.setImportance(importance)
             }
             val exitInfo = spy(builder.build()) {
-                whenever(mock.traceInputStream).thenReturn("""
+                whenever(mock.traceInputStream).thenReturn(
+                    """
 "main" prio=5 tid=1 Blocked
   | group="main" sCount=1 ucsCount=0 flags=1 obj=0x72a985e0 self=0xb400007cabc57380
   | sysTid=28941 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8
@@ -136,7 +136,8 @@ class AnrV2IntegrationTest {
   native: #02 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
   native: #03 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
   (no managed stack frames)
-                """.trimIndent().byteInputStream())
+                    """.trimIndent().byteInputStream()
+                )
             }
             shadowActivityManager.addApplicationExitInfo(exitInfo)
         }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -1,0 +1,15 @@
+package io.sentry.android.core.internal.threaddump
+
+import java.io.File
+import kotlin.test.Test
+
+class ThreadDumpParserTest {
+
+    @Test
+    fun `test`() {
+        val lines = Lines.readLines(File("src/test/resources/thread_dump.txt"))
+        val parser = ThreadDumpParser()
+        val dump = parser.parse(lines)
+
+    }
+}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -1,15 +1,67 @@
 package io.sentry.android.core.internal.threaddump
 
+import io.sentry.SentryLockReason
+import io.sentry.SentryOptions
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ThreadDumpParserTest {
 
     @Test
-    fun `test`() {
+    fun `parses thread dump into SentryThread list`() {
         val lines = Lines.readLines(File("src/test/resources/thread_dump.txt"))
-        val parser = ThreadDumpParser()
-        val dump = parser.parse(lines)
+        val parser = ThreadDumpParser(
+            SentryOptions().apply { addInAppInclude("io.sentry.samples") },
+            false
+        )
+        val threads = parser.parse(lines)
+        // just verifying a few important threads, as there are many
+        val main = threads.find { it.name == "main" }
+        assertEquals(1, main!!.id)
+        assertEquals("Blocked", main.state)
+        assertEquals(true, main.isCrashed)
+        assertEquals(true, main.isMain)
+        assertEquals(true, main.isCurrent)
+        assertNotNull(main.heldLocks!!["0x0d3a2f0a"])
+        assertEquals(SentryLockReason.BLOCKED, main.heldLocks!!["0x0d3a2f0a"]!!.type)
+        assertEquals(5, main.heldLocks!!["0x0d3a2f0a"]!!.threadId)
+        val firstFrame = main.stacktrace!!.frames!!.first()
+        assertEquals("io.sentry.samples.android.MainActivity$2", firstFrame.module)
+        assertEquals("MainActivity.java", firstFrame.filename)
+        assertEquals("run", firstFrame.function)
+        assertEquals(177, firstFrame.lineno)
+        assertEquals(true, firstFrame.isInApp)
 
+        val blockingThread = threads.find { it.name == "Thread-9" }
+        assertEquals(5, blockingThread!!.id)
+        assertEquals("Sleeping", blockingThread.state)
+        assertEquals(false, blockingThread.isCrashed)
+        assertEquals(false, blockingThread.isMain)
+        assertNotNull(blockingThread.heldLocks!!["0x0d3a2f0a"])
+        assertEquals(SentryLockReason.LOCKED, blockingThread.heldLocks!!["0x0d3a2f0a"]!!.type)
+        assertEquals(null, blockingThread.heldLocks!!["0x0d3a2f0a"]!!.threadId)
+        assertNotNull(blockingThread.heldLocks!!["0x09228c2d"])
+        assertEquals(SentryLockReason.SLEEPING, blockingThread.heldLocks!!["0x09228c2d"]!!.type)
+        assertEquals(null, blockingThread.heldLocks!!["0x09228c2d"]!!.threadId)
+
+        val randomThread =
+            threads.find { it.name == "io.sentry.android.core.internal.util.SentryFrameMetricsCollector" }
+        assertEquals(19, randomThread!!.id)
+        assertEquals("Native", randomThread.state)
+        assertEquals(false, randomThread.isCrashed)
+        assertEquals(false, randomThread.isMain)
+        assertEquals(false, randomThread.isCurrent)
+        assertEquals(
+            "/apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)",
+            randomThread.stacktrace!!.frames!!.first().`package`
+        )
+        val lastFrame = randomThread.stacktrace!!.frames!!.last()
+        assertEquals("android.os.HandlerThread", lastFrame.module)
+        assertEquals("run", lastFrame.function)
+        assertEquals("HandlerThread.java", lastFrame.filename)
+        assertEquals(67, lastFrame.lineno)
+        assertEquals(null, lastFrame.isInApp)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -27,12 +27,12 @@ class ThreadDumpParserTest {
         assertNotNull(main.heldLocks!!["0x0d3a2f0a"])
         assertEquals(SentryLockReason.BLOCKED, main.heldLocks!!["0x0d3a2f0a"]!!.type)
         assertEquals(5, main.heldLocks!!["0x0d3a2f0a"]!!.threadId)
-        val firstFrame = main.stacktrace!!.frames!!.first()
-        assertEquals("io.sentry.samples.android.MainActivity$2", firstFrame.module)
-        assertEquals("MainActivity.java", firstFrame.filename)
-        assertEquals("run", firstFrame.function)
-        assertEquals(177, firstFrame.lineno)
-        assertEquals(true, firstFrame.isInApp)
+        val lastFrame = main.stacktrace!!.frames!!.last()
+        assertEquals("io.sentry.samples.android.MainActivity$2", lastFrame.module)
+        assertEquals("MainActivity.java", lastFrame.filename)
+        assertEquals("run", lastFrame.function)
+        assertEquals(177, lastFrame.lineno)
+        assertEquals(true, lastFrame.isInApp)
 
         val blockingThread = threads.find { it.name == "Thread-9" }
         assertEquals(5, blockingThread!!.id)
@@ -55,13 +55,13 @@ class ThreadDumpParserTest {
         assertEquals(false, randomThread.isCurrent)
         assertEquals(
             "/apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)",
-            randomThread.stacktrace!!.frames!!.first().`package`
+            randomThread.stacktrace!!.frames!!.last().`package`
         )
-        val lastFrame = randomThread.stacktrace!!.frames!!.last()
-        assertEquals("android.os.HandlerThread", lastFrame.module)
-        assertEquals("run", lastFrame.function)
-        assertEquals("HandlerThread.java", lastFrame.filename)
-        assertEquals(67, lastFrame.lineno)
-        assertEquals(null, lastFrame.isInApp)
+        val firstFrame = randomThread.stacktrace!!.frames!!.first()
+        assertEquals("android.os.HandlerThread", firstFrame.module)
+        assertEquals("run", firstFrame.function)
+        assertEquals("HandlerThread.java", firstFrame.filename)
+        assertEquals(67, firstFrame.lineno)
+        assertEquals(null, firstFrame.isInApp)
     }
 }

--- a/sentry-android-core/src/test/resources/thread_dump.txt
+++ b/sentry-android-core/src/test/resources/thread_dump.txt
@@ -1,0 +1,660 @@
+
+----- pid 28941 at 2023-04-04 22:06:31.064728684+0200 -----
+Cmd line: io.sentry.samples.android
+Build fingerprint: 'google/sdk_gphone64_arm64/emu64a:13/TE1A.220922.012/9302419:userdebug/dev-keys'
+ABI: 'arm64'
+Build type: optimized
+Zygote loaded classes=21575 post zygote classes=2000
+Dumping registered class loaders
+#0 dalvik.system.PathClassLoader: [], parent #1
+#1 java.lang.BootClassLoader: [], no parent
+#2 dalvik.system.PathClassLoader: [/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes20.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes18.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes17.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes9.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes7.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes11.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes13.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes12.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes8.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes15.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes10.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes16.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes19.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes21.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes14.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes3.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes2.dex:/data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/base.apk!classes4.dex], parent #1
+Done dumping class loaders
+Classes initialized: 0 in 0
+Intern table: 31377 strong; 1217 weak
+JNI: CheckJNI is on; globals=412 (plus 73 weak)
+Libraries: /data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/lib/arm64/libsentry-android.so /data/app/~~YQzOOq5EdbRpDSLuP4W5bg==/io.sentry.samples.android-rf1QICG-91naFlmtGfmOTQ==/lib/arm64/libsentry.so /system/lib64/liblog.so libandroid.so libaudioeffect_jni.so libcompiler_rt.so libframework-connectivity-jni.so libframework-connectivity-tiramisu-jni.so libicu_jni.so libjavacore.so libjavacrypto.so libjnigraphics.so libmedia_jni.so libopenjdk.so librs_jni.so librtp_jni.so libsoundpool.so libstats_jni.so libwebviewchromium_loader.so (19)
+Heap: 40% free, 4484KB/7592KB; 169353 objects
+Dumping cumulative Gc timings
+Start Dumping Averages for 1 iterations for concurrent copying
+SweepSystemWeaks:	Sum: 5.115ms Avg: 5.115ms
+Process mark stacks and References:	Sum: 1.689ms Avg: 1.689ms
+VisitConcurrentRoots:	Sum: 1.549ms Avg: 1.549ms
+MarkingPhase:	Sum: 1.212ms Avg: 1.212ms
+ScanImmuneSpaces:	Sum: 913us Avg: 913us
+GrayAllDirtyImmuneObjects:	Sum: 500us Avg: 500us
+ClearFromSpace:	Sum: 245us Avg: 245us
+SweepLargeObjects:	Sum: 113us Avg: 113us
+CaptureThreadRootsForMarking:	Sum: 96us Avg: 96us
+EnqueueFinalizerReferences:	Sum: 94us Avg: 94us
+ScanCardsForSpace:	Sum: 69us Avg: 69us
+FlipOtherThreads:	Sum: 33us Avg: 33us
+ForwardSoftReferences:	Sum: 30us Avg: 30us
+InitializePhase:	Sum: 28us Avg: 28us
+ResumeRunnableThreads:	Sum: 19us Avg: 19us
+VisitNonThreadRoots:	Sum: 17us Avg: 17us
+MarkStackAsLive:	Sum: 15us Avg: 15us
+RecordFree:	Sum: 13us Avg: 13us
+MarkZygoteLargeObjects:	Sum: 10us Avg: 10us
+SweepAllocSpace:	Sum: 10us Avg: 10us
+ProcessReferences:	Sum: 10us Avg: 10us
+(Paused)GrayAllNewlyDirtyImmuneObjects:	Sum: 9us Avg: 9us
+SwapBitmaps:	Sum: 7us Avg: 7us
+EmptyRBMarkBitStack:	Sum: 4us Avg: 4us
+CopyingPhase:	Sum: 2us Avg: 2us
+ThreadListFlip:	Sum: 2us Avg: 2us
+(Paused)ClearCards:	Sum: 2us Avg: 2us
+ReclaimPhase:	Sum: 1us Avg: 1us
+(Paused)FlipCallback:	Sum: 0 Avg: 0
+UnBindBitmaps:	Sum: 0 Avg: 0
+ResumeOtherThreads:	Sum: 0 Avg: 0
+FlipThreadRoots:	Sum: 0 Avg: 0
+Sweep:	Sum: 0 Avg: 0
+(Paused)SetFromSpace:	Sum: 0 Avg: 0
+Done Dumping Averages
+concurrent copying paused:	Sum: 20us 99% C.I. 5us-15us Avg: 10us Max: 15us
+concurrent copying freed-bytes: Avg: 7364KB Max: 7364KB Min: 7364KB
+Freed-bytes histogram: 7040:1
+concurrent copying total time: 11.807ms mean time: 11.807ms
+concurrent copying freed: 53426 objects with total size 7364KB
+concurrent copying throughput: 4.85691e+06/s / 653MB/s  per cpu-time: 1077389714/s / 1027MB/s
+concurrent copying tracing throughput: 198MB/s  per cpu-time: 312MB/s
+Average major GC reclaim bytes ratio 1.11802 over 1 GC cycles
+Average major GC copied live bytes ratio 0.725846 over 5 major GCs
+Cumulative bytes moved 30421320
+Cumulative objects moved 534294
+Peak regions allocated 50 (12MB) / 768 (192MB)
+Total madvise time 1.829ms
+Average minor GC reclaim bytes ratio inf over 0 GC cycles
+Average minor GC copied live bytes ratio 0.28859 over 2 minor GCs
+Cumulative bytes moved 3695344
+Cumulative objects moved 89281
+Peak regions allocated 50 (12MB) / 768 (192MB)
+Total time spent in GC: 11.807ms
+Mean GC size throughput: 609MB/s per cpu-time: 937MB/s
+Mean GC object throughput: 4.52494e+06 objects/s
+Total number of allocations 222779
+Total bytes allocated 11MB
+Total bytes freed 7364KB
+Free memory 3107KB
+Free memory until GC 3107KB
+Free memory until OOME 187MB
+Total memory 7592KB
+Max memory 192MB
+Zygote space size 7744KB
+Total mutator paused time: 20us
+Total time waiting for GC to complete: 8.054ms
+Total GC count: 1
+Total GC time: 11.807ms
+Total blocking GC count: 1
+Total blocking GC time: 11.873ms
+Total pre-OOME GC count: 0
+Histogram of GC count per 10000 ms: 0:1
+Histogram of blocking GC count per 10000 ms: 0:1
+Native bytes total: 18678627 registered: 635795
+Total native bytes at last GC: 21677907
+/system/framework/oat/arm64/android.hidl.manager-V1.0-java.odex: verify
+/system/framework/oat/arm64/android.hidl.base-V1.0-java.odex: verify
+/system/framework/oat/arm64/android.test.base.odex: verify
+Current JIT code cache size (used / resident): 59KB / 64KB
+Current JIT data cache size (used / resident): 47KB / 52KB
+Zygote JIT code cache size (at point of fork): 19KB / 32KB
+Zygote JIT data cache size (at point of fork): 14KB / 32KB
+Current JIT mini-debug-info size: 32KB
+Current JIT capacity: 128KB
+Current number of JIT JNI stub entries: 0
+Current number of JIT code cache entries: 44
+Total number of JIT baseline compilations: 31
+Total number of JIT optimized compilations: 1
+Total number of JIT compilations for on stack replacement: 0
+Total number of JIT code cache collections: 1
+Memory used for stack maps: Avg: 533B Max: 2728B Min: 32B
+Memory used for compiled code: Avg: 2014B Max: 7140B Min: 196B
+Memory used for profiling info: Avg: 371B Max: 1296B Min: 24B
+Start Dumping Averages for 47 iterations for JIT timings
+Compiling optimized:	Sum: 66.471ms Avg: 1.414ms
+Code cache collection:	Sum: 21.797ms Avg: 463.765us
+Compiling baseline:	Sum: 14.750ms Avg: 313.829us
+TrimMaps:	Sum: 717us Avg: 15.255us
+Done Dumping Averages
+Memory used for compilation: Avg: 156KB Max: 1693KB Min: 16KB
+ProfileSaver total_bytes_written=0
+ProfileSaver total_number_of_writes=0
+ProfileSaver total_number_of_code_cache_queries=0
+ProfileSaver total_number_of_skipped_writes=0
+ProfileSaver total_number_of_failed_writes=0
+ProfileSaver total_ms_of_sleep=5000
+ProfileSaver total_ms_of_work=0
+ProfileSaver total_number_of_hot_spikes=0
+ProfileSaver total_number_of_wake_ups=0
+
+*** ART internal metrics ***
+  Metadata:
+    timestamp_since_start_ms: 18063
+  Metrics:
+    ClassLoadingTotalTime: count = 26287
+    ClassVerificationTotalTime: count = 99135
+    ClassVerificationCount: count = 1044
+    WorldStopTimeDuringGCAvg: count = 21
+    YoungGcCount: count = 0
+    FullGcCount: count = 1
+    TotalBytesAllocated: count = 10151688
+    TotalGcCollectionTime: count = 11
+    YoungGcThroughputAvg: count = 0
+    FullGcThroughputAvg: count = 393
+    YoungGcTracingThroughputAvg: count = 0
+    FullGcTracingThroughputAvg: count = 184
+    JitMethodCompileTotalTime: count = 70979
+    JitMethodCompileCount: count = 32
+    YoungGcCollectionTime: range = 0...60000, buckets: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    FullGcCollectionTime: range = 0...60000, buckets: 1,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    YoungGcThroughput: range = 0...10000, buckets: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    FullGcThroughput: range = 0...10000, buckets: 1,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    YoungGcTracingThroughput: range = 0...10000, buckets: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    FullGcTracingThroughput: range = 0...10000, buckets: 1,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    GcWorldStopTime: count = 21
+    GcWorldStopCount: count = 1
+    YoungGcScannedBytes: count = 0
+    YoungGcFreedBytes: count = 0
+    YoungGcDuration: count = 0
+    FullGcScannedBytes: count = 2293021
+    FullGcFreedBytes: count = 4957152
+    FullGcDuration: count = 11
+*** Done dumping ART internal metrics ***
+
+suspend all histogram:	Sum: 3.220ms 99% C.I. 0.161us-58.527us Avg: 5.639us Max: 1225us
+DALVIK THREADS (29):
+"Signal Catcher" daemon prio=10 tid=6 Runnable
+  | group="system" sCount=0 ucsCount=0 flags=0 obj=0x136c0248 self=0xb400007cabc689a0
+  | sysTid=28957 nice=-20 cgrp=top-app sched=0/0 handle=0x7b21319cb0
+  | state=R schedstat=( 6825503 402209 26 ) utm=0 stm=0 core=0 HZ=100
+  | stack=0x7b21222000-0x7b21224000 stackSize=991KB
+  | held mutexes= "mutator lock"(shared held)
+  native: #00 pc 000000000053a6e0  /apex/com.android.art/lib64/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, BacktraceMap*, char const*, art::ArtMethod*, void*, bool)+128) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #01 pc 00000000006f0e84  /apex/com.android.art/lib64/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool, BacktraceMap*, bool) const+236) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #02 pc 00000000006fe710  /apex/com.android.art/lib64/libart.so (art::DumpCheckpoint::Run(art::Thread*)+208) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #03 pc 0000000000364248  /apex/com.android.art/lib64/libart.so (art::ThreadList::RunCheckpoint(art::Closure*, art::Closure*)+440) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #04 pc 00000000006fceb0  /apex/com.android.art/lib64/libart.so (art::ThreadList::Dump(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, bool)+280) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #05 pc 00000000006fc8a4  /apex/com.android.art/lib64/libart.so (art::ThreadList::DumpForSigQuit(std::__1::basic_ostream<char, std::__1::char_traits<char> >&)+292) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #06 pc 00000000006d5974  /apex/com.android.art/lib64/libart.so (art::Runtime::DumpForSigQuit(std::__1::basic_ostream<char, std::__1::char_traits<char> >&)+184) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #07 pc 00000000006e1a20  /apex/com.android.art/lib64/libart.so (art::SignalCatcher::HandleSigQuit()+468) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #08 pc 0000000000574230  /apex/com.android.art/lib64/libart.so (art::SignalCatcher::Run(void*)+264) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #09 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #10 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"main" prio=5 tid=1 Blocked
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x72a985e0 self=0xb400007cabc57380
+  | sysTid=28941 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8
+  | state=S schedstat=( 324804784 183300334 997 ) utm=23 stm=8 core=3 HZ=100
+  | stack=0x7ff93a9000-0x7ff93ab000 stackSize=8188KB
+  | held mutexes=
+  at io.sentry.samples.android.MainActivity$2.run(MainActivity.java:177)
+  - waiting to lock <0x0d3a2f0a> (a java.lang.Object) held by thread 5
+  at android.os.Handler.handleCallback(Handler.java:942)
+  at android.os.Handler.dispatchMessage(Handler.java:99)
+  at android.os.Looper.loopOnce(Looper.java:201)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.app.ActivityThread.main(ActivityThread.java:7872)
+  at java.lang.reflect.Method.invoke(Native method)
+  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
+  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
+
+"perfetto_hprof_listener" prio=10 tid=7 Native (still starting up)
+  | group="" sCount=1 ucsCount=0 flags=1 obj=0x0 self=0xb400007cabc5ab20
+  | sysTid=28959 nice=-20 cgrp=top-app sched=0/0 handle=0x7b2021bcb0
+  | state=S schedstat=( 72750 1679167 1 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7b20124000-0x7b20126000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a20f4  /apex/com.android.runtime/lib64/bionic/libc.so (read+4) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000001d840  /apex/com.android.art/lib64/libperfetto_hprof.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ArtPlugin_Initialize::$_34> >(void*)+260) (BuildId: 525cc92a7dc49130157aeb74f6870364)
+  native: #02 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #03 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"ADB-JDWP Connection Control Thread" daemon prio=0 tid=8 WaitingInMainDebuggerLoop
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c02c0 self=0xb400007cabc5c6f0
+  | sysTid=28960 nice=-20 cgrp=top-app sched=0/0 handle=0x7b2011dcb0
+  | state=S schedstat=( 1003335 1331749 27 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7b20026000-0x7b20028000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a34b8  /apex/com.android.runtime/lib64/bionic/libc.so (__ppoll+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000005dc1c  /apex/com.android.runtime/lib64/bionic/libc.so (poll+92) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 00000000000099e4  /apex/com.android.art/lib64/libadbconnection.so (adbconnection::AdbConnectionState::RunPollLoop(art::Thread*)+724) (BuildId: 3952e992b55a158a16b3d569cf8894e7)
+  native: #03 pc 00000000000080ac  /apex/com.android.art/lib64/libadbconnection.so (adbconnection::CallbackFunction(void*)+1320) (BuildId: 3952e992b55a158a16b3d569cf8894e7)
+  native: #04 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #05 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"HeapTaskDaemon" daemon prio=5 tid=9 WaitingForTaskProcessor
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c1690 self=0xb400007cabc80f00
+  | sysTid=28962 nice=4 cgrp=top-app sched=0/0 handle=0x7ad35e8cb0
+  | state=S schedstat=( 9212958 1006583 26 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7ad34e5000-0x7ad34e7000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 000000000004df60  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000048771c  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::TimedWait(art::Thread*, long, int)+252) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #02 pc 000000000046cf20  /apex/com.android.art/lib64/libart.so (art::gc::TaskProcessor::GetTask(art::Thread*)+196) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #03 pc 000000000046ce10  /apex/com.android.art/lib64/libart.so (art::gc::TaskProcessor::RunAllTasks(art::Thread*)+32) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  at dalvik.system.VMRuntime.runHeapTasks(Native method)
+  at java.lang.Daemons$HeapTaskDaemon.runInternal(Daemons.java:609)
+  at java.lang.Daemons$Daemon.run(Daemons.java:140)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"FinalizerDaemon" daemon prio=5 tid=10 Waiting
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c0338 self=0xb400007cabc7f330
+  | sysTid=28964 nice=4 cgrp=top-app sched=0/0 handle=0x7ad33d4cb0
+  | state=S schedstat=( 1727043 1091459 22 ) utm=0 stm=0 core=0 HZ=100
+  | stack=0x7ad32d1000-0x7ad32d3000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Object.wait(Native method)
+  - waiting on <0x07d7437b> (a java.lang.Object)
+  at java.lang.Object.wait(Object.java:442)
+  at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:203)
+  - locked <0x07d7437b> (a java.lang.Object)
+  at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:224)
+  at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:300)
+  at java.lang.Daemons$Daemon.run(Daemons.java:140)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"FinalizerWatchdogDaemon" daemon prio=5 tid=11 Sleeping
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c03b0 self=0xb400007cabc7bb90
+  | sysTid=28965 nice=4 cgrp=top-app sched=0/0 handle=0x7ad32cacb0
+  | state=S schedstat=( 176667 969916 4 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7ad31c7000-0x7ad31c9000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Thread.sleep(Native method)
+  - sleeping on <0x09596598> (a java.lang.Object)
+  at java.lang.Thread.sleep(Thread.java:450)
+  - locked <0x09596598> (a java.lang.Object)
+  at java.lang.Thread.sleep(Thread.java:355)
+  at java.lang.Daemons$FinalizerWatchdogDaemon.sleepForNanos(Daemons.java:438)
+  at java.lang.Daemons$FinalizerWatchdogDaemon.waitForProgress(Daemons.java:480)
+  at java.lang.Daemons$FinalizerWatchdogDaemon.runInternal(Daemons.java:369)
+  at java.lang.Daemons$Daemon.run(Daemons.java:140)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"ReferenceQueueDaemon" daemon prio=5 tid=12 Waiting
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c0428 self=0xb400007cabc7d760
+  | sysTid=28963 nice=4 cgrp=top-app sched=0/0 handle=0x7ad34decb0
+  | state=S schedstat=( 437749 1043042 4 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ad33db000-0x7ad33dd000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Object.wait(Native method)
+  - waiting on <0x0394c1f1> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
+  at java.lang.Object.wait(Object.java:442)
+  at java.lang.Object.wait(Object.java:568)
+  at java.lang.Daemons$ReferenceQueueDaemon.runInternal(Daemons.java:232)
+  - locked <0x0394c1f1> (a java.lang.Class<java.lang.ref.ReferenceQueue>)
+  at java.lang.Daemons$Daemon.run(Daemons.java:140)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"Jit thread pool worker thread 0" daemon prio=5 tid=13 Native
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c04a0 self=0xb400007cabc87e40
+  | sysTid=28961 nice=9 cgrp=top-app sched=0/0 handle=0x7ad36eecb0
+  | state=S schedstat=( 17155174 12570536 78 ) utm=1 stm=0 core=3 HZ=100
+  | stack=0x7ad35ef000-0x7ad35f1000 stackSize=1023KB
+  | held mutexes=
+  native: #00 pc 000000000004df5c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000047cc80  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::WaitHoldingLocks(art::Thread*)+140) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #02 pc 000000000047cb18  /apex/com.android.art/lib64/libart.so (art::ThreadPool::GetTask(art::Thread*)+120) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #03 pc 00000000006199e4  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Run()+136) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #04 pc 00000000006198c4  /apex/com.android.art/lib64/libart.so (art::ThreadPoolWorker::Callback(void*)+160) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #05 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #06 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"binder:28941_1" prio=5 tid=14 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0518 self=0xb400007cabc82ad0
+  | sysTid=28966 nice=0 cgrp=top-app sched=0/0 handle=0x7ace0a9cb0
+  | state=S schedstat=( 574039 4838087 11 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7acdfb2000-0x7acdfb4000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a23d8  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000005b50c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 0000000000094690  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+316) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #03 pc 0000000000094540  /system/lib64/libbinder.so (android::PoolThread::threadLoop()+24) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #04 pc 00000000000148e8  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+528) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #05 pc 00000000000c8918  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+140) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  native: #06 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #07 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"binder:28941_2" prio=5 tid=15 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0590 self=0xb400007cabc86270
+  | sysTid=28967 nice=0 cgrp=top-app sched=0/0 handle=0x7accfabcb0
+  | state=S schedstat=( 4159627 3435666 30 ) utm=0 stm=0 core=2 HZ=100
+  | stack=0x7acceb4000-0x7acceb6000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a23d8  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000005b50c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 0000000000094690  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+316) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #03 pc 0000000000094540  /system/lib64/libbinder.so (android::PoolThread::threadLoop()+24) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #04 pc 00000000000148e8  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+528) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #05 pc 00000000000c8918  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+140) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  native: #06 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #07 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"binder:28941_3" prio=5 tid=16 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0608 self=0xb400007cabc846a0
+  | sysTid=28975 nice=0 cgrp=top-app sched=0/0 handle=0x7acbeadcb0
+  | state=S schedstat=( 2250710 7051668 27 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7acbdb6000-0x7acbdb8000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a23d8  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000005b50c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 0000000000094690  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+316) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #03 pc 0000000000094540  /system/lib64/libbinder.so (android::PoolThread::threadLoop()+24) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #04 pc 00000000000148e8  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+528) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #05 pc 00000000000c8918  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+140) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  native: #06 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #07 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"Profile Saver" daemon prio=5 tid=17 Native
+  | group="system" sCount=1 ucsCount=0 flags=1 obj=0x136c0680 self=0xb400007cabc89a10
+  | sysTid=28980 nice=9 cgrp=top-app sched=0/0 handle=0x7ac9a80cb0
+  | state=S schedstat=( 6243002 407667 10 ) utm=0 stm=0 core=2 HZ=100
+  | stack=0x7ac9989000-0x7ac998b000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 000000000004df5c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000047cc80  /apex/com.android.art/lib64/libart.so (art::ConditionVariable::WaitHoldingLocks(art::Thread*)+140) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #02 pc 0000000000543774  /apex/com.android.art/lib64/libart.so (art::ProfileSaver::Run()+372) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #03 pc 0000000000538fc0  /apex/com.android.art/lib64/libart.so (art::ProfileSaver::RunProfileSaverThread(void*)+148) (BuildId: e24a1818231cfb1649cb83a5d2869598)
+  native: #04 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #05 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"io.sentry.android.core.internal.util.SentryFrameMetricsCollector" prio=5 tid=19 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c06f8 self=0xb400007cabc8b5e0
+  | sysTid=28991 nice=0 cgrp=top-app sched=0/0 handle=0x7ac74d0cb0
+  | state=S schedstat=( 6494997 2246873 96 ) utm=0 stm=0 core=0 HZ=100
+  | stack=0x7ac73cd000-0x7ac73cf000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 00000000000a33b8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000010dfc  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+176) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #02 pc 000000000015a56c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce(_JNIEnv*, _jobject*, long, int)+44) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  at android.os.MessageQueue.nativePollOnce(Native method)
+  at android.os.MessageQueue.next(MessageQueue.java:335)
+  at android.os.Looper.loopOnce(Looper.java:161)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.os.HandlerThread.run(HandlerThread.java:67)
+
+"pool-2-thread-1" prio=5 tid=20 TimedWaiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0818 self=0xb400007cabc95cc0
+  | sysTid=28993 nice=0 cgrp=top-app sched=0/0 handle=0x7ac63a6cb0
+  | state=S schedstat=( 51027282 10362044 134 ) utm=2 stm=2 core=2 HZ=100
+  | stack=0x7ac62a3000-0x7ac62a5000 stackSize=1039KB
+  | held mutexes=
+  at jdk.internal.misc.Unsafe.park(Native method)
+  - waiting on an unknown object
+  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
+  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2123)
+  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1188)
+  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:905)
+  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1063)
+  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1123)
+  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"SentryAsyncConnection-0" daemon prio=5 tid=18 Waiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0970 self=0xb400007cabc8d1b0
+  | sysTid=28994 nice=0 cgrp=top-app sched=0/0 handle=0x7ac857acb0
+  | state=S schedstat=( 48202960 58606620 247 ) utm=4 stm=0 core=1 HZ=100
+  | stack=0x7ac8477000-0x7ac8479000 stackSize=1039KB
+  | held mutexes=
+  at jdk.internal.misc.Unsafe.park(Native method)
+  - waiting on an unknown object
+  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
+  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)
+  at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:433)
+  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1063)
+  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1123)
+  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"FileObserver" prio=5 tid=21 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0ae8 self=0xb400007cabc92520
+  | sysTid=28995 nice=0 cgrp=top-app sched=0/0 handle=0x7ac8450cb0
+  | state=S schedstat=( 147291 1694959 5 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7ac834d000-0x7ac834f000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 00000000000a20f4  /apex/com.android.runtime/lib64/bionic/libc.so (read+4) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 00000000001b0fe4  /system/lib64/libandroid_runtime.so (android::android_os_fileobserver_observe(_JNIEnv*, _jobject*, int)+164) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  at android.os.FileObserver$ObserverThread.observe(Native method)
+  at android.os.FileObserver$ObserverThread.run(FileObserver.java:116)
+
+"Timer-0" daemon prio=5 tid=22 Waiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0b68 self=0xb400007cabc940f0
+  | sysTid=28996 nice=0 cgrp=top-app sched=0/0 handle=0x7ac8346cb0
+  | state=S schedstat=( 32541 2753958 2 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac8243000-0x7ac8245000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Object.wait(Native method)
+  - waiting on <0x0ad431d6> (a java.util.TaskQueue)
+  at java.lang.Object.wait(Object.java:442)
+  at java.lang.Object.wait(Object.java:568)
+  at java.util.TimerThread.mainLoop(Timer.java:534)
+  - locked <0x0ad431d6> (a java.util.TaskQueue)
+  at java.util.TimerThread.run(Timer.java:513)
+
+"ConnectivityThread" prio=5 tid=23 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0bf0 self=0xb400007cabc90950
+  | sysTid=28997 nice=0 cgrp=top-app sched=0/0 handle=0x7ac823ccb0
+  | state=S schedstat=( 4569546 2179707 44 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac8139000-0x7ac813b000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 00000000000a33b8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000010dfc  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+176) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #02 pc 000000000015a56c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce(_JNIEnv*, _jobject*, long, int)+44) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  at android.os.MessageQueue.nativePollOnce(Native method)
+  at android.os.MessageQueue.next(MessageQueue.java:335)
+  at android.os.Looper.loopOnce(Looper.java:161)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.os.HandlerThread.run(HandlerThread.java:67)
+
+"LeakCanary-Heap-Dump" prio=5 tid=24 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0d10 self=0xb400007cabc8ed80
+  | sysTid=29000 nice=0 cgrp=top-app sched=0/0 handle=0x7ac80d2cb0
+  | state=S schedstat=( 10523711 3945164 46 ) utm=0 stm=0 core=2 HZ=100
+  | stack=0x7ac7fcf000-0x7ac7fd1000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 00000000000a33b8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000010dfc  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+176) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #02 pc 000000000015a56c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce(_JNIEnv*, _jobject*, long, int)+44) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  at android.os.MessageQueue.nativePollOnce(Native method)
+  at android.os.MessageQueue.next(MessageQueue.java:335)
+  at android.os.Looper.loopOnce(Looper.java:161)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.os.HandlerThread.run(HandlerThread.java:67)
+
+"plumber-android-leaks" prio=5 tid=25 TimedWaiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0e30 self=0xb400007cabc99460
+  | sysTid=29001 nice=10 cgrp=top-app sched=0/0 handle=0x7ac7fc8cb0
+  | state=S schedstat=( 3488459 357249 18 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac7ec5000-0x7ac7ec7000 stackSize=1039KB
+  | held mutexes=
+  at jdk.internal.misc.Unsafe.park(Native method)
+  - waiting on an unknown object
+  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
+  at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2123)
+  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1188)
+  at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:905)
+  at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1063)
+  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1123)
+  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
+  at leakcanary.AndroidLeakFixes$Companion$backgroundExecutor$1$thread$1.run(AndroidLeakFixes.kt:728)
+
+"RenderThread" daemon prio=7 tid=26 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0f88 self=0xb400007cabc97890
+  | sysTid=29004 nice=-10 cgrp=top-app sched=0/0 handle=0x7ac7ebecb0
+  | state=S schedstat=( 160761573 37179129 468 ) utm=4 stm=11 core=1 HZ=100
+  | stack=0x7ac7dc7000-0x7ac7dc9000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a33b8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000010dfc  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+176) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #02 pc 000000000057c4c0  /system/lib64/libhwui.so (android::uirenderer::renderthread::RenderThread::threadLoop()+220) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #03 pc 00000000000148e8  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+528) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #04 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #05 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"OkHttp ConnectionPool" daemon prio=5 tid=29 TimedWaiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c1000 self=0xb400007cabca03a0
+  | sysTid=29010 nice=0 cgrp=top-app sched=0/0 handle=0x7ac7905cb0
+  | state=S schedstat=( 198166 0 1 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac7802000-0x7ac7804000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Object.wait(Native method)
+  - waiting on <0x050c9c57> (a com.android.okhttp.ConnectionPool)
+  at com.android.okhttp.ConnectionPool$1.run(ConnectionPool.java:106)
+  - locked <0x050c9c57> (a com.android.okhttp.ConnectionPool)
+  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
+  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"FrameMetricsAggregator" prio=5 tid=30 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c1128 self=0xb400007cabca1f70
+  | sysTid=29011 nice=0 cgrp=top-app sched=0/0 handle=0x7ac77fbcb0
+  | state=S schedstat=( 7302250 10493628 107 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac76f8000-0x7ac76fa000 stackSize=1039KB
+  | held mutexes=
+  native: #00 pc 00000000000a33b8  /apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000010dfc  /system/lib64/libutils.so (android::Looper::pollOnce(int, int*, int*, void**)+176) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #02 pc 000000000015a56c  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce(_JNIEnv*, _jobject*, long, int)+44) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  at android.os.MessageQueue.nativePollOnce(Native method)
+  at android.os.MessageQueue.next(MessageQueue.java:335)
+  at android.os.Looper.loopOnce(Looper.java:161)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.os.HandlerThread.run(HandlerThread.java:67)
+
+"hwuiTask0" daemon prio=6 tid=31 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c1248 self=0xb400007cabca3b40
+  | sysTid=29026 nice=-2 cgrp=top-app sched=0/0 handle=0x7ac75f3cb0
+  | state=S schedstat=( 148373 0 2 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7ac74fc000-0x7ac74fe000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 000000000004df5c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000052664  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+144) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 00000000000b56cc  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+76) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #03 pc 00000000000699e0  /system/lib64/libc++.so (std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)+20) (BuildId: 6ae0290e5bfb8abb216bde2a4ee48d9e)
+  native: #04 pc 0000000000250af8  /system/lib64/libhwui.so (android::uirenderer::CommonPool::workerLoop()+96) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #05 pc 0000000000250d5c  /system/lib64/libhwui.so (android::uirenderer::CommonPool::CommonPool()::$_0::operator()() const (.__uniq.99815402873434996937524029735804459536)+188) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #06 pc 0000000000250c9c  /system/lib64/libhwui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, android::uirenderer::CommonPool::CommonPool()::$_0> >(void*) (.__uniq.99815402873434996937524029735804459536)+40) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #07 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #08 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"hwuiTask1" daemon prio=6 tid=32 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c12c0 self=0xb400007cabcb19c0
+  | sysTid=29027 nice=-2 cgrp=top-app sched=0/0 handle=0x7ab7b63cb0
+  | state=S schedstat=( 112416 0 2 ) utm=0 stm=0 core=0 HZ=100
+  | stack=0x7ab7a6c000-0x7ab7a6e000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 000000000004df5c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000052664  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+144) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 00000000000b56cc  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+76) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #03 pc 00000000000699e0  /system/lib64/libc++.so (std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)+20) (BuildId: 6ae0290e5bfb8abb216bde2a4ee48d9e)
+  native: #04 pc 0000000000250af8  /system/lib64/libhwui.so (android::uirenderer::CommonPool::workerLoop()+96) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #05 pc 0000000000250d5c  /system/lib64/libhwui.so (android::uirenderer::CommonPool::CommonPool()::$_0::operator()() const (.__uniq.99815402873434996937524029735804459536)+188) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #06 pc 0000000000250c9c  /system/lib64/libhwui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, android::uirenderer::CommonPool::CommonPool()::$_0> >(void*) (.__uniq.99815402873434996937524029735804459536)+40) (BuildId: 5e787210ce0f171dbee073e4a14a376c)
+  native: #07 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #08 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"Okio Watchdog" daemon prio=5 tid=33 Waiting
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c1338 self=0xb400007cabcb6d30
+  | sysTid=29029 nice=0 cgrp=top-app sched=0/0 handle=0x7ab7967cb0
+  | state=S schedstat=( 231164 396334 6 ) utm=0 stm=0 core=0 HZ=100
+  | stack=0x7ab7864000-0x7ab7866000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Object.wait(Native method)
+  - waiting on <0x004b4344> (a java.lang.Class<com.android.okhttp.okio.AsyncTimeout>)
+  at java.lang.Object.wait(Object.java:442)
+  at java.lang.Object.wait(Object.java:568)
+  at com.android.okhttp.okio.AsyncTimeout.awaitTimeout(AsyncTimeout.java:313)
+  - locked <0x004b4344> (a java.lang.Class<com.android.okhttp.okio.AsyncTimeout>)
+  at com.android.okhttp.okio.AsyncTimeout.access$000(AsyncTimeout.java:42)
+  at com.android.okhttp.okio.AsyncTimeout$Watchdog.run(AsyncTimeout.java:288)
+
+"binder:28941_4" prio=5 tid=35 Native
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c13b0 self=0xb400007cabcb8900
+  | sysTid=29039 nice=0 cgrp=top-app sched=0/0 handle=0x7ab06b5cb0
+  | state=S schedstat=( 11108162 4295500 140 ) utm=1 stm=0 core=2 HZ=100
+  | stack=0x7ab05be000-0x7ab05c0000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a23d8  /apex/com.android.runtime/lib64/bionic/libc.so (__ioctl+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000005b50c  /apex/com.android.runtime/lib64/bionic/libc.so (ioctl+156) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 0000000000094690  /system/lib64/libbinder.so (android::IPCThreadState::joinThreadPool(bool)+316) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #03 pc 0000000000094540  /system/lib64/libbinder.so (android::PoolThread::threadLoop()+24) (BuildId: ee18e52b95e38eaab55a9a48518c8c3b)
+  native: #04 pc 00000000000148e8  /system/lib64/libutils.so (android::Thread::_threadLoop(void*)+528) (BuildId: 5a0d720732600c94ad8354a1188e9f52)
+  native: #05 pc 00000000000c8918  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::javaThreadShell(void*)+140) (BuildId: a31474ac581b716d4588f8c97eb06009)
+  native: #06 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #07 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+
+"Thread-9" prio=5 tid=5 Sleeping
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c1600 self=0xb400007cabcae220
+  | sysTid=29157 nice=0 cgrp=top-app sched=0/0 handle=0x7b21c88cb0
+  | state=S schedstat=( 38083 149917 1 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7b21b85000-0x7b21b87000 stackSize=1039KB
+  | held mutexes=
+  at java.lang.Thread.sleep(Native method)
+  - sleeping on <0x09228c2d> (a java.lang.Object)
+  at java.lang.Thread.sleep(Thread.java:450)
+  - locked <0x09228c2d> (a java.lang.Object)
+  at java.lang.Thread.sleep(Thread.java:355)
+  at io.sentry.samples.android.MainActivity$1.run(MainActivity.java:162)
+  - locked <0x0d3a2f0a> (a java.lang.Object)
+  at java.lang.Thread.run(Thread.java:1012)
+
+"binder:28941_3" prio=5 (not attached)
+  | sysTid=29028 nice=0 cgrp=top-app
+  | state=S schedstat=( 3124378 30612789 84 ) utm=0 stm=0 core=0 HZ=100
+  native: #00 pc 000000000004df5c  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+28) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 0000000000052664  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+144) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #02 pc 00000000000b56cc  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_cond_wait+76) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #03 pc 00000000000699e0  /system/lib64/libc++.so (std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)+20) (BuildId: 6ae0290e5bfb8abb216bde2a4ee48d9e)
+  native: #04 pc 00000000000a048c  /system/lib64/libgui.so (android::AsyncWorker::run()+112) (BuildId: 383a37b5342fd0249afb25e7134deb33)
+  native: #05 pc 00000000000a0878  /system/lib64/libgui.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (android::AsyncWorker::*)(), android::AsyncWorker*> >(void*)+80) (BuildId: 383a37b5342fd0249afb25e7134deb33)
+  native: #06 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #07 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+
+----- end 28941 -----
+
+----- Waiting Channels: pid 28941 at 2023-04-04 22:06:31.057056350+0200 -----
+Cmd line: io.sentry.samples.android
+
+sysTid=28941     futex_wait_queue_me
+sysTid=28957     do_sigtimedwait
+sysTid=28959     pipe_read
+sysTid=28960     do_sys_poll
+sysTid=28961     futex_wait_queue_me
+sysTid=28962     futex_wait_queue_me
+sysTid=28963     futex_wait_queue_me
+sysTid=28964     futex_wait_queue_me
+sysTid=28965     futex_wait_queue_me
+sysTid=28966     binder_wait_for_work
+sysTid=28967     binder_wait_for_work
+sysTid=28975     binder_wait_for_work
+sysTid=28980     futex_wait_queue_me
+sysTid=28991     do_epoll_wait
+sysTid=28993     futex_wait_queue_me
+sysTid=28994     futex_wait_queue_me
+sysTid=28995     inotify_read
+sysTid=28996     futex_wait_queue_me
+sysTid=28997     do_epoll_wait
+sysTid=29000     do_epoll_wait
+sysTid=29001     futex_wait_queue_me
+sysTid=29004     do_epoll_wait
+sysTid=29010     futex_wait_queue_me
+sysTid=29011     do_epoll_wait
+sysTid=29026     futex_wait_queue_me
+sysTid=29027     futex_wait_queue_me
+sysTid=29028     futex_wait_queue_me
+sysTid=29029     futex_wait_queue_me
+sysTid=29039     binder_wait_for_work
+sysTid=29157     futex_wait_queue_me
+
+----- end 28941 -----

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1498,6 +1498,7 @@ public final class io/sentry/SentryEvent$JsonKeys {
 public final class io/sentry/SentryExceptionFactory {
 	public fun <init> (Lio/sentry/SentryStackTraceFactory;)V
 	public fun getSentryExceptions (Ljava/lang/Throwable;)Ljava/util/List;
+	public fun getSentryExceptionsFromThread (Lio/sentry/protocol/SentryThread;Lio/sentry/protocol/Mechanism;Ljava/lang/Throwable;)Ljava/util/List;
 }
 
 public final class io/sentry/SentryInstantDate : io/sentry/SentryDate {
@@ -1548,6 +1549,46 @@ public final class io/sentry/SentryLevel : java/lang/Enum, io/sentry/JsonSeriali
 	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryLevel;
 	public static fun values ()[Lio/sentry/SentryLevel;
+}
+
+public final class io/sentry/SentryLockReason : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field ANY I
+	public static final field BLOCKED I
+	public static final field LOCKED I
+	public static final field SLEEPING I
+	public static final field WAITING I
+	public fun <init> ()V
+	public fun <init> (Lio/sentry/SentryLockReason;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAddress ()Ljava/lang/String;
+	public fun getClassName ()Ljava/lang/String;
+	public fun getPackageName ()Ljava/lang/String;
+	public fun getThreadId ()Ljava/lang/Long;
+	public fun getType ()I
+	public fun getUnknown ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun serialize (Lio/sentry/JsonObjectWriter;Lio/sentry/ILogger;)V
+	public fun setAddress (Ljava/lang/String;)V
+	public fun setClassName (Ljava/lang/String;)V
+	public fun setPackageName (Ljava/lang/String;)V
+	public fun setThreadId (Ljava/lang/Long;)V
+	public fun setType (I)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/SentryLockReason$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryLockReason;
+	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/SentryLockReason$JsonKeys {
+	public static final field ADDRESS Ljava/lang/String;
+	public static final field CLASS_NAME Ljava/lang/String;
+	public static final field PACKAGE_NAME Ljava/lang/String;
+	public static final field THREAD_ID Ljava/lang/String;
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
 }
 
 public final class io/sentry/SentryLongDate : io/sentry/SentryDate {
@@ -1800,9 +1841,10 @@ public final class io/sentry/SentrySpanStorage {
 }
 
 public final class io/sentry/SentryStackTraceFactory {
-	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun getInAppCallStack ()Ljava/util/List;
 	public fun getStackFrames ([Ljava/lang/StackTraceElement;)Ljava/util/List;
+	public fun isInApp (Ljava/lang/String;)Ljava/lang/Boolean;
 }
 
 public final class io/sentry/SentryThreadFactory {
@@ -3516,6 +3558,7 @@ public final class io/sentry/protocol/SentryStackFrame : io/sentry/JsonSerializa
 	public fun getPostContext ()Ljava/util/List;
 	public fun getPreContext ()Ljava/util/List;
 	public fun getRawFunction ()Ljava/lang/String;
+	public fun getSymbol ()Ljava/lang/String;
 	public fun getSymbolAddr ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getVars ()Ljava/util/Map;
@@ -3539,6 +3582,7 @@ public final class io/sentry/protocol/SentryStackFrame : io/sentry/JsonSerializa
 	public fun setPostContext (Ljava/util/List;)V
 	public fun setPreContext (Ljava/util/List;)V
 	public fun setRawFunction (Ljava/lang/String;)V
+	public fun setSymbol (Ljava/lang/String;)V
 	public fun setSymbolAddr (Ljava/lang/String;)V
 	public fun setUnknown (Ljava/util/Map;)V
 	public fun setVars (Ljava/util/Map;)V
@@ -3565,6 +3609,7 @@ public final class io/sentry/protocol/SentryStackFrame$JsonKeys {
 	public static final field PACKAGE Ljava/lang/String;
 	public static final field PLATFORM Ljava/lang/String;
 	public static final field RAW_FUNCTION Ljava/lang/String;
+	public static final field SYMBOL Ljava/lang/String;
 	public static final field SYMBOL_ADDR Ljava/lang/String;
 	public fun <init> ()V
 }
@@ -3598,6 +3643,7 @@ public final class io/sentry/protocol/SentryStackTrace$JsonKeys {
 
 public final class io/sentry/protocol/SentryThread : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> ()V
+	public fun getHeldLocks ()Ljava/util/Map;
 	public fun getId ()Ljava/lang/Long;
 	public fun getName ()Ljava/lang/String;
 	public fun getPriority ()Ljava/lang/Integer;
@@ -3612,6 +3658,7 @@ public final class io/sentry/protocol/SentryThread : io/sentry/JsonSerializable,
 	public fun setCrashed (Ljava/lang/Boolean;)V
 	public fun setCurrent (Ljava/lang/Boolean;)V
 	public fun setDaemon (Ljava/lang/Boolean;)V
+	public fun setHeldLocks (Ljava/util/Map;)V
 	public fun setId (Ljava/lang/Long;)V
 	public fun setMain (Ljava/lang/Boolean;)V
 	public fun setName (Ljava/lang/String;)V
@@ -3631,6 +3678,7 @@ public final class io/sentry/protocol/SentryThread$JsonKeys {
 	public static final field CRASHED Ljava/lang/String;
 	public static final field CURRENT Ljava/lang/String;
 	public static final field DAEMON Ljava/lang/String;
+	public static final field HELD_LOCKS Ljava/lang/String;
 	public static final field ID Ljava/lang/String;
 	public static final field MAIN Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -98,6 +98,7 @@ public final class JsonSerializer implements ISerializer {
     deserializersByClass.put(SentryException.class, new SentryException.Deserializer());
     deserializersByClass.put(SentryItemType.class, new SentryItemType.Deserializer());
     deserializersByClass.put(SentryLevel.class, new SentryLevel.Deserializer());
+    deserializersByClass.put(SentryLockReason.class, new SentryLockReason.Deserializer());
     deserializersByClass.put(SentryPackage.class, new SentryPackage.Deserializer());
     deserializersByClass.put(SentryRuntime.class, new SentryRuntime.Deserializer());
     deserializersByClass.put(SentrySpan.class, new SentrySpan.Deserializer());

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -32,8 +32,7 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
     this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
 
     final SentryStackTraceFactory sentryStackTraceFactory =
-        new SentryStackTraceFactory(
-            this.options.getInAppExcludes(), this.options.getInAppIncludes());
+        new SentryStackTraceFactory(this.options);
 
     sentryExceptionFactory = new SentryExceptionFactory(sentryStackTraceFactory);
     sentryThreadFactory = new SentryThreadFactory(sentryStackTraceFactory, this.options);

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -9,7 +9,6 @@ import io.sentry.protocol.SentryThread;
 import io.sentry.util.Objects;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -38,16 +38,17 @@ public final class SentryExceptionFactory {
 
   @NotNull
   public List<SentryException> getSentryExceptionsFromThread(
-    final @NotNull SentryThread thread,
-    final @NotNull Mechanism mechanism,
-    final @NotNull Throwable throwable
-  ) {
+      final @NotNull SentryThread thread,
+      final @NotNull Mechanism mechanism,
+      final @NotNull Throwable throwable) {
     final SentryStackTrace threadStacktrace = thread.getStacktrace();
     if (threadStacktrace == null) {
       return Collections.emptyList();
     }
     final List<SentryException> exceptions = new ArrayList<>(1);
-    exceptions.add(getSentryException(throwable, mechanism, thread.getId(), threadStacktrace.getFrames(), true));
+    exceptions.add(
+        getSentryException(
+            throwable, mechanism, thread.getId(), threadStacktrace.getFrames(), true));
     return exceptions;
   }
 
@@ -80,7 +81,8 @@ public final class SentryExceptionFactory {
    * @param throwable Java exception to send to Sentry.
    * @param exceptionMechanism The optional {@link Mechanism} of the {@code throwable}. Or null if
    *     none exist.
-   * @param threadId The optional id of a {@link Thread} which the exception originated. Or null if not known.
+   * @param threadId The optional id of a {@link Thread} which the exception originated. Or null if
+   *     not known.
    * @param frames
    * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot, See {@link
    *     SentryStackTrace#getSnapshot()}
@@ -159,9 +161,10 @@ public final class SentryExceptionFactory {
       }
 
       final List<SentryStackFrame> frames =
-        sentryStackTraceFactory.getStackFrames(currentThrowable.getStackTrace());
+          sentryStackTraceFactory.getStackFrames(currentThrowable.getStackTrace());
       SentryException exception =
-          getSentryException(currentThrowable, exceptionMechanism, thread.getId(), frames, snapshot);
+          getSentryException(
+              currentThrowable, exceptionMechanism, thread.getId(), frames, snapshot);
       exceptions.addFirst(exception);
       currentThrowable = currentThrowable.getCause();
     }

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -5,6 +5,7 @@ import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.SentryException;
 import io.sentry.protocol.SentryStackFrame;
 import io.sentry.protocol.SentryStackTrace;
+import io.sentry.protocol.SentryThread;
 import io.sentry.util.Objects;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -32,6 +33,30 @@ public final class SentryExceptionFactory {
   public SentryExceptionFactory(final @NotNull SentryStackTraceFactory sentryStackTraceFactory) {
     this.sentryStackTraceFactory =
         Objects.requireNonNull(sentryStackTraceFactory, "The SentryStackTraceFactory is required.");
+  }
+
+  @NotNull
+  public List<SentryException> getSentryExceptionsFromThread(
+    final @NotNull SentryThread thread,
+    final @NotNull Mechanism mechanism,
+    final boolean snapshot
+  ) {
+    final ArrayList<SentryException> exceptions = new ArrayList<>();
+    final SentryException exception = new SentryException();
+
+    final SentryStackTrace threadStacktrace = thread.getStacktrace();
+    if (threadStacktrace != null) {
+      final SentryStackTrace stacktrace = new SentryStackTrace(threadStacktrace.getFrames());
+      if (snapshot) {
+        stacktrace.setSnapshot(true);
+      }
+      exception.setStacktrace(stacktrace);
+    }
+    exception.setThreadId(thread.getId());
+    exception.setMechanism(mechanism);
+
+    exceptions.add(exception);
+    return exceptions;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -43,7 +43,7 @@ public final class SentryExceptionFactory {
       final @NotNull Throwable throwable) {
     final SentryStackTrace threadStacktrace = thread.getStacktrace();
     if (threadStacktrace == null) {
-      return Collections.emptyList();
+      return new ArrayList<>(0);
     }
     final List<SentryException> exceptions = new ArrayList<>(1);
     exceptions.add(
@@ -83,7 +83,7 @@ public final class SentryExceptionFactory {
    *     none exist.
    * @param threadId The optional id of a {@link Thread} which the exception originated. Or null if
    *     not known.
-   * @param frames
+   * @param frames stack frames that should be assigned to the stacktrace of this exception.
    * @param snapshot if the captured {@link java.lang.Thread}'s stacktrace is a snapshot, See {@link
    *     SentryStackTrace#getSnapshot()}
    */

--- a/sentry/src/main/java/io/sentry/SentryLockReason.java
+++ b/sentry/src/main/java/io/sentry/SentryLockReason.java
@@ -1,0 +1,188 @@
+package io.sentry;
+
+import io.sentry.util.CollectionUtils;
+import io.sentry.util.Objects;
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents an instance of a held lock (java monitor object) in a thread.
+ */
+public final class SentryLockReason implements JsonUnknown, JsonSerializable {
+
+  public static final int LOCKED = 1;
+  public static final int WAITING = 2;
+  public static final int SLEEPING = 4;
+  public static final int BLOCKED = 8;
+
+  public static final int ANY = LOCKED | WAITING | SLEEPING | BLOCKED;
+
+  private int type;
+  private @Nullable String address;
+  private @Nullable String packageName;
+  private @Nullable String className;
+  private @Nullable Long threadId;
+  private @Nullable Map<String, Object> unknown;
+
+  public SentryLockReason() {
+  }
+
+  public SentryLockReason(final @NotNull SentryLockReason other) {
+    this.type = other.type;
+    this.address = other.address;
+    this.packageName = other.packageName;
+    this.className = other.className;
+    this.threadId = other.threadId;
+    this.unknown = CollectionUtils.newConcurrentHashMap(other.unknown);
+  }
+
+  @SuppressWarnings("unused")
+
+  public int getType() {
+    return type;
+  }
+
+  public void setType(final int type) {
+    this.type = type;
+  }
+
+  @Nullable
+  public String getAddress() {
+    return address;
+  }
+
+  public void setAddress(final @Nullable String address) {
+    this.address = address;
+  }
+
+  @Nullable
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public void setPackageName(final @Nullable String packageName) {
+    this.packageName = packageName;
+  }
+
+  @Nullable
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(final @Nullable String className) {
+    this.className = className;
+  }
+
+  @Nullable
+  public Long getThreadId() {
+    return threadId;
+  }
+
+  public void setThreadId(final @Nullable Long threadId) {
+    this.threadId = threadId;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SentryLockReason that = (SentryLockReason) o;
+    return Objects.equals(address, that.address);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(address);
+  }
+
+
+  // region json
+
+  @Nullable
+  @Override
+  public Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
+  @Override
+  public void setUnknown(final @Nullable Map<String, Object> unknown) {
+    this.unknown = unknown;
+  }
+
+  public static final class JsonKeys {
+    public static final String TYPE = "type";
+    public static final String ADDRESS = "address";
+    public static final String PACKAGE_NAME = "package_name";
+    public static final String CLASS_NAME = "class_name";
+    public static final String THREAD_ID = "thread_id";
+  }
+
+  @Override public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
+    throws IOException {
+    writer.beginObject();
+    writer.name(JsonKeys.TYPE).value(type);
+    if (address != null) {
+      writer.name(JsonKeys.ADDRESS).value(address);
+    }
+    if (packageName != null) {
+      writer.name(JsonKeys.PACKAGE_NAME).value(packageName);
+    }
+    if (className != null) {
+      writer.name(JsonKeys.CLASS_NAME).value(className);
+    }
+    if (threadId != null) {
+      writer.name(JsonKeys.THREAD_ID).value(threadId);
+    }
+    if (unknown != null) {
+      for (String key : unknown.keySet()) {
+        Object value = unknown.get(key);
+        writer.name(key);
+        writer.value(logger, value);
+      }
+    }
+    writer.endObject();
+  }
+
+  public static final class Deserializer implements JsonDeserializer<SentryLockReason> {
+
+    @Override public @NotNull SentryLockReason deserialize(@NotNull JsonObjectReader reader,
+      @NotNull ILogger logger) throws Exception {
+      final SentryLockReason sentryLockReason = new SentryLockReason();
+      Map<String, Object> unknown = null;
+      reader.beginObject();
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.TYPE:
+            sentryLockReason.type = reader.nextInt();
+            break;
+          case JsonKeys.ADDRESS:
+            sentryLockReason.address = reader.nextStringOrNull();
+            break;
+          case JsonKeys.PACKAGE_NAME:
+            sentryLockReason.packageName = reader.nextStringOrNull();
+            break;
+          case JsonKeys.CLASS_NAME:
+            sentryLockReason.className = reader.nextStringOrNull();
+            break;
+          case JsonKeys.THREAD_ID:
+            sentryLockReason.threadId = reader.nextLongOrNull();
+            break;
+          default:
+            if (unknown == null) {
+              unknown = new ConcurrentHashMap<>();
+            }
+            reader.nextUnknown(logger, unknown, nextName);
+            break;
+        }
+      }
+      sentryLockReason.setUnknown(unknown);
+      reader.endObject();
+      return sentryLockReason;
+    }
+  }
+
+  // endregion
+}

--- a/sentry/src/main/java/io/sentry/SentryLockReason.java
+++ b/sentry/src/main/java/io/sentry/SentryLockReason.java
@@ -9,9 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * Represents an instance of a held lock (java monitor object) in a thread.
- */
+/** Represents an instance of a held lock (java monitor object) in a thread. */
 public final class SentryLockReason implements JsonUnknown, JsonSerializable {
 
   public static final int LOCKED = 1;
@@ -28,8 +26,7 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
   private @Nullable Long threadId;
   private @Nullable Map<String, Object> unknown;
 
-  public SentryLockReason() {
-  }
+  public SentryLockReason() {}
 
   public SentryLockReason(final @NotNull SentryLockReason other) {
     this.type = other.type;
@@ -41,7 +38,6 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
   }
 
   @SuppressWarnings("unused")
-
   public int getType() {
     return type;
   }
@@ -86,17 +82,18 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
     this.threadId = threadId;
   }
 
-  @Override public boolean equals(Object o) {
+  @Override
+  public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SentryLockReason that = (SentryLockReason) o;
     return Objects.equals(address, that.address);
   }
 
-  @Override public int hashCode() {
+  @Override
+  public int hashCode() {
     return Objects.hash(address);
   }
-
 
   // region json
 
@@ -119,8 +116,9 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
     public static final String THREAD_ID = "thread_id";
   }
 
-  @Override public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
-    throws IOException {
+  @Override
+  public void serialize(@NotNull JsonObjectWriter writer, @NotNull ILogger logger)
+      throws IOException {
     writer.beginObject();
     writer.name(JsonKeys.TYPE).value(type);
     if (address != null) {
@@ -147,8 +145,9 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SentryLockReason> {
 
-    @Override public @NotNull SentryLockReason deserialize(@NotNull JsonObjectReader reader,
-      @NotNull ILogger logger) throws Exception {
+    @Override
+    public @NotNull SentryLockReason deserialize(
+        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
       final SentryLockReason sentryLockReason = new SentryLockReason();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -14,16 +14,10 @@ import org.jetbrains.annotations.TestOnly;
 @ApiStatus.Internal
 public final class SentryStackTraceFactory {
 
-  /** list of inApp excludes */
-  private final @Nullable List<String> inAppExcludes;
+  private final @NotNull SentryOptions options;
 
-  /** list of inApp includes */
-  private final @Nullable List<String> inAppIncludes;
-
-  public SentryStackTraceFactory(
-      @Nullable final List<String> inAppExcludes, @Nullable List<String> inAppIncludes) {
-    this.inAppExcludes = inAppExcludes;
-    this.inAppIncludes = inAppIncludes;
+  public SentryStackTraceFactory(final @NotNull SentryOptions options) {
+    this.options = options;
   }
 
   /**
@@ -76,27 +70,26 @@ public final class SentryStackTraceFactory {
    * @param className the className
    * @return true if it is or false otherwise
    */
-  @TestOnly
   @Nullable
-  Boolean isInApp(final @Nullable String className) {
+  public Boolean isInApp(final @Nullable String className) {
     if (className == null || className.isEmpty()) {
       return true;
     }
 
-    if (inAppIncludes != null) {
-      for (String include : inAppIncludes) {
-        if (className.startsWith(include)) {
-          return true;
-        }
+    final List<String> inAppIncludes = options.getInAppIncludes();
+    for (String include : inAppIncludes) {
+      if (className.startsWith(include)) {
+        return true;
       }
     }
-    if (inAppExcludes != null) {
-      for (String exclude : inAppExcludes) {
-        if (className.startsWith(exclude)) {
-          return false;
-        }
+
+    final List<String> inAppExcludes = options.getInAppExcludes();
+    for (String exclude : inAppExcludes) {
+      if (className.startsWith(exclude)) {
+        return false;
       }
     }
+
     return null;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 
 /** class responsible for converting Java StackTraceElements to SentryStackFrames */
 @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -39,8 +39,7 @@ final class FileIOSpanManager {
     this.currentSpan = currentSpan;
     this.file = file;
     this.options = options;
-    this.stackTraceFactory =
-        new SentryStackTraceFactory(options.getInAppExcludes(), options.getInAppIncludes());
+    this.stackTraceFactory = new SentryStackTraceFactory(options);
     SentryIntegrationPackageStorage.getInstance().addIntegration("FileIO");
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -95,9 +95,9 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
 
   /**
    * Potentially mangled name of the symbol as it appears in an executable.
-   * <p>
-   * This is different from a function name by generally being the mangled name that appears
-   * natively in the binary.  This is relevant for languages like Swift, C++ or Rust.
+   *
+   * <p>This is different from a function name by generally being the mangled name that appears
+   * natively in the binary. This is relevant for languages like Swift, C++ or Rust.
    */
   private @Nullable String symbol;
 
@@ -274,7 +274,6 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
   public void setRawFunction(final @Nullable String rawFunction) {
     this.rawFunction = rawFunction;
   }
-
 
   @Nullable
   public String getSymbol() {

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -93,6 +93,14 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
    */
   private @Nullable String instructionAddr;
 
+  /**
+   * Potentially mangled name of the symbol as it appears in an executable.
+   * <p>
+   * This is different from a function name by generally being the mangled name that appears
+   * natively in the binary.  This is relevant for languages like Swift, C++ or Rust.
+   */
+  private @Nullable String symbol;
+
   @SuppressWarnings("unused")
   private @Nullable Map<String, Object> unknown;
 
@@ -267,6 +275,16 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     this.rawFunction = rawFunction;
   }
 
+
+  @Nullable
+  public String getSymbol() {
+    return symbol;
+  }
+
+  public void setSymbol(final @Nullable String symbol) {
+    this.symbol = symbol;
+  }
+
   // region json
 
   @Nullable
@@ -296,6 +314,7 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     public static final String SYMBOL_ADDR = "symbol_addr";
     public static final String INSTRUCTION_ADDR = "instruction_addr";
     public static final String RAW_FUNCTION = "raw_function";
+    public static final String SYMBOL = "symbol";
   }
 
   @Override
@@ -346,6 +365,9 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     }
     if (rawFunction != null) {
       writer.name(JsonKeys.RAW_FUNCTION).value(rawFunction);
+    }
+    if (symbol != null) {
+      writer.name(JsonKeys.SYMBOL).value(symbol);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -411,6 +433,9 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.RAW_FUNCTION:
             sentryStackFrame.rawFunction = reader.nextStringOrNull();
+            break;
+          case JsonKeys.SYMBOL:
+            sentryStackFrame.symbol = reader.nextStringOrNull();
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -6,8 +6,12 @@ import io.sentry.JsonObjectReader;
 import io.sentry.JsonObjectWriter;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.SentryLockReason;
+import io.sentry.profilemeasurements.ProfileMeasurement;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
@@ -37,6 +41,8 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
   private @Nullable Boolean daemon;
   private @Nullable Boolean main;
   private @Nullable SentryStackTrace stacktrace;
+
+  private @Nullable Map<String, SentryLockReason> heldLocks;
 
   @SuppressWarnings("unused")
   private @Nullable Map<String, Object> unknown;
@@ -208,6 +214,24 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
     this.state = state;
   }
 
+  /**
+   * Gets locks held by this thread.
+   *
+   * @return locks held by this thread
+   */
+  public @Nullable Map<String, SentryLockReason> getHeldLocks() {
+    return heldLocks;
+  }
+
+  /**
+   * Sets locks held by this thread.
+   *
+   * @param heldLocks list of locks held by this thread
+   */
+  public void setHeldLocks(final @Nullable Map<String, SentryLockReason> heldLocks) {
+    this.heldLocks = heldLocks;
+  }
+
   // region json
 
   @Nullable
@@ -231,6 +255,7 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
     public static final String DAEMON = "daemon";
     public static final String MAIN = "main";
     public static final String STACKTRACE = "stacktrace";
+    public static final String HELD_LOCKS = "held_locks";
   }
 
   @Override
@@ -263,6 +288,9 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
     }
     if (stacktrace != null) {
       writer.name(JsonKeys.STACKTRACE).value(logger, stacktrace);
+    }
+    if (heldLocks != null) {
+      writer.name(JsonKeys.HELD_LOCKS).value(logger, heldLocks);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -313,6 +341,12 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
             sentryThread.stacktrace =
                 reader.nextOrNull(logger, new SentryStackTrace.Deserializer());
             break;
+          case JsonKeys.HELD_LOCKS:
+            final Map<String, SentryLockReason> heldLocks =
+              reader.nextMapOrNull(logger, new SentryLockReason.Deserializer());
+            if (heldLocks != null) {
+              sentryThread.heldLocks = new HashMap<>(heldLocks);
+            }
           default:
             if (unknown == null) {
               unknown = new ConcurrentHashMap<>();

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -345,6 +345,7 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
             if (heldLocks != null) {
               sentryThread.heldLocks = new HashMap<>(heldLocks);
             }
+            break;
           default:
             if (unknown == null) {
               unknown = new ConcurrentHashMap<>();

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -7,11 +7,9 @@ import io.sentry.JsonObjectWriter;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
 import io.sentry.SentryLockReason;
-import io.sentry.profilemeasurements.ProfileMeasurement;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
@@ -343,7 +341,7 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.HELD_LOCKS:
             final Map<String, SentryLockReason> heldLocks =
-              reader.nextMapOrNull(logger, new SentryLockReason.Deserializer());
+                reader.nextMapOrNull(logger, new SentryLockReason.Deserializer());
             if (heldLocks != null) {
               sentryThread.heldLocks = new HashMap<>(heldLocks);
             }

--- a/sentry/src/test/java/io/sentry/JsonUnknownSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonUnknownSerializationTest.kt
@@ -51,7 +51,7 @@ class JsonUnknownSerializationTest(
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters
+        @Parameterized.Parameters(name = "{0}")
         fun data(): Collection<Array<Any>> {
             val app = givenJsonUnknown(App())
             val breadcrumb = givenJsonUnknown(Breadcrumb())
@@ -75,6 +75,7 @@ class JsonUnknownSerializationTest(
             val sentryStackFrame = givenJsonUnknown(SentryStackFrame())
             val sentryStackTrace = givenJsonUnknown(SentryStackTrace())
             val sentryThread = givenJsonUnknown(SentryThread())
+            val sentryLockReason = givenJsonUnknown(SentryLockReason())
             val sentryTransaction = givenJsonUnknown(SentryTransactionSerializationTest.Fixture().getSut())
             val session = givenJsonUnknown(SessionSerializationTest.Fixture().getSut())
             val skdVersion = givenJsonUnknown(SdkVersion("3e934135-3f2b-49bc-8756-9f025b55143e", "3e31738e-4106-42d0-8be2-4a3a1bc648d3"))
@@ -110,6 +111,7 @@ class JsonUnknownSerializationTest(
                 arrayOf(sentryStackFrame, sentryStackFrame, SentryStackFrame.Deserializer()::deserialize),
                 arrayOf(sentryStackTrace, sentryStackTrace, SentryStackTrace.Deserializer()::deserialize),
                 arrayOf(sentryThread, sentryThread, SentryThread.Deserializer()::deserialize),
+                arrayOf(sentryLockReason, sentryLockReason, SentryLockReason.Deserializer()::deserialize),
                 arrayOf(sentryTransaction, sentryTransaction, SentryTransaction.Deserializer()::deserialize),
                 arrayOf(session, session, Session.Deserializer()::deserialize),
                 arrayOf(skdVersion, skdVersion, SdkVersion.Deserializer()::deserialize),

--- a/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
@@ -171,13 +171,13 @@ class SentryExceptionFactoryTest {
                 )
             }
         }
-        val mechanism = Mechanism().apply { type = "ANRv2" }
+        val mechanism = Mechanism().apply { type = "AppExitInfo" }
         val throwable = Exception("msg")
 
         val exceptions = fixture.getSut().getSentryExceptionsFromThread(thread, mechanism, throwable)
 
         val exception = exceptions.first()
-        assertEquals("ANRv2", exception.mechanism!!.type)
+        assertEquals("AppExitInfo", exception.mechanism!!.type)
         assertEquals("java.lang", exception.module)
         assertEquals("Exception", exception.type)
         assertEquals("msg", exception.value)

--- a/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
@@ -15,7 +15,11 @@ import kotlin.test.assertTrue
 class SentryExceptionFactoryTest {
     private class Fixture {
 
-        fun getSut(stackTraceFactory: SentryStackTraceFactory = SentryStackTraceFactory(listOf("io.sentry"), listOf())): SentryExceptionFactory {
+        fun getSut(
+            stackTraceFactory: SentryStackTraceFactory = SentryStackTraceFactory(
+                SentryOptions().apply { addInAppExclude("io.sentry") }
+            )
+        ): SentryExceptionFactory {
             return SentryExceptionFactory(stackTraceFactory)
         }
     }
@@ -88,7 +92,8 @@ class SentryExceptionFactoryTest {
     fun `When ExceptionMechanismException has threads snapshot, stack trace should set snapshot flag`() {
         val error = Exception("Exception")
 
-        val throwable = ExceptionMechanismException(Mechanism(), error, Thread.currentThread(), true)
+        val throwable =
+            ExceptionMechanismException(Mechanism(), error, Thread.currentThread(), true)
         val sentryExceptions = fixture.getSut().getSentryExceptions(throwable)
 
         assertTrue(sentryExceptions[0].stacktrace?.snapshot!!)

--- a/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
@@ -2,6 +2,9 @@ package io.sentry
 
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.Mechanism
+import io.sentry.protocol.SentryStackFrame
+import io.sentry.protocol.SentryStackTrace
+import io.sentry.protocol.SentryThread
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -141,6 +144,49 @@ class SentryExceptionFactoryTest {
         val queue = fixture.getSut().extractExceptionQueue(throwable)
 
         assertEquals(thread.id, queue.first.threadId)
+    }
+
+    @Test
+    fun `returns empty list if stacktrace is not available for SentryThread`() {
+        val thread = SentryThread()
+        val mechanism = Mechanism()
+        val throwable = Exception("msg")
+
+        val exceptions = fixture.getSut().getSentryExceptionsFromThread(thread, mechanism, throwable)
+
+        assertTrue(exceptions.isEmpty())
+    }
+
+    @Test
+    fun `returns proper exception backfilled from SentryThread`() {
+        val thread = SentryThread().apply {
+            id = 121
+            stacktrace = SentryStackTrace().apply {
+                frames = listOf(
+                    SentryStackFrame().apply {
+                        lineno = 777
+                        module = "io.sentry.samples.MainActivity"
+                        function = "run"
+                    }
+                )
+            }
+        }
+        val mechanism = Mechanism().apply { type = "ANRv2" }
+        val throwable = Exception("msg")
+
+        val exceptions = fixture.getSut().getSentryExceptionsFromThread(thread, mechanism, throwable)
+
+        val exception = exceptions.first()
+        assertEquals("ANRv2", exception.mechanism!!.type)
+        assertEquals("java.lang", exception.module)
+        assertEquals("Exception", exception.type)
+        assertEquals("msg", exception.value)
+        assertEquals(121, exception.threadId)
+        assertEquals(true, exception.stacktrace!!.snapshot)
+        val frame = exception.stacktrace!!.frames!!.first()
+        assertEquals("io.sentry.samples.MainActivity", frame.module)
+        assertEquals("run", frame.function)
+        assertEquals(777, frame.lineno)
     }
 
     internal class InnerClassThrowable constructor(cause: Throwable? = null) : Throwable(cause)

--- a/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryThreadFactoryTest.kt
@@ -12,7 +12,7 @@ class SentryThreadFactoryTest {
 
     class Fixture {
         internal fun getSut(attachStacktrace: Boolean = true) = SentryThreadFactory(
-            SentryStackTraceFactory(listOf("io.sentry"), listOf()),
+            SentryStackTraceFactory(SentryOptions().apply { addInAppExclude("io.sentry") }),
             with(SentryOptions()) {
                 isAttachStacktrace = attachStacktrace
                 this

--- a/sentry/src/test/java/io/sentry/protocol/SentryLockReasonSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryLockReasonSerializationTest.kt
@@ -1,0 +1,44 @@
+package io.sentry.protocol
+
+import io.sentry.ILogger
+import io.sentry.SentryLockReason
+import org.junit.Test
+import org.mockito.kotlin.mock
+import kotlin.test.assertEquals
+
+class SentryLockReasonSerializationTest {
+
+    class Fixture {
+        val logger = mock<ILogger>()
+
+        fun getSut() = SentryLockReason().apply {
+            address = "0x0d3a2f0a"
+            type = SentryLockReason.BLOCKED
+            threadId = 11
+            className = "Object"
+            packageName = "java.lang"
+        }
+    }
+    private val fixture = Fixture()
+
+    @Test
+    fun serialize() {
+        val expected = SerializationUtils.sanitizedFile("json/sentry_lock_reason.json")
+        val actual = SerializationUtils.serializeToString(fixture.getSut(), fixture.logger)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deserialize() {
+        val expectedJson = SerializationUtils.sanitizedFile("json/sentry_lock_reason.json")
+        val actual = SerializationUtils.deserializeJson<SentryLockReason>(
+            expectedJson,
+            SentryLockReason.Deserializer(),
+            fixture.logger
+        )
+        val actualJson = SerializationUtils.serializeToString(actual, fixture.logger)
+
+        assertEquals(expectedJson, actualJson)
+    }
+}

--- a/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
@@ -32,6 +32,7 @@ class SentryStackFrameSerializationTest {
             symbolAddr = "180e12cd-1fa8-405d-8dd8-e87b33fa2eb0"
             instructionAddr = "19864a78-2466-461f-9f0b-93a5c9ae7622"
             rawFunction = "f33035a4-0cf0-453d-b6f4-d7c27e9af924"
+            symbol = "d9807ffe-d517-11ed-afa1-0242ac120002"
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/java/io/sentry/protocol/SentryThreadSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryThreadSerializationTest.kt
@@ -5,6 +5,7 @@ import io.sentry.ILogger
 import io.sentry.JsonObjectReader
 import io.sentry.JsonObjectWriter
 import io.sentry.JsonSerializable
+import io.sentry.SentryLockReason
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.io.StringReader
@@ -50,6 +51,13 @@ class SentryThreadSerializationTest {
                     "e7a3db0b-8cad-4eab-8315-03d5dc2edcd9" to "8bba0819-ac58-4e5c-bec7-32e1033b7bdf"
                 )
                 snapshot = true
+                heldLocks = mapOf("0x0d3a2f0a" to SentryLockReason().apply {
+                    address = "0x0d3a2f0a"
+                    className = "Object"
+                    packageName = "java.lang"
+                    type = SentryLockReason.BLOCKED
+                    threadId = 11
+                })
             }
         }
     }

--- a/sentry/src/test/java/io/sentry/protocol/SentryThreadSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryThreadSerializationTest.kt
@@ -51,13 +51,15 @@ class SentryThreadSerializationTest {
                     "e7a3db0b-8cad-4eab-8315-03d5dc2edcd9" to "8bba0819-ac58-4e5c-bec7-32e1033b7bdf"
                 )
                 snapshot = true
-                heldLocks = mapOf("0x0d3a2f0a" to SentryLockReason().apply {
-                    address = "0x0d3a2f0a"
-                    className = "Object"
-                    packageName = "java.lang"
-                    type = SentryLockReason.BLOCKED
-                    threadId = 11
-                })
+                heldLocks = mapOf(
+                    "0x0d3a2f0a" to SentryLockReason().apply {
+                        address = "0x0d3a2f0a"
+                        className = "Object"
+                        packageName = "java.lang"
+                        type = SentryLockReason.BLOCKED
+                        threadId = 11
+                    }
+                )
             }
         }
     }

--- a/sentry/src/test/resources/json/sentry_event.json
+++ b/sentry/src/test/resources/json/sentry_event.json
@@ -52,6 +52,17 @@
                         "e7a3db0b-8cad-4eab-8315-03d5dc2edcd9": "8bba0819-ac58-4e5c-bec7-32e1033b7bdf"
                     },
                     "snapshot": true
+                },
+                "held_locks":
+                {
+                  "0x0d3a2f0a":
+                  {
+                    "type": 8,
+                    "address": "0x0d3a2f0a",
+                    "package_name": "java.lang",
+                    "class_name": "Object",
+                    "thread_id": 11
+                  }
                 }
             }
         ]

--- a/sentry/src/test/resources/json/sentry_lock_reason.json
+++ b/sentry/src/test/resources/json/sentry_lock_reason.json
@@ -1,0 +1,7 @@
+{
+  "type": 8,
+  "address": "0x0d3a2f0a",
+  "package_name": "java.lang",
+  "class_name": "Object",
+  "thread_id": 11
+}

--- a/sentry/src/test/resources/json/sentry_stack_frame.json
+++ b/sentry/src/test/resources/json/sentry_stack_frame.json
@@ -13,5 +13,6 @@
     "image_addr": "27ec1be5-e8a1-485c-b020-f4d9f80a6624",
     "symbol_addr": "180e12cd-1fa8-405d-8dd8-e87b33fa2eb0",
     "instruction_addr": "19864a78-2466-461f-9f0b-93a5c9ae7622",
-    "raw_function": "f33035a4-0cf0-453d-b6f4-d7c27e9af924"
+    "raw_function": "f33035a4-0cf0-453d-b6f4-d7c27e9af924",
+    "symbol": "d9807ffe-d517-11ed-afa1-0242ac120002"
 }

--- a/sentry/src/test/resources/json/sentry_thread.json
+++ b/sentry/src/test/resources/json/sentry_thread.json
@@ -35,5 +35,16 @@
             "e7a3db0b-8cad-4eab-8315-03d5dc2edcd9": "8bba0819-ac58-4e5c-bec7-32e1033b7bdf"
         },
         "snapshot": true
+    },
+    "held_locks":
+    {
+      "0x0d3a2f0a":
+      {
+        "type": 8,
+        "address": "0x0d3a2f0a",
+        "package_name": "java.lang",
+        "class_name": "Object",
+        "thread_id": 11
+      }
     }
 }


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Parses a thread dump that we can get from AppExitInfo via `getTraceInputStream()`. Most of the parsing has been adapted from AOSP (with license header!), and each thread is transformed directly to `SentryThread`.
* The exception for the ANR is backfilled by the stacktrace of the main thread from the thread dump
* Adds `SentryLockReason` which we can infer from the thread dump and which can tell us if a thread is blocked on a lock by another thread. A `SentryThread` can have a dictionary/map of held locks.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #1796 

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
* Merge it and ship it all
* Do frontend changes accordingly