### PR TITLE
Fix crash on double SDK init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Unreleased
+
+## Fixes
+
+- Fix crash on double SDK init ([#2679](https://github.com/getsentry/sentry-java/pull/2679))
+
 ## 6.18.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -37,6 +37,7 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -255,12 +256,12 @@ public final class ActivityLifecycleIntegration
                   .getExecutorService()
                   .schedule(
                       () -> finishExceededTtfdSpan(ttidSpanMap.get(activity)), TTFD_TIMEOUT_MILLIS);
-        } catch (Throwable e) {
+        } catch (RejectedExecutionException e) {
           options
               .getLogger()
               .log(
                   SentryLevel.ERROR,
-                  "Failed to call the executor. Time to full display span will not be finished automatically.",
+                  "Failed to call the executor. Time to full display span will not be finished automatically. Did you call Sentry.close()?",
                   e);
         }
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -249,11 +249,20 @@ public final class ActivityLifecycleIntegration
         ttfdSpan =
             transaction.startChild(
                 TTFD_OP, getTtfdDesc(activityName), ttidStartTime, Instrumenter.SENTRY);
-        ttfdAutoCloseFuture =
-            options
-                .getExecutorService()
-                .schedule(
-                    () -> finishExceededTtfdSpan(ttidSpanMap.get(activity)), TTFD_TIMEOUT_MILLIS);
+        try {
+          ttfdAutoCloseFuture =
+              options
+                  .getExecutorService()
+                  .schedule(
+                      () -> finishExceededTtfdSpan(ttidSpanMap.get(activity)), TTFD_TIMEOUT_MILLIS);
+        } catch (Throwable e) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.ERROR,
+                  "Failed to call the executor. Time to full display span will not be finished automatically.",
+                  e);
+        }
       }
 
       // lets bind to the scope so other integrations can pick it up

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 final class AndroidTransactionProfiler implements ITransactionProfiler {
 
@@ -76,6 +77,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   private final @NotNull ArrayDeque<ProfileMeasurementValue> frozenFrameRenderMeasurements =
       new ArrayDeque<>();
   private final @NotNull Map<String, ProfileMeasurement> measurementsMap = new HashMap<>();
+
+  private @Nullable ITransaction currentTransaction = null;
 
   public AndroidTransactionProfiler(
       final @NotNull Context context,
@@ -140,7 +143,13 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
 
   @Override
   public synchronized void onTransactionStart(final @NotNull ITransaction transaction) {
-    options.getExecutorService().submit(() -> onTransactionStartSafe(transaction));
+    try {
+      options.getExecutorService().submit(() -> onTransactionStartSafe(transaction));
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to call the executor. Profiling will not be started", e);
+    }
   }
 
   @SuppressLint("NewApi")
@@ -235,13 +244,24 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
               }
             });
 
+    currentTransaction = transaction;
+
     // We stop profiling after a timeout to avoid huge profiles to be sent
-    scheduledFinish =
-        options
-            .getExecutorService()
-            .schedule(
-                () -> timedOutProfilingData = onTransactionFinish(transaction, true, null),
-                PROFILING_TIMEOUT_MILLIS);
+    try {
+      scheduledFinish =
+          options
+              .getExecutorService()
+              .schedule(
+                  () -> timedOutProfilingData = onTransactionFinish(transaction, true, null),
+                  PROFILING_TIMEOUT_MILLIS);
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "Failed to call the executor. Profiling will not be automatically finished",
+              e);
+    }
 
     transactionStartNanos = SystemClock.elapsedRealtimeNanos();
     profileStartCpuMillis = Process.getElapsedCpuTime();
@@ -265,6 +285,11 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       options.getLogger().log(SentryLevel.ERROR, "Error finishing profiling: ", e);
     } catch (InterruptedException e) {
       options.getLogger().log(SentryLevel.ERROR, "Error finishing profiling: ", e);
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR, "Failed to call the executor. Profiling could not be finished", e);
     }
     return null;
   }
@@ -349,6 +374,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     currentProfilingTransactionData = null;
     // We clear the counter in case of a timeout
     transactionsCounter = 0;
+    currentTransaction = null;
 
     if (scheduledFinish != null) {
       scheduledFinish.cancel(true);
@@ -483,6 +509,19 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     }
   }
 
