### PR TITLE
Apply OkHttp listener auto finish timestamp to all running spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Apply OkHttp listener auto finish timestamp to all running spans ([#3167](https://github.com/getsentry/sentry-java/pull/3167))
 - Fix not eligible for auto proxying warnings ([#3154](https://github.com/getsentry/sentry-java/pull/3154))
 - Set default fingerprint for ANRv2 events to correctly group background and foreground ANRs ([#3164](https://github.com/getsentry/sentry-java/pull/3164))
   - This will improve grouping of ANRs that have similar stacktraces but differ in background vs foreground state. Only affects newly-ingested ANR events with `mechanism:AppExitInfo`

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventTest.kt
@@ -23,6 +23,7 @@ import io.sentry.okhttp.SentryOkHttpEventListener.Companion.REQUEST_HEADERS_EVEN
 import io.sentry.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_BODY_EVENT
 import io.sentry.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_HEADERS_EVENT
 import io.sentry.okhttp.SentryOkHttpEventListener.Companion.SECURE_CONNECT_EVENT
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.getProperty
 import okhttp3.Protocol
 import okhttp3.Request
@@ -31,7 +32,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -39,9 +39,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
-import kotlin.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -255,16 +253,6 @@ class SentryOkHttpEventTest {
     }
 
     @Test
-    fun `when finishEvent, all running spans are finished with internal_error status`() {
-        val sut = fixture.getSut()
-        sut.startSpan("span")
-        val spans = sut.getEventSpans()
-        assertNull(spans["span"]!!.status)
-        sut.finishEvent()
-        assertEquals(SpanStatus.INTERNAL_ERROR, spans["span"]!!.status)
-    }
-
-    @Test
     fun `when finishEvent, does not override running spans status if set`() {
         val sut = fixture.getSut()
         sut.startSpan("span")
@@ -273,6 +261,7 @@ class SentryOkHttpEventTest {
         spans["span"]!!.status = SpanStatus.OK
         assertEquals(SpanStatus.OK, spans["span"]!!.status)
         sut.finishEvent()
+        assertTrue(spans["span"]!!.isFinished)
         assertEquals(SpanStatus.OK, spans["span"]!!.status)
     }
 
@@ -533,18 +522,15 @@ class SentryOkHttpEventTest {
     }
 
     @Test
-    fun `scheduleFinish schedules finishEvent`() {
-        val mockExecutor = mock<ISentryExecutorService>()
-        val captor = argumentCaptor<Runnable>()
-        whenever(mockExecutor.schedule(captor.capture(), any())).then {
-            captor.lastValue.run()
-            mock<Future<Runnable>>()
-        }
-        fixture.hub.options.executorService = mockExecutor
+    fun `scheduleFinish schedules finishEvent and finish running spans to specific timestamp`() {
+        fixture.hub.options.executorService = ImmediateExecutorService()
         val sut = spy(fixture.getSut())
         val timestamp = mock<SentryDate>()
+        sut.startSpan(CONNECTION_EVENT)
         sut.scheduleFinish(timestamp)
         verify(sut).finishEvent(eq(timestamp), anyOrNull())
+        val spans = sut.getEventSpans()
+        assertEquals(timestamp, spans[CONNECTION_EVENT]?.finishDate)
     }
 
     @Test


### PR DESCRIPTION
… to http root call span

## :scroll: Description
scheduled finish timestamp now applies to all running spans, not only to http root call span


## :bulb: Motivation and Context
When the response is not read, we finish the OkHttp span automatically.
We were finishing the root call span at the last http span timestamp, but we were not applying it to all other OkHttp running spans.
[An image is worth more than a thousand words](https://demo.sentry.io/performance/android:c2475d976c3942c296351f558a7dc936/?limit=100&transaction=EmpowerPlantActivity)


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
