### PR TITLE
Add API to set custom sentry-native sdk name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - Bump Gradle from v8.1.0 to v8.1.1 ([#2666](https://github.com/getsentry/sentry-java/pull/2666))
   - [changelog](https://github.com/gradle/gradle/blob/master release-test/CHANGELOG.md#v811)
   - [diff](https://github.com/gradle/gradle/compare/v8.1.0...v8.1.1)
+- Bump Native SDK from v0.6.1 to v0.6.2 ([#2689](https://github.com/getsentry/sentry-java/pull/2689))
+  - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#062)
+  - [diff](https://github.com/getsentry/sentry-native/compare/0.6.1...0.6.2)
 
 ## 6.18.1
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -208,6 +208,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun enableAllAutoBreadcrumbs (Z)V
 	public fun getAnrTimeoutIntervalMillis ()J
 	public fun getDebugImagesLoader ()Lio/sentry/android/core/IDebugImagesLoader;
+	public fun getNativeSdkName ()Ljava/lang/String;
 	public fun getProfilingTracesHz ()I
 	public fun getProfilingTracesIntervalMillis ()I
 	public fun getStartupCrashDurationThresholdMillis ()J
@@ -239,6 +240,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableFramesTracking (Z)V
 	public fun setEnableNetworkEventBreadcrumbs (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V
+	public fun setNativeSdkName (Ljava/lang/String;)V
 	public fun setProfilingTracesHz (I)V
 	public fun setProfilingTracesIntervalMillis (I)V
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -8,6 +8,7 @@ import io.sentry.SpanStatus;
 import io.sentry.protocol.SdkVersion;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 /** Sentry SDK options for Android */
@@ -132,6 +133,8 @@ public final class SentryAndroidOptions extends SentryOptions {
   private final long startupCrashDurationThresholdMillis = 2000; // 2s
 
   private boolean enableFramesTracking = true;
+
+  private @Nullable String nativeSdkName = null;
 
   public SentryAndroidOptions() {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
@@ -401,5 +404,26 @@ public final class SentryAndroidOptions extends SentryOptions {
   @ApiStatus.Internal
   public long getStartupCrashDurationThresholdMillis() {
     return startupCrashDurationThresholdMillis;
+  }
+
+  /**
+   * Sets the sdk name for the sentry-native ndk module. The value is used for the event->sdk
+   * attribute and the sentry_client auth header.
+   *
+   * @param nativeSdkName the native sdk name
+   */
+  @ApiStatus.Internal
+  public void setNativeSdkName(final @Nullable String nativeSdkName) {
+    this.nativeSdkName = nativeSdkName;
+  }
+
+  /**
+   * Returns the sdk name for the sentry native ndk module.
+   *
+   * @return the custom SDK name if set, otherwise null
+   */
+  @ApiStatus.Internal
+  public @Nullable String getNativeSdkName() {
+    return nativeSdkName;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryAndroidOptionsTest {
@@ -109,6 +110,27 @@ class SentryAndroidOptionsTest {
         val sentryOptions = SentryAndroidOptions()
 
         assertFalse(sentryOptions.isAttachViewHierarchy)
+    }
+
+    @Test
+    fun `native sdk name is null by default`() {
+        val sentryOptions = SentryAndroidOptions()
+        assertNull(sentryOptions.nativeSdkName)
+    }
+
+    @Test
+    fun `native sdk name can be properly set`() {
+        val sentryOptions = SentryAndroidOptions()
+        sentryOptions.nativeSdkName = "test_ndk_name"
+        assertEquals("test_ndk_name", sentryOptions.nativeSdkName)
+    }
+
+    @Test
+    fun `native sdk name can be properly set to null`() {
+        val sentryOptions = SentryAndroidOptions()
+        sentryOptions.nativeSdkName = "test_ndk_name"
+        sentryOptions.nativeSdkName = null
+        assertNull(sentryOptions.nativeSdkName)
     }
 
     private class CustomDebugImagesLoader : IDebugImagesLoader {

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -252,7 +252,7 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
                                                     "()Ljava/lang/String;");
     jmethodID dist_mid = (*env)->GetMethodID(env, options_cls, "getDist", "()Ljava/lang/String;");
     jmethodID max_crumbs_mid = (*env)->GetMethodID(env, options_cls, "getMaxBreadcrumbs", "()I");
-    jmethodID native_sdk_name_mid = (*env)->GetMethodID(env, options_cls, "getNdkSdkName",
+    jmethodID native_sdk_name_mid = (*env)->GetMethodID(env, options_cls, "getNativeSdkName",
                                                     "()Ljava/lang/String;");
 
     (*env)->DeleteLocalRef(env, options_cls);

--- a/sentry-android-ndk/src/main/jni/sentry.c
+++ b/sentry-android-ndk/src/main/jni/sentry.c
@@ -252,6 +252,8 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
                                                     "()Ljava/lang/String;");
     jmethodID dist_mid = (*env)->GetMethodID(env, options_cls, "getDist", "()Ljava/lang/String;");
     jmethodID max_crumbs_mid = (*env)->GetMethodID(env, options_cls, "getMaxBreadcrumbs", "()I");
+    jmethodID native_sdk_name_mid = (*env)->GetMethodID(env, options_cls, "getNdkSdkName",
+                                                    "()Ljava/lang/String;");
 
     (*env)->DeleteLocalRef(env, options_cls);
 
@@ -264,6 +266,7 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
     char *release_str = NULL;
     char *environment_str = NULL;
     char *dist_str = NULL;
+    char *native_sdk_name_str = NULL;
 
     options = sentry_options_new();
     ENSURE_OR_FAIL(options);
@@ -326,6 +329,12 @@ Java_io_sentry_android_ndk_SentryNdk_initSentryNative(
     {
         sentry_options_set_dist(options, dist_str);
         sentry_free(dist_str);
+    }
+
+    native_sdk_name_str = call_get_string(env, sentry_sdk_options, native_sdk_name_mid);
+    if (native_sdk_name_str) {
+        sentry_options_set_sdk_name(options, native_sdk_name_str);
+        sentry_free(native_sdk_name_str);
     }
 
     sentry_init(options);


### PR DESCRIPTION
## :scroll: Description

Update sentry-native to 0.6.2
Add `SentryAndroidOptions.setNativeSdkName`

Fixes https://github.com/getsentry/sentry-java/issues/2678

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Added some unit tests. Ideally we would have some integration test for this as well, but there's nothing setup as of now.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

#skip-changelog