### PR TITLE
Avoid multiple breadcrumbs from OkHttpEventListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 
+- Avoid multiple breadcrumbs from OkHttpEventListener ([#3175](https://github.com/getsentry/sentry-java/pull/3175))
 - Apply OkHttp listener auto finish timestamp to all running spans ([#3167](https://github.com/getsentry/sentry-java/pull/3167))
 - Fix not eligible for auto proxying warnings ([#3154](https://github.com/getsentry/sentry-java/pull/3154))
 - Set default fingerprint for ANRv2 events to correctly group background and foreground ANRs ([#3164](https://github.com/getsentry/sentry-java/pull/3164))

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 private const val PROTOCOL_KEY = "protocol"
 private const val ERROR_MESSAGE_KEY = "error_message"
-private const val RESPONSE_BODY_TIMEOUT_MILLIS = 500L
+private const val RESPONSE_BODY_TIMEOUT_MILLIS = 800L
 internal const val TRACE_ORIGIN = "auto.http.okhttp"
 
 @Suppress("TooManyFunctions")
@@ -37,6 +37,7 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
     private var response: Response? = null
     private var clientErrorResponse: Response? = null
     private val isReadingResponseBody = AtomicBoolean(false)
+    private val isEventFinished = AtomicBoolean(false)
 
     init {
         val urlDetails = UrlUtils.parse(request.url.toString())
@@ -138,6 +139,10 @@ internal class SentryOkHttpEvent(private val hub: IHub, private val request: Req
 
     /** Finishes the call root span, and runs [beforeFinish] on it. Then a breadcrumb is sent. */
     fun finishEvent(finishDate: SentryDate? = null, beforeFinish: ((span: ISpan) -> Unit)? = null) {
+        // If the event already finished, we don't do anything
+        if (isEventFinished.getAndSet(true)) {
+            return
+        }
         // We put data in the hint and send a breadcrumb
         val hint = Hint()
         hint.set(TypeCheckHint.OKHTTP_REQUEST, request)

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventTest.kt
@@ -37,6 +37,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.RejectedExecutionException
@@ -250,6 +251,14 @@ class SentryOkHttpEventTest {
                 assertEquals(fixture.mockRequest, it[TypeCheckHint.OKHTTP_REQUEST])
             }
         )
+    }
+
+    @Test
+    fun `when finishEvent multiple times, only one breadcrumb is captured`() {
+        val sut = fixture.getSut()
+        sut.finishEvent()
+        sut.finishEvent()
+        verify(fixture.hub, times(1)).addBreadcrumb(any<Breadcrumb>(), any())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
increased SentryOkHttpEvent.scheduleFinish timeout 500ms -> 800ms
added a guard to avoid finishing an already finished event


## :bulb: Motivation and Context
If an OkHttp event was finished multiple times, multiple breadcrumbs would been sent.
This was possible when the response of a call was closed (or read) after more than 500ms since it was received, as our timeout automatically closes the call after 500ms.
I increased the timeout to 800ms to make it less likely to happen. And I added a flag to skip closing the event if it was already closed.
Likely relates to https://github.com/getsentry/sentry-android-gradle-plugin/issues/617


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