+  @Override
+  public void close() {
+    // we cancel any scheduled work
+    if (scheduledFinish != null) {
+      scheduledFinish.cancel(true);
+      scheduledFinish = null;
+    }
+    // we stop profiling
+    if (currentTransaction != null) {
+      onTransactionFinish(currentTransaction, true, null);
+    }
+  }
+
   /**
    * Get MemoryInfo object representing the memory state of the application.
    *
@@ -502,5 +541,11 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       options.getLogger().log(SentryLevel.ERROR, "Error getting MemoryInfo.", e);
       return null;
     }
+  }
+
+  @TestOnly
+  @Nullable
+  ITransaction getCurrentTransaction() {
+    return currentTransaction;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -285,10 +285,10 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
           .getExecutorService()
           .submit(() -> onTransactionFinish(transaction, false, performanceCollectionData))
           .get();
-    } catch (ExecutionException e) {
+    } catch (ExecutionException | InterruptedException e) {
       options.getLogger().log(SentryLevel.ERROR, "Error finishing profiling: ", e);
-    } catch (InterruptedException e) {
-      options.getLogger().log(SentryLevel.ERROR, "Error finishing profiling: ", e);
+      // We stop profiling even on exceptions, so profiles don't run indefinitely
+      onTransactionFinish(transaction, false, null);
     } catch (RejectedExecutionException e) {
       options
           .getLogger()
@@ -296,6 +296,8 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
               SentryLevel.ERROR,
               "Failed to call the executor. Profiling could not be finished. Did you call Sentry.close()?",
               e);
+      // We stop profiling even on exceptions, so profiles don't run indefinitely
+      onTransactionFinish(transaction, false, null);
     }
     return null;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -7,6 +7,7 @@ import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.util.Objects;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
@@ -74,6 +75,13 @@ final class SendCachedEnvelopeIntegration implements Integration {
         }
       }
       androidOptions.getLogger().log(SentryLevel.DEBUG, "SendCachedEnvelopeIntegration installed.");
+    } catch (RejectedExecutionException e) {
+      androidOptions
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "Failed to call the executor. Cached events will not be sent. Did you call Sentry.close()?",
+              e);
     } catch (Throwable e) {
       androidOptions
           .getLogger()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -1097,6 +1097,7 @@ class ActivityLifecycleIntegrationTest {
                 return FutureTask {}
             }
             override fun close(timeoutMillis: Long) {}
+            override fun isClosed() = false
         }
         fixture.options.tracesSampleRate = 1.0
         fixture.options.isEnableTimeToFullDisplayTracing = true
@@ -1321,6 +1322,7 @@ class ActivityLifecycleIntegrationTest {
                 return FutureTask {}
             }
             override fun close(timeoutMillis: Long) {}
+            override fun isClosed() = false
         }
         fixture.options.tracesSampleRate = 1.0
         fixture.options.isEnableTimeToFullDisplayTracing = true

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -76,6 +76,7 @@ class AndroidTransactionProfilerTest {
                 return FutureTask {}
             }
             override fun close(timeoutMillis: Long) {}
+            override fun isClosed() = false
         }
 
         val options = spy(SentryAndroidOptions()).apply {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -17,6 +17,7 @@ import io.sentry.TransactionContext
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector
 import io.sentry.profilemeasurements.ProfileMeasurement
 import io.sentry.test.getCtor
+import io.sentry.test.getProperty
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -150,8 +151,11 @@ class AndroidTransactionProfilerTest {
     @Test
     fun `profiler profiles current transaction`() {
         val profiler = fixture.getSut(context)
+        assertNull(profiler.currentTransaction)
         profiler.onTransactionStart(fixture.transaction1)
+        assertNotNull(profiler.currentTransaction)
         val profilingTraceData = profiler.onTransactionFinish(fixture.transaction1, null)
+        assertNull(profiler.currentTransaction)
 
         assertNotNull(profilingTraceData)
         assertEquals(profilingTraceData.transactionId, fixture.transaction1.eventId.toString())
@@ -400,5 +404,23 @@ class AndroidTransactionProfilerTest {
             listOf(3.0, 4.0),
             data.measurementsMap[ProfileMeasurement.ID_MEMORY_NATIVE_FOOTPRINT]!!.values.map { it.value }
         )
+    }
+
+    @Test
+    fun `profiler stops profiling, clear current transaction and scheduled job on close`() {
+        val profiler = fixture.getSut(context)
+        profiler.onTransactionStart(fixture.transaction1)
+        assertNotNull(profiler.currentTransaction)
+
+        profiler.close()
+        assertNull(profiler.currentTransaction)
+
+        // The timeout scheduled job should be cleared
+        val scheduledJob = profiler.getProperty<Future<*>?>("scheduledFinish")
+        assertNull(scheduledJob)
+
+        // Calling transaction finish returns null, as the profiler was stopped
+        val profilingTraceData = profiler.onTransactionFinish(fixture.transaction1, null)
+        assertNull(profilingTraceData)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -115,5 +115,7 @@ class SentryAndroidOptionsTest {
             transaction: ITransaction,
             performanceCollectionData: List<PerformanceCollectionData>?
         ): ProfilingTraceData? = null
+
+        override fun close() {}
     }
 }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -1,0 +1,31 @@
+package io.sentry.uitest.android
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.launchActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroidOptions
+import org.junit.runner.RunWith
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+class SdkInitTests : BaseUiTest() {
+
+    @Test
+    fun doubleInitDoesNotThrow() {
+        initSentry(false) { options: SentryAndroidOptions ->
+            options.tracesSampleRate = 1.0
+            options.profilesSampleRate = 1.0
+        }
+        val transaction = Sentry.startTransaction("e2etests", "testInit")
+        val sampleScenario = launchActivity<EmptyActivity>()
+        initSentry(false) { options: SentryAndroidOptions ->
+            options.tracesSampleRate = 1.0
+            options.profilesSampleRate = 1.0
+        }
+        transaction.finish()
+        sampleScenario.moveToState(Lifecycle.State.DESTROYED)
+        val transaction2 = Sentry.startTransaction("e2etests", "testInit")
+        transaction2.finish()
+    }
+}

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -3,10 +3,14 @@ package io.sentry.uitest.android
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.launchActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.ProfilingTraceData
 import io.sentry.Sentry
 import io.sentry.android.core.SentryAndroidOptions
+import io.sentry.assertEnvelopeItem
+import io.sentry.protocol.SentryTransaction
 import org.junit.runner.RunWith
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class SdkInitTests : BaseUiTest() {
@@ -27,5 +31,47 @@ class SdkInitTests : BaseUiTest() {
         sampleScenario.moveToState(Lifecycle.State.DESTROYED)
         val transaction2 = Sentry.startTransaction("e2etests", "testInit")
         transaction2.finish()
+    }
+
+    @Test
+    fun doubleInitWithSameOptionsDoesNotThrow() {
+        val options = SentryAndroidOptions()
+
+        initSentry(true) {
+            it.tracesSampleRate = 1.0
+            it.profilesSampleRate = 1.0
+            // We use the same executorService before and after closing the SDK
+            it.executorService = options.executorService
+            it.isDebug = true
+        }
+        val transaction = Sentry.startTransaction("e2etests", "testInit")
+        val sampleScenario = launchActivity<EmptyActivity>()
+        initSentry(true) {
+            it.tracesSampleRate = 1.0
+            it.profilesSampleRate = 1.0
+            // We use the same executorService before and after closing the SDK
+            it.executorService = options.executorService
+            it.isDebug = true
+        }
+        relayIdlingResource.increment()
+        transaction.finish()
+        sampleScenario.moveToState(Lifecycle.State.DESTROYED)
+        val transaction2 = Sentry.startTransaction("e2etests2", "testInit")
+        transaction2.finish()
+
+        relay.assert {
+            findEnvelope {
+                assertEnvelopeItem<SentryTransaction>(it.items.toList()).transaction == "e2etests2"
+            }.assert {
+                val transactionItem: SentryTransaction = it.assertItem()
+                // Profiling uses executorService, so if the executorService is shutdown it would fail
+                val profilingTraceData: ProfilingTraceData = it.assertItem()
+                it.assertNoOtherItems()
+                assertEquals("e2etests2", transactionItem.transaction)
+                assertEquals("e2etests2", profilingTraceData.transactionName)
+            }
+            assertNoOtherEnvelopes()
+            assertNoOtherRequests()
+        }
     }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -188,6 +188,7 @@ public final class io/sentry/DateUtils {
 
 public final class io/sentry/DefaultTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun close ()V
 	public fun start (Lio/sentry/ITransaction;)V
 	public fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
@@ -597,6 +598,7 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 }
 
 public abstract interface class io/sentry/ITransactionProfiler {
+	public abstract fun close ()V
 	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;)Lio/sentry/ProfilingTraceData;
 	public abstract fun onTransactionStart (Lio/sentry/ITransaction;)V
 }
@@ -905,12 +907,14 @@ public final class io/sentry/NoOpTransaction : io/sentry/ITransaction {
 }
 
 public final class io/sentry/NoOpTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
+	public fun close ()V
 	public static fun getInstance ()Lio/sentry/NoOpTransactionPerformanceCollector;
 	public fun start (Lio/sentry/ITransaction;)V
 	public fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }
 
 public final class io/sentry/NoOpTransactionProfiler : io/sentry/ITransactionProfiler {
+	public fun close ()V
 	public static fun getInstance ()Lio/sentry/NoOpTransactionProfiler;
 	public fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;)Lio/sentry/ProfilingTraceData;
 	public fun onTransactionStart (Lio/sentry/ITransaction;)V
@@ -2151,6 +2155,7 @@ public final class io/sentry/TransactionOptions : io/sentry/SpanOptions {
 }
 
 public abstract interface class io/sentry/TransactionPerformanceCollector {
+	public abstract fun close ()V
 	public abstract fun start (Lio/sentry/ITransaction;)V
 	public abstract fun stop (Lio/sentry/ITransaction;)Ljava/util/List;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -532,6 +532,7 @@ public abstract interface class io/sentry/ISentryClient {
 
 public abstract interface class io/sentry/ISentryExecutorService {
 	public abstract fun close (J)V
+	public abstract fun isClosed ()Z
 	public abstract fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;

--- a/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultTransactionPerformanceCollector.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -49,12 +50,12 @@ public final class DefaultTransactionPerformanceCollector
         options
             .getExecutorService()
             .schedule(() -> stop(transaction), TRANSACTION_COLLECTION_TIMEOUT_MILLIS);
-      } catch (Throwable e) {
+      } catch (RejectedExecutionException e) {
         options
             .getLogger()
             .log(
                 SentryLevel.ERROR,
-                "Failed to call the executor. Performance collector will not be automatically finished",
+                "Failed to call the executor. Performance collector will not be automatically finished. Did you call Sentry.close()?",
                 e);
       }
     }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -340,18 +340,7 @@ public final class Hub implements IHub {
           }
         }
 
-        withScope(
-            scope -> {
-              ITransaction transaction = scope.getTransaction();
-              if (transaction != null) {
-                for (Span span : transaction.getSpans()) {
-                  span.setSpanFinishedCallback(null);
-                  span.finish(SpanStatus.CANCELLED);
-                }
-                transaction.finish(SpanStatus.CANCELLED);
-              }
-              scope.clear();
-            });
+        withScope(scope -> scope.clear());
         options.getTransactionProfiler().close();
         options.getTransactionPerformanceCollector().close();
         options.getExecutorService().close(options.getShutdownTimeoutMillis());

--- a/sentry/src/main/java/io/sentry/ISentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/ISentryExecutorService.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,7 +17,7 @@ public interface ISentryExecutorService {
    * @return a Future of the Runnable
    */
   @NotNull
