### PR TITLE
Add `CheckInUtils.withCheckIn` which abstracts away some of the manual check-ins complexity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `CheckInUtils.withCheckIn` which abstracts away some of the manual check-ins complexity ([#2959](https://github.com/getsentry/sentry-java/pull/2959))
+
 ## 6.30.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4317,6 +4317,7 @@ public abstract class io/sentry/transport/TransportResult {
 public final class io/sentry/util/CheckInUtils {
 	public fun <init> ()V
 	public static fun isIgnored (Ljava/util/List;Ljava/lang/String;)Z
+	public static fun withCheckIn (Ljava/lang/String;Ljava/util/concurrent/Callable;)Ljava/lang/Object;
 }
 
 public final class io/sentry/util/ClassLoaderUtils {

--- a/sentry/src/main/java/io/sentry/util/CheckInUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CheckInUtils.java
@@ -1,14 +1,54 @@
 package io.sentry.util;
 
+import io.sentry.CheckIn;
+import io.sentry.CheckInStatus;
+import io.sentry.DateUtils;
+import io.sentry.IHub;
+import io.sentry.Sentry;
+import io.sentry.protocol.SentryId;
 import java.util.List;
+import java.util.concurrent.Callable;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/** Checks if a check-in for a monitor (CRON) has been ignored. */
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class CheckInUtils {
 
+  /**
+   * Helper method to send monitor check-ins for a {@link Callable}
+   *
+   * @param callable - the {@link Callable} to be called
+   * @return the return value of the {@link Callable}
+   * @param <U> - the result type of the {@link Callable}
+   */
+  public static <U> U withCheckIn(
+      final @NotNull String monitorSlug, final @NotNull Callable<U> callable) throws Exception {
+    final @NotNull IHub hub = Sentry.getCurrentHub();
+    final long startTime = System.currentTimeMillis();
+    boolean didError = false;
+
+    hub.pushScope();
+    TracingUtils.startNewTrace(hub);
+
+    @Nullable
+    SentryId checkInId = hub.captureCheckIn(new CheckIn(monitorSlug, CheckInStatus.IN_PROGRESS));
+    try {
+      return callable.call();
+    } catch (Throwable t) {
+      didError = true;
+      throw t;
+    } finally {
+      final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
+      CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
+      checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
+      hub.captureCheckIn(checkIn);
+      hub.popScope();
+    }
+  }
+
+  /** Checks if a check-in for a monitor (CRON) has been ignored. */
+  @ApiStatus.Internal
   public static boolean isIgnored(
       final @Nullable List<String> ignoredSlugs, final @NotNull String slug) {
     if (ignoredSlugs == null || ignoredSlugs.isEmpty()) {

--- a/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
@@ -1,6 +1,17 @@
 package io.sentry.util
 
+import io.sentry.CheckInStatus
+import io.sentry.IHub
+import io.sentry.Sentry
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import java.lang.AssertionError
+import java.lang.RuntimeException
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -34,5 +45,70 @@ class CheckInUtilsTest {
     @Test
     fun `does not ignore if slug is does not match ignored list`() {
         assertFalse(CheckInUtils.isIgnored(listOf("slug-.*"), "slugA"))
+    }
+
+    @Test
+    fun `sends check-in for wrapped supplier`() {
+        Mockito.mockStatic(Sentry::class.java).use { sentry ->
+            val hub = mock<IHub>()
+            sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            val returnValue = CheckInUtils.withCheckIn("monitor-1") {
+                return@withCheckIn "test1"
+            }
+
+            assertEquals("test1", returnValue)
+            inOrder(hub) {
+                verify(hub).pushScope()
+                verify(hub).configureScope(any())
+                verify(hub).captureCheckIn(
+                    check {
+                        assertEquals("monitor-1", it.monitorSlug)
+                        assertEquals(CheckInStatus.IN_PROGRESS.apiName(), it.status)
+                    }
+                )
+                verify(hub).captureCheckIn(
+                    check {
+                        assertEquals("monitor-1", it.monitorSlug)
+                        assertEquals(CheckInStatus.OK.apiName(), it.status)
+                    }
+                )
+                verify(hub).popScope()
+            }
+        }
+    }
+
+    @Test
+    fun `sends check-in for wrapped supplier with exception`() {
+        Mockito.mockStatic(Sentry::class.java).use { sentry ->
+            val hub = mock<IHub>()
+            sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+
+            try {
+                CheckInUtils.withCheckIn("monitor-1") {
+                    throw RuntimeException("thrown on purpose")
+                }
+                throw AssertionError("expected exception to be rethrown")
+            } catch (e: Exception) {
+                assertEquals("thrown on purpose", e.message)
+            }
+
+            inOrder(hub) {
+                verify(hub).pushScope()
+                verify(hub).configureScope(any())
+                verify(hub).captureCheckIn(
+                    check {
+                        assertEquals("monitor-1", it.monitorSlug)
+                        assertEquals(CheckInStatus.IN_PROGRESS.apiName(), it.status)
+                    }
+                )
+                verify(hub).captureCheckIn(
+                    check {
+                        assertEquals("monitor-1", it.monitorSlug)
+                        assertEquals(CheckInStatus.ERROR.apiName(), it.status)
+                    }
+                )
+                verify(hub).popScope()
+            }
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
A util class that send a check-in (`IN_PROGRESS`) before the code being passed in is executed and another check-in (`OK` or `ERROR`) once the code has completed. It also starts a new trace.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplifies manual check-ins.

## :green_heart: How did you test it?
Manually + unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
