### PR TITLE
Cap max number of stack frames to 100 to not exceed payload size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Fix crash when HTTP connection error message contains formatting symbols ([#3002](https://github.com/getsentry/sentry-java/pull/3002))
+- Cap max number of stack frames to 100 to not exceed payload size limit ([#3009](https://github.com/getsentry/sentry-java/pull/3009))
+  - This will ensure we report errors with a big number of frames such as `StackOverflowError`
 
 ## 6.32.0
 

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -164,6 +164,8 @@ public class MainActivity extends AppCompatActivity {
           latch.countDown();
         });
 
+    binding.stackOverflow.setOnClickListener(view -> stackOverflow());
+
     binding.nativeCrash.setOnClickListener(view -> NativeSample.crash());
 
     binding.nativeCapture.setOnClickListener(view -> NativeSample.message());
@@ -250,6 +252,10 @@ public class MainActivity extends AppCompatActivity {
         });
 
     setContentView(binding.getRoot());
+  }
+
+  private void stackOverflow() {
+    stackOverflow();
   }
 
   @Override

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -71,6 +71,12 @@
       android:text="@string/out_of_memory" />
 
     <Button
+      android:id="@+id/stack_overflow"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/stack_overflow" />
+
+    <Button
       android:id="@+id/native_crash"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
   <string name="app_name">Sentry sample</string>
   <string name="crash_from_java">Crash from Java (UncaughtException)</string>
   <string name="out_of_memory">Out of Memory (Mulithreaded)</string>
+  <string name="stack_overflow">Stack Overflow</string>
   <string name="send_message">Send Message</string>
   <string name="send_message_from_inner_fragment">Send Message from inner fragment</string>
   <string name="add_attachment">Add Attachment</string>

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SentryStackTraceFactory {
 
+  private static final int STACKTRACE_FRAME_LIMIT = 100;
   private final @NotNull SentryOptions options;
 
   public SentryStackTraceFactory(final @NotNull SentryOptions options) {
@@ -55,6 +56,11 @@ public final class SentryStackTraceFactory {
           }
           sentryStackFrame.setNative(item.isNativeMethod());
           sentryStackFrames.add(sentryStackFrame);
+
+          // hard cap to not exceed payload size limit
+          if (sentryStackFrames.size() >= STACKTRACE_FRAME_LIMIT) {
+            break;
+          }
         }
       }
       Collections.reverse(sentryStackFrames);

--- a/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryStackTraceFactoryTest.kt
@@ -276,6 +276,17 @@ class SentryStackTraceFactoryTest {
         assertEquals("com.example.myapp.MainActivity", callStack[1].module)
     }
 
+    @Test
+    fun `caps number of stack frames to STACKTRACE_FRAME_LIMIT to not exceed payload size limit`() {
+        val exception = Exception()
+        exception.stackTrace = arrayOf()
+        repeat(120) { exception.stackTrace += generateStackTrace("com.me.stackoverflow") }
+
+        val sut = SentryStackTraceFactory(SentryOptions())
+        val sentryFrames = sut.getStackFrames(exception.stackTrace)
+
+        assertEquals(100, sentryFrames!!.size)
+    }
     private fun generateStackTrace(className: String?) =
         StackTraceElement(className, "method", "fileName", 10)
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2988 

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
