### PR TITLE
Set default fingerprint for ANR v2 events to correctly group background and foreground ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - Fix not eligible for auto proxying warnings ([#3154](https://github.com/getsentry/sentry-java/pull/3154))
+- Set default fingerprint for ANRv2 events to correctly group background and foreground ANRs ([#3164](https://github.com/getsentry/sentry-java/pull/3164))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix not eligible for auto proxying warnings ([#3154](https://github.com/getsentry/sentry-java/pull/3154))
 - Set default fingerprint for ANRv2 events to correctly group background and foreground ANRs ([#3164](https://github.com/getsentry/sentry-java/pull/3164))
+  - This will improve grouping of ANRs that have similar stacktraces but differ in background vs foreground state. Only affects newly-ingested ANR events with `mechanism:AppExitInfo`
 
 ### Breaking changes
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -533,6 +533,17 @@ class AnrV2EventProcessorTest {
         assertEquals("ANR", exception.value)
     }
 
+    @Test
+    fun `sets default fingerprint to distinguish between background and foreground ANRs`() {
+        val backgroundHint = HintUtils.createWithTypeCheckHint(AbnormalExitHint(mechanism = "anr_background"))
+        val processedBackground = processEvent(backgroundHint, populateScopeCache = false)
+        assertEquals(listOf("{{ default }}", "background-anr"), processedBackground.fingerprints)
+
+        val foregroundHint = HintUtils.createWithTypeCheckHint(AbnormalExitHint(mechanism = "anr_foreground"))
+        val processedForeground = processEvent(foregroundHint, populateScopeCache = false)
+        assertEquals(listOf("{{ default }}", "foreground-anr"), processedForeground.fingerprints)
+    }
+
     private fun processEvent(
         hint: Hint,
         populateScopeCache: Boolean = false,


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Ideally we would do this server-side, but built-in server-side fingerprint rules are still [WIP](https://github.com/getsentry/sentry/blob/58c2ce2469c5b81ec63a343ae98cb8710e7169d4/src/sentry/conf/server.py#L1552-L1553), so I think we can get away with doing it on the SDK side for now. We only set the fingerprint if user hasn't defined their custom rules to not override them. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Multiple internal reports from customers

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
