### PR TITLE
add property to disable AOP related features that break graalvm build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Send `http.request.method` in span data ([#2896](https://github.com/getsentry/sentry-java/pull/2896))
 - Add `enablePrettySerializationOutput` option for opting out of pretty print ([#2871](https://github.com/getsentry/sentry-java/pull/2871))
 
+### Fixes
+
+- Add `sentry.enable-aot-compatibility` property to SpringBoot Jakarta `SentryAutoConfiguration` to enable building for GraalVM ([#2915](https://github.com/getsentry/sentry-java/pull/2915))
+
 ## 6.28.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Add `sentry.enable-aot-compatibility` property to SpringBoot Jakarta `SentryAutoConfiguration` to enable building for GraalVM ([#2915](https://github.com/getsentry/sentry-java/pull/2915))
+
 ### Dependencies
 
 - Bump Gradle from v8.2.1 to v8.3.0 ([#2900](https://github.com/getsentry/sentry-java/pull/2900))
@@ -16,10 +20,6 @@
 - Send `db.system` and `db.name` in span data ([#2894](https://github.com/getsentry/sentry-java/pull/2894))
 - Send `http.request.method` in span data ([#2896](https://github.com/getsentry/sentry-java/pull/2896))
 - Add `enablePrettySerializationOutput` option for opting out of pretty print ([#2871](https://github.com/getsentry/sentry-java/pull/2871))
-
-### Fixes
-
-- Add `sentry.enable-aot-compatibility` property to SpringBoot Jakarta `SentryAutoConfiguration` to enable building for GraalVM ([#2915](https://github.com/getsentry/sentry-java/pull/2915))
 
 ## 6.28.0
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -14,7 +14,7 @@ sentry.debug=true
 in-app-includes="io.sentry.samples"
 
 # Uncomment and set to true to enable aot compatibility
-# This is disables all AOP related features (i.e. @SentryTransaction, @SentrySpan)
+# This flag disables all AOP related features (i.e. @SentryTransaction, @SentrySpan)
 # to successfully compile to GraalVM
 # sentry.enable-aot-compatibility=false
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -13,6 +13,11 @@ sentry.enable-tracing=true
 sentry.debug=true
 in-app-includes="io.sentry.samples"
 
+# Uncomment and set to true to enable aot compatibility
+# This is disables all AOP related features (i.e. @SentryTransaction, @SentrySpan)
+# to successfully compile to GraalVM
+# sentry.enable-aot-compatibility=false
+
 # Database configuration
 spring.datasource.url=jdbc:p6spy:hsqldb:mem:testdb
 spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver

--- a/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
+++ b/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
@@ -24,7 +24,9 @@ public class io/sentry/spring/boot/jakarta/SentryProperties : io/sentry/SentryOp
 	public fun getLogging ()Lio/sentry/spring/boot/jakarta/SentryProperties$Logging;
 	public fun getReactive ()Lio/sentry/spring/boot/jakarta/SentryProperties$Reactive;
 	public fun getUserFilterOrder ()Ljava/lang/Integer;
+	public fun isEnableAotCompatibility ()Z
 	public fun isUseGitCommitIdAsRelease ()Z
+	public fun setEnableAotCompatibility (Z)V
 	public fun setExceptionResolverOrder (I)V
 	public fun setLogging (Lio/sentry/spring/boot/jakarta/SentryProperties$Logging;)V
 	public fun setReactive (Lio/sentry/spring/boot/jakarta/SentryProperties$Reactive;)V

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -273,6 +273,10 @@ public class SentryAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
+    @ConditionalOnProperty(
+        value = "sentry.enable-aot-compatibility",
+        havingValue = "false",
+        matchIfMissing = true)
     @Conditional(SentryTracingCondition.class)
     @ConditionalOnClass(ProceedingJoinPoint.class)
     @Import(SentryAdviceConfiguration.class)

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
@@ -33,6 +33,11 @@ public class SentryProperties extends SentryOptions {
   /** Reactive framework (e.g. WebFlux) integration properties */
   private @NotNull Reactive reactive = new Reactive();
 
+  /**
+   * If set to true, this flag disables all AOP related features (e.g. {@link
+   * io.sentry.spring.jakarta.tracing.SentryTransaction}, {@link
+   * io.sentry.spring.jakarta.tracing.SentrySpan}) to successfully compile to GraalVM
+   */
   private boolean enableAotCompatibility = false;
 
   public boolean isUseGitCommitIdAsRelease() {

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
@@ -33,6 +33,8 @@ public class SentryProperties extends SentryOptions {
   /** Reactive framework (e.g. WebFlux) integration properties */
   private @NotNull Reactive reactive = new Reactive();
 
+  private boolean enableAotCompatibility = false;
+
   public boolean isUseGitCommitIdAsRelease() {
     return useGitCommitIdAsRelease;
   }
@@ -83,6 +85,14 @@ public class SentryProperties extends SentryOptions {
 
   public void setReactive(@NotNull Reactive reactive) {
     this.reactive = reactive;
+  }
+
+  public boolean isEnableAotCompatibility() {
+    return enableAotCompatibility;
+  }
+
+  public void setEnableAotCompatibility(boolean enableAotCompatibility) {
+    this.enableAotCompatibility = enableAotCompatibility;
   }
 
   @Open


### PR DESCRIPTION
## :scroll: Description
Add property `sentry.enable-aot-compatibility` to disable AOP, which breaks GraalVM Builds. 


## :bulb: Motivation and Context
Currently it's not possible to build for GraalVM with performance enabled due to AOP on `@SentryTransaction` and `@SentrySpan`. With this change performance can be enabled, but the AOP functionality is turned off.

Fixes #2742

## :green_heart: How did you test it?
Add `id("org.graalvm.buildtools.native") version "0.9.24"` plugin to `build.gradle` and run the `bootBuildImage` command.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
