### PR TITLE
Fix AndroidProfiler and SentryTracer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Base64 encode internal Apollo3 Headers ([#2707](https://github.com/getsentry/sentry-java/pull/2707))
+- Fix `SentryTracer` crash when scheduling auto-finish of a transaction, but the timer has already been cancelled ([#2731](https://github.com/getsentry/sentry-java/pull/2731))
+- Fix `AndroidTransactionProfiler` crash when finishing a profile that happened due to race condition ([#2731](https://github.com/getsentry/sentry-java/pull/2731))
 
 ## 6.19.1
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -283,7 +283,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @SuppressLint("NewApi")
-  private @Nullable ProfilingTraceData onTransactionFinish(
+  private @Nullable synchronized ProfilingTraceData onTransactionFinish(
       final @NotNull ITransaction transaction,
       final boolean isTimeout,
       final @Nullable List<PerformanceCollectionData> performanceCollectionData) {
@@ -365,7 +365,10 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     long transactionDurationNanos = transactionEndNanos - transactionStartNanos;
 
     List<ProfilingTransactionData> transactionList = new ArrayList<>(1);
-    transactionList.add(currentProfilingTransactionData);
+    final ProfilingTransactionData txData = currentProfilingTransactionData;
+    if (txData != null) {
+      transactionList.add(txData);
+    }
     currentProfilingTransactionData = null;
     // We clear the counter in case of a timeout
     transactionsCounter = 0;

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -1216,4 +1216,23 @@ class SentryTracerTest {
             anyOrNull()
         )
     }
+
+    @Test
+    fun `when timer is cancelled, schedule finish does not crash`() {
+        val tracer = fixture.getSut(idleTimeout = 50)
+        tracer.timer!!.cancel()
+        tracer.scheduleFinish()
+    }
+
+    @Test
+    fun `when timer is cancelled, schedule finish finishes the transaction immediately`() {
+        val tracer = fixture.getSut(idleTimeout = 50)
+        tracer.startChild("load").finish()
+
+        tracer.timer!!.cancel()
+        tracer.scheduleFinish()
+
+        assertTrue(tracer.isFinished)
+        verify(fixture.hub).captureTransaction(any(), anyOrNull(), anyOrNull(), anyOrNull())
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
A customer reported these 2 crashes internally, so this PR simply fixes/swallows them. Most likely they were caused by calling `Sentry.close()` in the middle of processing transactions.

*  The `synchronized` in `AndroidTransactionProfiler` should actually fix the root cause, but I've also added the null check just to make sure
* For SentryTracer fix we just swallow the exception and finish the transaction immediately if we failed to schedule the finish timer


![image](https://github.com/getsentry/sentry-java/assets/4999776/c0ea5425-c1a2-40f0-aa79-3a99979cd604)
![image](https://github.com/getsentry/sentry-java/assets/4999776/528e1ace-e171-4d61-8f28-0a321ea2b608)



## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
