### PR TITLE
Cache Android test emulators

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -16,6 +16,27 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: aosp_atd
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b # pin@v2
+        with:
+          api-level: 30
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          target: 'aosp_atd'
+          channel: canary # Necessary for ATDs
+          script: echo "Generated AVD snapshot for caching."
+
   agp-matrix-compatibility:
     timeout-minutes: 30
     runs-on: macos-latest
@@ -47,31 +68,10 @@ jobs:
       - name: Make assembleUiTests
         run: make assembleUiTests
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: aosp_atd
-
       # We stop gradle at the end to make sure the cache folders
       # don't contain any lock files and are free to be cached.
       - name: Make stop
         run: make stop
-
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
-        with:
-          api-level: 30
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          target: 'aosp_atd'
-          channel: canary # Necessary for ATDs
-          script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b # pin@v2

--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  cache-avd:
+    runs-on: macos-latest
+    steps:
       - name: AVD cache
         uses: actions/cache@v3
         id: avd-cache

--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -73,6 +73,15 @@ jobs:
       - name: Make stop
         run: make stop
 
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: aosp_atd
+
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b # pin@v2
         with:

--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -47,10 +47,31 @@ jobs:
       - name: Make assembleUiTests
         run: make assembleUiTests
 
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: aosp_atd
+
       # We stop gradle at the end to make sure the cache folders
       # don't contain any lock files and are free to be cached.
       - name: Make stop
         run: make stop
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
+        with:
+          api-level: 30
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          target: 'aosp_atd'
+          channel: canary # Necessary for ATDs
+          script: echo "Generated AVD snapshot for caching."
 
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b # pin@v2


### PR DESCRIPTION
## :scroll: Description
android emulators used for tests are now cached

#skip-changelog

## :bulb: Motivation and Context
Speedup the tests in CI


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
