### PR TITLE
Deduplicate events happening in multiple threads simultaneously

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -21,9 +21,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
 import timber.log.Timber;
 
 public class MainActivity extends AppCompatActivity {
@@ -137,6 +140,28 @@ public class MainActivity extends AppCompatActivity {
           // Use the client's IP address
           user.setIpAddress("{{auto}}");
           Sentry.setUser(user);
+        });
+
+    binding.outOfMemory.setOnClickListener(
+        view -> {
+          final CountDownLatch latch = new CountDownLatch(1);
+          for (int i = 0; i < 20; i++) {
+            new Thread(
+                    () -> {
+                      final List<String> data = new ArrayList<>();
+                      try {
+                        latch.await();
+                        for (int j = 0; j < 1_000_000; j++) {
+                          data.add(new String(new byte[1024 * 8]));
+                        }
+                      } catch (InterruptedException e) {
+                        e.printStackTrace();
+                      }
+                    })
+                .start();
+          }
+
+          latch.countDown();
         });
 
     binding.nativeCrash.setOnClickListener(view -> NativeSample.crash());

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -65,6 +65,12 @@
       android:text="@string/anr" />
 
     <Button
+      android:id="@+id/out_of_memory"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/out_of_memory" />
+
+    <Button
       android:id="@+id/native_crash"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
   <string name="app_name">Sentry sample</string>
   <string name="crash_from_java">Crash from Java (UncaughtException)</string>
+  <string name="out_of_memory">Out of Memory (Mulithreaded)</string>
   <string name="send_message">Send Message</string>
   <string name="send_message_from_inner_fragment">Send Message from inner fragment</string>
   <string name="add_attachment">Add Attachment</string>

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -195,6 +195,11 @@ public final class io/sentry/DateUtils {
 	public static fun toUtilDateNotNull (Lio/sentry/SentryDate;)Ljava/util/Date;
 }
 
+public final class io/sentry/DeduplicateMultithreadedEventProcessor : io/sentry/EventProcessor {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
+}
+
 public final class io/sentry/DefaultTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close ()V
@@ -1520,6 +1525,7 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 	public fun getThreads ()Ljava/util/List;
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun getTransaction ()Ljava/lang/String;
+	public fun getUnhandledException ()Lio/sentry/protocol/SentryException;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun isCrashed ()Z
 	public fun isErrored ()Z
