### PR TITLE
Do not send session updates for terminated sessions

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2057,6 +2057,7 @@ public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/Jso
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getUserAgent ()Ljava/lang/String;
+	public fun isTerminated ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setInitAsTrue ()V
 	public fun setUnknown (Ljava/util/Map;)V

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -137,7 +137,10 @@ public final class SentryClient implements ISentryClient {
     @Nullable Session session = null;
 
     if (event != null) {
-      session = updateSessionData(event, hint, scope);
+      // https://develop.sentry.dev/sdk/sessions/#terminal-session-states
+      if (sessionBeforeUpdate == null || !sessionBeforeUpdate.isTerminated()) {
+        session = updateSessionData(event, hint, scope);
+      }
 
       if (!sample()) {
         options
@@ -490,9 +493,8 @@ public final class SentryClient implements ISentryClient {
                     }
 
                     if (session.update(status, userAgent, crashedOrErrored, abnormalMechanism)) {
-                      // if we have an uncaughtExceptionHint we can end the session.
-                      if (HintUtils.hasType(
-                          hint, UncaughtExceptionHandlerIntegration.UncaughtExceptionHint.class)) {
+                      // if session terminated we can end it.
+                      if (session.isTerminated()) {
                         session.end();
                       }
                     }

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -125,6 +125,10 @@ public final class Session implements JsonUnknown, JsonSerializable {
         null);
   }
 
+  public boolean isTerminated() {
+    return status != State.Ok;
+  }
+
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
   public @Nullable Date getStarted() {
     if (started == null) {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import io.sentry.Scope.IWithPropagationContext
+import io.sentry.Session.State.Crashed
 import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
@@ -954,6 +955,21 @@ class SentryClientTest {
     }
 
     @Test
+    fun `When event is non handled, end the session`() {
+        val scope = Scope(fixture.sentryOptions)
+        scope.startSession()
+
+        val event = SentryEvent().apply {
+            exceptions = createNonHandledException()
+        }
+        fixture.getSut().updateSessionData(event, Hint(), scope)
+        scope.withSession {
+            assertEquals(Session.State.Crashed, it!!.status)
+            assertNull(it.init)
+        }
+    }
+
+    @Test
     fun `When event is handled, keep level as it is`() {
         val scope = Scope(fixture.sentryOptions)
         val sessionPair = scope.startSession()
@@ -1131,6 +1147,28 @@ class SentryClientTest {
                     val event = getEventFromData(it.items.first().data)
                     val map = event.contexts["key"] as Map<*, *>
                     assertEquals("abc", map["value"])
+                },
+                anyOrNull()
+            )
+        }
+    }
+
+    @Test
+    fun `when session is in terminal state, does not send session update`() {
+        val sut = fixture.getSut()
+
+        val event = SentryEvent().apply {
+            exceptions = createNonHandledException()
+        }
+        val scope = Scope(fixture.sentryOptions)
+        val sessionPair = scope.startSession()
+        scope.withSession { it!!.update(Crashed, null, false) }
+
+        assertNotNull(sessionPair) {
+            sut.captureEvent(event, scope, null)
+            verify(fixture.transport).send(
+                check {
+                    assertNull(it.items.find { item -> item.header.type == SentryItemType.Session })
                 },
                 anyOrNull()
             )


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
If the session is in terminal state (`!= Status.Ok`), we should not send any new session updates, because there's no protection for that server-side, so potentially we were reporting incorrect crash-free rate. Follow-up of #2845  

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal customer report

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
