### PR TITLE
Enrich database spans with blocked main thread info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Enrich database spans with blocked main thread info ([#2760](https://github.com/getsentry/sentry-java/pull/2760))
+
 ## 6.21.0
 
 ### Features


### PR DESCRIPTION
## :scroll: Description
Extends the instrumented spans with main thread information. If the query executes on the main thread, a stack trace is added as well. Based on https://github.com/getsentry/sentry-java/blob/baa4b26a8940ca5785af4ee5cf8fa18b8aedeadd/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java#L104-L108


## :bulb: Motivation and Context
We want to have database on main thread issues.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
