### PR TITLE
No longer use `String.join` in `Baggage` as it requires API level 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Enrich database spans with blocked main thread info ([#2760](https://github.com/getsentry/sentry-java/pull/2760))
 - Add `api_target` to `Request` and `data` to `Response` Protocols ([#2775](https://github.com/getsentry/sentry-java/pull/2775))
 
+### Fixes
+
+- No longer use `String.join` in `Baggage` as it requires API level 26 ([#2778](https://github.com/getsentry/sentry-java/pull/2778))
+
 ## 6.21.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4135,6 +4135,7 @@ public final class io/sentry/util/StringUtils {
 	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
 	public static fun countOf (Ljava/lang/String;C)I
 	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;
+	public static fun join (Ljava/lang/CharSequence;Ljava/lang/Iterable;)Ljava/lang/String;
 	public static fun normalizeUUID (Ljava/lang/String;)Ljava/lang/String;
 	public static fun removeSurrounding (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -69,7 +69,8 @@ public final class Baggage {
       final @NotNull ILogger logger) {
 
     if (headerValues != null) {
-      return Baggage.fromHeader(String.join(",", headerValues), includeThirdPartyValues, logger);
+      return Baggage.fromHeader(
+          StringUtils.join(",", headerValues), includeThirdPartyValues, logger);
     } else {
       return Baggage.fromHeader((String) null, includeThirdPartyValues, logger);
     }
@@ -118,7 +119,9 @@ public final class Baggage {
       }
     }
     final String thirdPartyHeader =
-        thirdPartyKeyValueStrings.isEmpty() ? null : String.join(",", thirdPartyKeyValueStrings);
+        thirdPartyKeyValueStrings.isEmpty()
+            ? null
+            : StringUtils.join(",", thirdPartyKeyValueStrings);
     return new Baggage(keyValues, thirdPartyHeader, mutable, logger);
   }
 

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -158,6 +158,13 @@ public final class StringUtils {
     return uuidString;
   }
 
+  /**
+   * Returns a new String joining together given strings using the given delimiter.
+   *
+   * @param delimiter the delimiter that separates elements
+   * @param elements the elements that should be joined together
+   * @return a new String with elements joined using delimiter
+   */
   public static String join(
       final @NotNull CharSequence delimiter,
       final @NotNull Iterable<? extends CharSequence> elements) {

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -8,6 +8,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
+import java.util.Iterator;
 import java.util.Locale;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -155,5 +156,22 @@ public final class StringUtils {
       return PROPER_NIL_UUID;
     }
     return uuidString;
+  }
+
+  public static String join(
+      final @NotNull CharSequence delimiter,
+      final @NotNull Iterable<? extends CharSequence> elements) {
+    final @NotNull StringBuilder stringBuilder = new StringBuilder();
+    final @NotNull Iterator<? extends CharSequence> iterator = elements.iterator();
+
+    if (iterator.hasNext()) {
+      stringBuilder.append(iterator.next());
+      while (iterator.hasNext()) {
+        stringBuilder.append(delimiter);
+        stringBuilder.append(iterator.next());
+      }
+    }
+
+    return stringBuilder.toString();
   }
 }

--- a/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
@@ -129,4 +129,22 @@ class StringUtilsTest {
         val normalized = StringUtils.normalizeUUID(original)
         assertEquals(original, normalized)
     }
+
+    @Test
+    fun `joins strings with delimiter`() {
+        val result = StringUtils.join(",", listOf("a", "b"))
+        assertEquals("a,b", result)
+    }
+
+    @Test
+    fun `joins single string without delimiter`() {
+        val result = StringUtils.join(",", listOf("a"))
+        assertEquals("a", result)
+    }
+
+    @Test
+    fun `joins list string into empty string`() {
+        val result = StringUtils.join(",", emptyList())
+        assertEquals("", result)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
No longer use `String.join` in `Baggage` as it requires API level 26

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/2774

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
