### PR TITLE
Use Base64.NO_WRAP to avoid unexpected char errors in Apollo

### DIFF
--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -125,7 +125,7 @@ class SentryApollo3HttpInterceptor @JvmOverloads constructor(private val hub: IH
     private fun decodeHeaderValue(request: HttpRequest, headerName: String): String? {
         return request.valueForHeader(headerName)?.let {
             try {
-                String(Base64.decode(it, Base64.DEFAULT))
+                String(Base64.decode(it, Base64.NO_WRAP))
             } catch (e: IllegalArgumentException) {
                 hub.options.logger.log(SentryLevel.ERROR, "Error decoding internal apolloHeader $headerName", e)
                 return null

--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3Interceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3Interceptor.kt
@@ -23,11 +23,11 @@ class SentryApollo3Interceptor : ApolloInterceptor {
         chain: ApolloInterceptorChain
     ): Flow<ApolloResponse<D>> {
         val builder = request.newBuilder()
-            .addHttpHeader(SENTRY_APOLLO_3_OPERATION_TYPE, Base64.encodeToString(operationType(request).toByteArray(), Base64.DEFAULT))
-            .addHttpHeader(SENTRY_APOLLO_3_OPERATION_NAME, Base64.encodeToString(request.operation.name().toByteArray(), Base64.DEFAULT))
+            .addHttpHeader(SENTRY_APOLLO_3_OPERATION_TYPE, Base64.encodeToString(operationType(request).toByteArray(), Base64.NO_WRAP))
+            .addHttpHeader(SENTRY_APOLLO_3_OPERATION_NAME, Base64.encodeToString(request.operation.name().toByteArray(), Base64.NO_WRAP))
 
         request.scalarAdapters?.let {
-            builder.addHttpHeader(SENTRY_APOLLO_3_VARIABLES, Base64.encodeToString(request.operation.variables(it).valueMap.toString().toByteArray(), Base64.DEFAULT))
+            builder.addHttpHeader(SENTRY_APOLLO_3_VARIABLES, Base64.encodeToString(request.operation.variables(it).valueMap.toString().toByteArray(), Base64.NO_WRAP))
         }
         return chain.proceed(builder.build())
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/2737

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
