### PR TITLE
moved assertions after "assume" call

### DIFF
--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -78,14 +78,6 @@ class EnvelopeTests : BaseUiTest() {
                 val profilingTraceData: ProfilingTraceData = it.assertProfile()
                 it.assertNoOtherItems()
 
-                assertEquals("profiledTransaction", transactionItem.transaction)
-                assertEquals(profilingTraceData.transactionId, transaction.eventId.toString())
-                assertEquals("profiledTransaction", profilingTraceData.transactionName)
-                assertTrue(profilingTraceData.environment.isNotEmpty())
-                assertTrue(profilingTraceData.cpuArchitecture.isNotEmpty())
-                assertTrue(profilingTraceData.transactions.isNotEmpty())
-                assertTrue(profilingTraceData.measurementsMap.isNotEmpty())
-
                 // We check the measurements have been collected with expected units
                 val slowFrames = profilingTraceData.measurementsMap[ProfileMeasurement.ID_SLOW_FRAME_RENDERS]
                 val frozenFrames = profilingTraceData.measurementsMap[ProfileMeasurement.ID_FROZEN_FRAME_RENDERS]
@@ -96,6 +88,14 @@ class EnvelopeTests : BaseUiTest() {
 
                 // Frame rate could be null in headless emulator tests (agp-matrix workflow)
                 assumeNotNull(frameRates)
+
+                assertEquals("profiledTransaction", transactionItem.transaction)
+                assertEquals(profilingTraceData.transactionId, transaction.eventId.toString())
+                assertEquals("profiledTransaction", profilingTraceData.transactionName)
+                assertTrue(profilingTraceData.environment.isNotEmpty())
+                assertTrue(profilingTraceData.cpuArchitecture.isNotEmpty())
+                assertTrue(profilingTraceData.transactions.isNotEmpty())
+                assertTrue(profilingTraceData.measurementsMap.isNotEmpty())
 
                 // Slow and frozen frames can be null (in case there were none)
                 if (slowFrames != null) {


### PR DESCRIPTION
## :scroll: Description
moved assertions after "assume" call

#skip-changelog

## :bulb: Motivation and Context
The `checkEnvelopeProfiledTransaction` test is already skipped on headless emulator (agp matrix), but some assertions were done before the `assume` call, which is the one that skips the test. So sometimes those assertions could throw in the agp matrix workflow. 
Fixes issues like https://github.com/getsentry/sentry-java/actions/runs/6814073423/job/18530091061?pr=3036


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
