### PR TITLE
Ignore TestOrchestrator failures

### DIFF
--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Verify Test Results
         run: |
-          processCrashed=$(cat test_logs.txt | grep "Process crashed." | wc -l)
+          processCrashed=$(cat test_logs.txt | grep "Instrumentation run failed due to 'Process crashed.'" | wc -l)
           if [[ ${{ steps.saucelabs.outcome }} == 'success' ]]; then
             exit 0
           elif [[ "$processCrashed" -ne 0 ]]; then

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -57,12 +57,11 @@ jobs:
 
       - name: Verify Test Results
         run: |
-          processCrashed=$(cat test_logs.txt | grep "Suite finished." | wc -l)
-          echo $processCrashed
-          if [[ ${{ steps.saucelabs.outcome }} == 'failure' ]]; then
+          processCrashed=$(cat test_logs.txt | grep "Process crashed." | wc -l)
+          if [[ ${{ steps.saucelabs.outcome }} == 'success' ]]; then
             exit 0
           elif [[ "$processCrashed" -ne 0 ]]; then
-            exit 1
+            exit 0
           else
             exit 1
           fi

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -17,6 +17,7 @@ jobs:
     # we copy the secret to the env variable in order to access it in the workflow
     env:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
 
     steps:
       - name: Git checkout
@@ -36,40 +37,29 @@ jobs:
         if: env.SAUCE_USERNAME != null
         run: make assembleUiTests
 
-      - name: Run Tests in SauceLab
-        id: saucelabs
+      - name: Install SauceLabs CLI
         uses: saucelabs/saucectl-run-action@7fe025ef1fdc6f211add3751a6c7d8bba27ba9b1 # pin@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          sauce-username: ${{ secrets.SAUCE_USERNAME }}
-          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
-          config-file: .sauce/sentry-uitest-android-ui.yml
+          skip-run: true
+        if: env.SAUCE_USERNAME != null
+
+      - name: Run Tests
+        id: saucelabs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          exec &> >(tee -a "test_logs.txt")
+          saucectl -c .sauce/sentry-uitest-android-ui.yml
         if: env.SAUCE_USERNAME != null
         continue-on-error: true
 
-      - name: Get Job ID
-        id: get-job-id
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
-          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
-          echo "job_id=$job_id" >> $GITHUB_OUTPUT
-
       - name: Verify Test Results
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          previousStepLogs="$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
-
-          processCrashed=$(grep "Suite finished." <<< "$previousStepLogs" | wc -l)
-          echo $previousStepLogs
+          processCrashed=$(cat test_logs.txt | grep "Suite finished." | wc -l)
           echo $processCrashed
-          if [[ "${{ steps.saucelabs.outcome }}" = "success" ]]; then
+          if [[ ${{ steps.saucelabs.outcome }} == 'success' ]]; then
             exit 0
           elif [[ "$processCrashed" -ne 0 ]]; then
             exit 1

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -66,12 +66,12 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
-          processCrashed=$(grep "Process crashed." <<< "$previousStepLogs" | wc -l)
+          processCrashed=$(grep "Suite finished." <<< "$previousStepLogs" | wc -l)
           echo $processCrashed
           if [[ "${{ steps.saucelabs.outcome }}" = "success" ]]; then
             exit 0
           elif [[ "$processCrashed" -ne 0 ]]; then
-            exit 0
+            exit 1
           else
             exit 1
           fi

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -37,6 +37,7 @@ jobs:
         run: make assembleUiTests
 
       - name: Run Tests in SauceLab
+        id: saucelabs
         uses: saucelabs/saucectl-run-action@7fe025ef1fdc6f211add3751a6c7d8bba27ba9b1 # pin@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -45,4 +46,22 @@ jobs:
           sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
           config-file: .sauce/sentry-uitest-android-ui.yml
         if: env.SAUCE_USERNAME != null
+        continue-on-error: true
 
