### PR TITLE
Don't send cached envelopes when rate-limiting is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes:
   - Previously performing a click on the same UI widget twice would keep the existing transaction running, the new behavior now better aligns with other SDKs
 - Android only: If global hub mode is enabled, Sentry.getSpan() returns the root span instead of the latest span ([#2855](https://github.com/getsentry/sentry-java/pull/2855))
 - Android only: Observe network state to upload any unsent envelopes ([#2910](https://github.com/getsentry/sentry-java/pull/2910))
+- Do not try to send and drop cached envelopes when rate-limiting is active ([#2937](https://github.com/getsentry/sentry-java/pull/2937))
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -43,7 +43,8 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
               options.getEnvelopeReader(),
               options.getSerializer(),
               logger,
-              options.getFlushTimeoutMillis());
+              options.getFlushTimeoutMillis(),
+              options.getMaxQueueSize());
 
       observer =
           new EnvelopeFileObserver(path, outboxSender, logger, options.getFlushTimeoutMillis());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -30,6 +30,7 @@ final class SendCachedEnvelopeIntegration
   private @Nullable IConnectionStatusProvider connectionStatusProvider;
   private @Nullable IHub hub;
   private @Nullable SentryAndroidOptions options;
+  private @Nullable SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget sender;
 
   public SendCachedEnvelopeIntegration(
       final @NotNull SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory factory,
@@ -56,6 +57,8 @@ final class SendCachedEnvelopeIntegration
     connectionStatusProvider = options.getConnectionStatusProvider();
     connectionStatusProvider.addConnectionStatusObserver(this);
 
+    sender = factory.create(hub, options);
+
     sendCachedEnvelopes(hub, this.options);
   }
 
@@ -73,6 +76,7 @@ final class SendCachedEnvelopeIntegration
     }
   }
 
+  @SuppressWarnings({"NullAway"})
   private synchronized void sendCachedEnvelopes(
       final @NotNull IHub hub, final @NotNull SentryAndroidOptions options) {
 
@@ -91,9 +95,6 @@ final class SendCachedEnvelopeIntegration
           .log(SentryLevel.INFO, "SendCachedEnvelopeIntegration, rate limiting active.");
       return;
     }
-
-    final SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget sender =
-        factory.create(hub, options);
 
     if (sender == null) {
       options.getLogger().log(SentryLevel.ERROR, "SendCachedEnvelopeIntegration factory is null.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -8,7 +8,6 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import io.sentry.IConnectionStatusProvider;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -63,9 +63,14 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
     return getConnectionType(context, logger, buildInfoProvider);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @SuppressLint("NewApi") // we have an if-check for that down below
   @Override
   public boolean addConnectionStatusObserver(@NotNull IConnectionStatusObserver observer) {
+    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) {
+      logger.log(SentryLevel.DEBUG, "addConnectionStatusObserver requires Android 5+.");
+      return false;
+    }
+
     final ConnectivityManager.NetworkCallback callback =
         new ConnectivityManager.NetworkCallback() {
           @Override

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -23,6 +23,7 @@ import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
 import io.sentry.transport.ITransport
+import io.sentry.transport.RateLimiter
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -62,6 +63,10 @@ class InternalSentrySdkTest {
 
                         override fun flush(timeoutMillis: Long) {
                             // no-op
+                        }
+
+                        override fun getRateLimiter(): RateLimiter? {
+                            return null
                         }
                     }
                 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SendCachedEnvelopeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SendCachedEnvelopeIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.sentry.ILogger
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory
 import io.sentry.SentryLevel.DEBUG
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.transport.RateLimiter
 import io.sentry.util.LazyEvaluator
 import org.awaitility.kotlin.await
@@ -36,8 +37,12 @@ class SendCachedEnvelopeIntegrationTest {
             hasStartupCrashMarker: Boolean = false,
             hasSender: Boolean = true,
             delaySend: Long = 0L,
-            taskFails: Boolean = false
+            taskFails: Boolean = false,
+            useImmediateExecutor: Boolean = false
         ): SendCachedEnvelopeIntegration {
+            if (useImmediateExecutor) {
+                options.executorService = ImmediateExecutorService()
+            }
             options.cacheDirPath = cacheDirPath
             options.setLogger(logger)
             options.isDebug = true
@@ -145,7 +150,7 @@ class SendCachedEnvelopeIntegrationTest {
         )
 
         sut.register(fixture.hub, fixture.options)
-        verify(fixture.factory, never()).create(any(), any())
+        verify(fixture.sender, never()).send()
     }
 
     @Test
@@ -165,7 +170,7 @@ class SendCachedEnvelopeIntegrationTest {
 
     @Test
     fun `whenever network connection status changes, retries sending for relevant statuses`() {
-        val sut = fixture.getSut(hasStartupCrashMarker = false)
+        val sut = fixture.getSut(hasStartupCrashMarker = false, useImmediateExecutor = true)
 
         val connectionStatusProvider = mock<IConnectionStatusProvider>()
         fixture.options.connectionStatusProvider = connectionStatusProvider
@@ -175,23 +180,23 @@ class SendCachedEnvelopeIntegrationTest {
         sut.register(fixture.hub, fixture.options)
 
         // when there's no connection no factory create call should be done
-        verify(fixture.factory, never()).create(any(), any())
+        verify(fixture.sender, never()).send()
 
         // but for any other status processing should be triggered
         // CONNECTED
         whenever(connectionStatusProvider.connectionStatus).thenReturn(ConnectionStatus.CONNECTED)
         sut.onConnectionStatusChanged(ConnectionStatus.CONNECTED)
-        verify(fixture.factory).create(any(), any())
+        verify(fixture.sender).send()
 
         // UNKNOWN
         whenever(connectionStatusProvider.connectionStatus).thenReturn(ConnectionStatus.UNKNOWN)
         sut.onConnectionStatusChanged(ConnectionStatus.UNKNOWN)
-        verify(fixture.factory, times(2)).create(any(), any())
+        verify(fixture.sender, times(2)).send()
 
         // NO_PERMISSION
         whenever(connectionStatusProvider.connectionStatus).thenReturn(ConnectionStatus.NO_PERMISSION)
         sut.onConnectionStatusChanged(ConnectionStatus.NO_PERMISSION)
-        verify(fixture.factory, times(3)).create(any(), any())
+        verify(fixture.sender, times(3)).send()
     }
 
     @Test
@@ -205,6 +210,6 @@ class SendCachedEnvelopeIntegrationTest {
         sut.register(fixture.hub, fixture.options)
 
         // no factory call should be done if there's rate limiting active
-        verify(fixture.factory, never()).create(any(), any())
+        verify(fixture.sender, never()).send()
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
@@ -21,6 +21,7 @@ import io.sentry.TraceContext
 import io.sentry.UserFeedback
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
+import io.sentry.transport.RateLimiter
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.annotation.Config
@@ -160,6 +161,10 @@ class SessionTrackingIntegrationTest {
             hint: Hint?,
             profilingTraceData: ProfilingTraceData?
         ): SentryId {
+            TODO("Not yet implemented")
+        }
+
+        override fun getRateLimiter(): RateLimiter? {
             TODO("Not yet implemented")
         }
     }

--- a/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
+++ b/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
@@ -2,6 +2,7 @@ public final class io/sentry/transport/apache/ApacheHttpClientTransport : io/sen
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;Lorg/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient;Lio/sentry/transport/RateLimiter;)V
 	public fun close ()V
 	public fun flush (J)V
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
 

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -190,6 +190,11 @@ public final class ApacheHttpClientTransport implements ITransport {
   }
 
   @Override
+  public @NotNull RateLimiter getRateLimiter() {
+    return rateLimiter;
+  }
+
+  @Override
   public void close() throws IOException {
     options.getLogger().log(DEBUG, "Shutting down");
     try {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -239,7 +239,7 @@ public final class io/sentry/EnvelopeReader : io/sentry/IEnvelopeReader {
 }
 
 public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;JI)V
 	public synthetic fun processDirectory (Ljava/io/File;)V
 	public fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/Hint;)V
 }
@@ -1075,7 +1075,7 @@ public final class io/sentry/OptionsContainer {
 }
 
 public final class io/sentry/OutboxSender : io/sentry/IEnvelopeSender {
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/IEnvelopeReader;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/IEnvelopeReader;Lio/sentry/ISerializer;Lio/sentry/ILogger;JI)V
 	public synthetic fun processDirectory (Ljava/io/File;)V
 	public fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/Hint;)V
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -373,6 +373,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun getBaggage ()Lio/sentry/BaggageHeader;
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun getSpan ()Lio/sentry/ISpan;
 	public fun getTraceparent ()Lio/sentry/SentryTraceHeader;
 	public fun getTransaction ()Lio/sentry/ITransaction;
@@ -422,6 +423,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public static fun getInstance ()Lio/sentry/HubAdapter;
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun getSpan ()Lio/sentry/ISpan;
 	public fun getTraceparent ()Lio/sentry/SentryTraceHeader;
 	public fun getTransaction ()Lio/sentry/ITransaction;
@@ -515,6 +517,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun getBaggage ()Lio/sentry/BaggageHeader;
 	public abstract fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getOptions ()Lio/sentry/SentryOptions;
+	public abstract fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public abstract fun getSpan ()Lio/sentry/ISpan;
 	public abstract fun getTraceparent ()Lio/sentry/SentryTraceHeader;
 	public abstract fun getTransaction ()Lio/sentry/ITransaction;
@@ -608,6 +611,7 @@ public abstract interface class io/sentry/ISentryClient {
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun close ()V
 	public abstract fun flush (J)V
+	public abstract fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public abstract fun isEnabled ()Z
 }
 
@@ -910,6 +914,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public static fun getInstance ()Lio/sentry/NoOpHub;
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun getSpan ()Lio/sentry/ISpan;
 	public fun getTraceparent ()Lio/sentry/SentryTraceHeader;
 	public fun getTransaction ()Lio/sentry/ITransaction;
@@ -1516,6 +1521,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun close ()V
 	public fun flush (J)V
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun isEnabled ()Z
 }
 
@@ -2472,6 +2478,7 @@ public final class io/sentry/TypeCheckHint {
 	public static final field OKHTTP_RESPONSE Ljava/lang/String;
 	public static final field OPEN_FEIGN_REQUEST Ljava/lang/String;
 	public static final field OPEN_FEIGN_RESPONSE Ljava/lang/String;
+	public static final field SENTRY_CACHED_ENVELOPE_FILE_PATH Ljava/lang/String;
 	public static final field SENTRY_DART_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_DOTNET_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_EVENT_DROP_REASON Ljava/lang/String;
@@ -4137,6 +4144,7 @@ public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/
 	public fun <init> (Lio/sentry/transport/QueuedThreadPoolExecutor;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V
 	public fun flush (J)V
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
 
@@ -4151,6 +4159,7 @@ public abstract interface class io/sentry/transport/ICurrentDateProvider {
 
 public abstract interface class io/sentry/transport/ITransport : java/io/Closeable {
 	public abstract fun flush (J)V
+	public abstract fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;)V
 	public abstract fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
@@ -4172,6 +4181,7 @@ public final class io/sentry/transport/NoOpTransport : io/sentry/transport/ITran
 	public fun close ()V
 	public fun flush (J)V
 	public static fun getInstance ()Lio/sentry/transport/NoOpTransport;
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
 
@@ -4184,7 +4194,7 @@ public final class io/sentry/transport/RateLimiter {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun <init> (Lio/sentry/transport/ICurrentDateProvider;Lio/sentry/SentryOptions;)V
 	public fun filter (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/SentryEnvelope;
-	public fun getRateLimitedUntilFor (Ljava/lang/String;)Ljava/util/Date;
+	public fun isActiveForCategory (Lio/sentry/DataCategory;)Z
 	public fun updateRetryAfterLimits (Ljava/lang/String;Ljava/lang/String;I)V
 }
 
@@ -4202,6 +4212,7 @@ public final class io/sentry/transport/StdoutTransport : io/sentry/transport/ITr
 	public fun <init> (Lio/sentry/ISerializer;)V
 	public fun close ()V
 	public fun flush (J)V
+	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -239,7 +239,7 @@ public final class io/sentry/EnvelopeReader : io/sentry/IEnvelopeReader {
 }
 
 public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;JLio/sentry/cache/IEnvelopeCache;)V
+	public fun <init> (Lio/sentry/IHub;Lio/sentry/ISerializer;Lio/sentry/ILogger;J)V
 	public synthetic fun processDirectory (Ljava/io/File;)V
 	public fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/Hint;)V
 }
@@ -2478,7 +2478,6 @@ public final class io/sentry/TypeCheckHint {
 	public static final field OKHTTP_RESPONSE Ljava/lang/String;
 	public static final field OPEN_FEIGN_REQUEST Ljava/lang/String;
 	public static final field OPEN_FEIGN_RESPONSE Ljava/lang/String;
-	public static final field SENTRY_CACHED_ENVELOPE_FILE_PATH Ljava/lang/String;
 	public static final field SENTRY_DART_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_DOTNET_SDK_NAME Ljava/lang/String;
 	public static final field SENTRY_EVENT_DROP_REASON Ljava/lang/String;
@@ -2765,6 +2764,10 @@ public abstract interface class io/sentry/hints/Cached {
 
 public abstract interface class io/sentry/hints/DiskFlushNotification {
 	public abstract fun markFlushed ()V
+}
+
+public abstract interface class io/sentry/hints/Enqueable {
+	public abstract fun markEnqueued ()V
 }
 
 public final class io/sentry/hints/EventDropReason : java/lang/Enum {

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -24,13 +24,14 @@ abstract class DirectoryProcessor {
   private final long flushTimeoutMillis;
   private final Queue<String> processedEnvelopes;
 
-  DirectoryProcessor(final @NotNull IHub hub,
-      final @NotNull ILogger logger, final long flushTimeoutMillis) {
+  DirectoryProcessor(
+      final @NotNull IHub hub, final @NotNull ILogger logger, final long flushTimeoutMillis) {
     this.hub = hub;
     this.logger = logger;
     this.flushTimeoutMillis = flushTimeoutMillis;
     this.processedEnvelopes =
-        SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(hub.getOptions().getMaxQueueSize()));
+        SynchronizedQueue.synchronizedQueue(
+            new CircularFifoQueue<>(hub.getOptions().getMaxQueueSize()));
   }
 
   public void processDirectory(final @NotNull File directory) {
@@ -85,9 +86,7 @@ abstract class DirectoryProcessor {
         // in case there's rate limiting active, skip processing
         final @Nullable RateLimiter rateLimiter = hub.getRateLimiter();
         if (rateLimiter != null && rateLimiter.isActiveForCategory(DataCategory.All)) {
-          logger.log(
-            SentryLevel.INFO,
-            "DirectoryProcessor, rate limiting active.");
+          logger.log(SentryLevel.INFO, "DirectoryProcessor, rate limiting active.");
           return;
         }
 
@@ -102,21 +101,8 @@ abstract class DirectoryProcessor {
 
         // a short delay between processing envelopes to avoid bursting our server and hitting
         // another rate limit https://develop.sentry.dev/sdk/features/#additional-capabilities
-        try {
-          Thread.sleep(ENVELOPE_PROCESS_DELAY);
-        } catch (InterruptedException e) {
-          try {
-            Thread.currentThread().interrupt();
-          } catch (SecurityException ignored) {
-            logger.log(
-              SentryLevel.INFO,
-              "Failed to interrupt due to SecurityException: %s",
-              e.getMessage());
-            return;
-          }
-          logger.log(SentryLevel.INFO, "Interrupted: %s", e.getMessage());
-          return;
-        }
+        // InterruptedException will be handled by the outer try-catch
+        Thread.sleep(ENVELOPE_PROCESS_DELAY);
       }
     } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, e, "Failed processing '%s'", directory.getAbsolutePath());

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -21,10 +21,12 @@ abstract class DirectoryProcessor {
 
   private final Queue<String> processedEnvelopes;
 
-  DirectoryProcessor(final @NotNull ILogger logger, final long flushTimeoutMillis, final int maxQueueSize) {
+  DirectoryProcessor(
+      final @NotNull ILogger logger, final long flushTimeoutMillis, final int maxQueueSize) {
     this.logger = logger;
     this.flushTimeoutMillis = flushTimeoutMillis;
-    this.processedEnvelopes = SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxQueueSize));
+    this.processedEnvelopes =
+        SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxQueueSize));
   }
 
   public void processDirectory(final @NotNull File directory) {
@@ -66,19 +68,21 @@ abstract class DirectoryProcessor {
         }
 
         final String filePath = file.getAbsolutePath();
-        // if envelope has already been submitted into the transport queue, we don't process it again
+        // if envelope has already been submitted into the transport queue, we don't process it
+        // again
         if (processedEnvelopes.contains(filePath)) {
           logger.log(
-            SentryLevel.DEBUG,
-            "File '%s' has already been processed so it will not be processed again.",
-            filePath);
+              SentryLevel.DEBUG,
+              "File '%s' has already been processed so it will not be processed again.",
+              filePath);
           continue;
         }
 
         logger.log(SentryLevel.DEBUG, "Processing file: %s", filePath);
 
         final SendCachedEnvelopeHint cachedHint =
-            new SendCachedEnvelopeHint(flushTimeoutMillis, logger, () -> processedEnvelopes.add(filePath));
+            new SendCachedEnvelopeHint(
+                flushTimeoutMillis, logger, () -> processedEnvelopes.add(filePath));
 
         final Hint hint = HintUtils.createWithTypeCheckHint(cachedHint);
         processFile(file, hint);
@@ -102,8 +106,10 @@ abstract class DirectoryProcessor {
     private final @NotNull ILogger logger;
     private final @NotNull Runnable onEnqueued;
 
-    public SendCachedEnvelopeHint(final long flushTimeoutMillis, final @NotNull ILogger logger,
-      final @NotNull Runnable onEnqueued) {
+    public SendCachedEnvelopeHint(
+        final long flushTimeoutMillis,
+        final @NotNull ILogger logger,
+        final @NotNull Runnable onEnqueued) {
       this.flushTimeoutMillis = flushTimeoutMillis;
       this.onEnqueued = onEnqueued;
       this.latch = new CountDownLatch(1);

--- a/sentry/src/main/java/io/sentry/EnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeSender.java
@@ -26,7 +26,7 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
       final long flushTimeoutMillis) {
-    super(logger, flushTimeoutMillis, hub.getOptions().getMaxQueueSize());
+    super(hub, logger, flushTimeoutMillis);
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");
     this.logger = Objects.requireNonNull(logger, "Logger is required.");

--- a/sentry/src/main/java/io/sentry/EnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeSender.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import io.sentry.cache.EnvelopeCache;
-import io.sentry.cache.IEnvelopeCache;
 import io.sentry.hints.Flushable;
 import io.sentry.hints.Retryable;
 import io.sentry.util.HintUtils;
@@ -21,19 +20,16 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
   private final @NotNull IHub hub;
   private final @NotNull ISerializer serializer;
   private final @NotNull ILogger logger;
-  private final @NotNull IEnvelopeCache envelopeCache;
 
   public EnvelopeSender(
       final @NotNull IHub hub,
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
-      final long flushTimeoutMillis,
-      final @NotNull IEnvelopeCache envelopeCache) {
-    super(logger, flushTimeoutMillis);
+      final long flushTimeoutMillis) {
+    super(logger, flushTimeoutMillis, hub.getOptions().getMaxQueueSize());
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");
     this.logger = Objects.requireNonNull(logger, "Logger is required.");
-    this.envelopeCache = Objects.requireNonNull(envelopeCache, "IEnvelopeCache is required.");
   }
 
   @Override
@@ -53,14 +49,6 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       logger.log(
           SentryLevel.WARNING,
           "File '%s' cannot be deleted so it will not be processed.",
-          file.getAbsolutePath());
-      return;
-    }
-
-    if (envelopeCache.containsFile(file)) {
-      logger.log(
-          SentryLevel.DEBUG,
-          "File '%s' is already in the cache so it will not be processed again.",
           file.getAbsolutePath());
       return;
     }

--- a/sentry/src/main/java/io/sentry/EnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/EnvelopeSender.java
@@ -25,8 +25,9 @@ public final class EnvelopeSender extends DirectoryProcessor implements IEnvelop
       final @NotNull IHub hub,
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
-      final long flushTimeoutMillis) {
-    super(hub, logger, flushTimeoutMillis);
+      final long flushTimeoutMillis,
+      final int maxQueueSize) {
+    super(hub, logger, flushTimeoutMillis, maxQueueSize);
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");
     this.logger = Objects.requireNonNull(logger, "Logger is required.");

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -7,6 +7,7 @@ import io.sentry.hints.SessionStartHint;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.transport.RateLimiter;
 import io.sentry.util.ExceptionUtils;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
@@ -882,5 +883,11 @@ public final class Hub implements IHub {
     }
 
     return null;
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    final StackItem item = stack.peek();
+    return item.getClient().getRateLimiter();
   }
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -885,6 +885,7 @@ public final class Hub implements IHub {
     return null;
   }
 
+  @ApiStatus.Internal
   @Override
   public @Nullable RateLimiter getRateLimiter() {
     final StackItem item = stack.peek();

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -264,6 +264,7 @@ public final class HubAdapter implements IHub {
     return Sentry.getBaggage();
   }
 
+  @ApiStatus.Internal
   @Override
   public @Nullable RateLimiter getRateLimiter() {
     return Sentry.getCurrentHub().getRateLimiter();

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.transport.RateLimiter;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -261,5 +262,10 @@ public final class HubAdapter implements IHub {
   @Override
   public @Nullable BaggageHeader getBaggage() {
     return Sentry.getBaggage();
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    return Sentry.getCurrentHub().getRateLimiter();
   }
 }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.transport.RateLimiter;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -633,4 +634,7 @@ public interface IHub {
    */
   @Nullable
   BaggageHeader getBaggage();
+
+  @Nullable
+  RateLimiter getRateLimiter();
 }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -635,6 +635,7 @@ public interface IHub {
   @Nullable
   BaggageHeader getBaggage();
 
+  @ApiStatus.Internal
   @Nullable
   RateLimiter getRateLimiter();
 }

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.transport.RateLimiter;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -264,4 +265,8 @@ public interface ISentryClient {
   default @NotNull SentryId captureTransaction(@NotNull SentryTransaction transaction) {
     return captureTransaction(transaction, null, null, null);
   }
+
+  @ApiStatus.Internal
+  @Nullable
+  RateLimiter getRateLimiter();
 }

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.transport.RateLimiter;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -213,6 +214,11 @@ public final class NoOpHub implements IHub {
 
   @Override
   public @Nullable BaggageHeader getBaggage() {
+    return null;
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
     return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.transport.RateLimiter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,5 +52,10 @@ final class NoOpSentryClient implements ISentryClient {
       @Nullable Hint hint,
       @Nullable ProfilingTraceData profilingTraceData) {
     return SentryId.EMPTY_ID;
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    return null;
   }
 }

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -11,6 +11,7 @@ import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.transport.RateLimiter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.HintUtils;
 import io.sentry.util.LogUtils;
@@ -47,7 +48,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
       final long flushTimeoutMillis) {
-    super(logger, flushTimeoutMillis);
+    super(logger, flushTimeoutMillis, hub.getOptions().getMaxQueueSize());
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.envelopeReader = Objects.requireNonNull(envelopeReader, "Envelope reader is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -46,8 +46,9 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
       final @NotNull IEnvelopeReader envelopeReader,
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
-      final long flushTimeoutMillis) {
-    super(hub, logger, flushTimeoutMillis);
+      final long flushTimeoutMillis,
+      final int maxQueueSize) {
+    super(hub, logger, flushTimeoutMillis, maxQueueSize);
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.envelopeReader = Objects.requireNonNull(envelopeReader, "Envelope reader is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -11,7 +11,6 @@ import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
-import io.sentry.transport.RateLimiter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.HintUtils;
 import io.sentry.util.LogUtils;

--- a/sentry/src/main/java/io/sentry/OutboxSender.java
+++ b/sentry/src/main/java/io/sentry/OutboxSender.java
@@ -47,7 +47,7 @@ public final class OutboxSender extends DirectoryProcessor implements IEnvelopeS
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
       final long flushTimeoutMillis) {
-    super(logger, flushTimeoutMillis, hub.getOptions().getMaxQueueSize());
+    super(hub, logger, flushTimeoutMillis);
     this.hub = Objects.requireNonNull(hub, "Hub is required.");
     this.envelopeReader = Objects.requireNonNull(envelopeReader, "Envelope reader is required.");
     this.serializer = Objects.requireNonNull(serializer, "Serializer is required.");

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import static io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion;
 
+import io.sentry.transport.RateLimiter;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.File;
@@ -109,6 +110,17 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
       options
           .getLogger()
           .log(SentryLevel.INFO, "SendCachedEnvelopeFireAndForgetIntegration, no connection.");
+      return;
+    }
+
+    // in case there's rate limiting active, skip processing
+    final @Nullable RateLimiter rateLimiter = hub.getRateLimiter();
+    if (rateLimiter != null && rateLimiter.isActiveForCategory(DataCategory.All)) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.INFO,
+              "SendCachedEnvelopeFireAndForgetIntegration, rate limiting active.");
       return;
     }
 

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -19,6 +19,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
   private @Nullable IConnectionStatusProvider connectionStatusProvider;
   private @Nullable IHub hub;
   private @Nullable SentryOptions options;
+  private @Nullable SendFireAndForget sender;
 
   public interface SendFireAndForget {
     void send();
@@ -83,6 +84,8 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
     connectionStatusProvider = options.getConnectionStatusProvider();
     connectionStatusProvider.addConnectionStatusObserver(this);
 
+    sender = factory.create(hub, options);
+
     sendCachedEnvelopes(hub, options);
   }
 
@@ -100,7 +103,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
     }
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored")
+  @SuppressWarnings({"FutureReturnValueIgnored", "NullAway"})
   private synchronized void sendCachedEnvelopes(@NotNull IHub hub, @NotNull SentryOptions options) {
 
     // skip run only if we're certainly disconnected
@@ -124,7 +127,6 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
       return;
     }
 
-    final SendFireAndForget sender = factory.create(hub, options);
     if (sender == null) {
       options.getLogger().log(SentryLevel.ERROR, "SendFireAndForget factory is null.");
       return;

--- a/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
@@ -36,8 +36,8 @@ public final class SendFireAndForgetEnvelopeSender
             hub,
             options.getSerializer(),
             options.getLogger(),
-            options.getFlushTimeoutMillis(),
-            options.getEnvelopeDiskCache());
+            options.getFlushTimeoutMillis()
+        );
 
     return processDir(envelopeSender, dirPath, options.getLogger());
   }

--- a/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
@@ -33,11 +33,7 @@ public final class SendFireAndForgetEnvelopeSender
 
     final EnvelopeSender envelopeSender =
         new EnvelopeSender(
-            hub,
-            options.getSerializer(),
-            options.getLogger(),
-            options.getFlushTimeoutMillis()
-        );
+            hub, options.getSerializer(), options.getLogger(), options.getFlushTimeoutMillis());
 
     return processDir(envelopeSender, dirPath, options.getLogger());
   }

--- a/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
+++ b/sentry/src/main/java/io/sentry/SendFireAndForgetEnvelopeSender.java
@@ -33,7 +33,11 @@ public final class SendFireAndForgetEnvelopeSender
 
     final EnvelopeSender envelopeSender =
         new EnvelopeSender(
-            hub, options.getSerializer(), options.getLogger(), options.getFlushTimeoutMillis());
+            hub,
+            options.getSerializer(),
+            options.getLogger(),
+            options.getFlushTimeoutMillis(),
+            options.getMaxQueueSize());
 
     return processDir(envelopeSender, dirPath, options.getLogger());
   }

--- a/sentry/src/main/java/io/sentry/SendFireAndForgetOutboxSender.java
+++ b/sentry/src/main/java/io/sentry/SendFireAndForgetOutboxSender.java
@@ -37,7 +37,8 @@ public final class SendFireAndForgetOutboxSender
             options.getEnvelopeReader(),
             options.getSerializer(),
             options.getLogger(),
-            options.getFlushTimeoutMillis());
+            options.getFlushTimeoutMillis(),
+            options.getMaxQueueSize());
 
     return processDir(outboxSender, dirPath, options.getLogger());
   }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -9,6 +9,7 @@ import io.sentry.protocol.Contexts;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.transport.ITransport;
