### PR TITLE
Improve error output for envelope tests

### DIFF
--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -118,16 +118,32 @@ class EnvelopeTests : BaseUiTest() {
                 val maxTimestampAllowed = profilingTraceData.durationNs.toLong() + TimeUnit.SECONDS.toNanos(2)
                 val allMeasurements = profilingTraceData.measurementsMap.values
 
-                allMeasurements.filter { it.values.isNotEmpty() }.forEach { measurement ->
+                profilingTraceData.measurementsMap.entries.filter {
+                    it.value.values.isNotEmpty()
+                }.forEach { entry ->
+                    val name = entry.key
+                    val measurement = entry.value
+
                     val values = measurement.values.sortedBy { it.relativeStartNs.toLong() }
                     // There should be no measurement before the profile starts
-                    assertTrue(values.first().relativeStartNs.toLong() > 0)
+                    assertTrue(
+                        values.first().relativeStartNs.toLong() > 0,
+                        "First measurement value for '$name' is <=0"
+                    )
                     // There should be no measurement after the profile ends
-                    assertTrue(values.last().relativeStartNs.toLong() < maxTimestampAllowed)
+                    assertTrue(
+                        values.last().relativeStartNs.toLong() < maxTimestampAllowed,
+                        "Last measurement value for '$name' is outside bounds (was: ${values.last().relativeStartNs.toLong()}ns, max: ${maxTimestampAllowed}ns"
+                    )
 
                     // Timestamps of measurements should differ at least 10 milliseconds from each other
                     (1 until values.size).forEach { i ->
-                        assertTrue(values[i].relativeStartNs.toLong() > values[i - 1].relativeStartNs.toLong() + TimeUnit.MILLISECONDS.toNanos(10))
+                        assertTrue(
+                            values[i].relativeStartNs.toLong() > values[i - 1].relativeStartNs.toLong() + TimeUnit.MILLISECONDS.toNanos(
+                                10
+                            ),
+                            "Measurement value timestamp for '$name' does not differ at least 10ms"
+                        )
                     }
                 }
 


### PR DESCRIPTION
## :scroll: Description
Since we see this test occasionally failing I added some more detailed error message in case the tests fail.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

#skip-changelog