### PR TITLE
Use configureScope instead of withScope for InternalSentrySdk

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -41,8 +41,11 @@ public final class InternalSentrySdk {
   @Nullable
   public static Scope getCurrentScope() {
     final @NotNull AtomicReference<Scope> scopeRef = new AtomicReference<>();
-    //noinspection Convert2MethodRef
-    HubAdapter.getInstance().withScope(scope -> scopeRef.set(scope));
+    HubAdapter.getInstance()
+        .configureScope(
+            scope -> {
+              scopeRef.set(new Scope(scope));
+            });
     return scopeRef.get();
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -120,6 +120,27 @@ class InternalSentrySdkTest {
     }
 
     @Test
+    fun `current scope returns a copy of the scope`() {
+        Sentry.setCurrentHub(
+            Hub(
+                SentryOptions().apply {
+                    dsn = "https://key@uri/1234567"
+                }
+            )
+        )
+        Sentry.addBreadcrumb("test")
+
+        // when the clone is modified
+        val clonedScope = InternalSentrySdk.getCurrentScope()!!
+        clonedScope.clearBreadcrumbs()
+
+        // then modifications should not be reflected
+        Sentry.configureScope { scope ->
+            assertEquals(1, scope.breadcrumbs.size)
+        }
+    }
+
+    @Test
     fun `serializeScope correctly creates top level map`() {
         val options = SentryAndroidOptions()
         val scope = Scope(options)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1205,6 +1205,7 @@ public final class io/sentry/SamplingContext {
 }
 
 public final class io/sentry/Scope {
+	public fun <init> (Lio/sentry/Scope;)V
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun addAttachment (Lio/sentry/Attachment;)V
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -306,7 +306,11 @@ public interface IHub {
   void popScope();
 
   /**
-   * Runs the callback with a new scope which gets dropped at the end
+   * Runs the callback with a new scope which gets dropped at the end. If you're using the Sentry
+   * SDK in globalHubMode (defaults to true on Android) {@link
+   * Sentry#init(Sentry.OptionsConfiguration, boolean)} calling withScope is discouraged, as scope
+   * changes may be dropped when executed in parallel. Use {@link
+   * IHub#configureScope(ScopeCallback)} instead.
    *
    * @param callback the callback
    */

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -87,7 +87,8 @@ public final class Scope {
     this.propagationContext = new PropagationContext();
   }
 
-  Scope(final @NotNull Scope scope) {
+  @ApiStatus.Internal
+  public Scope(final @NotNull Scope scope) {
     this.transaction = scope.transaction;
     this.transactionName = scope.transactionName;
     this.session = scope.session;


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/pull/2814#discussion_r1272111324

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

#skip-changelog