### PR TITLE
Reduced bitmap size and background work in ui tests

### DIFF
--- a/sentry-android-integration-tests/sentry-uitest-android/src/main/java/io/sentry/uitest/android/ProfilingSampleActivity.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/main/java/io/sentry/uitest/android/ProfilingSampleActivity.kt
@@ -26,8 +26,7 @@ class ProfilingSampleActivity : AppCompatActivity() {
     }
 
     private lateinit var binding: ActivityProfilingSampleBinding
-    private val backgroundThreadPoolSize = 2
-    private val executor: ExecutorService = Executors.newFixedThreadPool(backgroundThreadPoolSize)
+    private val executor: ExecutorService = Executors.newFixedThreadPool(1)
     private var resumed = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -64,10 +63,8 @@ class ProfilingSampleActivity : AppCompatActivity() {
         resumed = true
 
         // Do operations until the activity is paused.
-        repeat(backgroundThreadPoolSize) {
-            executor.execute {
-                fibonacci(50)
-            }
+        executor.execute {
+            fibonacci(50)
         }
     }
 
@@ -99,7 +96,7 @@ internal class ProfilingSampleListAdapter : RecyclerView.Adapter<ViewHolder>() {
 
     @Suppress("MagicNumber")
     private fun generateBitmap(): Bitmap {
-        val bitmapSize = 512
+        val bitmapSize = 256
         val colors = (0 until (bitmapSize * bitmapSize)).map {
             Color.rgb(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
         }.toIntArray()


### PR DESCRIPTION
## :scroll: Description
reduced bitmap size and background worker count in ProfilingSampleActivity to reduce the likeliness of ANRs during tests

#skip-changelog


## :bulb: Motivation and Context
Sometimes a test was failing, likely due to an ANR


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
