### PR TITLE
feat(debugmeta): Add `getProguardUuid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (Internal) Extract Android Profiler and Measurements for Hybrid SDKs ([#3016](https://github.com/getsentry/sentry-java/pull/3016))
 - (Internal) Remove SentryOptions dependency from AndroidProfiler ([#3051](https://github.com/getsentry/sentry-java/pull/3051))
 - (Internal) Add `readBytesFromFile` for use in Hybrid SDKs ([#3052](https://github.com/getsentry/sentry-java/pull/3052))
+- (Internal) Add `getProguardUuid` for use in Hybrid SDKs ([#3054](https://github.com/getsentry/sentry-java/pull/3054))
 
 ### Fixes
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4365,6 +4365,7 @@ public final class io/sentry/util/DebugMetaPropertiesApplier {
 	public static field DEBUG_META_PROPERTIES_FILENAME Ljava/lang/String;
 	public fun <init> ()V
 	public static fun applyToOptions (Lio/sentry/SentryOptions;Ljava/util/Properties;)V
+	public static fun getProguardUuid (Ljava/util/Properties;)Ljava/lang/String;
 }
 
 public final class io/sentry/util/ExceptionUtils {

--- a/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
+++ b/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
@@ -36,10 +36,13 @@ public final class DebugMetaPropertiesApplier {
   private static void applyProguardUuid(
       final @NotNull SentryOptions options, final @NotNull Properties debugMetaProperties) {
     if (options.getProguardUuid() == null) {
-      final @Nullable String proguardUuid =
-          debugMetaProperties.getProperty("io.sentry.ProguardUuids");
+      final @Nullable String proguardUuid = getProguardUuid(debugMetaProperties);
       options.getLogger().log(SentryLevel.DEBUG, "Proguard UUID found: %s", proguardUuid);
       options.setProguardUuid(proguardUuid);
     }
+  }
+
+  public static @Nullable String getProguardUuid(final @NotNull Properties debugMetaProperties) {
+    return debugMetaProperties.getProperty("io.sentry.ProguardUuids");
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR exposes funtion which retrieves the proguard uuid property.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will be used by Hybdrid SDKs.

- https://github.com/getsentry/sentry-react-native/pull/3397

## :green_heart: How did you test it?
RN sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
