### PR TITLE
Collect slow and frozen frames as measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - Add ContentProvider and start profile ([#3128](https://github.com/getsentry/sentry-java/pull/3128))
 - Extend internal performance collector APIs ([#3102](https://github.com/getsentry/sentry-java/pull/3102))
 - Collect slow and frozen frames for spans using `OnFrameMetricsAvailableListener` ([#3111](https://github.com/getsentry/sentry-java/pull/3111))
+- Interpolate total frame count to match span duration ([#3158](https://github.com/getsentry/sentry-java/pull/3158))
 
 ### Breaking changes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryFrameMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryFrameMetrics.java
@@ -13,14 +13,17 @@ final class SentryFrameMetrics {
   private long slowFrameDelayNanos;
   private long frozenFrameDelayNanos;
 
+  private long totalDurationNanos;
+
   public SentryFrameMetrics() {}
 
   public SentryFrameMetrics(
-      int normalFrameCount,
-      int slowFrameCount,
-      long slowFrameDelayNanos,
-      int frozenFrameCount,
-      long frozenFrameDelayNanos) {
+      final int normalFrameCount,
+      final int slowFrameCount,
+      final long slowFrameDelayNanos,
+      final int frozenFrameCount,
+      final long frozenFrameDelayNanos,
+      final long totalDurationNanos) {
     this.normalFrameCount = normalFrameCount;
 
     this.slowFrameCount = slowFrameCount;
@@ -28,19 +31,23 @@ final class SentryFrameMetrics {
 
     this.frozenFrameCount = frozenFrameCount;
     this.frozenFrameDelayNanos = frozenFrameDelayNanos;
+    this.totalDurationNanos = totalDurationNanos;
   }
 
-  public void addSlowFrame(final long delayNanos) {
+  public void addSlowFrame(final long durationNanos, final long delayNanos) {
+    totalDurationNanos += durationNanos;
     slowFrameDelayNanos += delayNanos;
     slowFrameCount++;
   }
 
-  public void addFrozenFrame(final long delayNanos) {
+  public void addFrozenFrame(final long durationNanos, final long delayNanos) {
+    totalDurationNanos += durationNanos;
     frozenFrameDelayNanos += delayNanos;
     frozenFrameCount++;
   }
 
-  public void addNormalFrame() {
+  public void addNormalFrame(final long durationNanos) {
+    totalDurationNanos += durationNanos;
     normalFrameCount++;
   }
 
@@ -68,6 +75,10 @@ final class SentryFrameMetrics {
     return normalFrameCount + slowFrameCount + frozenFrameCount;
   }
 
+  public long getTotalDurationNanos() {
+    return totalDurationNanos;
+  }
+
   public void clear() {
     normalFrameCount = 0;
 
@@ -76,6 +87,8 @@ final class SentryFrameMetrics {
 
     frozenFrameCount = 0;
     frozenFrameDelayNanos = 0;
+
+    totalDurationNanos = 0;
   }
 
   @NotNull
@@ -85,7 +98,8 @@ final class SentryFrameMetrics {
         slowFrameCount,
         slowFrameDelayNanos,
         frozenFrameCount,
-        frozenFrameDelayNanos);
+        frozenFrameDelayNanos,
+        totalDurationNanos);
   }
 
   /**
@@ -99,11 +113,20 @@ final class SentryFrameMetrics {
         slowFrameCount - other.slowFrameCount,
         slowFrameDelayNanos - other.slowFrameDelayNanos,
         frozenFrameCount - other.frozenFrameCount,
-        frozenFrameDelayNanos - other.frozenFrameDelayNanos);
+        frozenFrameDelayNanos - other.frozenFrameDelayNanos,
+        totalDurationNanos - other.totalDurationNanos);
   }
 
+  /**
+   * @return true if the frame metrics contain valid data, meaning all values are greater or equal
+   *     to 0
+   */
   public boolean containsValidData() {
-    // TODO sanity check durations?
-    return getTotalFrameCount() > 0;
+    return normalFrameCount >= 0
+        && slowFrameCount >= 0
+        && slowFrameDelayNanos >= 0
+        && frozenFrameCount >= 0
+        && frozenFrameDelayNanos >= 0
+        && totalDurationNanos >= 0;
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -2,11 +2,13 @@ package io.sentry.android.core;
 
 import io.sentry.IPerformanceContinuousCollector;
 import io.sentry.ISpan;
+import io.sentry.ITransaction;
 import io.sentry.NoOpSpan;
 import io.sentry.NoOpTransaction;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanId;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
+import io.sentry.protocol.MeasurementValue;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
@@ -80,6 +82,12 @@ public class SpanFrameMetricsCollector
       span.setData(SpanDataConvention.FRAMES_SLOW, diff.getSlowFrameCount());
       span.setData(SpanDataConvention.FRAMES_FROZEN, diff.getFrozenFrameCount());
       span.setData(SpanDataConvention.FRAMES_TOTAL, diff.getTotalFrameCount());
+
+      if (span instanceof ITransaction) {
+        span.setMeasurement(MeasurementValue.KEY_FRAMES_TOTAL, diff.getTotalFrameCount());
+        span.setMeasurement(MeasurementValue.KEY_FRAMES_SLOW, diff.getSlowFrameCount());
+        span.setMeasurement(MeasurementValue.KEY_FRAMES_FROZEN, diff.getFrozenFrameCount());
+      }
     }
 
     synchronized (lock) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -5,12 +5,14 @@ import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.NoOpSpan;
 import io.sentry.NoOpTransaction;
+import io.sentry.SentryDate;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanId;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.protocol.MeasurementValue;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 public class SpanFrameMetricsCollector
     implements IPerformanceContinuousCollector,
         SentryFrameMetricsCollector.FrameMetricsCollectorListener {
+
   private @NotNull final Object lock = new Object();
   private @Nullable final SentryFrameMetricsCollector frameMetricsCollector;
   private @Nullable volatile String listenerId;
@@ -26,6 +29,8 @@ public class SpanFrameMetricsCollector
 
   private @NotNull final SentryFrameMetrics currentFrameMetrics;
   private final boolean enabled;
+
+  private float lastRefreshRate = 60.0f;
 
   public SpanFrameMetricsCollector(final @NotNull SentryAndroidOptions options) {
     frameMetricsCollector = options.getFrameMetricsCollector();
@@ -78,13 +83,40 @@ public class SpanFrameMetricsCollector
         diff = currentFrameMetrics.diffTo(metricsAtStart);
       }
     }
+
     if (diff != null && diff.containsValidData()) {
+      int nonRenderedFrameCount = 0;
+
+      // if there are no content changes on Android, also no frames are rendered
+      // thus no frame metrics are provided
+      // in order to match the span duration with the total frame count,
+      // we simply interpolate the total number of frames based on the span duration
+      // this way the data is more sound and we also match the output of the cocoa SDK
+      final @Nullable SentryDate spanFinishDate = span.getFinishDate();
+      if (spanFinishDate != null) {
+        final long spanDurationNanos = spanFinishDate.diff(span.getStartDate());
+
+        final long frameMetricsDurationNanos = diff.getTotalDurationNanos();
+        final long nonRenderedDuration = spanDurationNanos - frameMetricsDurationNanos;
+        final double refreshRate = lastRefreshRate;
+
+        if (nonRenderedDuration > 0 && refreshRate > 0.0d) {
+          // e.g. at 60fps we would have 16.6ms per frame
+          final long normalFrameDurationNanos =
+              (long) ((double) TimeUnit.SECONDS.toNanos(1) / refreshRate);
+
+          nonRenderedFrameCount = (int) (nonRenderedDuration / normalFrameDurationNanos);
+        }
+      }
+
+      final int totalFrameCount = diff.getTotalFrameCount() + nonRenderedFrameCount;
+
+      span.setData(SpanDataConvention.FRAMES_TOTAL, totalFrameCount);
       span.setData(SpanDataConvention.FRAMES_SLOW, diff.getSlowFrameCount());
       span.setData(SpanDataConvention.FRAMES_FROZEN, diff.getFrozenFrameCount());
-      span.setData(SpanDataConvention.FRAMES_TOTAL, diff.getTotalFrameCount());
 
       if (span instanceof ITransaction) {
-        span.setMeasurement(MeasurementValue.KEY_FRAMES_TOTAL, diff.getTotalFrameCount());
+        span.setMeasurement(MeasurementValue.KEY_FRAMES_TOTAL, totalFrameCount);
         span.setMeasurement(MeasurementValue.KEY_FRAMES_SLOW, diff.getSlowFrameCount());
         span.setMeasurement(MeasurementValue.KEY_FRAMES_FROZEN, diff.getFrozenFrameCount());
       }
@@ -122,11 +154,13 @@ public class SpanFrameMetricsCollector
       final float refreshRate) {
 
     if (isFrozen) {
-      currentFrameMetrics.addFrozenFrame(delayNanos);
+      currentFrameMetrics.addFrozenFrame(durationNanos, delayNanos);
     } else if (isSlow) {
-      currentFrameMetrics.addSlowFrame(delayNanos);
+      currentFrameMetrics.addSlowFrame(durationNanos, delayNanos);
     } else {
-      currentFrameMetrics.addNormalFrame();
+      currentFrameMetrics.addNormalFrame(durationNanos);
     }
+
+    lastRefreshRate = refreshRate;
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryFrameMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryFrameMetricsTest.kt
@@ -9,21 +9,21 @@ class SentryFrameMetricsTest {
     @Test
     fun addFastFrame() {
         val frameMetrics = SentryFrameMetrics()
-        frameMetrics.addNormalFrame()
+        frameMetrics.addNormalFrame(10)
         assertEquals(1, frameMetrics.normalFrameCount)
 
-        frameMetrics.addNormalFrame()
+        frameMetrics.addNormalFrame(10)
         assertEquals(2, frameMetrics.normalFrameCount)
     }
 
     @Test
     fun addSlowFrame() {
         val frameMetrics = SentryFrameMetrics()
-        frameMetrics.addSlowFrame(100)
+        frameMetrics.addSlowFrame(116, 100)
         assertEquals(1, frameMetrics.slowFrameCount)
         assertEquals(100, frameMetrics.slowFrameDelayNanos)
 
-        frameMetrics.addSlowFrame(100)
+        frameMetrics.addSlowFrame(116, 100)
         assertEquals(2, frameMetrics.slowFrameCount)
         assertEquals(200, frameMetrics.slowFrameDelayNanos)
     }
@@ -31,11 +31,11 @@ class SentryFrameMetricsTest {
     @Test
     fun addFrozenFrame() {
         val frameMetrics = SentryFrameMetrics()
-        frameMetrics.addFrozenFrame(1000)
+        frameMetrics.addFrozenFrame(1016, 1000)
         assertEquals(1, frameMetrics.frozenFrameCount)
         assertEquals(1000, frameMetrics.frozenFrameDelayNanos)
 
-        frameMetrics.addFrozenFrame(1000)
+        frameMetrics.addFrozenFrame(1016, 1000)
         assertEquals(2, frameMetrics.frozenFrameCount)
         assertEquals(2000, frameMetrics.frozenFrameDelayNanos)
     }
@@ -43,18 +43,18 @@ class SentryFrameMetricsTest {
     @Test
     fun totalFrameCount() {
         val frameMetrics = SentryFrameMetrics()
-        frameMetrics.addNormalFrame()
-        frameMetrics.addSlowFrame(100)
-        frameMetrics.addFrozenFrame(1000)
+        frameMetrics.addNormalFrame(10)
+        frameMetrics.addSlowFrame(116, 100)
+        frameMetrics.addFrozenFrame(1016, 1000)
         assertEquals(3, frameMetrics.totalFrameCount)
     }
 
     @Test
     fun duplicate() {
         val frameMetrics = SentryFrameMetrics()
-        frameMetrics.addNormalFrame()
-        frameMetrics.addSlowFrame(100)
-        frameMetrics.addFrozenFrame(1000)
+        frameMetrics.addNormalFrame(10)
+        frameMetrics.addSlowFrame(116, 100)
+        frameMetrics.addFrozenFrame(1016, 1000)
 
         val dup = frameMetrics.duplicate()
         assertEquals(1, dup.normalFrameCount)
@@ -69,17 +69,17 @@ class SentryFrameMetricsTest {
     fun diffTo() {
         // given one fast, 2 slow and 3 frozen frame
         val frameMetricsA = SentryFrameMetrics()
-        frameMetricsA.addNormalFrame()
-        frameMetricsA.addSlowFrame(100)
-        frameMetricsA.addSlowFrame(100)
-        frameMetricsA.addFrozenFrame(1000)
-        frameMetricsA.addFrozenFrame(1000)
-        frameMetricsA.addFrozenFrame(1000)
+        frameMetricsA.addNormalFrame(10)
+        frameMetricsA.addSlowFrame(116, 100)
+        frameMetricsA.addSlowFrame(116, 100)
+        frameMetricsA.addFrozenFrame(1016, 1000)
+        frameMetricsA.addFrozenFrame(1016, 1000)
+        frameMetricsA.addFrozenFrame(1016, 1000)
 
         // when 1 more slow and frozen frame is happening
         val frameMetricsB = frameMetricsA.duplicate()
-        frameMetricsB.addSlowFrame(100)
-        frameMetricsB.addFrozenFrame(1000)
+        frameMetricsB.addSlowFrame(116, 100)
+        frameMetricsB.addFrozenFrame(1016, 1000)
 
         // then the diff only contains the new data
         val diff = frameMetricsB.diffTo(frameMetricsA)
@@ -95,9 +95,9 @@ class SentryFrameMetricsTest {
     @Test
     fun clear() {
         val frameMetrics = SentryFrameMetrics().apply {
-            addNormalFrame()
-            addSlowFrame(100)
-            addFrozenFrame(1000)
+            addNormalFrame(10)
+            addSlowFrame(116, 100)
+            addFrozenFrame(1016, 1000)
         }
 
         frameMetrics.clear()
@@ -112,12 +112,15 @@ class SentryFrameMetricsTest {
 
     @Test
     fun containsValidData() {
+        // when no data is added, it's still valid
         val frameMetrics = SentryFrameMetrics()
-        assertFalse(frameMetrics.containsValidData())
-
-        frameMetrics.addNormalFrame()
         assertTrue(frameMetrics.containsValidData())
 
+        // when a normal frame is added, it's still valid
+        frameMetrics.addNormalFrame(10)
+        assertTrue(frameMetrics.containsValidData())
+
+        // when frame metrics are negative, it's invalid
         val invalidData = SentryFrameMetrics().diffTo(frameMetrics)
         assertFalse(invalidData.containsValidData())
     }


### PR DESCRIPTION
## :scroll: Description

Similar to https://github.com/getsentry/sentry-java/blob/a45911fbaca266a0af3eee9a66bbcfecbfe0b40c/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java#L161-L172 we want to report slow and frozen frame count for transactions, just like we had before.

## :bulb: Motivation and Context

#skip-changelog


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
