### PR TITLE
usrivastava92/Ignore child exceptions if parent is ignored

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1533,7 +1533,12 @@ public class SentryOptions {
    * @return if the type of exception is ignored
    */
   boolean containsIgnoredExceptionForType(final @NotNull Throwable throwable) {
-    return this.ignoredExceptionsForType.contains(throwable.getClass());
+    for (Class<? extends Throwable> ignoredException : this.ignoredExceptionsForType) {
+      if (ignoredException.isInstance(throwable)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1533,6 +1533,11 @@ public class SentryOptions {
    * @return if the type of exception is ignored
    */
   boolean containsIgnoredExceptionForType(final @NotNull Throwable throwable) {
+    boolean contains = this.ignoredExceptionsForType.contains(throwable.getClass());
+    if (contains) {
+      // if the exception is ignored, we don't need to check the parents
+      return true;
+    }
     for (Class<? extends Throwable> ignoredException : this.ignoredExceptionsForType) {
       if (ignoredException.isInstance(throwable)) {
         return true;


### PR DESCRIPTION
## :scroll: Description
The Java SDK does not ignore child exceptions even if the parent exception class is added in `SentryOptions.ignoredExceptionsForType` set


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/2015

## :green_heart: How did you test it?
Unit Tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