-  Future<?> submit(final @NotNull Runnable runnable);
+  Future<?> submit(final @NotNull Runnable runnable) throws RejectedExecutionException;
 
   /**
    * Submits a Callable to the ThreadExecutor
@@ -25,10 +26,11 @@ public interface ISentryExecutorService {
    * @return a Future of the Callable
    */
   @NotNull
-  <T> Future<T> submit(final @NotNull Callable<T> callable);
+  <T> Future<T> submit(final @NotNull Callable<T> callable) throws RejectedExecutionException;
 
   @NotNull
-  Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis);
+  Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis)
+      throws RejectedExecutionException;
 
   /**
    * Closes the ThreadExecutor and awaits for the timeout

--- a/sentry/src/main/java/io/sentry/ISentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/ISentryExecutorService.java
@@ -38,4 +38,11 @@ public interface ISentryExecutorService {
    * @param timeoutMillis the timeout in millis
    */
   void close(long timeoutMillis);
+
+  /**
+   * Check if there was a previous call to the close() method.
+   *
+   * @return If the executorService was previously closed
+   */
+  boolean isClosed();
 }

--- a/sentry/src/main/java/io/sentry/ITransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/ITransactionProfiler.java
@@ -14,4 +14,7 @@ public interface ITransactionProfiler {
   ProfilingTraceData onTransactionFinish(
       @NotNull ITransaction transaction,
       @Nullable List<PerformanceCollectionData> performanceCollectionData);
+
+  /** Cancel the profiler and stops it. Used on SDK close. */
+  void close();
 }

