### PR TITLE
Allow filtering graphql errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 
 - Add `CheckInUtils.withCheckIn` which abstracts away some of the manual check-ins complexity ([#2959](https://github.com/getsentry/sentry-java/pull/2959))
+- Allow filtering GraphQL errors ([#2967](https://github.com/getsentry/sentry-java/pull/2967))
+  - This list can be set directly when calling the constructor of `SentryInstrumentation`
+  - For Spring Boot it can also be set in `application.properties` as `sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR`
 
 ## 6.30.0
 

--- a/sentry-graphql/api/sentry-graphql.api
+++ b/sentry-graphql/api/sentry-graphql.api
@@ -53,8 +53,9 @@ public final class io/sentry/graphql/SentryInstrumentation : graphql/execution/i
 	public fun <init> (Lio/sentry/IHub;)V
 	public fun <init> (Lio/sentry/IHub;Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;)V
 	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;)V
-	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;Lio/sentry/graphql/SentrySubscriptionHandler;Lio/sentry/graphql/ExceptionReporter;)V
+	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;Lio/sentry/graphql/SentrySubscriptionHandler;Lio/sentry/graphql/ExceptionReporter;Ljava/util/List;)V
 	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;Lio/sentry/graphql/SentrySubscriptionHandler;Z)V
+	public fun <init> (Lio/sentry/graphql/SentryInstrumentation$BeforeSpanCallback;Lio/sentry/graphql/SentrySubscriptionHandler;ZLjava/util/List;)V
 	public fun <init> (Lio/sentry/graphql/SentrySubscriptionHandler;Z)V
 	public fun beginExecuteOperation (Lgraphql/execution/instrumentation/parameters/InstrumentationExecuteOperationParameters;)Lgraphql/execution/instrumentation/InstrumentationContext;
 	public fun beginExecution (Lgraphql/execution/instrumentation/parameters/InstrumentationExecutionParameters;)Lgraphql/execution/instrumentation/InstrumentationContext;

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
@@ -118,6 +118,7 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
    *     this integration for query and mutation operations. This can be used to prevent unnecessary
    *     work by not adding the request body when another integration will add it anyways, as is the
    *     case with our spring integration for WebMVC.
