### PR TITLE
Bump OpenTelemetry version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - SchedulerFactoryBeanCustomizer now runs first so user customization is not overridden ([#3095](https://github.com/getsentry/sentry-java/pull/3095))
   - If you are setting global job listeners please also add `SentryJobListener`
 
+### Dependencies
+
+- Bump `opentelemetry-sdk` to `1.33.0` and `opentelemetry-javaagent` to `1.32.0` ([#3112](https://github.com/getsentry/sentry-java/pull/3112))
+
 ## 7.1.0
 
 ### Features

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -149,13 +149,14 @@ object Config {
         val apolloKotlin = "com.apollographql.apollo3:apollo-runtime:3.3.0"
 
         object OpenTelemetry {
-            val otelVersion = "1.23.1"
+            val otelVersion = "1.33.0"
             val otelAlphaVersion = "$otelVersion-alpha"
-            val otelJavaagentVersion = "1.23.0"
+            val otelJavaagentVersion = "1.32.0"
             val otelJavaagentAlphaVersion = "$otelJavaagentVersion-alpha"
+            val otelSemanticConvetionsVersion = "1.23.1-alpha"
 
             val otelSdk = "io.opentelemetry:opentelemetry-sdk:$otelVersion"
-            val otelSemconv = "io.opentelemetry:opentelemetry-semconv:$otelAlphaVersion"
+            val otelSemconv = "io.opentelemetry.semconv:opentelemetry-semconv:$otelSemanticConvetionsVersion"
             val otelJavaAgent = "io.opentelemetry.javaagent:opentelemetry-javaagent:$otelJavaagentVersion"
             val otelJavaAgentExtensionApi = "io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:$otelJavaagentAlphaVersion"
             val otelJavaAgentTooling = "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$otelJavaagentAlphaVersion"

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanProcessor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanProcessor.java
@@ -10,7 +10,7 @@ import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import io.sentry.Baggage;
 import io.sentry.DsnUtil;
 import io.sentry.HubAdapter;
@@ -233,6 +233,7 @@ public final class SentrySpanProcessor implements SpanProcessor {
     return true;
   }
 
+  @SuppressWarnings("deprecation")
   private boolean isSentryRequest(final @NotNull ReadableSpan otelSpan) {
     final @NotNull SpanKind kind = otelSpan.getKind();
     if (!spanKindsConsideredForSentryRequests.contains(kind)) {
@@ -311,6 +312,7 @@ public final class SentrySpanProcessor implements SpanProcessor {
     sentrySpan.setDescription(otelSpanInfo.getDescription());
   }
 
+  @SuppressWarnings("deprecation")
   private SpanStatus mapOtelStatus(final @NotNull ReadableSpan otelSpan) {
     final @NotNull SpanData otelSpanData = otelSpan.toSpanData();
     final @NotNull StatusData otelStatus = otelSpanData.getStatus();

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -2,7 +2,7 @@ package io.sentry.opentelemetry;
 
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.ReadableSpan;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import io.sentry.protocol.TransactionNameSource;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SpanDescriptionExtractor {
 
+  @SuppressWarnings("deprecation")
   public @NotNull OtelSpanInfo extractSpanDescription(final @NotNull ReadableSpan otelSpan) {
     final @NotNull String name = otelSpan.getName();
 
@@ -27,6 +28,7 @@ public final class SpanDescriptionExtractor {
     return new OtelSpanInfo(name, name, TransactionNameSource.CUSTOM);
   }
 
+  @SuppressWarnings("deprecation")
   private OtelSpanInfo descriptionForHttpMethod(
       final @NotNull ReadableSpan otelSpan, final @NotNull String httpMethod) {
     final @NotNull String name = otelSpan.getName();

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SentrySpanProcessorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SentrySpanProcessorTest.kt
@@ -17,7 +17,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SdkTracerProvider
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes
+import io.opentelemetry.semconv.SemanticAttributes
 import io.sentry.Baggage
 import io.sentry.BaggageHeader
 import io.sentry.Hint


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bump OpenTelemetry to `1.33.0` / `1.32.0` (Java). There also is a new dependency for semantic conventions (semconv) which has its own version (`1.23.1-alpha`) and requires different imports. There's also been some deprecations which I suppressed for now as Sentry still relies on e.g. `http.url` etc.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3082

## :green_heart: How did you test it?
Manually using Spring Boot 3 sample with OTEL agent and auto init turned on and off.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
