### PR TITLE
propagate okhttp status to parent spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- propagate okhttp status to parent spans ([#2872](https://github.com/getsentry/sentry-java/pull/2872))
+
+### Fixes
+
 ## 6.27.0
 
 ### Features

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
@@ -63,7 +63,6 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         breadcrumb.setData("status_code", response.code)
         callRootSpan?.setData(PROTOCOL_KEY, response.protocol.name)
         callRootSpan?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
-        callRootSpan?.status = SpanStatus.fromHttpStatusCode(response.code)
     }
 
     fun setProtocol(protocolName: String?) {
@@ -98,24 +97,20 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
     /** Starts a span, if the callRootSpan is not null. */
     fun startSpan(event: String) {
         // Find the parent of the span being created. E.g. secureConnect is child of connect
-        val parentSpan = when (event) {
-            // PROXY_SELECT, DNS, CONNECT and CONNECTION are not children of one another
-            SECURE_CONNECT_EVENT -> eventSpans[CONNECT_EVENT]
-            REQUEST_HEADERS_EVENT -> eventSpans[CONNECTION_EVENT]
-            REQUEST_BODY_EVENT -> eventSpans[CONNECTION_EVENT]
-            RESPONSE_HEADERS_EVENT -> eventSpans[CONNECTION_EVENT]
-            RESPONSE_BODY_EVENT -> eventSpans[CONNECTION_EVENT]
-            else -> callRootSpan
-        } ?: callRootSpan
+        val parentSpan = findParentSpan(event)
         val span = parentSpan?.startChild("http.client.$event") ?: return
         span.spanContext.origin = TRACE_ORIGIN
         eventSpans[event] = span
     }
 
-    /** Finishes a previously started span, and runs [beforeFinish] on it and on the call root span. */
+    /** Finishes a previously started span, and runs [beforeFinish] on it, on its parent and on the call root span. */
     fun finishSpan(event: String, beforeFinish: ((span: ISpan) -> Unit)? = null) {
         val span = eventSpans[event] ?: return
+        val parentSpan = findParentSpan(event)
         beforeFinish?.invoke(span)
+        if (parentSpan != null && parentSpan != callRootSpan) {
+            beforeFinish?.invoke(parentSpan)
+        }
         callRootSpan?.let { beforeFinish?.invoke(it) }
         span.finish()
     }
@@ -125,7 +120,10 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         callRootSpan ?: return
 
         // We forcefully finish all spans, even if they should already have been finished through finishSpan()
-        eventSpans.values.filter { !it.isFinished }.forEach { it.finish(SpanStatus.DEADLINE_EXCEEDED) }
+        eventSpans.values.filter { !it.isFinished }.forEach {
+            // If a status was set on the span, we use that, otherwise we set its status as error.
+            it.finish(it.status ?: SpanStatus.INTERNAL_ERROR)
+        }
         beforeFinish?.invoke(callRootSpan)
         callRootSpan.finish()
 
@@ -137,4 +135,14 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         hub.addBreadcrumb(breadcrumb, hint)
         return
     }
+
+    private fun findParentSpan(event: String): ISpan? = when (event) {
+        // PROXY_SELECT, DNS, CONNECT and CONNECTION are not children of one another
+        SECURE_CONNECT_EVENT -> eventSpans[CONNECT_EVENT]
+        REQUEST_HEADERS_EVENT -> eventSpans[CONNECTION_EVENT]
+        REQUEST_BODY_EVENT -> eventSpans[CONNECTION_EVENT]
+        RESPONSE_HEADERS_EVENT -> eventSpans[CONNECTION_EVENT]
+        RESPONSE_BODY_EVENT -> eventSpans[CONNECTION_EVENT]
+        else -> callRootSpan
+    } ?: callRootSpan
 }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEventListener.kt
@@ -313,7 +313,10 @@ class SentryOkHttpEventListener(
         okHttpEvent.setResponse(response)
         okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
             it.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
-            it.status = SpanStatus.fromHttpStatusCode(response.code)
+            // Let's not override the status of a span that was set
+            if (it.status == null) {
+                it.status = SpanStatus.fromHttpStatusCode(response.code)
+            }
         }
     }
 

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -314,7 +314,8 @@ class SentryOkHttpEventListenerTest {
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
         val callSpan = okHttpEvent?.callRootSpan
-        val responseHeaderSpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_headers" }
+        val responseHeaderSpan =
+            fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_headers" }
         val connectionSpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.connection" }
         response.close()
         assertNotNull(callSpan)

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -488,7 +488,7 @@ class SentryOkHttpEventTest {
         assertEquals(SpanStatus.DEADLINE_EXCEEDED, randomEventSpan.status)
         // requestHeadersSpan was finished with INTERNAL_ERROR, and it propagates to its parent
         assertEquals(SpanStatus.INTERNAL_ERROR, connectionSpan.status)
-        // requestHeadersSpan was finished with INTERNAL_ERROR, but random event was finished with DEADLINE_EXCEEDED, and it propagates to root call
+        // random event was finished last with DEADLINE_EXCEEDED, and it propagates to root call
         assertEquals(SpanStatus.DEADLINE_EXCEEDED, sut.callRootSpan!!.status)
     }
 


### PR DESCRIPTION
## :scroll: Description
status of OkHttp calls now gets propagated to parent span
when OkHttp call finishes, status of unfinished spans is not overridden and is set to INTERNAL_ERROR


## :bulb: Motivation and Context
OkHttp calls are grouped in a tree of parent-children. If a child span fails with status `internal_error`, the parent span has a different status, but it should be `internal_error`, too.
Fixes https://github.com/sentry-demos/android/issues/60 


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