+   * @param ignoredErrorTypes list of error types that should not be captured and sent to Sentry
    */
   public SentryInstrumentation(
       final @Nullable BeforeSpanCallback beforeSpan,
@@ -197,8 +198,6 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
                 final @NotNull List<GraphQLError> errors = result.getErrors();
                 if (errors != null) {
                   for (GraphQLError error : errors) {
-                    // not capturing INTERNAL_ERRORS as they should be reported via graphQlContext
-                    // above
                     String errorType = getErrorType(error);
                     if (!isIgnored(errorType)) {
                       exceptionReporter.captureThrowable(
@@ -225,6 +224,8 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
       return false;
     }
 
+    // not capturing INTERNAL_ERRORS as they should be reported via graphQlContext above
+    // also not capturing error types explicitly ignored by users
     return ERROR_TYPES_HANDLED_BY_DATA_FETCHERS.contains(errorType)
         || ignoredErrorTypes.contains(errorType);
   }

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
@@ -26,6 +26,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SpanStatus;
 import io.sentry.util.StringUtils;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -51,6 +52,8 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
   private final @NotNull SentrySubscriptionHandler subscriptionHandler;
 
   private final @NotNull ExceptionReporter exceptionReporter;
+
+  private final @NotNull List<String> ignoredErrorTypes;
 
   /**
    * @deprecated please use a constructor that takes a {@link SentrySubscriptionHandler} instead.
@@ -104,17 +107,40 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
     this(
         beforeSpan,
         subscriptionHandler,
-        new ExceptionReporter(captureRequestBodyForNonSubscriptions));
+        new ExceptionReporter(captureRequestBodyForNonSubscriptions),
+        new ArrayList<>());
+  }
+
+  /**
+   * @param beforeSpan callback when a span is created
+   * @param subscriptionHandler can report subscription errors
+   * @param captureRequestBodyForNonSubscriptions false if request bodies should not be captured by
+   *     this integration for query and mutation operations. This can be used to prevent unnecessary
+   *     work by not adding the request body when another integration will add it anyways, as is the
+   *     case with our spring integration for WebMVC.
+   */
+  public SentryInstrumentation(
+      final @Nullable BeforeSpanCallback beforeSpan,
+      final @NotNull SentrySubscriptionHandler subscriptionHandler,
+      final boolean captureRequestBodyForNonSubscriptions,
+      final @NotNull List<String> ignoredErrorTypes) {
+    this(
+        beforeSpan,
+        subscriptionHandler,
+        new ExceptionReporter(captureRequestBodyForNonSubscriptions),
+        ignoredErrorTypes);
   }
 
   @TestOnly
   public SentryInstrumentation(
       final @Nullable BeforeSpanCallback beforeSpan,
       final @NotNull SentrySubscriptionHandler subscriptionHandler,
-      final @NotNull ExceptionReporter exceptionReporter) {
+      final @NotNull ExceptionReporter exceptionReporter,
+      final @NotNull List<String> ignoredErrorTypes) {
     this.beforeSpan = beforeSpan;
     this.subscriptionHandler = subscriptionHandler;
     this.exceptionReporter = exceptionReporter;
+    this.ignoredErrorTypes = ignoredErrorTypes;
     SentryIntegrationPackageStorage.getInstance().addIntegration("GraphQL");
     SentryIntegrationPackageStorage.getInstance()
         .addPackage("maven:io.sentry:sentry-graphql", BuildConfig.VERSION_NAME);
@@ -174,8 +200,7 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
                     // not capturing INTERNAL_ERRORS as they should be reported via graphQlContext
                     // above
                     String errorType = getErrorType(error);
-                    if (errorType == null
-                        || !ERROR_TYPES_HANDLED_BY_DATA_FETCHERS.contains(errorType)) {
+                    if (!isIgnored(errorType)) {
                       exceptionReporter.captureThrowable(
                           new RuntimeException(error.getMessage()),
                           new ExceptionReporter.ExceptionDetails(
@@ -193,6 +218,15 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
                     null);
               }
             });
+  }
+
+  private boolean isIgnored(final @Nullable String errorType) {
+    if (errorType == null) {
+      return false;
+    }
+
+    return ERROR_TYPES_HANDLED_BY_DATA_FETCHERS.contains(errorType)
+        || ignoredErrorTypes.contains(errorType);
   }
 
   private @Nullable String getErrorType(final @Nullable GraphQLError error) {

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationTest.kt
@@ -170,7 +170,7 @@ class SentryInstrumentationTest {
         val subscriptionHandler = mock<SentrySubscriptionHandler>()
         whenever(subscriptionHandler.onSubscriptionResult(any(), any(), any(), any())).thenReturn("result modified by subscription handler")
         val operation = OperationDefinition.Operation.SUBSCRIPTION
-        val instrumentation = SentryInstrumentation(null, subscriptionHandler, exceptionReporter)
+        val instrumentation = SentryInstrumentation(null, subscriptionHandler, exceptionReporter, emptyList())
         val dataFetcher = mock<DataFetcher<Any?>>()
         whenever(dataFetcher.get(any())).thenReturn("raw result")
         val graphQLContext = GraphQLContext.newContext().build()

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -12,6 +12,7 @@ sentry.traces-sample-rate=1.0
 sentry.enable-tracing=true
 sentry.ignored-checkins=ignored_monitor_slug_1,ignored_monitor_slug_2
 sentry.debug=true
+sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 in-app-includes="io.sentry.samples"
 
 # Uncomment and set to true to enable aot compatibility

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -12,6 +12,7 @@ sentry.traces-sample-rate=1.0
 sentry.enable-tracing=true
 sentry.ignored-checkins=ignored_monitor_slug_1,ignored_monitor_slug_2
 sentry.debug=true
+sentry.graphql.ignored-error-types=SOME_ERROR,ANOTHER_ERROR
 in-app-includes="io.sentry.samples"
 
 # Database configuration

--- a/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
+++ b/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
@@ -21,6 +21,7 @@ public class io/sentry/spring/boot/jakarta/SentryLogbackAppenderAutoConfiguratio
 public class io/sentry/spring/boot/jakarta/SentryProperties : io/sentry/SentryOptions {
 	public fun <init> ()V
 	public fun getExceptionResolverOrder ()I
+	public fun getGraphql ()Lio/sentry/spring/boot/jakarta/SentryProperties$Graphql;
 	public fun getLogging ()Lio/sentry/spring/boot/jakarta/SentryProperties$Logging;
 	public fun getReactive ()Lio/sentry/spring/boot/jakarta/SentryProperties$Reactive;
 	public fun getUserFilterOrder ()Ljava/lang/Integer;
@@ -28,10 +29,17 @@ public class io/sentry/spring/boot/jakarta/SentryProperties : io/sentry/SentryOp
 	public fun isUseGitCommitIdAsRelease ()Z
 	public fun setEnableAotCompatibility (Z)V
 	public fun setExceptionResolverOrder (I)V
+	public fun setGraphql (Lio/sentry/spring/boot/jakarta/SentryProperties$Graphql;)V
 	public fun setLogging (Lio/sentry/spring/boot/jakarta/SentryProperties$Logging;)V
 	public fun setReactive (Lio/sentry/spring/boot/jakarta/SentryProperties$Reactive;)V
 	public fun setUseGitCommitIdAsRelease (Z)V
 	public fun setUserFilterOrder (Ljava/lang/Integer;)V
+}
+
+public class io/sentry/spring/boot/jakarta/SentryProperties$Graphql {
+	public fun <init> ()V
+	public fun getIgnoredErrorTypes ()Ljava/util/List;
+	public fun setIgnoredErrorTypes (Ljava/util/List;)V
 }
 
 public class io/sentry/spring/boot/jakarta/SentryProperties$Logging {
@@ -55,5 +63,13 @@ public class io/sentry/spring/boot/jakarta/SentryProperties$Reactive {
 public class io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration {
 	public fun <init> ()V
 	public fun sentryWebExceptionHandler (Lio/sentry/IHub;)Lio/sentry/spring/jakarta/webflux/SentryWebExceptionHandler;
+}
+
+public class io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration {
+	public fun <init> ()V
+	public fun exceptionResolverAdapter ()Lio/sentry/spring/jakarta/graphql/SentryDataFetcherExceptionResolverAdapter;
+	public fun graphqlBeanPostProcessor ()Lio/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor;
+	public fun sourceBuilderCustomizerWebflux (Lio/sentry/spring/boot/jakarta/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
+	public fun sourceBuilderCustomizerWebmvc (Lio/sentry/spring/boot/jakarta/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 }
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -14,6 +14,7 @@ import io.sentry.graphql.SentryGraphqlExceptionHandler;
 import io.sentry.opentelemetry.OpenTelemetryLinkErrorEventProcessor;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.quartz.SentryJobListener;
+import io.sentry.spring.boot.jakarta.graphql.SentryGraphqlAutoConfiguration;
 import io.sentry.spring.jakarta.ContextTagsEventProcessor;
 import io.sentry.spring.jakarta.SentryExceptionResolver;
 import io.sentry.spring.jakarta.SentryRequestResolver;
@@ -25,7 +26,6 @@ import io.sentry.spring.jakarta.SpringSecuritySentryUserProvider;
 import io.sentry.spring.jakarta.checkin.SentryCheckInAdviceConfiguration;
 import io.sentry.spring.jakarta.checkin.SentryCheckInPointcutConfiguration;
 import io.sentry.spring.jakarta.checkin.SentryQuartzConfiguration;
-import io.sentry.spring.jakarta.graphql.SentryGraphqlConfiguration;
 import io.sentry.spring.jakarta.tracing.SentryAdviceConfiguration;
 import io.sentry.spring.jakarta.tracing.SentrySpanPointcutConfiguration;
 import io.sentry.spring.jakarta.tracing.SentryTracingFilter;
@@ -164,7 +164,7 @@ public class SentryAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @Import(SentryGraphqlConfiguration.class)
+    @Import(SentryGraphqlAutoConfiguration.class)
     @Open
     @ConditionalOnClass({
       SentryGraphqlExceptionHandler.class,

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryProperties.java
@@ -2,6 +2,7 @@ package io.sentry.spring.boot.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.SentryOptions;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +40,9 @@ public class SentryProperties extends SentryOptions {
    * io.sentry.spring.jakarta.tracing.SentrySpan}) to successfully compile to GraalVM
    */
   private boolean enableAotCompatibility = false;
+
+  /** Graphql integration properties. */
+  private @NotNull Graphql graphql = new Graphql();
 
   public boolean isUseGitCommitIdAsRelease() {
     return useGitCommitIdAsRelease;
@@ -98,6 +102,14 @@ public class SentryProperties extends SentryOptions {
 
   public void setEnableAotCompatibility(boolean enableAotCompatibility) {
     this.enableAotCompatibility = enableAotCompatibility;
+  }
+
+  public @NotNull Graphql getGraphql() {
+    return graphql;
+  }
+
+  public void setGraphql(@NotNull Graphql graphql) {
+    this.graphql = graphql;
   }
 
   @Open
@@ -161,6 +173,22 @@ public class SentryProperties extends SentryOptions {
 
     public void setThreadLocalAccessorEnabled(boolean threadLocalAccessorEnabled) {
       this.threadLocalAccessorEnabled = threadLocalAccessorEnabled;
+    }
+  }
+
+  @Open
+  public static class Graphql {
+
+    /** List of error types the Sentry Graphql integration should ignore. */
+    private @NotNull List<String> ignoredErrorTypes = new ArrayList<>();
+
+    @NotNull
+    public List<String> getIgnoredErrorTypes() {
+      return ignoredErrorTypes;
+    }
+
+    public void setIgnoredErrorTypes(final @NotNull List<String> ignoredErrorTypes) {
+      this.ignoredErrorTypes = ignoredErrorTypes;
     }
   }
 }

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
@@ -1,0 +1,65 @@
+package io.sentry.spring.boot.jakarta.graphql;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.graphql.SentryInstrumentation;
+import io.sentry.spring.boot.jakarta.SentryProperties;
+import io.sentry.spring.jakarta.graphql.SentryDataFetcherExceptionResolverAdapter;
+import io.sentry.spring.jakarta.graphql.SentryGraphqlBeanPostProcessor;
+import io.sentry.spring.jakarta.graphql.SentrySpringSubscriptionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Configuration(proxyBeanMethods = false)
+@Open
+public class SentryGraphqlAutoConfiguration {
+
+  @Bean
+  @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+  public GraphQlSourceBuilderCustomizer sourceBuilderCustomizerWebmvc(
+      final @NotNull SentryProperties sentryProperties) {
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebMVC");
+    return sourceBuilderCustomizer(sentryProperties, false);
+  }
+
+  @Bean
+  @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+  public GraphQlSourceBuilderCustomizer sourceBuilderCustomizerWebflux(
+      final @NotNull SentryProperties sentryProperties) {
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring6GrahQLWebFlux");
+    return sourceBuilderCustomizer(sentryProperties, true);
+  }
+
+  /**
+   * We're not setting defaultDataFetcherExceptionHandler here on purpose and instead use the
+   * resolver adapter below. This way Springs handler can still forward to other resolver adapters.
+   */
+  private GraphQlSourceBuilderCustomizer sourceBuilderCustomizer(
+      final @NotNull SentryProperties sentryProperties, final boolean captureRequestBody) {
+    return (builder) ->
+        builder.configureGraphQl(
+            graphQlBuilder ->
+                graphQlBuilder.instrumentation(
+                    new SentryInstrumentation(
+                        null,
+                        new SentrySpringSubscriptionHandler(),
+                        captureRequestBody,
+                        sentryProperties.getGraphql().getIgnoredErrorTypes())));
+  }
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  public SentryDataFetcherExceptionResolverAdapter exceptionResolverAdapter() {
+    return new SentryDataFetcherExceptionResolverAdapter();
+  }
+
+  @Bean
+  public SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
+    return new SentryGraphqlBeanPostProcessor();
+  }
+}

--- a/sentry-spring-boot/api/sentry-spring-boot.api
+++ b/sentry-spring-boot/api/sentry-spring-boot.api
@@ -21,13 +21,21 @@ public class io/sentry/spring/boot/SentryLogbackAppenderAutoConfiguration {
 public class io/sentry/spring/boot/SentryProperties : io/sentry/SentryOptions {
 	public fun <init> ()V
 	public fun getExceptionResolverOrder ()I
+	public fun getGraphql ()Lio/sentry/spring/boot/SentryProperties$Graphql;
 	public fun getLogging ()Lio/sentry/spring/boot/SentryProperties$Logging;
 	public fun getUserFilterOrder ()Ljava/lang/Integer;
 	public fun isUseGitCommitIdAsRelease ()Z
 	public fun setExceptionResolverOrder (I)V
+	public fun setGraphql (Lio/sentry/spring/boot/SentryProperties$Graphql;)V
 	public fun setLogging (Lio/sentry/spring/boot/SentryProperties$Logging;)V
 	public fun setUseGitCommitIdAsRelease (Z)V
 	public fun setUserFilterOrder (Ljava/lang/Integer;)V
+}
+
+public class io/sentry/spring/boot/SentryProperties$Graphql {
+	public fun <init> ()V
+	public fun getIgnoredErrorTypes ()Ljava/util/List;
+	public fun setIgnoredErrorTypes (Ljava/util/List;)V
 }
 
 public class io/sentry/spring/boot/SentryProperties$Logging {
@@ -47,5 +55,13 @@ public class io/sentry/spring/boot/SentryWebfluxAutoConfiguration {
 	public fun sentryScheduleHookApplicationRunner ()Lorg/springframework/boot/ApplicationRunner;
 	public fun sentryWebExceptionHandler (Lio/sentry/IHub;)Lio/sentry/spring/webflux/SentryWebExceptionHandler;
 	public fun sentryWebFilter (Lio/sentry/IHub;)Lio/sentry/spring/webflux/SentryWebFilter;
+}
+
+public class io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration {
+	public fun <init> ()V
+	public fun exceptionResolverAdapter ()Lio/sentry/spring/graphql/SentryDataFetcherExceptionResolverAdapter;
+	public fun graphqlBeanPostProcessor ()Lio/sentry/spring/graphql/SentryGraphqlBeanPostProcessor;
+	public fun sourceBuilderCustomizerWebflux (Lio/sentry/spring/boot/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
+	public fun sourceBuilderCustomizerWebmvc (Lio/sentry/spring/boot/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 }
 

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -22,10 +22,10 @@ import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
 import io.sentry.spring.SentryWebConfiguration;
 import io.sentry.spring.SpringSecuritySentryUserProvider;
+import io.sentry.spring.boot.graphql.SentryGraphqlAutoConfiguration;
 import io.sentry.spring.checkin.SentryCheckInAdviceConfiguration;
 import io.sentry.spring.checkin.SentryCheckInPointcutConfiguration;
 import io.sentry.spring.checkin.SentryQuartzConfiguration;
-import io.sentry.spring.graphql.SentryGraphqlConfiguration;
 import io.sentry.spring.tracing.SentryAdviceConfiguration;
 import io.sentry.spring.tracing.SentrySpanPointcutConfiguration;
 import io.sentry.spring.tracing.SentryTracingFilter;
@@ -164,7 +164,7 @@ public class SentryAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @Import(SentryGraphqlConfiguration.class)
+    @Import(SentryGraphqlAutoConfiguration.class)
     @Open
     @ConditionalOnClass({
       SentryGraphqlExceptionHandler.class,

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryProperties.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryProperties.java
@@ -2,6 +2,7 @@ package io.sentry.spring.boot;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.SentryOptions;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -29,6 +30,9 @@ public class SentryProperties extends SentryOptions {
 
   /** Logging framework integration properties. */
   private @NotNull Logging logging = new Logging();
+
+  /** Graphql integration properties. */
+  private @NotNull Graphql graphql = new Graphql();
 
   public boolean isUseGitCommitIdAsRelease() {
     return useGitCommitIdAsRelease;
@@ -72,6 +76,14 @@ public class SentryProperties extends SentryOptions {
 
   public void setLogging(@NotNull Logging logging) {
     this.logging = logging;
+  }
+
+  public @NotNull Graphql getGraphql() {
+    return graphql;
+  }
+
+  public void setGraphql(@NotNull Graphql graphql) {
+    this.graphql = graphql;
   }
 
   @Open
@@ -119,6 +131,22 @@ public class SentryProperties extends SentryOptions {
 
     public void setLoggers(final @NotNull List<String> loggers) {
       this.loggers = loggers;
+    }
+  }
+
+  @Open
+  public static class Graphql {
+
+    /** List of error types the Sentry Graphql integration should ignore. */
+    private @NotNull List<String> ignoredErrorTypes = new ArrayList<>();
+
+    @NotNull
+    public List<String> getIgnoredErrorTypes() {
+      return ignoredErrorTypes;
+    }
+
+    public void setIgnoredErrorTypes(final @NotNull List<String> ignoredErrorTypes) {
+      this.ignoredErrorTypes = ignoredErrorTypes;
     }
   }
 }

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
@@ -1,0 +1,65 @@
+package io.sentry.spring.boot.graphql;
+
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.graphql.SentryInstrumentation;
+import io.sentry.spring.boot.SentryProperties;
+import io.sentry.spring.graphql.SentryDataFetcherExceptionResolverAdapter;
+import io.sentry.spring.graphql.SentryGraphqlBeanPostProcessor;
+import io.sentry.spring.graphql.SentrySpringSubscriptionHandler;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Configuration(proxyBeanMethods = false)
+@Open
+public class SentryGraphqlAutoConfiguration {
+
+  @Bean
+  @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+  public GraphQlSourceBuilderCustomizer sourceBuilderCustomizerWebmvc(
+      final @NotNull SentryProperties sentryProperties) {
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebMVC");
+    return sourceBuilderCustomizer(sentryProperties, false);
+  }
+
+  @Bean
+  @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+  public GraphQlSourceBuilderCustomizer sourceBuilderCustomizerWebflux(
+      final @NotNull SentryProperties sentryProperties) {
+    SentryIntegrationPackageStorage.getInstance().addIntegration("Spring5GrahQLWebFlux");
+    return sourceBuilderCustomizer(sentryProperties, true);
+  }
+
+  /**
+   * We're not setting defaultDataFetcherExceptionHandler here on purpose and instead use the
+   * resolver adapter below. This way Springs handler can still forward to other resolver adapters.
+   */
+  private GraphQlSourceBuilderCustomizer sourceBuilderCustomizer(
+      final @NotNull SentryProperties sentryProperties, final boolean captureRequestBody) {
+    return (builder) ->
+        builder.configureGraphQl(
+            graphQlBuilder ->
+                graphQlBuilder.instrumentation(
+                    new SentryInstrumentation(
+                        null,
+                        new SentrySpringSubscriptionHandler(),
+                        captureRequestBody,
+                        sentryProperties.getGraphql().getIgnoredErrorTypes())));
+  }
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  public SentryDataFetcherExceptionResolverAdapter exceptionResolverAdapter() {
+    return new SentryDataFetcherExceptionResolverAdapter();
+  }
+
+  @Bean
+  public SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
+    return new SentryGraphqlBeanPostProcessor();
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allow users to privde a `List<String>` to filter out certain GraphQL errors. Decided to use `String` instead of a specific type as `String` can easily be set in config files.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2899

## :green_heart: How did you test it?
Manually + unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
