### PR TITLE
Fix Hub.close using withScope and not configureScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use `configureScope` instead of `withScope` in `Hub.close()`. This ensures that the main scope releases the in-memory data when closing a hub instance.
+
 ### Dependencies
 
 - Bump Gradle from v8.1.0 to v8.1.1 ([#2666](https://github.com/getsentry/sentry-java/pull/2666))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Use `configureScope` instead of `withScope` in `Hub.close()`. This ensures that the main scope releases the in-memory data when closing a hub instance.
+- Use `configureScope` instead of `withScope` in `Hub.close()`. This ensures that the main scope releases the in-memory data when closing a hub instance. ([#2688](https://github.com/getsentry/sentry-java/pull/2688))
 
 ### Dependencies
 

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -340,7 +340,7 @@ public final class Hub implements IHub {
           }
         }
 
-        withScope(scope -> scope.clear());
+        configureScope(scope -> scope.clear());
         options.getTransactionProfiler().close();
         options.getTransactionPerformanceCollector().close();
         options.getExecutorService().close(options.getShutdownTimeoutMillis());

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1549,6 +1549,26 @@ class HubTest {
     }
 
     @Test
+    fun `Hub close should clear the scope`() {
+        val options = SentryOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+        }
+
+        val sut = Hub(options)
+        sut.addBreadcrumb("Test")
+        sut.startTransaction("test", "test.op", true)
+        sut.close()
+
+        // we have to clone the scope, so its isEnabled returns true, but it's still built up from
+        // the old scope preserving its data
+        val clone = sut.clone()
+        var oldScope: Scope? = null
+        clone.configureScope { scope -> oldScope = scope }
+        assertNull(oldScope!!.transaction)
+        assertTrue(oldScope!!.breadcrumbs.isEmpty())
+    }
+
+    @Test
     fun `when tracesSampleRate and tracesSampler are not set on SentryOptions, startTransaction returns NoOp`() {
         val hub = generateHub {
             it.tracesSampleRate = null

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1026,8 +1026,7 @@ class HubTest {
 
         hub.close()
 
-        hub.clearBreadcrumbs()
-        assertEquals(1, scope?.breadcrumbs?.count())
+        assertEquals(0, scope?.breadcrumbs?.count())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
https://github.com/getsentry/sentry-java/pull/2679#discussion_r1182190663

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed while reviewing #2679

## :green_heart: How did you test it?
With a test that was failing prior to the fix

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
