### PR TITLE
Move integrations registration to background during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Reduce main thread work on init ([#3036](https://github.com/getsentry/sentry-java/pull/3036))
+- Move Integrations registration to background on init ([#3043](https://github.com/getsentry/sentry-java/pull/3043))
  
 ## 6.33.1
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -55,27 +55,42 @@ public final class AnrIntegration implements Integration, Closeable {
         .log(SentryLevel.DEBUG, "AnrIntegration enabled: %s", options.isAnrEnabled());
 
     if (options.isAnrEnabled()) {
-      synchronized (watchDogLock) {
-        if (anrWatchDog == null) {
-          options
-              .getLogger()
-              .log(
-                  SentryLevel.DEBUG,
-                  "ANR timeout in milliseconds: %d",
-                  options.getAnrTimeoutIntervalMillis());
+      addIntegrationToSdkVersion();
+      try {
+        options.getExecutorService().submit(() -> startAnrWatchdog(hub, options));
+      } catch (Throwable e) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "Failed to start AnrIntegration on executor thread. Starting on the calling thread.",
+                e);
+        startAnrWatchdog(hub, options);
+      }
+    }
+  }
 
-          anrWatchDog =
-              new ANRWatchDog(
-                  options.getAnrTimeoutIntervalMillis(),
-                  options.isAnrReportInDebug(),
-                  error -> reportANR(hub, options, error),
-                  options.getLogger(),
-                  context);
-          anrWatchDog.start();
+  private void startAnrWatchdog(
+      final @NotNull IHub hub, final @NotNull SentryAndroidOptions options) {
+    synchronized (watchDogLock) {
+      if (anrWatchDog == null) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "ANR timeout in milliseconds: %d",
+                options.getAnrTimeoutIntervalMillis());
 
-          options.getLogger().log(SentryLevel.DEBUG, "AnrIntegration installed.");
-          addIntegrationToSdkVersion();
-        }
+        anrWatchDog =
+            new ANRWatchDog(
+                options.getAnrTimeoutIntervalMillis(),
+                options.isAnrReportInDebug(),
+                error -> reportANR(hub, options, error),
+                options.getLogger(),
+                context);
+        anrWatchDog.start();
+
+        options.getLogger().log(SentryLevel.DEBUG, "AnrIntegration installed.");
       }
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.sentry.IHub
 import io.sentry.SentryLevel
 import io.sentry.android.core.AnrIntegration.AnrHint
 import io.sentry.exception.ExceptionMechanismException
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
 import io.sentry.util.HintUtils
 import org.mockito.kotlin.any
@@ -102,6 +103,18 @@ class AnrIntegrationTest {
 
         sut.close()
 
+        assertNull(sut.anrWatchDog)
+    }
+
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut()
+        fixture.options.executorService = deferredExecutorService
+        sut.register(fixture.hub, fixture.options)
+        assertNull(sut.anrWatchDog)
+        sut.close()
+        deferredExecutorService.runAll()
         assertNull(sut.anrWatchDog)
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.sentry.IHub
 import io.sentry.SentryLevel
 import io.sentry.android.core.AnrIntegration.AnrHint
 import io.sentry.exception.ExceptionMechanismException
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.util.HintUtils
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
@@ -23,7 +24,7 @@ class AnrIntegrationTest {
     private class Fixture {
         val context = mock<Context>()
         val hub = mock<IHub>()
-        val options = SentryAndroidOptions().apply {
+        var options: SentryAndroidOptions = SentryAndroidOptions().apply {
             setLogger(mock())
         }
 
@@ -44,12 +45,23 @@ class AnrIntegrationTest {
 
     @Test
     fun `When ANR is enabled, ANR watch dog should be started`() {
+        fixture.options.executorService = ImmediateExecutorService()
         val sut = fixture.getSut()
 
         sut.register(fixture.hub, fixture.options)
 
         assertNotNull(sut.anrWatchDog)
         assertTrue((sut.anrWatchDog as ANRWatchDog).isAlive)
+    }
+
+    @Test
+    fun `ANR watch dog should be started in the executorService`() {
+        fixture.options.executorService = mock()
+        val sut = fixture.getSut()
+
+        sut.register(fixture.hub, fixture.options)
+
+        assertNull(sut.anrWatchDog)
     }
 
     @Test
@@ -82,6 +94,7 @@ class AnrIntegrationTest {
     @Test
     fun `When ANR integration is closed, watch dog should stop`() {
         val sut = fixture.getSut()
+        fixture.options.executorService = ImmediateExecutorService()
 
         sut.register(fixture.hub, fixture.options)
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
@@ -76,6 +77,17 @@ class PhoneStateBreadcrumbsIntegrationTest {
         sut.register(hub, fixture.options)
         sut.close()
         verify(fixture.manager).listen(any(), eq(PhoneStateListener.LISTEN_NONE))
+        assertNull(sut.listener)
+    }
+
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut(executorService = deferredExecutorService)
+        sut.register(mock(), fixture.options)
+        assertNull(sut.listener)
+        sut.close()
+        deferredExecutorService.runAll()
         assertNull(sut.listener)
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegrationTest.kt
@@ -5,7 +5,9 @@ import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
 import io.sentry.Breadcrumb
 import io.sentry.IHub
+import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
+import io.sentry.test.ImmediateExecutorService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
@@ -23,8 +25,10 @@ class PhoneStateBreadcrumbsIntegrationTest {
     private class Fixture {
         val context = mock<Context>()
         val manager = mock<TelephonyManager>()
+        val options = SentryAndroidOptions()
 
-        fun getSut(): PhoneStateBreadcrumbsIntegration {
+        fun getSut(executorService: ISentryExecutorService = ImmediateExecutorService()): PhoneStateBreadcrumbsIntegration {
+            options.executorService = executorService
             whenever(context.getSystemService(eq(Context.TELEPHONY_SERVICE))).thenReturn(manager)
 
             return PhoneStateBreadcrumbsIntegration(context)
@@ -36,21 +40,31 @@ class PhoneStateBreadcrumbsIntegrationTest {
     @Test
     fun `When system events breadcrumb is enabled, it registers callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         verify(fixture.manager).listen(any(), eq(PhoneStateListener.LISTEN_CALL_STATE))
         assertNotNull(sut.listener)
     }
 
     @Test
+    fun `Phone state callback is registered in the executorService`() {
+        val sut = fixture.getSut(mock())
+        val hub = mock<IHub>()
+        sut.register(hub, fixture.options)
+
+        assertNull(sut.listener)
+    }
+
+    @Test
     fun `When system events breadcrumb is disabled, it doesn't register callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions().apply {
-            isEnableSystemEventBreadcrumbs = false
-        }
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(
+            hub,
+            fixture.options.apply {
+                isEnableSystemEventBreadcrumbs = false
+            }
+        )
         verify(fixture.manager, never()).listen(any(), any())
         assertNull(sut.listener)
     }
@@ -58,9 +72,8 @@ class PhoneStateBreadcrumbsIntegrationTest {
     @Test
     fun `When ActivityBreadcrumbsIntegration is closed, it should unregister the callback`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         sut.close()
         verify(fixture.manager).listen(any(), eq(PhoneStateListener.LISTEN_NONE))
         assertNull(sut.listener)
@@ -69,9 +82,8 @@ class PhoneStateBreadcrumbsIntegrationTest {
     @Test
     fun `When on call state received, added breadcrumb with type and category`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         sut.listener!!.onCallStateChanged(TelephonyManager.CALL_STATE_RINGING, null)
 
         verify(hub).addBreadcrumb(
@@ -87,9 +99,8 @@ class PhoneStateBreadcrumbsIntegrationTest {
     @Test
     fun `When on idle state received, added breadcrumb with type and category`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         sut.listener!!.onCallStateChanged(TelephonyManager.CALL_STATE_IDLE, null)
         verify(hub, never()).addBreadcrumb(any<Breadcrumb>())
     }
@@ -97,9 +108,8 @@ class PhoneStateBreadcrumbsIntegrationTest {
     @Test
     fun `When on offhook state received, added breadcrumb with type and category`() {
         val sut = fixture.getSut()
-        val options = SentryAndroidOptions()
         val hub = mock<IHub>()
-        sut.register(hub, options)
+        sut.register(hub, fixture.options)
         sut.listener!!.onCallStateChanged(TelephonyManager.CALL_STATE_OFFHOOK, null)
         verify(hub, never()).addBreadcrumb(any<Breadcrumb>())
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -363,7 +363,6 @@ class SentryAndroidTest {
             // this is necessary to delay the AnrV2Integration processing to execute the configure
             // scope block below (otherwise it won't be possible as hub is no-op before .init)
             it.executorService.submit {
-                Thread.sleep(2000L)
                 Sentry.configureScope { scope ->
                     // make sure the scope values changed to test that we're still using previously
                     // persisted values for the old ANR events
@@ -380,7 +379,7 @@ class SentryAndroidTest {
             .untilTrue(asserted)
 
         // assert that persisted values have changed
-        options.executorService.close(1000L) // finalizes all enqueued persisting tasks
+        options.executorService.close(5000L) // finalizes all enqueued persisting tasks
         assertEquals(
             "TestActivity",
             PersistingScopeObserver.read(options, TRANSACTION_FILENAME, String::class.java)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.Intent
 import io.sentry.Breadcrumb
 import io.sentry.IHub
+import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
+import io.sentry.test.ImmediateExecutorService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.check
@@ -25,9 +27,10 @@ class SystemEventsBreadcrumbsIntegrationTest {
         var options = SentryAndroidOptions()
         val hub = mock<IHub>()
 
-        fun getSut(enableSystemEventBreadcrumbs: Boolean = true): SystemEventsBreadcrumbsIntegration {
+        fun getSut(enableSystemEventBreadcrumbs: Boolean = true, executorService: ISentryExecutorService = ImmediateExecutorService()): SystemEventsBreadcrumbsIntegration {
             options = SentryAndroidOptions().apply {
                 isEnableSystemEventBreadcrumbs = enableSystemEventBreadcrumbs
+                this.executorService = executorService
             }
             return SystemEventsBreadcrumbsIntegration(context)
         }
@@ -43,6 +46,15 @@ class SystemEventsBreadcrumbsIntegrationTest {
 
         verify(fixture.context).registerReceiver(any(), any())
         assertNotNull(sut.receiver)
+    }
+
+    @Test
+    fun `system events callback is registered in the executorService`() {
+        val sut = fixture.getSut(executorService = mock())
+        val hub = mock<IHub>()
+        sut.register(hub, fixture.options)
+
+        assertNull(sut.receiver)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -75,6 +76,17 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.close()
 
         verify(fixture.context).unregisterReceiver(any())
+        assertNull(sut.receiver)
+    }
+
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut(executorService = deferredExecutorService)
+        sut.register(fixture.hub, fixture.options)
+        assertNull(sut.receiver)
+        sut.close()
+        deferredExecutorService.runAll()
         assertNull(sut.receiver)
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TempSensorBreadcrumbsIntegrationTest.kt
@@ -11,6 +11,7 @@ import io.sentry.IHub
 import io.sentry.ISentryExecutorService
 import io.sentry.SentryLevel
 import io.sentry.TypeCheckHint
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.getDeclaredCtor
 import io.sentry.test.injectForField
@@ -82,6 +83,17 @@ class TempSensorBreadcrumbsIntegrationTest {
         sut.register(hub, fixture.options)
         sut.close()
         verify(fixture.manager).unregisterListener(any<SensorEventListener>())
+        assertNull(sut.sensorManager)
+    }
+
+    @Test
+    fun `when hub is closed right after start, integration is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut(executorService = deferredExecutorService)
+        sut.register(mock(), fixture.options)
+        assertNull(sut.sensorManager)
+        sut.close()
+        deferredExecutorService.runAll()
         assertNull(sut.sensorManager)
     }
 

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -2,13 +2,13 @@ package io.sentry.android.okhttp
 
 import io.sentry.BaggageHeader
 import io.sentry.IHub
-import io.sentry.ISentryExecutorService
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
+import io.sentry.test.ImmediateExecutorService
 import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
@@ -21,14 +21,12 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Future
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -334,13 +332,10 @@ class SentryOkHttpEventListenerTest {
 
     @Test
     fun `when response is not closed, root call is trimmed to responseHeadersEnd`() {
-        val mockExecutor = mock<ISentryExecutorService>()
-        val captor = argumentCaptor<Runnable>()
-        whenever(mockExecutor.schedule(captor.capture(), any())).then {
-            captor.lastValue.run()
-            mock<Future<Runnable>>()
-        }
-        val sut = fixture.getSut(httpStatusCode = 500, configureOptions = { it.executorService = mockExecutor })
+        val sut = fixture.getSut(
+            httpStatusCode = 500,
+            configureOptions = { it.executorService = ImmediateExecutorService() }
+        )
         val request = getRequest()
         val call = sut.newCall(request)
         val response = spy(call.execute())

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventTest.kt
@@ -23,6 +23,7 @@ import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_BOD
 import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_HEADERS_EVENT
 import io.sentry.android.okhttp.SentryOkHttpEventListener.Companion.SECURE_CONNECT_EVENT
 import io.sentry.exception.SentryHttpClientException
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.getProperty
 import okhttp3.Protocol
 import okhttp3.Request
@@ -31,7 +32,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -39,7 +39,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import kotlin.RuntimeException
 import kotlin.test.Test
@@ -534,13 +533,7 @@ class SentryOkHttpEventTest {
 
     @Test
     fun `scheduleFinish schedules finishEvent`() {
-        val mockExecutor = mock<ISentryExecutorService>()
-        val captor = argumentCaptor<Runnable>()
-        whenever(mockExecutor.schedule(captor.capture(), any())).then {
-            captor.lastValue.run()
-            mock<Future<Runnable>>()
-        }
-        fixture.hub.options.executorService = mockExecutor
+        fixture.hub.options.executorService = ImmediateExecutorService()
         val sut = spy(fixture.getSut())
         val timestamp = mock<SentryDate>()
         sut.scheduleFinish(timestamp)

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -14,6 +14,7 @@ public final class io/sentry/SkipError : java/lang/Error {
 public final class io/sentry/test/DeferredExecutorService : io/sentry/ISentryExecutorService {
 	public fun <init> ()V
 	public fun close (J)V
+	public final fun getScheduledRunnables ()Ljava/util/ArrayList;
 	public fun isClosed ()Z
 	public final fun runAll ()V
 	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -24,5 +24,6 @@ public final class io/sentry/test/ReflectionKt {
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Z
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;)Z
 	public static final fun getCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+	public static final fun getDeclaredCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
 }
 

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -13,7 +13,10 @@ class ImmediateExecutorService : ISentryExecutorService {
     }
 
     override fun <T> submit(callable: Callable<T>): Future<T> = mock()
-    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> = mock()
+    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> {
+        runnable.run()
+        return mock<Future<Runnable>>()
+    }
     override fun close(timeoutMillis: Long) {}
     override fun isClosed(): Boolean = false
 }
@@ -21,9 +24,11 @@ class ImmediateExecutorService : ISentryExecutorService {
 class DeferredExecutorService : ISentryExecutorService {
 
     private val runnables = ArrayList<Runnable>()
+    val scheduledRunnables = ArrayList<Runnable>()
 
     fun runAll() {
         runnables.forEach { it.run() }
+        scheduledRunnables.forEach { it.run() }
     }
 
     override fun submit(runnable: Runnable): Future<*> {
@@ -32,7 +37,10 @@ class DeferredExecutorService : ISentryExecutorService {
     }
 
     override fun <T> submit(callable: Callable<T>): Future<T> = mock()
-    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> = mock()
+    override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> {
+        scheduledRunnables.add(runnable)
+        return mock()
+    }
     override fun close(timeoutMillis: Long) {}
     override fun isClosed(): Boolean = false
 }

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
@@ -52,3 +52,10 @@ fun String.getCtor(ctorTypes: Array<Class<*>>): Constructor<*> {
     val clazz = Class.forName(this)
     return clazz.getConstructor(*ctorTypes)
 }
+
+fun String.getDeclaredCtor(ctorTypes: Array<Class<*>>): Constructor<*> {
+    val clazz = Class.forName(this)
+    val constructor = clazz.getDeclaredConstructor(*ctorTypes)
+    constructor.isAccessible = true
+    return constructor
+}

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -285,6 +285,8 @@ class SentryTest {
         dir.mkdirs()
         oldProfile.createNewFile()
         newProfile.createNewFile()
+        // Make the old profile look like it's created earlier
+        oldProfile.setLastModified(System.currentTimeMillis() - 10000)
         // Make the new profile look like it's created later
         newProfile.setLastModified(System.currentTimeMillis() + 10000)
 


### PR DESCRIPTION
## :scroll: Description
moved several integrations to the background to reduce main thread usage on SDK init:
-AnrIntegration
-PhoneStateBreadcrumbsIntegration
-SystemEventsBreadcrumbsIntegration
-TempSensorBreadcrumbsIntegration


## :bulb: Motivation and Context
Relates to https://github.com/getsentry/sentry-java/issues/2222
It continues the work done on https://github.com/getsentry/sentry-java/pull/3036
Fixes https://github.com/getsentry/sentry-java/issues/3040


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
