### PR TITLE
Improve exception grouping on Android for RuntimeExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Report process init time as a span for app start performance ([#3159](https://github.com/getsentry/sentry-java/pull/3159))
 - (perf-v2): Calculate frame delay on a span level ([#3197](https://github.com/getsentry/sentry-java/pull/3197))
 - Resolve spring properties in @SentryCheckIn annotation ([#3194](https://github.com/getsentry/sentry-java/pull/3194))
+- Improve exception grouping for Android RuntimeExceptions ([#3184](https://github.com/getsentry/sentry-java/pull/3184))
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.android.core;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import androidx.annotation.NonNull;
 import io.sentry.DateUtils;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
@@ -15,11 +16,16 @@ import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.protocol.App;
 import io.sentry.protocol.OperatingSystem;
+import io.sentry.protocol.SentryException;
+import io.sentry.protocol.SentryStackFrame;
+import io.sentry.protocol.SentryStackTrace;
 import io.sentry.protocol.SentryThread;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -68,7 +74,49 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     setCommons(event, true, applyScopeData);
 
+    fixExceptionOrder(event);
+
     return event;
+  }
+
+  /**
+   * The last exception is usually used for picking the issue title, but the convention is to send
+   * inner exceptions first, e.g. [inner, outer] This doesn't work very well on Android, as some
+   * hooks like Application.onCreate is wrapped by Android framework with a RuntimeException. Thus,
+   * if the last exception is a RuntimeInit$MethodAndArgsCaller, reverse the order to get a better
+   * issue title. This is a quick fix, for more details see: <a
+   * href="https://github.com/getsentry/sentry/issues/64074">#64074</a> <a
+   * href="https://github.com/getsentry/sentry/issues/59679">#59679</a> <a
+   * href="https://github.com/getsentry/sentry/issues/64088">#64088</a>
+   *
+   * @param event the event to process
+   */
+  private static void fixExceptionOrder(final @NonNull SentryEvent event) {
+    boolean reverseExceptions = false;
+
+    final @Nullable List<SentryException> exceptions = event.getExceptions();
+    if (exceptions != null && exceptions.size() > 1) {
+      final @NotNull SentryException lastException = exceptions.get(exceptions.size() - 1);
+      if ("java.lang".equals(lastException.getModule())) {
+        final @Nullable SentryStackTrace stacktrace = lastException.getStacktrace();
+        if (stacktrace != null) {
+          final @Nullable List<SentryStackFrame> frames = stacktrace.getFrames();
+          if (frames != null) {
+            for (SentryStackFrame frame : frames) {
+              if ("com.android.internal.os.RuntimeInit$MethodAndArgsCaller"
+                  .equals(frame.getModule())) {
+                reverseExceptions = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (reverseExceptions) {
+      Collections.reverse(exceptions);
+    }
   }
 
   private void setCommons(

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3798,8 +3798,11 @@ public final class io/sentry/protocol/Mechanism : io/sentry/JsonSerializable, io
 	public fun <init> (Ljava/lang/Thread;)V
 	public fun getData ()Ljava/util/Map;
 	public fun getDescription ()Ljava/lang/String;
+	public fun getExceptionId ()Ljava/lang/Integer;
 	public fun getHelpLink ()Ljava/lang/String;
+	public fun getIsExceptionGroup ()Ljava/lang/Boolean;
 	public fun getMeta ()Ljava/util/Map;
+	public fun getParentId ()Ljava/lang/Integer;
 	public fun getSynthetic ()Ljava/lang/Boolean;
 	public fun getType ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
@@ -3807,9 +3810,12 @@ public final class io/sentry/protocol/Mechanism : io/sentry/JsonSerializable, io
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setData (Ljava/util/Map;)V
 	public fun setDescription (Ljava/lang/String;)V
+	public fun setExceptionId (Ljava/lang/Integer;)V
 	public fun setHandled (Ljava/lang/Boolean;)V
 	public fun setHelpLink (Ljava/lang/String;)V
+	public fun setIsExceptionGroup (Ljava/lang/Boolean;)V
 	public fun setMeta (Ljava/util/Map;)V
+	public fun setParentId (Ljava/lang/Integer;)V
 	public fun setSynthetic (Ljava/lang/Boolean;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun setUnknown (Ljava/util/Map;)V
@@ -3824,9 +3830,12 @@ public final class io/sentry/protocol/Mechanism$Deserializer : io/sentry/JsonDes
 public final class io/sentry/protocol/Mechanism$JsonKeys {
 	public static final field DATA Ljava/lang/String;
 	public static final field DESCRIPTION Ljava/lang/String;
+	public static final field EXCEPTION_ID Ljava/lang/String;
 	public static final field HANDLED Ljava/lang/String;
 	public static final field HELP_LINK Ljava/lang/String;
+	public static final field IS_EXCEPTION_GROUP Ljava/lang/String;
 	public static final field META Ljava/lang/String;
+	public static final field PARENT_ID Ljava/lang/String;
 	public static final field SYNTHETIC Ljava/lang/String;
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -147,6 +147,11 @@ public final class UncaughtExceptionHandlerIntegration
     final Mechanism mechanism = new Mechanism();
     mechanism.setHandled(false);
     mechanism.setType("UncaughtExceptionHandler");
+
+    // probably should be Android only?
+    if (thrown instanceof RuntimeException) {
+      mechanism.setIsExceptionGroup(true);
+    }
     return new ExceptionMechanismException(mechanism, thrown, thread);
   }
 

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -147,11 +147,6 @@ public final class UncaughtExceptionHandlerIntegration
     final Mechanism mechanism = new Mechanism();
     mechanism.setHandled(false);
     mechanism.setType("UncaughtExceptionHandler");
-
-    // probably should be Android only?
-    if (thrown instanceof RuntimeException) {
-      mechanism.setIsExceptionGroup(true);
-    }
     return new ExceptionMechanismException(mechanism, thrown, thread);
   }
 

--- a/sentry/src/main/java/io/sentry/protocol/Mechanism.java
+++ b/sentry/src/main/java/io/sentry/protocol/Mechanism.java
@@ -68,6 +68,12 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
    */
   private @Nullable Boolean synthetic;
 
+  private @Nullable Boolean isExceptionGroup;
+
+  private @Nullable Integer parentId;
+
+  private @Nullable Integer exceptionId;
+
   @SuppressWarnings("unused")
   private @Nullable Map<String, Object> unknown;
 
@@ -140,6 +146,33 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
     this.synthetic = synthetic;
   }
 
+  @Nullable
+  public Boolean getIsExceptionGroup() {
+    return isExceptionGroup;
+  }
+
+  public void setIsExceptionGroup(@Nullable final Boolean exceptionGroup) {
+    isExceptionGroup = exceptionGroup;
+  }
+
+  @Nullable
+  public Integer getParentId() {
+    return parentId;
+  }
+
+  public void setParentId(@Nullable final Integer parentId) {
+    this.parentId = parentId;
+  }
+
+  @Nullable
+  public Integer getExceptionId() {
+    return exceptionId;
+  }
+
+  public void setExceptionId(@Nullable Integer exceptionId) {
+    this.exceptionId = exceptionId;
+  }
+
   // JsonKeys
 
   public static final class JsonKeys {
@@ -150,6 +183,9 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
     public static final String META = "meta";
     public static final String DATA = "data";
     public static final String SYNTHETIC = "synthetic";
+    public static final String IS_EXCEPTION_GROUP = "is_exception_group";
+    public static final String EXCEPTION_ID = "exception_id";
+    public static final String PARENT_ID = "parent_id";
   }
 
   // JsonUnknown
@@ -190,6 +226,15 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
     }
     if (synthetic != null) {
       writer.name(JsonKeys.SYNTHETIC).value(synthetic);
+    }
+    if (isExceptionGroup != null) {
+      writer.name(JsonKeys.IS_EXCEPTION_GROUP).value(isExceptionGroup);
+    }
+    if (exceptionId != null) {
+      writer.name(JsonKeys.EXCEPTION_ID).value(exceptionId);
+    }
+    if (parentId != null) {
+      writer.name(JsonKeys.PARENT_ID).value(parentId);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -237,6 +282,15 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.SYNTHETIC:
             mechanism.synthetic = reader.nextBooleanOrNull();
+            break;
+          case JsonKeys.IS_EXCEPTION_GROUP:
+            mechanism.isExceptionGroup = reader.nextBooleanOrNull();
+            break;
+          case JsonKeys.EXCEPTION_ID:
+            mechanism.exceptionId = reader.nextIntegerOrNull();
+            break;
+          case JsonKeys.PARENT_ID:
+            mechanism.parentId = reader.nextIntegerOrNull();
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
@@ -178,6 +178,20 @@ class SentryExceptionFactoryTest {
     }
 
     @Test
+    fun `the relationship between exceptions is set`() {
+        val exception = IllegalStateException("outer", IllegalStateException("inner"))
+        val exceptions = fixture.getSut().getSentryExceptions(exception)
+
+        assertFalse(exceptions.isEmpty())
+        assertEquals("inner", exceptions[0].value)
+        assertEquals(1, exceptions[0].mechanism!!.exceptionId)
+        assertEquals(0, exceptions[0].mechanism!!.parentId)
+
+        assertEquals("outer", exceptions[1].value)
+        assertEquals(0, exceptions[1].mechanism!!.exceptionId)
+    }
+
+    @Test
     fun `returns proper exception backfilled from SentryThread`() {
         val thread = SentryThread().apply {
             id = 121

--- a/sentry/src/test/java/io/sentry/protocol/MechanismSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/MechanismSerializationTest.kt
@@ -28,6 +28,9 @@ class MechanismSerializationTest {
                 "0275caba-1fd8-4de3-9ead-b6c8dcdd5666" to "669cc6ad-1435-4233-b199-2800f901bbcd"
             )
             synthetic = false
+            isExceptionGroup = false
+            exceptionId = 1
+            parentId = 0
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/resources/json/mechanism.json
+++ b/sentry/src/test/resources/json/mechanism.json
@@ -11,5 +11,8 @@
     {
         "0275caba-1fd8-4de3-9ead-b6c8dcdd5666": "669cc6ad-1435-4233-b199-2800f901bbcd"
     },
-    "synthetic": false
+    "synthetic": false,
+    "is_exception_group": false,
+    "exception_id": 1,
+    "parent_id": 0
 }


### PR DESCRIPTION
## :scroll: Description
Add `exception_id` and `parent_id` to describe the outer/inner exception relationships. 

Also add `is_exception_group=true` to `java.lang.RuntimeException` - not sure if we should apply this globally or not? Maybe @adinauer can provide some backend feedback here?

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry/issues/64074
This affects exception grouping and determining issue titles, [RFC details are here](https://github.com/getsentry/rfcs/blob/main/text/0079-exception-groups.md#sentry-issue-grouping).

Funny enough the same outcome can be achieved by doing nothing from the above and simply sending the exception->values in reverse order ([right now it's](https://github.com/getsentry/sentry-java/blob/5b57ad1e54e8ab749aabb392f4ce8d6f116215b8/sentry/src/main/java/io/sentry/SentryExceptionFactory.java#L187) `values = [inner, outer]`)


## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
