### PR TITLE
Fix crash accessing Choreographer instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `CheckInUtils.withCheckIn` which abstracts away some of the manual check-ins complexity ([#2959](https://github.com/getsentry/sentry-java/pull/2959))
 
+### Fixes
+
+- Fixed crash accessing Choreographer instance ([#2970](https://github.com/getsentry/sentry-java/pull/2970))
+
 ## 6.30.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -94,7 +94,20 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
     // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:metrics/metrics-performance/src/main/java/androidx/metrics/performance/JankStatsApi24Impl.kt
 
     // The Choreographer instance must be accessed on the main thread
-    new Handler(Looper.getMainLooper()).post(() -> choreographer = Choreographer.getInstance());
+    new Handler(Looper.getMainLooper())
+        .post(
+            () -> {
+              try {
+                choreographer = Choreographer.getInstance();
+              } catch (Throwable e) {
+                options
+                    .getLogger()
+                    .log(
+                        SentryLevel.ERROR,
+                        "Error retrieving Choreographer instance. Slow and frozen frames will not be reported.",
+                        e);
+              }
+            });
     // Let's get the last frame timestamp from the choreographer private field
     try {
       choreographerLastFrameTimeField = Choreographer.class.getDeclaredField("mLastFrameTimeNanos");


### PR DESCRIPTION
## :scroll: Description
choreographer instance is now retrieved in a try/catch block, due to a crash reported by Google Play SDK console

## :bulb: Motivation and Context
Fixes a crash. Closes https://github.com/getsentry/sentry-java/issues/2912


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
