### PR TITLE
Allow removing integrations in SentryAndroid.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add manifest `AutoInit` to integrations list ([#2795](https://github.com/getsentry/sentry-java/pull/2795))
+- Tracing headers (`sentry-trace` and `baggage`) are now attached and passed through even if performance is disabled ([#2788](https://github.com/getsentry/sentry-java/pull/2788))
 
 ### Fixes
 
@@ -38,7 +39,6 @@
   This is only useful as additional information, because the SDK attempts to parse the thread dump into proper threads with stacktraces by default.
   - If [ApplicationExitInfo#getTraceInputStream](https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()) returns null, the SDK no longer reports an ANR event, as these events are not very useful without it.
   - Enhance regex patterns for native stackframes
-- Tracing headers (`sentry-trace` and `baggage`) are now attached and passed through even if performance is disabled ([#2788](https://github.com/getsentry/sentry-java/pull/2788))
 
 ## 6.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Allow removing integrations in SentryAndroid.init ([#2826](https://github.com/getsentry/sentry-java/pull/2826))
+
 ## 6.25.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -100,14 +100,16 @@ final class AndroidOptionsInitializer {
 
   @TestOnly
   static void initializeIntegrationsAndProcessors(
-      final @NotNull SentryAndroidOptions options, final @NotNull Context context) {
+      final @NotNull SentryAndroidOptions options,
+      final @NotNull Context context,
+      final @NotNull LoadClass loadClass,
+      final @NotNull ActivityFramesTracker activityFramesTracker) {
     initializeIntegrationsAndProcessors(
         options,
         context,
         new BuildInfoProvider(new AndroidLogger()),
-        new LoadClass(),
-        false,
-        false);
+        loadClass,
+        activityFramesTracker);
   }
 
   static void initializeIntegrationsAndProcessors(
@@ -115,25 +117,12 @@ final class AndroidOptionsInitializer {
       final @NotNull Context context,
       final @NotNull BuildInfoProvider buildInfoProvider,
       final @NotNull LoadClass loadClass,
-      final boolean isFragmentAvailable,
-      final boolean isTimberAvailable) {
+      final @NotNull ActivityFramesTracker activityFramesTracker) {
 
     if (options.getCacheDirPath() != null
         && options.getEnvelopeDiskCache() instanceof NoOpEnvelopeCache) {
       options.setEnvelopeDiskCache(new AndroidEnvelopeCache(options));
     }
-
-    final ActivityFramesTracker activityFramesTracker =
-        new ActivityFramesTracker(loadClass, options);
-
-    installDefaultIntegrations(
-        context,
-        options,
-        buildInfoProvider,
-        loadClass,
-        activityFramesTracker,
-        isFragmentAvailable,
-        isTimberAvailable);
 
     options.addEventProcessor(
         new DefaultAndroidEventProcessor(context, buildInfoProvider, options));
@@ -192,7 +181,7 @@ final class AndroidOptionsInitializer {
     }
   }
 
-  private static void installDefaultIntegrations(
+  static void installDefaultIntegrations(
       final @NotNull Context context,
       final @NotNull SentryAndroidOptions options,
       final @NotNull BuildInfoProvider buildInfoProvider,
@@ -200,6 +189,9 @@ final class AndroidOptionsInitializer {
       final @NotNull ActivityFramesTracker activityFramesTracker,
       final boolean isFragmentAvailable,
       final boolean isTimberAvailable) {
+
+    // Integration MUST NOT cache option values in ctor, as they will be configured later by the
+    // user
 
     // read the startup crash marker here to avoid doing double-IO for the SendCachedEnvelope
     // integrations below

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -5,6 +5,7 @@ import io.sentry.Integration;
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.util.LazyEvaluator;
 import io.sentry.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -16,13 +17,13 @@ final class SendCachedEnvelopeIntegration implements Integration {
 
   private final @NotNull SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory
       factory;
-  private final boolean hasStartupCrashMarker;
+  private final @NotNull LazyEvaluator<Boolean> startupCrashMarkerEvaluator;
 
   public SendCachedEnvelopeIntegration(
       final @NotNull SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory factory,
-      final boolean hasStartupCrashMarker) {
+      final @NotNull LazyEvaluator<Boolean> startupCrashMarkerEvaluator) {
     this.factory = Objects.requireNonNull(factory, "SendFireAndForgetFactory is required");
-    this.hasStartupCrashMarker = hasStartupCrashMarker;
+    this.startupCrashMarkerEvaluator = startupCrashMarkerEvaluator;
   }
 
   @Override
@@ -62,7 +63,7 @@ final class SendCachedEnvelopeIntegration implements Integration {
                     }
                   });
 
-      if (hasStartupCrashMarker) {
+      if (startupCrashMarkerEvaluator.getValue()) {
         androidOptions
             .getLogger()
             .log(SentryLevel.DEBUG, "Startup Crash marker exists, blocking flush.");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -22,6 +22,9 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import java.io.File
@@ -597,6 +600,22 @@ class AndroidOptionsInitializerTest {
 
         assertFalse(fixture.sentryOptions.optionsObservers.any { it is PersistingOptionsObserver })
         assertFalse(fixture.sentryOptions.scopeObservers.any { it is PersistingScopeObserver })
+    }
+
+    @Test
+    fun `installDefaultIntegrations does not evaluate cacheDir or outboxPath when called`() {
+        val mockOptions = spy(fixture.sentryOptions)
+        AndroidOptionsInitializer.installDefaultIntegrations(
+            fixture.context,
+            mockOptions,
+            mock(),
+            mock(),
+            mock(),
+            false,
+            false
+        )
+        verify(mockOptions, never()).outboxPath
+        verify(mockOptions, never()).cacheDirPath
     }
 
     @Config(sdk = [30])

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -68,10 +68,26 @@ class AndroidOptionsInitializerTest {
                 sentryOptions,
                 if (useRealContext) context else mockContext
             )
+
+            val loadClass = LoadClass()
+            val activityFramesTracker = ActivityFramesTracker(loadClass, sentryOptions)
+
+            AndroidOptionsInitializer.installDefaultIntegrations(
+                if (useRealContext) context else mockContext,
+                sentryOptions,
+                BuildInfoProvider(AndroidLogger()),
+                loadClass,
+                activityFramesTracker,
+                false,
+                false
+            )
+
             sentryOptions.configureOptions()
             AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
                 sentryOptions,
-                if (useRealContext) context else mockContext
+                if (useRealContext) context else mockContext,
+                loadClass,
+                activityFramesTracker
             )
         }
 
@@ -89,6 +105,8 @@ class AndroidOptionsInitializerTest {
             )
             sentryOptions.isDebug = true
             val buildInfo = createBuildInfo(minApi)
+            val loadClass = createClassMock(classesToLoad)
+            val activityFramesTracker = ActivityFramesTracker(loadClass, sentryOptions)
 
             AndroidOptionsInitializer.loadDefaultAndMetadataOptions(
                 sentryOptions,
@@ -96,13 +114,23 @@ class AndroidOptionsInitializerTest {
                 logger,
                 buildInfo
             )
+
+            AndroidOptionsInitializer.installDefaultIntegrations(
+                context,
+                sentryOptions,
+                buildInfo,
+                loadClass,
+                activityFramesTracker,
+                isFragmentAvailable,
+                isTimberAvailable
+            )
+
             AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
                 sentryOptions,
                 context,
                 buildInfo,
-                createClassMock(classesToLoad),
-                isFragmentAvailable,
-                isTimberAvailable
+                loadClass,
+                activityFramesTracker
             )
         }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -109,19 +109,31 @@ class AndroidTransactionProfilerTest {
     fun `set up`() {
         context = ApplicationProvider.getApplicationContext()
         val buildInfoProvider = BuildInfoProvider(fixture.mockLogger)
+        val loadClass = LoadClass()
+        val activityFramesTracker = ActivityFramesTracker(loadClass, fixture.options)
         AndroidOptionsInitializer.loadDefaultAndMetadataOptions(
             fixture.options,
             context,
             fixture.mockLogger,
             buildInfoProvider
         )
+
+        AndroidOptionsInitializer.installDefaultIntegrations(
+            context,
+            fixture.options,
+            buildInfoProvider,
+            loadClass,
+            activityFramesTracker,
+            false,
+            false
+        )
+
         AndroidOptionsInitializer.initializeIntegrationsAndProcessors(
             fixture.options,
             context,
             buildInfoProvider,
-            LoadClass(),
-            false,
-            false
+            loadClass,
+            activityFramesTracker
         )
         // Profiler doesn't start if the folder doesn't exists.
         // Usually it's generated when calling Sentry.init, but for tests we can create it manually.

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SendCachedEnvelopeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SendCachedEnvelopeIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.sentry.ILogger
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory
 import io.sentry.SentryLevel.DEBUG
+import io.sentry.util.LazyEvaluator
 import org.awaitility.kotlin.await
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -53,7 +54,7 @@ class SendCachedEnvelopeIntegrationTest {
                 }
             )
 
-            return SendCachedEnvelopeIntegration(factory, hasStartupCrashMarker)
+            return SendCachedEnvelopeIntegration(factory, LazyEvaluator { hasStartupCrashMarker })
         }
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryInitProviderTest.kt
@@ -133,7 +133,20 @@ class SentryInitProviderTest {
         metaData.putBoolean(ManifestMetadataReader.NDK_ENABLE, false)
 
         AndroidOptionsInitializer.loadDefaultAndMetadataOptions(sentryOptions, mockContext)
-        AndroidOptionsInitializer.initializeIntegrationsAndProcessors(sentryOptions, mockContext)
+
+        val loadClass = LoadClass()
+        val activityFramesTracker = ActivityFramesTracker(loadClass, sentryOptions)
+        AndroidOptionsInitializer.installDefaultIntegrations(
+            mockContext,
+            sentryOptions,
+            BuildInfoProvider(AndroidLogger()),
+            loadClass,
+            activityFramesTracker,
+            false,
+            false
+        )
+
+        AndroidOptionsInitializer.initializeIntegrationsAndProcessors(sentryOptions, mockContext, loadClass, activityFramesTracker)
 
         assertFalse(sentryOptions.isEnableNdk)
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4151,6 +4151,15 @@ public final class io/sentry/util/JsonSerializationUtils {
 	public static fun calendarToMap (Ljava/util/Calendar;)Ljava/util/Map;
 }
 
+public final class io/sentry/util/LazyEvaluator {
+	public fun <init> (Lio/sentry/util/LazyEvaluator$Evaluator;)V
+	public fun getValue ()Ljava/lang/Object;
+}
+
+public abstract interface class io/sentry/util/LazyEvaluator$Evaluator {
+	public abstract fun evaluate ()Ljava/lang/Object;
+}
+
 public final class io/sentry/util/LogUtils {
 	public fun <init> ()V
 	public static fun logNotInstanceOf (Ljava/lang/Class;Ljava/lang/Object;Lio/sentry/ILogger;)V

--- a/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
+++ b/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
@@ -1,0 +1,42 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Class that evaluates a function lazily. It means the evaluator function is called only when
+ * getValue is called, and it's cached.
+ */
+@ApiStatus.Internal
+public final class LazyEvaluator<T> {
+  private @Nullable T value = null;
+  private final @NotNull Evaluator<T> evaluator;
+
+  /**
+   * Class that evaluates a function lazily. It means the evaluator function is called only when
+   * getValue is called, and it's cached.
+   *
+   * @param evaluator The function to evaluate.
+   */
+  public LazyEvaluator(final @NotNull Evaluator<T> evaluator) {
+    this.evaluator = evaluator;
+  }
+
+  /**
+   * Executes the evaluator function and caches its result, so that it's called only once.
+   *
+   * @return The result of the evaluator function.
+   */
+  public synchronized @NotNull T getValue() {
+    if (value == null) {
+      value = evaluator.evaluate();
+    }
+    return value;
+  }
+
+  public interface Evaluator<T> {
+    @NotNull
+    T evaluate();
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/LazyEvaluatorTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LazyEvaluatorTest.kt
@@ -1,0 +1,41 @@
+package io.sentry.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LazyEvaluatorTest {
+
+    class Fixture {
+        var count = 0
+
+        fun getSut(): LazyEvaluator<Int> {
+            count = 0
+            return LazyEvaluator<Int> { ++count }
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `does not evaluate on instantiation`() {
+        fixture.getSut()
+        assertEquals(0, fixture.count)
+    }
+
+    @Test
+    fun `evaluator is called on getValue`() {
+        val evaluator = fixture.getSut()
+        assertEquals(0, fixture.count)
+        assertEquals(1, evaluator.value)
+        assertEquals(1, fixture.count)
+    }
+
+    @Test
+    fun `evaluates only once`() {
+        val evaluator = fixture.getSut()
+        assertEquals(0, fixture.count)
+        assertEquals(1, evaluator.value)
+        assertEquals(1, evaluator.value)
+        assertEquals(1, fixture.count)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
configure options now happens after adding integrations in `SentryAndroid.init`
added LazyEvaluator to evaluate a function lazily
AndroidOptionsInitializer.installDefaultIntegrations now evaluate cache dir lazily 


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2821 and https://github.com/getsentry/sentry-java/issues/2355


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
