### PR TITLE
Add lock attribute to the frame protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `lock` attribute to the `SentryStackFrame` protocol to better highlight offending frames in the UI ([#2761](https://github.com/getsentry/sentry-java/pull/2761))
+
 ## 6.21.0
 
 ### Features

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -33,6 +33,12 @@ class ThreadDumpParserTest {
         assertEquals("run", lastFrame.function)
         assertEquals(177, lastFrame.lineno)
         assertEquals(true, lastFrame.isInApp)
+        val lock = lastFrame.lock
+        assertEquals("0x0d3a2f0a", lock!!.address)
+        assertEquals(SentryLockReason.BLOCKED, lock.type)
+        assertEquals("java.lang", lock.packageName)
+        assertEquals("Object", lock.className)
+        assertEquals(5, lock.threadId)
 
         val blockingThread = threads.find { it.name == "Thread-9" }
         assertEquals(5, blockingThread!!.id)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3600,6 +3600,7 @@ public final class io/sentry/protocol/SentryStackFrame : io/sentry/JsonSerializa
 	public fun getImageAddr ()Ljava/lang/String;
 	public fun getInstructionAddr ()Ljava/lang/String;
 	public fun getLineno ()Ljava/lang/Integer;
+	public fun getLock ()Lio/sentry/SentryLockReason;
 	public fun getModule ()Ljava/lang/String;
 	public fun getPackage ()Ljava/lang/String;
 	public fun getPlatform ()Ljava/lang/String;
@@ -3623,6 +3624,7 @@ public final class io/sentry/protocol/SentryStackFrame : io/sentry/JsonSerializa
 	public fun setInApp (Ljava/lang/Boolean;)V
 	public fun setInstructionAddr (Ljava/lang/String;)V
 	public fun setLineno (Ljava/lang/Integer;)V
+	public fun setLock (Lio/sentry/SentryLockReason;)V
 	public fun setModule (Ljava/lang/String;)V
 	public fun setNative (Ljava/lang/Boolean;)V
 	public fun setPackage (Ljava/lang/String;)V
@@ -3652,6 +3654,7 @@ public final class io/sentry/protocol/SentryStackFrame$JsonKeys {
 	public static final field INSTRUCTION_ADDR Ljava/lang/String;
 	public static final field IN_APP Ljava/lang/String;
 	public static final field LINENO Ljava/lang/String;
+	public static final field LOCK Ljava/lang/String;
 	public static final field MODULE Ljava/lang/String;
 	public static final field NATIVE Ljava/lang/String;
 	public static final field PACKAGE Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -124,9 +124,7 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
    */
   private @Nullable String rawFunction;
 
-  /**
-   * Represents a lock (java monitor object) held by this frame.
-   */
+  /** Represents a lock (java monitor object) held by this frame. */
   private @Nullable SentryLockReason lock;
 
   public @Nullable List<String> getPreContext() {

--- a/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
@@ -5,6 +5,7 @@ import io.sentry.ILogger
 import io.sentry.JsonObjectReader
 import io.sentry.JsonObjectWriter
 import io.sentry.JsonSerializable
+import io.sentry.SentryLockReason
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.io.StringReader
@@ -33,6 +34,13 @@ class SentryStackFrameSerializationTest {
             instructionAddr = "19864a78-2466-461f-9f0b-93a5c9ae7622"
             rawFunction = "f33035a4-0cf0-453d-b6f4-d7c27e9af924"
             symbol = "d9807ffe-d517-11ed-afa1-0242ac120002"
+            lock = SentryLockReason().apply {
+                address = "0x0d3a2f0a"
+                className = "Object"
+                packageName = "java.lang"
+                type = SentryLockReason.BLOCKED
+                threadId = 11
+            }
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/resources/json/sentry_stack_frame.json
+++ b/sentry/src/test/resources/json/sentry_stack_frame.json
@@ -14,5 +14,12 @@
     "symbol_addr": "180e12cd-1fa8-405d-8dd8-e87b33fa2eb0",
     "instruction_addr": "19864a78-2466-461f-9f0b-93a5c9ae7622",
     "raw_function": "f33035a4-0cf0-453d-b6f4-d7c27e9af924",
-    "symbol": "d9807ffe-d517-11ed-afa1-0242ac120002"
+    "symbol": "d9807ffe-d517-11ed-afa1-0242ac120002",
+    "lock": {
+      "type": 8,
+      "address": "0x0d3a2f0a",
+      "package_name": "java.lang",
+      "class_name": "Object",
+      "thread_id": 11
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This is necessary in addition to `SentryThread.held_locks` to highlight the offending frame in the UI, so the lock has to be also on the per-frame level.

Relay PR: https://github.com/getsentry/relay/pull/2171

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Q2 Goal

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
