### PR TITLE
Fix user interaction tracking not working for Jetpack Compose 1.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix crash when HTTP connection error message contains formatting symbols ([#3002](https://github.com/getsentry/sentry-java/pull/3002))
 - Cap max number of stack frames to 100 to not exceed payload size limit ([#3009](https://github.com/getsentry/sentry-java/pull/3009))
   - This will ensure we report errors with a big number of frames such as `StackOverflowError`
+- Fix user interaction tracking not working for Jetpack Compose 1.5+ ([#3010](https://github.com/getsentry/sentry-java/pull/3010))
 
 ## 6.32.0
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -10,7 +10,7 @@ object Config {
     val springBoot3Version = "3.0.3"
     val kotlinCompatibleLanguageVersion = "1.4"
 
-    val composeVersion = "1.3.0"
+    val composeVersion = "1.5.3"
     val androidComposeCompilerVersion = "1.4.0"
 
     object BuildPlugins {

--- a/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
+++ b/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
@@ -87,6 +87,15 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
                 }
               }
             }
+          } else {
+            // Newer Jetpack Compose 1.5 uses Node modifiers for clicks/scrolls
+            final @Nullable String type = modifierInfo.getModifier().getClass().getCanonicalName();
+            if ("androidx.compose.foundation.ClickableElement".equals(type)
+                || "androidx.compose.foundation.CombinedClickableElement".equals(type)) {
+              isClickable = true;
+            } else if ("androidx.compose.foundation.ScrollingLayoutElement".equals(type)) {
+              isScrollable = true;
+            }
           }
         }
 

--- a/sentry-compose/proguard-rules.pro
+++ b/sentry-compose/proguard-rules.pro
@@ -9,12 +9,17 @@
     private androidx.compose.ui.node.LayoutNodeLayoutDelegate layoutDelegate;
 }
 
+-keepnames class androidx.compose.foundation.ClickableElement
+-keepnames class androidx.compose.foundation.CombinedClickableElement
+-keepnames class androidx.compose.foundation.ScrollingLayoutElement
+
 # R8 will warn about missing classes if people don't have androidx.compose-navigation on their
 # classpath, but this is fine, these classes are used in an internal class which is only used when
 # someone is using withSentryObservableEffect extension function (which, in turn, cannot be used
 # without having androidx.compose-navigation on the classpath)
 -dontwarn androidx.navigation.NavController$OnDestinationChangedListener
 -dontwarn androidx.navigation.NavController
+-dontwarn androidx.compose.foundation.*
 
 # To ensure that stack traces is unambiguous
 # https://developer.android.com/studio/build/shrink-code#decode-stack-trace


### PR DESCRIPTION
## :scroll: Description
Extends the behaviour for determining if a LayoutNode is clickable/scrollable. This change should be backwards compatible as the old logic still stays intact for older versions of Jetpack Compose.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2978

## :green_heart: How did you test it?
Manual tests, we definitely should setup a test matrix for different Jetpack Compose versions.

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
