### PR TITLE
Changed OnePlus 9 Pro to Samsung Galaxy S10+ in Saucelabs

### DIFF
--- a/.sauce/sentry-uitest-android-benchmark.yml
+++ b/.sauce/sentry-uitest-android-benchmark.yml
@@ -32,7 +32,7 @@ suites:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: OnePlus_9_Pro_real_us # OnePlus 9 Pro - api 30 (11) - high end
+      - id: Samsung_Galaxy_S10_Plus_11_real_us # Samsung Galaxy S10+ - api 30 (11) - high end
       - id: Samsung_Galaxy_A71_5G_real_us # Samsung Galaxy A71 5G - api 30 (11) - mid end
       - id: Google_Pixel_3a_real # Google Pixel 3a - api 30 (11) - low end
 

--- a/.sauce/sentry-uitest-android-ui.yml
+++ b/.sauce/sentry-uitest-android-ui.yml
@@ -37,7 +37,7 @@ suites:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: OnePlus_9_Pro_real_us # OnePlus 9 Pro - api 30 (11)
+      - id: Samsung_Galaxy_S10_Plus_11_real_us # Samsung Galaxy S10+ - api 30 (11)
 
   - name: "Android 10 Ui test (api 29)"
     testOptions:


### PR DESCRIPTION
## :scroll: Description
changed OnePlus 9 Pro device to Samsung Galaxy S10+ in saucelabs as it doesn't exists anymore

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
