### PR TITLE
Reduce main thread work on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
-- Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
+  - Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
 
 ## 6.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
+- Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
 -  Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github.com/getsentry/sentry-java/issues/2955) for more details (fix provided by Native SDK bump)
 - Ensure DSN uses http/https protocol ([#3044](https://github.com/getsentry/sentry-java/pull/3044))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
+ 
 ## 6.33.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
 -  Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github.com/getsentry/sentry-java/issues/2955) for more details (fix provided by Native SDK bump)
 - Ensure DSN uses http/https protocol ([#3044](https://github.com/getsentry/sentry-java/pull/3044))
 
@@ -36,10 +37,6 @@
 - Add current activity name to app context ([#2999](https://github.com/getsentry/sentry-java/pull/2999))
 - Add `MonitorConfig` param to `CheckInUtils.withCheckIn` ([#3038](https://github.com/getsentry/sentry-java/pull/3038))
   - This makes it easier to automatically create or update (upsert) monitors.
-
-### Fixes
-
-- Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
  
 ## 6.33.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
-  - Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
+- Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
 
 ## 6.34.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog# Changelog
+# Changelog
 
 ## Unreleased
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -72,11 +72,7 @@ public final class AnrIntegration implements Integration, Closeable {
       } catch (Throwable e) {
         options
             .getLogger()
-            .log(
-                SentryLevel.DEBUG,
-                "Failed to start AnrIntegration on executor thread. Starting on the calling thread.",
-                e);
-        startAnrWatchdog(hub, options);
+            .log(SentryLevel.DEBUG, "Failed to start AnrIntegration on executor thread.", e);
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -53,7 +53,7 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
       } catch (Throwable e) {
         logger.log(
             SentryLevel.DEBUG,
-            "Failed to start EnvelopeFileObserverIntegration on executor thread. Starting on the calling thread.",
+            "Failed to start EnvelopeFileObserverIntegration on executor thread.",
             e);
       }
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -63,9 +63,8 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
-                "Failed to start PhoneStateBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                "Failed to start PhoneStateBreadcrumbsIntegration on executor thread.",
                 e);
-        startTelephonyListener(hub, options);
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -23,12 +23,13 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
   private @Nullable SentryAndroidOptions options;
   @TestOnly @Nullable PhoneStateChangeListener listener;
   private @Nullable TelephonyManager telephonyManager;
+  private boolean isClosed = false;
+  private final @NotNull Object startLock = new Object();
 
   public PhoneStateBreadcrumbsIntegration(final @NotNull Context context) {
     this.context = Objects.requireNonNull(context, "Context is required");
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   public void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
     Objects.requireNonNull(hub, "Hub is required");
@@ -46,28 +47,56 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
 
     if (this.options.isEnableSystemEventBreadcrumbs()
         && Permissions.hasPermission(context, READ_PHONE_STATE)) {
-      telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-      if (telephonyManager != null) {
-        try {
-          listener = new PhoneStateChangeListener(hub);
-          telephonyManager.listen(listener, android.telephony.PhoneStateListener.LISTEN_CALL_STATE);
-
-          options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
-          addIntegrationToSdkVersion();
-        } catch (Throwable e) {
-          this.options
-              .getLogger()
-              .log(SentryLevel.INFO, e, "TelephonyManager is not available or ready to use.");
-        }
-      } else {
-        this.options.getLogger().log(SentryLevel.INFO, "TelephonyManager is not available");
+      try {
+        options
+            .getExecutorService()
+            .submit(
+                () -> {
+                  synchronized (startLock) {
+                    if (!isClosed) {
+                      startTelephonyListener(hub, options);
+                    }
+                  }
+                });
+      } catch (Throwable e) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "Failed to start PhoneStateBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                e);
+        startTelephonyListener(hub, options);
       }
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void startTelephonyListener(
+      final @NotNull IHub hub, final @NotNull SentryOptions options) {
+    telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+    if (telephonyManager != null) {
+      try {
+        listener = new PhoneStateChangeListener(hub);
+        telephonyManager.listen(listener, android.telephony.PhoneStateListener.LISTEN_CALL_STATE);
+
+        options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
+        addIntegrationToSdkVersion();
+      } catch (Throwable e) {
+        options
+            .getLogger()
+            .log(SentryLevel.INFO, e, "TelephonyManager is not available or ready to use.");
+      }
+    } else {
+      options.getLogger().log(SentryLevel.INFO, "TelephonyManager is not available");
     }
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public void close() throws IOException {
+    synchronized (startLock) {
+      isClosed = true;
+    }
     if (telephonyManager != null && listener != null) {
       telephonyManager.listen(listener, android.telephony.PhoneStateListener.LISTEN_NONE);
       listener = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -40,20 +40,21 @@ final class SendCachedEnvelopeIntegration implements Integration {
       return;
     }
 
-    final SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget sender =
-        factory.create(hub, androidOptions);
-
-    if (sender == null) {
-      androidOptions.getLogger().log(SentryLevel.ERROR, "SendFireAndForget factory is null.");
-      return;
-    }
-
     try {
       Future<?> future =
           androidOptions
               .getExecutorService()
               .submit(
                   () -> {
+                    final SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget sender =
+                        factory.create(hub, androidOptions);
+
+                    if (sender == null) {
+                      androidOptions
+                          .getLogger()
+                          .log(SentryLevel.ERROR, "SendFireAndForget factory is null.");
+                      return;
+                    }
                     try {
                       sender.send();
                     } catch (Throwable e) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -65,6 +65,8 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
   private @Nullable SentryAndroidOptions options;
 
   private final @NotNull List<String> actions;
+  private boolean isClosed = false;
+  private final @NotNull Object startLock = new Object();
 
   public SystemEventsBreadcrumbsIntegration(final @NotNull Context context) {
     this(context, getDefaultActions());
@@ -92,24 +94,47 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
             this.options.isEnableSystemEventBreadcrumbs());
 
     if (this.options.isEnableSystemEventBreadcrumbs()) {
-      receiver = new SystemEventsBroadcastReceiver(hub, this.options.getLogger());
-      final IntentFilter filter = new IntentFilter();
-      for (String item : actions) {
-        filter.addAction(item);
-      }
+
       try {
-        // registerReceiver can throw SecurityException but it's not documented in the official docs
-        ContextUtils.registerReceiver(context, options, receiver, filter);
-        this.options
-            .getLogger()
-            .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
-        addIntegrationToSdkVersion();
+        options
+            .getExecutorService()
+            .submit(
+                () -> {
+                  synchronized (startLock) {
+                    if (!isClosed) {
+                      startSystemEventsReceiver(hub, (SentryAndroidOptions) options);
+                    }
+                  }
+                });
       } catch (Throwable e) {
-        this.options.setEnableSystemEventBreadcrumbs(false);
-        this.options
+        options
             .getLogger()
-            .log(SentryLevel.ERROR, "Failed to initialize SystemEventsBreadcrumbsIntegration.", e);
+            .log(
+                SentryLevel.DEBUG,
+                "Failed to start SystemEventsBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                e);
+        startSystemEventsReceiver(hub, (SentryAndroidOptions) options);
       }
+    }
+  }
+
+  private void startSystemEventsReceiver(
+      final @NotNull IHub hub, final @NotNull SentryAndroidOptions options) {
+    receiver = new SystemEventsBroadcastReceiver(hub, options.getLogger());
+    final IntentFilter filter = new IntentFilter();
+    for (String item : actions) {
+      filter.addAction(item);
+    }
+    try {
+      // registerReceiver can throw SecurityException but it's not documented in the official docs
+      ContextUtils.registerReceiver(context, options, receiver, filter);
+      options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
+      addIntegrationToSdkVersion();
+    } catch (Throwable e) {
+      options.setEnableSystemEventBreadcrumbs(false);
+      options
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to initialize SystemEventsBreadcrumbsIntegration.", e);
     }
   }
 
@@ -164,6 +189,9 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   @Override
   public void close() throws IOException {
+    synchronized (startLock) {
+      isClosed = true;
+    }
     if (receiver != null) {
       context.unregisterReceiver(receiver);
       receiver = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -111,9 +111,8 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
-                "Failed to start SystemEventsBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                "Failed to start SystemEventsBreadcrumbsIntegration on executor thread.",
                 e);
-        startSystemEventsReceiver(hub, (SentryAndroidOptions) options);
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -29,12 +29,13 @@ public final class TempSensorBreadcrumbsIntegration
   private @Nullable SentryAndroidOptions options;
 
   @TestOnly @Nullable SensorManager sensorManager;
+  private boolean isClosed = false;
+  private final @NotNull Object startLock = new Object();
 
   public TempSensorBreadcrumbsIntegration(final @NotNull Context context) {
     this.context = Objects.requireNonNull(context, "Context is required");
   }
 
-  @SuppressWarnings("deprecation")
   @Override
   public void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
     this.hub = Objects.requireNonNull(hub, "Hub is required");
@@ -51,34 +52,57 @@ public final class TempSensorBreadcrumbsIntegration
             this.options.isEnableSystemEventBreadcrumbs());
 
     if (this.options.isEnableSystemEventBreadcrumbs()) {
-      try {
-        sensorManager = (SensorManager) context.getSystemService(SENSOR_SERVICE);
-        if (sensorManager != null) {
-          final Sensor defaultSensor =
-              sensorManager.getDefaultSensor(Sensor.TYPE_AMBIENT_TEMPERATURE);
-          if (defaultSensor != null) {
-            sensorManager.registerListener(this, defaultSensor, SensorManager.SENSOR_DELAY_NORMAL);
 
-            options
-                .getLogger()
-                .log(SentryLevel.DEBUG, "TempSensorBreadcrumbsIntegration installed.");
-            addIntegrationToSdkVersion();
-          } else {
-            this.options
-                .getLogger()
-                .log(SentryLevel.INFO, "TYPE_AMBIENT_TEMPERATURE is not available.");
-          }
-        } else {
-          this.options.getLogger().log(SentryLevel.INFO, "SENSOR_SERVICE is not available.");
-        }
+      try {
+        options
+            .getExecutorService()
+            .submit(
+                () -> {
+                  synchronized (startLock) {
+                    if (!isClosed) {
+                      startSensorListener(options);
+                    }
+                  }
+                });
       } catch (Throwable e) {
-        options.getLogger().log(SentryLevel.ERROR, e, "Failed to init. the SENSOR_SERVICE.");
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "Failed to start TempSensorBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                e);
+        startSensorListener(options);
       }
+    }
+  }
+
+  private void startSensorListener(final @NotNull SentryOptions options) {
+    try {
+      sensorManager = (SensorManager) context.getSystemService(SENSOR_SERVICE);
+      if (sensorManager != null) {
+        final Sensor defaultSensor =
+            sensorManager.getDefaultSensor(Sensor.TYPE_AMBIENT_TEMPERATURE);
+        if (defaultSensor != null) {
+          sensorManager.registerListener(this, defaultSensor, SensorManager.SENSOR_DELAY_NORMAL);
+
+          options.getLogger().log(SentryLevel.DEBUG, "TempSensorBreadcrumbsIntegration installed.");
+          addIntegrationToSdkVersion();
+        } else {
+          options.getLogger().log(SentryLevel.INFO, "TYPE_AMBIENT_TEMPERATURE is not available.");
+        }
+      } else {
+        options.getLogger().log(SentryLevel.INFO, "SENSOR_SERVICE is not available.");
+      }
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.ERROR, e, "Failed to init. the SENSOR_SERVICE.");
     }
   }
 
   @Override
   public void close() throws IOException {
+    synchronized (startLock) {
+      isClosed = true;
+    }
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
       sensorManager = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -69,9 +69,8 @@ public final class TempSensorBreadcrumbsIntegration
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
-                "Failed to start TempSensorBreadcrumbsIntegration on executor thread. Starting on the calling thread.",
+                "Failed to start TempSensorBreadcrumbsIntegration on executor thread.",
                 e);
-        startSensorListener(options);
       }
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.sentry.IHub
 import io.sentry.ILogger
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
 import org.junit.runner.RunWith
 import org.mockito.kotlin.eq
@@ -76,6 +77,18 @@ class EnvelopeFileObserverIntegrationTest {
 //        verify(integrationMock).register(expected, options)
         hub.close()
         verify(integrationMock).close()
+    }
+
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val integration = fixture.getSut {
+            it.executorService = deferredExecutorService
+        }
+        integration.register(fixture.hub, fixture.hub.options)
+        integration.close()
+        deferredExecutorService.runAll()
+        verify(fixture.logger, never()).log(eq(SentryLevel.DEBUG), eq("EnvelopeFileObserverIntegration installed."))
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -363,7 +363,6 @@ class SentryAndroidTest {
             // this is necessary to delay the AnrV2Integration processing to execute the configure
             // scope block below (otherwise it won't be possible as hub is no-op before .init)
             it.executorService.submit {
-                Thread.sleep(2000L)
                 Sentry.configureScope { scope ->
                     // make sure the scope values changed to test that we're still using previously
                     // persisted values for the old ANR events
@@ -380,7 +379,7 @@ class SentryAndroidTest {
             .untilTrue(asserted)
 
         // assert that persisted values have changed
-        options.executorService.close(1000L) // finalizes all enqueued persisting tasks
+        options.executorService.close(5000L) // finalizes all enqueued persisting tasks
         assertEquals(
             "TestActivity",
             PersistingScopeObserver.read(options, TRANSACTION_FILENAME, String::class.java)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
@@ -6,8 +6,15 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import io.sentry.Breadcrumb
+import io.sentry.Hint
 import io.sentry.IHub
+import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
+import io.sentry.TypeCheckHint
+import io.sentry.test.DeferredExecutorService
+import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.getDeclaredCtor
+import io.sentry.test.injectForField
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
@@ -15,7 +22,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -26,8 +32,10 @@ class TempSensorBreadcrumbsIntegrationTest {
         val context = mock<Context>()
         val manager = mock<SensorManager>()
         val sensor = mock<Sensor>()
+        val options = SentryAndroidOptions()
 
-        fun getSut(): TempSensorBreadcrumbsIntegration {
+        fun getSut(executorService: ISentryExecutorService = ImmediateExecutorService()): TempSensorBreadcrumbsIntegration {
+            options.executorService = executorService
             whenever(context.getSystemService(Context.SENSOR_SERVICE)).thenReturn(manager)
             whenever(manager.getDefaultSensor(Sensor.TYPE_AMBIENT_TEMPERATURE)).thenReturn(sensor)
             return TempSensorBreadcrumbsIntegration(context)
@@ -39,21 +47,31 @@ class TempSensorBreadcrumbsIntegrationTest {
     @Test
     fun `When system events breadcrumb is enabled, it registers callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         verify(fixture.manager).registerListener(any(), any<Sensor>(), eq(SensorManager.SENSOR_DELAY_NORMAL))
         assertNotNull(sut.sensorManager)
     }
 
     @Test
+    fun `temp sensor listener is registered in the executorService`() {
+        val sut = fixture.getSut(executorService = mock())
+        val hub = mock<IHub>()
+        sut.register(hub, fixture.options)
+
+        assertNull(sut.sensorManager)
+    }
+
+    @Test
     fun `When system events breadcrumb is disabled, it should not register a callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions().apply {
-            isEnableSystemEventBreadcrumbs = false
-        }
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(
+            hub,
+            fixture.options.apply {
+                isEnableSystemEventBreadcrumbs = false
+            }
+        )
         verify(fixture.manager, never()).registerListener(any(), any<Sensor>(), any())
         assertNull(sut.sensorManager)
     }
@@ -61,28 +79,42 @@ class TempSensorBreadcrumbsIntegrationTest {
     @Test
     fun `When TempSensorBreadcrumbsIntegration is closed, it should unregister the callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         sut.close()
         verify(fixture.manager).unregisterListener(any<SensorEventListener>())
         assertNull(sut.sensorManager)
     }
 
-    @Ignore("SensorEvent.values is always null, even when mocking it")
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut(executorService = deferredExecutorService)
+        sut.register(mock(), fixture.options)
+        assertNull(sut.sensorManager)
+        sut.close()
+        deferredExecutorService.runAll()
+        assertNull(sut.sensorManager)
+    }
+
     @Test
     fun `When onSensorChanged received, add a breadcrumb with type and category`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
-        sut.onSensorChanged(mock())
+        sut.register(hub, fixture.options)
+        val sensorCtor = "android.hardware.SensorEvent".getDeclaredCtor(emptyArray())
+        val sensorEvent: SensorEvent = sensorCtor.newInstance() as SensorEvent
+        sensorEvent.injectForField("values", FloatArray(2) { 1F })
+        sut.onSensorChanged(sensorEvent)
 
         verify(hub).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("device.event", it.category)
                 assertEquals("system", it.type)
                 assertEquals(SentryLevel.INFO, it.level)
+            },
+            check<Hint> {
+                assertEquals(sensorEvent, it.get(TypeCheckHint.ANDROID_SENSOR_EVENT))
             }
         )
     }
@@ -90,9 +122,8 @@ class TempSensorBreadcrumbsIntegrationTest {
     @Test
     fun `When onSensorChanged received and null values, do not add a breadcrumb`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         val event = mock<SensorEvent>()
         assertNull(event.values)
         sut.onSensorChanged(event)

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -2,13 +2,13 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.IHub
-import io.sentry.ISentryExecutorService
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
+import io.sentry.test.ImmediateExecutorService
 import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
@@ -21,14 +21,12 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Future
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -334,13 +332,10 @@ class SentryOkHttpEventListenerTest {
 
     @Test
     fun `when response is not closed, root call is trimmed to responseHeadersEnd`() {
-        val mockExecutor = mock<ISentryExecutorService>()
-        val captor = argumentCaptor<Runnable>()
-        whenever(mockExecutor.schedule(captor.capture(), any())).then {
-            captor.lastValue.run()
-            mock<Future<Runnable>>()
-        }
-        val sut = fixture.getSut(httpStatusCode = 500, configureOptions = { it.executorService = mockExecutor })
+        val sut = fixture.getSut(
+            httpStatusCode = 500,
+            configureOptions = { it.executorService = ImmediateExecutorService() }
+        )
         val request = getRequest()
         val call = sut.newCall(request)
         val response = spy(call.execute())

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -23,6 +23,7 @@ import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_BOD
 import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_HEADERS_EVENT
 import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.SECURE_CONNECT_EVENT
 import io.sentry.exception.SentryHttpClientException
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.getProperty
 import okhttp3.Protocol
 import okhttp3.Request
@@ -31,7 +32,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -39,7 +39,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import kotlin.RuntimeException
 import kotlin.test.Test
@@ -534,13 +533,7 @@ class SentryOkHttpEventTest {
 
     @Test
     fun `scheduleFinish schedules finishEvent`() {
-        val mockExecutor = mock<ISentryExecutorService>()
-        val captor = argumentCaptor<Runnable>()
-        whenever(mockExecutor.schedule(captor.capture(), any())).then {
-            captor.lastValue.run()
-            mock<Future<Runnable>>()
-        }
-        fixture.hub.options.executorService = mockExecutor
+        fixture.hub.options.executorService = ImmediateExecutorService()
         val sut = spy(fixture.getSut())
         val timestamp = mock<SentryDate>()
         sut.scheduleFinish(timestamp)

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -11,6 +11,16 @@ public final class io/sentry/SkipError : java/lang/Error {
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class io/sentry/test/DeferredExecutorService : io/sentry/ISentryExecutorService {
+	public fun <init> ()V
+	public fun close (J)V
+	public fun isClosed ()Z
+	public final fun runAll ()V
+	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
+	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
+	public fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
+}
+
 public final class io/sentry/test/ImmediateExecutorService : io/sentry/ISentryExecutorService {
 	public fun <init> ()V
 	public fun close (J)V

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -14,6 +14,7 @@ public final class io/sentry/SkipError : java/lang/Error {
 public final class io/sentry/test/DeferredExecutorService : io/sentry/ISentryExecutorService {
 	public fun <init> ()V
 	public fun close (J)V
+	public final fun getScheduledRunnables ()Ljava/util/ArrayList;
 	public fun isClosed ()Z
 	public final fun runAll ()V
 	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
@@ -34,5 +35,6 @@ public final class io/sentry/test/ReflectionKt {
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Z
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;)Z
 	public static final fun getCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+	public static final fun getDeclaredCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
 }
 

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -17,3 +17,22 @@ class ImmediateExecutorService : ISentryExecutorService {
     override fun close(timeoutMillis: Long) {}
     override fun isClosed(): Boolean = false
 }
+
+class DeferredExecutorService : ISentryExecutorService {
+
+    private val runnables = ArrayList<Runnable>()
+
+    fun runAll() {
+        runnables.forEach { it.run() }
+    }
+
+    override fun submit(runnable: Runnable): Future<*> {
+        runnables.add(runnable)
+        return mock()
+    }
+
+    override fun <T> submit(callable: Callable<T>): Future<T> = mock()
+    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> = mock()
+    override fun close(timeoutMillis: Long) {}
+    override fun isClosed(): Boolean = false
+}

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -13,7 +13,10 @@ class ImmediateExecutorService : ISentryExecutorService {
     }
 
     override fun <T> submit(callable: Callable<T>): Future<T> = mock()
-    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> = mock()
+    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> {
+        runnable.run()
+        return mock<Future<Runnable>>()
+    }
     override fun close(timeoutMillis: Long) {}
     override fun isClosed(): Boolean = false
 }
@@ -21,9 +24,11 @@ class ImmediateExecutorService : ISentryExecutorService {
 class DeferredExecutorService : ISentryExecutorService {
 
     private val runnables = ArrayList<Runnable>()
+    val scheduledRunnables = ArrayList<Runnable>()
 
     fun runAll() {
         runnables.forEach { it.run() }
+        scheduledRunnables.forEach { it.run() }
     }
 
     override fun submit(runnable: Runnable): Future<*> {
@@ -32,7 +37,10 @@ class DeferredExecutorService : ISentryExecutorService {
     }
 
     override fun <T> submit(callable: Callable<T>): Future<T> = mock()
-    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> = mock()
+    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> {
+        scheduledRunnables.add(runnable)
+        return mock()
+    }
     override fun close(timeoutMillis: Long) {}
     override fun isClosed(): Boolean = false
 }

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
@@ -52,3 +52,10 @@ fun String.getCtor(ctorTypes: Array<Class<*>>): Constructor<*> {
     val clazz = Class.forName(this)
     return clazz.getConstructor(*ctorTypes)
 }
+
+fun String.getDeclaredCtor(ctorTypes: Array<Class<*>>): Constructor<*> {
+    val clazz = Class.forName(this)
+    val constructor = clazz.getDeclaredConstructor(*ctorTypes)
+    constructor.isAccessible = true
+    return constructor
+}

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -64,18 +64,17 @@ public final class SendCachedEnvelopeFireAndForgetIntegration implements Integra
       return;
     }
 
-    final SendFireAndForget sender = factory.create(hub, options);
-
-    if (sender == null) {
-      options.getLogger().log(SentryLevel.ERROR, "SendFireAndForget factory is null.");
-      return;
-    }
-
     try {
       options
           .getExecutorService()
           .submit(
               () -> {
+                final SendFireAndForget sender = factory.create(hub, options);
+
+                if (sender == null) {
+                  options.getLogger().log(SentryLevel.ERROR, "SendFireAndForget factory is null.");
+                  return;
+                }
                 try {
                   sender.send();
                 } catch (Throwable e) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -335,18 +335,21 @@ public final class Sentry {
 
       final File profilingTracesDir = new File(profilingTracesDirPath);
       profilingTracesDir.mkdirs();
-      final File[] oldTracesDirContent = profilingTracesDir.listFiles();
+      final long timestamp = System.currentTimeMillis();
 
       try {
         options
             .getExecutorService()
             .submit(
                 () -> {
+                  final File[] oldTracesDirContent = profilingTracesDir.listFiles();
                   if (oldTracesDirContent == null) return;
                   // Method trace files are normally deleted at the end of traces, but if that fails
                   // for some reason we try to clear any old files here.
                   for (File f : oldTracesDirContent) {
-                    FileUtils.deleteRecursively(f);
+                    if (f.lastModified() < timestamp) {
+                      FileUtils.deleteRecursively(f);
+                    }
                   }
                 });
       } catch (RejectedExecutionException e) {

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -285,6 +285,8 @@ class SentryTest {
         dir.mkdirs()
         oldProfile.createNewFile()
         newProfile.createNewFile()
+        // Make the old profile look like it's created earlier
+        oldProfile.setLastModified(System.currentTimeMillis() - 10000)
         // Make the new profile look like it's created later
         newProfile.setLastModified(System.currentTimeMillis() + 10000)
 

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -271,6 +271,40 @@ class SentryTest {
     }
 
     @Test
+    fun `only old profiles in profilingTracesDirPath should be cleared when profiling is enabled`() {
+        val tempPath = getTempPath()
+        val options = SentryOptions().also {
+            it.dsn = dsn
+            it.cacheDirPath = tempPath
+        }
+        val dir = File(options.profilingTracesDirPath!!)
+        val oldProfile = File(dir, "oldProfile")
+        val newProfile = File(dir, "newProfile")
+
+        // Create all files
+        dir.mkdirs()
+        oldProfile.createNewFile()
+        newProfile.createNewFile()
+        // Make the new profile look like it's created later
+        newProfile.setLastModified(System.currentTimeMillis() + 10000)
+
+        // Assert both file exist
+        assertTrue(oldProfile.exists())
+        assertTrue(newProfile.exists())
+
+        Sentry.init {
+            it.dsn = dsn
+            it.profilesSampleRate = 1.0
+            it.cacheDirPath = tempPath
+            it.executorService = ImmediateExecutorService()
+        }
+
+        // Assert only the new profile exists
+        assertFalse(oldProfile.exists())
+        assertTrue(newProfile.exists())
+    }
+
+    @Test
     fun `profilingTracesDirPath should not be created and cleared when profiling is disabled`() {
         val tempPath = getTempPath()
         var sentryOptions: SentryOptions? = null


### PR DESCRIPTION
## :scroll: Description
Moved old profiles deletion to the background
moved some Integration.register() to the background using executorService
added tests


## :bulb: Motivation and Context
This is an attempt to improve SDK startup timing.
Relates to https://github.com/getsentry/sentry-java/issues/2222


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
