### PR TITLE
Fix concurrent access to frameMetrics listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix concurrent access to frameMetrics listener ([#2823](https://github.com/getsentry/sentry-java/pull/2823))
+
 ## 6.25.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -19,11 +19,11 @@ import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.util.Objects;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SentryFrameMetricsCollector implements Application.ActivityLifecycleCallbacks {
   private final @NotNull BuildInfoProvider buildInfoProvider;
-  private final @NotNull Set<Window> trackedWindows = new HashSet<>();
+  private final @NotNull Set<Window> trackedWindows = new CopyOnWriteArraySet<>();
   private final @NotNull SentryOptions options;
   private @Nullable Handler handler;
   private @Nullable WeakReference<Window> currentWindow;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -19,10 +19,11 @@ import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.util.Objects;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,8 +35,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
   private final @NotNull SentryOptions options;
   private @Nullable Handler handler;
   private @Nullable WeakReference<Window> currentWindow;
-  private final @NotNull HashMap<String, FrameMetricsCollectorListener> listenerMap =
-      new HashMap<>();
+  private final @NotNull Map<String, FrameMetricsCollectorListener> listenerMap =
+      new ConcurrentHashMap<>();
   private boolean isAvailable = false;
   private final WindowFrameMetricsManager windowFrameMetricsManager;
 


### PR DESCRIPTION
## :scroll: Description
changed metrics listener map from HashMap to ConcurrentHashMap


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2816


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
