### PR TITLE
Get rid of "is not eligible for getting processed by all BeanPostProcessors" warnings in Spring Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Send breadcrumbs and client error in `SentryOkHttpEventListener` even without transactions ([#3087](https://github.com/getsentry/sentry-java/pull/3087))
 - Keep `io.sentry.exception.SentryHttpClientException` from obfuscation to display proper issue title on Sentry ([#3093](https://github.com/getsentry/sentry-java/pull/3093))
 - (Android) Fix wrong activity transaction duration in case SDK init is deferred ([#3092](https://github.com/getsentry/sentry-java/pull/3092))
+- Get rid of "is not eligible for getting processed by all BeanPostProcessors" warnings in Spring Boot ([#3108](https://github.com/getsentry/sentry-java/pull/3108))
 
 ### Dependencies
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -7,7 +7,7 @@ object Config {
     val kotlinStdLib = "stdlib-jdk8"
 
     val springBootVersion = "2.7.5"
-    val springBoot3Version = "3.0.3"
+    val springBoot3Version = "3.2.0"
     val kotlinCompatibleLanguageVersion = "1.4"
 
     val composeVersion = "1.5.3"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -116,7 +116,7 @@ object Config {
         val fragment = "androidx.fragment:fragment-ktx:1.3.5"
 
         val reactorCore = "io.projectreactor:reactor-core:3.5.3"
-        val contextPropagation = "io.micrometer:context-propagation:1.0.2"
+        val contextPropagation = "io.micrometer:context-propagation:1.1.0"
 
         private val feignVersion = "11.6"
         val feignCore = "io.github.openfeign:feign-core:$feignVersion"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/SecurityConfiguration.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/SecurityConfiguration.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfiguration {
 
   // this API is meant to be consumed by non-browser clients thus the CSRF protection is not needed.
-  @SuppressWarnings("lgtm[java/spring-disabled-csrf-protection]")
+  @SuppressWarnings({"lgtm[java/spring-disabled-csrf-protection]", "removal"})
   @Bean
   public SecurityFilterChain filterChain(final @NotNull HttpSecurity http) throws Exception {
     http.csrf().disable().authorizeHttpRequests().anyRequest().authenticated().and().httpBasic();

--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/SecurityConfiguration.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/SecurityConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfiguration {
 
   // this API is meant to be consumed by non-browser clients thus the CSRF protection is not needed.
-  @SuppressWarnings("lgtm[java/spring-disabled-csrf-protection]")
+  @SuppressWarnings({"lgtm[java/spring-disabled-csrf-protection]", "removal"})
   @Bean
   public SecurityFilterChain filterChain(final @NotNull HttpSecurity http) throws Exception {
     http.csrf().disable().authorizeHttpRequests().anyRequest().authenticated().and().httpBasic();

--- a/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
+++ b/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
@@ -68,7 +68,7 @@ public class io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration {
 public class io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration {
 	public fun <init> ()V
 	public fun exceptionResolverAdapter ()Lio/sentry/spring/jakarta/graphql/SentryDataFetcherExceptionResolverAdapter;
-	public fun graphqlBeanPostProcessor ()Lio/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor;
+	public static fun graphqlBeanPostProcessor ()Lio/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor;
 	public fun sourceBuilderCustomizerWebflux (Lio/sentry/spring/boot/jakarta/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 	public fun sourceBuilderCustomizerWebmvc (Lio/sentry/spring/boot/jakarta/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 }

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration.java
@@ -59,7 +59,7 @@ public class SentryGraphqlAutoConfiguration {
   }
 
   @Bean
-  public SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
+  public static SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
     return new SentryGraphqlBeanPostProcessor();
   }
 }

--- a/sentry-spring-boot/api/sentry-spring-boot.api
+++ b/sentry-spring-boot/api/sentry-spring-boot.api
@@ -60,7 +60,7 @@ public class io/sentry/spring/boot/SentryWebfluxAutoConfiguration {
 public class io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration {
 	public fun <init> ()V
 	public fun exceptionResolverAdapter ()Lio/sentry/spring/graphql/SentryDataFetcherExceptionResolverAdapter;
-	public fun graphqlBeanPostProcessor ()Lio/sentry/spring/graphql/SentryGraphqlBeanPostProcessor;
+	public static fun graphqlBeanPostProcessor ()Lio/sentry/spring/graphql/SentryGraphqlBeanPostProcessor;
 	public fun sourceBuilderCustomizerWebflux (Lio/sentry/spring/boot/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 	public fun sourceBuilderCustomizerWebmvc (Lio/sentry/spring/boot/SentryProperties;)Lorg/springframework/boot/autoconfigure/graphql/GraphQlSourceBuilderCustomizer;
 }

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration.java
@@ -59,7 +59,7 @@ public class SentryGraphqlAutoConfiguration {
   }
 
   @Bean
-  public SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
+  public static SentryGraphqlBeanPostProcessor graphqlBeanPostProcessor() {
     return new SentryGraphqlBeanPostProcessor();
   }
 }

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -169,8 +169,9 @@ public final class io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler
 	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
-public final class io/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor {
+public final class io/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor, org/springframework/core/PriorityOrdered {
 	public fun <init> ()V
+	public fun getOrder ()I
 	public fun postProcessAfterInitialization (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor.java
@@ -3,15 +3,23 @@ package io.sentry.spring.jakarta.graphql;
 import org.jetbrains.annotations.ApiStatus;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
 
 @ApiStatus.Internal
-public final class SentryGraphqlBeanPostProcessor implements BeanPostProcessor {
+public final class SentryGraphqlBeanPostProcessor implements BeanPostProcessor, PriorityOrdered {
+
   @Override
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
     if (bean instanceof BatchLoaderRegistry) {
       return new SentryBatchLoaderRegistry((BatchLoaderRegistry) bean);
     }
     return bean;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryReactorThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryReactorThreadLocalAccessor.java
@@ -27,6 +27,7 @@ public final class SentryReactorThreadLocalAccessor implements ThreadLocalAccess
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void reset() {
     Sentry.setCurrentHub(NoOpHub.getInstance());
   }

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -169,8 +169,9 @@ public final class io/sentry/spring/graphql/SentryDgsSubscriptionHandler : io/se
 	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
-public final class io/sentry/spring/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor {
+public final class io/sentry/spring/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor, org/springframework/core/PriorityOrdered {
 	public fun <init> ()V
+	public fun getOrder ()I
 	public fun postProcessAfterInitialization (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryGraphqlBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryGraphqlBeanPostProcessor.java
@@ -3,15 +3,22 @@ package io.sentry.spring.graphql;
 import org.jetbrains.annotations.ApiStatus;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
 import org.springframework.graphql.execution.BatchLoaderRegistry;
 
 @ApiStatus.Internal
-public final class SentryGraphqlBeanPostProcessor implements BeanPostProcessor {
+public final class SentryGraphqlBeanPostProcessor implements BeanPostProcessor, PriorityOrdered {
   @Override
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
     if (bean instanceof BatchLoaderRegistry) {
       return new SentryBatchLoaderRegistry((BatchLoaderRegistry) bean);
     }
     return bean;
+  }
+
+  @Override
+  public int getOrder() {
+    return Ordered.LOWEST_PRECEDENCE;
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Set `SentryGraphqlBeanPostProcessor` to run last so it does not trigger "is not eligible for getting processed by all BeanPostProcessors" warnings.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3042 

## :green_heart: How did you test it?
Manually using Spring Boot samples.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
