### PR TITLE
Send breadcrumbs and client error even without transactions

### DIFF
--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
@@ -139,7 +139,22 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
 
     /** Finishes the call root span, and runs [beforeFinish] on it. Then a breadcrumb is sent. */
     fun finishEvent(finishDate: SentryDate? = null, beforeFinish: ((span: ISpan) -> Unit)? = null) {
-        callRootSpan ?: return
+        // We put data in the hint and send a breadcrumb
+        val hint = Hint()
+        hint.set(TypeCheckHint.OKHTTP_REQUEST, request)
+        response?.let { hint.set(TypeCheckHint.OKHTTP_RESPONSE, it) }
+
+        // We send the breadcrumb even without spans.
+        hub.addBreadcrumb(breadcrumb, hint)
+        // No span is created (e.g. no transaction is running)
+        if (callRootSpan == null) {
+
+            // We report the client error even without spans.
+            clientErrorResponse?.let {
+                SentryOkHttpUtils.captureClientError(hub, it.request, it)
+            }
+            return
+        }
 
         // We forcefully finish all spans, even if they should already have been finished through finishSpan()
         eventSpans.values.filter { !it.isFinished }.forEach {
@@ -159,13 +174,6 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
         } else {
             callRootSpan.finish()
         }
-
-        // We put data in the hint and send a breadcrumb
-        val hint = Hint()
-        hint.set(TypeCheckHint.OKHTTP_REQUEST, request)
-        response?.let { hint.set(TypeCheckHint.OKHTTP_RESPONSE, it) }
-
-        hub.addBreadcrumb(breadcrumb, hint)
         return
     }
 


### PR DESCRIPTION
## :scroll: Description
moved breadcrumb sent before span null check in SentryOkHttpEvent
added client error reporting if call root span is null


## :bulb: Motivation and Context
OkHttp breadcrumb and client error were not sent in case the span was not created, like when no transaction is running.
Fixes https://github.com/getsentry/sentry-android-gradle-plugin/issues/606


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
