### PR TITLE
Fix ensure session is updated using configureScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fix ANRv2 thread dump parsing for native-only threads ([#2839](https://github.com/getsentry/sentry-java/pull/2839))
 - Derive `TracingContext` values from event for ANRv2 events ([#2839](https://github.com/getsentry/sentry-java/pull/2839))
 
+### Features
+- (Internal) Extend APIs for hybrid SDKs ([#2814](https://github.com/getsentry/sentry-java/pull/2814), [#2846](https://github.com/getsentry/sentry-java/pull/2846))
+
 ## 6.25.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
+### Features
+- (Internal) Extend APIs for hybrid SDKs ([#2814](https://github.com/getsentry/sentry-java/pull/2814), [#2846](https://github.com/getsentry/sentry-java/pull/2846))
+
 ### Fixes
 
 - Fix ANRv2 thread dump parsing for native-only threads ([#2839](https://github.com/getsentry/sentry-java/pull/2839))
 - Derive `TracingContext` values from event for ANRv2 events ([#2839](https://github.com/getsentry/sentry-java/pull/2839))
-
-### Features
-- (Internal) Extend APIs for hybrid SDKs ([#2814](https://github.com/getsentry/sentry-java/pull/2814), [#2846](https://github.com/getsentry/sentry-java/pull/2846))
 
 ## 6.25.2
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -54,7 +54,7 @@ public final class InternalSentrySdk {
    * @param options Sentry Options
    * @param scope the scope
    * @return a map containing all relevant scope data (user, contexts, tags, extras, fingerprint,
-   *     level, breadcrumbs) or null if the scope itself is null or serialization fails
+   *     level, breadcrumbs)
    */
   @NotNull
   public static Map<String, Object> serializeScope(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,7 +41,8 @@ public final class InternalSentrySdk {
   @Nullable
   public static Scope getCurrentScope() {
     final @NotNull AtomicReference<Scope> scopeRef = new AtomicReference<>();
-    HubAdapter.getInstance().withScope(scopeRef::set);
+    //noinspection Convert2MethodRef
+    HubAdapter.getInstance().withScope(scope -> scopeRef.set(scope));
     return scopeRef.get();
   }
 
@@ -53,22 +54,21 @@ public final class InternalSentrySdk {
    * @param options Sentry Options
    * @param scope the scope
    * @return a map containing all relevant scope data (user, contexts, tags, extras, fingerprint,
-   *     level, breadcrumbs)
+   *     level, breadcrumbs) or null if the scope itself is null or serialization fails
    */
   @NotNull
   public static Map<String, Object> serializeScope(
       final @NotNull Context context,
       final @NotNull SentryAndroidOptions options,
       final @Nullable Scope scope) {
+
     final @NotNull Map<String, Object> data = new HashMap<>();
     if (scope == null) {
       return data;
     }
-
-    final @NotNull ILogger logger = options.getLogger();
-    final @NotNull ObjectWriter writer = new MapObjectWriter(data);
-
     try {
+      final @NotNull ILogger logger = options.getLogger();
+      final @NotNull ObjectWriter writer = new MapObjectWriter(data);
 
       final @NotNull DeviceInfoUtil deviceInfoUtil = DeviceInfoUtil.getInstance(context, options);
       final @NotNull Device deviceInfo = deviceInfoUtil.collectDeviceInformation(true, true);
@@ -114,7 +114,7 @@ public final class InternalSentrySdk {
       writer.name("fingerprint").value(logger, scope.getFingerprint());
       writer.name("level").value(logger, scope.getLevel());
       writer.name("breadcrumbs").value(logger, scope.getBreadcrumbs());
-    } catch (Exception e) {
+    } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Could not serialize scope.", e);
       return new HashMap<>();
     }
@@ -124,54 +124,62 @@ public final class InternalSentrySdk {
 
   /**
    * Captures the provided envelope. Compared to {@link IHub#captureEvent(SentryEvent)} this method
-   * - will not enrich events with additional data (e.g. scope) - will not execute beforeSend: it's
-   * up to the caller to take care of this - will not perform any sampling: it's up to the caller to
-   * take care of this - will enrich the envelope with a Session updates is applicable
+   * <br>
+   * - will not enrich events with additional data (e.g. scope)<br>
+   * - will not execute beforeSend: it's up to the caller to take care of this<br>
+   * - will not perform any sampling: it's up to the caller to take care of this<br>
+   * - will enrich the envelope with a Session update if applicable<br>
    *
    * @param envelopeData the serialized envelope data
-   * @return The Id (SentryId object) of the event
-   * @throws Exception In case the provided envelope could not be parsed / is invalid
+   * @return The Id (SentryId object) of the event, or null in case the envelope could not be
+   *     captured
    */
-  public static SentryId captureEnvelope(final @NotNull byte[] envelopeData) throws Exception {
+  @Nullable
+  public static SentryId captureEnvelope(final @NotNull byte[] envelopeData) {
     final @NotNull IHub hub = HubAdapter.getInstance();
     final @NotNull SentryOptions options = hub.getOptions();
 
-    final @NotNull ISerializer serializer = options.getSerializer();
-    final @Nullable SentryEnvelope envelope =
-        options.getEnvelopeReader().read(new ByteArrayInputStream(envelopeData));
-    if (envelope == null) {
-      throw new IllegalArgumentException("Envelope could not be read");
-    }
+    try {
+      final @NotNull ISerializer serializer = options.getSerializer();
+      final @Nullable SentryEnvelope envelope =
+          options.getEnvelopeReader().read(new ByteArrayInputStream(envelopeData));
+      if (envelope == null) {
+        return null;
+      }
 
-    final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
+      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 
-    // determine session state based on events inside envelope
-    @Nullable Session.State status = null;
-    boolean crashedOrErrored = false;
-    for (SentryEnvelopeItem item : envelope.getItems()) {
-      envelopeItems.add(item);
+      // determine session state based on events inside envelope
+      @Nullable Session.State status = null;
+      boolean crashedOrErrored = false;
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        envelopeItems.add(item);
 
-      final SentryEvent event = item.getEvent(serializer);
-      if (event != null) {
-        if (event.isCrashed()) {
-          status = Session.State.Crashed;
-        }
-        if (event.isCrashed() || event.isErrored()) {
-          crashedOrErrored = true;
+        final SentryEvent event = item.getEvent(serializer);
+        if (event != null) {
+          if (event.isCrashed()) {
+            status = Session.State.Crashed;
+          }
+          if (event.isCrashed() || event.isErrored()) {
+            crashedOrErrored = true;
+          }
         }
       }
-    }
 
-    // update session and add it to envelope if necessary
-    final @Nullable Session session = updateSession(hub, options, status, crashedOrErrored);
-    if (session != null) {
-      final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
-      envelopeItems.add(sessionItem);
-    }
+      // update session and add it to envelope if necessary
+      final @Nullable Session session = updateSession(hub, options, status, crashedOrErrored);
+      if (session != null) {
+        final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
+        envelopeItems.add(sessionItem);
+      }
 
-    final SentryEnvelope repackagedEnvelope =
-        new SentryEnvelope(envelope.getHeader(), envelopeItems);
-    return hub.captureEnvelope(repackagedEnvelope);
+      final SentryEnvelope repackagedEnvelope =
+          new SentryEnvelope(envelope.getHeader(), envelopeItems);
+      return hub.captureEnvelope(repackagedEnvelope);
+    } catch (Throwable t) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    }
+    return null;
   }
 
   @Nullable

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -181,7 +181,7 @@ public final class InternalSentrySdk {
       final @Nullable Session.State status,
       final boolean crashedOrErrored) {
     final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
-    hub.withScope(
+    hub.configureScope(
         scope -> {
           final @Nullable Session session = scope.getSession();
           if (session != null) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -204,9 +203,7 @@ class InternalSentrySdkTest {
 
     @Test
     fun `captureEnvelope fails if payload is invalid`() {
-        assertFails {
-            InternalSentrySdk.captureEnvelope(ByteArray(8))
-        }
+        assertNull(InternalSentrySdk.captureEnvelope(ByteArray(8)))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Use configureScope instead of withScope, as it doesn't (partially) deep-copy the scope.
Doesn't really seem to be a problem as scope.session is never deep-copied.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps