### PR TITLE
Guard raw logback message and parameters with `sendDefaultPii` if an `encoder` has been configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Cleanup `startTransaction` overloads ([#2964](https://github.com/getsentry/sentry-java/pull/2964))
   - We have reduce the number of overloads by allowing to pass in `TransactionOptions` instead of having separate parameters for certain options.
   - `TransactionOptions` has defaults set and can be customized
+- Raw logback message and parameters are now guarded by `sendDefaultPii` if an `encoder` has been configured ([#2976](https://github.com/getsentry/sentry-java/pull/2976))
 
 ## 7.0.0-beta.1
 

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -99,9 +99,14 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   protected @NotNull SentryEvent createEvent(@NotNull ILoggingEvent loggingEvent) {
     final SentryEvent event = new SentryEvent(DateUtils.getDateTime(loggingEvent.getTimeStamp()));
     final Message message = new Message();
-    message.setMessage(loggingEvent.getMessage());
+
+    // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
+    if (encoder == null || options.isSendDefaultPii()) {
+      message.setMessage(loggingEvent.getMessage());
+      message.setParams(toParams(loggingEvent.getArgumentArray()));
+    }
+
     message.setFormatted(formatted(loggingEvent));
-    message.setParams(toParams(loggingEvent.getArgumentArray()));
     event.setMessage(message);
     event.setLogger(loggingEvent.getLoggerName());
     event.setLevel(formatLevel(loggingEvent.getLevel()));


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
There's tutorials out there suggesting to use an Encoder to mask/strip PII from log messages. Therefore we now guard the raw message and parameters with `sendDefaultPii` if an `encoder` has been configured.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/2973

## :green_heart: How did you test it?
Unit tests, manually using logback sample

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
