### PR TITLE
Do not register `sentrySpringFilter` in ServletContext for Spring Boot

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringServletContainerInitializer.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringServletContainerInitializer.java
@@ -1,5 +1,7 @@
 package io.sentry.spring.jakarta;
 
+import static io.sentry.util.ClassLoaderUtils.classLoaderOrDefault;
+
 import com.jakewharton.nopen.annotation.Open;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterRegistration;
@@ -20,10 +22,17 @@ public class SentrySpringServletContainerInitializer implements ServletContainer
   @Override
   public void onStartup(final @Nullable Set<Class<?>> c, final @NotNull ServletContext ctx)
       throws ServletException {
-    final FilterRegistration.Dynamic dynamic =
-        ctx.addFilter("sentrySpringFilter", SentrySpringFilter.class);
-    if (dynamic != null) {
-      dynamic.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "/*");
+    try {
+      Class.forName(
+          "org.springframework.boot.SpringApplication",
+          false,
+          classLoaderOrDefault(getClass().getClassLoader()));
+    } catch (ClassNotFoundException e) {
+      final FilterRegistration.Dynamic dynamic =
+          ctx.addFilter("sentrySpringFilter", SentrySpringFilter.class);
+      if (dynamic != null) {
+        dynamic.addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), false, "/*");
+      }
     }
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
In Spring Boot `3.1.x` our `SentrySpringServletContainerInitializer` is executed before Spring registers filters and Spring Boot now throws an exception if the filter has already been registered. We now check if the app is running as Spring Boot and skip registering the filter ourselves in that case.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3017

## :green_heart: How did you test it?
Manually using dockerized tomcat.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
