### PR TITLE
Fix Ui tests receiving empty requests

### DIFF
--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/BaseUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/BaseUiTest.kt
@@ -25,6 +25,7 @@ abstract class BaseUiTest {
     /** Application context for the current test. */
     protected lateinit var context: Context
 
+    // The mockDsn cannot be changed. If a custom dsn needs to be used, it can be set in the options as usual
     /** Mock dsn used to send envelopes to our mock [relay] server. */
     protected lateinit var mockDsn: String
         // The mockDsn cannot be changed. If a custom dsn needs to be used, it can be set in the options as usual

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/BaseUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/BaseUiTest.kt
@@ -25,7 +25,6 @@ abstract class BaseUiTest {
     /** Application context for the current test. */
     protected lateinit var context: Context
 
-    // The mockDsn cannot be changed. If a custom dsn needs to be used, it can be set in the options as usual
     /** Mock dsn used to send envelopes to our mock [relay] server. */
     protected lateinit var mockDsn: String
         // The mockDsn cannot be changed. If a custom dsn needs to be used, it can be set in the options as usual

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -42,7 +42,6 @@ class EnvelopeTests : BaseUiTest() {
                 assertTrue(event.message?.formatted == "Message captured during test")
             }
             assertNoOtherEnvelopes()
-            assertNoOtherRequests()
         }
     }
 
@@ -170,7 +169,6 @@ class EnvelopeTests : BaseUiTest() {
                 assertNotNull(transactionData)
             }
             assertNoOtherEnvelopes()
-            assertNoOtherRequests()
         }
     }
 
@@ -205,7 +203,6 @@ class EnvelopeTests : BaseUiTest() {
                 assertEquals(ProfilingTraceData.TRUNCATION_REASON_TIMEOUT, profilingTraceData.truncationReason)
             }
             assertNoOtherEnvelopes()
-            assertNoOtherRequests()
         }
     }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -72,7 +72,6 @@ class SdkInitTests : BaseUiTest() {
                 assertEquals("e2etests2", profilingTraceData.transactionName)
             }
             assertNoOtherEnvelopes()
-            assertNoOtherRequests()
         }
     }
 }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -31,6 +31,11 @@ class MockRelay(
     init {
         relay.dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
+                // If a request with a body size of 0 is received, we drop it.
+                // This shouldn't happen in reality, but it rarely happens in tests.
+                if (request.bodySize == 0L) {
+                    return MockResponse()
+                }
                 // We check if there is any custom response previously set to return to this request,
                 // otherwise we return a successful MockResponse.
                 val response = responses.asSequence()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -6,6 +6,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import kotlin.test.assertNotNull
 
 /** Mocks a relay server. */
 class MockRelay(
@@ -22,18 +23,18 @@ class MockRelay(
     /** List of unasserted requests sent to the [envelopePath]. */
     private val unassertedEnvelopes = mutableListOf<RelayAsserter.RelayResponse>()
 
-    /** List of unasserted requests not contained in [unassertedEnvelopes]. */
-    private val unassertedRequests = mutableListOf<RelayAsserter.RelayResponse>()
-
     /** List of responses to return when a request is sent. */
     private val responses = mutableListOf<(RecordedRequest) -> MockResponse?>()
+
+    /** Set to check already received envelopes, to avoid duplicates due to e.g. retrying. */
+    private val receivedEnvelopes: MutableSet<String> = HashSet()
 
     init {
         relay.dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 // If a request with a body size of 0 is received, we drop it.
                 // This shouldn't happen in reality, but it rarely happens in tests.
-                if (request.bodySize == 0L) {
+                if (request.bodySize == 0L || request.failure != null) {
                     return MockResponse()
                 }
                 // We check if there is any custom response previously set to return to this request,
@@ -43,15 +44,19 @@ class MockRelay(
                     .firstOrNull()
                     ?: MockResponse()
 
-                // Based on the path of the request, we populate the right list.
-                val relayResponse = RelayAsserter.RelayResponse(request, response)
-                when (request.path) {
-                    envelopePath -> {
-                        unassertedEnvelopes.add(relayResponse)
+                // We should receive only envelopes on this path.
+                if (request.path == envelopePath) {
+                    val relayResponse = RelayAsserter.RelayResponse(request, response)
+                    assertNotNull(relayResponse.envelope)
+                    val envelopeId: String = relayResponse.envelope!!.header.eventId!!.toString()
+                    // If we already received the envelope (e.g. retrying mechanism) we drop it
+                    if (receivedEnvelopes.contains(envelopeId)) {
+                        return MockResponse()
                     }
-                    else -> {
-                        unassertedRequests.add(relayResponse)
-                    }
+                    receivedEnvelopes.add(envelopeId)
+                    unassertedEnvelopes.add(relayResponse)
+                } else {
+                    throw AssertionError("Expected $envelopePath, but the request path was ${request.path}")
                 }
 
                 // If we are waiting for requests to be received, we decrement the associated counter.
@@ -67,7 +72,10 @@ class MockRelay(
     fun createMockDsn() = "http://key@${relay.hostName}:${relay.port}/$dsnProject"
 
     /** Starts the mock relay server. */
-    fun start() = relay.start()
+    fun start() {
+        receivedEnvelopes.clear()
+        relay.start()
+    }
 
     /** Shutdown the mock relay server and clear everything. */
     fun shutdown() {
@@ -103,6 +111,6 @@ class MockRelay(
         if (waitForRequests) {
             waitUntilIdle()
         }
-        assertion(RelayAsserter(unassertedEnvelopes, unassertedRequests))
+        assertion(RelayAsserter(unassertedEnvelopes))
     }
 }


### PR DESCRIPTION
## :scroll: Description
added a check to avoid processing requests with 0 bytes bodies in ui tests (probably useless)
added a check to drop duplicated envelopes

#skip-changelog

## :bulb: Motivation and Context
Some envelopes were sent twice, corrupting the counter in `MockRelay` and making tests fail


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
