### PR TITLE
Add send-modules option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `sendModules` option for disable sending modules ([#2926](https://github.com/getsentry/sentry-java/pull/2926))
+
 ## 6.29.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -94,6 +94,8 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_SENTRY = "io.sentry.enabled";
 
+  static final String SEND_MODULES = "io.sentry.send-modules";
+
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
 
@@ -356,6 +358,8 @@ final class ManifestMetadataReader {
 
         options.setEnableRootCheck(
             readBool(metadata, logger, ENABLE_ROOT_CHECK, options.isEnableRootCheck()));
+
+        options.setSendModules(readBool(metadata, logger, SEND_MODULES, options.isSendModules()));
       }
 
       options

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1293,4 +1293,29 @@ class ManifestMetadataReaderTest {
         // Assert
         assertTrue(fixture.options.isEnabled)
     }
+
+    @Test
+    fun `applyMetadata reads sendModules flag to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.SEND_MODULES to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.isSendModules)
+    }
+
+    @Test
+    fun `applyMetadata reads sendModules flag to options and keeps default if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.isSendModules)
+    }
 }

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -156,7 +156,8 @@ class SentryAutoConfigurationTest {
             "sentry.tags.tag2=tag2-value",
             "sentry.ignored-exceptions-for-type=java.lang.RuntimeException,java.lang.IllegalStateException,io.sentry.Sentry",
             "sentry.trace-propagation-targets=localhost,^(http|https)://api\\..*\$",
-            "sentry.enabled=false"
+            "sentry.enabled=false",
+            "sentry.send-modules=false"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -186,6 +187,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)
             assertThat(options.tracePropagationTargets).containsOnly("localhost", "^(http|https)://api\\..*\$")
             assertThat(options.isEnabled).isEqualTo(false)
+            assertThat(options.isSendModules).isEqualTo(false)
         }
     }
 

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -156,7 +156,8 @@ class SentryAutoConfigurationTest {
             "sentry.tags.tag2=tag2-value",
             "sentry.ignored-exceptions-for-type=java.lang.RuntimeException,java.lang.IllegalStateException,io.sentry.Sentry",
             "sentry.trace-propagation-targets=localhost,^(http|https)://api\\..*\$",
-            "sentry.enabled=false"
+            "sentry.enabled=false",
+            "sentry.send-modules=false"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -186,6 +187,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredExceptionsForType).containsOnly(RuntimeException::class.java, IllegalStateException::class.java)
             assertThat(options.tracePropagationTargets).containsOnly("localhost", "^(http|https)://api\\..*\$")
             assertThat(options.isEnabled).isEqualTo(false)
