### PR TITLE
Avoid concurrency in AndroidProfiler performance data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Avoid concurrency in AndroidProfiler performance data collection ([#3130](https://github.com/getsentry/sentry-java/pull/3130))
 - Improve thresholds for network changes breadcrumbs ([#3083](https://github.com/getsentry/sentry-java/pull/3083))
 - SchedulerFactoryBeanCustomizer now runs first so user customization is not overridden ([#3095](https://github.com/getsentry/sentry-java/pull/3095))
   - If you are setting global job listeners please also add `SentryJobListener`

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -313,26 +313,29 @@ public class AndroidProfiler {
           new ArrayDeque<>(performanceCollectionData.size());
       final @NotNull ArrayDeque<ProfileMeasurementValue> cpuUsageMeasurements =
           new ArrayDeque<>(performanceCollectionData.size());
-      for (PerformanceCollectionData performanceData : performanceCollectionData) {
-        CpuCollectionData cpuData = performanceData.getCpuData();
-        MemoryCollectionData memoryData = performanceData.getMemoryData();
-        if (cpuData != null) {
-          cpuUsageMeasurements.add(
+
+      synchronized (performanceCollectionData) {
+        for (PerformanceCollectionData performanceData : performanceCollectionData) {
+          CpuCollectionData cpuData = performanceData.getCpuData();
+          MemoryCollectionData memoryData = performanceData.getMemoryData();
+          if (cpuData != null) {
+            cpuUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  TimeUnit.MILLISECONDS.toNanos(cpuData.getTimestampMillis()) + timestampDiff,
-                  cpuData.getCpuUsagePercentage()));
-        }
-        if (memoryData != null && memoryData.getUsedHeapMemory() > -1) {
-          memoryUsageMeasurements.add(
+                TimeUnit.MILLISECONDS.toNanos(cpuData.getTimestampMillis()) + timestampDiff,
+                cpuData.getCpuUsagePercentage()));
+          }
+          if (memoryData != null && memoryData.getUsedHeapMemory() > -1) {
+            memoryUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
-                  memoryData.getUsedHeapMemory()));
-        }
-        if (memoryData != null && memoryData.getUsedNativeMemory() > -1) {
-          nativeMemoryUsageMeasurements.add(
+                TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
+                memoryData.getUsedHeapMemory()));
+          }
+          if (memoryData != null && memoryData.getUsedNativeMemory() > -1) {
+            nativeMemoryUsageMeasurements.add(
               new ProfileMeasurementValue(
-                  TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
-                  memoryData.getUsedNativeMemory()));
+                TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
+                memoryData.getUsedNativeMemory()));
+          }
         }
       }
       if (!cpuUsageMeasurements.isEmpty()) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -320,21 +320,21 @@ public class AndroidProfiler {
           MemoryCollectionData memoryData = performanceData.getMemoryData();
           if (cpuData != null) {
             cpuUsageMeasurements.add(
-              new ProfileMeasurementValue(
-                TimeUnit.MILLISECONDS.toNanos(cpuData.getTimestampMillis()) + timestampDiff,
-                cpuData.getCpuUsagePercentage()));
+                new ProfileMeasurementValue(
+                    TimeUnit.MILLISECONDS.toNanos(cpuData.getTimestampMillis()) + timestampDiff,
+                    cpuData.getCpuUsagePercentage()));
           }
           if (memoryData != null && memoryData.getUsedHeapMemory() > -1) {
             memoryUsageMeasurements.add(
-              new ProfileMeasurementValue(
-                TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
-                memoryData.getUsedHeapMemory()));
+                new ProfileMeasurementValue(
+                    TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
+                    memoryData.getUsedHeapMemory()));
           }
           if (memoryData != null && memoryData.getUsedNativeMemory() > -1) {
             nativeMemoryUsageMeasurements.add(
-              new ProfileMeasurementValue(
-                TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
-                memoryData.getUsedNativeMemory()));
+                new ProfileMeasurementValue(
+                    TimeUnit.MILLISECONDS.toNanos(memoryData.getTimestampMillis()) + timestampDiff,
+                    memoryData.getUsedNativeMemory()));
           }
         }
       }


### PR DESCRIPTION
## :scroll: Description
put list for loop in synchronized block in AndroidProfiler 


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3119


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
