### PR TITLE
Improve ANRv2 implementation based on customer feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 ### Features
 
 - Add debouncing mechanism and before-capture callbacks for screenshots and view hierarchies ([#2773](https://github.com/getsentry/sentry-java/pull/2773))
+- Improve ANRv2 implementation ([#2792](https://github.com/getsentry/sentry-java/pull/2792))
+  - Add a proguard rule to keep `ApplicationNotResponding` class from obfuscation
+  - Add a new option `setReportHistoricalAnrs`; when enabled, it will report all of the ANRs from the [getHistoricalExitReasons](https://developer.android.com/reference/android/app/ActivityManager?hl=en#getHistoricalProcessExitReasons(java.lang.String,%20int,%20int)) list. 
+  By default, the SDK only reports and enriches the latest ANR and only this one counts towards ANR rate. 
+  Worth noting that once the SDK has been updated to the version with the ANRv2 implementation, this option is not necessary, because the SDK always reads the latest ANR on the next app restart.
+  These ANRs are reported with the `HistoricalAppExitInfo` mechanism.
+  - Add a new option `setAttachAnrThreadDump` to send ANR thread dump from the system as an attachment. 
+  This is only useful as additional information, because the SDK attempts to parse the thread dump into proper threads with stacktraces by default.
+  - If [ApplicationExitInfo#getTraceInputStream](https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()) returns null, the SDK no longer reports an ANR event, as these events are not very useful without it.
+  - Enhance regex patterns for native stackframes
 
 ## 6.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Add a proguard rule to keep `ApplicationNotResponding` class from obfuscation
   - Add a new option `setReportHistoricalAnrs`; when enabled, it will report all of the ANRs from the [getHistoricalExitReasons](https://developer.android.com/reference/android/app/ActivityManager?hl=en#getHistoricalProcessExitReasons(java.lang.String,%20int,%20int)) list. 
   By default, the SDK only reports and enriches the latest ANR and only this one counts towards ANR rate. 
-  Worth noting that once the SDK has been updated to the version with the ANRv2 implementation, this option is not necessary, because the SDK always reads the latest ANR on the next app restart.
+  Worth noting that this option is mainly useful when updating the SDK to the version where ANRv2 has been introduced, to report all ANRs happened prior to the SDK update. After that, the SDK will always pick up the latest ANR from the historical exit reasons list on next app restart, so there should be no historical ANRs to report.
   These ANRs are reported with the `HistoricalAppExitInfo` mechanism.
   - Add a new option `setAttachAnrThreadDump` to send ANR thread dump from the system as an attachment. 
   This is only useful as additional information, because the SDK attempts to parse the thread dump into proper threads with stacktraces by default.

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -214,6 +214,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun getStartupCrashDurationThresholdMillis ()J
 	public fun isAnrEnabled ()Z
 	public fun isAnrReportInDebug ()Z
+	public fun isAttachAnrThreadDump ()Z
 	public fun isAttachScreenshot ()Z
 	public fun isAttachViewHierarchy ()Z
 	public fun isCollectAdditionalContext ()Z
@@ -226,9 +227,11 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableNetworkEventBreadcrumbs ()Z
 	public fun isEnableRootCheck ()Z
 	public fun isEnableSystemEventBreadcrumbs ()Z
+	public fun isReportHistoricalAnrs ()Z
 	public fun setAnrEnabled (Z)V
 	public fun setAnrReportInDebug (Z)V
 	public fun setAnrTimeoutIntervalMillis (J)V
+	public fun setAttachAnrThreadDump (Z)V
 	public fun setAttachScreenshot (Z)V
 	public fun setAttachViewHierarchy (Z)V
 	public fun setCollectAdditionalContext (Z)V
@@ -245,6 +248,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setNativeSdkName (Ljava/lang/String;)V
 	public fun setProfilingTracesHz (I)V
 	public fun setProfilingTracesIntervalMillis (I)V
+	public fun setReportHistoricalAnrs (Z)V
 }
 
 public final class io/sentry/android/core/SentryInitProvider {

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -37,6 +37,8 @@
 # Also keep method names, as they're e.g. used by native via JNI calls
 -keep class * extends io.sentry.SentryOptions { *; }
 
+-keepnames class io.sentry.android.core.ApplicationNotResponding
+
 ##---------------End: proguard configuration for android-core  ----------
 
 ##---------------Begin: proguard configuration for sentry-apollo-3  ----------

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -1,11 +1,14 @@
 package io.sentry.android.core;
 
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
 import io.sentry.ISpan;
 import io.sentry.Scope;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
 import io.sentry.android.core.internal.util.RootChecker;
+import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.SdkVersion;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -142,6 +145,24 @@ public final class SentryAndroidOptions extends SentryOptions {
    * flagged by some app stores as harmful.
    */
   private boolean enableRootCheck = true;
+
+  /**
+   * Controls whether to report historical ANRs (v2) from the {@link ApplicationExitInfo} system
+   * API. When enabled, reports all of the ANRs available in the {@link
+   * ActivityManager#getHistoricalProcessExitReasons(String, int, int)} list, as opposed to
+   * reporting only the latest one.
+   *
+   * <p>These events do not affect ANR rate nor are they enriched with additional information from
+   * {@link Scope} like breadcrumbs. The events are reported with 'HistoricalAppExitInfo' {@link
+   * Mechanism}.
+   */
+  private boolean reportHistoricalAnrs = false;
+
+  /**
+   * Controls whether to send ANR (v2) thread dump as an attachment with plain text. The thread dump
+   * is being attached from {@link ApplicationExitInfo#getTraceInputStream()}, if available.
+   */
+  private boolean attachAnrThreadDump = false;
 
   public SentryAndroidOptions() {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
@@ -440,5 +461,21 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   public void setEnableRootCheck(final boolean enableRootCheck) {
     this.enableRootCheck = enableRootCheck;
+  }
+
+  public boolean isReportHistoricalAnrs() {
+    return reportHistoricalAnrs;
+  }
+
+  public void setReportHistoricalAnrs(final boolean reportHistoricalAnrs) {
+    this.reportHistoricalAnrs = reportHistoricalAnrs;
+  }
+
+  public boolean isAttachAnrThreadDump() {
+    return attachAnrThreadDump;
+  }
+
+  public void setAttachAnrThreadDump(final boolean attachAnrThreadDump) {
+    this.attachAnrThreadDump = attachAnrThreadDump;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -39,9 +39,11 @@ public class ThreadDumpParser {
   private static final Pattern BEGIN_MANAGED_THREAD_RE =
       Pattern.compile("\"(.*)\" (.*) ?prio=(\\d+)\\s+tid=(\\d+)\\s*(.*)");
   private static final Pattern NATIVE_RE =
-      Pattern.compile("  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s+\\((.*)\\+(\\d+)\\)");
+      Pattern.compile(
+          "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*?)\\s+\\((.*)\\+(\\d+)\\)(?: \\(.*\\))?");
   private static final Pattern NATIVE_NO_LOC_RE =
-      Pattern.compile("  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?");
+      Pattern.compile(
+          "  (?:native: )?#\\d+ \\S+ [0-9a-fA-F]+\\s+(.*)\\s*\\(?(.*)\\)?(?: \\(.*\\))?");
   private static final Pattern JAVA_RE =
       Pattern.compile("  at (?:(.+)\\.)?([^.]+)\\.([^.]+)\\((.*):([\\d-]+)\\)");
   private static final Pattern JNI_RE =
@@ -179,14 +181,14 @@ public class ThreadDumpParser {
       if (matches(nativeRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         frame.setPackage(nativeRe.group(1));
-        frame.setSymbol(nativeRe.group(2));
+        frame.setFunction(nativeRe.group(2));
         frame.setLineno(getInteger(nativeRe, 3, null));
         frames.add(frame);
         lastJavaFrame = null;
       } else if (matches(nativeNoLocRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         frame.setPackage(nativeNoLocRe.group(1));
-        frame.setSymbol(nativeNoLocRe.group(2));
+        frame.setFunction(nativeNoLocRe.group(2));
         frames.add(frame);
         lastJavaFrame = null;
       } else if (matches(javaRe, text)) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -107,6 +107,7 @@ class AnrV2EventProcessorTest {
                 persistScope(
                     CONTEXTS_FILENAME,
                     Contexts().apply {
+                        trace = SpanContext("test")
                         setResponse(Response().apply { bodySize = 1024 })
                         setBrowser(Browser().apply { name = "Google Chrome" })
                     }
@@ -167,6 +168,15 @@ class AnrV2EventProcessorTest {
         assertNull(processed.platform)
         assertNull(processed.exceptions)
         assertEquals(emptyMap(), processed.contexts)
+    }
+
+    @Test
+    fun `when backfillable event is not enrichable, sets different mechanism`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint(shouldEnrich = false))
+
+        val processed = processEvent(hint)
+
+        assertEquals("HistoricalAppExitInfo", processed.exceptions!![0].mechanism!!.type)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
@@ -533,9 +533,12 @@ class AnrV2IntegrationTest {
 
         integration.register(fixture.hub, fixture.options)
 
-        verify(fixture.hub).captureEvent(any(), check<Hint> {
-            assertNotNull(it.threadDump)
-        })
+        verify(fixture.hub).captureEvent(
+            any(),
+            check<Hint> {
+                assertNotNull(it.threadDump)
+            }
+        )
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2IntegrationTest.kt
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.atMost
 import org.mockito.kotlin.check
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -42,6 +43,7 @@ import kotlin.concurrent.thread
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -67,7 +69,9 @@ class AnrV2IntegrationTest {
             flushTimeoutMillis: Long = 0L,
             lastReportedAnrTimestamp: Long? = null,
             lastEventId: SentryId = SentryId(),
-            sessionTrackingEnabled: Boolean = true
+            sessionTrackingEnabled: Boolean = true,
+            reportHistoricalAnrs: Boolean = true,
+            attachAnrThreadDump: Boolean = false
         ): AnrV2Integration {
             options.run {
                 setLogger(this@Fixture.logger)
@@ -78,6 +82,8 @@ class AnrV2IntegrationTest {
                 this.isAnrEnabled = isAnrEnabled
                 this.flushTimeoutMillis = flushTimeoutMillis
                 this.isEnableAutoSessionTracking = sessionTrackingEnabled
+                this.isReportHistoricalAnrs = reportHistoricalAnrs
+                this.isAttachAnrThreadDump = attachAnrThreadDump
                 addInAppInclude("io.sentry.samples")
                 setEnvelopeDiskCache(EnvelopeCache.create(this))
             }
@@ -93,7 +99,8 @@ class AnrV2IntegrationTest {
         fun addAppExitInfo(
             reason: Int? = ApplicationExitInfo.REASON_ANR,
             timestamp: Long? = null,
-            importance: Int? = null
+            importance: Int? = null,
+            addTrace: Boolean = true
         ) {
             val builder = ApplicationExitInfoBuilder.newBuilder()
             if (reason != null) {
@@ -106,6 +113,9 @@ class AnrV2IntegrationTest {
                 builder.setImportance(importance)
             }
             val exitInfo = spy(builder.build()) {
+                if (!addTrace) {
+                    return
+                }
                 whenever(mock.traceInputStream).thenReturn(
                     """
 "main" prio=5 tid=1 Blocked
@@ -259,9 +269,11 @@ class AnrV2IntegrationTest {
                 assertEquals(false, otherThread.isMain)
                 val firstFrame = otherThread.stacktrace!!.frames!!.first()
                 assertEquals(
-                    "/apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)",
+                    "/apex/com.android.runtime/lib64/bionic/libc.so",
                     firstFrame.`package`
                 )
+                assertEquals("__start_thread", firstFrame.function)
+                assertEquals(64, firstFrame.lineno)
             },
             argThat<Hint> {
                 val hint = HintUtils.getSentrySdkHint(this)
@@ -354,6 +366,29 @@ class AnrV2IntegrationTest {
             argThat<Hint> {
                 val hint = HintUtils.getSentrySdkHint(this)
                 !(hint as AnrV2Hint).shouldEnrich()
+            }
+        )
+    }
+
+    @Test
+    fun `when historical ANRs flag is disabled, does not report`() {
+        val integration = fixture.getSut(
+            tmpDir,
+            lastReportedAnrTimestamp = oldTimestamp,
+            reportHistoricalAnrs = false
+        )
+        fixture.addAppExitInfo(timestamp = newTimestamp - 2 * 60 * 1000)
+        fixture.addAppExitInfo(timestamp = newTimestamp - 1 * 60 * 1000)
+        fixture.addAppExitInfo(timestamp = newTimestamp)
+
+        integration.register(fixture.hub, fixture.options)
+
+        // only the latest anr is reported which should be enrichable
+        verify(fixture.hub, atMost(1)).captureEvent(
+            any(),
+            argThat<Hint> {
+                val hint = HintUtils.getSentrySdkHint(this)
+                (hint as AnrV2Hint).shouldEnrich()
             }
         )
     }
@@ -485,5 +520,31 @@ class AnrV2IntegrationTest {
         )
         // should return true, because latch is 0 now
         assertTrue((fixture.options.envelopeDiskCache as EnvelopeCache).waitPreviousSessionFlush())
+    }
+
+    @Test
+    fun `attaches plain thread dump, if enabled`() {
+        val integration = fixture.getSut(
+            tmpDir,
+            lastReportedAnrTimestamp = oldTimestamp,
+            attachAnrThreadDump = true
+        )
+        fixture.addAppExitInfo(timestamp = newTimestamp)
+
+        integration.register(fixture.hub, fixture.options)
+
+        verify(fixture.hub).captureEvent(any(), check<Hint> {
+            assertNotNull(it.threadDump)
+        })
+    }
+
+    @Test
+    fun `when traceInputStream is null, does not report ANR`() {
+        val integration = fixture.getSut(tmpDir, lastReportedAnrTimestamp = oldTimestamp)
+        fixture.addAppExitInfo(timestamp = newTimestamp, addTrace = false)
+
+        integration.register(fixture.hub, fixture.options)
+
+        verify(fixture.hub, never()).captureEvent(any(), anyOrNull<Hint>())
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -41,7 +41,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import org.robolectric.shadow.api.Shadow
 import org.robolectric.shadows.ShadowActivityManager
@@ -101,7 +103,41 @@ class SentryAndroidTest {
             if (importance != null) {
                 builder.setImportance(importance)
             }
-            shadowActivityManager.addApplicationExitInfo(builder.build())
+            val exitInfo = spy(builder.build()) {
+                whenever(mock.traceInputStream).thenReturn(
+                    """
+"main" prio=5 tid=1 Blocked
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x72a985e0 self=0xb400007cabc57380
+  | sysTid=28941 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8
+  | state=S schedstat=( 324804784 183300334 997 ) utm=23 stm=8 core=3 HZ=100
+  | stack=0x7ff93a9000-0x7ff93ab000 stackSize=8188KB
+  | held mutexes=
+  at io.sentry.samples.android.MainActivity${'$'}2.run(MainActivity.java:177)
+  - waiting to lock <0x0d3a2f0a> (a java.lang.Object) held by thread 5
+  at android.os.Handler.handleCallback(Handler.java:942)
+  at android.os.Handler.dispatchMessage(Handler.java:99)
+  at android.os.Looper.loopOnce(Looper.java:201)
+  at android.os.Looper.loop(Looper.java:288)
+  at android.app.ActivityThread.main(ActivityThread.java:7872)
+  at java.lang.reflect.Method.invoke(Native method)
+  at com.android.internal.os.RuntimeInit${'$'}MethodAndArgsCaller.run(RuntimeInit.java:548)
+  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
+
+"perfetto_hprof_listener" prio=10 tid=7 Native (still starting up)
+  | group="" sCount=1 ucsCount=0 flags=1 obj=0x0 self=0xb400007cabc5ab20
+  | sysTid=28959 nice=-20 cgrp=top-app sched=0/0 handle=0x7b2021bcb0
+  | state=S schedstat=( 72750 1679167 1 ) utm=0 stm=0 core=3 HZ=100
+  | stack=0x7b20124000-0x7b20126000 stackSize=991KB
+  | held mutexes=
+  native: #00 pc 00000000000a20f4  /apex/com.android.runtime/lib64/bionic/libc.so (read+4) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #01 pc 000000000001d840  /apex/com.android.art/lib64/libperfetto_hprof.so (void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ArtPlugin_Initialize::${'$'}_34> >(void*)+260) (BuildId: 525cc92a7dc49130157aeb74f6870364)
+  native: #02 pc 00000000000b63b0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  native: #03 pc 00000000000530b8  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)
+  (no managed stack frames)
+                    """.trimIndent().byteInputStream()
+                )
+            }
+            shadowActivityManager.addApplicationExitInfo(exitInfo)
         }
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -60,9 +60,11 @@ class ThreadDumpParserTest {
         assertEquals(false, randomThread.isMain)
         assertEquals(false, randomThread.isCurrent)
         assertEquals(
-            "/apex/com.android.runtime/lib64/bionic/libc.so (__epoll_pwait+8) (BuildId: 01331f74b0bb2cb958bdc15282b8ec7b)",
+            "/apex/com.android.runtime/lib64/bionic/libc.so",
             randomThread.stacktrace!!.frames!!.last().`package`
         )
+        assertEquals("__epoll_pwait", randomThread.stacktrace!!.frames!!.last()!!.function)
+        assertEquals(8, randomThread.stacktrace!!.frames!!.last()!!.lineno)
         val firstFrame = randomThread.stacktrace!!.frames!!.first()
         assertEquals("android.os.HandlerThread", firstFrame.module)
         assertEquals("run", firstFrame.function)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -16,6 +16,7 @@ public final class io/sentry/Attachment {
 	public fun <init> ([BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public fun <init> ([BLjava/lang/String;Ljava/lang/String;Z)V
 	public static fun fromScreenshot ([B)Lio/sentry/Attachment;
+	public static fun fromThreadDump ([B)Lio/sentry/Attachment;
 	public static fun fromViewHierarchy (Lio/sentry/protocol/ViewHierarchy;)Lio/sentry/Attachment;
 	public fun getAttachmentType ()Ljava/lang/String;
 	public fun getBytes ()[B
@@ -309,11 +310,13 @@ public final class io/sentry/Hint {
 	public fun getAs (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
 	public fun getAttachments ()Ljava/util/List;
 	public fun getScreenshot ()Lio/sentry/Attachment;
+	public fun getThreadDump ()Lio/sentry/Attachment;
 	public fun getViewHierarchy ()Lio/sentry/Attachment;
 	public fun remove (Ljava/lang/String;)V
 	public fun replaceAttachments (Ljava/util/List;)V
 	public fun set (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setScreenshot (Lio/sentry/Attachment;)V
+	public fun setThreadDump (Lio/sentry/Attachment;)V
 	public fun setViewHierarchy (Lio/sentry/Attachment;)V
 	public static fun withAttachment (Lio/sentry/Attachment;)Lio/sentry/Hint;
 	public static fun withAttachments (Ljava/util/List;)Lio/sentry/Hint;

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -334,4 +334,14 @@ public final class Attachment {
         VIEW_HIERARCHY_ATTACHMENT_TYPE,
         false);
   }
+
+  /**
+   * Creates a new Thread Dump Attachment
+   *
+   * @param bytes the array bytes
+   * @return the Attachment
+   */
+  public static @NotNull Attachment fromThreadDump(final byte[] bytes) {
+    return new Attachment(bytes, "thread-dump.txt", "text/plain", false);
+  }
 }

--- a/sentry/src/main/java/io/sentry/Hint.java
+++ b/sentry/src/main/java/io/sentry/Hint.java
@@ -30,6 +30,8 @@ public final class Hint {
   private @Nullable Attachment screenshot = null;
   private @Nullable Attachment viewHierarchy = null;
 
+  private @Nullable Attachment threadDump = null;
+
   public static @NotNull Hint withAttachment(@Nullable Attachment attachment) {
     @NotNull final Hint hint = new Hint();
     hint.addAttachment(attachment);
@@ -124,6 +126,14 @@ public final class Hint {
 
   public @Nullable Attachment getViewHierarchy() {
     return viewHierarchy;
+  }
+
+  public void setThreadDump(final @Nullable Attachment threadDump) {
+    this.threadDump = threadDump;
+  }
+
+  public @Nullable Attachment getThreadDump() {
+    return threadDump;
   }
 
   private boolean isCastablePrimitive(@Nullable Object hintValue, @NotNull Class<?> clazz) {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -251,6 +251,11 @@ public final class SentryClient implements ISentryClient {
       attachments.add(viewHierarchy);
     }
 
+    @Nullable final Attachment threadDump = hint.getThreadDump();
+    if (threadDump != null) {
+      attachments.add(threadDump);
+    }
+
     return attachments;
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -154,7 +154,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
 
       SentryCrashLastRunState.getInstance().setCrashedLastRun(crashedLastRun);
 
-      previousSessionLatch.countDown();
+      flushPreviousSession();
     }
 
     // TODO: probably we need to update the current session file for session updates to because of

--- a/sentry/src/test/java/io/sentry/hints/HintTest.kt
+++ b/sentry/src/test/java/io/sentry/hints/HintTest.kt
@@ -209,6 +209,7 @@ class HintTest {
         hint.addAttachment(newAttachment("test attachment"))
         hint.screenshot = newAttachment("2")
         hint.viewHierarchy = newAttachment("3")
+        hint.threadDump = newAttachment("4")
 
         hint.clear()
 
@@ -217,6 +218,7 @@ class HintTest {
         assertEquals(1, hint.attachments.size)
         assertNotNull(hint.screenshot)
         assertNotNull(hint.viewHierarchy)
+        assertNotNull(hint.threadDump)
     }
 
     @Test
@@ -235,6 +237,15 @@ class HintTest {
         hint.viewHierarchy = attachment
 
         assertNotNull(hint.viewHierarchy)
+    }
+
+    @Test
+    fun `can create hint with a thread dump`() {
+        val hint = Hint()
+        val attachment = newAttachment("thread-dump")
+        hint.threadDump = attachment
+
+        assertNotNull(hint.threadDump)
     }
 
     companion object {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The PR introduces various improvement to the existing ANRv2 implementation based on customer feedback, namely:
* Adds a rule to keep `ApplicationNotResponding` class from obfuscation so it doesn't look ugly in the issue stream
* Adds an option `setReportHistoricalAnrs`, when enabled it will report all of the ANRs from the `getHistoricalExitReasons` list. By default, the SDK only reports and enriches the latest ANR and only this one counts towards ANR rate. Hence, this reduces the noise quite a bit, but still leaves the possibility to get all of the ANR reports from the past. Worth noting that once the SDK has been updated to the version with the new implementation, we won't need this feature, because we'll always read the latest ANR on the next app restart. These ANRs are reported with the `HistoricalAppExitInfo` mechanism for distinction
* Adds an option to send the thread dump plain text as an attachment 
* If [getTraceInputStream](https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()) returns null, we do not report an ANR event because it's pretty much useless without the thread dump and makes it look confusing for our customers
* If we were not able to parse ANR thread dump due to regex issues or some exception, we'll send an event with a message instead, telling customers to use the flag to send raw thread dump and also let us know about this issue
* Adds null-check for span context values (I wasn't able to reproduce it, but sometimes they get reported as nulls, so this is just defensive here)
* Enhances regex patterns for native stackframes


The message looks like this:

![image](https://github.com/getsentry/sentry-java/assets/4999776/d72d5120-3016-49d3-a9fe-bcf2dae73fd3)

The ANR thread dump attachment looks like this:

![image](https://github.com/getsentry/sentry-java/assets/4999776/0dbceaea-b579-4805-b121-6cac3e02e480)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
