### PR TITLE
Do not overwrite UI transaction status if set by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking changes:
 
 ### Fixes
 
+- Do not overwrite UI transaction status if set by the user ([#2852](https://github.com/getsentry/sentry-java/pull/2852))
+
 Breaking changes:
 - Move enableNdk from SentryOptions to SentryAndroidOptions ([#2793](https://github.com/getsentry/sentry-java/pull/2793))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -255,7 +255,13 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
 
   void stopTracing(final @NotNull SpanStatus status) {
     if (activeTransaction != null) {
-      activeTransaction.finish(status);
+      final SpanStatus currentStatus = activeTransaction.getStatus();
+      // status might be set by other integrations, let's not overwrite it
+      if (currentStatus == null) {
+        activeTransaction.finish(status);
+      } else {
+        activeTransaction.finish();
+      }
     }
     hub.configureScope(
         scope -> {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
@@ -14,6 +14,7 @@ import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
+import io.sentry.SpanStatus.OUT_OF_RANGE
 import io.sentry.TransactionContext
 import io.sentry.TransactionOptions
 import io.sentry.android.core.SentryAndroidOptions
@@ -321,6 +322,17 @@ class SentryGestureListenerTracingTest {
         sut.onSingleTapUp(fixture.event)
 
         verify(fixture.transaction).scheduleFinish()
+    }
+
+    @Test
+    fun `preserves existing transaction status`() {
+        val sut = fixture.getSut<View>()
+
+        sut.onSingleTapUp(fixture.event)
+
+        fixture.transaction.status = OUT_OF_RANGE
+        sut.stopTracing(SpanStatus.CANCELLED)
+        assertEquals(OUT_OF_RANGE, fixture.transaction.status)
     }
 
     internal open class ScrollableListView : AbsListView(mock()) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not overwrite UI transaction status if set by the user

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2378 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
