### PR TITLE
Android Profiler on calling thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Android Profiler on calling thread ([#2691](https://github.com/getsentry/sentry-java/pull/2691))
 - Use `configureScope` instead of `withScope` in `Hub.close()`. This ensures that the main scope releases the in-memory data when closing a hub instance. ([#2688](https://github.com/getsentry/sentry-java/pull/2688))
 
 ### Dependencies

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -313,7 +313,7 @@ class AndroidTransactionProfilerTest {
         profiler.onTransactionFinish(fixture.transaction1, null)
         // We assert that no trace files are written
         assertTrue(File(fixture.options.profilingTracesDirPath!!).list()!!.isEmpty())
-        verify(fixture.mockLogger).log(eq(SentryLevel.ERROR), eq("Unable to write the profile to file: "), any())
+        verify(fixture.mockLogger).log(eq(SentryLevel.ERROR), eq("Error while stopping profiling: "), any())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
AndroidTransactionProfiler now starts/stops profiles without offloading to the executorService
removed any file checks due to the code running possibly on the main thread
wrapped Debug methods into try/catch to compensate lack of file checks


## :bulb: Motivation and Context
If the executor service is very busy, the profiler would start with some delay, and when finishing it would wait for the executor to finish, possibly causing ANRs.
fixes https://github.com/getsentry/sentry-java/issues/2649


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