+      - name: Get Job ID
+        id: get-job-id
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          jobs=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id}}/attempts/${{ github.run_attempt }}/jobs)
+          job_id=$(echo $jobs | jq -r '.jobs[] | select(.runner_name=="${{ runner.name }}") | .id')
+          echo "job_id=$job_id" >> $GITHUB_OUTPUT
+
+      - name: Verify Test Results
+        run: |
+          previousStepLogs="$(gh api
+            -H "Accept: application/vnd.github+json"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+            /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
+
+          echo $previousStepLogs

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           exec &> >(tee -a "test_logs.txt")
-          saucectl -c .sauce/sentry-uitest-android-ui.yml
+          saucectl run -c .sauce/sentry-uitest-android-ui.yml
         if: env.SAUCE_USERNAME != null
         continue-on-error: true
 

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -66,5 +66,11 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
-          echo "${{ steps.saucelabs.outcome }}"
-          echo "$(grep "Instrumentation run failed due to 'Process crashed.'" <<< "$previousStepLogs" | wc -l)"
+          processCrashed=$(grep "Instrumentation run failed due to 'Process crashed.'" <<< "$previousStepLogs" | wc -l)
+          if [[ ${{ steps.saucelabs.outcome }} = 'success' ]]; then
+            exit 0
+          elif [[ $processCrashed != "0" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -58,6 +58,8 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Verify Test Results
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           previousStepLogs="$(gh api \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -67,6 +67,7 @@ jobs:
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
           processCrashed=$(grep "Suite finished." <<< "$previousStepLogs" | wc -l)
+          echo $previousStepLogs
           echo $processCrashed
           if [[ "${{ steps.saucelabs.outcome }}" = "success" ]]; then
             exit 0

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -58,7 +58,7 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Verify Test Results
-        run: |
+        run: >
           previousStepLogs="$(gh api
             -H "Accept: application/vnd.github+json"
             -H "X-GitHub-Api-Version: 2022-11-28"

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -66,4 +66,5 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
-          echo $previousStepLogs
+          echo "${{ steps.saucelabs.outcome }}"
+          echo "$(grep "Instrumentation run failed due to 'Process crashed.'" <<< "$previousStepLogs" | wc -l)"

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           processCrashed=$(cat test_logs.txt | grep "Suite finished." | wc -l)
           echo $processCrashed
-          if [[ ${{ steps.saucelabs.outcome }} == 'success' ]]; then
+          if [[ ${{ steps.saucelabs.outcome }} == 'failure' ]]; then
             exit 0
           elif [[ "$processCrashed" -ne 0 ]]; then
             exit 1

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -58,10 +58,10 @@ jobs:
           echo "job_id=$job_id" >> $GITHUB_OUTPUT
 
       - name: Verify Test Results
-        run: >
-          previousStepLogs="$(gh api
-            -H "Accept: application/vnd.github+json"
-            -H "X-GitHub-Api-Version: 2022-11-28"
+        run: |
+          previousStepLogs="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
           echo $previousStepLogs

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -66,10 +66,11 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/getsentry/sentry-java/actions/jobs/${{ steps.get-job-id.outputs.job_id }}/logs)"
 
-          processCrashed=$(grep "Instrumentation run failed due to 'Process crashed.'" <<< "$previousStepLogs" | wc -l)
-          if [[ ${{ steps.saucelabs.outcome }} = 'success' ]]; then
+          processCrashed=$(grep "Process crashed." <<< "$previousStepLogs" | wc -l)
+          echo $processCrashed
+          if [[ "${{ steps.saucelabs.outcome }}" = "success" ]]; then
             exit 0
-          elif [[ $processCrashed != "0" ]]; then
+          elif [[ "$processCrashed" -ne 0 ]]; then
             exit 0
           else
             exit 1


### PR DESCRIPTION
_#skip-changelog_

Since we can't do much when test orchestrator itself fails, I think it's fair to ignore those failures.

Ignore TestOrchestrator failures by checking the logs for presence of "process crashed" entry. If there's a failing test, it will actually print a proper stacktrace (like [here](https://github.com/getsentry/sentry-java/actions/runs/7624407511/job/20766479920)), so we're narrowing this down only to test orchestration issues.