--- a/sentry/src/main/java/io/sentry/NoOpSentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryExecutorService.java
@@ -31,4 +31,9 @@ final class NoOpSentryExecutorService implements ISentryExecutorService {
 
   @Override
   public void close(long timeoutMillis) {}
+
+  @Override
+  public boolean isClosed() {
+    return false;
+  }
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionPerformanceCollector.java
@@ -22,4 +22,7 @@ public final class NoOpTransactionPerformanceCollector implements TransactionPer
   public @Nullable List<PerformanceCollectionData> stop(@NotNull ITransaction transaction) {
     return null;
   }
+
+  @Override
+  public void close() {}
 }

--- a/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
@@ -23,4 +23,7 @@ public final class NoOpTransactionProfiler implements ITransactionProfiler {
       @Nullable List<PerformanceCollectionData> performanceCollectionData) {
     return null;
   }
+
+  @Override
+  public void close() {}
 }

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.util.Objects;
 import java.io.File;
+import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -88,6 +89,13 @@ public final class SendCachedEnvelopeFireAndForgetIntegration implements Integra
           .getLogger()
           .log(SentryLevel.DEBUG, "SendCachedEventFireAndForgetIntegration installed.");
       addIntegrationToSdkVersion();
+    } catch (RejectedExecutionException e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "Failed to call the executor. Cached events will not be sent. Did you call Sentry.close()?",
+              e);
     } catch (Throwable e) {
       options
           .getLogger()

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -292,12 +293,12 @@ public final class Sentry {
                     FileUtils.deleteRecursively(f);
                   }
                 });
