### PR TITLE
Make DebugImagesLoader public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Make DebugImagesLoader public ([#2993](https://github.com/getsentry/sentry-java/pull/2993))
+
 ## 6.31.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Make DebugImagesLoader public ([#2993](https://github.com/getsentry/sentry-java/pull/2993))
+- Make `DebugImagesLoader` public ([#2993](https://github.com/getsentry/sentry-java/pull/2993))
 
 ## 6.31.0
 

--- a/sentry-android-ndk/api/sentry-android-ndk.api
+++ b/sentry-android-ndk/api/sentry-android-ndk.api
@@ -6,6 +6,12 @@ public final class io/sentry/android/ndk/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class io/sentry/android/ndk/DebugImagesLoader : io/sentry/android/core/IDebugImagesLoader {
+	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/android/ndk/NativeModuleListLoader;)V
+	public fun clearDebugImages ()V
+	public fun loadDebugImages ()Ljava/util/List;
+}
+
 public final class io/sentry/android/ndk/NdkScopeObserver : io/sentry/IScopeObserver {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun addBreadcrumb (Lio/sentry/Breadcrumb;)V

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/DebugImagesLoader.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/DebugImagesLoader.java
@@ -12,7 +12,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
-final class DebugImagesLoader implements IDebugImagesLoader {
+/**
+ * Class used for loading the list of debug images from sentry-native. Using this class requires
+ * manually initializing the SDK.
+ */
+public final class DebugImagesLoader implements IDebugImagesLoader {
 
   private final @NotNull SentryOptions options;
 
@@ -23,7 +27,7 @@ final class DebugImagesLoader implements IDebugImagesLoader {
   /** we need to lock it because it could be called from different threads */
   private static final @NotNull Object debugImagesLock = new Object();
 
-  DebugImagesLoader(
+  public DebugImagesLoader(
       final @NotNull SentryAndroidOptions options,
       final @NotNull NativeModuleListLoader moduleListLoader) {
     this.options = Objects.requireNonNull(options, "The SentryAndroidOptions is required.");


### PR DESCRIPTION
## :scroll: Description
DebugImagesLoader is now public, to allow manually init the NDK


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2957


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
