### PR TITLE
Keep SentryHttpClientException name from obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### Fixes
 
-- Send breadcrumbs and client error even without transactions ([#3087](https://github.com/getsentry/sentry-java/pull/3087))
+- Send breadcrumbs and client error in `SentryOkHttpEventListener` even without transactions ([#3087](https://github.com/getsentry/sentry-java/pull/3087))
+- Keep `io.sentry.exception.SentryHttpClientException` from obfuscation to display proper issue title on Sentry ([#3093](https://github.com/getsentry/sentry-java/pull/3093))
 
 ### Dependencies
 

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -65,3 +65,10 @@
 -keep class io.sentry.apollo3.SentryApollo3ClientException { <init>(...); }
 
 ##---------------End: proguard configuration for sentry-apollo-3  ----------
+
+##---------------Begin: proguard configuration for sentry-okhttp  ----------
+
+# we don't want this class to be obfuscated, otherwise issue's titles are obfuscated as well.
+-keepnames class io.sentry.exception.SentryHttpClientException
+
+##---------------End: proguard configuration for sentry-okhttp  ----------


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Came up in internal discussion

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