-      } catch (Throwable e) {
+      } catch (RejectedExecutionException e) {
         options
             .getLogger()
             .log(
                 SentryLevel.ERROR,
-                "Failed to call the executor. Old profiles will not be deleted",
+                "Failed to call the executor. Old profiles will not be deleted. Did you call Sentry.close()?",
                 e);
       }
     }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -217,6 +217,14 @@ public final class Sentry {
 
     hub.close();
 
+    // If the executorService passed in the init is the same that was previously closed, we have to
+    // set a new one
+    final ISentryExecutorService sentryExecutorService = options.getExecutorService();
+    // If the passed executor service was previously called we set a new one
+    if (sentryExecutorService.isClosed()) {
+      options.setExecutorService(new SentryExecutorService());
+    }
+
     // when integrations are registered on Hub ctor and async integrations are fired,
     // it might and actually happened that integrations called captureSomething
     // and hub was still NoOp.

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -280,17 +280,26 @@ public final class Sentry {
       profilingTracesDir.mkdirs();
       final File[] oldTracesDirContent = profilingTracesDir.listFiles();
 
-      options
-          .getExecutorService()
-          .submit(
-              () -> {
-                if (oldTracesDirContent == null) return;
-                // Method trace files are normally deleted at the end of traces, but if that fails
-                // for some reason we try to clear any old files here.
-                for (File f : oldTracesDirContent) {
-                  FileUtils.deleteRecursively(f);
-                }
-              });
+      try {
+        options
+            .getExecutorService()
+            .submit(
+                () -> {
+                  if (oldTracesDirContent == null) return;
+                  // Method trace files are normally deleted at the end of traces, but if that fails
+                  // for some reason we try to clear any old files here.
+                  for (File f : oldTracesDirContent) {
+                    FileUtils.deleteRecursively(f);
+                  }
+                });
+      } catch (Throwable e) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.ERROR,
+                "Failed to call the executor. Old profiles will not be deleted",
+                e);
+      }
     }
 
     final @NotNull IModulesLoader modulesLoader = options.getModulesLoader();

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -52,4 +52,11 @@ final class SentryExecutorService implements ISentryExecutorService {
       }
     }
   }
+
+  @Override
+  public boolean isClosed() {
+    synchronized (executorService) {
+      return executorService.isShutdown();
+    }
+  }
 }