+            assertThat(options.isSendModules).isEqualTo(false)
         }
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -285,14 +285,13 @@ public final class io/sentry/ExternalOptions {
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracingOrigins ()Ljava/util/List;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
-	public fun isSendModules ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
+	public fun isSendModules ()Ljava/lang/Boolean;
 	public fun setDebug (Ljava/lang/Boolean;)V
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnablePrettySerializationOutput (Ljava/lang/Boolean;)V
-	public fun setSendModules (Ljava/lang/Boolean;)V
 	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnabled (Ljava/lang/Boolean;)V
@@ -305,6 +304,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setSendClientReports (Ljava/lang/Boolean;)V
+	public fun setSendModules (Ljava/lang/Boolean;)V
 	public fun setServerName (Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
@@ -1841,6 +1841,7 @@ public class io/sentry/SentryOptions {
 	public fun isProfilingEnabled ()Z
 	public fun isSendClientReports ()Z
 	public fun isSendDefaultPii ()Z
+	public fun isSendModules ()Z
 	public fun isTraceOptionsRequests ()Z
 	public fun isTraceSampling ()Z
 	public fun isTracingEnabled ()Z
@@ -1905,6 +1906,7 @@ public class io/sentry/SentryOptions {
 	public fun setSdkVersion (Lio/sentry/protocol/SdkVersion;)V
 	public fun setSendClientReports (Z)V
 	public fun setSendDefaultPii (Z)V
+	public fun setSendModules (Z)V
 	public fun setSentryClientName (Ljava/lang/String;)V
 	public fun setSerializer (Lio/sentry/ISerializer;)V
 	public fun setServerName (Ljava/lang/String;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -285,12 +285,14 @@ public final class io/sentry/ExternalOptions {
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracingOrigins ()Ljava/util/List;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
+	public fun isSendModules ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
 	public fun setDebug (Ljava/lang/Boolean;)V
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnablePrettySerializationOutput (Ljava/lang/Boolean;)V
+	public fun setSendModules (Ljava/lang/Boolean;)V
 	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnabled (Ljava/lang/Boolean;)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -45,6 +45,8 @@ public final class ExternalOptions {
   private @Nullable Boolean enabled;
   private @Nullable Boolean enablePrettySerializationOutput;
 
+  private @Nullable Boolean sendModules;
+
   @SuppressWarnings("unchecked")
   public static @NotNull ExternalOptions from(
       final @NotNull PropertiesProvider propertiesProvider, final @NotNull ILogger logger) {
@@ -121,6 +123,8 @@ public final class ExternalOptions {
 
     options.setEnablePrettySerializationOutput(
         propertiesProvider.getBooleanProperty("enable-pretty-serialization-output"));
+
+    options.setSendModules(propertiesProvider.getBooleanProperty("send-modules"));
 
     for (final String ignoredExceptionType :
         propertiesProvider.getList("ignored-exceptions-for-type")) {
@@ -367,8 +371,16 @@ public final class ExternalOptions {
     return enablePrettySerializationOutput;
   }
 
+  public @Nullable Boolean isSendModules() {
+    return sendModules;
+  }
+
   public void setEnablePrettySerializationOutput(
       final @Nullable Boolean enablePrettySerializationOutput) {
     this.enablePrettySerializationOutput = enablePrettySerializationOutput;
+  }
+
+  public void setSendModules(final @Nullable Boolean sendModules) {
+    this.sendModules = sendModules;
   }
 }

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -371,13 +371,13 @@ public final class ExternalOptions {
     return enablePrettySerializationOutput;
   }
 
-  public @Nullable Boolean isSendModules() {
-    return sendModules;
-  }
-
   public void setEnablePrettySerializationOutput(
       final @Nullable Boolean enablePrettySerializationOutput) {
     this.enablePrettySerializationOutput = enablePrettySerializationOutput;
+  }
+
+  public @Nullable Boolean isSendModules() {
+    return sendModules;
   }
 
   public void setSendModules(final @Nullable Boolean sendModules) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -362,8 +362,7 @@ public final class Sentry {
     final @NotNull IModulesLoader modulesLoader = options.getModulesLoader();
     if (!options.isSendModules()) {
       options.setModulesLoader(NoOpModulesLoader.getInstance());
-    }
-    else if (modulesLoader instanceof NoOpModulesLoader) {
+    } else if (modulesLoader instanceof NoOpModulesLoader) {
       options.setModulesLoader(
           new CompositeModulesLoader(
               Arrays.asList(

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -360,7 +360,10 @@ public final class Sentry {
     }
 
     final @NotNull IModulesLoader modulesLoader = options.getModulesLoader();
-    if (modulesLoader instanceof NoOpModulesLoader) {
+    if (!options.isSendModules()) {
+      options.setModulesLoader(NoOpModulesLoader.getInstance());
+    }
+    else if (modulesLoader instanceof NoOpModulesLoader) {
       options.setModulesLoader(
           new CompositeModulesLoader(
               Arrays.asList(

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2404,7 +2404,7 @@ public class SentryOptions {
       setEnablePrettySerializationOutput(options.isEnablePrettySerializationOutput());
     }
 
-    if(options.isSendModules() != null) {
+    if (options.isSendModules() != null) {
       setSendModules(options.isSendModules());
     }
   }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -440,6 +440,9 @@ public class SentryOptions {
   /** Whether to format serialized data, e.g. events logged to console in debug mode */
   private boolean enablePrettySerializationOutput = true;
 
+  /** Whether to send modules containing information about versions. */
+  private boolean sendModules = true;
+
   /**
    * Adds an event processor
    *
@@ -2130,12 +2133,30 @@ public class SentryOptions {
   }
 
   /**
+   * Whether to send modules containing information about versions.
+   *
+   * @return true if modules should be sent.
+   */
+  public boolean isSendModules() {
+    return sendModules;
+  }
+
+  /**
    * Whether to format serialized data, e.g. events logged to console in debug mode
    *
    * @param enablePrettySerializationOutput true if output should be pretty printed
    */
   public void setEnablePrettySerializationOutput(boolean enablePrettySerializationOutput) {
     this.enablePrettySerializationOutput = enablePrettySerializationOutput;
+  }
+
+  /**
+   * Whether to send modules containing information about versions.
+   *
+   * @param sendModules true if modules should be sent.
+   */
+  public void setSendModules(boolean sendModules) {
+    this.sendModules = sendModules;
   }
 
   /** Returns the current {@link SentryDateProvider} that is used to retrieve the current date. */
@@ -2381,6 +2402,10 @@ public class SentryOptions {
     }
     if (options.isEnablePrettySerializationOutput() != null) {
       setEnablePrettySerializationOutput(options.isEnablePrettySerializationOutput());
+    }
+
+    if(options.isSendModules() != null) {
+      setSendModules(options.isSendModules());
     }
   }
 

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -254,6 +254,13 @@ class ExternalOptionsTest {
         }
     }
 
+    @Test
+    fun `creates options with sendModules set to false`() {
+        withPropertiesFile("send-modules=false") { options ->
+            assertTrue(options.isSendModules == false)
+        }
+    }
+
     private fun withPropertiesFile(textLines: List<String> = emptyList(), logger: ILogger = mock(), fn: (ExternalOptions) -> Unit) {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -370,6 +370,7 @@ class SentryOptionsTest {
         externalOptions.bundleIds.addAll(listOf("12ea7a02-46ac-44c0-a5bb-6d1fd9586411 ", " faa3ab42-b1bd-4659-af8e-1682324aa744"))
         externalOptions.isEnabled = false
         externalOptions.isEnablePrettySerializationOutput = false
+        externalOptions.isSendModules = false
         val options = SentryOptions()
 
         options.merge(externalOptions)
@@ -396,6 +397,7 @@ class SentryOptionsTest {
         assertEquals(setOf("12ea7a02-46ac-44c0-a5bb-6d1fd9586411", "faa3ab42-b1bd-4659-af8e-1682324aa744"), options.bundleIds)
         assertFalse(options.isEnabled)
         assertFalse(options.isEnablePrettySerializationOutput)
+        assertFalse(options.isSendModules)
     }
 
     @Test
@@ -496,5 +498,10 @@ class SentryOptionsTest {
     @Test
     fun `when options are initialized, enablePrettySerializationOutput is set to true by default`() {
         assertTrue(SentryOptions().isEnablePrettySerializationOutput)
+    }
+
+    @Test
+    fun `when options are initialized, sendModules is set to true by default`() {
+        assertTrue(SentryOptions().isSendModules)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -770,7 +770,7 @@ class SentryTest {
     }
 
     @Test
-    fun `if send modules is false, using NoOpModulesLoader`() {
+    fun `if send modules is false, uses NoOpModulesLoader`() {
         var sentryOptions: SentryOptions? = null
         Sentry.init {
             it.dsn = dsn

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -6,6 +6,7 @@ import io.sentry.internal.debugmeta.IDebugMetaLoader
 import io.sentry.internal.debugmeta.ResourcesDebugMetaLoader
 import io.sentry.internal.modules.CompositeModulesLoader
 import io.sentry.internal.modules.IModulesLoader
+import io.sentry.internal.modules.NoOpModulesLoader
 import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.test.ImmediateExecutorService
@@ -31,6 +32,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -765,6 +767,18 @@ class SentryTest {
 
         await.untilTrue(triggered)
         assertFalse(previousSessionFile.exists())
+    }
+
+    @Test
+    fun `if send modules is false, using NoOpModulesLoader`() {
+        var sentryOptions: SentryOptions? = null
+        Sentry.init {
+            it.dsn = dsn
+            it.isSendModules = false
+            sentryOptions = it
+        }
+
+        assertIs<NoOpModulesLoader>(sentryOptions?.modulesLoader)
     }
 
     private class InMemoryOptionsObserver : IOptionsObserver {


### PR DESCRIPTION
## :scroll: Description
A new option to disable sending modules.


## :bulb: Motivation and Context
I saw this option is in [ruby options](https://docs.sentry.io/platforms/ruby/configuration/options/), but this option is not present in java options.
This option can be useful when you don't need to send a list of modules with versions.
When using sentry-spring-boot-starter you can use this option in application.yaml



## :green_heart: How did you test it?
I tested it using spring boot app


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
