### PR TITLE
event builder

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -1,8 +1,10 @@
 package io.sentry;
 
+import io.sentry.builder.EventBuilder;
 import io.sentry.protocol.*;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -10,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -86,6 +89,10 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
   SentryEvent(final @NotNull SentryId eventId, final @NotNull Date timestamp) {
     super(eventId);
     this.timestamp = timestamp;
+  }
+
+  public static EventBuilder builder() {
+    return new EventBuilder(new SentryEvent());
   }
 
   /**
@@ -218,8 +225,8 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
     if (exception != null) {
       for (SentryException e : exception.getValues()) {
         if (e.getMechanism() != null
-            && e.getMechanism().isHandled() != null
-            && !e.getMechanism().isHandled()) {
+          && e.getMechanism().isHandled() != null
+          && !e.getMechanism().isHandled()) {
           return e;
         }
       }
@@ -252,7 +259,7 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
 
   @Override
   public void serialize(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
-      throws IOException {
+    throws IOException {
     writer.beginObject();
     writer.name(JsonKeys.TIMESTAMP).value(logger, timestamp);
     if (message != null) {
@@ -312,7 +319,7 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
     @SuppressWarnings("unchecked")
     @Override
     public @NotNull SentryEvent deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+      @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       SentryEvent event = new SentryEvent();
       Map<String, Object> unknown = null;
@@ -338,14 +345,14 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
             reader.beginObject();
             reader.nextName(); // SentryValues.JsonKeys.VALUES
             event.threads =
-                new SentryValues<>(reader.nextList(logger, new SentryThread.Deserializer()));
+              new SentryValues<>(reader.nextList(logger, new SentryThread.Deserializer()));
             reader.endObject();
             break;
           case JsonKeys.EXCEPTION:
             reader.beginObject();
             reader.nextName(); // SentryValues.JsonKeys.VALUES
             event.exception =
-                new SentryValues<>(reader.nextList(logger, new SentryException.Deserializer()));
+              new SentryValues<>(reader.nextList(logger, new SentryException.Deserializer()));
             reader.endObject();
             break;
           case JsonKeys.LEVEL:
@@ -362,7 +369,7 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
             break;
           case JsonKeys.MODULES:
             Map<String, String> deserializedModules =
-                (Map<String, String>) reader.nextObjectOrNull();
+              (Map<String, String>) reader.nextObjectOrNull();
             event.modules = CollectionUtils.newConcurrentHashMap(deserializedModules);
             break;
           default:

--- a/sentry/src/main/java/io/sentry/builder/EventBuilder.java
+++ b/sentry/src/main/java/io/sentry/builder/EventBuilder.java
@@ -1,0 +1,256 @@
+package io.sentry.builder;
+
+import io.sentry.Breadcrumb;
+import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+import io.sentry.SentryLevel;
+import io.sentry.protocol.Geo;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryId;
+import io.sentry.protocol.User;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class EventBuilder {
+
+//  public static void main(String[] args) {
+//
+//    SentryEvent.builder()
+//      .withMessage(m -> m.value("message"))
+//      .withThrowable(new RuntimeException("test"))
+//      .withUser(u -> u.withId("userId"))
+//      .withLevel(SentryLevel.FATAL)
+//      .captureEvent();
+//
+//  }
+
+  private final SentryEvent event;
+
+  public EventBuilder(SentryEvent event) {
+    this.event = event;
+  }
+
+  public EventBuilder withThrowable(Throwable throwable) {
+    event.setThrowable(throwable);
+    return this;
+  }
+
+  public EventBuilder withUser(Function<UserBuilder, UserBuilder> function) {
+
+    User user = event.getUser();
+
+    if (user == null) {
+      user = new User();
+    }
+
+    event.setUser(function.apply(new UserBuilder(user)).build());
+
+    return this;
+  }
+
+  public EventBuilder withMessage(Function<MessageBuilder, MessageBuilder> consumer) {
+    event.setMessage(consumer.apply(new MessageBuilder(new Message()))
+      .build());
+    return this;
+  }
+
+  public EventBuilder withFingerprint(String fingerprint) {
+    if (event.getFingerprints() == null) {
+      event.setFingerprints(new ArrayList<>());
+    }
+
+    event.getFingerprints().add(fingerprint);
+
+    return this;
+  }
+
+  public EventBuilder withFingerprints(Collection<String> fingerprints) {
+
+    if (event.getFingerprints() == null) {
+      event.setFingerprints(new ArrayList<>(fingerprints));
+      return this;
+    }
+
+    event.getFingerprints().addAll(fingerprints);
+
+    return this;
+  }
+
+  public EventBuilder withExtra(String key, Object value) {
+    event.setExtra(key, value);
+    return this;
+  }
+
+  public EventBuilder withEnvironment(String environment) {
+    event.setEnvironment(environment);
+    return this;
+  }
+
+  public EventBuilder withRelease(String release) {
+    event.setRelease(release);
+    return this;
+  }
+
+  public EventBuilder withDist(String dist) {
+    event.setDist(dist);
+    return this;
+  }
+
+  public EventBuilder withPlatform(String platform) {
+    event.setPlatform(platform);
+    return this;
+  }
+
+  public EventBuilder withServerName(String serverName) {
+    event.setServerName(serverName);
+    return this;
+  }
+
+  public EventBuilder withLogger(String logger) {
+    event.setLogger(logger);
+    return this;
+  }
+
+  public EventBuilder withLevel(SentryLevel level) {
+    event.setLevel(level);
+    return this;
+  }
+
+  public EventBuilder withTransaction(String transaction) {
+    event.setTransaction(transaction);
+    return this;
+  }
+
+  public EventBuilder withTag(String key, String value) {
+
+    if (event.getTags() == null) {
+      event.setTags(new HashMap<>());
+    }
+
+    event.getTags().put(key, value);
+    return this;
+  }
+
+  public EventBuilder withBreadcrumb(Breadcrumb breadcrumb) {
+    if (event.getBreadcrumbs() == null) {
+      event.setBreadcrumbs(new ArrayList<>());
+    }
+
+    event.getBreadcrumbs().add(breadcrumb);
+
+    return this;
+  }
+
+  public EventBuilder withMessage(String message) {
+    Message m = new Message();
+    m.setMessage(message);
+
+    event.setMessage(m);
+
+    return this;
+  }
+
+  public SentryEvent build() {
+    return event;
+  }
+
+  public SentryId captureEvent() {
+    return Sentry.captureEvent(build());
+  }
+
+  public static class UserBuilder {
+
+    private final User user;
+
+    public UserBuilder(User user) {
+      this.user = user;
+    }
+
+    public UserBuilder withId(String id) {
+      user.setId(id);
+      return this;
+    }
+
+    public UserBuilder withUsername(String username) {
+      user.setUsername(username);
+      return this;
+    }
+
+    public UserBuilder withIpAddress(String ipAddress) {
+      user.setIpAddress(ipAddress);
+      return this;
+    }
+
+    public UserBuilder withEmail(String email) {
+      user.setEmail(email);
+      return this;
+    }
+
+    public UserBuilder withData(Map<String, String> data) {
+      user.setData(data);
+      return this;
+    }
+
+    public UserBuilder withGeo(@NotNull Function<GeoBuilder, Geo> function) {
+      user.setGeo(function.apply(new GeoBuilder()));
+      return this;
+    }
+
+    public User build() {
+      return user;
+    }
+  }
+
+  public static class GeoBuilder {
+    private final Geo geo;
+
+    public GeoBuilder() {
+      this.geo = new Geo();
+    }
+
+    public GeoBuilder withCountryCode(String countryCode) {
+      geo.setCountryCode(countryCode);
+      return this;
+    }
+
+    public GeoBuilder withRegion(String region) {
+      geo.setRegion(region);
+      return this;
+    }
+
+    public GeoBuilder withCity(String city) {
+      geo.setCity(city);
+      return this;
+    }
+
+    public Geo build() {
+      return geo;
+    }
+  }
+
+  public static class MessageBuilder {
+
+    private final Message message;
+
+    public MessageBuilder(Message message) {
+      this.message = message;
+    }
+
+    public MessageBuilder value(String value) {
+      message.setMessage(value);
+      return this;
+    }
+
+
+    public Message build() {
+      return message;
+    }
+
+  }
+
+}


### PR DESCRIPTION
Sentry captures exceptions almost automatically and that's awesome, but sometimes we need to create events manually.

This PR Adds the ability to create and capture events using a builder pattern.

Examples:

```java
SentryEvent.builder()
      .withMessage(m -> m.value("message"))
      .withThrowable(new RuntimeException("test"))
      .withUser(u -> u.withId("userId"))
      .withLevel(SentryLevel.FATAL)
      .captureEvent();
```

```java
SentryEvent.builder()
      .withMessage(m -> m.value("message"))
      .withUser(u -> u.withId("userId"))
      .captureEvent();
```