### PR TITLE
Renamed startupProfiling to appStartProfiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-- Added Startup profiling
-    - This depends on the new option `io.sentry.profiling.enable-startup`, other than the already existing `io.sentry.traces.profiling.sample-rate`.
-    - Sampler functions can check the new `isForNextStartup` flag, to adjust startup profiling sampling programmatically.
+- Added App Start profiling
+    - This depends on the new option `io.sentry.profiling.enable-app-start`, other than the already existing `io.sentry.traces.profiling.sample-rate`.
+    - Sampler functions can check the new `isForNextAppStart` flag, to adjust startup profiling sampling programmatically.
       Relevant PRs:
     - Decouple Profiler from Transaction ([#3101](https://github.com/getsentry/sentry-java/pull/3101))
     - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -418,6 +418,8 @@ public class io/sentry/android/core/performance/AppStartMetrics {
 	public fun addActivityLifecycleTimeSpans (Lio/sentry/android/core/performance/ActivityLifecycleTimeSpan;)V
 	public fun clear ()V
 	public fun getActivityLifecycleTimeSpans ()Ljava/util/List;
+	public fun getAppStartProfiler ()Lio/sentry/ITransactionProfiler;
+	public fun getAppStartSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun getAppStartTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
 	public fun getAppStartTimeSpanWithFallback (Lio/sentry/android/core/SentryAndroidOptions;)Lio/sentry/android/core/performance/TimeSpan;
 	public fun getAppStartType ()Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;
@@ -425,16 +427,14 @@ public class io/sentry/android/core/performance/AppStartMetrics {
 	public fun getContentProviderOnCreateTimeSpans ()Ljava/util/List;
 	public static fun getInstance ()Lio/sentry/android/core/performance/AppStartMetrics;
 	public fun getSdkInitTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
-	public fun getStartupProfiler ()Lio/sentry/ITransactionProfiler;
-	public fun getStartupSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun isAppLaunchedInForeground ()Z
 	public static fun onApplicationCreate (Landroid/app/Application;)V
 	public static fun onApplicationPostCreate (Landroid/app/Application;)V
 	public static fun onContentProviderCreate (Landroid/content/ContentProvider;)V
 	public static fun onContentProviderPostCreate (Landroid/content/ContentProvider;)V
+	public fun setAppStartProfiler (Lio/sentry/ITransactionProfiler;)V
+	public fun setAppStartSamplingDecision (Lio/sentry/TracesSamplingDecision;)V
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
-	public fun setStartupProfiler (Lio/sentry/ITransactionProfiler;)V
-	public fun setStartupSamplingDecision (Lio/sentry/TracesSamplingDecision;)V
 }
 
 public final class io/sentry/android/core/performance/AppStartMetrics$AppStartType : java/lang/Enum {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -206,22 +206,22 @@ public final class ActivityLifecycleIntegration
 
         // This will be the start timestamp of the transaction, as well as the ttid/ttfd spans
         final @NotNull SentryDate ttidStartTime;
-        final @Nullable TracesSamplingDecision startupSamplingDecision;
+        final @Nullable TracesSamplingDecision appStartSamplingDecision;
 
         if (!(firstActivityCreated || appStartTime == null || coldStart == null)) {
           // The first activity ttid/ttfd spans should start at the app start time
           ttidStartTime = appStartTime;
-          // The app start transaction inherits the sampling decision from the startup profiling,
+          // The app start transaction inherits the sampling decision from the app start profiling,
           // then clears it
-          startupSamplingDecision = AppStartMetrics.getInstance().getStartupSamplingDecision();
-          AppStartMetrics.getInstance().setStartupSamplingDecision(null);
+          appStartSamplingDecision = AppStartMetrics.getInstance().getAppStartSamplingDecision();
+          AppStartMetrics.getInstance().setAppStartSamplingDecision(null);
         } else {
           // The ttid/ttfd spans should start when the previous activity called its onPause method
           ttidStartTime = lastPausedTime;
-          startupSamplingDecision = null;
+          appStartSamplingDecision = null;
         }
         transactionOptions.setStartTimestamp(ttidStartTime);
-        transactionOptions.setStartupTransaction(startupSamplingDecision != null);
+        transactionOptions.setAppStartTransaction(appStartSamplingDecision != null);
 
         // we can only bind to the scope if there's no running transaction
         ITransaction transaction =
@@ -230,7 +230,7 @@ public final class ActivityLifecycleIntegration
                     activityName,
                     TransactionNameSource.COMPONENT,
                     UI_LOAD_OP,
-                    startupSamplingDecision),
+                    appStartSamplingDecision),
                 transactionOptions);
         setSpanOrigin(transaction);
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -149,15 +149,15 @@ final class AndroidOptionsInitializer {
     options.addEventProcessor(new AnrV2EventProcessor(context, options, buildInfoProvider));
     options.setTransportGate(new AndroidTransportGate(options));
 
-    // Check if the profiler was already instantiated in the startup.
+    // Check if the profiler was already instantiated in the app start.
     // We use the Android profiler, that uses a global start/stop api, so we need to preserve the
     // state of the profiler, and it's only possible retaining the instance.
     synchronized (AppStartMetrics.getInstance()) {
-      final @Nullable ITransactionProfiler startupProfiler =
-          AppStartMetrics.getInstance().getStartupProfiler();
-      if (startupProfiler != null) {
-        options.setTransactionProfiler(startupProfiler);
-        AppStartMetrics.getInstance().setStartupProfiler(null);
+      final @Nullable ITransactionProfiler appStartProfiler =
+          AppStartMetrics.getInstance().getAppStartProfiler();
+      if (appStartProfiler != null) {
+        options.setTransactionProfiler(appStartProfiler);
+        AppStartMetrics.getInstance().setAppStartProfiler(null);
       } else {
         final SentryFrameMetricsCollector frameMetricsCollector =
             new SentryFrameMetricsCollector(context, options, buildInfoProvider);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -313,7 +313,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
           null,
           HubAdapter.getInstance().getOptions());
     } else if (transactionsCounter != 0) {
-      // in case the startup profiling is running, and it's not bound to a transaction, we still
+      // in case the app start profiling is running, and it's not bound to a transaction, we still
       // stop profiling, but we also have to manually update the counter.
       transactionsCounter--;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -98,7 +98,7 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_PERFORMANCE_V2 = "io.sentry.performance-v2.enable";
 
-  static final String ENABLE_STARTUP_PROFILING = "io.sentry.profiling.enable-startup";
+  static final String ENABLE_APP_START_PROFILING = "io.sentry.profiling.enable-app-start";
 
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
@@ -368,9 +368,9 @@ final class ManifestMetadataReader {
         options.setEnablePerformanceV2(
             readBool(metadata, logger, ENABLE_PERFORMANCE_V2, options.isEnablePerformanceV2()));
 
-        options.setEnableStartupProfiling(
+        options.setEnableAppStartProfiling(
             readBool(
-                metadata, logger, ENABLE_STARTUP_PROFILING, options.isEnableStartupProfiling()));
+                metadata, logger, ENABLE_APP_START_PROFILING, options.isEnableAppStartProfiling()));
       }
 
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -1,6 +1,6 @@
 package io.sentry.android.core;
 
-import static io.sentry.Sentry.App_START_PROFILING_CONFIG_FILE_NAME;
+import static io.sentry.Sentry.APP_START_PROFILING_CONFIG_FILE_NAME;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -1,6 +1,6 @@
 package io.sentry.android.core;
 
-import static io.sentry.Sentry.STARTUP_PROFILING_CONFIG_FILE_NAME;
+import static io.sentry.Sentry.App_START_PROFILING_CONFIG_FILE_NAME;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -17,10 +17,10 @@ import io.sentry.ILogger;
 import io.sentry.ITransactionProfiler;
 import io.sentry.JsonSerializer;
 import io.sentry.NoOpLogger;
+import io.sentry.SentryAppStartProfilingOptions;
 import io.sentry.SentryExecutorService;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.SentryStartupProfilingOptions;
 import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
@@ -70,7 +70,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
   public boolean onCreate() {
     final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
     onAppLaunched(getContext(), appStartMetrics);
-    launchStartupProfiler(appStartMetrics);
+    launchAppStartProfiler(appStartMetrics);
     return true;
   }
 
@@ -93,15 +93,15 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
   @Override
   public void shutdown() {
     synchronized (AppStartMetrics.getInstance()) {
-      final @Nullable ITransactionProfiler startupProfiler =
-          AppStartMetrics.getInstance().getStartupProfiler();
-      if (startupProfiler != null) {
-        startupProfiler.close();
+      final @Nullable ITransactionProfiler appStartProfiler =
+          AppStartMetrics.getInstance().getAppStartProfiler();
+      if (appStartProfiler != null) {
+        appStartProfiler.close();
       }
     }
   }
 
-  private void launchStartupProfiler(final @NotNull AppStartMetrics appStartMetrics) {
+  private void launchAppStartProfiler(final @NotNull AppStartMetrics appStartMetrics) {
     final @Nullable Context context = getContext();
 
     if (context == null) {
@@ -115,47 +115,49 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     }
 
     final @NotNull File cacheDir = AndroidOptionsInitializer.getCacheDir(context);
-    final @NotNull File configFile = new File(cacheDir, STARTUP_PROFILING_CONFIG_FILE_NAME);
+    final @NotNull File configFile = new File(cacheDir, App_START_PROFILING_CONFIG_FILE_NAME);
 
-    // No config exists: startup profiling is not enabled
+    // No config exists: app start profiling is not enabled
     if (!configFile.exists() || !configFile.canRead()) {
       return;
     }
 
     try (final @NotNull Reader reader =
             new BufferedReader(new InputStreamReader(new FileInputStream(configFile)))) {
-      final @Nullable SentryStartupProfilingOptions profilingOptions =
+      final @Nullable SentryAppStartProfilingOptions profilingOptions =
           new JsonSerializer(SentryOptions.empty())
-              .deserialize(reader, SentryStartupProfilingOptions.class);
+              .deserialize(reader, SentryAppStartProfilingOptions.class);
 
       if (profilingOptions == null) {
         logger.log(
             SentryLevel.WARNING,
-            "Unable to deserialize the SentryStartupProfilingOptions. Startup profiling will not start.");
+            "Unable to deserialize the SentryAppStartProfilingOptions. App start profiling will not start.");
         return;
       }
 
       if (!profilingOptions.isProfilingEnabled()) {
-        logger.log(SentryLevel.INFO, "Profiling is not enabled. Startup profiling will not start.");
+        logger.log(
+            SentryLevel.INFO, "Profiling is not enabled. App start profiling will not start.");
         return;
       }
 
-      final @NotNull TracesSamplingDecision startupSamplingDecision =
+      final @NotNull TracesSamplingDecision appStartSamplingDecision =
           new TracesSamplingDecision(
               profilingOptions.isTraceSampled(),
               profilingOptions.getTraceSampleRate(),
               profilingOptions.isProfileSampled(),
               profilingOptions.getProfileSampleRate());
       // We store any sampling decision, so we can respect it when the first transaction starts
-      appStartMetrics.setStartupSamplingDecision(startupSamplingDecision);
+      appStartMetrics.setAppStartSamplingDecision(appStartSamplingDecision);
 
-      if (!(startupSamplingDecision.getProfileSampled() && startupSamplingDecision.getSampled())) {
-        logger.log(SentryLevel.DEBUG, "Startup profiling was not sampled. It will not start.");
+      if (!(appStartSamplingDecision.getProfileSampled()
+          && appStartSamplingDecision.getSampled())) {
+        logger.log(SentryLevel.DEBUG, "App start profiling was not sampled. It will not start.");
         return;
       }
-      logger.log(SentryLevel.DEBUG, "Startup profiling started.");
+      logger.log(SentryLevel.DEBUG, "App start profiling started.");
 
-      final @NotNull ITransactionProfiler startupProfiler =
+      final @NotNull ITransactionProfiler appStartProfiler =
           new AndroidTransactionProfiler(
               context.getApplicationContext(),
               buildInfoProvider,
@@ -166,13 +168,13 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
               profilingOptions.isProfilingEnabled(),
               profilingOptions.getProfilingTracesHz(),
               new SentryExecutorService());
-      appStartMetrics.setStartupProfiler(startupProfiler);
-      startupProfiler.start();
+      appStartMetrics.setAppStartProfiler(appStartProfiler);
+      appStartProfiler.start();
 
     } catch (FileNotFoundException e) {
-      logger.log(SentryLevel.ERROR, "Startup profiling config file not found. ", e);
+      logger.log(SentryLevel.ERROR, "App start profiling config file not found. ", e);
     } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error reading startup profiling config file. ", e);
+      logger.log(SentryLevel.ERROR, "Error reading app start profiling config file. ", e);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -1,7 +1,5 @@
 package io.sentry.android.core;
 
-import static io.sentry.Sentry.APP_START_PROFILING_CONFIG_FILE_NAME;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -1,5 +1,7 @@
 package io.sentry.android.core;
 
+import static io.sentry.Sentry.APP_START_PROFILING_CONFIG_FILE_NAME;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
@@ -113,7 +115,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     }
 
     final @NotNull File cacheDir = AndroidOptionsInitializer.getCacheDir(context);
-    final @NotNull File configFile = new File(cacheDir, App_START_PROFILING_CONFIG_FILE_NAME);
+    final @NotNull File configFile = new File(cacheDir, APP_START_PROFILING_CONFIG_FILE_NAME);
 
     // No config exists: app start profiling is not enabled
     if (!configFile.exists() || !configFile.canRead()) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -41,8 +41,8 @@ public class AppStartMetrics {
   private final @NotNull TimeSpan applicationOnCreate;
   private final @NotNull Map<ContentProvider, TimeSpan> contentProviderOnCreates;
   private final @NotNull List<ActivityLifecycleTimeSpan> activityLifecycles;
-  private @Nullable ITransactionProfiler startupProfiler = null;
-  private @Nullable TracesSamplingDecision startupSamplingDecision = null;
+  private @Nullable ITransactionProfiler appStartProfiler = null;
+  private @Nullable TracesSamplingDecision appStartSamplingDecision = null;
 
   public static @NotNull AppStartMetrics getInstance() {
 
@@ -147,28 +147,28 @@ public class AppStartMetrics {
     applicationOnCreate.reset();
     contentProviderOnCreates.clear();
     activityLifecycles.clear();
-    if (startupProfiler != null) {
-      startupProfiler.close();
+    if (appStartProfiler != null) {
+      appStartProfiler.close();
     }
-    startupProfiler = null;
-    startupSamplingDecision = null;
+    appStartProfiler = null;
+    appStartSamplingDecision = null;
   }
 
-  public @Nullable ITransactionProfiler getStartupProfiler() {
-    return startupProfiler;
+  public @Nullable ITransactionProfiler getAppStartProfiler() {
+    return appStartProfiler;
   }
 
-  public void setStartupProfiler(final @Nullable ITransactionProfiler startupProfiler) {
-    this.startupProfiler = startupProfiler;
+  public void setAppStartProfiler(final @Nullable ITransactionProfiler appStartProfiler) {
+    this.appStartProfiler = appStartProfiler;
   }
 
-  public void setStartupSamplingDecision(
-      final @Nullable TracesSamplingDecision startupSamplingDecision) {
-    this.startupSamplingDecision = startupSamplingDecision;
+  public void setAppStartSamplingDecision(
+      final @Nullable TracesSamplingDecision appStartSamplingDecision) {
+    this.appStartSamplingDecision = appStartSamplingDecision;
   }
 
-  public @Nullable TracesSamplingDecision getStartupSamplingDecision() {
-    return startupSamplingDecision;
+  public @Nullable TracesSamplingDecision getAppStartSamplingDecision() {
+    return appStartSamplingDecision;
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -683,8 +683,8 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true and startup sampling decision is set, start transaction with isStartup true`() {
-        AppStartMetrics.getInstance().startupSamplingDecision = mock()
+    fun `When firstActivityCreated is true and app start sampling decision is set, start transaction with isAppStart true`() {
+        AppStartMetrics.getInstance().appStartSamplingDecision = mock()
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
 
@@ -698,13 +698,13 @@ class ActivityLifecycleIntegrationTest {
             any(),
             check<TransactionOptions> {
                 assertEquals(date.nanoTimestamp(), it.startTimestamp!!.nanoTimestamp())
-                assertTrue(it.isStartupTransaction)
+                assertTrue(it.isAppStartTransaction)
             }
         )
     }
 
     @Test
-    fun `When firstActivityCreated is true and startup sampling decision is not set, start transaction with isStartup false`() {
+    fun `When firstActivityCreated is true and app start sampling decision is not set, start transaction with isAppStart false`() {
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
 
@@ -718,21 +718,21 @@ class ActivityLifecycleIntegrationTest {
             any(),
             check<TransactionOptions> {
                 assertEquals(date.nanoTimestamp(), it.startTimestamp!!.nanoTimestamp())
-                assertFalse(it.isStartupTransaction)
+                assertFalse(it.isAppStartTransaction)
             }
         )
     }
 
     @Test
-    fun `When firstActivityCreated is false and startup sampling decision is set, start transaction with isStartup false`() {
-        AppStartMetrics.getInstance().startupSamplingDecision = mock()
+    fun `When firstActivityCreated is false and app start sampling decision is set, start transaction with isAppStart false`() {
+        AppStartMetrics.getInstance().appStartSamplingDecision = mock()
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
 
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, fixture.bundle)
 
-        verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertFalse(it.isStartupTransaction) })
+        verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertFalse(it.isAppStartTransaction) })
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1347,7 +1347,7 @@ class ManifestMetadataReaderTest {
     @Test
     fun `applyMetadata reads startupProfiling flag to options`() {
         // Arrange
-        val bundle = bundleOf(ManifestMetadataReader.ENABLE_STARTUP_PROFILING to true)
+        val bundle = bundleOf(ManifestMetadataReader.ENABLE_APP_START_PROFILING to true)
         val context = fixture.getContext(metaData = bundle)
         fixture.options.profilesSampleRate = 1.0
 
@@ -1355,7 +1355,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertTrue(fixture.options.isEnableStartupProfiling)
+        assertTrue(fixture.options.isEnableAppStartProfiling)
     }
 
     @Test
@@ -1368,6 +1368,6 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertFalse(fixture.options.isEnableStartupProfiling)
+        assertFalse(fixture.options.isEnableAppStartProfiling)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -8,9 +8,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
 import io.sentry.JsonSerializer
 import io.sentry.Sentry
+import io.sentry.SentryAppStartProfilingOptions
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
-import io.sentry.SentryStartupProfilingOptions
 import io.sentry.android.core.performance.AppStartMetrics
 import io.sentry.android.core.performance.AppStartMetrics.AppStartType
 import org.junit.runner.RunWith
@@ -56,7 +56,7 @@ class SentryPerformanceProviderTest {
             whenever(buildInfoProvider.sdkInfoVersion).thenReturn(sdkVersion)
             whenever(mockContext.cacheDir).thenReturn(cache)
             whenever(mockContext.applicationContext).thenReturn(mockContext)
-            configFile = File(sentryCache, Sentry.STARTUP_PROFILING_CONFIG_FILE_NAME)
+            configFile = File(sentryCache, Sentry.App_START_PROFILING_CONFIG_FILE_NAME)
             handleFile?.invoke(configFile)
 
             providerInfo.authority = authority
@@ -169,11 +169,11 @@ class SentryPerformanceProviderTest {
         verify(fixture.mockContext).unregisterActivityLifecycleCallbacks(any())
     }
 
-    //region startup profiling
+    //region app start profiling
     @Test
     fun `when config file does not exists, nothing happens`() {
         fixture.getSut()
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
         verify(fixture.logger, never()).log(any(), any())
     }
 
@@ -183,7 +183,7 @@ class SentryPerformanceProviderTest {
             writeConfig(config)
             config.setReadable(false)
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
         verify(fixture.logger, never()).log(any(), any())
     }
 
@@ -192,7 +192,7 @@ class SentryPerformanceProviderTest {
         fixture.getSut(sdkVersion = Build.VERSION_CODES.KITKAT) { config ->
             writeConfig(config)
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
         verify(fixture.logger, never()).log(any(), any())
     }
 
@@ -201,10 +201,10 @@ class SentryPerformanceProviderTest {
         fixture.getSut { config ->
             config.createNewFile()
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
         verify(fixture.logger).log(
             eq(SentryLevel.WARNING),
-            eq("Unable to deserialize the SentryStartupProfilingOptions. Startup profiling will not start.")
+            eq("Unable to deserialize the SentryAppStartProfilingOptions. App start profiling will not start.")
         )
     }
 
@@ -213,10 +213,10 @@ class SentryPerformanceProviderTest {
         fixture.getSut { config ->
             writeConfig(config, profilingEnabled = false)
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
         verify(fixture.logger).log(
             eq(SentryLevel.INFO),
-            eq("Profiling is not enabled. Startup profiling will not start.")
+            eq("Profiling is not enabled. App start profiling will not start.")
         )
     }
 
@@ -225,14 +225,14 @@ class SentryPerformanceProviderTest {
         fixture.getSut { config ->
             writeConfig(config, traceSampled = false, profileSampled = true)
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
-        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
-        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
+        assertNotNull(AppStartMetrics.getInstance().appStartSamplingDecision)
+        assertFalse(AppStartMetrics.getInstance().appStartSamplingDecision!!.sampled)
         // If trace is not sampled, profile is not sample, either
-        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        assertFalse(AppStartMetrics.getInstance().appStartSamplingDecision!!.profileSampled)
         verify(fixture.logger).log(
             eq(SentryLevel.DEBUG),
-            eq("Startup profiling was not sampled. It will not start.")
+            eq("App start profiling was not sampled. It will not start.")
         )
     }
 
@@ -241,13 +241,13 @@ class SentryPerformanceProviderTest {
         fixture.getSut { config ->
             writeConfig(config, traceSampled = true, profileSampled = false)
         }
-        assertNull(AppStartMetrics.getInstance().startupProfiler)
-        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
-        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
-        assertFalse(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
+        assertNotNull(AppStartMetrics.getInstance().appStartSamplingDecision)
+        assertTrue(AppStartMetrics.getInstance().appStartSamplingDecision!!.sampled)
+        assertFalse(AppStartMetrics.getInstance().appStartSamplingDecision!!.profileSampled)
         verify(fixture.logger).log(
             eq(SentryLevel.DEBUG),
-            eq("Startup profiling was not sampled. It will not start.")
+            eq("App start profiling was not sampled. It will not start.")
         )
     }
 
@@ -256,14 +256,14 @@ class SentryPerformanceProviderTest {
         fixture.getSut { config ->
             writeConfig(config)
         }
-        assertNotNull(AppStartMetrics.getInstance().startupProfiler)
-        assertNotNull(AppStartMetrics.getInstance().startupSamplingDecision)
-        assertTrue(AppStartMetrics.getInstance().startupProfiler!!.isRunning)
-        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.sampled)
-        assertTrue(AppStartMetrics.getInstance().startupSamplingDecision!!.profileSampled)
+        assertNotNull(AppStartMetrics.getInstance().appStartProfiler)
+        assertNotNull(AppStartMetrics.getInstance().appStartSamplingDecision)
+        assertTrue(AppStartMetrics.getInstance().appStartProfiler!!.isRunning)
+        assertTrue(AppStartMetrics.getInstance().appStartSamplingDecision!!.sampled)
+        assertTrue(AppStartMetrics.getInstance().appStartSamplingDecision!!.profileSampled)
         verify(fixture.logger).log(
             eq(SentryLevel.DEBUG),
-            eq("Startup profiling started.")
+            eq("App start profiling started.")
         )
     }
 
@@ -273,8 +273,8 @@ class SentryPerformanceProviderTest {
             writeConfig(config)
         }
         provider.shutdown()
-        assertNotNull(AppStartMetrics.getInstance().startupProfiler)
-        assertFalse(AppStartMetrics.getInstance().startupProfiler!!.isRunning)
+        assertNotNull(AppStartMetrics.getInstance().appStartProfiler)
+        assertFalse(AppStartMetrics.getInstance().appStartProfiler!!.isRunning)
     }
 
     private fun writeConfig(
@@ -286,15 +286,15 @@ class SentryPerformanceProviderTest {
         profileSampleRate: Double = 1.0,
         profilingTracesDirPath: String = traceDir.absolutePath
     ) {
-        val startupProfilingOptions = SentryStartupProfilingOptions()
-        startupProfilingOptions.isProfilingEnabled = profilingEnabled
-        startupProfilingOptions.isTraceSampled = traceSampled
-        startupProfilingOptions.traceSampleRate = traceSampleRate
-        startupProfilingOptions.isProfileSampled = profileSampled
-        startupProfilingOptions.profileSampleRate = profileSampleRate
-        startupProfilingOptions.profilingTracesDirPath = profilingTracesDirPath
-        startupProfilingOptions.profilingTracesHz = 101
-        JsonSerializer(SentryOptions.empty()).serialize(startupProfilingOptions, FileWriter(configFile))
+        val appStartProfilingOptions = SentryAppStartProfilingOptions()
+        appStartProfilingOptions.isProfilingEnabled = profilingEnabled
+        appStartProfilingOptions.isTraceSampled = traceSampled
+        appStartProfilingOptions.traceSampleRate = traceSampleRate
+        appStartProfilingOptions.isProfileSampled = profileSampled
+        appStartProfilingOptions.profileSampleRate = profileSampleRate
+        appStartProfilingOptions.profilingTracesDirPath = profilingTracesDirPath
+        appStartProfilingOptions.profilingTracesHz = 101
+        JsonSerializer(SentryOptions.empty()).serialize(appStartProfilingOptions, FileWriter(configFile))
     }
     //endregion
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -56,7 +56,7 @@ class SentryPerformanceProviderTest {
             whenever(buildInfoProvider.sdkInfoVersion).thenReturn(sdkVersion)
             whenever(mockContext.cacheDir).thenReturn(cache)
             whenever(mockContext.applicationContext).thenReturn(mockContext)
-            configFile = File(sentryCache, Sentry.App_START_PROFILING_CONFIG_FILE_NAME)
+            configFile = File(sentryCache, Sentry.APP_START_PROFILING_CONFIG_FILE_NAME)
             handleFile?.invoke(configFile)
 
             providerInfo.authority = authority

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -44,8 +44,8 @@ class AppStartMetricsTest {
         metrics.addActivityLifecycleTimeSpans(ActivityLifecycleTimeSpan())
         AppStartMetrics.onApplicationCreate(mock<Application>())
         AppStartMetrics.onContentProviderCreate(mock<ContentProvider>())
-        metrics.setStartupProfiler(mock())
-        metrics.startupSamplingDecision = mock()
+        metrics.setAppStartProfiler(mock())
+        metrics.appStartSamplingDecision = mock()
 
         metrics.clear()
 
@@ -56,8 +56,8 @@ class AppStartMetricsTest {
 
         assertTrue(metrics.activityLifecycleTimeSpans.isEmpty())
         assertTrue(metrics.contentProviderOnCreateTimeSpans.isEmpty())
-        assertNull(metrics.startupProfiler)
-        assertNull(metrics.startupSamplingDecision)
+        assertNull(metrics.appStartProfiler)
+        assertNull(metrics.appStartSamplingDecision)
     }
 
     @Test

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -109,7 +109,8 @@
         <!--    how to enable profiling when starting transactions -->
         <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
 
-        <meta-data android:name="io.sentry.traces.profiling.enable-startup" android:value="true" />
+      <!--    how to enable app start profiling -->
+        <meta-data android:name="io.sentry.traces.profiling.enable-app-start" android:value="true" />
 
         <!--    how to disable the Activity auto instrumentation for tracing-->
         <!--    <meta-data android:name="io.sentry.traces.activity.enable" android:value="false" />-->

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1637,7 +1637,7 @@ public final class io/sentry/SendFireAndForgetOutboxSender : io/sentry/SendCache
 }
 
 public final class io/sentry/Sentry {
-	public static final field App_START_PROFILING_CONFIG_FILE_NAME Ljava/lang/String;
+	public static final field APP_START_PROFILING_CONFIG_FILE_NAME Ljava/lang/String;
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/Hint;)V
 	public static fun addBreadcrumb (Ljava/lang/String;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1637,7 +1637,7 @@ public final class io/sentry/SendFireAndForgetOutboxSender : io/sentry/SendCache
 }
 
 public final class io/sentry/Sentry {
-	public static final field STARTUP_PROFILING_CONFIG_FILE_NAME Ljava/lang/String;
+	public static final field App_START_PROFILING_CONFIG_FILE_NAME Ljava/lang/String;
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;)V
 	public static fun addBreadcrumb (Lio/sentry/Breadcrumb;Lio/sentry/Hint;)V
 	public static fun addBreadcrumb (Ljava/lang/String;)V
@@ -1704,6 +1704,44 @@ public final class io/sentry/Sentry {
 
 public abstract interface class io/sentry/Sentry$OptionsConfiguration {
 	public abstract fun configure (Lio/sentry/SentryOptions;)V
+}
+
+public final class io/sentry/SentryAppStartProfilingOptions : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> ()V
+	public fun getProfileSampleRate ()Ljava/lang/Double;
+	public fun getProfilingTracesDirPath ()Ljava/lang/String;
+	public fun getProfilingTracesHz ()I
+	public fun getTraceSampleRate ()Ljava/lang/Double;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun isProfileSampled ()Z
+	public fun isProfilingEnabled ()Z
+	public fun isTraceSampled ()Z
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setProfileSampleRate (Ljava/lang/Double;)V
+	public fun setProfileSampled (Z)V
+	public fun setProfilingEnabled (Z)V
+	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
+	public fun setProfilingTracesHz (I)V
+	public fun setTraceSampleRate (Ljava/lang/Double;)V
+	public fun setTraceSampled (Z)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/SentryAppStartProfilingOptions$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryAppStartProfilingOptions;
+	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
+	public static final field IS_PROFILING_ENABLED Ljava/lang/String;
+	public static final field PROFILE_SAMPLED Ljava/lang/String;
+	public static final field PROFILE_SAMPLE_RATE Ljava/lang/String;
+	public static final field PROFILING_TRACES_DIR_PATH Ljava/lang/String;
+	public static final field PROFILING_TRACES_HZ Ljava/lang/String;
+	public static final field TRACE_SAMPLED Ljava/lang/String;
+	public static final field TRACE_SAMPLE_RATE Ljava/lang/String;
+	public fun <init> ()V
 }
 
 public final class io/sentry/SentryAutoDateProvider : io/sentry/SentryDateProvider {
@@ -2174,13 +2212,13 @@ public class io/sentry/SentryOptions {
 	public fun isAttachStacktrace ()Z
 	public fun isAttachThreads ()Z
 	public fun isDebug ()Z
+	public fun isEnableAppStartProfiling ()Z
 	public fun isEnableAutoSessionTracking ()Z
 	public fun isEnableBackpressureHandling ()Z
 	public fun isEnableDeduplication ()Z
 	public fun isEnableExternalConfiguration ()Z
 	public fun isEnablePrettySerializationOutput ()Z
 	public fun isEnableShutdownHook ()Z
-	public fun isEnableStartupProfiling ()Z
 	public fun isEnableTimeToFullDisplayTracing ()Z
 	public fun isEnableUncaughtExceptionHandler ()Z
 	public fun isEnableUserInteractionBreadcrumbs ()Z
@@ -2212,13 +2250,13 @@ public class io/sentry/SentryOptions {
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDistinctId (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
+	public fun setEnableAppStartProfiling (Z)V
 	public fun setEnableAutoSessionTracking (Z)V
 	public fun setEnableBackpressureHandling (Z)V
 	public fun setEnableDeduplication (Z)V
 	public fun setEnableExternalConfiguration (Z)V
 	public fun setEnablePrettySerializationOutput (Z)V
 	public fun setEnableShutdownHook (Z)V
-	public fun setEnableStartupProfiling (Z)V
 	public fun setEnableTimeToFullDisplayTracing (Z)V
 	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Z)V
@@ -2337,44 +2375,6 @@ public final class io/sentry/SentryStackTraceFactory {
 	public fun getInAppCallStack ()Ljava/util/List;
 	public fun getStackFrames ([Ljava/lang/StackTraceElement;Z)Ljava/util/List;
 	public fun isInApp (Ljava/lang/String;)Ljava/lang/Boolean;
-}
-
-public final class io/sentry/SentryStartupProfilingOptions : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
-	public fun <init> ()V
-	public fun getProfileSampleRate ()Ljava/lang/Double;
-	public fun getProfilingTracesDirPath ()Ljava/lang/String;
-	public fun getProfilingTracesHz ()I
-	public fun getTraceSampleRate ()Ljava/lang/Double;
-	public fun getUnknown ()Ljava/util/Map;
-	public fun isProfileSampled ()Z
-	public fun isProfilingEnabled ()Z
-	public fun isTraceSampled ()Z
-	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
-	public fun setProfileSampleRate (Ljava/lang/Double;)V
-	public fun setProfileSampled (Z)V
-	public fun setProfilingEnabled (Z)V
-	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
-	public fun setProfilingTracesHz (I)V
-	public fun setTraceSampleRate (Ljava/lang/Double;)V
-	public fun setTraceSampled (Z)V
-	public fun setUnknown (Ljava/util/Map;)V
-}
-
-public final class io/sentry/SentryStartupProfilingOptions$Deserializer : io/sentry/JsonDeserializer {
-	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryStartupProfilingOptions;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
-}
-
-public final class io/sentry/SentryStartupProfilingOptions$JsonKeys {
-	public static final field IS_PROFILING_ENABLED Ljava/lang/String;
-	public static final field PROFILE_SAMPLED Ljava/lang/String;
-	public static final field PROFILE_SAMPLE_RATE Ljava/lang/String;
-	public static final field PROFILING_TRACES_DIR_PATH Ljava/lang/String;
-	public static final field PROFILING_TRACES_HZ Ljava/lang/String;
-	public static final field TRACE_SAMPLED Ljava/lang/String;
-	public static final field TRACE_SAMPLE_RATE Ljava/lang/String;
-	public fun <init> ()V
 }
 
 public final class io/sentry/SentryThreadFactory {
@@ -2764,8 +2764,8 @@ public final class io/sentry/TransactionContext : io/sentry/SpanContext {
 	public fun getParentSampled ()Ljava/lang/Boolean;
 	public fun getParentSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun getTransactionNameSource ()Lio/sentry/protocol/TransactionNameSource;
-	public fun isForNextStartup ()Z
-	public fun setForNextStartup (Z)V
+	public fun isForNextAppStart ()Z
+	public fun setForNextAppStart (Z)V
 	public fun setInstrumenter (Lio/sentry/Instrumenter;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setParentSampled (Ljava/lang/Boolean;)V
@@ -2785,15 +2785,15 @@ public final class io/sentry/TransactionOptions : io/sentry/SpanOptions {
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getStartTimestamp ()Lio/sentry/SentryDate;
 	public fun getTransactionFinishedCallback ()Lio/sentry/TransactionFinishedCallback;
+	public fun isAppStartTransaction ()Z
 	public fun isBindToScope ()Z
-	public fun isStartupTransaction ()Z
 	public fun isWaitForChildren ()Z
+	public fun setAppStartTransaction (Z)V
 	public fun setBindToScope (Z)V
 	public fun setCustomSamplingContext (Lio/sentry/CustomSamplingContext;)V
 	public fun setDeadlineTimeout (Ljava/lang/Long;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setStartTimestamp (Lio/sentry/SentryDate;)V
-	public fun setStartupTransaction (Z)V
 	public fun setTransactionFinishedCallback (Lio/sentry/TransactionFinishedCallback;)V
 	public fun setWaitForChildren (Z)V
 }

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -749,8 +749,8 @@ public final class Hub implements IHub {
         if (!transactionProfiler.isRunning()) {
           transactionProfiler.start();
           transactionProfiler.bindTransaction(transaction);
-        } else if (transactionOptions.isStartupTransaction()) {
-          // If the profiler is running and the current transaction is the app startup, we bind it.
+        } else if (transactionOptions.isAppStartTransaction()) {
+          // If the profiler is running and the current transaction is the app start, we bind it.
           transactionProfiler.bindTransaction(transaction);
         }
       }

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -105,7 +105,7 @@ public final class JsonSerializer implements ISerializer {
     deserializersByClass.put(SentryStackFrame.class, new SentryStackFrame.Deserializer());
     deserializersByClass.put(SentryStackTrace.class, new SentryStackTrace.Deserializer());
     deserializersByClass.put(
-        SentryStartupProfilingOptions.class, new SentryStartupProfilingOptions.Deserializer());
+        SentryAppStartProfilingOptions.class, new SentryAppStartProfilingOptions.Deserializer());
     deserializersByClass.put(SentryThread.class, new SentryThread.Deserializer());
     deserializersByClass.put(SentryTransaction.class, new SentryTransaction.Deserializer());
     deserializersByClass.put(Session.class, new Session.Deserializer());

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -54,8 +54,8 @@ public final class Sentry {
   private static volatile boolean globalHubMode = GLOBAL_HUB_DEFAULT_MODE;
 
   @ApiStatus.Internal
-  public static final @NotNull String STARTUP_PROFILING_CONFIG_FILE_NAME =
-      "startup_profiling_config";
+  public static final @NotNull String App_START_PROFILING_CONFIG_FILE_NAME =
+      "app_start_profiling_config";
 
   @SuppressWarnings("CharsetObjectCanBeUsed")
   private static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -257,11 +257,11 @@ public final class Sentry {
 
     finalizePreviousSession(options, HubAdapter.getInstance());
 
-    handleStartupProfilingConfig(options, options.getExecutorService());
+    handleAppStartProfilingConfig(options, options.getExecutorService());
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")
-  private static void handleStartupProfilingConfig(
+  private static void handleAppStartProfilingConfig(
       final @NotNull SentryOptions options,
       final @NotNull ISentryExecutorService sentryExecutorService) {
     try {
@@ -269,12 +269,12 @@ public final class Sentry {
           () -> {
             final String cacheDirPath = options.getCacheDirPathWithoutDsn();
             if (cacheDirPath != null) {
-              final @NotNull File startupProfilingConfigFile =
-                  new File(cacheDirPath, STARTUP_PROFILING_CONFIG_FILE_NAME);
+              final @NotNull File appStartProfilingConfigFile =
+                  new File(cacheDirPath, App_START_PROFILING_CONFIG_FILE_NAME);
               try {
-                // We always delete the config file for startup profiling
-                FileUtils.deleteRecursively(startupProfilingConfigFile);
-                if (!options.isEnableStartupProfiling()) {
+                // We always delete the config file for app start profiling
+                FileUtils.deleteRecursively(appStartProfilingConfigFile);
+                if (!options.isEnableAppStartProfiling()) {
                   return;
                 }
                 if (!options.isTracingEnabled()) {
@@ -282,25 +282,26 @@ public final class Sentry {
                       .getLogger()
                       .log(
                           SentryLevel.INFO,
-                          "Tracing is disabled and startup profiling will not start.");
+                          "Tracing is disabled and app start profiling will not start.");
                   return;
                 }
-                if (startupProfilingConfigFile.createNewFile()) {
-                  final @NotNull TracesSamplingDecision startupSamplingDecision =
-                      sampleStartupProfiling(options);
-                  final @NotNull SentryStartupProfilingOptions startupProfilingOptions =
-                      new SentryStartupProfilingOptions(options, startupSamplingDecision);
+                if (appStartProfilingConfigFile.createNewFile()) {
+                  final @NotNull TracesSamplingDecision appStartSamplingDecision =
+                      sampleAppStartProfiling(options);
+                  final @NotNull SentryAppStartProfilingOptions appStartProfilingOptions =
+                      new SentryAppStartProfilingOptions(options, appStartSamplingDecision);
                   try (final OutputStream outputStream =
-                          new FileOutputStream(startupProfilingConfigFile);
+                          new FileOutputStream(appStartProfilingConfigFile);
                       final Writer writer =
                           new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
-                    options.getSerializer().serialize(startupProfilingOptions, writer);
+                    options.getSerializer().serialize(appStartProfilingOptions, writer);
                   }
                 }
               } catch (Throwable e) {
                 options
                     .getLogger()
-                    .log(SentryLevel.ERROR, "Unable to create startup profiling config file. ", e);
+                    .log(
+                        SentryLevel.ERROR, "Unable to create app start profiling config file. ", e);
               }
             }
           });
@@ -309,17 +310,17 @@ public final class Sentry {
           .getLogger()
           .log(
               SentryLevel.ERROR,
-              "Failed to call the executor. Startup profiling config will not be changed. Did you call Sentry.close()?",
+              "Failed to call the executor. App start profiling config will not be changed. Did you call Sentry.close()?",
               e);
     }
   }
 
-  private static @NotNull TracesSamplingDecision sampleStartupProfiling(
+  private static @NotNull TracesSamplingDecision sampleAppStartProfiling(
       final @NotNull SentryOptions options) {
-    TransactionContext startupTransactionContext = new TransactionContext("app.launch", "profile");
-    startupTransactionContext.setForNextStartup(true);
-    SamplingContext startupSamplingContext = new SamplingContext(startupTransactionContext, null);
-    return new TracesSampler(options).sample(startupSamplingContext);
+    TransactionContext appStartTransactionContext = new TransactionContext("app.launch", "profile");
+    appStartTransactionContext.setForNextAppStart(true);
+    SamplingContext appStartSamplingContext = new SamplingContext(appStartTransactionContext, null);
+    return new TracesSampler(options).sample(appStartSamplingContext);
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -54,7 +54,7 @@ public final class Sentry {
   private static volatile boolean globalHubMode = GLOBAL_HUB_DEFAULT_MODE;
 
   @ApiStatus.Internal
-  public static final @NotNull String App_START_PROFILING_CONFIG_FILE_NAME =
+  public static final @NotNull String APP_START_PROFILING_CONFIG_FILE_NAME =
       "app_start_profiling_config";
 
   @SuppressWarnings("CharsetObjectCanBeUsed")
@@ -270,7 +270,7 @@ public final class Sentry {
             final String cacheDirPath = options.getCacheDirPathWithoutDsn();
             if (cacheDirPath != null) {
               final @NotNull File appStartProfilingConfigFile =
-                  new File(cacheDirPath, App_START_PROFILING_CONFIG_FILE_NAME);
+                  new File(cacheDirPath, APP_START_PROFILING_CONFIG_FILE_NAME);
               try {
                 // We always delete the config file for app start profiling
                 FileUtils.deleteRecursively(appStartProfilingConfigFile);

--- a/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 @ApiStatus.Internal
-public final class SentryStartupProfilingOptions implements JsonUnknown, JsonSerializable {
+public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSerializable {
 
   boolean profileSampled;
   @Nullable Double profileSampleRate;
@@ -23,7 +23,7 @@ public final class SentryStartupProfilingOptions implements JsonUnknown, JsonSer
   private @Nullable Map<String, Object> unknown;
 
   @VisibleForTesting
-  public SentryStartupProfilingOptions() {
+  public SentryAppStartProfilingOptions() {
     traceSampled = false;
     traceSampleRate = null;
     profileSampled = false;
@@ -33,7 +33,7 @@ public final class SentryStartupProfilingOptions implements JsonUnknown, JsonSer
     profilingTracesHz = 0;
   }
 
-  SentryStartupProfilingOptions(
+  SentryAppStartProfilingOptions(
       final @NotNull SentryOptions options,
       final @NotNull TracesSamplingDecision samplingDecision) {
     traceSampled = samplingDecision.getSampled();
@@ -147,13 +147,13 @@ public final class SentryStartupProfilingOptions implements JsonUnknown, JsonSer
   }
 
   public static final class Deserializer
-      implements JsonDeserializer<SentryStartupProfilingOptions> {
+      implements JsonDeserializer<SentryAppStartProfilingOptions> {
 
     @Override
-    public @NotNull SentryStartupProfilingOptions deserialize(
+    public @NotNull SentryAppStartProfilingOptions deserialize(
         @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
-      SentryStartupProfilingOptions options = new SentryStartupProfilingOptions();
+      SentryAppStartProfilingOptions options = new SentryAppStartProfilingOptions();
       Map<String, Object> unknown = null;
 
       while (reader.peek() == JsonToken.NAME) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -454,8 +454,8 @@ public class SentryOptions {
 
   @ApiStatus.Experimental private boolean enableBackpressureHandling = false;
 
-  /** Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate. */
-  private boolean enableStartupProfiling = false;
+  /** Whether to profile app launches, depending on profilesSampler or profilesSampleRate. */
+  private boolean enableAppStartProfiling = false;
 
   /**
    * Profiling traces rate. 101 hz means 101 traces in 1 second. Defaults to 101 to avoid possible
@@ -2154,22 +2154,22 @@ public class SentryOptions {
   }
 
   /**
-   * Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate.
-   * Depends on {@link SentryOptions#isProfilingEnabled()}
+   * Whether to profile app launches, depending on profilesSampler or profilesSampleRate. Depends on
+   * {@link SentryOptions#isProfilingEnabled()}
    *
-   * @return true if startup profiling should be started.
+   * @return true if app launches should be profiled.
    */
-  public boolean isEnableStartupProfiling() {
-    return isProfilingEnabled() && enableStartupProfiling;
+  public boolean isEnableAppStartProfiling() {
+    return isProfilingEnabled() && enableAppStartProfiling;
   }
 
   /**
-   * Whether to enable startup profiling, depending on profilesSampler or profilesSampleRate.
+   * Whether to profile app launches, depending on profilesSampler or profilesSampleRate.
    *
-   * @param enableStartupProfiling true if startup profiling should be started.
+   * @param enableAppStartProfiling true if app launches should be profiled.
    */
-  public void setEnableStartupProfiling(boolean enableStartupProfiling) {
-    this.enableStartupProfiling = enableStartupProfiling;
+  public void setEnableAppStartProfiling(boolean enableAppStartProfiling) {
+    this.enableAppStartProfiling = enableAppStartProfiling;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -18,7 +18,7 @@ public final class TransactionContext extends SpanContext {
   private @Nullable TracesSamplingDecision parentSamplingDecision;
   private @Nullable Baggage baggage;
   private @NotNull Instrumenter instrumenter = Instrumenter.SENTRY;
-  private boolean isForNextStartup = false;
+  private boolean isForNextAppStart = false;
 
   /**
    * Creates {@link TransactionContext} from sentry-trace header.
@@ -203,18 +203,18 @@ public final class TransactionContext extends SpanContext {
   }
 
   @ApiStatus.Internal
-  public void setForNextStartup(final boolean forNextStartup) {
-    isForNextStartup = forNextStartup;
+  public void setForNextAppStart(final boolean forNextAppStart) {
+    isForNextAppStart = forNextAppStart;
   }
 
   /**
-   * Whether this {@link TransactionContext} evaluates for the next startup. If this is true, it
+   * Whether this {@link TransactionContext} evaluates for the next app start. If this is true, it
    * gets called only once when the SDK initializes. This is set only if {@link
-   * SentryOptions#isEnableStartupProfiling()} is true.
+   * SentryOptions#isEnableAppStartProfiling()} is true.
    *
-   * @return True if this {@link TransactionContext} will be used for the next startup.
+   * @return True if this {@link TransactionContext} will be used for the next app start.
    */
-  public boolean isForNextStartup() {
-    return isForNextStartup;
+  public boolean isForNextAppStart() {
+    return isForNextAppStart;
   }
 }

--- a/sentry/src/main/java/io/sentry/TransactionOptions.java
+++ b/sentry/src/main/java/io/sentry/TransactionOptions.java
@@ -20,8 +20,8 @@ public final class TransactionOptions extends SpanOptions {
   /** The start timestamp of the transaction */
   private @Nullable SentryDate startTimestamp = null;
 
-  /** Defines if transaction refers to the startup process */
-  private boolean isStartupTransaction = false;
+  /** Defines if transaction refers to the app start process */
+  private boolean isAppStartTransaction = false;
 
   /**
    * When `waitForChildren` is set to `true`, tracer will finish only when both conditions are met
@@ -188,12 +188,12 @@ public final class TransactionOptions extends SpanOptions {
   }
 
   @ApiStatus.Internal
-  public void setStartupTransaction(final boolean startupTransaction) {
-    isStartupTransaction = startupTransaction;
+  public void setAppStartTransaction(final boolean appStartTransaction) {
+    isAppStartTransaction = appStartTransaction;
   }
 
   @ApiStatus.Internal
-  public boolean isStartupTransaction() {
-    return isStartupTransaction;
+  public boolean isAppStartTransaction() {
+    return isAppStartTransaction;
   }
 }

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -1505,7 +1505,7 @@ class HubTest {
     }
 
     @Test
-    fun `when profiler is running and isStartupTransaction is false, startTransaction does not interact with profiler`() {
+    fun `when profiler is running and isAppStartTransaction is false, startTransaction does not interact with profiler`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
         whenever(mockTransactionProfiler.isRunning).thenReturn(true)
         val hub = generateHub {
@@ -1513,13 +1513,13 @@ class HubTest {
             it.setTransactionProfiler(mockTransactionProfiler)
         }
         val context = TransactionContext("name", "op")
-        hub.startTransaction(context, TransactionOptions().apply { isStartupTransaction = false })
+        hub.startTransaction(context, TransactionOptions().apply { isAppStartTransaction = false })
         verify(mockTransactionProfiler, never()).start()
         verify(mockTransactionProfiler, never()).bindTransaction(any())
     }
 
     @Test
-    fun `when profiler is running and isStartupTransaction is true, startTransaction binds current profile`() {
+    fun `when profiler is running and isAppStartTransaction is true, startTransaction binds current profile`() {
         val mockTransactionProfiler = mock<ITransactionProfiler>()
         whenever(mockTransactionProfiler.isRunning).thenReturn(true)
         val hub = generateHub {
@@ -1527,7 +1527,7 @@ class HubTest {
             it.setTransactionProfiler(mockTransactionProfiler)
         }
         val context = TransactionContext("name", "op")
-        val transaction = hub.startTransaction(context, TransactionOptions().apply { isStartupTransaction = true })
+        val transaction = hub.startTransaction(context, TransactionOptions().apply { isAppStartTransaction = true })
         verify(mockTransactionProfiler, never()).start()
         verify(mockTransactionProfiler).bindTransaction(eq(transaction))
     }
@@ -1541,7 +1541,7 @@ class HubTest {
             it.setTransactionProfiler(mockTransactionProfiler)
         }
         val context = TransactionContext("name", "op")
-        val transaction = hub.startTransaction(context, TransactionOptions().apply { isStartupTransaction = false })
+        val transaction = hub.startTransaction(context, TransactionOptions().apply { isAppStartTransaction = false })
         verify(mockTransactionProfiler).start()
         verify(mockTransactionProfiler).bindTransaction(eq(transaction))
     }

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -981,8 +981,8 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `serializing SentryStartupProfilingOptions`() {
-        val actual = serializeToString(startupProfilingOptions)
+    fun `serializing SentryAppStartProfilingOptions`() {
+        val actual = serializeToString(appStartProfilingOptions)
 
         val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\":false," +
             "\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false,\"profiling_traces_hz\":65}"
@@ -991,19 +991,19 @@ class JsonSerializerTest {
     }
 
     @Test
-    fun `deserializing SentryStartupProfilingOptions`() {
-        val jsonStartupProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
+    fun `deserializing SentryAppStartProfilingOptions`() {
+        val jsonAppStartProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
             ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false,\"profiling_traces_hz\":65}"
 
-        val actual = fixture.serializer.deserialize(StringReader(jsonStartupProfilingOptions), SentryStartupProfilingOptions::class.java)
+        val actual = fixture.serializer.deserialize(StringReader(jsonAppStartProfilingOptions), SentryAppStartProfilingOptions::class.java)
         assertNotNull(actual)
-        assertEquals(startupProfilingOptions.traceSampled, actual.traceSampled)
-        assertEquals(startupProfilingOptions.traceSampleRate, actual.traceSampleRate)
-        assertEquals(startupProfilingOptions.profileSampled, actual.profileSampled)
-        assertEquals(startupProfilingOptions.profileSampleRate, actual.profileSampleRate)
-        assertEquals(startupProfilingOptions.isProfilingEnabled, actual.isProfilingEnabled)
-        assertEquals(startupProfilingOptions.profilingTracesHz, actual.profilingTracesHz)
-        assertEquals(startupProfilingOptions.profilingTracesDirPath, actual.profilingTracesDirPath)
+        assertEquals(appStartProfilingOptions.traceSampled, actual.traceSampled)
+        assertEquals(appStartProfilingOptions.traceSampleRate, actual.traceSampleRate)
+        assertEquals(appStartProfilingOptions.profileSampled, actual.profileSampled)
+        assertEquals(appStartProfilingOptions.profileSampleRate, actual.profileSampleRate)
+        assertEquals(appStartProfilingOptions.isProfilingEnabled, actual.isProfilingEnabled)
+        assertEquals(appStartProfilingOptions.profilingTracesHz, actual.profilingTracesHz)
+        assertEquals(appStartProfilingOptions.profilingTracesDirPath, actual.profilingTracesDirPath)
         assertNull(actual.unknown)
     }
 
@@ -1283,7 +1283,7 @@ class JsonSerializerTest {
         }
     }
 
-    private val startupProfilingOptions = SentryStartupProfilingOptions().apply {
+    private val appStartProfilingOptions = SentryAppStartProfilingOptions().apply {
         traceSampled = false
         traceSampleRate = 0.1
         profileSampled = true

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -555,24 +555,24 @@ class SentryOptionsTest {
     }
 
     @Test
-    fun `when options are initialized, enableStartupProfiling is set to false by default`() {
-        assertFalse(SentryOptions().isEnableStartupProfiling)
+    fun `when options are initialized, enableAppStartProfiling is set to false by default`() {
+        assertFalse(SentryOptions().isEnableAppStartProfiling)
     }
 
     @Test
-    fun `when setEnableStartupProfiling is called, overrides default`() {
+    fun `when setEnableAppStartProfiling is called, overrides default`() {
         val options = SentryOptions()
-        options.isEnableStartupProfiling = true
+        options.isEnableAppStartProfiling = true
         options.profilesSampleRate = 1.0
-        assertTrue(options.isEnableStartupProfiling)
+        assertTrue(options.isEnableAppStartProfiling)
     }
 
     @Test
-    fun `when profiling is disabled, isEnableStartupProfiling is always false`() {
+    fun `when profiling is disabled, isEnableAppStartProfiling is always false`() {
         val options = SentryOptions()
-        options.isEnableStartupProfiling = true
+        options.isEnableAppStartProfiling = true
         options.profilesSampleRate = 0.0
-        assertFalse(options.isEnableStartupProfiling)
+        assertFalse(options.isEnableAppStartProfiling)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -968,83 +968,83 @@ class SentryTest {
     }
 
     @Test
-    fun `init calls samplers if isEnableStartupProfiling is true`() {
+    fun `init calls samplers if isEnableAppStartProfiling is true`() {
         val mockSampleTracer = mock<TracesSamplerCallback>()
         val mockProfilesSampler = mock<ProfilesSamplerCallback>()
         Sentry.init {
             it.dsn = dsn
             it.enableTracing = true
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 1.0
             it.tracesSampler = mockSampleTracer
             it.profilesSampler = mockProfilesSampler
             it.executorService = ImmediateExecutorService()
             it.cacheDirPath = getTempPath()
         }
-        // Samplers are called with isForNextStartup flag set to true
+        // Samplers are called with isForNextAppStart flag set to true
         verify(mockSampleTracer).sample(
             check {
                 assertEquals("app.launch", it.transactionContext.name)
                 assertEquals("profile", it.transactionContext.operation)
-                assertTrue(it.transactionContext.isForNextStartup)
+                assertTrue(it.transactionContext.isForNextAppStart)
             }
         )
         verify(mockProfilesSampler).sample(
             check {
                 assertEquals("app.launch", it.transactionContext.name)
                 assertEquals("profile", it.transactionContext.operation)
-                assertTrue(it.transactionContext.isForNextStartup)
+                assertTrue(it.transactionContext.isForNextAppStart)
             }
         )
     }
 
     @Test
-    fun `init calls startup profiling samplers in the background`() {
+    fun `init calls app start profiling samplers in the background`() {
         val mockSampleTracer = mock<TracesSamplerCallback>()
         val mockProfilesSampler = mock<ProfilesSamplerCallback>()
         Sentry.init {
             it.dsn = dsn
             it.enableTracing = true
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 1.0
             it.tracesSampler = mockSampleTracer
             it.profilesSampler = mockProfilesSampler
             it.executorService = NoOpSentryExecutorService.getInstance()
             it.cacheDirPath = getTempPath()
         }
-        // Samplers are called with isForNextStartup flag set to true
+        // Samplers are called with isForNextAppStart flag set to true
         verify(mockSampleTracer, never()).sample(any())
         verify(mockProfilesSampler, never()).sample(any())
     }
 
     @Test
-    fun `init does not call startup profiling samplers if cache dir is null`() {
+    fun `init does not call app start profiling samplers if cache dir is null`() {
         val mockSampleTracer = mock<TracesSamplerCallback>()
         val mockProfilesSampler = mock<ProfilesSamplerCallback>()
         Sentry.init {
             it.dsn = dsn
             it.enableTracing = true
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 1.0
             it.tracesSampler = mockSampleTracer
             it.profilesSampler = mockProfilesSampler
             it.executorService = NoOpSentryExecutorService.getInstance()
             it.cacheDirPath = null
         }
-        // Samplers are called with isForNextStartup flag set to true
+        // Samplers are called with isForNextAppStart flag set to true
         verify(mockSampleTracer, never()).sample(any())
         verify(mockProfilesSampler, never()).sample(any())
     }
 
     @Test
-    fun `init does not call startup profiling samplers if enableTracing is false`() {
+    fun `init does not call app start profiling samplers if enableTracing is false`() {
         val logger = mock<ILogger>()
         val mockTraceSampler = mock<TracesSamplerCallback>()
         val mockProfilesSampler = mock<ProfilesSamplerCallback>()
         Sentry.init {
             it.dsn = dsn
             it.enableTracing = false
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 1.0
             it.tracesSampler = mockTraceSampler
             it.profilesSampler = mockProfilesSampler
@@ -1053,46 +1053,46 @@ class SentryTest {
             it.isDebug = true
             it.setLogger(logger)
         }
-        verify(logger).log(eq(SentryLevel.INFO), eq("Tracing is disabled and startup profiling will not start."))
+        verify(logger).log(eq(SentryLevel.INFO), eq("Tracing is disabled and app start profiling will not start."))
         verify(mockTraceSampler, never()).sample(any())
         verify(mockProfilesSampler, never()).sample(any())
     }
 
     @Test
-    fun `init deletes startup profiling config`() {
+    fun `init deletes app start profiling config`() {
         val path = getTempPath()
         File(path).mkdirs()
-        val startupProfilingConfigFile = File(path, "startup_profiling_config")
-        startupProfilingConfigFile.createNewFile()
-        assertTrue(startupProfilingConfigFile.exists())
+        val appStartProfilingConfigFile = File(path, "app_start_profiling_config")
+        appStartProfilingConfigFile.createNewFile()
+        assertTrue(appStartProfilingConfigFile.exists())
         Sentry.init {
             it.dsn = dsn
             it.executorService = ImmediateExecutorService()
             it.cacheDirPath = path
         }
-        assertFalse(startupProfilingConfigFile.exists())
+        assertFalse(appStartProfilingConfigFile.exists())
     }
 
     @Test
-    fun `init creates startup profiling config if isEnableStartupProfiling and enableTracing is true`() {
+    fun `init creates app start profiling config if isEnableAppStartProfiling and enableTracing is true`() {
         val path = getTempPath()
         File(path).mkdirs()
-        val startupProfilingConfigFile = File(path, "startup_profiling_config")
-        startupProfilingConfigFile.createNewFile()
-        assertTrue(startupProfilingConfigFile.exists())
+        val appStartProfilingConfigFile = File(path, "app_start_profiling_config")
+        appStartProfilingConfigFile.createNewFile()
+        assertTrue(appStartProfilingConfigFile.exists())
         Sentry.init {
             it.dsn = dsn
             it.cacheDirPath = path
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 1.0
             it.enableTracing = true
             it.executorService = ImmediateExecutorService()
         }
-        assertTrue(startupProfilingConfigFile.exists())
+        assertTrue(appStartProfilingConfigFile.exists())
     }
 
     @Test
-    fun `init saves SentryStartupProfilingOptions to disk`() {
+    fun `init saves SentryAppStartProfilingOptions to disk`() {
         var options = SentryOptions()
         val path = getTempPath()
         Sentry.init {
@@ -1100,19 +1100,19 @@ class SentryTest {
             it.cacheDirPath = path
             it.enableTracing = true
             it.tracesSampleRate = 0.5
-            it.isEnableStartupProfiling = true
+            it.isEnableAppStartProfiling = true
             it.profilesSampleRate = 0.2
             it.executorService = ImmediateExecutorService()
             options = it
         }
-        val startupProfilingConfigFile = File(path, "startup_profiling_config")
-        assertTrue(startupProfilingConfigFile.exists())
-        val startupOption =
-            JsonSerializer(options).deserialize(FileReader(startupProfilingConfigFile), SentryStartupProfilingOptions::class.java)
-        assertNotNull(startupOption)
-        assertEquals(0.5, startupOption.traceSampleRate)
-        assertEquals(0.2, startupOption.profileSampleRate)
-        assertTrue(startupOption.isProfilingEnabled)
+        val appStartProfilingConfigFile = File(path, "app_start_profiling_config")
+        assertTrue(appStartProfilingConfigFile.exists())
+        val appStartOption =
+            JsonSerializer(options).deserialize(FileReader(appStartProfilingConfigFile), SentryAppStartProfilingOptions::class.java)
+        assertNotNull(appStartOption)
+        assertEquals(0.5, appStartOption.traceSampleRate)
+        assertEquals(0.2, appStartOption.profileSampleRate)
+        assertTrue(appStartOption.isProfilingEnabled)
     }
 
     private class InMemoryOptionsObserver : IOptionsObserver {

--- a/sentry/src/test/java/io/sentry/TransactionContextTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionContextTest.kt
@@ -18,7 +18,7 @@ class TransactionContextTest {
         assertNull(context.parentSampled)
         assertEquals("name", context.name)
         assertEquals("op", context.op)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
@@ -28,7 +28,7 @@ class TransactionContextTest {
         assertNull(context.sampled)
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
@@ -44,7 +44,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertFalse(context.parentSampled!!)
         assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
@@ -60,7 +60,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertFalse(context.parentSampled!!)
         assertNull(context.parentSamplingDecision!!.sampleRate)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
@@ -76,7 +76,7 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
         assertEquals(0.3, context.parentSamplingDecision!!.sampleRate)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
@@ -92,13 +92,13 @@ class TransactionContextTest {
         assertNull(context.profileSampled)
         assertTrue(context.parentSampled!!)
         assertNull(context.parentSamplingDecision!!.sampleRate)
-        assertFalse(context.isForNextStartup)
+        assertFalse(context.isForNextAppStart)
     }
 
     @Test
-    fun `setForNextStartup sets the isForNextStartup flag`() {
+    fun `setForNextAppStart sets the isForNextAppStart flag`() {
         val context = TransactionContext("name", "op")
-        context.isForNextStartup = true
-        assertTrue(context.isForNextStartup)
+        context.isForNextAppStart = true
+        assertTrue(context.isForNextAppStart)
     }
 }


### PR DESCRIPTION
## :scroll: Description
Manifest option: 
io.sentry.traces.profiling.enable-startup -> io.sentry.traces.profiling.enable-app-start

Sentry option:
enableStartupProfiling -> enableAppStartProfiling

AppStartMetrics fields:
startupSamplingDecision -> appStartSamplingDecision
startupProfiler -> appStartProfiler

TransactionContext field:
isForNextStartup -> isForNextAppStart

TransactionOptions field:
isStartupTransaction -> isAppStartTransaction

Class
SentryStartupProfilingOptions -> SentryAppStartProfilingOptions

Config file name:
startup_profiling_config -> app_start_profiling_config

#skip-changelog

## :bulb: Motivation and Context
Let's align with appStartTracing naming. Also, cocoa is going to do the same.
We didn't release a version, so we don't need to support the old name.
This is mostly to make this feature more clear to the user 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
