### PR TITLE
Improve start transaction overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Breaking changes:**
+- Cleanup `startTransaction` overloads ([#2964](https://github.com/getsentry/sentry-java/pull/2964))
+  - We have reduce the number of overloads by allowing to pass in `TransactionOptions` instead of having separate parameters for certain options.
+  - `TransactionOptions` has defaults set and can be customized
+
 ## 7.0.0-beta.1
 
 ### Features

--- a/sentry-samples/sentry-samples-openfeign/src/main/java/io/sentry/samples/openfeign/Main.java
+++ b/sentry-samples/sentry-samples-openfeign/src/main/java/io/sentry/samples/openfeign/Main.java
@@ -7,6 +7,7 @@ import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
+import io.sentry.TransactionOptions;
 import io.sentry.openfeign.SentryCapability;
 import java.util.List;
 
@@ -40,7 +41,10 @@ public class Main {
             .decoder(new GsonDecoder())
             .target(TodoApi.class, "https://jsonplaceholder.typicode.com/");
 
-    final ITransaction transaction = Sentry.startTransaction("load-todos2", "console", true);
+    final TransactionOptions transactionOptions = new TransactionOptions();
+    transactionOptions.setBindToScope(true);
+    final ITransaction transaction =
+        Sentry.startTransaction("load-todos2", "console", transactionOptions);
     final List<Todo> all = todoApi.findAll();
     System.out.println("Loaded " + all.size() + " todos");
     System.out.println(todoApi.findById(1L));

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -448,7 +448,6 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
@@ -499,8 +498,6 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
-	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
@@ -596,14 +593,9 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
 	public abstract fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
-	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
 	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Z)Lio/sentry/ITransaction;
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ITransaction;
-	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
-	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
-	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
+	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public abstract fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -1086,8 +1078,6 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
-	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
-	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
@@ -1571,16 +1561,10 @@ public final class io/sentry/Sentry {
 	public static fun setUser (Lio/sentry/protocol/User;)V
 	public static fun startSession ()V
 	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
 	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Lio/sentry/TransactionContext;Z)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/CustomSamplingContext;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/CustomSamplingContext;Z)Lio/sentry/ITransaction;
-	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ITransaction;
-	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
-	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/ITransaction;
+	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
+	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public static fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public static fun withScope (Lio/sentry/ScopeCallback;)V
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -676,24 +676,10 @@ public final class Hub implements IHub {
     return sentryId;
   }
 
-  @ApiStatus.Internal
   @Override
   public @NotNull ITransaction startTransaction(
       final @NotNull TransactionContext transactionContext,
       final @NotNull TransactionOptions transactionOptions) {
-    return createTransaction(transactionContext, transactionOptions);
-  }
-
-  @Override
-  public @NotNull ITransaction startTransaction(
-      final @NotNull TransactionContext transactionContext,
-      final @Nullable CustomSamplingContext customSamplingContext,
-      final boolean bindToScope) {
-
-    final TransactionOptions transactionOptions = new TransactionOptions();
-    transactionOptions.setCustomSamplingContext(customSamplingContext);
-    transactionOptions.setBindToScope(bindToScope);
-
     return createTransaction(transactionContext, transactionOptions);
   }
 

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -189,19 +189,6 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public @NotNull ITransaction startTransaction(@NotNull TransactionContext transactionContexts) {
-    return Sentry.startTransaction(transactionContexts);
-  }
-
-  @Override
-  public @NotNull ITransaction startTransaction(
-      @NotNull TransactionContext transactionContexts,
-      @Nullable CustomSamplingContext customSamplingContext,
-      boolean bindToScope) {
-    return Sentry.startTransaction(transactionContexts, customSamplingContext, bindToScope);
-  }
-
-  @Override
   public @NotNull ITransaction startTransaction(
       @NotNull TransactionContext transactionContext,
       @NotNull TransactionOptions transactionOptions) {

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -404,84 +404,8 @@ public interface IHub {
    * @return created transaction
    */
   default @NotNull ITransaction startTransaction(@NotNull TransactionContext transactionContexts) {
-    return startTransaction(transactionContexts, false);
+    return startTransaction(transactionContexts, new TransactionOptions());
   }
-
-  /**
-   * Creates a Transaction and returns the instance.
-   *
-   * @param transactionContexts the transaction contexts
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction
-   */
-  default @NotNull ITransaction startTransaction(
-      @NotNull TransactionContext transactionContexts, boolean bindToScope) {
-    return startTransaction(transactionContexts, null, bindToScope);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed sampling context the
-   * decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param customSamplingContext the sampling context
-   * @return created transaction.
-   */
-  default @NotNull ITransaction startTransaction(
-      @NotNull String name,
-      @NotNull String operation,
-      @Nullable CustomSamplingContext customSamplingContext) {
-    return startTransaction(name, operation, customSamplingContext, false);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed sampling context the
-   * decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param customSamplingContext the sampling context
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction.
-   */
-  default @NotNull ITransaction startTransaction(
-      @NotNull String name,
-      @NotNull String operation,
-      @Nullable CustomSamplingContext customSamplingContext,
-      boolean bindToScope) {
-    return startTransaction(
-        new TransactionContext(name, operation), customSamplingContext, bindToScope);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed transaction and sampling
-   * contexts the decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param transactionContexts the transaction context
-   * @param customSamplingContext the sampling context
-   * @return created transaction.
-   */
-  default @NotNull ITransaction startTransaction(
-      @NotNull TransactionContext transactionContexts,
-      @Nullable CustomSamplingContext customSamplingContext) {
-    return startTransaction(transactionContexts, customSamplingContext, false);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed transaction and sampling
-   * contexts the decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param transactionContexts the transaction context
-   * @param customSamplingContext the sampling context
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction.
-   */
-  @NotNull
-  ITransaction startTransaction(
-      @NotNull TransactionContext transactionContexts,
-      @Nullable CustomSamplingContext customSamplingContext,
-      boolean bindToScope);
 
   /**
    * Creates a Transaction and returns the instance. Based on the {@link
@@ -494,7 +418,24 @@ public interface IHub {
    */
   default @NotNull ITransaction startTransaction(
       final @NotNull String name, final @NotNull String operation) {
-    return startTransaction(name, operation, null);
+    return startTransaction(name, operation, new TransactionOptions());
+  }
+
+  /**
+   * Creates a Transaction and returns the instance. Based on the {@link
+   * SentryOptions#getTracesSampleRate()} the decision if transaction is sampled will be taken by
+   * {@link TracesSampler}.
+   *
+   * @param name the transaction name
+   * @param operation the operation
+   * @param transactionOptions the transaction options
+   * @return created transaction
+   */
+  default @NotNull ITransaction startTransaction(
+      final @NotNull String name,
+      final @NotNull String operation,
+      final @NotNull TransactionOptions transactionOptions) {
+    return startTransaction(new TransactionContext(name, operation), transactionOptions);
   }
 
   /**
@@ -510,21 +451,6 @@ public interface IHub {
   ITransaction startTransaction(
       final @NotNull TransactionContext transactionContext,
       final @NotNull TransactionOptions transactionOptions);
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the {@link
-   * SentryOptions#getTracesSampleRate()} the decision if transaction is sampled will be taken by
-   * {@link TracesSampler}.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction
-   */
-  default @NotNull ITransaction startTransaction(
-      final @NotNull String name, final @NotNull String operation, final boolean bindToScope) {
-    return startTransaction(name, operation, (CustomSamplingContext) null, bindToScope);
-  }
 
   /**
    * Returns the "sentry-trace" header that allows tracing across services. Can also be used in

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -147,19 +147,6 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public @NotNull ITransaction startTransaction(@NotNull TransactionContext transactionContexts) {
-    return NoOpTransaction.getInstance();
-  }
-
-  @Override
-  public @NotNull ITransaction startTransaction(
-      @NotNull TransactionContext transactionContexts,
-      @Nullable CustomSamplingContext customSamplingContext,
-      boolean bindToScope) {
-    return NoOpTransaction.getInstance();
-  }
-
-  @Override
   public @NotNull ITransaction startTransaction(
       @NotNull TransactionContext transactionContext,
       @NotNull TransactionOptions transactionOptions) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -764,27 +764,14 @@ public final class Sentry {
    *
    * @param name the transaction name
    * @param operation the operation
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull String name, final @NotNull String operation, final boolean bindToScope) {
-    return getCurrentHub().startTransaction(name, operation, bindToScope);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param description the description
+   * @param transactionOptions options for the transaction
    * @return created transaction
    */
   public static @NotNull ITransaction startTransaction(
       final @NotNull String name,
       final @NotNull String operation,
-      final @Nullable String description) {
-    return startTransaction(name, operation, description, false);
+      final @NotNull TransactionOptions transactionOptions) {
+    return getCurrentHub().startTransaction(name, operation, transactionOptions);
   }
 
   /**
@@ -793,15 +780,16 @@ public final class Sentry {
    * @param name the transaction name
    * @param operation the operation
    * @param description the description
-   * @param bindToScope if transaction should be bound to scope
+   * @param transactionOptions options for the transaction
    * @return created transaction
    */
   public static @NotNull ITransaction startTransaction(
       final @NotNull String name,
       final @NotNull String operation,
       final @Nullable String description,
-      final boolean bindToScope) {
-    final ITransaction transaction = getCurrentHub().startTransaction(name, operation, bindToScope);
+      final @NotNull TransactionOptions transactionOptions) {
+    final ITransaction transaction =
+        getCurrentHub().startTransaction(name, operation, transactionOptions);
     transaction.setDescription(description);
     return transaction;
   }
@@ -815,83 +803,6 @@ public final class Sentry {
   public static @NotNull ITransaction startTransaction(
       final @NotNull TransactionContext transactionContexts) {
     return getCurrentHub().startTransaction(transactionContexts);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance.
-   *
-   * @param transactionContexts the transaction contexts
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull TransactionContext transactionContexts, boolean bindToScope) {
-    return getCurrentHub().startTransaction(transactionContexts, bindToScope);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed sampling context the
-   * decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param customSamplingContext the sampling context
-   * @return created transaction.
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull String name,
-      final @NotNull String operation,
-      final @NotNull CustomSamplingContext customSamplingContext) {
-    return getCurrentHub().startTransaction(name, operation, customSamplingContext);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed sampling context the
-   * decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param name the transaction name
-   * @param operation the operation
-   * @param customSamplingContext the sampling context
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction.
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull String name,
-      final @NotNull String operation,
-      final @NotNull CustomSamplingContext customSamplingContext,
-      final boolean bindToScope) {
-    return getCurrentHub().startTransaction(name, operation, customSamplingContext, bindToScope);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed transaction and sampling
-   * contexts the decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param transactionContexts the transaction context
-   * @param customSamplingContext the sampling context
-   * @return created transaction.
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull TransactionContext transactionContexts,
-      final @NotNull CustomSamplingContext customSamplingContext) {
-    return getCurrentHub().startTransaction(transactionContexts, customSamplingContext);
-  }
-
-  /**
-   * Creates a Transaction and returns the instance. Based on the passed transaction and sampling
-   * contexts the decision if transaction is sampled will be taken by {@link TracesSampler}.
-   *
-   * @param transactionContexts the transaction context
-   * @param customSamplingContext the sampling context
-   * @param bindToScope if transaction should be bound to scope
-   * @return created transaction.
-   */
-  public static @NotNull ITransaction startTransaction(
-      final @NotNull TransactionContext transactionContexts,
-      final @Nullable CustomSamplingContext customSamplingContext,
-      final boolean bindToScope) {
-    return getCurrentHub()
-        .startTransaction(transactionContexts, customSamplingContext, bindToScope);
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/HubAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/HubAdapterTest.kt
@@ -2,8 +2,10 @@ package io.sentry
 
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -206,10 +208,9 @@ class HubAdapterTest {
         val samplingContext = mock<CustomSamplingContext>()
         val transactionOptions = mock<TransactionOptions>()
         HubAdapter.getInstance().startTransaction(transactionContext)
-        verify(hub).startTransaction(eq(transactionContext))
+        verify(hub).startTransaction(eq(transactionContext), any<TransactionOptions>())
 
-        HubAdapter.getInstance().startTransaction(transactionContext, samplingContext, false)
-        verify(hub).startTransaction(eq(transactionContext), eq(samplingContext), eq(false))
+        reset(hub)
 
         HubAdapter.getInstance().startTransaction(transactionContext, transactionOptions)
         verify(hub).startTransaction(eq(transactionContext), eq(transactionOptions))

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1497,7 +1497,7 @@ class HubTest {
     fun `when startTransaction with bindToScope set to false, transaction is not attached to the scope`() {
         val hub = generateHub()
 
-        hub.startTransaction("name", "op", false)
+        hub.startTransaction("name", "op", TransactionOptions())
 
         hub.configureScope {
             assertNull(it.span)
@@ -1519,7 +1519,7 @@ class HubTest {
     fun `when startTransaction with bindToScope set to true, transaction is attached to the scope`() {
         val hub = generateHub()
 
-        val transaction = hub.startTransaction("name", "op", true)
+        val transaction = hub.startTransaction("name", "op", TransactionOptions().also { it.isBindToScope = true })
 
         hub.configureScope {
             assertEquals(transaction, it.span)
@@ -1595,7 +1595,7 @@ class HubTest {
 
         val sut = Hub(options)
         sut.addBreadcrumb("Test")
-        sut.startTransaction("test", "test.op", true)
+        sut.startTransaction("test", "test.op", TransactionOptions().also { it.isBindToScope = true })
         sut.close()
 
         // we have to clone the scope, so its isEnabled returns true, but it's still built up from

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -240,7 +240,7 @@ class SentryTest {
             it.tracesSampleRate = 1.0
         }
 
-        val transaction = Sentry.startTransaction("name", "op", "desc")
+        val transaction = Sentry.startTransaction("name", "op", "desc", TransactionOptions())
         assertEquals("name", transaction.name)
         assertEquals("op", transaction.operation)
         assertEquals("desc", transaction.description)
@@ -823,7 +823,7 @@ class SentryTest {
             it.sampleRate = 1.0
         }, true)
 
-        val transaction = Sentry.startTransaction("name", "op-root", true)
+        val transaction = Sentry.startTransaction("name", "op-root", TransactionOptions().also { it.isBindToScope = true })
         transaction.startChild("op-child")
 
         val span = Sentry.getSpan()!!
@@ -840,7 +840,7 @@ class SentryTest {
             it.sampleRate = 1.0
         }, false)
 
-        val transaction = Sentry.startTransaction("name", "op-root", true)
+        val transaction = Sentry.startTransaction("name", "op-root", TransactionOptions().also { it.isBindToScope = true })
         transaction.startChild("op-child")
 
         val span = Sentry.getSpan()!!
@@ -855,7 +855,7 @@ class SentryTest {
             it.sampleRate = 1.0
         }, false)
 
-        val transaction = Sentry.startTransaction("name", "op-root", true)
+        val transaction = Sentry.startTransaction("name", "op-root", TransactionOptions().also { it.isBindToScope = true })
         transaction.startChild("op-child")
 
         val span = Sentry.getSpan()!!


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Remove `startTransaction` overloads that can be replaced by passing `TransactionOptions`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2754

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