@@ -2344,6 +2350,7 @@ public final class io/sentry/TypeCheckHint {
 	public static final field OPEN_FEIGN_RESPONSE Ljava/lang/String;
 	public static final field SENTRY_DART_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_DOTNET_SDK_NAME Ljava/lang/String;
+	public static final field SENTRY_EVENT_DROP_REASON Ljava/lang/String;
 	public static final field SENTRY_IS_FROM_HYBRID_SDK Ljava/lang/String;
 	public static final field SENTRY_JAVASCRIPT_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_SYNTHETIC_EXCEPTION Ljava/lang/String;
@@ -2625,6 +2632,12 @@ public abstract interface class io/sentry/hints/Cached {
 
 public abstract interface class io/sentry/hints/DiskFlushNotification {
 	public abstract fun markFlushed ()V
+}
+
+public final class io/sentry/hints/EventDropReason : java/lang/Enum {
+	public static final field MULTITHREADED_DEDUPLICATION Lio/sentry/hints/EventDropReason;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/hints/EventDropReason;
+	public static fun values ()[Lio/sentry/hints/EventDropReason;
 }
 
 public abstract interface class io/sentry/hints/Flushable {
@@ -4110,6 +4123,7 @@ public final class io/sentry/util/FileUtils {
 
 public final class io/sentry/util/HintUtils {
 	public static fun createWithTypeCheckHint (Ljava/lang/Object;)Lio/sentry/Hint;
+	public static fun getEventDropReason (Lio/sentry/Hint;)Lio/sentry/hints/EventDropReason;
 	public static fun getSentrySdkHint (Lio/sentry/Hint;)Ljava/lang/Object;
 	public static fun hasType (Lio/sentry/Hint;Ljava/lang/Class;)Z
 	public static fun isFromHybridSdk (Lio/sentry/Hint;)Z
@@ -4117,6 +4131,7 @@ public final class io/sentry/util/HintUtils {
 	public static fun runIfHasType (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;)V
 	public static fun runIfHasType (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/util/HintUtils$SentryConsumer;Lio/sentry/util/HintUtils$SentryHintFallback;)V
 	public static fun runIfHasTypeLogIfNot (Lio/sentry/Hint;Ljava/lang/Class;Lio/sentry/ILogger;Lio/sentry/util/HintUtils$SentryConsumer;)V
+	public static fun setEventDropReason (Lio/sentry/Hint;Lio/sentry/hints/EventDropReason;)V
 	public static fun setIsFromHybridSdk (Lio/sentry/Hint;Ljava/lang/String;)V
 	public static fun setTypeCheckHint (Lio/sentry/Hint;Ljava/lang/Object;)V
 	public static fun shouldApplyScopeData (Lio/sentry/Hint;)Z

--- a/sentry/src/main/java/io/sentry/DeduplicateMultithreadedEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DeduplicateMultithreadedEventProcessor.java
@@ -1,0 +1,64 @@
+package io.sentry;
+
+import io.sentry.hints.EventDropReason;
+import io.sentry.protocol.SentryException;
+import io.sentry.util.HintUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An event processor that deduplicates crash events of the same type that are simultaneously from
+ * multiple threads. This can be the case for OutOfMemory errors or CursorWindowAllocationException,
+ * basically any error related to allocating memory when it's low.
+ */
+public final class DeduplicateMultithreadedEventProcessor implements EventProcessor {
+
+  private final @NotNull Map<String, Long> processedEvents =
+      Collections.synchronizedMap(new HashMap<>());
+
+  private final @NotNull SentryOptions options;
+
+  public DeduplicateMultithreadedEventProcessor(final @NotNull SentryOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public @Nullable SentryEvent process(final @NotNull SentryEvent event, final @NotNull Hint hint) {
+    if (!event.isCrashed()) {
+      // only dedupe crashes, because handled errors might be sent simultaneously on purpose
+      return event;
+    }
+
+    final SentryException exception = event.getUnhandledException();
+    if (exception == null) {
+      return event;
+    }
+
+    final String type = exception.getType();
+    if (type == null) {
+      return event;
+    }
+
+    final Long currentEventTid = exception.getThreadId();
+    if (currentEventTid == null) {
+      return event;
+    }
+
+    final Long tid = processedEvents.get(type);
+    if (tid != null && !tid.equals(currentEventTid)) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.INFO,
+              "Event %s has been dropped due to multi-threaded deduplication",
+              event.getEventId());
+      HintUtils.setEventDropReason(hint, EventDropReason.MULTITHREADED_DEDUPLICATION);
+      return null;
+    }
+    processedEvents.put(type, currentEventTid);
+    return event;
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -211,17 +211,20 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
    * @return true if its crashed or false otherwise
    */
   public boolean isCrashed() {
+    return getUnhandledException() != null;
+  }
+
+  public @Nullable SentryException getUnhandledException() {
     if (exception != null) {
       for (SentryException e : exception.getValues()) {
         if (e.getMechanism() != null
             && e.getMechanism().isHandled() != null
             && !e.getMechanism().isHandled()) {
-          return true;
+          return e;
         }
       }
     }
-
-    return false;
+    return null;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2239,6 +2239,7 @@ public class SentryOptions {
 
       eventProcessors.add(new MainEventProcessor(this));
       eventProcessors.add(new DuplicateEventDetectionEventProcessor(this));
+      eventProcessors.add(new DeduplicateMultithreadedEventProcessor(this));
 
       if (Platform.isJvm()) {
         eventProcessors.add(new SentryRuntimeEventProcessor());

--- a/sentry/src/main/java/io/sentry/TypeCheckHint.java
+++ b/sentry/src/main/java/io/sentry/TypeCheckHint.java
@@ -10,6 +10,9 @@ public final class TypeCheckHint {
   @ApiStatus.Internal
   public static final String SENTRY_IS_FROM_HYBRID_SDK = "sentry:isFromHybridSdk";
 
+  @ApiStatus.Internal
+  public static final String SENTRY_EVENT_DROP_REASON = "sentry:eventDropReason";
+
   @ApiStatus.Internal public static final String SENTRY_JAVASCRIPT_SDK_NAME = "sentry.javascript";
 
   @ApiStatus.Internal public static final String SENTRY_DOTNET_SDK_NAME = "sentry.dotnet";

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -3,6 +3,7 @@ package io.sentry;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.hints.BlockingFlushHint;
+import io.sentry.hints.EventDropReason;
 import io.sentry.hints.SessionEnd;
 import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.SentryId;
@@ -98,7 +99,11 @@ public final class UncaughtExceptionHandlerIntegration
 
         final @NotNull SentryId sentryId = hub.captureEvent(event, hint);
         final boolean isEventDropped = sentryId.equals(SentryId.EMPTY_ID);
-        if (!isEventDropped) {
+        final EventDropReason eventDropReason = HintUtils.getEventDropReason(hint);
+        // in case the event has been dropped by multithreaded deduplicator, the other threads will
+        // crash the app without a chance to persist the main event so we have to special-case this
+        if (!isEventDropped
+            || EventDropReason.MULTITHREADED_DEDUPLICATION.equals(eventDropReason)) {
           // Block until the event is flushed to disk
           if (!exceptionHint.waitFlush()) {
             options

--- a/sentry/src/main/java/io/sentry/hints/EventDropReason.java
+++ b/sentry/src/main/java/io/sentry/hints/EventDropReason.java
@@ -1,0 +1,9 @@
+package io.sentry.hints;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/** A reason for which an event was dropped, used for (not to confuse with ClientReports) */
+@ApiStatus.Internal
+public enum EventDropReason {
+  MULTITHREADED_DEDUPLICATION
+}

--- a/sentry/src/main/java/io/sentry/util/HintUtils.java
+++ b/sentry/src/main/java/io/sentry/util/HintUtils.java
@@ -2,6 +2,7 @@ package io.sentry.util;
 
 import static io.sentry.TypeCheckHint.SENTRY_DART_SDK_NAME;
 import static io.sentry.TypeCheckHint.SENTRY_DOTNET_SDK_NAME;
+import static io.sentry.TypeCheckHint.SENTRY_EVENT_DROP_REASON;
 import static io.sentry.TypeCheckHint.SENTRY_IS_FROM_HYBRID_SDK;
 import static io.sentry.TypeCheckHint.SENTRY_JAVASCRIPT_SDK_NAME;
 import static io.sentry.TypeCheckHint.SENTRY_TYPE_CHECK_HINT;
@@ -11,6 +12,7 @@ import io.sentry.ILogger;
 import io.sentry.hints.ApplyScopeData;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.Cached;
+import io.sentry.hints.EventDropReason;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +33,16 @@ public final class HintUtils {
 
   public static boolean isFromHybridSdk(final @NotNull Hint hint) {
     return Boolean.TRUE.equals(hint.getAs(SENTRY_IS_FROM_HYBRID_SDK, Boolean.class));
+  }
+
+  public static void setEventDropReason(
+      final @NotNull Hint hint, final @NotNull EventDropReason eventDropReason) {
+    hint.set(SENTRY_EVENT_DROP_REASON, eventDropReason);
+  }
+
+  @Nullable
+  public static EventDropReason getEventDropReason(final @NotNull Hint hint) {
+    return hint.getAs(SENTRY_EVENT_DROP_REASON, EventDropReason.class);
   }
 
   public static Hint createWithTypeCheckHint(Object typeCheckHint) {

--- a/sentry/src/test/java/io/sentry/DeduplicateMultithreadedEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/DeduplicateMultithreadedEventProcessorTest.kt
@@ -1,0 +1,134 @@
+package io.sentry
+
+import io.sentry.hints.EventDropReason
+import io.sentry.protocol.Mechanism
+import io.sentry.protocol.SentryException
+import io.sentry.util.HintUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DeduplicateMultithreadedEventProcessorTest {
+
+    class Fixture {
+
+        fun getSut(): DeduplicateMultithreadedEventProcessor {
+            return DeduplicateMultithreadedEventProcessor(SentryOptions())
+        }
+
+        fun getEvent(
+            type: String? = null,
+            isHandled: Boolean = true,
+            tid: Long? = null
+        ): SentryEvent {
+            val event = SentryEvent().apply {
+                exceptions = listOf(
+                    SentryException().apply {
+                        this.type = type
+                        this.threadId = tid
+                        mechanism = Mechanism().apply {
+                            this.isHandled = isHandled
+                        }
+                    }
+                )
+            }
+            return event
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `does not drop if not a crash`() {
+        val processor = fixture.getSut()
+        val processedEvent = processor.process(SentryEvent(), Hint())
+
+        assertNotNull(processedEvent)
+    }
+
+    @Test
+    fun `does not drop if no type`() {
+        val event = fixture.getEvent(isHandled = false)
+        val processor = fixture.getSut()
+        val processedEvent = processor.process(SentryEvent(), Hint())
+
+        assertNotNull(processedEvent)
+    }
+
+    @Test
+    fun `does not drop if no tid`() {
+        val event = fixture.getEvent(isHandled = false, type = "OutOfMemoryError")
+        val processor = fixture.getSut()
+        val processedEvent = processor.process(SentryEvent(), Hint())
+
+        assertNotNull(processedEvent)
+    }
+
+    @Test
+    fun `does not drop if not yet processed`() {
+        val event = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+        val processor = fixture.getSut()
+        val processedEvent = processor.process(SentryEvent(), Hint())
+
+        assertNotNull(processedEvent)
+    }
+
+    @Test
+    fun `does not drop if an event of this type was not processed yet`() {
+        val event1 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+        val event2 = fixture.getEvent(isHandled = false, type = "RuntimeException", tid = 2)
+
+        val processor = fixture.getSut()
+
+        val processedEvent1 = processor.process(event1, Hint())
+        assertNotNull(processedEvent1)
+
+        val processedEvent2 = processor.process(event2, Hint())
+        assertNotNull(processedEvent2)
+    }
+
+    @Test
+    fun `does not drop if an event of this type is from the same thread`() {
+        val event1 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+        val event2 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+
+        val processor = fixture.getSut()
+
+        val processedEvent1 = processor.process(event1, Hint())
+        assertNotNull(processedEvent1)
+
+        val processedEvent2 = processor.process(event2, Hint())
+        assertNotNull(processedEvent2)
+    }
+
+    @Test
+    fun `drops if the same event of this type is from a different thread`() {
+        val event1 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+        val event2 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 2)
+
+        val processor = fixture.getSut()
+
+        val processedEvent1 = processor.process(event1, Hint())
+        assertNotNull(processedEvent1)
+
+        val processedEvent2 = processor.process(event2, Hint())
+        assertNull(processedEvent2)
+    }
+
+    @Test
+    fun `sets drop reason when dropped`() {
+        val event1 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 1)
+        val event2 = fixture.getEvent(isHandled = false, type = "OutOfMemoryError", tid = 2)
+
+        val processor = fixture.getSut()
+
+        val hint = Hint()
+        processor.process(event1, hint)
+        processor.process(event2, hint)
+        assertEquals(
+            EventDropReason.MULTITHREADED_DEDUPLICATION,
+            HintUtils.getEventDropReason(hint)
+        )
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Introduce new DeduplicateMultithreadedEventProcessor which keeps an in-memory cache of crashed events in a form of map/dict (crash type - thread id). If a crash type has already been processed once and coming in again from a different thread, the processor will drop the event. 

This can be the case for OutOfMemoryError, when multiple threads are trying to allocate new memory and therefore crashing within the same millisecond from multiple threads. When this happens, the events are almost equal, except the thread id and timestamp. We've seen this for one of our customers and also were somewhat able to reproduce it locally.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2827 

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
