### PR TITLE
Startup Profiling 2 - Add options and sampling logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Handle `monitor`/`check_in` in client reports and rate limiter ([#3096](https://github.com/getsentry/sentry-java/pull/3096))
 - Startup profiling 1 - Decouple Profiler from Transaction ([#3101](https://github.com/getsentry/sentry-java/pull/3101))
 - Startup profiling 2 - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
+- Startup Profiling 3 - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Handle `monitor`/`check_in` in client reports and rate limiter ([#3096](https://github.com/getsentry/sentry-java/pull/3096))
 - Startup profiling 1 - Decouple Profiler from Transaction ([#3101](https://github.com/getsentry/sentry-java/pull/3101))
+- Startup profiling 2 - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ### Features
 
 - Handle `monitor`/`check_in` in client reports and rate limiter ([#3096](https://github.com/getsentry/sentry-java/pull/3096))
-- Startup profiling 1 - Decouple Profiler from Transaction ([#3101](https://github.com/getsentry/sentry-java/pull/3101))
-- Startup profiling 2 - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
-- Startup Profiling 3 - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
+- Added Startup profiling
+  - This depends on the new option `io.sentry.profiling.enable-startup`, other than the already existing `io.sentry.traces.profiling.sample-rate`.
+  - Sampler functions can check the new `isForNextStartup` flag, to adjust startup profiling sampling programmatically.
+  Relevant PRs:
+  - Decouple Profiler from Transaction ([#3101](https://github.com/getsentry/sentry-java/pull/3101))
+  - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
+  - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 
 ### Fixes
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -260,7 +260,6 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun getBeforeViewHierarchyCaptureCallback ()Lio/sentry/android/core/SentryAndroidOptions$BeforeCaptureCallback;
 	public fun getDebugImagesLoader ()Lio/sentry/android/core/IDebugImagesLoader;
 	public fun getNativeSdkName ()Ljava/lang/String;
-	public fun getProfilingTracesHz ()I
 	public fun getProfilingTracesIntervalMillis ()I
 	public fun getStartupCrashDurationThresholdMillis ()J
 	public fun isAnrEnabled ()Z
@@ -305,7 +304,6 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableScopeSync (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V
 	public fun setNativeSdkName (Ljava/lang/String;)V
-	public fun setProfilingTracesHz (I)V
 	public fun setProfilingTracesIntervalMillis (I)V
 	public fun setReportHistoricalAnrs (Z)V
 }
@@ -345,6 +343,7 @@ public final class io/sentry/android/core/SentryPerformanceProvider {
 	public fun attachInfo (Landroid/content/Context;Landroid/content/pm/ProviderInfo;)V
 	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
 	public fun onCreate ()Z
+	public fun shutdown ()V
 }
 
 public final class io/sentry/android/core/SystemEventsBreadcrumbsIntegration : io/sentry/Integration, java/io/Closeable {
@@ -426,12 +425,16 @@ public class io/sentry/android/core/performance/AppStartMetrics {
 	public fun getContentProviderOnCreateTimeSpans ()Ljava/util/List;
 	public static fun getInstance ()Lio/sentry/android/core/performance/AppStartMetrics;
 	public fun getSdkInitTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
+	public fun getStartupProfiler ()Lio/sentry/ITransactionProfiler;
+	public fun getStartupSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun isAppLaunchedInForeground ()Z
 	public static fun onApplicationCreate (Landroid/app/Application;)V
 	public static fun onApplicationPostCreate (Landroid/app/Application;)V
 	public static fun onContentProviderCreate (Landroid/content/ContentProvider;)V
 	public static fun onContentProviderPostCreate (Landroid/content/ContentProvider;)V
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
+	public fun setStartupProfiler (Lio/sentry/ITransactionProfiler;)V
+	public fun setStartupSamplingDecision (Lio/sentry/TracesSamplingDecision;)V
 }
 
 public final class io/sentry/android/core/performance/AppStartMetrics$AppStartType : java/lang/Enum {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -23,6 +23,7 @@ import io.sentry.SentryDate;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SpanStatus;
+import io.sentry.TracesSamplingDecision;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.android.core.internal.util.ClassUtil;
@@ -161,7 +162,7 @@ public final class ActivityLifecycleIntegration
 
         final @Nullable SentryDate appStartTime;
         final @Nullable Boolean coldStart;
-        final TimeSpan appStartTimeSpan =
+        final @NotNull TimeSpan appStartTimeSpan =
             AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options);
 
         // we only track app start for processes that will show an Activity (full launch).
@@ -205,20 +206,31 @@ public final class ActivityLifecycleIntegration
 
         // This will be the start timestamp of the transaction, as well as the ttid/ttfd spans
         final @NotNull SentryDate ttidStartTime;
+        final @Nullable TracesSamplingDecision startupSamplingDecision;
 
         if (!(firstActivityCreated || appStartTime == null || coldStart == null)) {
           // The first activity ttid/ttfd spans should start at the app start time
           ttidStartTime = appStartTime;
+          // The app start transaction inherits the sampling decision from the startup profiling,
+          // then clears it
+          startupSamplingDecision = AppStartMetrics.getInstance().getStartupSamplingDecision();
+          AppStartMetrics.getInstance().setStartupSamplingDecision(null);
         } else {
           // The ttid/ttfd spans should start when the previous activity called its onPause method
           ttidStartTime = lastPausedTime;
+          startupSamplingDecision = null;
         }
         transactionOptions.setStartTimestamp(ttidStartTime);
+        transactionOptions.setStartupTransaction(startupSamplingDecision != null);
 
         // we can only bind to the scope if there's no running transaction
         ITransaction transaction =
             hub.startTransaction(
-                new TransactionContext(activityName, TransactionNameSource.COMPONENT, UI_LOAD_OP),
+                new TransactionContext(
+                    activityName,
+                    TransactionNameSource.COMPONENT,
+                    UI_LOAD_OP,
+                    startupSamplingDecision),
                 transactionOptions);
         setSpanOrigin(transaction);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -297,6 +297,11 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @Override
+  public boolean isRunning() {
+    return transactionsCounter != 0;
+  }
+
+  @Override
   public void close() {
     // we stop profiling
     if (currentProfilingTransactionData != null) {
@@ -307,6 +312,10 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
           true,
           null,
           HubAdapter.getInstance().getOptions());
+    } else if (transactionsCounter != 0) {
+      // in case the startup profiling is running, and it's not bound to a transaction, we still
+      // stop profiling, but we also have to manually update the counter.
+      transactionsCounter--;
     }
 
     // we have to first stop profiling otherwise we would lost the last profile

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -98,6 +98,8 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_PERFORMANCE_V2 = "io.sentry.performance-v2.enable";
 
+  static final String ENABLE_STARTUP_PROFILING = "io.sentry.profiling.enable-startup";
+
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
 
@@ -365,6 +367,10 @@ final class ManifestMetadataReader {
 
         options.setEnablePerformanceV2(
             readBool(metadata, logger, ENABLE_PERFORMANCE_V2, options.isEnablePerformanceV2()));
+
+        options.setEnableStartupProfiling(
+            readBool(
+                metadata, logger, ENABLE_STARTUP_PROFILING, options.isEnableStartupProfiling()));
       }
 
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -93,13 +93,6 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   private boolean enableActivityLifecycleTracingAutoFinish = true;
 
-  /**
-   * Profiling traces rate. 101 hz means 101 traces in 1 second. Defaults to 101 to avoid possible
-   * lockstep sampling. More on
-   * https://stackoverflow.com/questions/45470758/what-is-lockstep-sampling
-   */
-  private int profilingTracesHz = 101;
-
   /** Interface that loads the debug images list */
   private @NotNull IDebugImagesLoader debugImagesLoader = NoOpDebugImagesLoader.getInstance();
 
@@ -361,22 +354,6 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   @Deprecated
   public void setProfilingTracesIntervalMillis(final int profilingTracesIntervalMillis) {}
-
-  /**
-   * Returns the rate the profiler will sample rates at. 100 hz means 100 traces in 1 second.
-   *
-   * @return Rate the profiler will sample rates at.
-   */
-  @ApiStatus.Internal
-  public int getProfilingTracesHz() {
-    return profilingTracesHz;
-  }
-
-  /** Sets the rate the profiler will sample rates at. 100 hz means 100 traces in 1 second. */
-  @ApiStatus.Internal
-  public void setProfilingTracesHz(final int profilingTracesHz) {
-    this.profilingTracesHz = profilingTracesHz;
-  }
 
   /**
    * Returns the Debug image loader

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -1,20 +1,39 @@
 package io.sentry.android.core;
 
+import static io.sentry.Sentry.STARTUP_PROFILING_CONFIG_FILE_NAME;
+
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.ProviderInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Process;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
+import io.sentry.ILogger;
+import io.sentry.ITransactionProfiler;
+import io.sentry.JsonSerializer;
 import io.sentry.NoOpLogger;
+import io.sentry.SentryExecutorService;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.SentryStartupProfilingOptions;
+import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
+import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.ActivityLifecycleCallbacksAdapter;
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.ApiStatus;
@@ -32,9 +51,26 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
   private @Nullable Application app;
   private @Nullable Application.ActivityLifecycleCallbacks activityCallback;
 
+  private final @NotNull ILogger logger;
+  private final @NotNull BuildInfoProvider buildInfoProvider;
+
+  @TestOnly
+  SentryPerformanceProvider(
+      final @NotNull ILogger logger, final @NotNull BuildInfoProvider buildInfoProvider) {
+    this.logger = logger;
+    this.buildInfoProvider = buildInfoProvider;
+  }
+
+  public SentryPerformanceProvider() {
+    logger = new AndroidLogger();
+    buildInfoProvider = new BuildInfoProvider(logger);
+  }
+
   @Override
   public boolean onCreate() {
-    onAppLaunched(getContext());
+    final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
+    onAppLaunched(getContext(), appStartMetrics);
+    launchStartupProfiler(appStartMetrics);
     return true;
   }
 
@@ -54,8 +90,95 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     return null;
   }
 
-  private void onAppLaunched(final @Nullable Context context) {
-    final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
+  @Override
+  public void shutdown() {
+    synchronized (AppStartMetrics.getInstance()) {
+      final @Nullable ITransactionProfiler startupProfiler =
+          AppStartMetrics.getInstance().getStartupProfiler();
+      if (startupProfiler != null) {
+        startupProfiler.close();
+      }
+    }
+  }
+
+  private void launchStartupProfiler(final @NotNull AppStartMetrics appStartMetrics) {
+    final @Nullable Context context = getContext();
+
+    if (context == null) {
+      logger.log(SentryLevel.FATAL, "App. Context from ContentProvider is null");
+      return;
+    }
+
+    // Debug.startMethodTracingSampling() is only available since Lollipop
+    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) {
+      return;
+    }
+
+    final @NotNull File cacheDir = AndroidOptionsInitializer.getCacheDir(context);
+    final @NotNull File configFile = new File(cacheDir, STARTUP_PROFILING_CONFIG_FILE_NAME);
+
+    // No config exists: startup profiling is not enabled
+    if (!configFile.exists() || !configFile.canRead()) {
+      return;
+    }
+
+    try (final @NotNull Reader reader =
+            new BufferedReader(new InputStreamReader(new FileInputStream(configFile)))) {
+      final @Nullable SentryStartupProfilingOptions profilingOptions =
+          new JsonSerializer(SentryOptions.empty())
+              .deserialize(reader, SentryStartupProfilingOptions.class);
+
+      if (profilingOptions == null) {
+        logger.log(
+            SentryLevel.WARNING,
+            "Unable to deserialize the SentryStartupProfilingOptions. Startup profiling will not start.");
+        return;
+      }
+
+      if (!profilingOptions.isProfilingEnabled()) {
+        logger.log(SentryLevel.INFO, "Profiling is not enabled. Startup profiling will not start.");
+        return;
+      }
+
+      final @NotNull TracesSamplingDecision startupSamplingDecision =
+          new TracesSamplingDecision(
+              profilingOptions.isTraceSampled(),
+              profilingOptions.getTraceSampleRate(),
+              profilingOptions.isProfileSampled(),
+              profilingOptions.getProfileSampleRate());
+      // We store any sampling decision, so we can respect it when the first transaction starts
+      appStartMetrics.setStartupSamplingDecision(startupSamplingDecision);
+
+      if (!(startupSamplingDecision.getProfileSampled() && startupSamplingDecision.getSampled())) {
+        logger.log(SentryLevel.DEBUG, "Startup profiling was not sampled. It will not start.");
+        return;
+      }
+      logger.log(SentryLevel.DEBUG, "Startup profiling started.");
+
+      final @NotNull ITransactionProfiler startupProfiler =
+          new AndroidTransactionProfiler(
+              context.getApplicationContext(),
+              buildInfoProvider,
+              new SentryFrameMetricsCollector(
+                  context.getApplicationContext(), logger, buildInfoProvider),
+              logger,
+              profilingOptions.getProfilingTracesDirPath(),
+              profilingOptions.isProfilingEnabled(),
+              profilingOptions.getProfilingTracesHz(),
+              new SentryExecutorService());
+      appStartMetrics.setStartupProfiler(startupProfiler);
+      startupProfiler.start();
+
+    } catch (FileNotFoundException e) {
+      logger.log(SentryLevel.ERROR, "Startup profiling config file not found. ", e);
+    } catch (Throwable e) {
+      logger.log(SentryLevel.ERROR, "Error reading startup profiling config file. ", e);
+    }
+  }
+
+  @SuppressLint("NewApi")
+  private void onAppLaunched(
+      final @Nullable Context context, final @NotNull AppStartMetrics appStartMetrics) {
 
     // sdk-init uses static field init as start time
     final @NotNull TimeSpan sdkInitTimeSpan = appStartMetrics.getSdkInitTimeSpan();
@@ -63,7 +186,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
 
     // performance v2: Uses Process.getStartUptimeMillis()
     // requires API level 24+
-    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
+    if (buildInfoProvider.getSdkInfoVersion() < android.os.Build.VERSION_CODES.N) {
       return;
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import android.content.ContentProvider;
 import android.os.SystemClock;
 import androidx.annotation.Nullable;
+import io.sentry.ITransactionProfiler;
+import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.ContextUtils;
 import io.sentry.android.core.SentryAndroidOptions;
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * An in-memory representation for app-metrics during app start. As the SDK can't be initialized
@@ -38,6 +41,8 @@ public class AppStartMetrics {
   private final @NotNull TimeSpan applicationOnCreate;
   private final @NotNull Map<ContentProvider, TimeSpan> contentProviderOnCreates;
   private final @NotNull List<ActivityLifecycleTimeSpan> activityLifecycles;
+  private @Nullable ITransactionProfiler startupProfiler = null;
+  private @Nullable TracesSamplingDecision startupSamplingDecision = null;
 
   public static @NotNull AppStartMetrics getInstance() {
 
@@ -134,6 +139,7 @@ public class AppStartMetrics {
     return getSdkInitTimeSpan();
   }
 
+  @TestOnly
   public void clear() {
     appStartType = AppStartType.UNKNOWN;
     appStartSpan.reset();
@@ -141,6 +147,28 @@ public class AppStartMetrics {
     applicationOnCreate.reset();
     contentProviderOnCreates.clear();
     activityLifecycles.clear();
+    if (startupProfiler != null) {
+      startupProfiler.close();
+    }
+    startupProfiler = null;
+    startupSamplingDecision = null;
+  }
+
+  public @Nullable ITransactionProfiler getStartupProfiler() {
+    return startupProfiler;
+  }
+
+  public void setStartupProfiler(final @Nullable ITransactionProfiler startupProfiler) {
+    this.startupProfiler = startupProfiler;
+  }
+
+  public void setStartupSamplingDecision(
+      final @Nullable TracesSamplingDecision startupSamplingDecision) {
+    this.startupSamplingDecision = startupSamplingDecision;
+  }
+
+  public @Nullable TracesSamplingDecision getStartupSamplingDecision() {
+    return startupSamplingDecision;
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -683,6 +683,59 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
+    fun `When firstActivityCreated is true and startup sampling decision is set, start transaction with isStartup true`() {
+        AppStartMetrics.getInstance().startupSamplingDecision = mock()
+        val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
+        sut.register(fixture.hub, fixture.options)
+
+        val date = SentryNanotimeDate(Date(1), 0)
+        setAppStartTime(date)
+
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, fixture.bundle)
+
+        verify(fixture.hub).startTransaction(
+            any(),
+            check<TransactionOptions> {
+                assertEquals(date.nanoTimestamp(), it.startTimestamp!!.nanoTimestamp())
+                assertTrue(it.isStartupTransaction)
+            }
+        )
+    }
+
+    @Test
+    fun `When firstActivityCreated is true and startup sampling decision is not set, start transaction with isStartup false`() {
+        val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
+        sut.register(fixture.hub, fixture.options)
+
+        val date = SentryNanotimeDate(Date(1), 0)
+        setAppStartTime(date)
+
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, fixture.bundle)
+
+        verify(fixture.hub).startTransaction(
+            any(),
+            check<TransactionOptions> {
+                assertEquals(date.nanoTimestamp(), it.startTimestamp!!.nanoTimestamp())
+                assertFalse(it.isStartupTransaction)
+            }
+        )
+    }
+
+    @Test
+    fun `When firstActivityCreated is false and startup sampling decision is set, start transaction with isStartup false`() {
+        AppStartMetrics.getInstance().startupSamplingDecision = mock()
+        val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
+        sut.register(fixture.hub, fixture.options)
+
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, fixture.bundle)
+
+        verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertFalse(it.isStartupTransaction) })
+    }
+
+    @Test
     fun `When firstActivityCreated is true, do not create app start span if not foregroundImportance`() {
         val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_BACKGROUND)
         fixture.options.tracesSampleRate = 1.0
@@ -697,7 +750,10 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityCreated(activity, fixture.bundle)
 
         // call only once
-        verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertNotEquals(date, it.startTimestamp) })
+        verify(fixture.hub).startTransaction(
+            any(),
+            check<TransactionOptions> { assertNotEquals(date, it.startTimestamp) }
+        )
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -248,6 +248,12 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
+    fun `getCacheDir returns sentry subfolder`() {
+        fixture.initSut()
+        assertTrue(AndroidOptionsInitializer.getCacheDir(fixture.context).path.endsWith("${File.separator}cache${File.separator}sentry"))
+    }
+
+    @Test
     fun `profilingTracesDirPath should be set at initialization`() {
         fixture.initSut()
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1343,4 +1343,31 @@ class ManifestMetadataReaderTest {
         // Assert
         assertFalse(fixture.options.isEnablePerformanceV2)
     }
+
+    @Test
+    fun `applyMetadata reads startupProfiling flag to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.ENABLE_STARTUP_PROFILING to true)
+        val context = fixture.getContext(metaData = bundle)
+        fixture.options.profilesSampleRate = 1.0
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.isEnableStartupProfiling)
+    }
+
+    @Test
+    fun `applyMetadata reads startupProfiling flag to options and keeps default if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+        fixture.options.profilesSampleRate = 1.0
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.isEnableStartupProfiling)
+    }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -1,21 +1,37 @@
 package io.sentry.android.core
 
 import android.app.Application
-import android.content.Context
 import android.content.pm.ProviderInfo
 import android.os.Build
 import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.ILogger
+import io.sentry.JsonSerializer
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions
+import io.sentry.SentryStartupProfilingOptions
 import io.sentry.android.core.performance.AppStartMetrics
 import io.sentry.android.core.performance.AppStartMetrics.AppStartType
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
+import java.io.File
+import java.io.FileWriter
+import java.nio.file.Files
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -25,24 +41,71 @@ import kotlin.test.assertTrue
 )
 class SentryPerformanceProviderTest {
 
+    private lateinit var cache: File
+    private lateinit var sentryCache: File
+    private lateinit var traceDir: File
+
+    private inner class Fixture {
+        val mockContext = mock<Application>()
+        val providerInfo = ProviderInfo()
+        val logger = mock<ILogger>()
+        lateinit var configFile: File
+
+        fun getSut(sdkVersion: Int = Build.VERSION_CODES.S, authority: String = AUTHORITY, handleFile: ((config: File) -> Unit)? = null): SentryPerformanceProvider {
+            val buildInfoProvider: BuildInfoProvider = mock()
+            whenever(buildInfoProvider.sdkInfoVersion).thenReturn(sdkVersion)
+            whenever(mockContext.cacheDir).thenReturn(cache)
+            whenever(mockContext.applicationContext).thenReturn(mockContext)
+            configFile = File(sentryCache, Sentry.STARTUP_PROFILING_CONFIG_FILE_NAME)
+            handleFile?.invoke(configFile)
+
+            providerInfo.authority = authority
+            return SentryPerformanceProvider(logger, buildInfoProvider).apply {
+                attachInfo(mockContext, providerInfo)
+            }
+        }
+    }
+
+    private val fixture = Fixture()
+
     @BeforeTest
     fun `set up`() {
         AppStartMetrics.getInstance().clear()
         SentryShadowProcess.setStartUptimeMillis(1234)
+        cache = Files.createTempDirectory("sentry-disk-cache-test").toAbsolutePath().toFile()
+        sentryCache = File(cache, "sentry")
+        traceDir = File(sentryCache, "traces")
+        cache.mkdir()
+        sentryCache.mkdir()
+        traceDir.mkdir()
+    }
+
+    @AfterTest
+    fun cleanup() {
+        AppStartMetrics.getInstance().clear()
+        cache.deleteRecursively()
+        Sentry.close()
+    }
+
+    @Test
+    fun `when missing applicationId, SentryPerformanceProvider throws`() {
+        assertFailsWith<IllegalStateException> {
+            fixture.getSut(authority = SentryPerformanceProvider::class.java.name)
+        }
     }
 
     @Test
     fun `provider starts appStartTimeSpan`() {
         assertTrue(AppStartMetrics.getInstance().sdkInitTimeSpan.hasNotStarted())
         assertTrue(AppStartMetrics.getInstance().appStartTimeSpan.hasNotStarted())
-        setupProvider()
+        fixture.getSut()
         assertTrue(AppStartMetrics.getInstance().sdkInitTimeSpan.hasStarted())
         assertTrue(AppStartMetrics.getInstance().appStartTimeSpan.hasStarted())
     }
 
     @Test
     fun `provider sets cold start based on first activity`() {
-        val provider = setupProvider()
+        val provider = fixture.getSut()
 
         // up until this point app start is not known
         assertEquals(AppStartType.UNKNOWN, AppStartMetrics.getInstance().appStartType)
@@ -55,7 +118,7 @@ class SentryPerformanceProviderTest {
 
     @Test
     fun `provider sets warm start based on first activity`() {
-        val provider = setupProvider()
+        val provider = fixture.getSut()
 
         // up until this point app start is not known
         assertEquals(AppStartType.UNKNOWN, AppStartMetrics.getInstance().appStartType)
@@ -69,7 +132,7 @@ class SentryPerformanceProviderTest {
 
     @Test
     fun `provider keeps startup state even if multiple activities are launched`() {
-        val provider = setupProvider()
+        val provider = fixture.getSut()
 
         // when there's a saved state
         provider.activityCallback!!.onActivityCreated(mock(), Bundle())
@@ -86,7 +149,7 @@ class SentryPerformanceProviderTest {
 
     @Test
     fun `provider sets both appstart and sdk init start + end times`() {
-        val provider = setupProvider()
+        val provider = fixture.getSut()
         provider.onAppStartDone()
 
         val metrics = AppStartMetrics.getInstance()
@@ -99,23 +162,141 @@ class SentryPerformanceProviderTest {
 
     @Test
     fun `provider properly registers and unregisters ActivityLifecycleCallbacks`() {
-        val context = mock<Application>()
-        val provider = setupProvider(context)
+        val provider = fixture.getSut()
 
-        verify(context).registerActivityLifecycleCallbacks(any())
+        verify(fixture.mockContext).registerActivityLifecycleCallbacks(any())
         provider.onAppStartDone()
-        verify(context).unregisterActivityLifecycleCallbacks(any())
+        verify(fixture.mockContext).unregisterActivityLifecycleCallbacks(any())
     }
 
-    private fun setupProvider(context: Context = mock<Application>()): SentryPerformanceProvider {
-        val providerInfo = ProviderInfo()
-        providerInfo.authority = AUTHORITY
-
-        // calls onCreate under the hood
-        val provider = SentryPerformanceProvider()
-        provider.attachInfo(context, providerInfo)
-        return provider
+    //region startup profiling
+    @Test
+    fun `when config file does not exists, nothing happens`() {
+        fixture.getSut()
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        verify(fixture.logger, never()).log(any(), any())
     }
+
+    @Test
+    fun `when config file is not readable, nothing happens`() {
+        fixture.getSut { config ->
+            writeConfig(config)
+            config.setReadable(false)
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        verify(fixture.logger, never()).log(any(), any())
+    }
+
+    @Test
+    fun `when SDK is lower than 21, nothing happens`() {
+        fixture.getSut(sdkVersion = Build.VERSION_CODES.KITKAT) { config ->
+            writeConfig(config)
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        verify(fixture.logger, never()).log(any(), any())
+    }
+
+    @Test
+    fun `when config file is empty, profiler is not started`() {
+        fixture.getSut { config ->
+            config.createNewFile()
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        verify(fixture.logger).log(
+            eq(SentryLevel.WARNING),
+            eq("Unable to deserialize the SentryStartupProfilingOptions. Startup profiling will not start.")
+        )
+    }
+
+    @Test
+    fun `when profiling is disabled, profiler is not started`() {
+        fixture.getSut { config ->
+            writeConfig(config, profilingEnabled = false)
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        verify(fixture.logger).log(
+            eq(SentryLevel.INFO),
+            eq("Profiling is not enabled. Startup profiling will not start.")
+        )
+    }
+
+    @Test
+    fun `when trace is not sampled, profiler is not started and sample decision is stored`() {
+        fixture.getSut { config ->
+            writeConfig(config, traceSampled = false, profileSampled = true)
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
+        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
+        // If trace is not sampled, profile is not sample, either
+        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        verify(fixture.logger).log(
+            eq(SentryLevel.DEBUG),
+            eq("Startup profiling was not sampled. It will not start.")
+        )
+    }
+
+    @Test
+    fun `when profile is not sampled, profiler is not started and sample decision is stored`() {
+        fixture.getSut { config ->
+            writeConfig(config, traceSampled = true, profileSampled = false)
+        }
+        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
+        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
+        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        verify(fixture.logger).log(
+            eq(SentryLevel.DEBUG),
+            eq("Startup profiling was not sampled. It will not start.")
+        )
+    }
+
+    @Test
+    fun `when profiler starts, it is set in AppStartMetrics`() {
+        fixture.getSut { config ->
+            writeConfig(config)
+        }
+        assertNotNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
+        assertTrue(AppStartMetrics.getInstance().startupProfiler!!.isRunning)
+        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
+        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        verify(fixture.logger).log(
+            eq(SentryLevel.DEBUG),
+            eq("Startup profiling started.")
+        )
+    }
+
+    @Test
+    fun `when provider is closed, profiler is stopped`() {
+        val provider = fixture.getSut { config ->
+            writeConfig(config)
+        }
+        provider.shutdown()
+        assertNotNull(AppStartMetrics.getInstance().startupProfiler)
+        assertFalse(AppStartMetrics.getInstance().startupProfiler!!.isRunning)
+    }
+
+    private fun writeConfig(
+        configFile: File,
+        profilingEnabled: Boolean = true,
+        traceSampled: Boolean = true,
+        traceSampleRate: Double = 1.0,
+        profileSampled: Boolean = true,
+        profileSampleRate: Double = 1.0,
+        profilingTracesDirPath: String = traceDir.absolutePath
+    ) {
+        val startupProfilingOptions = SentryStartupProfilingOptions()
+        startupProfilingOptions.isProfilingEnabled = profilingEnabled
+        startupProfilingOptions.isTraceSampled = traceSampled
+        startupProfilingOptions.traceSampleRate = traceSampleRate
+        startupProfilingOptions.isProfileSampled = profileSampled
+        startupProfilingOptions.profileSampleRate = profileSampleRate
+        startupProfilingOptions.profilingTracesDirPath = profilingTracesDirPath
+        startupProfilingOptions.profilingTracesHz = 101
+        JsonSerializer(SentryOptions.empty()).serialize(startupProfilingOptions, FileWriter(configFile))
+    }
+    //endregion
 
     companion object {
         private const val AUTHORITY = "io.sentry.sample.SentryPerformanceProvider"

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.mock
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -43,6 +44,8 @@ class AppStartMetricsTest {
         metrics.addActivityLifecycleTimeSpans(ActivityLifecycleTimeSpan())
         AppStartMetrics.onApplicationCreate(mock<Application>())
         AppStartMetrics.onContentProviderCreate(mock<ContentProvider>())
+        metrics.setStartupProfiler(mock())
+        metrics.startupSamplingDecision = mock()
 
         metrics.clear()
 
@@ -50,10 +53,11 @@ class AppStartMetricsTest {
         assertTrue(metrics.sdkInitTimeSpan.hasNotStarted())
         assertTrue(metrics.applicationOnCreateTimeSpan.hasNotStarted())
         assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
-        assertTrue(metrics.applicationOnCreateTimeSpan.hasNotStarted())
 
         assertTrue(metrics.activityLifecycleTimeSpans.isEmpty())
         assertTrue(metrics.contentProviderOnCreateTimeSpans.isEmpty())
+        assertNull(metrics.startupProfiler)
+        assertNull(metrics.startupSamplingDecision)
     }
 
     @Test

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -109,6 +109,8 @@
         <!--    how to enable profiling when starting transactions -->
         <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 
+        <meta-data android:name="io.sentry.traces.profiling.enable-startup" android:value="true" />
+
         <!--    how to disable the Activity auto instrumentation for tracing-->
         <!--    <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />-->
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2162,6 +2162,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableExternalConfiguration ()Z
 	public fun isEnablePrettySerializationOutput ()Z
 	public fun isEnableShutdownHook ()Z
+	public fun isEnableStartupProfiling ()Z
 	public fun isEnableTimeToFullDisplayTracing ()Z
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isEnableUserInteractionBreadcrumbs ()Z
@@ -2197,6 +2198,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableExternalConfiguration (Z)V
 	public fun setEnablePrettySerializationOutput (Z)V
 	public fun setEnableShutdownHook (Z)V
+	public fun setEnableStartupProfiling (Z)V
 	public fun setEnableTimeToFullDisplayTracing (Z)V
 	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Z)V
@@ -2702,6 +2704,8 @@ public final class io/sentry/TransactionContext : io/sentry/SpanContext {
 	public fun getParentSampled ()Ljava/lang/Boolean;
 	public fun getParentSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun getTransactionNameSource ()Lio/sentry/protocol/TransactionNameSource;
+	public fun isForNextStartup ()Z
+	public fun setForNextStartup (Z)V
 	public fun setInstrumenter (Lio/sentry/Instrumenter;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setParentSampled (Ljava/lang/Boolean;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -800,6 +800,7 @@ public abstract interface class io/sentry/ITransaction : io/sentry/ISpan {
 public abstract interface class io/sentry/ITransactionProfiler {
 	public abstract fun bindTransaction (Lio/sentry/ITransaction;)V
 	public abstract fun close ()V
+	public abstract fun isRunning ()Z
 	public abstract fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;Lio/sentry/SentryOptions;)Lio/sentry/ProfilingTraceData;
 	public abstract fun start ()V
 }
@@ -1307,6 +1308,7 @@ public final class io/sentry/NoOpTransactionProfiler : io/sentry/ITransactionPro
 	public fun bindTransaction (Lio/sentry/ITransaction;)V
 	public fun close ()V
 	public static fun getInstance ()Lio/sentry/NoOpTransactionProfiler;
+	public fun isRunning ()Z
 	public fun onTransactionFinish (Lio/sentry/ITransaction;Ljava/util/List;Lio/sentry/SentryOptions;)Lio/sentry/ProfilingTraceData;
 	public fun start ()V
 }
@@ -1635,6 +1637,7 @@ public final class io/sentry/SendFireAndForgetOutboxSender : io/sentry/SendCache
 }
 
 public final class io/sentry/Sentry {
+	public static final field STARTUP_PROFILING_CONFIG_FILE_NAME Ljava/lang/String;
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/Hint;)V
 	public static fun addBreadcrumb (Ljava/lang/String;)V
@@ -2090,6 +2093,7 @@ public class io/sentry/SentryOptions {
 	public fun addOptionsObserver (Lio/sentry/IOptionsObserver;)V
 	public fun addScopeObserver (Lio/sentry/IScopeObserver;)V
 	public fun addTracingOrigin (Ljava/lang/String;)V
+	public static fun empty ()Lio/sentry/SentryOptions;
 	public fun getBackpressureMonitor ()Lio/sentry/backpressure/IBackpressureMonitor;
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
@@ -2140,6 +2144,7 @@ public class io/sentry/SentryOptions {
 	public fun getProfilesSampleRate ()Ljava/lang/Double;
 	public fun getProfilesSampler ()Lio/sentry/SentryOptions$ProfilesSamplerCallback;
 	public fun getProfilingTracesDirPath ()Ljava/lang/String;
+	public fun getProfilingTracesHz ()I
 	public fun getProguardUuid ()Ljava/lang/String;
 	public fun getProxy ()Lio/sentry/SentryOptions$Proxy;
 	public fun getReadTimeoutMillis ()I
@@ -2244,6 +2249,7 @@ public class io/sentry/SentryOptions {
 	public fun setProfilesSampleRate (Ljava/lang/Double;)V
 	public fun setProfilesSampler (Lio/sentry/SentryOptions$ProfilesSamplerCallback;)V
 	public fun setProfilingEnabled (Z)V
+	public fun setProfilingTracesHz (I)V
 	public fun setProguardUuid (Ljava/lang/String;)V
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V
 	public fun setReadTimeoutMillis (I)V
@@ -2329,6 +2335,44 @@ public final class io/sentry/SentryStackTraceFactory {
 	public fun getInAppCallStack ()Ljava/util/List;
 	public fun getStackFrames ([Ljava/lang/StackTraceElement;Z)Ljava/util/List;
 	public fun isInApp (Ljava/lang/String;)Ljava/lang/Boolean;
+}
+
+public final class io/sentry/SentryStartupProfilingOptions : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> ()V
+	public fun getProfileSampleRate ()Ljava/lang/Double;
+	public fun getProfilingTracesDirPath ()Ljava/lang/String;
+	public fun getProfilingTracesHz ()I
+	public fun getTraceSampleRate ()Ljava/lang/Double;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun isProfileSampled ()Z
+	public fun isProfilingEnabled ()Z
+	public fun isTraceSampled ()Z
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setProfileSampleRate (Ljava/lang/Double;)V
+	public fun setProfileSampled (Z)V
+	public fun setProfilingEnabled (Z)V
+	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
+	public fun setProfilingTracesHz (I)V
+	public fun setTraceSampleRate (Ljava/lang/Double;)V
+	public fun setTraceSampled (Z)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/SentryStartupProfilingOptions$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryStartupProfilingOptions;
+	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/SentryStartupProfilingOptions$JsonKeys {
+	public static final field IS_PROFILING_ENABLED Ljava/lang/String;
+	public static final field PROFILE_SAMPLED Ljava/lang/String;
+	public static final field PROFILE_SAMPLE_RATE Ljava/lang/String;
+	public static final field PROFILING_TRACES_DIR_PATH Ljava/lang/String;
+	public static final field PROFILING_TRACES_HZ Ljava/lang/String;
+	public static final field TRACE_SAMPLED Ljava/lang/String;
+	public static final field TRACE_SAMPLE_RATE Ljava/lang/String;
+	public fun <init> ()V
 }
 
 public final class io/sentry/SentryThreadFactory {
@@ -2740,12 +2784,14 @@ public final class io/sentry/TransactionOptions : io/sentry/SpanOptions {
 	public fun getStartTimestamp ()Lio/sentry/SentryDate;
 	public fun getTransactionFinishedCallback ()Lio/sentry/TransactionFinishedCallback;
 	public fun isBindToScope ()Z
+	public fun isStartupTransaction ()Z
 	public fun isWaitForChildren ()Z
 	public fun setBindToScope (Z)V
 	public fun setCustomSamplingContext (Lio/sentry/CustomSamplingContext;)V
 	public fun setDeadlineTimeout (Ljava/lang/Long;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setStartTimestamp (Lio/sentry/SentryDate;)V
+	public fun setStartupTransaction (Z)V
 	public fun setTransactionFinishedCallback (Lio/sentry/TransactionFinishedCallback;)V
 	public fun setWaitForChildren (Z)V
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -745,8 +745,14 @@ public final class Hub implements IHub {
       // stop it
       if (samplingDecision.getSampled() && samplingDecision.getProfileSampled()) {
         final ITransactionProfiler transactionProfiler = options.getTransactionProfiler();
-        transactionProfiler.start();
-        transactionProfiler.bindTransaction(transaction);
+        // If the profiler is not running, we start and bind it here.
+        if (!transactionProfiler.isRunning()) {
+          transactionProfiler.start();
+          transactionProfiler.bindTransaction(transaction);
+        } else if (transactionOptions.isStartupTransaction()) {
+          // If the profiler is running and the current transaction is the app startup, we bind it.
+          transactionProfiler.bindTransaction(transaction);
+        }
       }
     }
     if (transactionOptions.isBindToScope()) {

--- a/sentry/src/main/java/io/sentry/ITransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/ITransactionProfiler.java
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.Nullable;
 /** Used for performing operations when a transaction is started or ended. */
 @ApiStatus.Internal
 public interface ITransactionProfiler {
+  boolean isRunning();
+
   void start();
 
   void bindTransaction(@NotNull ITransaction transaction);

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -104,6 +104,8 @@ public final class JsonSerializer implements ISerializer {
     deserializersByClass.put(SentrySpan.class, new SentrySpan.Deserializer());
     deserializersByClass.put(SentryStackFrame.class, new SentryStackFrame.Deserializer());
     deserializersByClass.put(SentryStackTrace.class, new SentryStackTrace.Deserializer());
+    deserializersByClass.put(
+        SentryStartupProfilingOptions.class, new SentryStartupProfilingOptions.Deserializer());
     deserializersByClass.put(SentryThread.class, new SentryThread.Deserializer());
     deserializersByClass.put(SentryTransaction.class, new SentryTransaction.Deserializer());
     deserializersByClass.put(Session.class, new Session.Deserializer());

--- a/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpTransactionProfiler.java
@@ -18,6 +18,11 @@ public final class NoOpTransactionProfiler implements ITransactionProfiler {
   public void start() {}
 
   @Override
+  public boolean isRunning() {
+    return false;
+  }
+
+  @Override
   public void bindTransaction(@NotNull ITransaction transaction) {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -23,7 +23,6 @@ import io.sentry.util.thread.NoOpMainThreadChecker;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -54,11 +53,15 @@ public final class Sentry {
   /** whether to use a single (global) Hub as opposed to one per thread. */
   private static volatile boolean globalHubMode = GLOBAL_HUB_DEFAULT_MODE;
 
-  private static final @NotNull String STARTUP_PROFILING_CONFIG_FILE_NAME =
+  @ApiStatus.Internal
+  public static final @NotNull String STARTUP_PROFILING_CONFIG_FILE_NAME =
       "startup_profiling_config";
 
   @SuppressWarnings("CharsetObjectCanBeUsed")
   private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  /** Timestamp used to check old profiles to delete. */
+  private static final long classCreationTimestamp = System.currentTimeMillis();
 
   /**
    * Returns the current (threads) hub, if none, clones the mainHub and returns it.
@@ -261,51 +264,59 @@ public final class Sentry {
   private static void handleStartupProfilingConfig(
       final @NotNull SentryOptions options,
       final @NotNull ISentryExecutorService sentryExecutorService) {
-    sentryExecutorService.submit(
-        () -> {
-          final String cacheDirPath = options.getCacheDirPathWithoutDsn();
-          if (cacheDirPath != null) {
-            final @NotNull File startupProfilingConfigFile =
-                new File(cacheDirPath, STARTUP_PROFILING_CONFIG_FILE_NAME);
-            try {
-              // We always delete the config file for startup profiling
-              FileUtils.deleteRecursively(startupProfilingConfigFile);
-              if (!options.isEnableStartupProfiling()) {
-                return;
-              }
-              if (!options.isTracingEnabled()) {
+    try {
+      sentryExecutorService.submit(
+          () -> {
+            final String cacheDirPath = options.getCacheDirPathWithoutDsn();
+            if (cacheDirPath != null) {
+              final @NotNull File startupProfilingConfigFile =
+                  new File(cacheDirPath, STARTUP_PROFILING_CONFIG_FILE_NAME);
+              try {
+                // We always delete the config file for startup profiling
+                FileUtils.deleteRecursively(startupProfilingConfigFile);
+                if (!options.isEnableStartupProfiling()) {
+                  return;
+                }
+                if (!options.isTracingEnabled()) {
+                  options
+                      .getLogger()
+                      .log(
+                          SentryLevel.INFO,
+                          "Tracing is disabled and startup profiling will not start.");
+                  return;
+                }
+                if (startupProfilingConfigFile.createNewFile()) {
+                  final @NotNull TracesSamplingDecision startupSamplingDecision =
+                      sampleStartupProfiling(options);
+                  final @NotNull SentryStartupProfilingOptions startupProfilingOptions =
+                      new SentryStartupProfilingOptions(options, startupSamplingDecision);
+                  try (final OutputStream outputStream =
+                          new FileOutputStream(startupProfilingConfigFile);
+                      final Writer writer =
+                          new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
+                    options.getSerializer().serialize(startupProfilingOptions, writer);
+                  }
+                }
+              } catch (Throwable e) {
                 options
                     .getLogger()
-                    .log(
-                        SentryLevel.INFO,
-                        "Tracing is disabled and startup profiling will not start.");
-                return;
+                    .log(SentryLevel.ERROR, "Unable to create startup profiling config file. ", e);
               }
-
-              if (startupProfilingConfigFile.createNewFile()) {
-                final @NotNull TracesSamplingDecision startupSamplingDecision =
-                    sampleStartupProfiling(options);
-                final @NotNull SentryStartupProfilingOptions startupProfilingOptions =
-                    new SentryStartupProfilingOptions(options, startupSamplingDecision);
-                try (final OutputStream outputStream =
-                        new FileOutputStream(startupProfilingConfigFile);
-                    final Writer writer =
-                        new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
-                  options.getSerializer().serialize(startupProfilingOptions, writer);
-                }
-              }
-            } catch (IOException e) {
-              options
-                  .getLogger()
-                  .log(SentryLevel.ERROR, "Unable to create startup profiling config file. ", e);
             }
-          }
-        });
+          });
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "Failed to call the executor. Startup profiling config will not be changed. Did you call Sentry.close()?",
+              e);
+    }
   }
 
   private static @NotNull TracesSamplingDecision sampleStartupProfiling(
       final @NotNull SentryOptions options) {
-    TransactionContext startupTransactionContext = new TransactionContext("ui.load", "");
+    TransactionContext startupTransactionContext = new TransactionContext("app.launch", "profile");
     startupTransactionContext.setForNextStartup(true);
     SamplingContext startupSamplingContext = new SamplingContext(startupTransactionContext, null);
     return new TracesSampler(options).sample(startupSamplingContext);
@@ -404,7 +415,6 @@ public final class Sentry {
 
       final File profilingTracesDir = new File(profilingTracesDirPath);
       profilingTracesDir.mkdirs();
-      final long timestamp = System.currentTimeMillis();
 
       try {
         options
@@ -416,7 +426,7 @@ public final class Sentry {
                   // Method trace files are normally deleted at the end of traces, but if that fails
                   // for some reason we try to clear any old files here.
                   for (File f : oldTracesDirContent) {
-                    if (f.lastModified() < timestamp) {
+                    if (f.lastModified() < classCreationTimestamp) {
                       FileUtils.deleteRecursively(f);
                     }
                   }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -451,6 +451,13 @@ public class SentryOptions {
   private boolean enableStartupProfiling = false;
 
   /**
+   * Profiling traces rate. 101 hz means 101 traces in 1 second. Defaults to 101 to avoid possible
+   * lockstep sampling. More on
+   * https://stackoverflow.com/questions/45470758/what-is-lockstep-sampling
+   */
+  private int profilingTracesHz = 101;
+
+  /**
    * Adds an event processor
    *
    * @param eventProcessor the event processor
@@ -2251,6 +2258,22 @@ public class SentryOptions {
     this.enableBackpressureHandling = enableBackpressureHandling;
   }
 
+  /**
+   * Returns the rate the profiler will sample rates at. 100 hz means 100 traces in 1 second.
+   *
+   * @return Rate the profiler will sample rates at.
+   */
+  @ApiStatus.Internal
+  public int getProfilingTracesHz() {
+    return profilingTracesHz;
+  }
+
+  /** Sets the rate the profiler will sample rates at. 100 hz means 100 traces in 1 second. */
+  @ApiStatus.Internal
+  public void setProfilingTracesHz(final int profilingTracesHz) {
+    this.profilingTracesHz = profilingTracesHz;
+  }
+
   @ApiStatus.Experimental
   public boolean isEnableBackpressureHandling() {
     return enableBackpressureHandling;
@@ -2334,7 +2357,8 @@ public class SentryOptions {
    *
    * @return SentryOptions
    */
-  static @NotNull SentryOptions empty() {
+  @ApiStatus.Internal
+  public static @NotNull SentryOptions empty() {
     return new SentryOptions(true);
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -727,6 +727,20 @@ public class SentryOptions {
   }
 
   /**
+   * Returns the cache dir path if set, without the appended dsn hash.
+   *
+   * @return the cache dir path, without the appended dsn hash, or null if not set.
+   */
+  @Nullable
+  String getCacheDirPathWithoutDsn() {
+    if (cacheDirPath == null || cacheDirPath.isEmpty()) {
+      return null;
+    }
+
+    return cacheDirPath;
+  }
+
+  /**
    * Returns the outbox path if cacheDirPath is set
    *
    * @return the outbox path or null if not set
@@ -2120,11 +2134,12 @@ public class SentryOptions {
 
   /**
    * Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate.
+   * Depends on {@link SentryOptions#isProfilingEnabled()}
    *
    * @return true if startup profiling should be started.
    */
   public boolean isEnableStartupProfiling() {
-    return enableStartupProfiling;
+    return isProfilingEnabled() && enableStartupProfiling;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -440,6 +440,9 @@ public class SentryOptions {
   /** Contains a list of monitor slugs for which check-ins should not be sent. */
   @ApiStatus.Experimental private @Nullable List<String> ignoredCheckIns = null;
 
+  /** Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate. */
+  private boolean enableStartupProfiling = false;
+
   /**
    * Adds an event processor
    *
@@ -2113,6 +2116,24 @@ public class SentryOptions {
    */
   public void setEnablePrettySerializationOutput(boolean enablePrettySerializationOutput) {
     this.enablePrettySerializationOutput = enablePrettySerializationOutput;
+  }
+
+  /**
+   * Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate.
+   *
+   * @return true if startup profiling should be started.
+   */
+  public boolean isEnableStartupProfiling() {
+    return enableStartupProfiling;
+  }
+
+  /**
+   * Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate.
+   *
+   * @param enableStartupProfiling true if startup profiling should be started.
+   */
+  public void setEnableStartupProfiling(boolean enableStartupProfiling) {
+    this.enableStartupProfiling = enableStartupProfiling;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryStartupProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryStartupProfilingOptions.java
@@ -4,10 +4,13 @@ import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
-final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializable {
+@ApiStatus.Internal
+public final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializable {
 
   boolean profileSampled;
   @Nullable Double profileSampleRate;
@@ -15,16 +18,19 @@ final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializab
   @Nullable Double traceSampleRate;
   @Nullable String profilingTracesDirPath;
   boolean isProfilingEnabled;
+  int profilingTracesHz;
 
   private @Nullable Map<String, Object> unknown;
 
-  SentryStartupProfilingOptions() {
+  @VisibleForTesting
+  public SentryStartupProfilingOptions() {
     traceSampled = false;
     traceSampleRate = null;
     profileSampled = false;
     profileSampleRate = null;
     profilingTracesDirPath = null;
     isProfilingEnabled = false;
+    profilingTracesHz = 0;
   }
 
   SentryStartupProfilingOptions(
@@ -36,6 +42,63 @@ final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializab
     profileSampleRate = samplingDecision.getProfileSampleRate();
     profilingTracesDirPath = options.getProfilingTracesDirPath();
     isProfilingEnabled = options.isProfilingEnabled();
+    profilingTracesHz = options.getProfilingTracesHz();
+  }
+
+  public void setProfileSampled(final boolean profileSampled) {
+    this.profileSampled = profileSampled;
+  }
+
+  public boolean isProfileSampled() {
+    return profileSampled;
+  }
+
+  public void setProfileSampleRate(final @Nullable Double profileSampleRate) {
+    this.profileSampleRate = profileSampleRate;
+  }
+
+  public @Nullable Double getProfileSampleRate() {
+    return profileSampleRate;
+  }
+
+  public void setTraceSampled(final boolean traceSampled) {
+    this.traceSampled = traceSampled;
+  }
+
+  public boolean isTraceSampled() {
+    return traceSampled;
+  }
+
+  public void setTraceSampleRate(final @Nullable Double traceSampleRate) {
+    this.traceSampleRate = traceSampleRate;
+  }
+
+  public @Nullable Double getTraceSampleRate() {
+    return traceSampleRate;
+  }
+
+  public void setProfilingTracesDirPath(final @Nullable String profilingTracesDirPath) {
+    this.profilingTracesDirPath = profilingTracesDirPath;
+  }
+
+  public @Nullable String getProfilingTracesDirPath() {
+    return profilingTracesDirPath;
+  }
+
+  public void setProfilingEnabled(final boolean profilingEnabled) {
+    isProfilingEnabled = profilingEnabled;
+  }
+
+  public boolean isProfilingEnabled() {
+    return isProfilingEnabled;
+  }
+
+  public void setProfilingTracesHz(final int profilingTracesHz) {
+    this.profilingTracesHz = profilingTracesHz;
+  }
+
+  public int getProfilingTracesHz() {
+    return profilingTracesHz;
   }
 
   // JsonSerializable
@@ -47,6 +110,7 @@ final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializab
     public static final String TRACE_SAMPLE_RATE = "trace_sample_rate";
     public static final String PROFILING_TRACES_DIR_PATH = "profiling_traces_dir_path";
     public static final String IS_PROFILING_ENABLED = "is_profiling_enabled";
+    public static final String PROFILING_TRACES_HZ = "profiling_traces_hz";
   }
 
   @Override
@@ -59,6 +123,7 @@ final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializab
     writer.name(JsonKeys.TRACE_SAMPLE_RATE).value(logger, traceSampleRate);
     writer.name(JsonKeys.PROFILING_TRACES_DIR_PATH).value(logger, profilingTracesDirPath);
     writer.name(JsonKeys.IS_PROFILING_ENABLED).value(logger, isProfilingEnabled);
+    writer.name(JsonKeys.PROFILING_TRACES_HZ).value(logger, profilingTracesHz);
 
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -128,6 +193,12 @@ final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializab
             Boolean isProfilingEnabled = reader.nextBooleanOrNull();
             if (isProfilingEnabled != null) {
               options.isProfilingEnabled = isProfilingEnabled;
+            }
+            break;
+          case JsonKeys.PROFILING_TRACES_HZ:
+            Integer profilingTracesHz = reader.nextIntegerOrNull();
+            if (profilingTracesHz != null) {
+              options.profilingTracesHz = profilingTracesHz;
             }
             break;
           default:

--- a/sentry/src/main/java/io/sentry/SentryStartupProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryStartupProfilingOptions.java
@@ -1,0 +1,146 @@
+package io.sentry;
+
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializable {
+
+  boolean profileSampled;
+  @Nullable Double profileSampleRate;
+  boolean traceSampled;
+  @Nullable Double traceSampleRate;
+  @Nullable String profilingTracesDirPath;
+  boolean isProfilingEnabled;
+
+  private @Nullable Map<String, Object> unknown;
+
+  SentryStartupProfilingOptions() {
+    traceSampled = false;
+    traceSampleRate = null;
+    profileSampled = false;
+    profileSampleRate = null;
+    profilingTracesDirPath = null;
+    isProfilingEnabled = false;
+  }
+
+  SentryStartupProfilingOptions(
+      final @NotNull SentryOptions options,
+      final @NotNull TracesSamplingDecision samplingDecision) {
+    traceSampled = samplingDecision.getSampled();
+    traceSampleRate = samplingDecision.getSampleRate();
+    profileSampled = samplingDecision.getProfileSampled();
+    profileSampleRate = samplingDecision.getProfileSampleRate();
+    profilingTracesDirPath = options.getProfilingTracesDirPath();
+    isProfilingEnabled = options.isProfilingEnabled();
+  }
+
+  // JsonSerializable
+
+  public static final class JsonKeys {
+    public static final String PROFILE_SAMPLED = "profile_sampled";
+    public static final String PROFILE_SAMPLE_RATE = "profile_sample_rate";
+    public static final String TRACE_SAMPLED = "trace_sampled";
+    public static final String TRACE_SAMPLE_RATE = "trace_sample_rate";
+    public static final String PROFILING_TRACES_DIR_PATH = "profiling_traces_dir_path";
+    public static final String IS_PROFILING_ENABLED = "is_profiling_enabled";
+  }
+
+  @Override
+  public void serialize(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
+      throws IOException {
+    writer.beginObject();
+    writer.name(JsonKeys.PROFILE_SAMPLED).value(logger, profileSampled);
+    writer.name(JsonKeys.PROFILE_SAMPLE_RATE).value(logger, profileSampleRate);
+    writer.name(JsonKeys.TRACE_SAMPLED).value(logger, traceSampled);
+    writer.name(JsonKeys.TRACE_SAMPLE_RATE).value(logger, traceSampleRate);
+    writer.name(JsonKeys.PROFILING_TRACES_DIR_PATH).value(logger, profilingTracesDirPath);
+    writer.name(JsonKeys.IS_PROFILING_ENABLED).value(logger, isProfilingEnabled);
+
+    if (unknown != null) {
+      for (String key : unknown.keySet()) {
+        Object value = unknown.get(key);
+        writer.name(key);
+        writer.value(logger, value);
+      }
+    }
+    writer.endObject();
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
+  @Override
+  public void setUnknown(@Nullable Map<String, Object> unknown) {
+    this.unknown = unknown;
+  }
+
+  public static final class Deserializer
+      implements JsonDeserializer<SentryStartupProfilingOptions> {
+
+    @Override
+    public @NotNull SentryStartupProfilingOptions deserialize(
+        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+      reader.beginObject();
+      SentryStartupProfilingOptions options = new SentryStartupProfilingOptions();
+      Map<String, Object> unknown = null;
+
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.PROFILE_SAMPLED:
+            Boolean profileSampled = reader.nextBooleanOrNull();
+            if (profileSampled != null) {
+              options.profileSampled = profileSampled;
+            }
+            break;
+          case JsonKeys.PROFILE_SAMPLE_RATE:
+            Double profileSampleRate = reader.nextDoubleOrNull();
+            if (profileSampleRate != null) {
+              options.profileSampleRate = profileSampleRate;
+            }
+            break;
+          case JsonKeys.TRACE_SAMPLED:
+            Boolean traceSampled = reader.nextBooleanOrNull();
+            if (traceSampled != null) {
+              options.traceSampled = traceSampled;
+            }
+            break;
+          case JsonKeys.TRACE_SAMPLE_RATE:
+            Double traceSampleRate = reader.nextDoubleOrNull();
+            if (traceSampleRate != null) {
+              options.traceSampleRate = traceSampleRate;
+            }
+            break;
+          case JsonKeys.PROFILING_TRACES_DIR_PATH:
+            String profilingTracesDirPath = reader.nextStringOrNull();
+            if (profilingTracesDirPath != null) {
+              options.profilingTracesDirPath = profilingTracesDirPath;
+            }
+            break;
+          case JsonKeys.IS_PROFILING_ENABLED:
+            Boolean isProfilingEnabled = reader.nextBooleanOrNull();
+            if (isProfilingEnabled != null) {
+              options.isProfilingEnabled = isProfilingEnabled;
+            }
+            break;
+          default:
+            if (unknown == null) {
+              unknown = new ConcurrentHashMap<>();
+            }
+            reader.nextUnknown(logger, unknown, nextName);
+            break;
+        }
+      }
+      options.setUnknown(unknown);
+      reader.endObject();
+      return options;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -208,9 +208,9 @@ public final class TransactionContext extends SpanContext {
   }
 
   /**
-   * Whether this {@link TransactionContext} evaluates for the next startup.
-   *  If this is true, it gets called only once when the SDK initializes.
-   *  This is set only if {@link SentryOptions#isEnableStartupProfiling()} is true.
+   * Whether this {@link TransactionContext} evaluates for the next startup. If this is true, it
+   * gets called only once when the SDK initializes. This is set only if {@link
+   * SentryOptions#isEnableStartupProfiling()} is true.
    *
    * @return True if this {@link TransactionContext} will be used for the next startup.
    */

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -18,6 +18,7 @@ public final class TransactionContext extends SpanContext {
   private @Nullable TracesSamplingDecision parentSamplingDecision;
   private @Nullable Baggage baggage;
   private @NotNull Instrumenter instrumenter = Instrumenter.SENTRY;
+  private boolean isForNextStartup = false;
 
   /**
    * Creates {@link TransactionContext} from sentry-trace header.
@@ -199,5 +200,21 @@ public final class TransactionContext extends SpanContext {
 
   public void setTransactionNameSource(final @NotNull TransactionNameSource transactionNameSource) {
     this.transactionNameSource = transactionNameSource;
+  }
+
+  @ApiStatus.Internal
+  public void setForNextStartup(final boolean forNextStartup) {
+    isForNextStartup = forNextStartup;
+  }
+
+  /**
+   * Whether this {@link TransactionContext} evaluates for the next startup.
+   *  If this is true, it gets called only once when the SDK initializes.
+   *  This is set only if {@link SentryOptions#isEnableStartupProfiling()} is true.
+   *
+   * @return True if this {@link TransactionContext} will be used for the next startup.
+   */
+  public boolean isForNextStartup() {
+    return isForNextStartup;
   }
 }

--- a/sentry/src/main/java/io/sentry/TransactionOptions.java
+++ b/sentry/src/main/java/io/sentry/TransactionOptions.java
@@ -20,6 +20,9 @@ public final class TransactionOptions extends SpanOptions {
   /** The start timestamp of the transaction */
   private @Nullable SentryDate startTimestamp = null;
 
+  /** Defines if transaction refers to the startup process */
+  private boolean isStartupTransaction = false;
+
   /**
    * When `waitForChildren` is set to `true`, tracer will finish only when both conditions are met
    * (the order of meeting condition does not matter): - tracer itself is finished - all child spans
@@ -182,5 +185,15 @@ public final class TransactionOptions extends SpanOptions {
   public void setTransactionFinishedCallback(
       @Nullable TransactionFinishedCallback transactionFinishedCallback) {
     this.transactionFinishedCallback = transactionFinishedCallback;
+  }
+
+  @ApiStatus.Internal
+  public void setStartupTransaction(final boolean startupTransaction) {
+    isStartupTransaction = startupTransaction;
+  }
+
+  @ApiStatus.Internal
+  public boolean isStartupTransaction() {
+    return isStartupTransaction;
   }
 }

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -978,7 +978,7 @@ class JsonSerializerTest {
         val actual = serializeToString(startupProfilingOptions)
 
         val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\":false," +
-            "\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false}"
+            "\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false,\"profiling_traces_hz\":65}"
 
         assertEquals(expected, actual)
     }
@@ -986,7 +986,7 @@ class JsonSerializerTest {
     @Test
     fun `deserializing SentryStartupProfilingOptions`() {
         val jsonStartupProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
-            ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false}"
+            ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false,\"profiling_traces_hz\":65}"
 
         val actual = fixture.serializer.deserialize(StringReader(jsonStartupProfilingOptions), SentryStartupProfilingOptions::class.java)
         assertNotNull(actual)
@@ -995,6 +995,8 @@ class JsonSerializerTest {
         assertEquals(startupProfilingOptions.profileSampled, actual.profileSampled)
         assertEquals(startupProfilingOptions.profileSampleRate, actual.profileSampleRate)
         assertEquals(startupProfilingOptions.isProfilingEnabled, actual.isProfilingEnabled)
+        assertEquals(startupProfilingOptions.profilingTracesHz, actual.profilingTracesHz)
+        assertEquals(startupProfilingOptions.profilingTracesDirPath, actual.profilingTracesDirPath)
         assertNull(actual.unknown)
     }
 
@@ -1280,6 +1282,7 @@ class JsonSerializerTest {
         profileSampled = true
         profileSampleRate = 0.8
         isProfilingEnabled = false
+        profilingTracesHz = 65
     }
 
     private fun createSpan(): ISpan {

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -974,6 +974,31 @@ class JsonSerializerTest {
     }
 
     @Test
+    fun `serializing SentryStartupProfilingOptions`() {
+        val actual = serializeToString(startupProfilingOptions)
+
+        val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\":false," +
+            "\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false}"
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `deserializing SentryStartupProfilingOptions`() {
+        val jsonStartupProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
+            ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false}"
+
+        val actual = fixture.serializer.deserialize(StringReader(jsonStartupProfilingOptions), SentryStartupProfilingOptions::class.java)
+        assertNotNull(actual)
+        assertEquals(startupProfilingOptions.traceSampled, actual.traceSampled)
+        assertEquals(startupProfilingOptions.traceSampleRate, actual.traceSampleRate)
+        assertEquals(startupProfilingOptions.profileSampled, actual.profileSampled)
+        assertEquals(startupProfilingOptions.profileSampleRate, actual.profileSampleRate)
+        assertEquals(startupProfilingOptions.isProfilingEnabled, actual.isProfilingEnabled)
+        assertNull(actual.unknown)
+    }
+
+    @Test
     fun `serializes span data`() {
         val sentrySpan = SentrySpan(createSpan() as Span, mapOf("data1" to "value1"))
 
@@ -1247,6 +1272,14 @@ class JsonSerializerTest {
             email = "john@me.com"
             comments = "comment"
         }
+    }
+
+    private val startupProfilingOptions = SentryStartupProfilingOptions().apply {
+        traceSampled = false
+        traceSampleRate = 0.1
+        profileSampled = true
+        profileSampleRate = 0.8
+        isProfilingEnabled = false
     }
 
     private fun createSpan(): ISpan {

--- a/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpTransactionProfilerTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import org.mockito.kotlin.mock
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class NoOpTransactionProfilerTest {
@@ -14,6 +15,11 @@ class NoOpTransactionProfilerTest {
     @Test
     fun `bindTransaction does not throw`() =
         profiler.bindTransaction(mock())
+
+    @Test
+    fun `isRunning returns false`() {
+        assertFalse(profiler.isRunning)
+    }
 
     @Test
     fun `onTransactionFinish does returns null`() {

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -514,6 +514,7 @@ class SentryOptionsTest {
         assertEquals(customProvider, options.connectionStatusProvider)
     }
 
+    @Test
     fun `when options are initialized, enabled is set to true by default`() {
         assertTrue(SentryOptions().isEnabled)
     }
@@ -526,5 +527,17 @@ class SentryOptionsTest {
     @Test
     fun `when options are initialized, sendModules is set to true by default`() {
         assertTrue(SentryOptions().isSendModules)
+    }
+
+    @Test
+    fun `when options are initialized, enableStartupProfiling is set to false by default`() {
+        assertFalse(SentryOptions().isEnableStartupProfiling)
+    }
+
+    @Test
+    fun `when setEnableStartupProfiling is called, overrides default`() {
+        val options = SentryOptions()
+        options.isEnableStartupProfiling = true
+        assertTrue(options.isEnableStartupProfiling)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -461,6 +462,21 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `getCacheDirPathWithoutDsn does not contain dsn hash`() {
+        val dsn = "http://key@localhost/proj"
+        val hash = StringUtils.calculateStringHash(dsn, mock())
+        val options = SentryOptions().apply {
+            setDsn(dsn)
+            cacheDirPath = "${File.separator}test"
+        }
+
+        val cacheDirPathWithoutDsn = options.cacheDirPathWithoutDsn!!
+        assertNotEquals(cacheDirPathWithoutDsn, options.cacheDirPath)
+        assertEquals(cacheDirPathWithoutDsn, options.cacheDirPath!!.substringBeforeLast("/"))
+        assertFalse(cacheDirPathWithoutDsn.contains(hash.toString()))
+    }
+
+    @Test
     fun `when options are initialized, idleTimeout is 3000`() {
         assertEquals(3000L, SentryOptions().idleTimeout)
     }
@@ -538,6 +554,15 @@ class SentryOptionsTest {
     fun `when setEnableStartupProfiling is called, overrides default`() {
         val options = SentryOptions()
         options.isEnableStartupProfiling = true
+        options.profilesSampleRate = 1.0
         assertTrue(options.isEnableStartupProfiling)
+    }
+
+    @Test
+    fun `when profiling is disabled, isEnableStartupProfiling is always false`() {
+        val options = SentryOptions()
+        options.isEnableStartupProfiling = true
+        options.profilesSampleRate = 0.0
+        assertFalse(options.isEnableStartupProfiling)
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -574,4 +574,16 @@ class SentryOptionsTest {
         options.profilesSampleRate = 0.0
         assertFalse(options.isEnableStartupProfiling)
     }
+
+    @Test
+    fun `when options are initialized, profilingTracesHz is set to 101 by default`() {
+        assertEquals(101, SentryOptions().profilingTracesHz)
+    }
+
+    @Test
+    fun `when setProfilingTracesHz is called, overrides default`() {
+        val options = SentryOptions()
+        options.profilingTracesHz = 13
+        assertEquals(13, options.profilingTracesHz)
+    }
 }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -310,7 +310,7 @@ class SentryTest {
         oldProfile.createNewFile()
         newProfile.createNewFile()
         // Make the old profile look like it's created earlier
-        oldProfile.setLastModified(System.currentTimeMillis() - 10000)
+        oldProfile.setLastModified(10000)
         // Make the new profile look like it's created later
         newProfile.setLastModified(System.currentTimeMillis() + 10000)
 
@@ -945,11 +945,11 @@ class SentryTest {
     @Test
     fun `backpressure monitor is a NoOp if handling is disabled`() {
         var sentryOptions: SentryOptions? = null
-        Sentry.init({
+        Sentry.init {
             it.dsn = dsn
             it.isEnableBackpressureHandling = false
             sentryOptions = it
-        })
+        }
         assertIs<NoOpBackpressureMonitor>(sentryOptions?.backpressureMonitor)
     }
 
@@ -957,11 +957,11 @@ class SentryTest {
     fun `backpressure monitor is set if handling is enabled`() {
         var sentryOptions: SentryOptions? = null
 
-        Sentry.init({
+        Sentry.init {
             it.dsn = dsn
             it.isEnableBackpressureHandling = true
             sentryOptions = it
-        })
+        }
         assertIs<BackpressureMonitor>(sentryOptions?.backpressureMonitor)
     }
 
@@ -982,11 +982,15 @@ class SentryTest {
         // Samplers are called with isForNextStartup flag set to true
         verify(mockSampleTracer).sample(
             check {
+                assertEquals("app.launch", it.transactionContext.name)
+                assertEquals("profile", it.transactionContext.operation)
                 assertTrue(it.transactionContext.isForNextStartup)
             }
         )
         verify(mockProfilesSampler).sample(
             check {
+                assertEquals("app.launch", it.transactionContext.name)
+                assertEquals("profile", it.transactionContext.operation)
                 assertTrue(it.transactionContext.isForNextStartup)
             }
         )

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1,5 +1,7 @@
 package io.sentry
 
+import io.sentry.SentryOptions.ProfilesSamplerCallback
+import io.sentry.SentryOptions.TracesSamplerCallback
 import io.sentry.cache.EnvelopeCache
 import io.sentry.cache.IEnvelopeCache
 import io.sentry.internal.debugmeta.IDebugMetaLoader
@@ -21,11 +23,14 @@ import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
+import java.io.FileReader
 import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.CompletableFuture
@@ -79,6 +84,21 @@ class SentryTest {
         }
 
         val file = File(sentryOptions!!.cacheDirPath!!)
+        assertTrue(file.exists())
+        file.deleteOnExit()
+    }
+
+    @Test
+    fun `getCacheDirPathWithoutDsn should be created at initialization`() {
+        var sentryOptions: SentryOptions? = null
+        Sentry.init {
+            it.dsn = dsn
+            it.cacheDirPath = getTempPath()
+            sentryOptions = it
+        }
+
+        val cacheDirPathWithoutDsn = sentryOptions!!.cacheDirPathWithoutDsn!!
+        val file = File(cacheDirPathWithoutDsn)
         assertTrue(file.exists())
         file.deleteOnExit()
     }
@@ -918,6 +938,150 @@ class SentryTest {
 
         val span = Sentry.getSpan()!!
         assertEquals("op-child", span.operation)
+    }
+
+    @Test
+    fun `init calls samplers if isEnableStartupProfiling is true`() {
+        val mockSampleTracer = mock<TracesSamplerCallback>()
+        val mockProfilesSampler = mock<ProfilesSamplerCallback>()
+        Sentry.init {
+            it.dsn = dsn
+            it.enableTracing = true
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 1.0
+            it.tracesSampler = mockSampleTracer
+            it.profilesSampler = mockProfilesSampler
+            it.executorService = ImmediateExecutorService()
+            it.cacheDirPath = getTempPath()
+        }
+        // Samplers are called with isForNextStartup flag set to true
+        verify(mockSampleTracer).sample(
+            check {
+                assertTrue(it.transactionContext.isForNextStartup)
+            }
+        )
+        verify(mockProfilesSampler).sample(
+            check {
+                assertTrue(it.transactionContext.isForNextStartup)
+            }
+        )
+    }
+
+    @Test
+    fun `init calls startup profiling samplers in the background`() {
+        val mockSampleTracer = mock<TracesSamplerCallback>()
+        val mockProfilesSampler = mock<ProfilesSamplerCallback>()
+        Sentry.init {
+            it.dsn = dsn
+            it.enableTracing = true
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 1.0
+            it.tracesSampler = mockSampleTracer
+            it.profilesSampler = mockProfilesSampler
+            it.executorService = NoOpSentryExecutorService.getInstance()
+            it.cacheDirPath = getTempPath()
+        }
+        // Samplers are called with isForNextStartup flag set to true
+        verify(mockSampleTracer, never()).sample(any())
+        verify(mockProfilesSampler, never()).sample(any())
+    }
+
+    @Test
+    fun `init does not call startup profiling samplers if cache dir is null`() {
+        val mockSampleTracer = mock<TracesSamplerCallback>()
+        val mockProfilesSampler = mock<ProfilesSamplerCallback>()
+        Sentry.init {
+            it.dsn = dsn
+            it.enableTracing = true
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 1.0
+            it.tracesSampler = mockSampleTracer
+            it.profilesSampler = mockProfilesSampler
+            it.executorService = NoOpSentryExecutorService.getInstance()
+            it.cacheDirPath = null
+        }
+        // Samplers are called with isForNextStartup flag set to true
+        verify(mockSampleTracer, never()).sample(any())
+        verify(mockProfilesSampler, never()).sample(any())
+    }
+
+    @Test
+    fun `init does not call startup profiling samplers if enableTracing is false`() {
+        val logger = mock<ILogger>()
+        val mockTraceSampler = mock<TracesSamplerCallback>()
+        val mockProfilesSampler = mock<ProfilesSamplerCallback>()
+        Sentry.init {
+            it.dsn = dsn
+            it.enableTracing = false
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 1.0
+            it.tracesSampler = mockTraceSampler
+            it.profilesSampler = mockProfilesSampler
+            it.executorService = ImmediateExecutorService()
+            it.cacheDirPath = getTempPath()
+            it.isDebug = true
+            it.setLogger(logger)
+        }
+        verify(logger).log(eq(SentryLevel.INFO), eq("Tracing is disabled and startup profiling will not start."))
+        verify(mockTraceSampler, never()).sample(any())
+        verify(mockProfilesSampler, never()).sample(any())
+    }
+
+    @Test
+    fun `init deletes startup profiling config`() {
+        val path = getTempPath()
+        File(path).mkdirs()
+        val startupProfilingConfigFile = File(path, "startup_profiling_config")
+        startupProfilingConfigFile.createNewFile()
+        assertTrue(startupProfilingConfigFile.exists())
+        Sentry.init {
+            it.dsn = dsn
+            it.executorService = ImmediateExecutorService()
+            it.cacheDirPath = path
+        }
+        assertFalse(startupProfilingConfigFile.exists())
+    }
+
+    @Test
+    fun `init creates startup profiling config if isEnableStartupProfiling and enableTracing is true`() {
+        val path = getTempPath()
+        File(path).mkdirs()
+        val startupProfilingConfigFile = File(path, "startup_profiling_config")
+        startupProfilingConfigFile.createNewFile()
+        assertTrue(startupProfilingConfigFile.exists())
+        Sentry.init {
+            it.dsn = dsn
+            it.cacheDirPath = path
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 1.0
+            it.enableTracing = true
+            it.executorService = ImmediateExecutorService()
+        }
+        assertTrue(startupProfilingConfigFile.exists())
+    }
+
+    @Test
+    fun `init saves SentryStartupProfilingOptions to disk`() {
+        var options = SentryOptions()
+        val path = getTempPath()
+        Sentry.init {
+            it.dsn = dsn
+            it.cacheDirPath = path
+            it.enableTracing = true
+            it.tracesSampleRate = 0.5
+            it.isEnableStartupProfiling = true
+            it.profilesSampleRate = 0.2
+            it.executorService = ImmediateExecutorService()
+            options = it
+        }
+        val startupProfilingConfigFile = File(path, "startup_profiling_config")
+        assertTrue(startupProfilingConfigFile.exists())
+        val startupOption =
+            JsonSerializer(options).deserialize(FileReader(startupProfilingConfigFile), SentryStartupProfilingOptions::class.java)
+        assertNotNull(startupOption)
+        assertEquals(0.5, startupOption.traceSampleRate)
+        assertEquals(0.2, startupOption.profileSampleRate)
+        assertTrue(startupOption.isProfilingEnabled)
     }
 
     private class InMemoryOptionsObserver : IOptionsObserver {

--- a/sentry/src/test/java/io/sentry/TransactionContextTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionContextTest.kt
@@ -18,6 +18,7 @@ class TransactionContextTest {
         assertNull(context.parentSampled)
         assertEquals("name", context.name)
         assertEquals("op", context.op)
+        assertFalse(context.isForNextStartup)
     }
 
     @Test
@@ -27,6 +28,7 @@ class TransactionContextTest {
         assertNull(context.sampled)
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
+        assertFalse(context.isForNextStartup)
     }
 
     @Test
@@ -42,6 +44,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertFalse(context.parentSampled!!)
         assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
+        assertFalse(context.isForNextStartup)
     }
 
     @Test
@@ -57,6 +60,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertFalse(context.parentSampled!!)
         assertNull(context.parentSamplingDecision!!.sampleRate)
+        assertFalse(context.isForNextStartup)
     }
 
     @Test
@@ -72,6 +76,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
         assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
+        assertFalse(context.isForNextStartup)
     }
 
     @Test
@@ -87,5 +92,13 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
         assertNull(context.parentSamplingDecision!!.sampleRate)
+        assertFalse(context.isForNextStartup)
+    }
+
+    @Test
+    fun `setForNextStartup sets the isForNextStartup flag`() {
+        val context = TransactionContext("name", "op")
+        context.isForNextStartup = true
+        assertTrue(context.isForNextStartup)
     }
 }


### PR DESCRIPTION
## :scroll: Description
followup of https://github.com/getsentry/sentry-java/pull/3101/
added SentryStartupProfilingOptions class with Json ser/deser
added startupProfilingConfigFile deletion and creation on init
added sampling decision on SDK init with isForNextStartup flag set to true
added SentryOptions.getCacheDirPathWithoutDsn for startupProfiling config file

Here is the decision tree. 
The only missing part is actually starting the profiler and bind it to the first transaction, which will come in the next PR.
Note: the auto instrumentation flag is available on `SentryAndroidOptions`, so it will be evaluated (in the next PR) before starting the startup profiler
![photo_2023-12-15 14 57 18](https://github.com/getsentry/sentry-java/assets/16819053/01f35074-f45d-4e6c-a616-a35d22937280)


## :bulb: Motivation and Context
For the startup profiling feature, we need to add an option to enable it and we also need to respect the sampling decisions of the user.
Then, we need to save this info to disk, as the startup profiler will not have access to the `SentryOptions` object, as it will start before the SDK is initialized.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
