### PR TITLE
UI tests on saucelabs are now selected based on OS version only

### DIFF
--- a/.sauce/sentry-uitest-android-ui.yml
+++ b/.sauce/sentry-uitest-android-ui.yml
@@ -24,7 +24,7 @@ suites:
       useTestOrchestrator: true
     devices:
       - name: ".*"
-        platformVersion: 13
+        platformVersion: "13"
 
   - name: "Android 12 Ui test (api 31)"
     testOptions:
@@ -32,7 +32,7 @@ suites:
       useTestOrchestrator: true
     devices:
       - name: ".*"
-        platformVersion: 12
+        platformVersion: "12"
 
   - name: "Android 11 Ui test (api 30)"
     testOptions:
@@ -40,7 +40,7 @@ suites:
       useTestOrchestrator: true
     devices:
       - name: ".*"
-        platformVersion: 11
+        platformVersion: "11"
 
   - name: "Android 10 Ui test (api 29)"
     testOptions:
@@ -48,7 +48,7 @@ suites:
       useTestOrchestrator: true
     devices:
       - name: ".*"
-        platformVersion: 10
+        platformVersion: "10"
 
 # Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
 artifacts:

--- a/.sauce/sentry-uitest-android-ui.yml
+++ b/.sauce/sentry-uitest-android-ui.yml
@@ -23,28 +23,32 @@ suites:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: Google_Pixel_5_13_real_us # Google Pixel 5 - api 33 (13)
+      - name: ".*"
+        platformVersion: 13
 
   - name: "Android 12 Ui test (api 31)"
     testOptions:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: Samsung_Galaxy_S22_Ultra_5G_real_us # Samsung Galaxy S22 Ultra 5G - api 31 (12)
+      - name: ".*"
+        platformVersion: 12
 
   - name: "Android 11 Ui test (api 30)"
     testOptions:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: Samsung_Galaxy_S10_Plus_11_real_us # Samsung Galaxy S10+ - api 30 (11)
+      - name: ".*"
+        platformVersion: 11
 
   - name: "Android 10 Ui test (api 29)"
     testOptions:
       clearPackageData: true
       useTestOrchestrator: true
     devices:
-      - id: OnePlus_7T_real_us # OnePlus 7T - api 29 (10)
+      - name: ".*"
+        platformVersion: 10
 
 # Controls what artifacts to fetch when the suite on Sauce Cloud has finished.
 artifacts:


### PR DESCRIPTION
## :scroll: Description
ui tests on saucelabs now are selected based on OS version only
#skip-changelog

## :bulb: Motivation and Context
We don't care about the specific device the tests run on, only the OS version, contrary to benchmarks.
This will improve saucelabs faults due to a specific device being already in use when we try to run a test.


## :green_heart: How did you test it?
🙃 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
