### PR TITLE
SentryOkHttpEvent report exceptions only on the call root span

### DIFF
--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpEvent.kt
@@ -29,6 +29,7 @@ private const val ERROR_MESSAGE_KEY = "error_message"
 private const val RESPONSE_BODY_TIMEOUT_MILLIS = 500L
 internal const val TRACE_ORIGIN = "auto.http.okhttp"
 
+@Suppress("TooManyFunctions")
 internal class SentryOkHttpEvent(private val hub: IHub, private val request: Request) {
     private val eventSpans: MutableMap<String, ISpan> = ConcurrentHashMap()
     private val breadcrumb: Breadcrumb
@@ -119,8 +120,10 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         val span = eventSpans[event] ?: return null
         val parentSpan = findParentSpan(event)
         beforeFinish?.invoke(span)
+        moveThrowableToRootSpan(span)
         if (parentSpan != null && parentSpan != callRootSpan) {
             beforeFinish?.invoke(parentSpan)
+            moveThrowableToRootSpan(parentSpan)
         }
         callRootSpan?.let { beforeFinish?.invoke(it) }
         span.finish()
@@ -134,7 +137,9 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         // We forcefully finish all spans, even if they should already have been finished through finishSpan()
         eventSpans.values.filter { !it.isFinished }.forEach {
             // If a status was set on the span, we use that, otherwise we set its status as error.
-            it.finish(it.status ?: SpanStatus.INTERNAL_ERROR)
+            it.status = it.status ?: SpanStatus.INTERNAL_ERROR
+            moveThrowableToRootSpan(it)
+            it.finish()
         }
         beforeFinish?.invoke(callRootSpan)
         if (finishDate != null) {
@@ -150,6 +155,15 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
 
         hub.addBreadcrumb(breadcrumb, hint)
         return
+    }
+
+    /** Move any throwable from an inner span to the call root span. */
+    private fun moveThrowableToRootSpan(span: ISpan) {
+        if (span != callRootSpan && span.throwable != null && span.status != null) {
+            callRootSpan?.throwable = span.throwable
+            callRootSpan?.status = span.status
+            span.throwable = null
+        }
     }
 
     private fun findParentSpan(event: String): ISpan? = when (event) {

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -38,6 +38,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
+import kotlin.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -482,6 +483,7 @@ class SentryOkHttpEventTest {
         sut.finishSpan(REQUEST_HEADERS_EVENT) { it.status = SpanStatus.INTERNAL_ERROR }
         sut.finishSpan("random event") { it.status = SpanStatus.DEADLINE_EXCEEDED }
         sut.finishSpan(CONNECTION_EVENT)
+        sut.finishEvent()
         val spans = sut.getEventSpans()
         val connectionSpan = spans[CONNECTION_EVENT] as Span?
         val requestHeadersSpan = spans[REQUEST_HEADERS_EVENT] as Span?
@@ -497,6 +499,34 @@ class SentryOkHttpEventTest {
         assertEquals(SpanStatus.INTERNAL_ERROR, connectionSpan.status)
         // random event was finished last with DEADLINE_EXCEEDED, and it propagates to root call
         assertEquals(SpanStatus.DEADLINE_EXCEEDED, sut.callRootSpan!!.status)
+    }
+
+    @Test
+    fun `finishEvent moves throwables from inner span to call root span`() {
+        val sut = fixture.getSut()
+        val throwable = RuntimeException()
+        sut.startSpan(CONNECTION_EVENT)
+        sut.startSpan("random event")
+        sut.finishSpan("random event") { it.status = SpanStatus.DEADLINE_EXCEEDED }
+        sut.finishSpan(CONNECTION_EVENT) {
+            it.status = SpanStatus.INTERNAL_ERROR
+            it.throwable = throwable
+        }
+        sut.finishEvent()
+        val spans = sut.getEventSpans()
+        val connectionSpan = spans[CONNECTION_EVENT] as Span?
+        val randomEventSpan = spans["random event"] as Span?
+        assertNotNull(connectionSpan)
+        assertNotNull(randomEventSpan)
+        // randomEventSpan was finished with DEADLINE_EXCEEDED
+        assertEquals(SpanStatus.DEADLINE_EXCEEDED, randomEventSpan.status)
+        // connectionSpan was finished with INTERNAL_ERROR
+        assertEquals(SpanStatus.INTERNAL_ERROR, connectionSpan.status)
+
+        // connectionSpan was finished last with INTERNAL_ERROR and a throwable, and it's moved to the root call
+        assertEquals(SpanStatus.INTERNAL_ERROR, sut.callRootSpan!!.status)
+        assertEquals(throwable, sut.callRootSpan.throwable)
+        assertNull(connectionSpan.throwable)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
SentryOkHttpEvent now shows exceptions only on the call root span


## :bulb: Motivation and Context
Having the expection shown in the inner spans of the http call could be confusing, as in https://github.com/sentry-demos/android/issues/60


## :green_heart: How did you test it?
Unit

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
