### PR TITLE
Track auto-init usage in manifest

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import io.sentry.Sentry;
+import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryLevel;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -22,6 +23,7 @@ public final class SentryInitProvider extends EmptySecureContentProvider {
     }
     if (ManifestMetadataReader.isAutoInit(context, logger)) {
       SentryAndroid.init(context, logger);
+      SentryIntegrationPackageStorage.getInstance().addIntegration("AutoInit");
     }
     return true;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Adds `AutoInit` to the integrations list

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to understand how often manifest is used versus manual init in code.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
