### PR TITLE
Ensure serialVersionUID of Exception classes are unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - SchedulerFactoryBeanCustomizer now runs first so user customization is not overridden ([#3095](https://github.com/getsentry/sentry-java/pull/3095))
   - If you are setting global job listeners please also add `SentryJobListener`
+- Ensure serialVersionUID of Exception classes are unique ([#3115](https://github.com/getsentry/sentry-java/pull/3115))
 
 ### Dependencies
 

--- a/sentry-apollo-3/api/sentry-apollo-3.api
+++ b/sentry-apollo-3/api/sentry-apollo-3.api
@@ -4,8 +4,11 @@ public final class io/sentry/apollo3/BuildConfig {
 }
 
 public final class io/sentry/apollo3/SentryApollo3ClientException : java/lang/Exception {
+	public static final field Companion Lio/sentry/apollo3/SentryApollo3ClientException$Companion;
 	public fun <init> (Ljava/lang/String;)V
-	public final fun getSerialVersionUID ()J
+}
+
+public final class io/sentry/apollo3/SentryApollo3ClientException$Companion {
 }
 
 public final class io/sentry/apollo3/SentryApollo3HttpInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {

--- a/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3ClientException.kt
+++ b/sentry-apollo-3/src/main/java/io/sentry/apollo3/SentryApollo3ClientException.kt
@@ -5,5 +5,7 @@ package io.sentry.apollo3
  * returns 4xx, 5xx or the `errors` field.
  */
 class SentryApollo3ClientException(message: String?) : Exception(message) {
-    val serialVersionUID = 1L
+    companion object {
+        private const val serialVersionUID = 4312120066430858144L
+    }
 }

--- a/sentry/src/main/java/io/sentry/exception/InvalidSentryTraceHeaderException.java
+++ b/sentry/src/main/java/io/sentry/exception/InvalidSentryTraceHeaderException.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * "sentry-trace" header field.
  */
 public final class InvalidSentryTraceHeaderException extends Exception {
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = -8353316997083420940L;
   private final @NotNull String sentryTraceHeader;
 
   public InvalidSentryTraceHeaderException(final @NotNull String sentryTraceHeader) {

--- a/sentry/src/main/java/io/sentry/exception/SentryHttpClientException.java
+++ b/sentry/src/main/java/io/sentry/exception/SentryHttpClientException.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
  * returns 5xx.
  */
 public final class SentryHttpClientException extends Exception {
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 348162238030337390L;
 
   public SentryHttpClientException(final @Nullable String message) {
     super(message);


### PR DESCRIPTION
## :scroll: Description

Exceptions implement `Serializable`, thus it's a good pratice to give `serialVersionUID` a unique value.

This _may_ helps with regard to code obfuscation too, as we've seen customer reports where Exception subclasses with the same fields get merged into a single class, giving confusing de-obfuscated results.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
