### PR TITLE
Fix UI tests deserialization of envelope items

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ContextUtils.java
@@ -351,7 +351,7 @@ public final class ContextUtils {
     }
   }
 
-  /** Register a not exported BroadcastReceiver, independently from platform version. */
+  /** Register an exported BroadcastReceiver, independently from platform version. */
   static @Nullable Intent registerReceiver(
       final @NotNull Context context,
       final @NotNull SentryOptions options,
@@ -360,7 +360,7 @@ public final class ContextUtils {
     return registerReceiver(context, new BuildInfoProvider(options.getLogger()), receiver, filter);
   }
 
-  /** Register a not exported BroadcastReceiver, independently from platform version. */
+  /** Register an exported BroadcastReceiver, independently from platform version. */
   @SuppressLint({"NewApi", "UnspecifiedRegisterReceiverFlag"})
   static @Nullable Intent registerReceiver(
       final @NotNull Context context,

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
@@ -35,7 +35,7 @@ class AutomaticSpansTest : BaseUiTest() {
 
         relay.assert {
             assertFirstEnvelope {
-                val transactionItem: SentryTransaction = it.assertItem()
+                val transactionItem: SentryTransaction = it.assertTransaction()
                 assertTrue("TTID span missing") {
                     transactionItem.spans.any { span ->
                         span.op == "ui.load.initial_display"

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -6,7 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ProfilingTraceData
 import io.sentry.Sentry
 import io.sentry.android.core.SentryAndroidOptions
-import io.sentry.assertEnvelopeItem
+import io.sentry.assertEnvelopeTransaction
 import io.sentry.protocol.SentryTransaction
 import org.junit.runner.RunWith
 import kotlin.test.Test
@@ -61,11 +61,11 @@ class SdkInitTests : BaseUiTest() {
 
         relay.assert {
             findEnvelope {
-                assertEnvelopeItem<SentryTransaction>(it.items.toList()).transaction == "e2etests2"
+                assertEnvelopeTransaction(it.items.toList()).transaction == "e2etests2"
             }.assert {
-                val transactionItem: SentryTransaction = it.assertItem()
+                val transactionItem: SentryTransaction = it.assertTransaction()
                 // Profiling uses executorService, so if the executorService is shutdown it would fail
-                val profilingTraceData: ProfilingTraceData = it.assertItem()
+                val profilingTraceData: ProfilingTraceData = it.assertProfile()
                 it.assertNoOtherItems()
                 assertEquals("e2etests2", transactionItem.transaction)
                 assertEquals("e2etests2", profilingTraceData.transactionName)

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/EnvelopeAsserter.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/EnvelopeAsserter.kt
@@ -1,7 +1,11 @@
 package io.sentry.uitest.android.mockservers
 
+import io.sentry.ProfilingTraceData
 import io.sentry.SentryEnvelope
 import io.sentry.assertEnvelopeItem
+import io.sentry.assertEnvelopeProfile
+import io.sentry.assertEnvelopeTransaction
+import io.sentry.protocol.SentryTransaction
 import okhttp3.mockwebserver.MockResponse
 
 /**
@@ -17,6 +21,24 @@ class EnvelopeAsserter(val envelope: SentryEnvelope, val response: MockResponse)
      * The asserted item is then removed from internal list of unasserted items.
      */
     inline fun <reified T> assertItem(): T = assertEnvelopeItem(unassertedItems) { index, item ->
+        unassertedItems.removeAt(index)
+        return item
+    }
+
+    /**
+     * Asserts a transaction exists and returns the first one.
+     * It is then removed from internal list of unasserted items.
+     */
+    inline fun assertTransaction(): SentryTransaction = assertEnvelopeTransaction(unassertedItems) { index, item ->
+        unassertedItems.removeAt(index)
+        return item
+    }
+
+    /**
+     * Asserts a profile exists and returns the first one.
+     * It is then removed from internal list of unasserted items.
+     */
+    inline fun assertProfile(): ProfilingTraceData = assertEnvelopeProfile(unassertedItems) { index, item ->
         unassertedItems.removeAt(index)
         return item
     }

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -1,4 +1,8 @@
 public final class io/sentry/AssertionsKt {
+	public static final fun assertEnvelopeProfile (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lio/sentry/ProfilingTraceData;
+	public static synthetic fun assertEnvelopeProfile$default (Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/sentry/ProfilingTraceData;
+	public static final fun assertEnvelopeTransaction (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lio/sentry/protocol/SentryTransaction;
+	public static synthetic fun assertEnvelopeTransaction$default (Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/sentry/protocol/SentryTransaction;
 	public static final fun checkEvent (Lkotlin/jvm/functions/Function1;)Lio/sentry/SentryEnvelope;
 	public static final fun checkTransaction (Lkotlin/jvm/functions/Function1;)Lio/sentry/SentryEnvelope;
 }


### PR DESCRIPTION
## :scroll: Description
improved deserialization of envelope items using header type to avoid oom errors
removed screen refresh rate from maximum allowed timestamp

#skip-changelog


## :bulb: Motivation and Context
Fixes errors like https://github.com/getsentry/sentry-java/actions/runs/6743234669/job/18330770480


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
