### PR TITLE
Send `db.system` and `db.name`  in span data for androidx.sqlite spans

### DIFF
--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
@@ -11,7 +11,8 @@ import io.sentry.SpanStatus
 private const val TRACE_ORIGIN = "auto.db.sqlite"
 
 internal class SQLiteSpanManager(
-    private val hub: IHub = HubAdapter.getInstance()
+    private val hub: IHub = HubAdapter.getInstance(),
+    private val databaseName: String? = null
 ) {
     private val stackTraceFactory = SentryStackTraceFactory(hub.options)
 
@@ -46,6 +47,15 @@ internal class SQLiteSpanManager(
                 if (isMainThread) {
                     setData(SpanDataConvention.CALL_STACK_KEY, stackTraceFactory.inAppCallStack)
                 }
+                // if db name is null, then it's an in-memory database as per
+                // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:sqlite/sqlite/src/main/java/androidx/sqlite/db/SupportSQLiteOpenHelper.kt;l=38-42
+                if (databaseName != null) {
+                    setData(SpanDataConvention.DB_SYSTEM_KEY, "sqlite")
+                    setData(SpanDataConvention.DB_NAME_KEY, databaseName)
+                } else {
+                    setData(SpanDataConvention.DB_SYSTEM_KEY, "in-memory")
+                }
+
                 finish()
             }
         }

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelper.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelper.kt
@@ -34,7 +34,7 @@ class SentrySupportSQLiteOpenHelper private constructor(
     private val delegate: SupportSQLiteOpenHelper
 ) : SupportSQLiteOpenHelper by delegate {
 
-    private val sqLiteSpanManager = SQLiteSpanManager()
+    private val sqLiteSpanManager = SQLiteSpanManager(databaseName = delegate.databaseName)
 
     private val sentryWritableDatabase: SupportSQLiteDatabase by lazy {
         SentrySupportSQLiteDatabase(delegate.writableDatabase, sqLiteSpanManager)

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelperTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelperTest.kt
@@ -2,6 +2,7 @@ package io.sentry.android.sqlite
 
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -37,7 +38,7 @@ class SentrySupportSQLiteOpenHelperTest {
         verify(fixture.mockOpenHelper).readableDatabase
 
         openHelper.databaseName
-        verify(fixture.mockOpenHelper).databaseName
+        verify(fixture.mockOpenHelper, times(2)).databaseName
 
         openHelper.close()
         verify(fixture.mockOpenHelper).close()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

* Send `db.system` and `db.name`  in span data for androidx.sqlite spans

![image](https://github.com/getsentry/sentry-java/assets/4999776/174e1ce3-2714-4c58-80b0-2861a240cdfd)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2893 

## :green_heart: How did you test it?
Manually on the SAGP repo

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
