### PR TITLE
Add slow and frozen frames span data conventions

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2563,6 +2563,9 @@ public abstract interface class io/sentry/SpanDataConvention {
 	public static final field CALL_STACK_KEY Ljava/lang/String;
 	public static final field DB_NAME_KEY Ljava/lang/String;
 	public static final field DB_SYSTEM_KEY Ljava/lang/String;
+	public static final field FRAMES_FROZEN Ljava/lang/String;
+	public static final field FRAMES_SLOW Ljava/lang/String;
+	public static final field FRAMES_TOTAL Ljava/lang/String;
 	public static final field HTTP_FRAGMENT_KEY Ljava/lang/String;
 	public static final field HTTP_METHOD_KEY Ljava/lang/String;
 	public static final field HTTP_QUERY_KEY Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -17,4 +17,7 @@ public interface SpanDataConvention {
   String CALL_STACK_KEY = "call_stack";
   String THREAD_ID = "thread.id";
   String THREAD_NAME = "thread.name";
+  String FRAMES_TOTAL = "frames.total";
+  String FRAMES_SLOW = "frames.slow";
+  String FRAMES_FROZEN = "frames.frozen";
 }


### PR DESCRIPTION
## :scroll: Description
Add slow and frozen frame keys to span conventions, as per https://github.com/getsentry/develop/pull/1099/files

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
