### PR TITLE
Move enableNdk to SentryAndroidOptions

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -225,6 +225,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableAppLifecycleBreadcrumbs ()Z
 	public fun isEnableAutoActivityLifecycleTracing ()Z
 	public fun isEnableFramesTracking ()Z
+	public fun isEnableNdk ()Z
 	public fun isEnableNetworkEventBreadcrumbs ()Z
 	public fun isEnableRootCheck ()Z
 	public fun isEnableSystemEventBreadcrumbs ()Z
@@ -243,6 +244,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableAppLifecycleBreadcrumbs (Z)V
 	public fun setEnableAutoActivityLifecycleTracing (Z)V
 	public fun setEnableFramesTracking (Z)V
+	public fun setEnableNdk (Z)V
 	public fun setEnableNetworkEventBreadcrumbs (Z)V
 	public fun setEnableRootCheck (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -68,7 +68,7 @@ public final class NdkIntegration implements Integration, Closeable {
     }
   }
 
-  private void disableNdkIntegration(final @NotNull SentryOptions options) {
+  private void disableNdkIntegration(final @NotNull SentryAndroidOptions options) {
     options.setEnableNdk(false);
     options.setEnableScopeSync(false);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -157,6 +157,9 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   private @Nullable BeforeCaptureCallback beforeViewHierarchyCaptureCallback;
 
+  /** Turns NDK on or off. Default is enabled. */
+  private boolean enableNdk = true;
+
   public interface BeforeCaptureCallback {
 
     /**
@@ -509,5 +512,23 @@ public final class SentryAndroidOptions extends SentryOptions {
   public void setBeforeViewHierarchyCaptureCallback(
       final @NotNull BeforeCaptureCallback beforeViewHierarchyCaptureCallback) {
     this.beforeViewHierarchyCaptureCallback = beforeViewHierarchyCaptureCallback;
+  }
+
+  /**
+   * Check if NDK is ON or OFF Default is ON
+   *
+   * @return true if ON or false otherwise
+   */
+  public boolean isEnableNdk() {
+    return enableNdk;
+  }
+
+  /**
+   * Sets NDK to ON or OFF
+   *
+   * @param enableNdk true if ON or false otherwise
+   */
+  public void setEnableNdk(boolean enableNdk) {
+    this.enableNdk = enableNdk;
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1718,7 +1718,6 @@ public class io/sentry/SentryOptions {
 	public fun isEnableAutoSessionTracking ()Z
 	public fun isEnableDeduplication ()Z
 	public fun isEnableExternalConfiguration ()Z
-	public fun isEnableNdk ()Z
 	public fun isEnableScopeSync ()Z
 	public fun isEnableShutdownHook ()Z
 	public fun isEnableTimeToFullDisplayTracing ()Z
@@ -1751,7 +1750,6 @@ public class io/sentry/SentryOptions {
 	public fun setEnableAutoSessionTracking (Z)V
 	public fun setEnableDeduplication (Z)V
 	public fun setEnableExternalConfiguration (Z)V
-	public fun setEnableNdk (Z)V
 	public fun setEnableScopeSync (Z)V
 	public fun setEnableShutdownHook (Z)V
 	public fun setEnableTimeToFullDisplayTracing (Z)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -103,9 +103,6 @@ public class SentryOptions {
    */
   private boolean debug;
 
-  /** Turns NDK on or off. Default is enabled. */
-  private boolean enableNdk = true;
-
   /** Logger interface to log useful debugging information if debug is enabled */
   private @NotNull ILogger logger = NoOpLogger.getInstance();
 
@@ -587,24 +584,6 @@ public class SentryOptions {
   public void setEnvelopeReader(final @Nullable IEnvelopeReader envelopeReader) {
     this.envelopeReader =
         envelopeReader != null ? envelopeReader : NoOpEnvelopeReader.getInstance();
-  }
-
-  /**
-   * Check if NDK is ON or OFF Default is ON
-   *
-   * @return true if ON or false otherwise
-   */
-  public boolean isEnableNdk() {
-    return enableNdk;
-  }
-
-  /**
-   * Sets NDK to ON or OFF
-   *
-   * @param enableNdk true if ON or false otherwise
-   */
-  public void setEnableNdk(boolean enableNdk) {
-    this.enableNdk = enableNdk;
   }
 
   /**


### PR DESCRIPTION
## :scroll: Description
This is a breaking change due to binary incompatibility.


## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-java/issues/1994


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
