### PR TITLE
Fix wrong txn duration in case SDK init is deferred

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -431,6 +431,10 @@ public final class ActivityLifecycleIntegration
   public void onActivityPrePaused(@NonNull Activity activity) {
     // only executed if API >= 29 otherwise it happens on onActivityPaused
     if (isAllActivityCallbacksAvailable) {
+      // as the SDK may gets (re-)initialized mid activity lifecycle, ensure we set the flag here as
+      // well
+      // this ensures any newly launched activity will not use the app start timestamp as txn start
+      firstActivityCreated = true;
       if (hub == null) {
         lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
       } else {
@@ -443,6 +447,10 @@ public final class ActivityLifecycleIntegration
   public synchronized void onActivityPaused(final @NotNull Activity activity) {
     // only executed if API < 29 otherwise it happens on onActivityPrePaused
     if (!isAllActivityCallbacksAvailable) {
+      // as the SDK may gets (re-)initialized mid activity lifecycle, ensure we set the flag here as
+      // well
+      // this ensures any newly launched activity will not use the app start timestamp as txn start
+      firstActivityCreated = true;
       if (hub == null) {
         lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
       } else {


### PR DESCRIPTION
## :scroll: Description
Ensure the `firstActivityCreated` flag is also set when activities go to background. 


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3059


## :green_heart: How did you test it?
Manual testing + unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
