### PR TITLE
Fix broken test with param names

### DIFF
--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorWithVariablesTest.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorWithVariablesTest.kt
@@ -68,7 +68,7 @@ class SentryApollo3InterceptorWithVariablesTest {
             )
 
             return ApolloClient.Builder().serverUrl(server.url("/").toString())
-                .sentryTracing(hub, beforeSpan)
+                .sentryTracing(hub = hub, beforeSpan = beforeSpan)
                 .build()
         }
     }


### PR DESCRIPTION
## :scroll: Description
_#skip-changelog_


## :bulb: Motivation and Context

> e: file:///home/runner/work/sentry-java/sentry-java/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorWithVariablesTest.kt:71:18 None of the following functions can be called with the arguments supplied: 
> 
> public fun ApolloClient.Builder.sentryTracing(hub: IHub = ..., captureFailedRequests: Boolean = ..., failedRequestTargets: List<String> = ..., beforeSpan: SentryApollo3HttpInterceptor.BeforeSpanCallback? = ...): ApolloClient.Builder defined in io.sentry.apollo3
> public fun ApolloClient.Builder.sentryTracing(captureFailedRequests: Boolean = ..., failedRequestTargets: List<String> = ..., beforeSpan: SentryApollo3HttpInterceptor.BeforeSpanCallback? = ...): ApolloClient.Builder defined in io.sentry.apollo3
> > Task :sentry-apollo-3:compileTestKotlin FAILED


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
