### PR TITLE
Fix slow/frozen frames were not reported with transactions

### DIFF
--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -727,7 +727,7 @@ public final class Hub implements IHub {
 
       transaction =
           new SentryTracer(
-              transactionContext, this, transactionOptions, null, transactionPerformanceCollector);
+              transactionContext, this, transactionOptions, transactionPerformanceCollector);
 
       // The listener is called only if the transaction exists, as the transaction is needed to
       // stop it

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -55,7 +55,8 @@ class SentryTracerTest {
             transactionOptions.isWaitForChildren = waitForChildren
             transactionOptions.idleTimeout = idleTimeout
             transactionOptions.isTrimEnd = trimEnd
-            return SentryTracer(TransactionContext("name", "op", samplingDecision), hub, transactionOptions, transactionFinishedCallback, performanceCollector)
+            transactionOptions.transactionFinishedCallback = transactionFinishedCallback
+            return SentryTracer(TransactionContext("name", "op", samplingDecision), hub, transactionOptions, performanceCollector)
         }
     }
 

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -41,7 +41,7 @@ class SpanTest {
         }
 
         fun getRootSut(options: TransactionOptions = TransactionOptions()): Span {
-            return SentryTracer(TransactionContext("name", "op"), hub, options, null).root
+            return SentryTracer(TransactionContext("name", "op"), hub, options).root
         }
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We were setting the `transactionFinishedCallback` to `transactionOptions`, but were never calling it

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal discussions

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
