### PR TITLE
Fix not eligible for auto proxying warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
     - Add options and sampling logic ([#3121](https://github.com/getsentry/sentry-java/pull/3121))
     - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 
+### Fixes
+
+- Fix not eligible for auto proxying warnings ([#3154](https://github.com/getsentry/sentry-java/pull/3154))
+
 ### Breaking changes
 
 - Remove `HostnameVerifier` option as it's flagged by security tools of some app stores ([#3150](https://github.com/getsentry/sentry-java/pull/3150))

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -96,6 +96,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/checkin/Sent
 
 public class io/sentry/spring/jakarta/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -125,6 +126,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/exception/Se
 
 public class io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -204,6 +206,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 
 public class io/sentry/spring/jakarta/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -241,6 +244,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 
 public class io/sentry/spring/jakarta/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -95,13 +95,13 @@ public abstract interface annotation class io/sentry/spring/jakarta/checkin/Sent
 }
 
 public class io/sentry/spring/jakarta/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentryCheckInAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryCheckInAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryCheckInAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -124,7 +124,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/exception/Se
 }
 
 public class io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -139,7 +139,7 @@ public class io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterP
 
 public class io/sentry/spring/jakarta/exception/SentryExceptionParameterAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentryCaptureExceptionParameterAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryCaptureExceptionParameterAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryCaptureExceptionParameterAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -190,9 +190,9 @@ public final class io/sentry/spring/jakarta/graphql/SentrySpringSubscriptionHand
 
 public class io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentrySpanAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentrySpanAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentrySpanAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
-	public fun sentryTransactionAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryTransactionAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryTransactionAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -203,7 +203,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 }
 
 public class io/sentry/spring/jakarta/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -240,7 +240,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 }
 
 public class io/sentry/spring/jakarta/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -8,6 +8,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
+import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -30,7 +31,11 @@ public class SentryCheckInAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentryCheckInAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryCheckInAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -8,7 +8,6 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
-import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -4,6 +4,7 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.CheckIn;
 import io.sentry.CheckInStatus;
 import io.sentry.DateUtils;
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
@@ -29,8 +30,8 @@ import org.springframework.util.ObjectUtils;
 public class SentryCheckInAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
