### PR TITLE
Remove HostnameVerifier option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
     - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 
-### Chores
+### Breaking changes
 
 - Remove `HostnameVerifier` option as it's flagged by security tools of some app stores ([#3150](https://github.com/getsentry/sentry-java/pull/3150))
   - If you were using this option, you have 3 possible paths going forward:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
     - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
     - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 
+### Chores
+
+- Remove `HostnameVerifier` option as it's flagged by security tools of some app stores ([#3150](https://github.com/getsentry/sentry-java/pull/3150))
+  - If you were using this option, you have 3 possible paths going forward:
+    - Provide a custom `ITransportFactory` through `SentryOptions.setTransportFactory()`, where you can copy over most of the parts like `HttpConnection` and `AsyncHttpTransport` from the SDK with necessary modifications
+    - Get a certificate for your server through e.g. [Let's Encrypt](https://letsencrypt.org/)
+    - Fork the SDK and add the hostname verifier back
+
 ### Dependencies
 
 - Bump Native SDK from v0.6.7 to v0.7.0 ([#3133](https://github.com/getsentry/sentry-java/pull/3133))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2158,7 +2158,6 @@ public class io/sentry/SentryOptions {
 	public fun getFlushTimeoutMillis ()J
 	public fun getFullyDisplayedReporter ()Lio/sentry/FullyDisplayedReporter;
 	public fun getGestureTargetLocators ()Ljava/util/List;
-	public fun getHostnameVerifier ()Ljavax/net/ssl/HostnameVerifier;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getIgnoredCheckIns ()Ljava/util/List;
 	public fun getIgnoredExceptionsForType ()Ljava/util/Set;
@@ -2269,7 +2268,6 @@ public class io/sentry/SentryOptions {
 	public fun setExecutorService (Lio/sentry/ISentryExecutorService;)V
 	public fun setFlushTimeoutMillis (J)V
 	public fun setGestureTargetLocators (Ljava/util/List;)V
-	public fun setHostnameVerifier (Ljavax/net/ssl/HostnameVerifier;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
 	public fun setInstrumenter (Lio/sentry/Instrumenter;)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -285,9 +284,6 @@ public class SentryOptions {
 
   /** whether to send personal identifiable information along with events */
   private boolean sendDefaultPii = false;
-
-  /** HostnameVerifier for self-signed certificate trust* */
-  private @Nullable HostnameVerifier hostnameVerifier;
 
   /** SSLSocketFactory for self-signed certificate trust * */
   private @Nullable SSLSocketFactory sslSocketFactory;
@@ -1336,24 +1332,6 @@ public class SentryOptions {
    */
   public void setSslSocketFactory(final @Nullable SSLSocketFactory sslSocketFactory) {
     this.sslSocketFactory = sslSocketFactory;
-  }
-
-  /**
-   * Returns HostnameVerifier
-   *
-   * @return HostnameVerifier object or null
-   */
-  public @Nullable HostnameVerifier getHostnameVerifier() {
-    return hostnameVerifier;
-  }
-
-  /**
-   * Set custom HostnameVerifier
-   *
-   * @param hostnameVerifier the HostnameVerifier
-   */
-  public void setHostnameVerifier(final @Nullable HostnameVerifier hostnameVerifier) {
-    this.hostnameVerifier = hostnameVerifier;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/transport/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/transport/HttpConnection.java
@@ -18,7 +18,6 @@ import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import org.jetbrains.annotations.NotNull;
@@ -129,12 +128,6 @@ final class HttpConnection {
 
     connection.setConnectTimeout(options.getConnectionTimeoutMillis());
     connection.setReadTimeout(options.getReadTimeoutMillis());
-
-    final HostnameVerifier hostnameVerifier = options.getHostnameVerifier();
-
-    if (connection instanceof HttpsURLConnection && hostnameVerifier != null) {
-      ((HttpsURLConnection) connection).setHostnameVerifier(hostnameVerifier);
-    }
 
     final SSLSocketFactory sslSocketFactory = options.getSslSocketFactory();
 

--- a/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
@@ -22,7 +22,6 @@ import java.net.InetSocketAddress
 import java.net.Proxy.Type
 import java.net.URL
 import java.nio.charset.Charset
-import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLSocketFactory
 import kotlin.test.Test
@@ -41,14 +40,12 @@ class HttpConnectionTest {
         val authenticatorWrapper = mock<AuthenticatorWrapper>()
         val rateLimiter = mock<RateLimiter>()
         var sslSocketFactory: SSLSocketFactory? = null
-        var hostnameVerifier: HostnameVerifier? = null
         val requestDetails = mock<RequestDetails>()
         val options = SentryOptions()
 
         init {
             whenever(connection.outputStream).thenReturn(mock())
             whenever(connection.inputStream).thenReturn(mock())
-            whenever(connection.setHostnameVerifier(any())).thenCallRealMethod()
             whenever(connection.setSSLSocketFactory(any())).thenCallRealMethod()
             whenever(requestDetails.headers).thenReturn(mapOf("header-name" to "header-value"))
             val url = mock<URL>()
@@ -61,7 +58,6 @@ class HttpConnectionTest {
             options.setSerializer(serializer)
             options.proxy = proxy
             options.sslSocketFactory = sslSocketFactory
-            options.hostnameVerifier = hostnameVerifier
 
             return HttpConnection(options, requestDetails, authenticatorWrapper, rateLimiter)
         }
@@ -168,26 +164,6 @@ class HttpConnectionTest {
         transport.send(createEnvelope())
 
         verify(fixture.connection, never()).sslSocketFactory = any()
-    }
-
-    @Test
-    fun `When HostnameVerifier is given, set to connection`() {
-        val hostname = mock<HostnameVerifier>()
-        fixture.hostnameVerifier = hostname
-        val transport = fixture.getSUT()
-
-        transport.send(createEnvelope())
-
-        verify(fixture.connection).hostnameVerifier = eq(hostname)
-    }
-
-    @Test
-    fun `When HostnameVerifier is not given, do not set to connection`() {
-        val transport = fixture.getSUT()
-
-        transport.send(createEnvelope())
-
-        verify(fixture.connection, never()).hostnameVerifier = any()
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This was mainly used by self-hosted users who has a self-signed certificate. There will be 3 options for them going forward:
* Provide a custom `ITransportFactory`, where they can copy over most parts like `HttpConnection` and `AsyncHttpTransport` with necessary modifications
* Get a certificate for their server through e.g. Let's Encrypt
* Fork the SDK and add the hostname verifier back

It's a breaking change, but we agreed that the impact is gonna be so small that it's not worth waiting for the next major, given that it produces so many false positives by security tools of some app stores

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-unity/issues/1513

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