+import io.sentry.transport.RateLimiter;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
@@ -817,6 +818,11 @@ public final class SentryClient implements ISentryClient {
   @Override
   public void flush(final long timeoutMillis) {
     transport.flush(timeoutMillis);
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    return transport.getRateLimiter();
   }
 
   private boolean sample() {

--- a/sentry/src/main/java/io/sentry/TypeCheckHint.java
+++ b/sentry/src/main/java/io/sentry/TypeCheckHint.java
@@ -13,9 +13,6 @@ public final class TypeCheckHint {
   @ApiStatus.Internal
   public static final String SENTRY_EVENT_DROP_REASON = "sentry:eventDropReason";
 
-  @ApiStatus.Internal
-  public static final String SENTRY_CACHED_ENVELOPE_FILE_PATH = "sentry:cachedEnvelopeFilePath";
-
   @ApiStatus.Internal public static final String SENTRY_JAVASCRIPT_SDK_NAME = "sentry.javascript";
 
   @ApiStatus.Internal public static final String SENTRY_DOTNET_SDK_NAME = "sentry.dotnet";

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -163,7 +163,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     // TODO: probably we need to update the current session file for session updates to because of
     // hardcrash events
 
-    final File envelopeFile = getEnvelopeFile(envelope, hint);
+    final File envelopeFile = getEnvelopeFile(envelope);
     if (envelopeFile.exists()) {
       options
           .getLogger()
@@ -339,7 +339,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
   public void discard(final @NotNull SentryEnvelope envelope, final @NotNull Hint hint) {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
-    final File envelopeFile = getEnvelopeFile(envelope, hint);
+    final File envelopeFile = getEnvelopeFile(envelope);
     if (envelopeFile.exists()) {
       options
           .getLogger()
@@ -363,25 +363,18 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
    * @return the file
    */
   private synchronized @NotNull File getEnvelopeFile(
-      final @NotNull SentryEnvelope envelope, final @NotNull Hint hint) {
+      final @NotNull SentryEnvelope envelope) {
     String fileName;
     if (fileNameMap.containsKey(envelope)) {
       fileName = fileNameMap.get(envelope);
     } else {
-      final @Nullable Object cachedFilePath =
-          hint.get(TypeCheckHint.SENTRY_CACHED_ENVELOPE_FILE_PATH);
-      if (cachedFilePath instanceof String) {
-        fileName = (String) cachedFilePath;
-        fileNameMap.put(envelope, fileName);
+      if (envelope.getHeader().getEventId() != null) {
+        fileName = envelope.getHeader().getEventId().toString();
       } else {
-        if (envelope.getHeader().getEventId() != null) {
-          fileName = envelope.getHeader().getEventId().toString();
-        } else {
-          fileName = UUID.randomUUID().toString();
-        }
-        fileName += SUFFIX_ENVELOPE_FILE;
-        fileNameMap.put(envelope, fileName);
+        fileName = UUID.randomUUID().toString();
       }
+      fileName += SUFFIX_ENVELOPE_FILE;
+      fileNameMap.put(envelope, fileName);
     }
 
     return new File(directory.getAbsolutePath(), fileName);

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -16,7 +16,6 @@ import io.sentry.SentryItemType;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.Session;
-import io.sentry.TypeCheckHint;
 import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.SessionEnd;
@@ -362,8 +361,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
    * @param envelope the SentryEnvelope object
    * @return the file
    */
-  private synchronized @NotNull File getEnvelopeFile(
-      final @NotNull SentryEnvelope envelope) {
+  private synchronized @NotNull File getEnvelopeFile(final @NotNull SentryEnvelope envelope) {
     String fileName;
     if (fileNameMap.containsKey(envelope)) {
       fileName = fileNameMap.get(envelope);

--- a/sentry/src/main/java/io/sentry/hints/Enqueable.java
+++ b/sentry/src/main/java/io/sentry/hints/Enqueable.java
@@ -1,0 +1,5 @@
+package io.sentry.hints;
+
+public interface Enqueable {
+  void markEnqueued();
+}

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -136,6 +136,11 @@ public final class AsyncHttpTransport implements ITransport {
   }
 
   @Override
+  public @NotNull RateLimiter getRateLimiter() {
+    return rateLimiter;
+  }
+
+  @Override
   public void close() throws IOException {
     executor.shutdown();
     options.getLogger().log(SentryLevel.DEBUG, "Shutting down");

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -13,6 +13,7 @@ import io.sentry.cache.IEnvelopeCache;
 import io.sentry.clientreport.DiscardReason;
 import io.sentry.hints.Cached;
 import io.sentry.hints.DiskFlushNotification;
+import io.sentry.hints.Enqueable;
 import io.sentry.hints.Retryable;
 import io.sentry.hints.SubmissionResult;
 import io.sentry.util.HintUtils;
@@ -103,6 +104,11 @@ public final class AsyncHttpTransport implements ITransport {
         options
             .getClientReportRecorder()
             .recordLostEnvelope(DiscardReason.QUEUE_OVERFLOW, envelopeThatMayIncludeClientReport);
+      } else {
+        HintUtils.runIfHasType(hint, Enqueable.class, enqueable -> {
+          enqueable.markEnqueued();
+          options.getLogger().log(SentryLevel.DEBUG, "Envelope enqueued");
+        });
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -105,10 +105,13 @@ public final class AsyncHttpTransport implements ITransport {
             .getClientReportRecorder()
             .recordLostEnvelope(DiscardReason.QUEUE_OVERFLOW, envelopeThatMayIncludeClientReport);
       } else {
-        HintUtils.runIfHasType(hint, Enqueable.class, enqueable -> {
-          enqueable.markEnqueued();
-          options.getLogger().log(SentryLevel.DEBUG, "Envelope enqueued");
-        });
+        HintUtils.runIfHasType(
+            hint,
+            Enqueable.class,
+            enqueable -> {
+              enqueable.markEnqueued();
+              options.getLogger().log(SentryLevel.DEBUG, "Envelope enqueued");
+            });
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/transport/ITransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ITransport.java
@@ -5,6 +5,7 @@ import io.sentry.SentryEnvelope;
 import java.io.Closeable;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** A transport is in charge of sending the event to the Sentry server. */
 public interface ITransport extends Closeable {
@@ -20,4 +21,7 @@ public interface ITransport extends Closeable {
    * @param timeoutMillis time in milliseconds
    */
   void flush(long timeoutMillis);
+
+  @Nullable
+  RateLimiter getRateLimiter();
 }

--- a/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
@@ -5,6 +5,7 @@ import io.sentry.SentryEnvelope;
 import java.io.IOException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class NoOpTransport implements ITransport {
@@ -23,6 +24,11 @@ public final class NoOpTransport implements ITransport {
 
   @Override
   public void flush(long timeoutMillis) {}
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    return null;
+  }
 
   @Override
   public void close() throws IOException {}

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -131,7 +131,7 @@ public final class RateLimiter {
    * @return true if retry after or false otherwise
    */
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
-  public boolean isRetryAfter(final @NotNull String itemType) {
+  private boolean isRetryAfter(final @NotNull String itemType) {
     final DataCategory dataCategory = getCategoryFromItemType(itemType);
     return isActiveForCategory(dataCategory);
   }

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -48,7 +48,7 @@ public final class RateLimiter {
     // Optimize for/No allocations if no items are under 429
     List<SentryEnvelopeItem> dropItems = null;
     for (SentryEnvelopeItem item : envelope.getItems()) {
-      //       using the raw value of the enum to not expose SentryEnvelopeItemType
+      // using the raw value of the enum to not expose SentryEnvelopeItemType
       if (isRetryAfter(item.getHeader().getType().getItemType())) {
         if (dropItems == null) {
           dropItems = new ArrayList<>();
@@ -87,31 +87,8 @@ public final class RateLimiter {
     return envelope;
   }
 
-  @Nullable
-  public Date getRateLimitedUntilFor(final @NotNull String itemType) {
-    return null;
-  }
-
-  /**
-   * It marks the hint when sending has failed, so it's not necessary to wait the timeout
-   *
-   * @param hint the Hints
-   * @param retry if event should be retried or not
-   */
-  private static void markHintWhenSendingFailed(final @NotNull Hint hint, final boolean retry) {
-    HintUtils.runIfHasType(hint, SubmissionResult.class, result -> result.setResult(false));
-    HintUtils.runIfHasType(hint, Retryable.class, retryable -> retryable.setRetry(retry));
-  }
-
-  /**
-   * Check if an itemType is retry after or not
-   *
-   * @param itemType the itemType (eg event, session, etc...)
-   * @return true if retry after or false otherwise
-   */
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
-  private boolean isRetryAfter(final @NotNull String itemType) {
-    final DataCategory dataCategory = getCategoryFromItemType(itemType);
+  public boolean isActiveForCategory(final @NotNull DataCategory dataCategory) {
     final Date currentDate = new Date(currentDateProvider.getCurrentTimeMillis());
 
     // check all categories
@@ -134,6 +111,29 @@ public final class RateLimiter {
     }
 
     return false;
+  }
+
+  /**
+   * It marks the hint when sending has failed, so it's not necessary to wait the timeout
+   *
+   * @param hint the Hints
+   * @param retry if event should be retried or not
+   */
+  private static void markHintWhenSendingFailed(final @NotNull Hint hint, final boolean retry) {
+    HintUtils.runIfHasType(hint, SubmissionResult.class, result -> result.setResult(false));
+    HintUtils.runIfHasType(hint, Retryable.class, retryable -> retryable.setRetry(retry));
+  }
+
+  /**
+   * Check if an itemType is retry after or not
+   *
+   * @param itemType the itemType (eg event, session, etc...)
+   * @return true if retry after or false otherwise
+   */
+  @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
+  private boolean isRetryAfter(final @NotNull String itemType) {
+    final DataCategory dataCategory = getCategoryFromItemType(itemType);
+    return isActiveForCategory(dataCategory);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -131,7 +131,7 @@ public final class RateLimiter {
    * @return true if retry after or false otherwise
    */
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
-  private boolean isRetryAfter(final @NotNull String itemType) {
+  public boolean isRetryAfter(final @NotNull String itemType) {
     final DataCategory dataCategory = getCategoryFromItemType(itemType);
     return isActiveForCategory(dataCategory);
   }

--- a/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
@@ -6,6 +6,7 @@ import io.sentry.SentryEnvelope;
 import io.sentry.util.Objects;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class StdoutTransport implements ITransport {
 
@@ -31,6 +32,11 @@ public final class StdoutTransport implements ITransport {
   @Override
   public void flush(long timeoutMillis) {
     System.out.println("Flushing");
+  }
+
+  @Override
+  public @Nullable RateLimiter getRateLimiter() {
+    return null;
   }
 
   @Override

--- a/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
@@ -33,10 +33,10 @@ class EnvelopeSenderTest {
 
         fun getSut(): EnvelopeSender {
             return EnvelopeSender(
-              hub!!,
-              serializer!!,
-              logger!!,
-              options.flushTimeoutMillis
+                hub!!,
+                serializer!!,
+                logger!!,
+                options.flushTimeoutMillis
             )
         }
     }

--- a/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
@@ -33,11 +33,10 @@ class EnvelopeSenderTest {
 
         fun getSut(): EnvelopeSender {
             return EnvelopeSender(
-                hub!!,
-                serializer!!,
-                logger!!,
-                options.flushTimeoutMillis,
-                options.envelopeDiskCache
+              hub!!,
+              serializer!!,
+              logger!!,
+              options.flushTimeoutMillis
             )
         }
     }

--- a/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/EnvelopeSenderTest.kt
@@ -5,9 +5,11 @@ import io.sentry.hints.Retryable
 import io.sentry.util.HintUtils
 import io.sentry.util.noFlushTimeout
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -36,7 +38,8 @@ class EnvelopeSenderTest {
                 hub!!,
                 serializer!!,
                 logger!!,
-                options.flushTimeoutMillis
+                options.flushTimeoutMillis,
+                options.maxQueueSize
             )
         }
     }
@@ -79,7 +82,7 @@ class EnvelopeSenderTest {
         sut.processDirectory(File(tempDirectory.toUri()))
         testFile.deleteOnExit()
         verify(fixture.logger)!!.log(eq(SentryLevel.DEBUG), eq("File '%s' doesn't match extension expected."), any<Any>())
-        verifyNoMoreInteractions(fixture.hub)
+        verify(fixture.hub, never())!!.captureEnvelope(any(), anyOrNull())
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -22,7 +22,6 @@ import java.util.Date
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -42,7 +41,7 @@ class OutboxSenderTest {
         }
 
         fun getSut(): OutboxSender {
-            return OutboxSender(hub, envelopeReader, serializer, logger, 15000)
+            return OutboxSender(hub, envelopeReader, serializer, logger, 15000, 30)
         }
     }
 
@@ -273,38 +272,6 @@ class OutboxSenderTest {
         val hints = HintUtils.createWithTypeCheckHint(mock<Retryable>())
         sut.processEnvelopeFile(File.separator + "i-hope-it-doesnt-exist" + File.separator + "file.txt", hints)
         verify(fixture.logger).log(eq(SentryLevel.ERROR), any<String>(), argWhere { it is FileNotFoundException })
-    }
-
-    @Test
-    fun `when hub is null, ctor throws`() {
-        val clazz = Class.forName("io.sentry.OutboxSender")
-        val ctor = clazz.getConstructor(IHub::class.java, IEnvelopeReader::class.java, ISerializer::class.java, ILogger::class.java, Long::class.java)
-        val params = arrayOf(null, mock<IEnvelopeReader>(), mock<ISerializer>(), mock<ILogger>(), null)
-        assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
-    }
-
-    @Test
-    fun `when envelopeReader is null, ctor throws`() {
-        val clazz = Class.forName("io.sentry.OutboxSender")
-        val ctor = clazz.getConstructor(IHub::class.java, IEnvelopeReader::class.java, ISerializer::class.java, ILogger::class.java, Long::class.java)
-        val params = arrayOf(mock<IHub>(), null, mock<ISerializer>(), mock<ILogger>(), 15000)
-        assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
-    }
-
-    @Test
-    fun `when serializer is null, ctor throws`() {
-        val clazz = Class.forName("io.sentry.OutboxSender")
-        val ctor = clazz.getConstructor(IHub::class.java, IEnvelopeReader::class.java, ISerializer::class.java, ILogger::class.java, Long::class.java)
-        val params = arrayOf(mock<IHub>(), mock<IEnvelopeReader>(), null, mock<ILogger>(), 15000)
-        assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
-    }
-
-    @Test
-    fun `when logger is null, ctor throws`() {
-        val clazz = Class.forName("io.sentry.OutboxSender")
-        val ctor = clazz.getConstructor(IHub::class.java, IEnvelopeReader::class.java, ISerializer::class.java, ILogger::class.java, Long::class.java)
-        val params = arrayOf(mock<IHub>(), mock<IEnvelopeReader>(), mock<ISerializer>(), null, 15000)
-        assertFailsWith<IllegalArgumentException> { ctor.newInstance(params) }
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Expose RateLimiter via Hub to let SendCachedEnvelope integrations decide if they should send envelopes now or later.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/1926

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
