### PR TITLE
Reduce timeout of AsyncHttpTransport to avoid ANR

### DIFF
--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -140,7 +140,7 @@ public final class AsyncHttpTransport implements ITransport {
     executor.shutdown();
     options.getLogger().log(SentryLevel.DEBUG, "Shutting down");
     try {
-      if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+      if (!executor.awaitTermination(options.getFlushTimeoutMillis(), TimeUnit.MILLISECONDS)) {
         options
             .getLogger()
             .log(

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.util.Date
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -319,6 +320,15 @@ class AsyncHttpTransportTest {
                 assertEquals(it.header.sentAt, now)
             }
         )
+    }
+
+    @Test
+    fun `close uses flushTimeoutMillis option to schedule termination`() {
+        fixture.sentryOptions.flushTimeoutMillis = 123
+        val sut = fixture.getSUT()
+        sut.close()
+
+        verify(fixture.executor).awaitTermination(eq(123), eq(TimeUnit.MILLISECONDS))
     }
 
     private fun createSession(): Session {


### PR DESCRIPTION
## :scroll: Description
reduced timeout of AsyncHttpTransport close to flushTimeoutMillis (default 4s in Android and 15s in Java) to avoid ANRs in Android


## :bulb: Motivation and Context
Closing the hub could cause an ANR, since the SDK would wait for 1 minute to send any cached envelope


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
