### PR TITLE
Ensure no Java 8 method reference sugar is used for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Deduplicate events happening in multiple threads simultaneously (e.g. `OutOfMemoryError`) ([#2845](https://github.com/getsentry/sentry-java/pull/2845))
   - This will improve Crash-Free Session Rate as we no longer will send multiple Session updates with `Crashed` status, but only the one that is relevant
+- Ensure no Java 8 method reference sugar is used for Android ([#2857](https://github.com/getsentry/sentry-java/pull/2857))
 
 ## 6.26.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ANRWatchDog.java
@@ -44,6 +44,8 @@ final class ANRWatchDog extends Thread {
       @NotNull ANRListener listener,
       @NotNull ILogger logger,
       final @NotNull Context context) {
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     this(
         () -> SystemClock.uptimeMillis(),
         timeoutIntervalMillis,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -130,6 +130,8 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
     } else {
       // some versions of the androidx lifecycle-process require this to be executed on the main
       // thread.
+      // avoid method refs on Android due to some issues with older AGP setups
+      // noinspection Convert2MethodRef
       handler.post(() -> removeObserver());
     }
   }

--- a/sentry/src/main/java/io/sentry/HostnameCache.java
+++ b/sentry/src/main/java/io/sentry/HostnameCache.java
@@ -59,6 +59,8 @@ final class HostnameCache {
   }
 
   HostnameCache(long cacheDuration) {
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     this(cacheDuration, () -> InetAddress.getLocalHost());
   }
 

--- a/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
@@ -103,13 +103,17 @@ public final class JsonObjectDeserializer {
         pushCurrentToken(new TokenName(reader.nextName()));
         break;
       case STRING:
-        done = handlePrimitive(reader::nextString);
+        // avoid method refs on Android due to some issues with older AGP setups
+        // noinspection Convert2MethodRef
+        done = handlePrimitive(() -> reader.nextString());
         break;
       case NUMBER:
         done = handlePrimitive(() -> nextNumber(reader));
         break;
       case BOOLEAN:
-        done = handlePrimitive(reader::nextBoolean);
+        // avoid method refs on Android due to some issues with older AGP setups
+        // noinspection Convert2MethodRef
+        done = handlePrimitive(() -> reader.nextBoolean());
         break;
       case NULL:
         reader.nextNull();

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -87,7 +87,8 @@ public final class SentryEnvelopeItem {
         new SentryEnvelopeItemHeader(
             SentryItemType.Session, () -> cachedItem.getBytes().length, "application/json", null);
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -124,7 +125,8 @@ public final class SentryEnvelopeItem {
             "application/json",
             null);
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -161,7 +163,8 @@ public final class SentryEnvelopeItem {
             "application/json",
             null);
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -206,7 +209,8 @@ public final class SentryEnvelopeItem {
             attachment.getFilename(),
             attachment.getAttachmentType());
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -271,7 +275,8 @@ public final class SentryEnvelopeItem {
             "application-json",
             traceFile.getName());
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 
@@ -340,7 +345,8 @@ public final class SentryEnvelopeItem {
             "application/json",
             null);
 
-    // Don't use method reference. This can cause issues on Android
+    // avoid method refs on Android due to some issues with older AGP setups
+    // noinspection Convert2MethodRef
     return new SentryEnvelopeItem(itemHeader, () -> cachedItem.getBytes());
   }
 


### PR DESCRIPTION
## :scroll: Description
As discussed, let's try to avoid using methods refs for code which gets executed on the Android platform.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2848


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