--- a/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/TransactionPerformanceCollector.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,4 +11,8 @@ public interface TransactionPerformanceCollector {
 
   @Nullable
   List<PerformanceCollectionData> stop(@NotNull ITransaction transaction);
+
+  /** Cancel the collector and stops it. Used on SDK close. */
+  @ApiStatus.Internal
+  void close();
 }

--- a/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
@@ -47,6 +47,7 @@ class DefaultTransactionPerformanceCollectorTest {
                 return FutureTask {}
             }
             override fun close(timeoutMillis: Long) {}
+            override fun isClosed() = false
         }
 
         val mockCpuCollector: ICollector = object : ICollector {

--- a/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
@@ -226,6 +226,20 @@ class DefaultTransactionPerformanceCollectorTest {
         verify(threadCheckerCollector, atLeast(1)).collect(any())
     }
 
+    @Test
+    fun `when close, timer is stopped and data is cleared`() {
+        val collector = fixture.getSut()
+        collector.start(fixture.transaction1)
+        collector.close()
+
+        // Timer was canceled
+        verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+        verify(fixture.mockTimer)!!.cancel()
+
+        // Data was cleared
+        assertNull(collector.stop(fixture.transaction1))
+    }
+
     inner class ThreadCheckerCollector : ICollector {
         override fun setup() {
             if (mainThreadChecker.isMainThread) {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1549,26 +1549,6 @@ class HubTest {
     }
 
     @Test
-    fun `Hub should cancel current transaction bound to the scope and its spans`() {
-        val hub = generateHub {
-            it.tracesSampleRate = 1.0
-        }
-        val transaction = hub.startTransaction("test", "test", true)
-        val span = transaction.startChild("span1")
-        val span2 = transaction.startChild("span1")
-        assertFalse(transaction.isFinished)
-        assertFalse(span.isFinished)
-        assertFalse(span2.isFinished)
-        hub.close()
-        assertTrue(transaction.isFinished)
-        assertTrue(span.isFinished)
-        assertTrue(span2.isFinished)
-        assertEquals(SpanStatus.CANCELLED, transaction.status)
-        assertEquals(SpanStatus.CANCELLED, span.status)
-        assertEquals(SpanStatus.CANCELLED, span2.status)
-    }
-
-    @Test
     fun `when tracesSampleRate and tracesSampler are not set on SentryOptions, startTransaction returns NoOp`() {
         val hub = generateHub {
             it.tracesSampleRate = null

--- a/sentry/src/test/java/io/sentry/NoOpSentryExecutorServiceTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSentryExecutorServiceTest.kt
@@ -1,0 +1,37 @@
+package io.sentry
+
+import org.mockito.kotlin.mock
+import java.util.concurrent.Callable
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+class NoOpSentryExecutorServiceTest {
+    private var sut: ISentryExecutorService = NoOpSentryExecutorService.getInstance()
+
+    @Test
+    fun `submit runnable returns a Future`() {
+        val future = sut.submit(mock())
+        assertNotNull(future)
+    }
+
+    @Test
+    fun `submit callable returns a Future`() {
+        val future = sut.submit(mock<Callable<*>>())
+        assertNotNull(future)
+    }
+
+    @Test
+    fun `schedule returns a Future`() {
+        val future = sut.submit(mock<Callable<*>>())
+        assertNotNull(future)
+    }
+
+    @Test
+    fun `close does not throw`() = sut.close(0)
+
+    @Test
+    fun `isClosed returns false`() {
+        assertFalse(sut.isClosed)
+    }
+}

--- a/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
@@ -14,4 +14,8 @@ class NoOpTransactionProfilerTest {
     fun `onTransactionFinish does returns null`() {
         assertNull(profiler.onTransactionFinish(NoOpTransaction.getInstance(), null))
     }
+
+    @Test
+    fun `close does not throw`() =
+        profiler.close()
 }

--- a/sentry/src/test/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegrationTest.kt
@@ -82,6 +82,16 @@ class SendCachedEnvelopeFireAndForgetIntegrationTest {
         assert(fixture.options.sdkVersion!!.integrationSet.contains("SendCachedEnvelopeFireAndForget"))
     }
 
+    @Test
+    fun `register does not throw on executor shut down`() {
+        fixture.options.cacheDirPath = "cache"
+        fixture.options.executorService.close(0)
+        whenever(fixture.callback.create(any(), any())).thenReturn(mock())
+        val sut = fixture.getSut()
+        sut.register(fixture.hub, fixture.options)
+        verify(fixture.logger).log(eq(SentryLevel.ERROR), eq("Failed to call the executor. Cached events will not be sent. Did you call Sentry.close()?"), any())
+    }
+
     private class CustomFactory : SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory {
         override fun create(hub: IHub, options: SentryOptions): SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget? {
             return null

--- a/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SentryExecutorServiceTest {
@@ -86,5 +87,21 @@ class SentryExecutorServiceTest {
         }
         await.untilFalse(atomicBoolean)
         sentryExecutor.close(15000)
+    }
+
+    @Test
+    fun `SentryExecutorService isClosed returns true if executor is shutdown`() {
+        val executor = mock<ScheduledExecutorService>()
+        val sentryExecutor = SentryExecutorService(executor)
+        whenever(executor.isShutdown).thenReturn(true)
+        assertTrue(sentryExecutor.isClosed)
+    }
+
+    @Test
+    fun `SentryExecutorService isClosed returns false if executor is not shutdown`() {
+        val executor = mock<ScheduledExecutorService>()
+        val sentryExecutor = SentryExecutorService(executor)
+        whenever(executor.isShutdown).thenReturn(false)
+        assertFalse(sentryExecutor.isClosed)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -481,6 +481,21 @@ class SentryTest {
     }
 
     @Test
+    fun `init does not throw on executor shut down`() {
+        val logger = mock<ILogger>()
+
+        Sentry.init {
+            it.dsn = dsn
+            it.profilesSampleRate = 1.0
+            it.cacheDirPath = getTempPath()
+            it.setLogger(logger)
+            it.executorService.close(0)
+            it.isDebug = true
+        }
+        verify(logger).log(eq(SentryLevel.ERROR), eq("Failed to call the executor. Old profiles will not be deleted. Did you call Sentry.close()?"), any())
+    }
+
+    @Test
     fun `reportFullyDisplayed calls hub reportFullyDisplayed`() {
         val hub = mock<IHub>()
         Sentry.init {

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.CompletableFuture
@@ -21,6 +22,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -498,6 +500,36 @@ class SentryTest {
         Sentry.setCurrentHub(hub)
         Sentry.reportFullDisplayed()
         verify(hub).reportFullyDisplayed()
+    }
+
+    @Test
+    fun `ignores executorService if it is closed`() {
+        var sentryOptions: SentryOptions? = null
+        val executorService = mock<ISentryExecutorService>()
+        whenever(executorService.isClosed).thenReturn(true)
+
+        Sentry.init {
+            it.dsn = dsn
+            it.executorService = executorService
+            sentryOptions = it
+        }
+
+        assertNotEquals(executorService, sentryOptions!!.executorService)
+    }
+
+    @Test
+    fun `accept executorService if it is not closed`() {
+        var sentryOptions: SentryOptions? = null
+        val executorService = mock<ISentryExecutorService>()
+        whenever(executorService.isClosed).thenReturn(false)
+
+        Sentry.init {
+            it.dsn = dsn
+            it.executorService = executorService
+            sentryOptions = it
+        }
+
+        assertEquals(executorService, sentryOptions!!.executorService)
     }
 
     private class CustomMainThreadChecker : IMainThreadChecker {

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -1069,6 +1069,7 @@ class SentryTracerTest {
         val mockPerformanceCollector = object : TransactionPerformanceCollector {
             override fun start(transaction: ITransaction) {}
             override fun stop(transaction: ITransaction): MutableList<PerformanceCollectionData> = data
+            override fun close() {}
         }
         val transaction = fixture.getSut(optionsConfiguration = {
             it.profilesSampleRate = 1.0


### PR DESCRIPTION
## :scroll: Description
all calls to ISentryExecutorService are now wrapped in a try catch block
closing the hub will close the profiler and the performance collector


## :bulb: Motivation and Context
Calling `init()` multiple times closes any previous instance of the SDK. 
After closing, any call to the executor service which was previously scheduled resulted in a crash due to `RejectedExecutionException`.
Fixes https://github.com/getsentry/sentry-java/issues/2493


## :green_heart: How did you test it?
Unit and ui test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
