### PR TITLE
Use env from SentryOptions if none persisted in ANRv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add manifest `AutoInit` to integrations list ([#2795](https://github.com/getsentry/sentry-java/pull/2795))
 - Tracing headers (`sentry-trace` and `baggage`) are now attached and passed through even if performance is disabled ([#2788](https://github.com/getsentry/sentry-java/pull/2788))
 
+### Fixes
+
+- Set `environment` from `SentryOptions` if none persisted in ANRv2 ([#2809](https://github.com/getsentry/sentry-java/pull/2809))
+
 ### Dependencies
 
 - Bump Native SDK from v0.6.3 to v0.6.4 ([#2796](https://github.com/getsentry/sentry-java/pull/2796))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -30,7 +30,6 @@ import io.sentry.SentryBaseEvent;
 import io.sentry.SentryEvent;
 import io.sentry.SentryExceptionFactory;
 import io.sentry.SentryLevel;
-import io.sentry.SentryOptions;
 import io.sentry.SentryStackTraceFactory;
 import io.sentry.SpanContext;
 import io.sentry.android.core.internal.util.CpuInfoUtils;
@@ -68,12 +67,6 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 @WorkerThread
 public final class AnrV2EventProcessor implements BackfillingEventProcessor {
-
-  /**
-   * Default value for {@link SentryEvent#getEnvironment()} set when both event and {@link
-   * SentryOptions} do not have the environment field set.
-   */
-  static final String DEFAULT_ENVIRONMENT = "production";
 
   private final @NotNull Context context;
 
@@ -337,7 +330,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
     if (event.getEnvironment() == null) {
       final String environment =
           PersistingOptionsObserver.read(options, ENVIRONMENT_FILENAME, String.class);
-      event.setEnvironment(environment != null ? environment : DEFAULT_ENVIRONMENT);
+      event.setEnvironment(environment != null ? environment : options.getEnvironment());
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -89,6 +89,7 @@ class AnrV2EventProcessorTest {
             populateOptionsCache: Boolean = false
         ): AnrV2EventProcessor {
             options.cacheDirPath = dir.newFolder().absolutePath
+            options.environment = "release"
             whenever(buildInfo.sdkInfoVersion).thenReturn(currentSdk)
             whenever(buildInfo.isEmulator).thenReturn(true)
 
@@ -337,12 +338,12 @@ class AnrV2EventProcessorTest {
     }
 
     @Test
-    fun `if environment is not persisted, uses default`() {
+    fun `if environment is not persisted, uses environment from options`() {
         val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
 
         val processed = processEvent(hint)
 
-        assertEquals(AnrV2EventProcessor.DEFAULT_ENVIRONMENT, processed.environment)
+        assertEquals("release", processed.environment)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use env from SentryOptions if none persisted in ANRv2

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal feedback

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
