### PR TITLE
Graphql Use new async `handleException` method

### DIFF
--- a/sentry-graphql/api/sentry-graphql.api
+++ b/sentry-graphql/api/sentry-graphql.api
@@ -32,18 +32,20 @@ public final class io/sentry/graphql/NoOpSubscriptionHandler : io/sentry/graphql
 public final class io/sentry/graphql/SentryDataFetcherExceptionHandler : graphql/execution/DataFetcherExceptionHandler {
 	public fun <init> (Lgraphql/execution/DataFetcherExceptionHandler;)V
 	public fun <init> (Lio/sentry/IHub;Lgraphql/execution/DataFetcherExceptionHandler;)V
+	public fun handleException (Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Ljava/util/concurrent/CompletableFuture;
 	public fun onException (Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Lgraphql/execution/DataFetcherExceptionHandlerResult;
 }
 
 public final class io/sentry/graphql/SentryGenericDataFetcherExceptionHandler : graphql/execution/DataFetcherExceptionHandler {
 	public fun <init> (Lgraphql/execution/DataFetcherExceptionHandler;)V
 	public fun <init> (Lio/sentry/IHub;Lgraphql/execution/DataFetcherExceptionHandler;)V
+	public fun handleException (Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Ljava/util/concurrent/CompletableFuture;
 	public fun onException (Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Lgraphql/execution/DataFetcherExceptionHandlerResult;
 }
 
 public final class io/sentry/graphql/SentryGraphqlExceptionHandler {
 	public fun <init> (Lgraphql/execution/DataFetcherExceptionHandler;)V
-	public fun onException (Ljava/lang/Throwable;Lgraphql/schema/DataFetchingEnvironment;Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Lgraphql/execution/DataFetcherExceptionHandlerResult;
+	public fun handleException (Ljava/lang/Throwable;Lgraphql/schema/DataFetchingEnvironment;Lgraphql/execution/DataFetcherExceptionHandlerParameters;)Ljava/util/concurrent/CompletableFuture;
 }
 
 public final class io/sentry/graphql/SentryInstrumentation : graphql/execution/instrumentation/SimpleInstrumentation {

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryDataFetcherExceptionHandler.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryDataFetcherExceptionHandler.java
@@ -10,7 +10,9 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Captures exceptions that occur during data fetching, passes them to Sentry and invokes a delegate
@@ -36,13 +38,25 @@ public final class SentryDataFetcherExceptionHandler implements DataFetcherExcep
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public DataFetcherExceptionHandlerResult onException(
-      final @NotNull DataFetcherExceptionHandlerParameters handlerParameters) {
+  public CompletableFuture<DataFetcherExceptionHandlerResult> handleException(
+      DataFetcherExceptionHandlerParameters handlerParameters) {
     final Hint hint = new Hint();
     hint.set(GRAPHQL_HANDLER_PARAMETERS, handlerParameters);
 
     hub.captureException(handlerParameters.getException(), hint);
-    return delegate.onException(handlerParameters);
+    return delegate.handleException(handlerParameters);
+  }
+
+  @SuppressWarnings("deprecation")
+  public DataFetcherExceptionHandlerResult onException(
+      final @NotNull DataFetcherExceptionHandlerParameters handlerParameters) {
+    final @Nullable CompletableFuture<DataFetcherExceptionHandlerResult> futureResult =
+        handleException(handlerParameters);
+
+    if (futureResult != null) {
+      return futureResult.join();
+    } else {
+      return CompletableFuture.completedFuture((DataFetcherExceptionHandlerResult) null).join();
+    }
   }
 }

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryGraphqlExceptionHandler.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryGraphqlExceptionHandler.java
@@ -8,6 +8,7 @@ import graphql.execution.DataFetcherExceptionHandlerParameters;
 import graphql.execution.DataFetcherExceptionHandlerResult;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -22,8 +23,7 @@ public final class SentryGraphqlExceptionHandler {
     this.delegate = delegate;
   }
 
-  @SuppressWarnings("deprecation")
-  public @Nullable DataFetcherExceptionHandlerResult onException(
+  public @Nullable CompletableFuture<DataFetcherExceptionHandlerResult> handleException(
       final @NotNull Throwable throwable,
       final @Nullable DataFetchingEnvironment environment,
       final @Nullable DataFetcherExceptionHandlerParameters handlerParameters) {
@@ -40,9 +40,9 @@ public final class SentryGraphqlExceptionHandler {
       }
     }
     if (delegate != null) {
-      return delegate.onException(handlerParameters);
+      return delegate.handleException(handlerParameters);
     } else {
-      return null;
+      return CompletableFuture.completedFuture(null);
     }
   }
 }

--- a/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
+++ b/sentry-graphql/src/main/java/io/sentry/graphql/SentryInstrumentation.java
@@ -8,7 +8,6 @@ import graphql.execution.ExecutionContext;
 import graphql.execution.ExecutionStepInfo;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.SimpleInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
@@ -37,7 +36,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-public final class SentryInstrumentation extends SimpleInstrumentation {
+@SuppressWarnings("deprecation")
+public final class SentryInstrumentation extends graphql.execution.instrumentation.SimpleInstrumentation {
 
   private static final @NotNull List<String> ERROR_TYPES_HANDLED_BY_DATA_FETCHERS =
       Arrays.asList(
@@ -161,11 +161,13 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public @NotNull InstrumentationState createState() {
     return new TracingState();
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public @NotNull InstrumentationContext<ExecutionResult> beginExecution(
       final @NotNull InstrumentationExecutionParameters parameters) {
     final TracingState tracingState = parameters.getInstrumentationState();
@@ -176,6 +178,7 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public CompletableFuture<ExecutionResult> instrumentExecutionResult(
       ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
     return super.instrumentExecutionResult(executionResult, parameters)
@@ -246,6 +249,7 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public @NotNull InstrumentationContext<ExecutionResult> beginExecuteOperation(
       final @NotNull InstrumentationExecuteOperationParameters parameters) {
     final @Nullable ExecutionContext executionContext = parameters.getExecutionContext();
@@ -276,7 +280,8 @@ public final class SentryInstrumentation extends SimpleInstrumentation {
   }
 
   @Override
-  @SuppressWarnings("FutureReturnValueIgnored")
+  @SuppressWarnings({"FutureReturnValueIgnored", "deprecation"})
+
   public @NotNull DataFetcher<?> instrumentDataFetcher(
       final @NotNull DataFetcher<?> dataFetcher,
       final @NotNull InstrumentationFieldFetchParameters parameters) {

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryDataFetcherExceptionHandlerTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryDataFetcherExceptionHandlerTest.kt
@@ -23,6 +23,6 @@ class SentryDataFetcherExceptionHandlerTest {
         handler.onException(parameters)
 
         verify(hub).captureException(eq(exception), anyOrNull<Hint>())
-        verify(delegate).onException(parameters)
+        verify(delegate).handleException(parameters)
     }
 }

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryGenericDataFetcherExceptionHandlerTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryGenericDataFetcherExceptionHandlerTest.kt
@@ -36,6 +36,6 @@ class SentryGenericDataFetcherExceptionHandlerTest {
         assertNotNull(exceptions)
         assertEquals(1, exceptions.size)
         assertEquals(exception, exceptions.first())
-        verify(delegate).onException(parameters)
+        verify(delegate).handleException(parameters)
     }
 }

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationAnotherTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationAnotherTest.kt
@@ -131,7 +131,8 @@ class SentryInstrumentationAnotherTest {
                     it.transaction = activeSpan
                 }
             }
-            fieldFetchParameters = InstrumentationFieldFetchParameters(executionContext, environment, executionStrategyParameters, false).withNewState(
+            fieldFetchParameters = InstrumentationFieldFetchParameters(executionContext,
+                { environment } , executionStrategyParameters, false).withNewState(
                 instrumentationState
             )
             val executionInput = ExecutionInput.newExecutionInput()

--- a/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationTest.kt
+++ b/sentry-graphql/src/test/kotlin/io/sentry/graphql/SentryInstrumentationTest.kt
@@ -193,7 +193,8 @@ class SentryInstrumentationTest {
             .fields(MergedSelectionSet.newMergedSelectionSet().build())
             .field(MergedField.newMergedField().addField(Field.newField("myFieldName").build()).build())
             .build()
-        val parameters = InstrumentationFieldFetchParameters(executionContext, environment, executionStrategyParameters, false).withNewState(SentryInstrumentation.TracingState())
+        val parameters = InstrumentationFieldFetchParameters(executionContext,
+            { environment }, executionStrategyParameters, false).withNewState(SentryInstrumentation.TracingState())
         val instrumentedDataFetcher = instrumentation.instrumentDataFetcher(dataFetcher, parameters)
         val result = instrumentedDataFetcher.get(environment)
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDataFetcherExceptionResolverAdapter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDataFetcherExceptionResolverAdapter.java
@@ -5,6 +5,7 @@ import graphql.execution.DataFetcherExceptionHandlerResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.sentry.graphql.SentryGraphqlExceptionHandler;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,9 +37,11 @@ public final class SentryDataFetcherExceptionResolverAdapter
   @Override
   protected @Nullable List<GraphQLError> resolveToMultipleErrors(
       Throwable ex, DataFetchingEnvironment env) {
-    @Nullable DataFetcherExceptionHandlerResult result = handler.onException(ex, env, null);
+    @Nullable
+    CompletableFuture<DataFetcherExceptionHandlerResult> result =
+        handler.handleException(ex, env, null);
     if (result != null) {
-      return result.getErrors();
+      return result.join().getErrors();
     }
     return null;
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDataFetcherExceptionResolverAdapter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDataFetcherExceptionResolverAdapter.java
@@ -5,6 +5,7 @@ import graphql.execution.DataFetcherExceptionHandlerResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.sentry.graphql.SentryGraphqlExceptionHandler;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,9 +37,11 @@ public final class SentryDataFetcherExceptionResolverAdapter
   @Override
   protected @Nullable List<GraphQLError> resolveToMultipleErrors(
       Throwable ex, DataFetchingEnvironment env) {
-    @Nullable DataFetcherExceptionHandlerResult result = handler.onException(ex, env, null);
+    @Nullable
+    CompletableFuture<DataFetcherExceptionHandlerResult> result =
+        handler.handleException(ex, env, null);
     if (result != null) {
-      return result.getErrors();
+      return result.join().getErrors();
     }
     return null;
   }


### PR DESCRIPTION
## :scroll: Description
Use new async `handleException` method for compatibility with newer Graphql-Java Versions.
In order to also stay backwards compatible, the `@Override` annotation of the deprecated `onException` method has been removed. `onException` now calls the `handleException` implementation.  The min supported GraphQL Version is 17.


## :bulb: Motivation and Context
Starting with `graphql-java` v21, implementing the `handleException` method is required and the deprecated method `onException` has been removed from the `DataFetcherExceptionHandler` interface.

Fixes #3017 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
