### PR TITLE
Add deadline timeout for automatic transactions

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -192,6 +192,8 @@ public final class ActivityLifecycleIntegration
 
         final TransactionOptions transactionOptions = new TransactionOptions();
         if (options.isEnableActivityLifecycleTracingAutoFinish()) {
+          transactionOptions.setDeadlineTimeout(
+              TransactionOptions.SENTRY_AUTO_TRANSACTION_DEADLINE_MS);
           transactionOptions.setIdleTimeout(options.getIdleTimeout());
           transactionOptions.setTrimEnd(true);
         }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -236,6 +236,7 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
 
     final TransactionOptions transactionOptions = new TransactionOptions();
     transactionOptions.setWaitForChildren(true);
+    transactionOptions.setDeadlineTimeout(TransactionOptions.SENTRY_AUTO_TRANSACTION_DEADLINE_MS);
     transactionOptions.setIdleTimeout(options.getIdleTimeout());
     transactionOptions.setTrimEnd(true);
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -354,7 +354,7 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `Transaction op is ui_load`() {
+    fun `Transaction op is ui_load and idle+deadline timeouts are set`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
@@ -365,11 +365,14 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
 
         verify(fixture.hub).startTransaction(
-            check {
+            check<TransactionContext> {
                 assertEquals("ui.load", it.operation)
                 assertEquals(TransactionNameSource.COMPONENT, it.transactionNameSource)
             },
-            any<TransactionOptions>()
+            check<TransactionOptions> { transactionOptions ->
+                assertEquals(fixture.options.idleTimeout, transactionOptions.idleTimeout)
+                assertEquals(TransactionOptions.SENTRY_AUTO_TRANSACTION_DEADLINE_MS, transactionOptions.deadlineTimeout)
+            }
         )
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
@@ -204,6 +204,24 @@ class SentryGestureListenerTracingTest {
     }
 
     @Test
+    fun `captures transaction and both idle+deadline timeouts are set`() {
+        val sut = fixture.getSut<View>()
+
+        sut.onSingleTapUp(fixture.event)
+
+        verify(fixture.hub).startTransaction(
+            any<TransactionContext>(),
+            check<TransactionOptions> { transactionOptions ->
+                assertEquals(fixture.options.idleTimeout, transactionOptions.idleTimeout)
+                assertEquals(
+                    TransactionOptions.SENTRY_AUTO_TRANSACTION_DEADLINE_MS,
+                    transactionOptions.deadlineTimeout
+                )
+            }
+        )
+    }
+
+    @Test
     fun `captures transaction with interaction event type as op`() {
         val sut = fixture.getSut<View>()
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2297,8 +2297,10 @@ public abstract interface class io/sentry/TransactionFinishedCallback {
 }
 
 public final class io/sentry/TransactionOptions : io/sentry/SpanOptions {
+	public static final field SENTRY_AUTO_TRANSACTION_DEADLINE_MS J
 	public fun <init> ()V
 	public fun getCustomSamplingContext ()Lio/sentry/CustomSamplingContext;
+	public fun getDeadlineTimeout ()Ljava/lang/Long;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getStartTimestamp ()Lio/sentry/SentryDate;
 	public fun getTransactionFinishedCallback ()Lio/sentry/TransactionFinishedCallback;
@@ -2306,6 +2308,7 @@ public final class io/sentry/TransactionOptions : io/sentry/SpanOptions {
 	public fun isWaitForChildren ()Z
 	public fun setBindToScope (Z)V
 	public fun setCustomSamplingContext (Lio/sentry/CustomSamplingContext;)V
+	public fun setDeadlineTimeout (Ljava/lang/Long;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setStartTimestamp (Lio/sentry/SentryDate;)V
 	public fun setTransactionFinishedCallback (Lio/sentry/TransactionFinishedCallback;)V

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -37,10 +37,14 @@ public final class SentryTracer implements ITransaction {
    */
   private @NotNull FinishStatus finishStatus = FinishStatus.NOT_FINISHED;
 
-  private volatile @Nullable TimerTask timerTask;
+  private volatile @Nullable TimerTask idleTimeoutTask;
+  private volatile @Nullable TimerTask deadlineTimeoutTask;
+
   private volatile @Nullable Timer timer = null;
   private final @NotNull Object timerLock = new Object();
-  private final @NotNull AtomicBoolean isFinishTimerRunning = new AtomicBoolean(false);
+
+  private final @NotNull AtomicBoolean isIdleFinishTimerRunning = new AtomicBoolean(false);
+  private final @NotNull AtomicBoolean isDeadlineTimerRunning = new AtomicBoolean(false);
 
   private final @NotNull Baggage baggage;
   private @NotNull TransactionNameSource transactionNameSource;
@@ -92,7 +96,8 @@ public final class SentryTracer implements ITransaction {
       transactionPerformanceCollector.start(this);
     }
 
-    if (transactionOptions.getIdleTimeout() != null) {
+    if (transactionOptions.getIdleTimeout() != null
+        || transactionOptions.getDeadlineTimeout() != null) {
       timer = new Timer(true);
       scheduleFinish();
     }
@@ -101,34 +106,71 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void scheduleFinish() {
     synchronized (timerLock) {
-      cancelTimer();
-      if (timer != null) {
-        isFinishTimerRunning.set(true);
-        timerTask =
-            new TimerTask() {
-              @Override
-              public void run() {
-                finishFromTimer();
-              }
-            };
+      cancelIdleTimer();
+      cancelDeadlineTimer();
 
-        try {
-          timer.schedule(timerTask, transactionOptions.getIdleTimeout());
-        } catch (Throwable e) {
-          hub.getOptions()
-              .getLogger()
-              .log(SentryLevel.WARNING, "Failed to schedule finish timer", e);
-          // if we failed to schedule the finish timer for some reason, we finish it here right away
-          finishFromTimer();
+      if (timer != null) {
+        final @Nullable Long idleTimeout = transactionOptions.getIdleTimeout();
+        final @Nullable Long deadlineTimeOut = transactionOptions.getDeadlineTimeout();
+
+        if (idleTimeout != null) {
+          isIdleFinishTimerRunning.set(true);
+          idleTimeoutTask =
+              new TimerTask() {
+                @Override
+                public void run() {
+                  onIdleTimeoutReached();
+                }
+              };
+
+          try {
+            timer.schedule(idleTimeoutTask, idleTimeout);
+          } catch (Throwable e) {
+            hub.getOptions()
+                .getLogger()
+                .log(SentryLevel.WARNING, "Failed to schedule finish timer", e);
+            // if we failed to schedule the finish timer for some reason, we finish it here right
+            // away
+            onIdleTimeoutReached();
+          }
+        }
+        if (deadlineTimeOut != null) {
+          isDeadlineTimerRunning.set(true);
+          deadlineTimeoutTask =
+              new TimerTask() {
+                @Override
+                public void run() {
+                  onDeadlineTimeoutReached();
+                }
+              };
+
+          try {
+            timer.schedule(deadlineTimeoutTask, deadlineTimeOut);
+          } catch (Throwable e) {
+            hub.getOptions()
+                .getLogger()
+                .log(SentryLevel.WARNING, "Failed to schedule finish timer", e);
+            // if we failed to schedule the finish timer for some reason, we finish it here right
+            // away
+            onDeadlineTimeoutReached();
+          }
         }
       }
     }
   }
 
-  private void finishFromTimer() {
-    final SpanStatus status = getStatus();
+  private void onIdleTimeoutReached() {
+    final @Nullable SpanStatus status = getStatus();
     finish((status != null) ? status : SpanStatus.OK);
-    isFinishTimerRunning.set(false);
+    isIdleFinishTimerRunning.set(false);
+  }
+
+  private void onDeadlineTimeoutReached() {
+    final @Nullable SpanStatus status = getStatus();
+    forceFinish(
+        (status != null) ? status : SpanStatus.DEADLINE_EXCEEDED,
+        transactionOptions.getIdleTimeout() != null);
+    isDeadlineTimerRunning.set(false);
   }
 
   @Override
@@ -222,6 +264,8 @@ public final class SentryTracer implements ITransaction {
       if (timer != null) {
         synchronized (timerLock) {
           if (timer != null) {
+            cancelIdleTimer();
+            cancelDeadlineTimer();
             timer.cancel();
             timer = null;
           }
@@ -244,12 +288,22 @@ public final class SentryTracer implements ITransaction {
     }
   }
 
-  private void cancelTimer() {
+  private void cancelIdleTimer() {
     synchronized (timerLock) {
-      if (timerTask != null) {
-        timerTask.cancel();
-        isFinishTimerRunning.set(false);
-        timerTask = null;
+      if (idleTimeoutTask != null) {
+        idleTimeoutTask.cancel();
+        isIdleFinishTimerRunning.set(false);
+        idleTimeoutTask = null;
+      }
+    }
+  }
+
+  private void cancelDeadlineTimer() {
+    synchronized (timerLock) {
+      if (deadlineTimeoutTask != null) {
+        deadlineTimeoutTask.cancel();
+        isDeadlineTimerRunning.set(false);
+        deadlineTimeoutTask = null;
       }
     }
   }
@@ -360,7 +414,7 @@ public final class SentryTracer implements ITransaction {
 
     Objects.requireNonNull(parentSpanId, "parentSpanId is required");
     Objects.requireNonNull(operation, "operation is required");
-    cancelTimer();
+    cancelIdleTimer();
     final Span span =
         new Span(
             root.getTraceId(),
@@ -720,8 +774,14 @@ public final class SentryTracer implements ITransaction {
 
   @TestOnly
   @Nullable
-  TimerTask getTimerTask() {
-    return timerTask;
+  TimerTask getIdleTimeoutTask() {
+    return idleTimeoutTask;
+  }
+
+  @TestOnly
+  @Nullable
+  TimerTask getDeadlineTimeoutTask() {
+    return deadlineTimeoutTask;
   }
 
   @TestOnly
@@ -733,7 +793,13 @@ public final class SentryTracer implements ITransaction {
   @TestOnly
   @NotNull
   AtomicBoolean isFinishTimerRunning() {
-    return isFinishTimerRunning;
+    return isIdleFinishTimerRunning;
+  }
+
+  @TestOnly
+  @NotNull
+  AtomicBoolean isDeadlineTimerRunning() {
+    return isDeadlineTimerRunning;
   }
 
   @TestOnly

--- a/sentry/src/main/java/io/sentry/TransactionOptions.java
+++ b/sentry/src/main/java/io/sentry/TransactionOptions.java
@@ -5,6 +5,8 @@ import org.jetbrains.annotations.Nullable;
 /** Sentry Transaction options */
 public final class TransactionOptions extends SpanOptions {
 
+  public static final long SENTRY_AUTO_TRANSACTION_DEADLINE_MS = 300000;
+
   /**
    * Arbitrary data used in {@link SamplingContext} to determine if transaction is going to be
    * sampled.
@@ -33,6 +35,16 @@ public final class TransactionOptions extends SpanOptions {
    * <p>The default is 3 seconds.
    */
   private @Nullable Long idleTimeout = null;
+
+  /**
+   * The deadline time, measured in ms, to wait until the transaction will be force-finished with
+   * deadline-exceeded status./
+   *
+   * <p>When set to {@code null} the transaction won't be forcefully finished.
+   *
+   * <p>The default is 30 seconds.
+   */
+  private @Nullable Long deadlineTimeout = null;
 
   /**
    * When `waitForChildren` is set to `true` and this callback is set, it's called before the
@@ -119,6 +131,26 @@ public final class TransactionOptions extends SpanOptions {
    */
   public @Nullable Long getIdleTimeout() {
     return idleTimeout;
+  }
+
+  /**
+   * Sets the deadlineTimeout. If set, an transaction and it's child spans will be force-finished
+   * with status {@link SpanStatus#DEADLINE_EXCEEDED} in case the transaction isn't finished in
+   * time.
+   *
+   * @param deadlineTimeoutMs - the deadlineTimeout, in ms - or null if no deadline should be set
+   */
+  public void setDeadlineTimeout(@Nullable Long deadlineTimeoutMs) {
+    this.deadlineTimeout = deadlineTimeoutMs;
+  }
+
+  /**
+   * Gets the deadlineTimeout
+   *
+   * @return deadlineTimeout - the deadlineTimeout, in ms - or null if no deadline is set
+   */
+  public @Nullable Long getDeadlineTimeout() {
+    return deadlineTimeout;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -43,6 +43,7 @@ class SentryTracerTest {
             startTimestamp: SentryDate? = null,
             waitForChildren: Boolean = false,
             idleTimeout: Long? = null,
+            deadlineTimeout: Long? = null,
             trimEnd: Boolean = false,
             transactionFinishedCallback: TransactionFinishedCallback? = null,
             samplingDecision: TracesSamplingDecision? = null,
@@ -54,6 +55,7 @@ class SentryTracerTest {
             transactionOptions.startTimestamp = startTimestamp
             transactionOptions.isWaitForChildren = waitForChildren
             transactionOptions.idleTimeout = idleTimeout
+            transactionOptions.deadlineTimeout = deadlineTimeout
             transactionOptions.isTrimEnd = trimEnd
             transactionOptions.transactionFinishedCallback = transactionFinishedCallback
             return SentryTracer(TransactionContext("name", "op", samplingDecision), hub, transactionOptions, performanceCollector)
@@ -751,17 +753,60 @@ class SentryTracerTest {
     }
 
     @Test
+    fun `when initialized without deadlineTimeout, does not schedule finish timer`() {
+        val transaction = fixture.getSut()
+        assertNull(transaction.deadlineTimeoutTask)
+    }
+
+    @Test
+    fun `when initialized with deadlineTimeout, schedules finish timer`() {
+        val transaction = fixture.getSut(deadlineTimeout = 50)
+
+        assertTrue(transaction.isDeadlineTimerRunning.get())
+        assertNotNull(transaction.deadlineTimeoutTask)
+    }
+
+    @Test
+    fun `when deadline is reached transaction is finished`() {
+        // when a transaction with a deadline timeout is created
+        // and the tx and child keep on running
+        val transaction = fixture.getSut(deadlineTimeout = 20)
+        val span = transaction.startChild("op")
+
+        // and the deadline is exceed
+        await.untilFalse(transaction.isDeadlineTimerRunning)
+
+        // then both tx + span should be force finished
+        assertEquals(transaction.isFinished, true)
+        assertEquals(SpanStatus.DEADLINE_EXCEEDED, transaction.status)
+        assertEquals(SpanStatus.DEADLINE_EXCEEDED, span.status)
+    }
+
+    @Test
+    fun `when transaction is finished before deadline is reached, deadline should not be running anymore`() {
+        val transaction = fixture.getSut(deadlineTimeout = 1000)
+        val span = transaction.startChild("op")
+
+        span.finish(SpanStatus.OK)
+        transaction.finish(SpanStatus.OK)
+
+        assertEquals(transaction.isDeadlineTimerRunning.get(), false)
+        assertNull(transaction.deadlineTimeoutTask)
+        assertEquals(transaction.isFinished, true)
+        assertEquals(SpanStatus.OK, transaction.status)
+        assertEquals(SpanStatus.OK, span.status)
+    }
+
+    @Test
     fun `when initialized without idleTimeout, does not schedule finish timer`() {
         val transaction = fixture.getSut()
-
-        assertNull(transaction.timerTask)
+        assertNull(transaction.idleTimeoutTask)
     }
 
     @Test
     fun `when initialized with idleTimeout, schedules finish timer`() {
         val transaction = fixture.getSut(idleTimeout = 50)
-
-        assertNotNull(transaction.timerTask)
+        assertNotNull(transaction.idleTimeoutTask)
     }
 
     @Test
@@ -801,20 +846,20 @@ class SentryTracerTest {
 
         transaction.startChild("op")
 
-        assertNull(transaction.timerTask)
+        assertNull(transaction.idleTimeoutTask)
     }
 
     @Test
     fun `when a child is finished and the transaction is idle, resets the timer`() {
         val transaction = fixture.getSut(waitForChildren = true, idleTimeout = 3000)
 
-        val initialTime = transaction.timerTask!!.scheduledExecutionTime()
+        val initialTime = transaction.idleTimeoutTask!!.scheduledExecutionTime()
 
         val span = transaction.startChild("op")
         Thread.sleep(1)
         span.finish()
 
-        val timerAfterFinishingChild = transaction.timerTask!!.scheduledExecutionTime()
+        val timerAfterFinishingChild = transaction.idleTimeoutTask!!.scheduledExecutionTime()
 
         assertTrue { timerAfterFinishingChild > initialTime }
     }
@@ -828,7 +873,7 @@ class SentryTracerTest {
         Thread.sleep(1)
         span.finish()
 
-        assertNull(transaction.timerTask)
+        assertNull(transaction.idleTimeoutTask)
     }
 
     @Test
@@ -1220,7 +1265,7 @@ class SentryTracerTest {
 
     @Test
     fun `when timer is cancelled, schedule finish does not crash`() {
-        val tracer = fixture.getSut(idleTimeout = 50)
+        val tracer = fixture.getSut(idleTimeout = 50, deadlineTimeout = 100)
         tracer.timer!!.cancel()
         tracer.scheduleFinish()
     }


### PR DESCRIPTION
## :scroll: Description

Adds a timeout of 30s to automatic UI transactions.
Inspired by cocoa: https://github.com/getsentry/sentry-cocoa/blob/a176fc448cf5f3ea7b188449b8170b14ce6805cf/Sources/Sentry/SentryTracer.m#L248-L266


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2514


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
