### PR TITLE
Add profile rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add profile rate limiting ([#2782](https://github.com/getsentry/sentry-java/pull/2782))
+
 ## 6.22.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -163,6 +163,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static final field Attachment Lio/sentry/DataCategory;
 	public static final field Default Lio/sentry/DataCategory;
 	public static final field Error Lio/sentry/DataCategory;
+	public static final field Profile Lio/sentry/DataCategory;
 	public static final field Security Lio/sentry/DataCategory;
 	public static final field Session Lio/sentry/DataCategory;
 	public static final field Transaction Lio/sentry/DataCategory;

--- a/sentry/src/main/java/io/sentry/DataCategory.java
+++ b/sentry/src/main/java/io/sentry/DataCategory.java
@@ -10,6 +10,7 @@ public enum DataCategory {
   Error("error"),
   Session("session"),
   Attachment("attachment"),
+  Profile("profile"),
   Transaction("transaction"),
   Security("security"),
   UserReport("user_report"),

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -143,6 +143,9 @@ public final class ClientReportRecorder implements IClientReportRecorder {
     if (SentryItemType.UserFeedback.equals(itemType)) {
       return DataCategory.UserReport;
     }
+    if (SentryItemType.Profile.equals(itemType)) {
+      return DataCategory.Profile;
+    }
     if (SentryItemType.Attachment.equals(itemType)) {
       return DataCategory.Attachment;
     }

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -145,6 +145,8 @@ public final class RateLimiter {
         return DataCategory.Session;
       case "attachment":
         return DataCategory.Attachment;
+      case "profile":
+        return DataCategory.Profile;
       case "transaction":
         return DataCategory.Transaction;
       default:


### PR DESCRIPTION
## :scroll: Description
added profile rate limiting
added Profile type in ClientReportRecorder, DataCategory and RateLimiter


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/2017 


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
