### PR TITLE
Ensure DSN uses http/https protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Ensure DSN uses http/https protocol ([#3044](https://github.com/getsentry/sentry-java/pull/3044))
+
 ### Features
 
 - Add current activity name to app context ([#2999](https://github.com/getsentry/sentry-java/pull/2999))

--- a/sentry/src/main/java/io/sentry/Dsn.java
+++ b/sentry/src/main/java/io/sentry/Dsn.java
@@ -54,7 +54,7 @@ final class Dsn {
       final URI uri = new URI(dsn).normalize();
       final String scheme = uri.getScheme();
       if (!("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
-        throw new IllegalArgumentException("Invalid DSN scheme: " + uri.getScheme());
+        throw new IllegalArgumentException("Invalid DSN scheme: " + scheme);
       }
 
       String userInfo = uri.getUserInfo();

--- a/sentry/src/main/java/io/sentry/Dsn.java
+++ b/sentry/src/main/java/io/sentry/Dsn.java
@@ -51,7 +51,12 @@ final class Dsn {
   Dsn(@Nullable String dsn) throws IllegalArgumentException {
     try {
       Objects.requireNonNull(dsn, "The DSN is required.");
-      URI uri = new URI(dsn).normalize();
+      final URI uri = new URI(dsn).normalize();
+      final String scheme = uri.getScheme();
+      if (!("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))) {
+        throw new IllegalArgumentException("Invalid DSN scheme: " + uri.getScheme());
+      }
+
       String userInfo = uri.getUserInfo();
       if (userInfo == null || userInfo.isEmpty()) {
         throw new IllegalArgumentException("Invalid DSN: No public key provided.");
@@ -78,13 +83,7 @@ final class Dsn {
       }
       sentryUri =
           new URI(
-              uri.getScheme(),
-              null,
-              uri.getHost(),
-              uri.getPort(),
-              path + "api/" + projectId,
-              null,
-              null);
+              scheme, null, uri.getHost(), uri.getPort(), path + "api/" + projectId, null, null);
     } catch (Throwable e) {
       throw new IllegalArgumentException(e);
     }

--- a/sentry/src/test/java/io/sentry/DsnTest.kt
+++ b/sentry/src/test/java/io/sentry/DsnTest.kt
@@ -80,4 +80,19 @@ class DsnTest {
         val dsn = Dsn("http://key@host//id")
         assertEquals("http://host/api/id", dsn.sentryUri.toURL().toString())
     }
+
+    @Test
+    fun `non http protocols are not accepted`() {
+        assertFailsWith<IllegalArgumentException> { Dsn("ftp://publicKey:secretKey@host/path/id") }
+        assertFailsWith<IllegalArgumentException> { Dsn("jar://publicKey:secretKey@host/path/id") }
+    }
+
+    @Test
+    fun `http or https protocol are accepted`() {
+        Dsn("http://publicKey:secretKey@host/path/id")
+        Dsn("https://publicKey:secretKey@host/path/id")
+
+        Dsn("HTTP://publicKey:secretKey@host/path/id")
+        Dsn("HTTPS://publicKey:secretKey@host/path/id")
+    }
 }

--- a/sentry/src/test/java/io/sentry/DsnTest.kt
+++ b/sentry/src/test/java/io/sentry/DsnTest.kt
@@ -88,7 +88,7 @@ class DsnTest {
     }
 
     @Test
-    fun `http or https protocol are accepted`() {
+    fun `both http and https protocols are accepted`() {
         Dsn("http://publicKey:secretKey@host/path/id")
         Dsn("https://publicKey:secretKey@host/path/id")
 


### PR DESCRIPTION
## :scroll: Description

Fixes https://github.com/getsentry/sentry-java/issues/3025
Inspired by https://github.com/getsentry/sentry-python/blob/36c2650ccc6edcd300e2d207d7123b12c8b77b27/sentry_sdk/utils.py#L237-L238


## :bulb: Motivation and Context
Ensure we crash early on when an invalid dsn is provided.

## :green_heart: How did you test it?
Added unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
