### PR TITLE
Tag all spans with main thread flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Tag all spans with main thread flag ([#2998](https://github.com/getsentry/sentry-java/pull/2998))
+
 ## 6.32.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Features
 
-- Cap max number of stack frames to 100 to not exceed payload size limit ([#3009](https://github.com/getsentry/sentry-java/pull/3009))
-  - This will ensure we report errors with a big number of frames such as `StackOverflowError`
 - Add thread information to spans ([#2998](https://github.com/getsentry/sentry-java/pull/2998))
 
 ### Fixes
 
 - Fix crash when HTTP connection error message contains formatting symbols ([#3002](https://github.com/getsentry/sentry-java/pull/3002))
+- Cap max number of stack frames to 100 to not exceed payload size limit ([#3009](https://github.com/getsentry/sentry-java/pull/3009))
+  - This will ensure we report errors with a big number of frames such as `StackOverflowError`
 
 ## 6.32.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2397,6 +2397,8 @@ public abstract interface class io/sentry/SpanDataConvention {
 	public static final field HTTP_QUERY_KEY Ljava/lang/String;
 	public static final field HTTP_RESPONSE_CONTENT_LENGTH_KEY Ljava/lang/String;
 	public static final field HTTP_STATUS_CODE_KEY Ljava/lang/String;
+	public static final field THREAD_ID Ljava/lang/String;
+	public static final field THREAD_NAME Ljava/lang/String;
 }
 
 public final class io/sentry/SpanId : io/sentry/JsonSerializable {

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -7,7 +7,6 @@ import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.TransactionNameSource;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
-import io.sentry.util.thread.MainThreadChecker;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -385,8 +384,12 @@ public final class SentryTracer implements ITransaction {
               }
             });
     span.setDescription(description);
+    span.setData(SpanDataConvention.THREAD_ID, String.valueOf(Thread.currentThread().getId()));
     span.setData(
-        SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, MainThreadChecker.getInstance().isMainThread());
+        SpanDataConvention.THREAD_NAME,
+        hub.getOptions().getMainThreadChecker().isMainThread()
+            ? "main"
+            : Thread.currentThread().getName());
     this.children.add(span);
     return span;
   }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -7,6 +7,7 @@ import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.TransactionNameSource;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
+import io.sentry.util.thread.MainThreadChecker;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -384,6 +385,8 @@ public final class SentryTracer implements ITransaction {
               }
             });
     span.setDescription(description);
+    span.setData(
+        SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, MainThreadChecker.getInstance().isMainThread());
     this.children.add(span);
     return span;
   }

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -15,4 +15,6 @@ public interface SpanDataConvention {
   String HTTP_RESPONSE_CONTENT_LENGTH_KEY = "http.response_content_length";
   String BLOCKED_MAIN_THREAD_KEY = "blocked_main_thread";
   String CALL_STACK_KEY = "call_stack";
+  String THREAD_ID = "thread.id";
+  String THREAD_NAME = "thread.name";
 }

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -5,6 +5,7 @@ import io.sentry.hints.Retryable
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.util.HintUtils
+import io.sentry.util.thread.NoOpMainThreadChecker
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.check
@@ -38,6 +39,7 @@ class OutboxSenderTest {
         init {
             whenever(options.dsn).thenReturn("https://key@sentry.io/proj")
             whenever(options.dateProvider).thenReturn(SentryNanotimeDateProvider())
+            whenever(options.mainThreadChecker).thenReturn(NoOpMainThreadChecker.getInstance())
             whenever(hub.options).thenReturn(this.options)
         }
 

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -1236,4 +1236,10 @@ class SentryTracerTest {
         assertTrue(tracer.isFinished)
         verify(fixture.hub).captureTransaction(any(), anyOrNull(), anyOrNull(), anyOrNull())
     }
+
+    @Test
+    fun `when a span is launched, the main thread flag is set as span data`() {
+        val tracer = fixture.getSut()
+        assertNotNull(tracer.startChild("span.op").getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY))
+    }
 }

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import io.sentry.protocol.TransactionNameSource
 import io.sentry.protocol.User
+import io.sentry.util.thread.IMainThreadChecker
 import org.awaitility.kotlin.await
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -11,12 +12,14 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -1238,8 +1241,28 @@ class SentryTracerTest {
     }
 
     @Test
-    fun `when a span is launched, the main thread flag is set as span data`() {
-        val tracer = fixture.getSut()
-        assertNotNull(tracer.startChild("span.op").getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY))
+    fun `when a span is launched on the main thread, the thread info should be set correctly`() {
+        val mainThreadChecker = mock<IMainThreadChecker>()
+        whenever(mainThreadChecker.isMainThread).thenReturn(true)
+
+        val tracer = fixture.getSut(optionsConfiguration = { options ->
+            options.mainThreadChecker = mainThreadChecker
+        })
+        val span = tracer.startChild("span.op")
+        assertNotNull(span.getData(SpanDataConvention.THREAD_ID))
+        assertEquals("main", span.getData(SpanDataConvention.THREAD_NAME))
+    }
+
+    @Test
+    fun `when a span is launched on the background thread, the thread info should be set correctly`() {
+        val mainThreadChecker = mock<IMainThreadChecker>()
+        whenever(mainThreadChecker.isMainThread).thenReturn(false)
+
+        val tracer = fixture.getSut(optionsConfiguration = { options ->
+            options.mainThreadChecker = mainThreadChecker
+        })
+        val span = tracer.startChild("span.op")
+        assertNotNull(span.getData(SpanDataConvention.THREAD_ID))
+        assertNotEquals("main", span.getData(SpanDataConvention.THREAD_NAME))
     }
 }


### PR DESCRIPTION
## :scroll: Description
Whenever SentryTracer creates a span, it immediately sets the main thread flag.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2997

Open questions: How do deal with our existing main thread flagging.
E.g. SentryFileInputStream sets the flag on `.close()` and right now would overwrite the flag - IMHO that's fine.


## :green_heart: How did you test it?
Add Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
