### PR TITLE
Send SDK frames in case of crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Do not filter out Sentry SDK frames in case of uncaught exceptions ([#3021](https://github.com/getsentry/sentry-java/pull/3021))
+
 **Breaking changes:**
 - Cleanup `startTransaction` overloads ([#2964](https://github.com/getsentry/sentry-java/pull/2964))
     - We have reduce the number of overloads by allowing to pass in `TransactionOptions` instead of having separate parameters for certain options.

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2181,7 +2181,7 @@ public final class io/sentry/SentrySpanStorage {
 public final class io/sentry/SentryStackTraceFactory {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun getInAppCallStack ()Ljava/util/List;
-	public fun getStackFrames ([Ljava/lang/StackTraceElement;)Ljava/util/List;
+	public fun getStackFrames ([Ljava/lang/StackTraceElement;Z)Ljava/util/List;
 	public fun isInApp (Ljava/lang/String;)Ljava/lang/Boolean;
 }
 

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -159,7 +159,7 @@ public final class SentryExceptionFactory {
         thread = Thread.currentThread();
       }
 
-      boolean includeSentryFrames =
+      final boolean includeSentryFrames =
           exceptionMechanism != null && Boolean.FALSE.equals(exceptionMechanism.isHandled());
       final List<SentryStackFrame> frames =
           sentryStackTraceFactory.getStackFrames(

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -159,8 +159,10 @@ public final class SentryExceptionFactory {
         thread = Thread.currentThread();
       }
 
+      boolean includeSentryFrames = exceptionMechanism != null
+        && Boolean.FALSE.equals(exceptionMechanism.isHandled());
       final List<SentryStackFrame> frames =
-          sentryStackTraceFactory.getStackFrames(currentThrowable.getStackTrace());
+          sentryStackTraceFactory.getStackFrames(currentThrowable.getStackTrace(), includeSentryFrames);
       SentryException exception =
           getSentryException(
               currentThrowable, exceptionMechanism, thread.getId(), frames, snapshot);

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -159,10 +159,11 @@ public final class SentryExceptionFactory {
         thread = Thread.currentThread();
       }
 
-      boolean includeSentryFrames = exceptionMechanism != null
-        && Boolean.FALSE.equals(exceptionMechanism.isHandled());
+      boolean includeSentryFrames =
+          exceptionMechanism != null && Boolean.FALSE.equals(exceptionMechanism.isHandled());
       final List<SentryStackFrame> frames =
-          sentryStackTraceFactory.getStackFrames(currentThrowable.getStackTrace(), includeSentryFrames);
+          sentryStackTraceFactory.getStackFrames(
+              currentThrowable.getStackTrace(), includeSentryFrames);
       SentryException exception =
           getSentryException(
               currentThrowable, exceptionMechanism, thread.getId(), frames, snapshot);

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -26,7 +26,10 @@ public final class SentryStackTraceFactory {
    * @return list of SentryStackFrames or null if none
    */
   @Nullable
-  public List<SentryStackFrame> getStackFrames(@Nullable final StackTraceElement[] elements) {
+  public List<SentryStackFrame> getStackFrames(
+    @Nullable final StackTraceElement[] elements,
+    final boolean includeSentryFrames
+  ) {
     List<SentryStackFrame> sentryStackFrames = null;
 
     if (elements != null && elements.length > 0) {
@@ -102,7 +105,7 @@ public final class SentryStackTraceFactory {
   @NotNull
   List<SentryStackFrame> getInAppCallStack(final @NotNull Throwable exception) {
     final StackTraceElement[] stacktrace = exception.getStackTrace();
-    final List<SentryStackFrame> frames = getStackFrames(stacktrace);
+    final List<SentryStackFrame> frames = getStackFrames(stacktrace, false);
     if (frames == null) {
       return Collections.emptyList();
     }

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -27,9 +27,7 @@ public final class SentryStackTraceFactory {
    */
   @Nullable
   public List<SentryStackFrame> getStackFrames(
-    @Nullable final StackTraceElement[] elements,
-    final boolean includeSentryFrames
-  ) {
+      @Nullable final StackTraceElement[] elements, final boolean includeSentryFrames) {
     List<SentryStackFrame> sentryStackFrames = null;
 
     if (elements != null && elements.length > 0) {
@@ -39,9 +37,10 @@ public final class SentryStackTraceFactory {
 
           // we don't want to add our own frames
           final String className = item.getClassName();
-          if (!includeSentryFrames && (className.startsWith("io.sentry.")
-              && !className.startsWith("io.sentry.samples.")
-              && !className.startsWith("io.sentry.mobile."))) {
+          if (!includeSentryFrames
+              && (className.startsWith("io.sentry.")
+                  && !className.startsWith("io.sentry.samples.")
+                  && !className.startsWith("io.sentry.mobile."))) {
             continue;
           }
 

--- a/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryStackTraceFactory.java
@@ -39,9 +39,9 @@ public final class SentryStackTraceFactory {
 
           // we don't want to add our own frames
           final String className = item.getClassName();
-          if (className.startsWith("io.sentry.")
+          if (!includeSentryFrames && (className.startsWith("io.sentry.")
               && !className.startsWith("io.sentry.samples.")
-              && !className.startsWith("io.sentry.mobile.")) {
+              && !className.startsWith("io.sentry.mobile."))) {
             continue;
           }
 

--- a/sentry/src/main/java/io/sentry/SentryThreadFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryThreadFactory.java
@@ -136,7 +136,7 @@ public final class SentryThreadFactory {
     sentryThread.setCrashed(crashed);
 
     final List<SentryStackFrame> frames =
-        sentryStackTraceFactory.getStackFrames(stackFramesElements);
+        sentryStackTraceFactory.getStackFrames(stackFramesElements, false);
 
     if (options.isAttachStacktrace() && frames != null && !frames.isEmpty()) {
       final SentryStackTrace sentryStackTrace = new SentryStackTrace(frames);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Send SDK frames for uncaught exceptions to enable SDK detection on Java/Android

Here's a sample event for testing https://sentry-sdks.sentry.io/issues/4595173909/events/ea05056bfc2b4f42ae04df91a4745881/

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2758 

## :green_heart: How did you test it?
Manually and automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
