### PR TITLE
Always send memory stats for transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Add `sendModules` option for disable sending modules ([#2926](https://github.com/getsentry/sentry-java/pull/2926))
 - Send `db.system` and `db.name` in span data for androidx.sqlite spans ([#2928](https://github.com/getsentry/sentry-java/pull/2928))
 
+### Fixes
+
+- Always send memory stats for transactions ([#2936](https://github.com/getsentry/sentry-java/pull/2936))
+  - This makes it possible to query transactions by the `device.class` tag on Sentry
+
 ### Dependencies
 
 - Bump Gradle from v8.2.1 to v8.3.0 ([#2900](https://github.com/getsentry/sentry-java/pull/2900))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
@@ -62,7 +62,7 @@ public final class DeviceInfoUtil {
     sideLoadedInfo =
         ContextUtils.retrieveSideLoadedInfo(context, options.getLogger(), buildInfoProvider);
     final @Nullable ActivityManager.MemoryInfo memInfo =
-      ContextUtils.getMemInfo(context, options.getLogger());
+        ContextUtils.getMemInfo(context, options.getLogger());
     if (memInfo != null) {
       totalMem = getMemorySize(memInfo);
     } else {
@@ -204,11 +204,11 @@ public final class DeviceInfoUtil {
     device.setOnline(connected);
 
     final @Nullable ActivityManager.MemoryInfo memInfo =
-      ContextUtils.getMemInfo(context, options.getLogger());
+        ContextUtils.getMemInfo(context, options.getLogger());
     if (memInfo != null && includeDynamicData) {
-        // in bytes
-        device.setFreeMemory(memInfo.availMem);
-        device.setLowMemory(memInfo.lowMemory);
+      // in bytes
+      device.setFreeMemory(memInfo.availMem);
+      device.setLowMemory(memInfo.lowMemory);
     }
 
     // this way of getting the size of storage might be problematic for storages bigger than 2GB

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
@@ -132,9 +132,20 @@ public final class DeviceInfoUtil {
       device.setProcessorCount(cpuFrequencies.size());
     }
 
+    final @Nullable ActivityManager.MemoryInfo memInfo =
+        ContextUtils.getMemInfo(context, options.getLogger());
+    if (memInfo != null) {
+      // in bytes
+      device.setMemorySize(getMemorySize(memInfo));
+      if (collectDynamicData) {
+        device.setFreeMemory(memInfo.availMem);
+        device.setLowMemory(memInfo.lowMemory);
+      }
+    }
+
     // setting such values require IO hence we don't run for transactions
     if (collectDeviceIO && options.isCollectAdditionalContext()) {
-      setDeviceIO(device, collectDynamicData);
+      setDeviceIO(device);
     }
 
     return device;
@@ -171,7 +182,7 @@ public final class DeviceInfoUtil {
     return sideLoadedInfo;
   }
 
-  private void setDeviceIO(final @NotNull Device device, final boolean includeDynamicData) {
+  private void setDeviceIO(final @NotNull Device device) {
     final Intent batteryIntent = getBatteryIntent();
     if (batteryIntent != null) {
       device.setBatteryLevel(getBatteryLevel(batteryIntent));
@@ -191,19 +202,6 @@ public final class DeviceInfoUtil {
         connected = null;
     }
     device.setOnline(connected);
-
-    final @Nullable ActivityManager.MemoryInfo memInfo =
-        ContextUtils.getMemInfo(context, options.getLogger());
-    if (memInfo != null) {
-      // in bytes
-      device.setMemorySize(getMemorySize(memInfo));
-      if (includeDynamicData) {
-        device.setFreeMemory(memInfo.availMem);
-        device.setLowMemory(memInfo.lowMemory);
-      }
-      // there are runtime.totalMemory() and runtime.freeMemory(), but I kept the same for
-      // compatibility
-    }
 
     // this way of getting the size of storage might be problematic for storages bigger than 2GB
     // check the use of

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DeviceInfoUtilTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DeviceInfoUtilTest.kt
@@ -99,19 +99,6 @@ class DeviceInfoUtilTest {
     }
 
     @Test
-    fun `does not include device io data when disabled`() {
-        val options = SentryAndroidOptions().apply {
-            isCollectAdditionalContext = true
-        }
-        val deviceInfoUtil = DeviceInfoUtil.getInstance(context, options)
-        val deviceInfo = deviceInfoUtil.collectDeviceInformation(false, false)
-
-        assertNull(deviceInfo.memorySize)
-        assertNull(deviceInfo.storageSize)
-        assertNull(deviceInfo.freeStorage)
-    }
-
-    @Test
     fun `does include dynamic data when enabled`() {
         val options = SentryAndroidOptions().apply {
             isCollectAdditionalContext = true

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DeviceInfoUtilTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DeviceInfoUtilTest.kt
@@ -34,7 +34,7 @@ class DeviceInfoUtilTest {
     }
 
     @Test
-    fun `provides os and sideloaded info`() {
+    fun `provides os, memory and sideloaded info`() {
         val deviceInfoUtil = DeviceInfoUtil.getInstance(context, SentryAndroidOptions())
 
         val os = deviceInfoUtil.operatingSystem
@@ -48,6 +48,7 @@ class DeviceInfoUtilTest {
         assertNotNull(sideLoadedInfo.isSideLoaded)
 
         assertNotNull(deviceInfo.isSimulator)
+        assertNotNull(deviceInfo.memorySize)
     }
 
     @Test
@@ -96,6 +97,18 @@ class DeviceInfoUtilTest {
         assertNotNull(deviceInfo.memorySize)
         assertNotNull(deviceInfo.storageSize)
         assertNotNull(deviceInfo.freeStorage)
+    }
+
+    @Test
+    fun `does not include device io data when disabled`() {
+        val options = SentryAndroidOptions().apply {
+            isCollectAdditionalContext = true
+        }
+        val deviceInfoUtil = DeviceInfoUtil.getInstance(context, options)
+        val deviceInfo = deviceInfoUtil.collectDeviceInformation(false, false)
+
+        assertNull(deviceInfo.storageSize)
+        assertNull(deviceInfo.freeStorage)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We were not sending memory stats for transactions by default, but reading memory stats does not require any IO or IPC, we just querying `ActivityManager`, so it should be fine to always send it.

As a result we can query transactions by `device.class` now
![image](https://github.com/getsentry/sentry-java/assets/4999776/74d49420-3361-4433-9d53-a50907655244)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2929 

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
