### PR TITLE
Reduce flush timeout to 4s on Android to avoid ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 Breaking changes:
 - Capture failed HTTP requests by default ([#2794](https://github.com/getsentry/sentry-java/pull/2794))
+- Reduce flush timeout to 4s on Android to avoid ANRs ([#2858](https://github.com/getsentry/sentry-java/pull/2858))
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -41,6 +41,8 @@ import org.jetbrains.annotations.TestOnly;
 @SuppressWarnings("Convert2MethodRef") // older AGP versions do not support method references
 final class AndroidOptionsInitializer {
 
+  static final long DEFAULT_FLUSH_TIMEOUT_MS = 4000;
+
   static final String SENTRY_COMPOSE_GESTURE_INTEGRATION_CLASS_NAME =
       "io.sentry.compose.gestures.ComposeGestureTargetLocator";
 
@@ -92,6 +94,9 @@ final class AndroidOptionsInitializer {
     options.setLogger(logger);
 
     options.setDateProvider(new SentryAndroidDateProvider());
+
+    // set a lower flush timeout on Android to avoid ANRs
+    options.setFlushTimeoutMillis(DEFAULT_FLUSH_TIMEOUT_MS);
 
     ManifestMetadataReader.applyMetadata(context, options, buildInfoProvider);
     initializeCacheDirs(context, options);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -175,6 +175,20 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
+    fun `flush timeout is set to Android specific default value`() {
+        fixture.initSut()
+        assertEquals(AndroidOptionsInitializer.DEFAULT_FLUSH_TIMEOUT_MS, fixture.sentryOptions.flushTimeoutMillis)
+    }
+
+    @Test
+    fun `flush timeout can be overridden`() {
+        fixture.initSut(configureOptions = {
+            flushTimeoutMillis = 1234
+        })
+        assertEquals(1234, fixture.sentryOptions.flushTimeoutMillis)
+    }
+
+    @Test
     fun `AndroidEventProcessor added to processors list`() {
         fixture.initSut()
         val actual =

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -67,6 +67,8 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
 
   public static final String STARTUP_CRASH_MARKER_FILE = "startup_crash";
 
+  private static final long SESSION_FLUSH_DISK_TIMEOUT_MS = 15000;
+
   private final CountDownLatch previousSessionLatch;
 
   private final @NotNull Map<SentryEnvelope, String> fileNameMap = new WeakHashMap<>();
@@ -429,7 +431,9 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
   /** Awaits until the previous session (if any) is flushed to its own file. */
   public boolean waitPreviousSessionFlush() {
     try {
-      return previousSessionLatch.await(options.getFlushTimeoutMillis(), TimeUnit.MILLISECONDS);
+      // use fixed timeout instead of configurable options.getFlushTimeoutMillis() to ensure there's
+      // enough time to flush the session to disk
+      return previousSessionLatch.await(SESSION_FLUSH_DISK_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       options.getLogger().log(DEBUG, "Timed out waiting for previous session to flush.");


### PR DESCRIPTION
## :scroll: Description
Reduce flush timeout to 4s on Android to avoid ANRs


## :bulb: Motivation and Context
[Fixes #2732](https://github.com/getsentry/sentry-java/issues/2732)


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
