### PR TITLE
Apollo v2 BeforeSpanCallback: Allow returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
 - Reduce timeout of AsyncHttpTransport to avoid ANR ([#2879](https://github.com/getsentry/sentry-java/pull/2879))
 - Add deadline timeout for automatic transactions ([#2865](https://github.com/getsentry/sentry-java/pull/2865))
   - This affects all automatically generated transactions on Android (UI, clicks), the default timeout is 30s
+- Apollo v2 BeforeSpanCallback now allows returning null ([#2890](https://github.com/getsentry/sentry-java/pull/2890))
 
 ### Fixes
 

--- a/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
+++ b/sentry-apollo/src/test/java/io/sentry/apollo/SentryApolloInterceptorTest.kt
@@ -35,6 +35,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SentryApolloInterceptorTest {
 
@@ -170,6 +171,24 @@ class SentryApolloInterceptorTest {
                 assertEquals(1, it.spans.size)
                 val httpClientSpan = it.spans.first()
                 assertEquals("overwritten description", httpClientSpan.description)
+            },
+            anyOrNull<TraceContext>(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `when beforeSpan callback returns null, span is dropped`() {
+        executeQuery(
+            fixture.getSut { _, _, _ ->
+                null
+            }
+        )
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertTrue(it.spans.isEmpty())
             },
             anyOrNull<TraceContext>(),
             anyOrNull(),


### PR DESCRIPTION
## :scroll: Description
Adds nullability to BeforeSpanCallback callback


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2149


## :green_heart: How did you test it?
Added unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