-  public SentryCheckInAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCheckInAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
@@ -9,20 +9,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 @Configuration(proxyBeanMethods = false)
 @Open
 @ApiStatus.Experimental
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInAdviceConfiguration {
 
   @Bean
-  public @NotNull Advice sentryCheckInAdvice(final @NotNull IHub hub) {
-    return new SentryCheckInAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryCheckInAdvice() {
+    return new SentryCheckInAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryCheckInAdvisor(
       final @NotNull @Qualifier("sentryCheckInPointcut") Pointcut sentryCheckInPointcut,
       final @NotNull @Qualifier("sentryCheckInAdvice") Advice sentryCheckInAdvice) {

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
@@ -7,13 +7,16 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryCheckIn}. */
 @Configuration(proxyBeanMethods = false)
 @Open
 @ApiStatus.Experimental
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInPointcutConfiguration {
 
   /**
@@ -22,6 +25,7 @@ public class SentryCheckInPointcutConfiguration {
    * @return pointcut used by {@link SentryCheckInAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryCheckInPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentryCheckIn.class, true))
         .union(new AnnotationMatchingPointcut(null, SentryCheckIn.class));

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
@@ -5,6 +5,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +25,11 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
   private final @NotNull IHub hub;
 
   public SentryCaptureExceptionParameterAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.jakarta.exception;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
@@ -23,8 +25,8 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
   private static final String MECHANISM_TYPE = "SentrySpring6CaptureExceptionParameterAdvice";
   private final @NotNull IHub hub;
 
-  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCaptureExceptionParameterAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,12 +1,10 @@
 package io.sentry.spring.jakarta.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryCaptureExceptionParameter}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCaptureExceptionParameterPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentryCaptureExceptionParameterPointcutConfiguration {
    * @return pointcut used by {@link SentryCaptureExceptionParameterAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryCaptureExceptionParameterPointcut() {
     return new ComposablePointcut(
             new AnnotationClassFilter(SentryCaptureExceptionParameter.class, true))

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryExceptionParameterAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryExceptionParameterAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;
@@ -17,7 +16,7 @@ import org.springframework.context.annotation.Role;
 @Configuration(proxyBeanMethods = false)
 @Open
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-public class SentryExceptionParameterAdviceConfiguration   {
+public class SentryExceptionParameterAdviceConfiguration {
 
   @Bean
   @Role(BeanDefinition.ROLE_INFRASTRUCTURE)

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryExceptionParameterAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryExceptionParameterAdviceConfiguration.java
@@ -8,20 +8,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** Creates advice infrastructure for {@link SentryCaptureExceptionParameter}. */
 @Configuration(proxyBeanMethods = false)
 @Open
-public class SentryExceptionParameterAdviceConfiguration {
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+public class SentryExceptionParameterAdviceConfiguration   {
 
   @Bean
-  public @NotNull Advice sentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    return new SentryCaptureExceptionParameterAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryCaptureExceptionParameterAdvice() {
+    return new SentryCaptureExceptionParameterAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryCaptureExceptionParameterAdvisor(
       final @NotNull @Qualifier("sentryCaptureExceptionParameterPointcut") Pointcut
               sentryCaptureExceptionParameterPointcut,

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration.java
@@ -8,20 +8,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** Creates advice infrastructure for {@link SentrySpan} and {@link SentryTransaction}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryAdviceConfiguration {
 
   @Bean
-  public @NotNull Advice sentryTransactionAdvice(final @NotNull IHub hub) {
-    return new SentryTransactionAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryTransactionAdvice() {
+    return new SentryTransactionAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryTransactionAdvisor(
       final @NotNull @Qualifier("sentryTransactionPointcut") Pointcut sentryTransactionPointcut,
       final @NotNull @Qualifier("sentryTransactionAdvice") Advice sentryTransactionAdvice) {
@@ -29,11 +34,13 @@ public class SentryAdviceConfiguration {
   }
 
   @Bean
-  public @NotNull Advice sentrySpanAdvice(final @NotNull IHub hub) {
-    return new SentrySpanAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentrySpanAdvice() {
+    return new SentrySpanAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentrySpanAdvisor(
       final @NotNull @Qualifier("sentrySpanPointcut") Pointcut sentrySpanPointcut,
       final @NotNull @Qualifier("sentrySpanAdvice") Advice sentrySpanAdvice) {

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
@@ -1,12 +1,10 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
@@ -23,8 +25,8 @@ public class SentrySpanAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring_jakarta.advice";
   private final @NotNull IHub hub;
 
-  public SentrySpanAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentrySpanAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
@@ -5,6 +5,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +25,11 @@ public class SentrySpanAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentrySpanAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentrySpanAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentrySpan}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentrySpanPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentrySpanPointcutConfiguration {
    * @return pointcut used by {@link SentrySpanAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentrySpanPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentrySpan.class, true))
         .union(new AnnotationMatchingPointcut(null, SentrySpan.class));

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
@@ -8,6 +8,7 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.protocol.TransactionNameSource;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -30,7 +31,11 @@ public class SentryTransactionAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentryTransactionAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryTransactionAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ITransaction;
@@ -9,7 +8,6 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.protocol.TransactionNameSource;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -34,7 +32,6 @@ public class SentryTransactionAdvice implements MethodInterceptor {
   public SentryTransactionAdvice() {
     this.hub = HubAdapter.getInstance();
   }
-
 
   @SuppressWarnings("deprecation")
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ITransaction;
 import io.sentry.SpanStatus;
@@ -26,11 +28,13 @@ import org.springframework.util.StringUtils;
 @Open
 public class SentryTransactionAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring_jakarta.advice";
+
   private final @NotNull IHub hub;
 
-  public SentryTransactionAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryTransactionAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
+
 
   @SuppressWarnings("deprecation")
   @Override

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTransactionPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryTransaction}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryTransactionPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentryTransactionPointcutConfiguration {
    * @return pointcut used by {@link SentryTransactionAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryTransactionPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentryTransaction.class, true))
         .union(new AnnotationMatchingPointcut(null, SentryTransaction.class));

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryCheckInAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryCheckInAdviceTest.kt
@@ -3,6 +3,7 @@ package io.sentry.spring.jakarta
 import io.sentry.CheckIn
 import io.sentry.CheckInStatus
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
 import io.sentry.spring.jakarta.checkin.SentryCheckIn
@@ -171,7 +172,11 @@ class SentryCheckInAdviceTest {
         open fun sampleServiceHeartbeat() = SampleServiceHeartbeat()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdviceTest.kt
@@ -1,8 +1,11 @@
 package io.sentry.spring.jakarta.exception
 
+import io.sentry.Hint
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.exception.ExceptionMechanismException
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
@@ -41,10 +44,10 @@ class SentryCaptureExceptionParameterAdviceTest {
         verify(hub).captureException(
             check {
                 assertTrue(it is ExceptionMechanismException)
-                val mechanismException = it as ExceptionMechanismException
-                assertEquals(exception, mechanismException.throwable)
-                assertEquals("SentrySpring6CaptureExceptionParameterAdvice", mechanismException.exceptionMechanism.type)
-            }
+                assertEquals(exception, it.throwable)
+                assertEquals("SentrySpring6CaptureExceptionParameterAdvice", it.exceptionMechanism.type)
+            },
+            any<Hint>()
         )
     }
 
@@ -57,7 +60,11 @@ class SentryCaptureExceptionParameterAdviceTest {
         open fun sampleService() = SampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentrySpanAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentrySpanAdviceTest.kt
@@ -2,6 +2,7 @@ package io.sentry.spring.jakarta.tracing
 
 import io.sentry.IHub
 import io.sentry.Scope
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
@@ -150,7 +151,11 @@ class SentrySpanAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTransactionAdviceTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.jakarta.tracing
 
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
@@ -164,7 +165,11 @@ class SentryTransactionAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -96,6 +96,7 @@ public abstract interface annotation class io/sentry/spring/checkin/SentryCheckI
 
 public class io/sentry/spring/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -125,6 +126,7 @@ public abstract interface annotation class io/sentry/spring/exception/SentryCapt
 
 public class io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -204,6 +206,7 @@ public abstract interface annotation class io/sentry/spring/tracing/SentrySpan :
 
 public class io/sentry/spring/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -241,6 +244,7 @@ public abstract interface annotation class io/sentry/spring/tracing/SentryTransa
 
 public class io/sentry/spring/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
+	public fun <init> (Lio/sentry/IHub;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -95,13 +95,13 @@ public abstract interface annotation class io/sentry/spring/checkin/SentryCheckI
 }
 
 public class io/sentry/spring/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/checkin/SentryCheckInAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentryCheckInAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryCheckInAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryCheckInAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -124,7 +124,7 @@ public abstract interface annotation class io/sentry/spring/exception/SentryCapt
 }
 
 public class io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -139,7 +139,7 @@ public class io/sentry/spring/exception/SentryCaptureExceptionParameterPointcutC
 
 public class io/sentry/spring/exception/SentryExceptionParameterAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentryCaptureExceptionParameterAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryCaptureExceptionParameterAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryCaptureExceptionParameterAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -190,9 +190,9 @@ public final class io/sentry/spring/graphql/SentrySpringSubscriptionHandler : io
 
 public class io/sentry/spring/tracing/SentryAdviceConfiguration {
 	public fun <init> ()V
-	public fun sentrySpanAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentrySpanAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentrySpanAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
-	public fun sentryTransactionAdvice (Lio/sentry/IHub;)Lorg/aopalliance/aop/Advice;
+	public fun sentryTransactionAdvice ()Lorg/aopalliance/aop/Advice;
 	public fun sentryTransactionAdvisor (Lorg/springframework/aop/Pointcut;Lorg/aopalliance/aop/Advice;)Lorg/springframework/aop/Advisor;
 }
 
@@ -203,7 +203,7 @@ public abstract interface annotation class io/sentry/spring/tracing/SentrySpan :
 }
 
 public class io/sentry/spring/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -240,7 +240,7 @@ public abstract interface annotation class io/sentry/spring/tracing/SentryTransa
 }
 
 public class io/sentry/spring/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> ()V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -8,6 +8,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
+import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -30,7 +31,11 @@ public class SentryCheckInAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentryCheckInAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryCheckInAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @Override

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -8,7 +8,6 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
-import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -4,6 +4,7 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.CheckIn;
 import io.sentry.CheckInStatus;
 import io.sentry.DateUtils;
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
@@ -29,8 +30,8 @@ import org.springframework.util.ObjectUtils;
 public class SentryCheckInAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
-  public SentryCheckInAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCheckInAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @Override

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
@@ -9,20 +9,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 @Configuration(proxyBeanMethods = false)
 @Open
 @ApiStatus.Experimental
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInAdviceConfiguration {
 
   @Bean
-  public @NotNull Advice sentryCheckInAdvice(final @NotNull IHub hub) {
-    return new SentryCheckInAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryCheckInAdvice() {
+    return new SentryCheckInAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryCheckInAdvisor(
       final @NotNull @Qualifier("sentryCheckInPointcut") Pointcut sentryCheckInPointcut,
       final @NotNull @Qualifier("sentryCheckInAdvice") Advice sentryCheckInAdvice) {

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
@@ -7,13 +7,16 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryCheckIn}. */
 @Configuration(proxyBeanMethods = false)
 @Open
 @ApiStatus.Experimental
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInPointcutConfiguration {
 
   /**
@@ -22,6 +25,7 @@ public class SentryCheckInPointcutConfiguration {
    * @return pointcut used by {@link SentryCheckInAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryCheckInPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentryCheckIn.class, true))
         .union(new AnnotationMatchingPointcut(null, SentryCheckIn.class));

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,12 +1,10 @@
 package io.sentry.spring.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
@@ -5,6 +5,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +25,11 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
   private final @NotNull IHub hub;
 
   public SentryCaptureExceptionParameterAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @Override

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.exception;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
@@ -23,8 +25,8 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
   private static final String MECHANISM_TYPE = "SentrySpring5CaptureExceptionParameterAdvice";
   private final @NotNull IHub hub;
 
-  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCaptureExceptionParameterAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @Override

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryCaptureExceptionParameter}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCaptureExceptionParameterPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentryCaptureExceptionParameterPointcutConfiguration {
    * @return pointcut used by {@link SentryCaptureExceptionParameterAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryCaptureExceptionParameterPointcut() {
     return new ComposablePointcut(
             new AnnotationClassFilter(SentryCaptureExceptionParameter.class, true))

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryExceptionParameterAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryExceptionParameterAdviceConfiguration.java
@@ -8,20 +8,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** Creates advice infrastructure for {@link SentryCaptureExceptionParameter}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryExceptionParameterAdviceConfiguration {
 
   @Bean
-  public @NotNull Advice sentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    return new SentryCaptureExceptionParameterAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryCaptureExceptionParameterAdvice() {
+    return new SentryCaptureExceptionParameterAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryCaptureExceptionParameterAdvisor(
       final @NotNull @Qualifier("sentryCaptureExceptionParameterPointcut") Pointcut
               sentryCaptureExceptionParameterPointcut,

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryExceptionParameterAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryExceptionParameterAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryAdviceConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import org.aopalliance.aop.Advice;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryAdviceConfiguration.java
@@ -8,20 +8,25 @@ import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** Creates advice infrastructure for {@link SentrySpan} and {@link SentryTransaction}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryAdviceConfiguration {
 
   @Bean
-  public @NotNull Advice sentryTransactionAdvice(final @NotNull IHub hub) {
-    return new SentryTransactionAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentryTransactionAdvice() {
+    return new SentryTransactionAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentryTransactionAdvisor(
       final @NotNull @Qualifier("sentryTransactionPointcut") Pointcut sentryTransactionPointcut,
       final @NotNull @Qualifier("sentryTransactionAdvice") Advice sentryTransactionAdvice) {
@@ -29,11 +34,13 @@ public class SentryAdviceConfiguration {
   }
 
   @Bean
-  public @NotNull Advice sentrySpanAdvice(final @NotNull IHub hub) {
-    return new SentrySpanAdvice(hub);
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+  public @NotNull Advice sentrySpanAdvice() {
+    return new SentrySpanAdvice();
   }
 
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Advisor sentrySpanAdvisor(
       final @NotNull @Qualifier("sentrySpanPointcut") Pointcut sentrySpanPointcut,
       final @NotNull @Qualifier("sentrySpanAdvice") Advice sentrySpanAdvice) {

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
@@ -1,12 +1,10 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
@@ -5,6 +5,7 @@ import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -24,7 +25,11 @@ public class SentrySpanAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentrySpanAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentrySpanAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
 import io.sentry.SpanStatus;
@@ -23,8 +25,8 @@ public class SentrySpanAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring.advice";
   private final @NotNull IHub hub;
 
-  public SentrySpanAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentrySpanAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentrySpan}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentrySpanPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentrySpanPointcutConfiguration {
    * @return pointcut used by {@link SentrySpanAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentrySpanPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentrySpan.class, true))
         .union(new AnnotationMatchingPointcut(null, SentrySpan.class));

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ITransaction;
@@ -9,7 +8,6 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.protocol.TransactionNameSource;
-import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -1,6 +1,8 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
+
+import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ITransaction;
 import io.sentry.SpanStatus;
@@ -28,8 +30,8 @@ public class SentryTransactionAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring.advice";
   private final @NotNull IHub hub;
 
-  public SentryTransactionAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryTransactionAdvice() {
+    this.hub = HubAdapter.getInstance();
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -8,6 +8,7 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.protocol.TransactionNameSource;
+import io.sentry.util.Objects;
 import java.lang.reflect.Method;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -29,7 +30,11 @@ public class SentryTransactionAdvice implements MethodInterceptor {
   private final @NotNull IHub hub;
 
   public SentryTransactionAdvice() {
-    this.hub = HubAdapter.getInstance();
+    this(HubAdapter.getInstance());
+  }
+
+  public SentryTransactionAdvice(final @NotNull IHub hub) {
+    this.hub = Objects.requireNonNull(hub, "hub is required");
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionPointcutConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;
 import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 
 /** AOP pointcut configuration for {@link SentryTransaction}. */
 @Configuration(proxyBeanMethods = false)
 @Open
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryTransactionPointcutConfiguration {
 
   /**
@@ -20,6 +23,7 @@ public class SentryTransactionPointcutConfiguration {
    * @return pointcut used by {@link SentryTransactionAdvice}.
    */
   @Bean
+  @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
   public @NotNull Pointcut sentryTransactionPointcut() {
     return new ComposablePointcut(new AnnotationClassFilter(SentryTransaction.class, true))
         .union(new AnnotationMatchingPointcut(null, SentryTransaction.class));

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryCheckInAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryCheckInAdviceTest.kt
@@ -3,6 +3,7 @@ package io.sentry.spring
 import io.sentry.CheckIn
 import io.sentry.CheckInStatus
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
 import io.sentry.spring.checkin.SentryCheckIn
@@ -171,7 +172,11 @@ class SentryCheckInAdviceTest {
         open fun sampleServiceHeartbeat() = SampleServiceHeartbeat()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
@@ -1,8 +1,11 @@
 package io.sentry.spring.exception
 
+import io.sentry.Hint
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.exception.ExceptionMechanismException
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
@@ -41,10 +44,10 @@ class SentryCaptureExceptionParameterAdviceTest {
         verify(hub).captureException(
             check {
                 assertTrue(it is ExceptionMechanismException)
-                val mechanismException = it as ExceptionMechanismException
-                assertEquals(exception, mechanismException.throwable)
-                assertEquals("SentrySpring5CaptureExceptionParameterAdvice", mechanismException.exceptionMechanism.type)
-            }
+                assertEquals(exception, it.throwable)
+                assertEquals("SentrySpring5CaptureExceptionParameterAdvice", it.exceptionMechanism.type)
+            },
+            any<Hint>()
         )
     }
 
@@ -57,7 +60,11 @@ class SentryCaptureExceptionParameterAdviceTest {
         open fun sampleService() = SampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentrySpanAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentrySpanAdviceTest.kt
@@ -2,6 +2,7 @@ package io.sentry.spring.tracing
 
 import io.sentry.IHub
 import io.sentry.Scope
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
@@ -150,7 +151,11 @@ class SentrySpanAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.tracing
 
 import io.sentry.IHub
+import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.SpanStatus
@@ -164,7 +165,11 @@ class SentryTransactionAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub() = mock<IHub>()
+        open fun hub(): IHub {
+            val hub = mock<IHub>()
+            Sentry.setCurrentHub(hub)
+            return hub
+        }
     }
 
     open class SampleService {


### PR DESCRIPTION
## :scroll: Description
Fix not eligible for auto proxying warnings by:
- Removing the hub dependency from all `Advice` Beans
- Mark all AOP related classes/methods annoted with `@Configuration` or `@Bean` with `@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
`


## :bulb: Motivation and Context
Fixes #3042 


## :green_heart: How did you test it?
Manually by checking the log output

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
