### PR TITLE
Set export flag on Android receivers on API 33+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set export flag on Android receivers on API 33+ ([#2990](https://github.com/getsentry/sentry-java/pull/2990))
+
 ## 6.31.0
 
 ### Features

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -30,7 +30,7 @@ object Config {
     }
 
     object Android {
-        private val sdkVersion = 33
+        private val sdkVersion = 34
 
         val minSdkVersion = 14
         val minSdkVersionOkHttp = 21
@@ -181,10 +181,10 @@ object Config {
         val espressoCore = "androidx.test.espresso:espresso-core:$espressoVersion"
         val espressoIdlingResource = "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
         val androidxTestOrchestrator = "androidx.test:orchestrator:1.4.2"
-        val androidxJunit = "androidx.test.ext:junit:1.1.3"
+        val androidxJunit = "androidx.test.ext:junit:1.1.5"
         val androidxCoreKtx = "androidx.core:core-ktx:1.7.0"
-        val robolectric = "org.robolectric:robolectric:4.7.3"
-        val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
+        val robolectric = "org.robolectric:robolectric:4.10.3"
+        val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:4.1.0"
         val mockitoInline = "org.mockito:mockito-inline:4.8.0"
         val awaitility = "org.awaitility:awaitility-kotlin:4.1.1"
         val mockWebserver = "com.squareup.okhttp3:mockwebserver:${Libs.okHttpVersion}"

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
@@ -2,7 +2,7 @@ package io.sentry.android.core;
 
 import static android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
 import static android.content.Context.ACTIVITY_SERVICE;
-import static android.content.Context.RECEIVER_NOT_EXPORTED;
+import static android.content.Context.RECEIVER_EXPORTED;
 import static android.content.pm.PackageInfo.REQUESTED_PERMISSION_GRANTED;
 
 import android.annotation.SuppressLint;
@@ -368,7 +368,11 @@ public final class ContextUtils {
       final @Nullable BroadcastReceiver receiver,
       final @NotNull IntentFilter filter) {
     if (buildInfoProvider.getSdkInfoVersion() >= Build.VERSION_CODES.TIRAMISU) {
-      return context.registerReceiver(receiver, filter, RECEIVER_NOT_EXPORTED);
+      // From https://developer.android.com/guide/components/broadcasts#context-registered-receivers
+      // If this receiver is listening for broadcasts sent from the system or from other apps, even
+      // other apps that you own—use the RECEIVER_EXPORTED flag. If instead this receiver is
+      // listening only for broadcasts sent by your app, use the RECEIVER_NOT_EXPORTED flag.
+      return context.registerReceiver(receiver, filter, RECEIVER_EXPORTED);
     } else {
       return context.registerReceiver(receiver, filter);
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DeviceInfoUtil.java
@@ -262,7 +262,8 @@ public final class DeviceInfoUtil {
 
   @Nullable
   private Intent getBatteryIntent() {
-    return context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+    return ContextUtils.registerReceiver(
+        context, buildInfoProvider, null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -99,7 +99,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       }
       try {
         // registerReceiver can throw SecurityException but it's not documented in the official docs
-        context.registerReceiver(receiver, filter);
+        ContextUtils.registerReceiver(context, options, receiver, filter);
         this.options
             .getLogger()
             .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsUnitTests.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsUnitTests.kt
@@ -2,15 +2,20 @@ package io.sentry.android.core
 
 import android.app.ActivityManager
 import android.app.ActivityManager.MemoryInfo
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.IntentFilter
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
 import io.sentry.NoOpLogger
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import org.robolectric.shadow.api.Shadow
@@ -161,4 +166,28 @@ class ContextUtilsUnitTests {
         val memInfo = ContextUtils.getMemInfo(mock(), logger)
         assertNull(memInfo)
     }
+
+    @Test
+    fun `registerReceiver calls context_registerReceiver without exported flag on API 32-`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        val receiver = mock<BroadcastReceiver>()
+        val filter = mock<IntentFilter>()
+        val context = mock<Context>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.S)
+        ContextUtils.registerReceiver(context, buildInfo, receiver, filter)
+        verify(context).registerReceiver(eq(receiver), eq(filter))
+    }
+/*
+    context.registerReceiver(BroadcastReceiver, IntentFilter, int) throws with NoSuchMethod exception in tests
+    Re-enable this test when possible
+    @Test
+    fun `registerReceiver calls context_registerReceiver with exported flag on API 33+`() {
+        val buildInfo = mock<BuildInfoProvider>()
+        val receiver = mock<BroadcastReceiver>()
+        val filter = mock<IntentFilter>()
+        val context = mock<Context>()
+        whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.TIRAMISU)
+        ContextUtils.registerReceiver(context, buildInfo, receiver, filter)
+        verify(context).registerReceiver(eq(receiver), eq(filter), eq(RECEIVER_NOT_EXPORTED))
+    }*/
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsUnitTests.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ContextUtilsUnitTests.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@Config(sdk = [33])
 @RunWith(AndroidJUnit4::class)
 class ContextUtilsUnitTests {
 
@@ -177,9 +178,7 @@ class ContextUtilsUnitTests {
         ContextUtils.registerReceiver(context, buildInfo, receiver, filter)
         verify(context).registerReceiver(eq(receiver), eq(filter))
     }
-/*
-    context.registerReceiver(BroadcastReceiver, IntentFilter, int) throws with NoSuchMethod exception in tests
-    Re-enable this test when possible
+
     @Test
     fun `registerReceiver calls context_registerReceiver with exported flag on API 33+`() {
         val buildInfo = mock<BuildInfoProvider>()
@@ -188,6 +187,6 @@ class ContextUtilsUnitTests {
         val context = mock<Context>()
         whenever(buildInfo.sdkInfoVersion).thenReturn(Build.VERSION_CODES.TIRAMISU)
         ContextUtils.registerReceiver(context, buildInfo, receiver, filter)
-        verify(context).registerReceiver(eq(receiver), eq(filter), eq(RECEIVER_NOT_EXPORTED))
-    }*/
+        verify(context).registerReceiver(eq(receiver), eq(filter), eq(Context.RECEIVER_EXPORTED))
+    }
 }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -150,6 +150,6 @@
 
         <!--    how to disable sentry -->
         <!--    <meta-data android:name="io.sentry.enabled" android:value="false" /> -->
-      
+
     </application>
 </manifest>


### PR DESCRIPTION
## :scroll: Description
registerReceiver now sets the RECEIVER_NOT_EXPORTED flag on API 33+
updated SDK target version to 34



## :bulb: Motivation and Context
Starting from Android 14, it is necessary to explicitly set the export behavior for runtime-registered broadcasts as described [here](https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported).
Fixes https://github.com/getsentry/sentry-java/issues/2986


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
