### PR TITLE
Document breaking change in `6.2.1` and remove internal annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -996,6 +996,9 @@ val apolloClient = ApolloClient.Builder()
 - New package `sentry-compose` for Jetpack Compose support (Navigation) ([#2136](https://github.com/getsentry/sentry-java/pull/2136))
 - Add sample rate to baggage as well as trace in envelope header and flatten user ([#2135](https://github.com/getsentry/sentry-java/pull/2135))
 
+Breaking Changes:
+- The boolean parameter `samplingDecision` in the `TransactionContext` constructor has been replaced with a `TracesSamplingDecision` object. Feel free to ignore the `@ApiStatus.Internal` in this case.
+
 ## 6.1.4
 
 ### Fixes

--- a/sentry/src/main/java/io/sentry/TracesSamplingDecision.java
+++ b/sentry/src/main/java/io/sentry/TracesSamplingDecision.java
@@ -1,10 +1,8 @@
 package io.sentry;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Internal
 public final class TracesSamplingDecision {
 
   private final @NotNull Boolean sampled;


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
We had a breaking change which we thought wasn't used by (many) customers. This documents the breaking change and explains how to fix.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
