### PR TITLE
Align http.status to span data convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features
 
-- Align http.status to span data convention ([#2786](https://github.com/getsentry/sentry-java/pull/2786))
 - Support for automatically capturing Failed GraphQL (Apollo 3) Client errors ([#2781](https://github.com/getsentry/sentry-java/pull/2781))
 
 ```kotlin
@@ -22,6 +21,10 @@ val apolloClient = ApolloClient.Builder()
 - Bump Native SDK from v0.6.2 to v0.6.3 ([#2746](https://github.com/getsentry/sentry-java/pull/2746))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#063)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.6.2...0.6.3)
+
+### Fixes
+
+- Align http.status to span data convention ([#2786](https://github.com/getsentry/sentry-java/pull/2786))
 
 ## 6.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Align http.status to span data convention ([#2786](https://github.com/getsentry/sentry-java/pull/2786))
 - Support for automatically capturing Failed GraphQL (Apollo 3) Client errors ([#2781](https://github.com/getsentry/sentry-java/pull/2781))
 
 ```kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ val apolloClient = ApolloClient.Builder()
 
 ### Fixes
 
-- Align http.status to span data convention ([#2786](https://github.com/getsentry/sentry-java/pull/2786))
+- Align http.status with [span data conventions](https://develop.sentry.dev/sdk/performance/span-data-conventions/) ([#2786](https://github.com/getsentry/sentry-java/pull/2786))
 
 ## 6.22.0
 

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.okhttp
 
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.ISpan
@@ -48,7 +49,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         callRootSpan?.setData("url", url)
         callRootSpan?.setData("host", host)
         callRootSpan?.setData("path", encodedPath)
-        callRootSpan?.setData("http.method", method)
+        callRootSpan?.setData(DataConvention.HTTP_METHOD_KEY, method)
     }
 
     /**
@@ -60,7 +61,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         breadcrumb.setData(PROTOCOL_KEY, response.protocol.name)
         breadcrumb.setData("status_code", response.code)
         callRootSpan?.setData(PROTOCOL_KEY, response.protocol.name)
-        callRootSpan?.setData("http.status_code", response.code)
+        callRootSpan?.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.code)
         callRootSpan?.status = SpanStatus.fromHttpStatusCode(response.code)
     }
 
@@ -81,7 +82,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
     fun setResponseBodySize(byteCount: Long) {
         if (byteCount > -1) {
             breadcrumb.setData("response_content_length", byteCount)
-            callRootSpan?.setData("http.response_content_length", byteCount)
+            callRootSpan?.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
         }
     }
 

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
@@ -1,10 +1,10 @@
 package io.sentry.android.okhttp
 
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.ISpan
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint
 import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.CONNECTION_EVENT
@@ -49,7 +49,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         callRootSpan?.setData("url", url)
         callRootSpan?.setData("host", host)
         callRootSpan?.setData("path", encodedPath)
-        callRootSpan?.setData(DataConvention.HTTP_METHOD_KEY, method)
+        callRootSpan?.setData(SpanDataConvention.HTTP_METHOD_KEY, method)
     }
 
     /**
@@ -61,7 +61,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         breadcrumb.setData(PROTOCOL_KEY, response.protocol.name)
         breadcrumb.setData("status_code", response.code)
         callRootSpan?.setData(PROTOCOL_KEY, response.protocol.name)
-        callRootSpan?.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.code)
+        callRootSpan?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
         callRootSpan?.status = SpanStatus.fromHttpStatusCode(response.code)
     }
 
@@ -82,7 +82,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
     fun setResponseBodySize(byteCount: Long) {
         if (byteCount > -1) {
             breadcrumb.setData("response_content_length", byteCount)
-            callRootSpan?.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
+            callRootSpan?.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
         }
     }
 

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.okhttp
 
-import io.sentry.DataConvention
 import io.sentry.HubAdapter
 import io.sentry.IHub
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import okhttp3.Call
 import okhttp3.Connection
@@ -312,7 +312,7 @@ class SentryOkHttpEventListener(
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setResponse(response)
         okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
-            it.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.code)
+            it.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
             it.status = SpanStatus.fromHttpStatusCode(response.code)
         }
     }
@@ -335,7 +335,7 @@ class SentryOkHttpEventListener(
         okHttpEvent.setResponseBodySize(byteCount)
         okHttpEvent.finishSpan(RESPONSE_BODY_EVENT) {
             if (byteCount > 0) {
-                it.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
+                it.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
             }
         }
     }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.okhttp
 
+import io.sentry.DataConvention
 import io.sentry.HubAdapter
 import io.sentry.IHub
 import io.sentry.SpanStatus
@@ -311,7 +312,7 @@ class SentryOkHttpEventListener(
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setResponse(response)
         okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
-            it.setData("status_code", response.code)
+            it.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.code)
             it.status = SpanStatus.fromHttpStatusCode(response.code)
         }
     }
@@ -334,7 +335,7 @@ class SentryOkHttpEventListener(
         okHttpEvent.setResponseBodySize(byteCount)
         okHttpEvent.finishSpan(RESPONSE_BODY_EVENT) {
             if (byteCount > 0) {
-                it.setData("http.response_content_length", byteCount)
+                it.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
             }
         }
     }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -2,7 +2,6 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HttpStatusCodeRange
 import io.sentry.HubAdapter
@@ -12,6 +11,7 @@ import io.sentry.IntegrationName
 import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions.DEFAULT_PROPAGATION_TARGETS
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint.OKHTTP_REQUEST
 import io.sentry.TypeCheckHint.OKHTTP_RESPONSE
@@ -102,7 +102,7 @@ class SentryOkHttpInterceptor(
             request = requestBuilder.build()
             response = chain.proceed(request)
             code = response.code
-            span?.setData(DataConvention.HTTP_STATUS_CODE_KEY, code)
+            span?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, code)
             span?.status = SpanStatus.fromHttpStatusCode(code)
 
             // OkHttp errors (4xx, 5xx) don't throw, so it's safe to call within this block.
@@ -136,7 +136,7 @@ class SentryOkHttpInterceptor(
         val hint = Hint().also { it.set(OKHTTP_REQUEST, request) }
         response?.let {
             it.body?.contentLength().ifHasValidLength { responseBodySize ->
-                breadcrumb.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, responseBodySize)
+                breadcrumb.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, responseBodySize)
             }
 
             hint[OKHTTP_RESPONSE] = it

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -2,6 +2,7 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HttpStatusCodeRange
 import io.sentry.HubAdapter
@@ -101,6 +102,7 @@ class SentryOkHttpInterceptor(
             request = requestBuilder.build()
             response = chain.proceed(request)
             code = response.code
+            span?.setData(DataConvention.HTTP_STATUS_CODE_KEY, code)
             span?.status = SpanStatus.fromHttpStatusCode(code)
 
             // OkHttp errors (4xx, 5xx) don't throw, so it's safe to call within this block.
@@ -134,7 +136,7 @@ class SentryOkHttpInterceptor(
         val hint = Hint().also { it.set(OKHTTP_REQUEST, request) }
         response?.let {
             it.body?.contentLength().ifHasValidLength { responseBodySize ->
-                breadcrumb.setData("http.response_content_length", responseBodySize)
+                breadcrumb.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, responseBodySize)
             }
 
             hint[OKHTTP_RESPONSE] = it

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -1,11 +1,11 @@
 package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import okhttp3.Call
@@ -159,7 +159,7 @@ class SentryOkHttpEventListenerTest {
                     assertNotNull(span.data["proxies"])
                     assertNotNull(span.data["domain_name"])
                     assertNotNull(span.data["dns_addresses"])
-                    assertEquals(201, span.data[DataConvention.HTTP_STATUS_CODE_KEY])
+                    assertEquals(201, span.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
                 }
                 1 -> {
                     assertEquals("http.client.proxy_select", span.operation)
@@ -181,7 +181,7 @@ class SentryOkHttpEventListenerTest {
                 }
                 6 -> {
                     assertEquals("http.client.response_headers", span.operation)
-                    assertEquals(201, span.data[DataConvention.HTTP_STATUS_CODE_KEY])
+                    assertEquals(201, span.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
                 }
                 7 -> {
                     assertEquals("http.client.response_body", span.operation)
@@ -224,8 +224,14 @@ class SentryOkHttpEventListenerTest {
         response.close()
         val requestBodySpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_body" }
         assertNotNull(requestBodySpan)
-        assertEquals(responseBytes.size.toLong(), requestBodySpan.data[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
-        assertEquals(responseBytes.size.toLong(), callSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
+        assertEquals(
+            responseBytes.size.toLong(),
+            requestBodySpan.data[SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY]
+        )
+        assertEquals(
+            responseBytes.size.toLong(),
+            callSpan?.getData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY)
+        )
     }
 
     @Test

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
@@ -158,7 +159,7 @@ class SentryOkHttpEventListenerTest {
                     assertNotNull(span.data["proxies"])
                     assertNotNull(span.data["domain_name"])
                     assertNotNull(span.data["dns_addresses"])
-                    assertEquals(201, span.data["status_code"])
+                    assertEquals(201, span.data[DataConvention.HTTP_STATUS_CODE_KEY])
                 }
                 1 -> {
                     assertEquals("http.client.proxy_select", span.operation)
@@ -180,7 +181,7 @@ class SentryOkHttpEventListenerTest {
                 }
                 6 -> {
                     assertEquals("http.client.response_headers", span.operation)
-                    assertEquals(201, span.data["status_code"])
+                    assertEquals(201, span.data[DataConvention.HTTP_STATUS_CODE_KEY])
                 }
                 7 -> {
                     assertEquals("http.client.response_body", span.operation)
@@ -223,8 +224,8 @@ class SentryOkHttpEventListenerTest {
         response.close()
         val requestBodySpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_body" }
         assertNotNull(requestBodySpan)
-        assertEquals(responseBytes.size.toLong(), requestBodySpan.data["http.response_content_length"])
-        assertEquals(responseBytes.size.toLong(), callSpan?.getData("http.response_content_length"))
+        assertEquals(responseBytes.size.toLong(), requestBodySpan.data[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
+        assertEquals(responseBytes.size.toLong(), callSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
     }
 
     @Test

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.okhttp
 
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ISpan
 import io.sentry.SentryOptions
@@ -106,7 +107,7 @@ class SentryOkHttpEventTest {
         assertEquals(fixture.mockRequest.url.toString(), callSpan.getData("url"))
         assertEquals(fixture.mockRequest.url.host, callSpan.getData("host"))
         assertEquals(fixture.mockRequest.url.encodedPath, callSpan.getData("path"))
-        assertEquals(fixture.mockRequest.method, callSpan.getData("http.method"))
+        assertEquals(fixture.mockRequest.method, callSpan.getData(DataConvention.HTTP_METHOD_KEY))
     }
 
     @Test
@@ -247,7 +248,7 @@ class SentryOkHttpEventTest {
         sut.setResponse(fixture.response)
 
         assertEquals(fixture.response.protocol.name, sut.callRootSpan?.getData("protocol"))
-        assertEquals(fixture.response.code, sut.callRootSpan?.getData("http.status_code"))
+        assertEquals(fixture.response.code, sut.callRootSpan?.getData(DataConvention.HTTP_STATUS_CODE_KEY))
         sut.finishEvent()
 
         verify(fixture.hub).addBreadcrumb(
@@ -321,7 +322,7 @@ class SentryOkHttpEventTest {
     fun `setResponseBodySize set ResponseBodySize in the breadcrumb and in the root span`() {
         val sut = fixture.getSut()
         sut.setResponseBodySize(10)
-        assertEquals(10L, sut.callRootSpan?.getData("http.response_content_length"))
+        assertEquals(10L, sut.callRootSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
         sut.finishEvent()
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
@@ -335,7 +336,7 @@ class SentryOkHttpEventTest {
     fun `setResponseBodySize is ignored if ResponseBodySize is negative`() {
         val sut = fixture.getSut()
         sut.setResponseBodySize(-1)
-        assertNull(sut.callRootSpan?.getData("http.response_content_length"))
+        assertNull(sut.callRootSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
         sut.finishEvent()
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -1,12 +1,12 @@
 package io.sentry.android.okhttp
 
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ISpan
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.Span
+import io.sentry.SpanDataConvention
 import io.sentry.SpanOptions
 import io.sentry.TracesSamplingDecision
 import io.sentry.TransactionContext
@@ -107,7 +107,7 @@ class SentryOkHttpEventTest {
         assertEquals(fixture.mockRequest.url.toString(), callSpan.getData("url"))
         assertEquals(fixture.mockRequest.url.host, callSpan.getData("host"))
         assertEquals(fixture.mockRequest.url.encodedPath, callSpan.getData("path"))
-        assertEquals(fixture.mockRequest.method, callSpan.getData(DataConvention.HTTP_METHOD_KEY))
+        assertEquals(fixture.mockRequest.method, callSpan.getData(SpanDataConvention.HTTP_METHOD_KEY))
     }
 
     @Test
@@ -248,7 +248,7 @@ class SentryOkHttpEventTest {
         sut.setResponse(fixture.response)
 
         assertEquals(fixture.response.protocol.name, sut.callRootSpan?.getData("protocol"))
-        assertEquals(fixture.response.code, sut.callRootSpan?.getData(DataConvention.HTTP_STATUS_CODE_KEY))
+        assertEquals(fixture.response.code, sut.callRootSpan?.getData(SpanDataConvention.HTTP_STATUS_CODE_KEY))
         sut.finishEvent()
 
         verify(fixture.hub).addBreadcrumb(
@@ -322,7 +322,7 @@ class SentryOkHttpEventTest {
     fun `setResponseBodySize set ResponseBodySize in the breadcrumb and in the root span`() {
         val sut = fixture.getSut()
         sut.setResponseBodySize(10)
-        assertEquals(10L, sut.callRootSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
+        assertEquals(10L, sut.callRootSpan?.getData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
         sut.finishEvent()
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
@@ -336,7 +336,7 @@ class SentryOkHttpEventTest {
     fun `setResponseBodySize is ignored if ResponseBodySize is negative`() {
         val sut = fixture.getSut()
         sut.setResponseBodySize(-1)
-        assertNull(sut.callRootSpan?.getData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
+        assertNull(sut.callRootSpan?.getData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY))
         sut.finishEvent()
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -4,13 +4,13 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HttpStatusCodeRange
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.TypeCheckHint
@@ -227,7 +227,7 @@ class SentryOkHttpInterceptorTest {
         val httpClientSpan = fixture.sentryTracer.children.first()
         assertEquals("http.client", httpClientSpan.operation)
         assertEquals("GET ${request.url}", httpClientSpan.description)
-        assertEquals(201, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertEquals(201, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.OK, httpClientSpan.status)
         assertTrue(httpClientSpan.isFinished)
     }
@@ -237,7 +237,7 @@ class SentryOkHttpInterceptorTest {
         val sut = fixture.getSut(httpStatusCode = 400)
         sut.newCall(getRequest()).execute()
         val httpClientSpan = fixture.sentryTracer.children.first()
-        assertEquals(400, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertEquals(400, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INVALID_ARGUMENT, httpClientSpan.status)
     }
 
@@ -246,7 +246,7 @@ class SentryOkHttpInterceptorTest {
         val sut = fixture.getSut(httpStatusCode = 502)
         sut.newCall(getRequest()).execute()
         val httpClientSpan = fixture.sentryTracer.children.first()
-        assertEquals(502, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertEquals(502, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertNull(httpClientSpan.status)
     }
 
@@ -257,7 +257,7 @@ class SentryOkHttpInterceptorTest {
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
-                assertEquals(13L, it.data[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
+                assertEquals(13L, it.data[SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
                 assertEquals(12L, it.data["http.request_content_length"])
             },
             anyOrNull()
@@ -300,7 +300,7 @@ class SentryOkHttpInterceptorTest {
             // ignore
         }
         val httpClientSpan = fixture.sentryTracer.children.first()
-        assertNull(httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertNull(httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INTERNAL_ERROR, httpClientSpan.status)
         assertTrue(httpClientSpan.throwable is IOException)
     }

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpInterceptorTest.kt
@@ -4,6 +4,7 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HttpStatusCodeRange
 import io.sentry.IHub
@@ -226,6 +227,7 @@ class SentryOkHttpInterceptorTest {
         val httpClientSpan = fixture.sentryTracer.children.first()
         assertEquals("http.client", httpClientSpan.operation)
         assertEquals("GET ${request.url}", httpClientSpan.description)
+        assertEquals(201, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.OK, httpClientSpan.status)
         assertTrue(httpClientSpan.isFinished)
     }
@@ -235,6 +237,7 @@ class SentryOkHttpInterceptorTest {
         val sut = fixture.getSut(httpStatusCode = 400)
         sut.newCall(getRequest()).execute()
         val httpClientSpan = fixture.sentryTracer.children.first()
+        assertEquals(400, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INVALID_ARGUMENT, httpClientSpan.status)
     }
 
@@ -243,6 +246,7 @@ class SentryOkHttpInterceptorTest {
         val sut = fixture.getSut(httpStatusCode = 502)
         sut.newCall(getRequest()).execute()
         val httpClientSpan = fixture.sentryTracer.children.first()
+        assertEquals(502, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertNull(httpClientSpan.status)
     }
 
@@ -253,7 +257,7 @@ class SentryOkHttpInterceptorTest {
         verify(fixture.hub).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
-                assertEquals(13L, it.data["http.response_content_length"])
+                assertEquals(13L, it.data[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
                 assertEquals(12L, it.data["http.request_content_length"])
             },
             anyOrNull()
@@ -296,6 +300,7 @@ class SentryOkHttpInterceptorTest {
             // ignore
         }
         val httpClientSpan = fixture.sentryTracer.children.first()
+        assertNull(httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INTERNAL_ERROR, httpClientSpan.status)
         assertTrue(httpClientSpan.throwable is IOException)
     }

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
@@ -1,11 +1,11 @@
 package io.sentry.android.sqlite
 
 import android.database.SQLException
-import io.sentry.DataConvention
 import io.sentry.HubAdapter
 import io.sentry.IHub
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryStackTraceFactory
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 
 internal class SQLiteSpanManager(
@@ -39,9 +39,9 @@ internal class SQLiteSpanManager(
         } finally {
             span?.apply {
                 val isMainThread: Boolean = hub.options.mainThreadChecker.isMainThread
-                setData(DataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread)
+                setData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread)
                 if (isMainThread) {
-                    setData(DataConvention.CALL_STACK_KEY, stackTraceFactory.inAppCallStack)
+                    setData(SpanDataConvention.CALL_STACK_KEY, stackTraceFactory.inAppCallStack)
                 }
                 finish()
             }

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.sqlite
 
 import android.database.SQLException
+import io.sentry.DataConvention
 import io.sentry.HubAdapter
 import io.sentry.IHub
 import io.sentry.SentryIntegrationPackageStorage
@@ -38,9 +39,9 @@ internal class SQLiteSpanManager(
         } finally {
             span?.apply {
                 val isMainThread: Boolean = hub.options.mainThreadChecker.isMainThread
-                setData("blocked_main_thread", isMainThread)
+                setData(DataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread)
                 if (isMainThread) {
-                    setData("call_stack", stackTraceFactory.inAppCallStack)
+                    setData(DataConvention.CALL_STACK_KEY, stackTraceFactory.inAppCallStack)
                 }
                 finish()
             }

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.sqlite
 
 import android.database.SQLException
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
@@ -100,8 +101,8 @@ class SQLiteSpanManagerTest {
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()
 
-        assertFalse(span.getData("blocked_main_thread") as Boolean)
-        assertNull(span.getData("call_stack"))
+        assertFalse(span.getData(DataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
+        assertNull(span.getData(DataConvention.CALL_STACK_KEY))
     }
 
     @Test
@@ -114,7 +115,7 @@ class SQLiteSpanManagerTest {
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()
 
-        assertTrue(span.getData("blocked_main_thread") as Boolean)
-        assertNotNull(span.getData("call_stack"))
+        assertTrue(span.getData(DataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
+        assertNotNull(span.getData(DataConvention.CALL_STACK_KEY))
     }
 }

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
@@ -1,11 +1,11 @@
 package io.sentry.android.sqlite
 
 import android.database.SQLException
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.util.thread.IMainThreadChecker
@@ -101,8 +101,8 @@ class SQLiteSpanManagerTest {
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()
 
-        assertFalse(span.getData(DataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
-        assertNull(span.getData(DataConvention.CALL_STACK_KEY))
+        assertFalse(span.getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
+        assertNull(span.getData(SpanDataConvention.CALL_STACK_KEY))
     }
 
     @Test
@@ -115,7 +115,7 @@ class SQLiteSpanManagerTest {
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()
 
-        assertTrue(span.getData(DataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
-        assertNotNull(span.getData(DataConvention.CALL_STACK_KEY))
+        assertTrue(span.getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
+        assertNotNull(span.getData(SpanDataConvention.CALL_STACK_KEY))
     }
 }

--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3HttpInterceptor.kt
@@ -10,7 +10,6 @@ import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import io.sentry.BaggageHeader.BAGGAGE_HEADER
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HubAdapter
 import io.sentry.IHub
@@ -20,6 +19,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions.DEFAULT_PROPAGATION_TARGETS
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint.APOLLO_REQUEST
 import io.sentry.TypeCheckHint.APOLLO_RESPONSE
@@ -108,7 +108,7 @@ class SentryApollo3HttpInterceptor @JvmOverloads constructor(
         try {
             httpResponse = chain.proceed(modifiedRequest)
             statusCode = httpResponse.statusCode
-            span?.setData(DataConvention.HTTP_STATUS_CODE_KEY, statusCode)
+            span?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, statusCode)
             span?.status = SpanStatus.fromHttpStatusCode(statusCode)
 
             captureEvent(modifiedRequest, httpResponse, operationName, operationType)
@@ -119,7 +119,7 @@ class SentryApollo3HttpInterceptor @JvmOverloads constructor(
             when (e) {
                 is ApolloHttpException -> {
                     statusCode = e.statusCode
-                    span?.setData(DataConvention.HTTP_STATUS_CODE_KEY, statusCode)
+                    span?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, statusCode)
                     span?.status =
                         SpanStatus.fromHttpStatusCode(statusCode, SpanStatus.INTERNAL_ERROR)
                 }
@@ -212,10 +212,10 @@ class SentryApollo3HttpInterceptor @JvmOverloads constructor(
 
         if (span != null) {
             statusCode?.let {
-                span.setData(DataConvention.HTTP_STATUS_CODE_KEY, statusCode)
+                span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, statusCode)
             }
             responseContentLength?.let {
-                span.setData(DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, it)
+                span.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, it)
             }
             if (beforeSpan != null) {
                 try {

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorTest.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorTest.kt
@@ -9,13 +9,13 @@ import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
 import io.sentry.SentryOptions.DEFAULT_PROPAGATION_TARGETS
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TraceContext
 import io.sentry.TracesSamplingDecision
@@ -148,7 +148,7 @@ class SentryApollo3InterceptorTest {
         verify(fixture.hub).captureTransaction(
             check {
                 assertTransactionDetails(it, httpStatusCode = 404, contentLength = null)
-                assertEquals(404, it.spans.first().data?.get(DataConvention.HTTP_STATUS_CODE_KEY))
+                assertEquals(404, it.spans.first().data?.get(SpanDataConvention.HTTP_STATUS_CODE_KEY))
                 assertEquals(SpanStatus.NOT_FOUND, it.spans.first().status)
             },
             anyOrNull<TraceContext>(),
@@ -300,10 +300,10 @@ class SentryApollo3InterceptorTest {
             assertNotNull(it["operationId"])
             assertEquals("Post", it["http.method"])
             httpStatusCode?.let { code ->
-                assertEquals(code, it[DataConvention.HTTP_STATUS_CODE_KEY])
+                assertEquals(code, it[SpanDataConvention.HTTP_STATUS_CODE_KEY])
             }
             contentLength?.let { contentLength ->
-                assertEquals(contentLength, it[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
+                assertEquals(contentLength, it[SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
             }
         }
     }

--- a/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorTest.kt
+++ b/sentry-apollo-3/src/test/java/io/sentry/apollo3/SentryApollo3InterceptorTest.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.ApolloException
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
@@ -101,7 +102,7 @@ class SentryApollo3InterceptorTest {
 
         verify(fixture.hub).captureTransaction(
             check {
-                assertTransactionDetails(it)
+                assertTransactionDetails(it, httpStatusCode = 200)
                 assertEquals(SpanStatus.OK, it.spans.first().status)
             },
             anyOrNull<TraceContext>(),
@@ -268,10 +269,10 @@ class SentryApollo3InterceptorTest {
             assertNotNull(it["operationId"])
             assertEquals("Post", it["http.method"])
             httpStatusCode?.let { code ->
-                assertEquals(code, it["http.response.status_code"])
+                assertEquals(code, it[DataConvention.HTTP_STATUS_CODE_KEY])
             }
             contentLength?.let { contentLength ->
-                assertEquals(contentLength, it["http.response_content_length"])
+                assertEquals(contentLength, it[DataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY])
             }
         }
     }

--- a/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
+++ b/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
@@ -13,7 +13,6 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRespons
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.Hint
 import io.sentry.HubAdapter
 import io.sentry.IHub
@@ -21,6 +20,7 @@ import io.sentry.ISpan
 import io.sentry.IntegrationName
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TypeCheckHint.APOLLO_REQUEST
 import io.sentry.TypeCheckHint.APOLLO_RESPONSE
@@ -74,7 +74,7 @@ class SentryApolloInterceptor(
                         val statusCode: Int? = response.httpResponse.map { it.code() }.orNull()
                         if (statusCode != null) {
                             span.status = SpanStatus.fromHttpStatusCode(statusCode, SpanStatus.UNKNOWN)
-                            span.setData(DataConvention.HTTP_STATUS_CODE_KEY, statusCode)
+                            span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, statusCode)
                         } else {
                             span.status = SpanStatus.UNKNOWN
                         }
@@ -90,7 +90,7 @@ class SentryApolloInterceptor(
                     override fun onFailure(e: ApolloException) {
                         span.apply {
                             status = if (e is ApolloHttpException) {
-                                setData(DataConvention.HTTP_STATUS_CODE_KEY, e.code())
+                                setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, e.code())
                                 SpanStatus.fromHttpStatusCode(e.code(), SpanStatus.INTERNAL_ERROR)
                             } else {
                                 SpanStatus.INTERNAL_ERROR

--- a/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
+++ b/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.apollographql.apollo.exception.ApolloException
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
@@ -106,6 +107,7 @@ class SentryApolloInterceptorTest {
             check {
                 assertTransactionDetails(it)
                 assertEquals(SpanStatus.PERMISSION_DENIED, it.spans.first().status)
+                assertEquals(403, it.spans.first().data?.get(DataConvention.HTTP_STATUS_CODE_KEY))
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),
@@ -121,6 +123,7 @@ class SentryApolloInterceptorTest {
             check {
                 assertTransactionDetails(it)
                 assertEquals(SpanStatus.INTERNAL_ERROR, it.spans.first().status)
+                assertNull(it.spans.first().data?.get(DataConvention.HTTP_STATUS_CODE_KEY))
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),

--- a/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
+++ b/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
@@ -4,12 +4,12 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
 import com.apollographql.apollo.exception.ApolloException
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransaction
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TraceContext
 import io.sentry.TracesSamplingDecision
@@ -107,7 +107,7 @@ class SentryApolloInterceptorTest {
             check {
                 assertTransactionDetails(it)
                 assertEquals(SpanStatus.PERMISSION_DENIED, it.spans.first().status)
-                assertEquals(403, it.spans.first().data?.get(DataConvention.HTTP_STATUS_CODE_KEY))
+                assertEquals(403, it.spans.first().data?.get(SpanDataConvention.HTTP_STATUS_CODE_KEY))
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),
@@ -123,7 +123,7 @@ class SentryApolloInterceptorTest {
             check {
                 assertTransactionDetails(it)
                 assertEquals(SpanStatus.INTERNAL_ERROR, it.spans.first().status)
-                assertNull(it.spans.first().data?.get(DataConvention.HTTP_STATUS_CODE_KEY))
+                assertNull(it.spans.first().data?.get(SpanDataConvention.HTTP_STATUS_CODE_KEY))
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -8,11 +8,11 @@ import feign.Request;
 import feign.Response;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
-import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import io.sentry.util.PropagationTargetsUtils;
@@ -77,7 +77,7 @@ public final class SentryFeignClient implements Client {
       try {
         response = delegate.execute(requestWrapper.build(), options);
         // handles both success and error responses
-        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.status());
+        span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.status());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.status()));
         return response;
       } catch (Throwable e) {

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryFeignClient.java
@@ -8,6 +8,7 @@ import feign.Request;
 import feign.Response;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
+import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -76,6 +77,7 @@ public final class SentryFeignClient implements Client {
       try {
         response = delegate.execute(requestWrapper.build(), options);
         // handles both success and error responses
+        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.status());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.status()));
         return response;
       } catch (Throwable e) {

--- a/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
+++ b/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
@@ -7,11 +7,11 @@ import feign.HeaderMap
 import feign.RequestLine
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import okhttp3.mockwebserver.MockResponse
@@ -151,7 +151,7 @@ class SentryFeignClientTest {
         val httpClientSpan = fixture.sentryTracer.children.first()
         assertEquals("http.client", httpClientSpan.operation)
         assertEquals("GET ${fixture.server.url("/status/200")}", httpClientSpan.description)
-        assertEquals(201, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertEquals(201, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.OK, httpClientSpan.status)
         assertTrue(httpClientSpan.isFinished)
     }
@@ -163,7 +163,7 @@ class SentryFeignClientTest {
             sut.getOk()
         } catch (e: FeignException) {
             val httpClientSpan = fixture.sentryTracer.children.first()
-            assertEquals(400, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+            assertEquals(400, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
             assertEquals(SpanStatus.INVALID_ARGUMENT, httpClientSpan.status)
         }
     }
@@ -175,7 +175,7 @@ class SentryFeignClientTest {
             sut.getOk()
         } catch (e: FeignException) {
             val httpClientSpan = fixture.sentryTracer.children.first()
-            assertEquals(502, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+            assertEquals(502, httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
             assertNull(httpClientSpan.status)
         }
     }
@@ -238,7 +238,7 @@ class SentryFeignClientTest {
             // ignore
         }
         val httpClientSpan = fixture.sentryTracer.children.first()
-        assertNull(httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
+        assertNull(httpClientSpan.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INTERNAL_ERROR, httpClientSpan.status)
         assertTrue(httpClientSpan.throwable is Exception)
     }

--- a/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
+++ b/sentry-openfeign/src/test/kotlin/io/sentry/openfeign/SentryFeignClientTest.kt
@@ -7,6 +7,7 @@ import feign.HeaderMap
 import feign.RequestLine
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
@@ -150,6 +151,7 @@ class SentryFeignClientTest {
         val httpClientSpan = fixture.sentryTracer.children.first()
         assertEquals("http.client", httpClientSpan.operation)
         assertEquals("GET ${fixture.server.url("/status/200")}", httpClientSpan.description)
+        assertEquals(201, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.OK, httpClientSpan.status)
         assertTrue(httpClientSpan.isFinished)
     }
@@ -161,6 +163,7 @@ class SentryFeignClientTest {
             sut.getOk()
         } catch (e: FeignException) {
             val httpClientSpan = fixture.sentryTracer.children.first()
+            assertEquals(400, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
             assertEquals(SpanStatus.INVALID_ARGUMENT, httpClientSpan.status)
         }
     }
@@ -172,6 +175,7 @@ class SentryFeignClientTest {
             sut.getOk()
         } catch (e: FeignException) {
             val httpClientSpan = fixture.sentryTracer.children.first()
+            assertEquals(502, httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
             assertNull(httpClientSpan.status)
         }
     }
@@ -234,6 +238,7 @@ class SentryFeignClientTest {
             // ignore
         }
         val httpClientSpan = fixture.sentryTracer.children.first()
+        assertNull(httpClientSpan.data[DataConvention.HTTP_STATUS_CODE_KEY])
         assertEquals(SpanStatus.INTERNAL_ERROR, httpClientSpan.status)
         assertTrue(httpClientSpan.throwable is Exception)
     }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -7,6 +7,7 @@ import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
+import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -68,6 +69,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       try {
         response = execution.execute(request, body);
         // handles both success and error responses
+        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.getStatusCode().value()));
         responseStatusCode = response.getStatusCode().value();
         return response;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -7,11 +7,11 @@ import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
-import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import io.sentry.util.PropagationTargetsUtils;
@@ -69,7 +69,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       try {
         response = execution.execute(request, body);
         // handles both success and error responses
-        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
+        span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.getStatusCode().value()));
         responseStatusCode = response.getStatusCode().value();
         return response;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
@@ -6,11 +6,11 @@ import static io.sentry.TypeCheckHint.SPRING_EXCHANGE_FILTER_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
-import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import io.sentry.util.PropagationTargetsUtils;
@@ -67,7 +67,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
     return next.exchange(clientRequestWithSentryTraceHeader)
         .flatMap(
             response -> {
-              span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
+              span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
               span.setStatus(SpanStatus.fromHttpStatusCode(response.statusCode().value()));
               addBreadcrumb(request, response);
               span.finish();

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
@@ -6,6 +6,7 @@ import static io.sentry.TypeCheckHint.SPRING_EXCHANGE_FILTER_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
+import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -66,6 +67,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
     return next.exchange(clientRequestWithSentryTraceHeader)
         .flatMap(
             response -> {
+              span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
               span.setStatus(SpanStatus.fromHttpStatusCode(response.statusCode().value()));
               addBreadcrumb(request, response);
               span.finish();

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
@@ -1,10 +1,10 @@
 package io.sentry.spring.jakarta.mvc
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.SentryOptions
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.checkEvent
 import io.sentry.checkTransaction
@@ -308,7 +308,7 @@ class SentrySpringIntegrationTest {
                     val span = transaction.spans.first()
                     assertThat(span.op).isEqualTo("http.client")
                     assertThat(span.description).isEqualTo("GET http://localhost:$port/hello")
-                    assertThat(span.data?.get(DataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
+                    assertThat(span.data?.get(SpanDataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
                     assertThat(span.status).isEqualTo(SpanStatus.OK)
                 },
                 anyOrNull()

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.spring.jakarta.mvc
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
@@ -307,6 +308,7 @@ class SentrySpringIntegrationTest {
                     val span = transaction.spans.first()
                     assertThat(span.op).isEqualTo("http.client")
                     assertThat(span.description).isEqualTo("GET http://localhost:$port/hello")
+                    assertThat(span.data?.get(DataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
                     assertThat(span.status).isEqualTo(SpanStatus.OK)
                 },
                 anyOrNull()

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -7,6 +7,7 @@ import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
+import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -68,6 +69,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       try {
         response = execution.execute(request, body);
         // handles both success and error responses
+        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.getStatusCode().value()));
         responseStatusCode = response.getStatusCode().value();
         return response;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -7,11 +7,11 @@ import static io.sentry.TypeCheckHint.SPRING_REQUEST_INTERCEPTOR_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
-import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import io.sentry.util.PropagationTargetsUtils;
@@ -69,7 +69,7 @@ public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequest
       try {
         response = execution.execute(request, body);
         // handles both success and error responses
-        span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
+        span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.getStatusCode().value());
         span.setStatus(SpanStatus.fromHttpStatusCode(response.getStatusCode().value()));
         responseStatusCode = response.getStatusCode().value();
         return response;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
@@ -6,11 +6,11 @@ import static io.sentry.TypeCheckHint.SPRING_EXCHANGE_FILTER_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
-import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import io.sentry.util.PropagationTargetsUtils;
@@ -71,7 +71,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
     return next.exchange(clientRequestWithSentryTraceHeader)
         .flatMap(
             response -> {
-              span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
+              span.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
               span.setStatus(SpanStatus.fromHttpStatusCode(response.statusCode().value()));
               addBreadcrumb(request, response);
               span.finish();

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanClientWebRequestFilter.java
@@ -6,6 +6,7 @@ import static io.sentry.TypeCheckHint.SPRING_EXCHANGE_FILTER_RESPONSE;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
+import io.sentry.DataConvention;
 import io.sentry.Hint;
 import io.sentry.IHub;
 import io.sentry.ISpan;
@@ -70,6 +71,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
     return next.exchange(clientRequestWithSentryTraceHeader)
         .flatMap(
             response -> {
+              span.setData(DataConvention.HTTP_STATUS_CODE_KEY, response.statusCode().value());
               span.setStatus(SpanStatus.fromHttpStatusCode(response.statusCode().value()));
               addBreadcrumb(request, response);
               span.finish();

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.spring.mvc
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
@@ -307,6 +308,7 @@ class SentrySpringIntegrationTest {
                     val span = transaction.spans.first()
                     assertThat(span.op).isEqualTo("http.client")
                     assertThat(span.description).isEqualTo("GET http://localhost:$port/hello")
+                    assertThat(span.data?.get(DataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
                     assertThat(span.status).isEqualTo(SpanStatus.OK)
                 },
                 anyOrNull()

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
@@ -1,10 +1,10 @@
 package io.sentry.spring.mvc
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.SentryOptions
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.checkEvent
 import io.sentry.checkTransaction
@@ -308,7 +308,7 @@ class SentrySpringIntegrationTest {
                     val span = transaction.spans.first()
                     assertThat(span.op).isEqualTo("http.client")
                     assertThat(span.description).isEqualTo("GET http://localhost:$port/hello")
-                    assertThat(span.data?.get(DataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
+                    assertThat(span.data?.get(SpanDataConvention.HTTP_STATUS_CODE_KEY)).isEqualTo(200)
                     assertThat(span.status).isEqualTo(SpanStatus.OK)
                 },
                 anyOrNull()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -173,16 +173,6 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static fun values ()[Lio/sentry/DataCategory;
 }
 
-public abstract interface class io/sentry/DataConvention {
-	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
-	public static final field CALL_STACK_KEY Ljava/lang/String;
-	public static final field HTTP_FRAGMENT_KEY Ljava/lang/String;
-	public static final field HTTP_METHOD_KEY Ljava/lang/String;
-	public static final field HTTP_QUERY_KEY Ljava/lang/String;
-	public static final field HTTP_RESPONSE_CONTENT_LENGTH_KEY Ljava/lang/String;
-	public static final field HTTP_STATUS_CODE_KEY Ljava/lang/String;
-}
-
 public final class io/sentry/DateUtils {
 	public static fun dateToNanos (Ljava/util/Date;)J
 	public static fun dateToSeconds (Ljava/util/Date;)D
@@ -2116,6 +2106,16 @@ public final class io/sentry/SpanContext$JsonKeys {
 	public static final field TAGS Ljava/lang/String;
 	public static final field TRACE_ID Ljava/lang/String;
 	public fun <init> ()V
+}
+
+public abstract interface class io/sentry/SpanDataConvention {
+	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
+	public static final field CALL_STACK_KEY Ljava/lang/String;
+	public static final field HTTP_FRAGMENT_KEY Ljava/lang/String;
+	public static final field HTTP_METHOD_KEY Ljava/lang/String;
+	public static final field HTTP_QUERY_KEY Ljava/lang/String;
+	public static final field HTTP_RESPONSE_CONTENT_LENGTH_KEY Ljava/lang/String;
+	public static final field HTTP_STATUS_CODE_KEY Ljava/lang/String;
 }
 
 public final class io/sentry/SpanId : io/sentry/JsonSerializable {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -173,6 +173,16 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static fun values ()[Lio/sentry/DataCategory;
 }
 
+public abstract interface class io/sentry/DataConvention {
+	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
+	public static final field CALL_STACK_KEY Ljava/lang/String;
+	public static final field HTTP_FRAGMENT_KEY Ljava/lang/String;
+	public static final field HTTP_METHOD_KEY Ljava/lang/String;
+	public static final field HTTP_QUERY_KEY Ljava/lang/String;
+	public static final field HTTP_RESPONSE_CONTENT_LENGTH_KEY Ljava/lang/String;
+	public static final field HTTP_STATUS_CODE_KEY Ljava/lang/String;
+}
+
 public final class io/sentry/DateUtils {
 	public static fun dateToNanos (Ljava/util/Date;)J
 	public static fun dateToSeconds (Ljava/util/Date;)D

--- a/sentry/src/main/java/io/sentry/DataConvention.java
+++ b/sentry/src/main/java/io/sentry/DataConvention.java
@@ -1,0 +1,16 @@
+package io.sentry;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public interface DataConvention {
+  // Keys that should respect the span data conventions, as described in
+  //  https://develop.sentry.dev/sdk/performance/span-data-conventions/
+  String HTTP_QUERY_KEY = "http.query";
+  String HTTP_FRAGMENT_KEY = "http.fragment";
+  String HTTP_METHOD_KEY = "http.method";
+  String HTTP_STATUS_CODE_KEY = "http.response.status_code";
+  String HTTP_RESPONSE_CONTENT_LENGTH_KEY = "http.response_content_length";
+  String BLOCKED_MAIN_THREAD_KEY = "blocked_main_thread";
+  String CALL_STACK_KEY = "call_stack";
+}

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -3,7 +3,7 @@ package io.sentry;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-public interface DataConvention {
+public interface SpanDataConvention {
   // Keys that should respect the span data conventions, as described in
   //  https://develop.sentry.dev/sdk/performance/span-data-conventions/
   String HTTP_QUERY_KEY = "http.query";

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -1,11 +1,11 @@
 package io.sentry.instrumentation.file;
 
-import io.sentry.DataConvention;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
 import io.sentry.SentryStackTraceFactory;
+import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.util.Platform;
 import io.sentry.util.StringUtils;
@@ -103,9 +103,10 @@ final class FileIOSpanManager {
       }
       currentSpan.setData("file.size", byteCount);
       final boolean isMainThread = options.getMainThreadChecker().isMainThread();
-      currentSpan.setData(DataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread);
+      currentSpan.setData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread);
       if (isMainThread) {
-        currentSpan.setData(DataConvention.CALL_STACK_KEY, stackTraceFactory.getInAppCallStack());
+        currentSpan.setData(
+            SpanDataConvention.CALL_STACK_KEY, stackTraceFactory.getInAppCallStack());
       }
       currentSpan.finish(spanStatus);
     }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file;
 
+import io.sentry.DataConvention;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SentryIntegrationPackageStorage;
@@ -102,9 +103,9 @@ final class FileIOSpanManager {
       }
       currentSpan.setData("file.size", byteCount);
       final boolean isMainThread = options.getMainThreadChecker().isMainThread();
-      currentSpan.setData("blocked_main_thread", isMainThread);
+      currentSpan.setData(DataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread);
       if (isMainThread) {
-        currentSpan.setData("call_stack", stackTraceFactory.getInAppCallStack());
+        currentSpan.setData(DataConvention.CALL_STACK_KEY, stackTraceFactory.getInAppCallStack());
       }
       currentSpan.finish(spanStatus);
     }

--- a/sentry/src/main/java/io/sentry/util/UrlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/UrlUtils.java
@@ -1,7 +1,7 @@
 package io.sentry.util;
 
-import io.sentry.DataConvention;
 import io.sentry.ISpan;
+import io.sentry.SpanDataConvention;
 import io.sentry.protocol.Request;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -182,10 +182,10 @@ public final class UrlUtils {
       }
 
       if (query != null) {
-        span.setData(DataConvention.HTTP_QUERY_KEY, query);
+        span.setData(SpanDataConvention.HTTP_QUERY_KEY, query);
       }
       if (fragment != null) {
-        span.setData(DataConvention.HTTP_FRAGMENT_KEY, fragment);
+        span.setData(SpanDataConvention.HTTP_FRAGMENT_KEY, fragment);
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/util/UrlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/UrlUtils.java
@@ -1,5 +1,6 @@
 package io.sentry.util;
 
+import io.sentry.DataConvention;
 import io.sentry.ISpan;
 import io.sentry.protocol.Request;
 import java.net.MalformedURLException;
@@ -181,10 +182,10 @@ public final class UrlUtils {
       }
 
       if (query != null) {
-        span.setData("http.query", query);
+        span.setData(DataConvention.HTTP_QUERY_KEY, query);
       }
       if (fragment != null) {
-        span.setData("http.fragment", fragment);
+        span.setData(DataConvention.HTTP_FRAGMENT_KEY, fragment);
       }
     }
   }

--- a/sentry/src/test/java/io/sentry/UrlDetailsTest.kt
+++ b/sentry/src/test/java/io/sentry/UrlDetailsTest.kt
@@ -23,8 +23,8 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData(DataConvention.HTTP_QUERY_KEY, "q=1")
-        verify(span).setData(DataConvention.HTTP_FRAGMENT_KEY, "top")
+        verify(span).setData(SpanDataConvention.HTTP_QUERY_KEY, "q=1")
+        verify(span).setData(SpanDataConvention.HTTP_FRAGMENT_KEY, "top")
     }
 
     @Test
@@ -33,7 +33,7 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData(DataConvention.HTTP_QUERY_KEY, "q=1")
+        verify(span).setData(SpanDataConvention.HTTP_QUERY_KEY, "q=1")
         verifyNoMoreInteractions(span)
     }
 
@@ -43,7 +43,7 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData(DataConvention.HTTP_FRAGMENT_KEY, "top")
+        verify(span).setData(SpanDataConvention.HTTP_FRAGMENT_KEY, "top")
         verifyNoMoreInteractions(span)
     }
 

--- a/sentry/src/test/java/io/sentry/UrlDetailsTest.kt
+++ b/sentry/src/test/java/io/sentry/UrlDetailsTest.kt
@@ -23,8 +23,8 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData("http.query", "q=1")
-        verify(span).setData("http.fragment", "top")
+        verify(span).setData(DataConvention.HTTP_QUERY_KEY, "q=1")
+        verify(span).setData(DataConvention.HTTP_FRAGMENT_KEY, "top")
     }
 
     @Test
@@ -33,7 +33,7 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData("http.query", "q=1")
+        verify(span).setData(DataConvention.HTTP_QUERY_KEY, "q=1")
         verifyNoMoreInteractions(span)
     }
 
@@ -43,7 +43,7 @@ class UrlDetailsTest {
         val span = mock<ISpan>()
         urlDetails.applyToSpan(span)
 
-        verify(span).setData("http.fragment", "top")
+        verify(span).setData(DataConvention.HTTP_FRAGMENT_KEY, "top")
         verifyNoMoreInteractions(span)
     }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -1,9 +1,9 @@
 package io.sentry.instrumentation.file
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.SpanStatus.INTERNAL_ERROR
 import io.sentry.TransactionContext
@@ -218,10 +218,10 @@ class SentryFileInputStreamTest {
         fis.close()
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(true, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertEquals(true, fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY])
         // assuming our "in-app" is org.junit, we check that only org.junit frames are in the call stack
         assertTrue {
-            (fileIOSpan.data[DataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
+            (fileIOSpan.data[SpanDataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
                 it.module?.startsWith("org.junit") == true
             }
         }
@@ -239,8 +239,8 @@ class SentryFileInputStreamTest {
         await.untilTrue(finished)
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(false, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
-        assertNull(fileIOSpan.data[DataConvention.CALL_STACK_KEY])
+        assertEquals(false, fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertNull(fileIOSpan.data[SpanDataConvention.CALL_STACK_KEY])
     }
 }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -217,10 +218,10 @@ class SentryFileInputStreamTest {
         fis.close()
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(true, fileIOSpan.data["blocked_main_thread"])
+        assertEquals(true, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
         // assuming our "in-app" is org.junit, we check that only org.junit frames are in the call stack
         assertTrue {
-            (fileIOSpan.data["call_stack"] as List<SentryStackFrame>).all {
+            (fileIOSpan.data[DataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
                 it.module?.startsWith("org.junit") == true
             }
         }
@@ -238,8 +239,8 @@ class SentryFileInputStreamTest {
         await.untilTrue(finished)
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(false, fileIOSpan.data["blocked_main_thread"])
-        assertNull(fileIOSpan.data["call_stack"])
+        assertEquals(false, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertNull(fileIOSpan.data[DataConvention.CALL_STACK_KEY])
     }
 }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -132,10 +133,10 @@ class SentryFileOutputStreamTest {
         fis.close()
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(true, fileIOSpan.data["blocked_main_thread"])
+        assertEquals(true, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
         // assuming our "in-app" is org.junit, we check that only org.junit frames are in the call stack
         assertTrue {
-            (fileIOSpan.data["call_stack"] as List<SentryStackFrame>).all {
+            (fileIOSpan.data[DataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
                 it.module?.startsWith("org.junit") == true
             }
         }
@@ -153,7 +154,7 @@ class SentryFileOutputStreamTest {
         await.untilTrue(finished)
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(false, fileIOSpan.data["blocked_main_thread"])
-        assertNull(fileIOSpan.data["call_stack"])
+        assertEquals(false, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertNull(fileIOSpan.data[DataConvention.CALL_STACK_KEY])
     }
 }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -1,9 +1,9 @@
 package io.sentry.instrumentation.file
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.protocol.SentryStackFrame
@@ -133,10 +133,10 @@ class SentryFileOutputStreamTest {
         fis.close()
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(true, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertEquals(true, fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY])
         // assuming our "in-app" is org.junit, we check that only org.junit frames are in the call stack
         assertTrue {
-            (fileIOSpan.data[DataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
+            (fileIOSpan.data[SpanDataConvention.CALL_STACK_KEY] as List<SentryStackFrame>).all {
                 it.module?.startsWith("org.junit") == true
             }
         }
@@ -154,7 +154,7 @@ class SentryFileOutputStreamTest {
         await.untilTrue(finished)
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(false, fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY])
-        assertNull(fileIOSpan.data[DataConvention.CALL_STACK_KEY])
+        assertEquals(false, fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY])
+        assertNull(fileIOSpan.data[SpanDataConvention.CALL_STACK_KEY])
     }
 }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
@@ -1,9 +1,9 @@
 package io.sentry.instrumentation.file
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus.OK
 import io.sentry.TransactionContext
 import io.sentry.util.thread.MainThreadChecker
@@ -58,7 +58,7 @@ class SentryFileReaderTest {
         assertEquals(fileIOSpan.data["file.size"], 4L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
-        assertEquals(fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY], true)
+        assertEquals(fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY], true)
         assertEquals(fileIOSpan.status, OK)
     }
 }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -57,7 +58,7 @@ class SentryFileReaderTest {
         assertEquals(fileIOSpan.data["file.size"], 4L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
-        assertEquals(fileIOSpan.data["blocked_main_thread"], true)
+        assertEquals(fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY], true)
         assertEquals(fileIOSpan.status, OK)
     }
 }

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
@@ -1,9 +1,9 @@
 package io.sentry.instrumentation.file
 
-import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus.OK
 import io.sentry.TransactionContext
 import io.sentry.util.thread.MainThreadChecker
@@ -58,7 +58,7 @@ class SentryFileWriterTest {
         assertEquals(fileIOSpan.data["file.size"], 4L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
-        assertEquals(fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY], true)
+        assertEquals(fileIOSpan.data[SpanDataConvention.BLOCKED_MAIN_THREAD_KEY], true)
         assertEquals(fileIOSpan.status, OK)
     }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.instrumentation.file
 
+import io.sentry.DataConvention
 import io.sentry.IHub
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -57,7 +58,7 @@ class SentryFileWriterTest {
         assertEquals(fileIOSpan.data["file.size"], 4L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
-        assertEquals(fileIOSpan.data["blocked_main_thread"], true)
+        assertEquals(fileIOSpan.data[DataConvention.BLOCKED_MAIN_THREAD_KEY], true)
         assertEquals(fileIOSpan.status, OK)
     }
 


### PR DESCRIPTION
## :scroll: Description
added DataConvention interface to hold all strings aligned with span data convention
added `http.response.status_code` to http request spans


## :bulb: Motivation and Context
The http status should be set in the same place by all the SDKs
Relates to https://github.com/getsentry/team-mobile/issues/121


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
