### PR TITLE
Remove usage of ThreadLocal for IHubs

### DIFF
--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -236,7 +236,7 @@ class SentryTest {
 
     @Test
     fun `using sentry before calling init creates NoOpHub but after init Sentry uses a new clone`() {
-        // noop as not yet initialized, caches NoOpHub in ThreadLocal
+        // noop as not yet initialized, caches NoOpHub in hubMap
         Sentry.captureMessage("noop caused")
 
         assertTrue(Sentry.getCurrentHub() is NoOpHub)
@@ -260,7 +260,7 @@ class SentryTest {
 
     @Test
     fun `main hub can be cloned and does not share scope with current hub`() {
-        // noop as not yet initialized, caches NoOpHub in ThreadLocal
+        // noop as not yet initialized, caches NoOpHub in hubMap
         Sentry.addBreadcrumb("breadcrumbNoOp")
         Sentry.captureMessage("messageNoOp")
 
@@ -311,7 +311,7 @@ class SentryTest {
 
     @Test
     fun `main hub is not cloned in global hub mode and shares scope with current hub`() {
-        // noop as not yet initialized, caches NoOpHub in ThreadLocal
+        // noop as not yet initialized, caches NoOpHub in hubMap
         Sentry.addBreadcrumb("breadcrumbNoOp")
         Sentry.captureMessage("messageNoOp")
 


### PR DESCRIPTION
## :scroll: Description
Migrate from using `ThreadLocal` to store `IHub`, since they are difficult to remove from framework managed threads.


## :bulb: Motivation and Context
Fixes #2079.


## :green_heart: How did you test it?
Running the test suite.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [x] I ran the test suite to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
