### PR TITLE
Fix crash when HTTP connection error message contains formatting symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix crash when HTTP connection error message contains formatting symbols ([#3002](https://github.com/getsentry/sentry-java/pull/3002))
+
 ## 6.32.0
 
 ### Features

--- a/sentry/src/main/java/io/sentry/transport/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/transport/HttpConnection.java
@@ -182,8 +182,10 @@ final class HttpConnection {
         options.getLogger().log(ERROR, "Request failed, API returned %s", responseCode);
         // double check because call is expensive
         if (options.isDebug()) {
-          String errorMessage = getErrorMessageFromStream(connection);
-          options.getLogger().log(ERROR, errorMessage);
+          final @NotNull String errorMessage = getErrorMessageFromStream(connection);
+          // the error message may contain anything (including formatting symbols), so provide it as
+          // an argument itself
+          options.getLogger().log(ERROR, "%s", errorMessage);
         }
 
         return TransportResult.error(responseCode);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3001


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
