### PR TITLE
Defaults for Cron - MonitorConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add new threshold parameters to monitor config ([#3181](https://github.com/getsentry/sentry-java/pull/3181))
+- Configurable defaults for Cron - MonitorConfig ([#3195](https://github.com/getsentry/sentry-java/pull/3195))
 
 ## 7.3.0
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -168,7 +168,10 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
-            "sentry.enable-backpressure-handling=true"
+            "sentry.enable-backpressure-handling=true",
+            "sentry.cron.default-checkin-margin=10",
+            "sentry.cron.default-max-runtime=30",
+            "sentry.cron.default-timezone=America/New_York"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -201,6 +204,10 @@ class SentryAutoConfigurationTest {
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(true)
+            assertThat(options.cron).isNotNull
+            assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
+            assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)
+            assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
         }
     }
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -171,7 +171,9 @@ class SentryAutoConfigurationTest {
             "sentry.enable-backpressure-handling=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
-            "sentry.cron.default-timezone=America/New_York"
+            "sentry.cron.default-timezone=America/New_York",
+            "sentry.cron.default-failure-issue-threshold=40",
+            "sentry.cron.default-recovery-threshold=50"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -208,6 +210,8 @@ class SentryAutoConfigurationTest {
             assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
             assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)
             assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
+            assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
+            assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
         }
     }
 

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -168,7 +168,10 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
-            "sentry.enable-backpressure-handling=true"
+            "sentry.enable-backpressure-handling=true",
+            "sentry.cron.default-checkin-margin=10",
+            "sentry.cron.default-max-runtime=30",
+            "sentry.cron.default-timezone=America/New_York"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -201,6 +204,10 @@ class SentryAutoConfigurationTest {
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(true)
+            assertThat(options.cron).isNotNull
+            assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
+            assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)
+            assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
         }
     }
 

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -171,7 +171,9 @@ class SentryAutoConfigurationTest {
             "sentry.enable-backpressure-handling=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
-            "sentry.cron.default-timezone=America/New_York"
+            "sentry.cron.default-timezone=America/New_York",
+            "sentry.cron.default-failure-issue-threshold=40",
+            "sentry.cron.default-recovery-threshold=50"
         ).run {
             val options = it.getBean(SentryProperties::class.java)
             assertThat(options.readTimeoutMillis).isEqualTo(10)
@@ -208,6 +210,8 @@ class SentryAutoConfigurationTest {
             assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
             assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)
             assertThat(options.cron!!.defaultTimezone).isEqualTo("America/New_York")
+            assertThat(options.cron!!.defaultFailureIssueThreshold).isEqualTo(40L)
+            assertThat(options.cron!!.defaultRecoveryThreshold).isEqualTo(50L)
         }
     }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2355,12 +2355,16 @@ public abstract interface class io/sentry/SentryOptions$BeforeSendTransactionCal
 
 public final class io/sentry/SentryOptions$Cron {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)V
 	public fun getDefaultCheckinMargin ()Ljava/lang/Long;
+	public fun getDefaultFailureIssueThreshold ()Ljava/lang/Long;
 	public fun getDefaultMaxRuntime ()Ljava/lang/Long;
+	public fun getDefaultRecoveryThreshold ()Ljava/lang/Long;
 	public fun getDefaultTimezone ()Ljava/lang/String;
 	public fun setDefaultCheckinMargin (Ljava/lang/Long;)V
+	public fun setDefaultFailureIssueThreshold (Ljava/lang/Long;)V
 	public fun setDefaultMaxRuntime (Ljava/lang/Long;)V
+	public fun setDefaultRecoveryThreshold (Ljava/lang/Long;)V
 	public fun setDefaultTimezone (Ljava/lang/String;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2373,7 +2373,6 @@ public abstract interface class io/sentry/SentryOptions$BeforeSendTransactionCal
 
 public final class io/sentry/SentryOptions$Cron {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)V
 	public fun getDefaultCheckinMargin ()Ljava/lang/Long;
 	public fun getDefaultFailureIssueThreshold ()Ljava/lang/Long;
 	public fun getDefaultMaxRuntime ()Ljava/lang/Long;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -315,6 +315,7 @@ public final class io/sentry/ExternalOptions {
 	public static fun from (Lio/sentry/config/PropertiesProvider;Lio/sentry/ILogger;)Lio/sentry/ExternalOptions;
 	public fun getBundleIds ()Ljava/util/Set;
 	public fun getContextTags ()Ljava/util/List;
+	public fun getCron ()Lio/sentry/SentryOptions$Cron;
 	public fun getDebug ()Ljava/lang/Boolean;
 	public fun getDist ()Ljava/lang/String;
 	public fun getDsn ()Ljava/lang/String;
@@ -343,6 +344,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
 	public fun isSendModules ()Ljava/lang/Boolean;
+	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDebug (Ljava/lang/Boolean;)V
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
@@ -2161,6 +2163,7 @@ public class io/sentry/SentryOptions {
 	public fun getConnectionStatusProvider ()Lio/sentry/IConnectionStatusProvider;
 	public fun getConnectionTimeoutMillis ()I
 	public fun getContextTags ()Ljava/util/List;
+	public fun getCron ()Lio/sentry/SentryOptions$Cron;
 	public fun getDateProvider ()Lio/sentry/SentryDateProvider;
 	public fun getDebugMetaLoader ()Lio/sentry/internal/debugmeta/IDebugMetaLoader;
 	public fun getDiagnosticLevel ()Lio/sentry/SentryLevel;
@@ -2261,6 +2264,7 @@ public class io/sentry/SentryOptions {
 	public fun setCacheDirPath (Ljava/lang/String;)V
 	public fun setConnectionStatusProvider (Lio/sentry/IConnectionStatusProvider;)V
 	public fun setConnectionTimeoutMillis (I)V
+	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDateProvider (Lio/sentry/SentryDateProvider;)V
 	public fun setDebug (Z)V
 	public fun setDebugMetaLoader (Lio/sentry/internal/debugmeta/IDebugMetaLoader;)V
@@ -2347,6 +2351,17 @@ public abstract interface class io/sentry/SentryOptions$BeforeSendCallback {
 
 public abstract interface class io/sentry/SentryOptions$BeforeSendTransactionCallback {
 	public abstract fun execute (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
+}
+
+public final class io/sentry/SentryOptions$Cron {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;)V
+	public fun getDefaultCheckinMargin ()Ljava/lang/Long;
+	public fun getDefaultMaxRuntime ()Ljava/lang/Long;
+	public fun getDefaultTimezone ()Ljava/lang/String;
+	public fun setDefaultCheckinMargin (Ljava/lang/Long;)V
+	public fun setDefaultMaxRuntime (Ljava/lang/Long;)V
+	public fun setDefaultTimezone (Ljava/lang/String;)V
 }
 
 public abstract interface class io/sentry/SentryOptions$ProfilesSamplerCallback {

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -51,6 +51,8 @@ public final class ExternalOptions {
   private @Nullable Boolean sendModules;
   private @Nullable Boolean enableBackpressureHandling;
 
+  private @Nullable SentryOptions.Cron cron;
+
   @SuppressWarnings("unchecked")
   public static @NotNull ExternalOptions from(
       final @NotNull PropertiesProvider propertiesProvider, final @NotNull ILogger logger) {
@@ -156,6 +158,15 @@ public final class ExternalOptions {
             ignoredExceptionType);
       }
     }
+
+    final String cronDefaultCheckinMargin = propertiesProvider.getProperty("cron.default-checkin-margin");
+    final String cronDefaultMaxRuntime = propertiesProvider.getProperty("cron.default-max-runtime");
+    final String cronDefaultTimezone = propertiesProvider.getProperty("cron.default-timezone");
+
+    if (cronDefaultCheckinMargin != null || cronDefaultMaxRuntime != null || cronDefaultTimezone != null) {
+      options.setCron(new SentryOptions.Cron(cronDefaultCheckinMargin, cronDefaultMaxRuntime, cronDefaultTimezone));
+    }
+
     return options;
   }
 
@@ -411,5 +422,15 @@ public final class ExternalOptions {
   @ApiStatus.Experimental
   public @Nullable Boolean isEnableBackpressureHandling() {
     return enableBackpressureHandling;
+  }
+
+  @ApiStatus.Experimental
+  public @Nullable SentryOptions.Cron getCron() {
+    return cron;
+  }
+
+  @ApiStatus.Experimental
+  public void setCron(final @Nullable SentryOptions.Cron cron) {
+    this.cron = cron;
   }
 }

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -164,13 +164,23 @@ public final class ExternalOptions {
     final Long cronDefaultMaxRuntime =
         propertiesProvider.getLongProperty("cron.default-max-runtime");
     final String cronDefaultTimezone = propertiesProvider.getProperty("cron.default-timezone");
+    final Long cronDefaultFailureIssueThreshold =
+        propertiesProvider.getLongProperty("cron.default-failure-issue-threshold");
+    final Long cronDefaultRecoveryThreshold =
+        propertiesProvider.getLongProperty("cron.default-recovery-threshold");
 
     if (cronDefaultCheckinMargin != null
         || cronDefaultMaxRuntime != null
-        || cronDefaultTimezone != null) {
+        || cronDefaultTimezone != null
+        || cronDefaultFailureIssueThreshold != null
+        || cronDefaultRecoveryThreshold != null) {
       options.setCron(
           new SentryOptions.Cron(
-              cronDefaultCheckinMargin, cronDefaultMaxRuntime, cronDefaultTimezone));
+              cronDefaultCheckinMargin,
+              cronDefaultMaxRuntime,
+              cronDefaultTimezone,
+              cronDefaultFailureIssueThreshold,
+              cronDefaultRecoveryThreshold));
     }
 
     return options;

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -159,12 +159,18 @@ public final class ExternalOptions {
       }
     }
 
-    final String cronDefaultCheckinMargin = propertiesProvider.getProperty("cron.default-checkin-margin");
-    final String cronDefaultMaxRuntime = propertiesProvider.getProperty("cron.default-max-runtime");
+    final Long cronDefaultCheckinMargin =
+        propertiesProvider.getLongProperty("cron.default-checkin-margin");
+    final Long cronDefaultMaxRuntime =
+        propertiesProvider.getLongProperty("cron.default-max-runtime");
     final String cronDefaultTimezone = propertiesProvider.getProperty("cron.default-timezone");
 
-    if (cronDefaultCheckinMargin != null || cronDefaultMaxRuntime != null || cronDefaultTimezone != null) {
-      options.setCron(new SentryOptions.Cron(cronDefaultCheckinMargin, cronDefaultMaxRuntime, cronDefaultTimezone));
+    if (cronDefaultCheckinMargin != null
+        || cronDefaultMaxRuntime != null
+        || cronDefaultTimezone != null) {
+      options.setCron(
+          new SentryOptions.Cron(
+              cronDefaultCheckinMargin, cronDefaultMaxRuntime, cronDefaultTimezone));
     }
 
     return options;

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -174,13 +174,14 @@ public final class ExternalOptions {
         || cronDefaultTimezone != null
         || cronDefaultFailureIssueThreshold != null
         || cronDefaultRecoveryThreshold != null) {
-      options.setCron(
-          new SentryOptions.Cron(
-              cronDefaultCheckinMargin,
-              cronDefaultMaxRuntime,
-              cronDefaultTimezone,
-              cronDefaultFailureIssueThreshold,
-              cronDefaultRecoveryThreshold));
+      SentryOptions.Cron cron = new SentryOptions.Cron();
+      cron.setDefaultCheckinMargin(cronDefaultCheckinMargin);
+      cron.setDefaultMaxRuntime(cronDefaultMaxRuntime);
+      cron.setDefaultTimezone(cronDefaultTimezone);
+      cron.setDefaultFailureIssueThreshold(cronDefaultFailureIssueThreshold);
+      cron.setDefaultRecoveryThreshold(cronDefaultRecoveryThreshold);
+
+      options.setCron(cron);
     }
 
     return options;

--- a/sentry/src/main/java/io/sentry/MonitorConfig.java
+++ b/sentry/src/main/java/io/sentry/MonitorConfig.java
@@ -21,6 +21,12 @@ public final class MonitorConfig implements JsonUnknown, JsonSerializable {
 
   public MonitorConfig(final @NotNull MonitorSchedule schedule) {
     this.schedule = schedule;
+    final SentryOptions.Cron defaultCron = HubAdapter.getInstance().getOptions().getCron();
+    if (defaultCron != null) {
+      this.checkinMargin = defaultCron.getDefaultCheckinMargin();
+      this.maxRuntime = defaultCron.getDefaultMaxRuntime();
+      this.timezone = defaultCron.getDefaultTimezone();
+    }
   }
 
   public @NotNull MonitorSchedule getSchedule() {

--- a/sentry/src/main/java/io/sentry/MonitorConfig.java
+++ b/sentry/src/main/java/io/sentry/MonitorConfig.java
@@ -26,6 +26,8 @@ public final class MonitorConfig implements JsonUnknown, JsonSerializable {
       this.checkinMargin = defaultCron.getDefaultCheckinMargin();
       this.maxRuntime = defaultCron.getDefaultMaxRuntime();
       this.timezone = defaultCron.getDefaultTimezone();
+      this.failureIssueThreshold = defaultCron.getDefaultFailureIssueThreshold();
+      this.recoveryThreshold = defaultCron.getDefaultRecoveryThreshold();
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2673,23 +2673,6 @@ public class SentryOptions {
     private @Nullable Long defaultFailureIssueThreshold;
     private @Nullable Long defaultRecoveryThreshold;
 
-    public Cron(
-        final @Nullable Long checkinMargin,
-        final @Nullable Long maxRuntime,
-        final @Nullable String timezone,
-        final @Nullable Long failureIssueThreshold,
-        final @Nullable Long recoveryThreshold) {
-      this.defaultCheckinMargin = checkinMargin;
-      this.defaultMaxRuntime = maxRuntime;
-      this.defaultTimezone = timezone;
-      this.defaultFailureIssueThreshold = failureIssueThreshold;
-      this.defaultRecoveryThreshold = recoveryThreshold;
-    }
-
-    public Cron() {
-      this(null, null, null, null, null);
-    }
-
     public @Nullable Long getDefaultCheckinMargin() {
       return defaultCheckinMargin;
     }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -460,6 +460,8 @@ public class SentryOptions {
    */
   private int profilingTracesHz = 101;
 
+  @ApiStatus.Experimental private @Nullable Cron cron = null;
+
   /**
    * Adds an event processor
    *
@@ -2274,6 +2276,16 @@ public class SentryOptions {
     this.sessionFlushTimeoutMillis = sessionFlushTimeoutMillis;
   }
 
+  @ApiStatus.Experimental
+  public @Nullable Cron getCron() {
+    return cron;
+  }
+
+  @ApiStatus.Experimental
+  public void setCron(@Nullable Cron cron) {
+    this.cron = cron;
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -2493,6 +2505,10 @@ public class SentryOptions {
     if (options.isEnableBackpressureHandling() != null) {
       setEnableBackpressureHandling(options.isEnableBackpressureHandling());
     }
+
+    if (options.getCron() != null) {
+      setCron(options.getCron());
+    }
   }
 
   private @NotNull SdkVersion createSdkVersion() {
@@ -2564,6 +2580,45 @@ public class SentryOptions {
 
     public void setPass(final @Nullable String pass) {
       this.pass = pass;
+    }
+  }
+
+  public static final class Cron {
+    private @Nullable String checkinMargin;
+    private @Nullable String maxRuntime;
+    private @Nullable String timezone;
+
+public Cron(
+        final @Nullable String checkinMargin,
+        final @Nullable String maxRuntime,
+        final @Nullable String timezone) {
+      this.checkinMargin = checkinMargin;
+      this.maxRuntime = maxRuntime;
+      this.timezone = timezone;
+    }
+
+    public @Nullable String getCheckinMargin() {
+      return checkinMargin;
+    }
+
+    public void setCheckinMargin(@Nullable String checkinMargin) {
+      this.checkinMargin = checkinMargin;
+    }
+
+    public @Nullable String getMaxRuntime() {
+      return maxRuntime;
+    }
+
+    public void setMaxRuntime(@Nullable String maxRuntime) {
+      this.maxRuntime = maxRuntime;
+    }
+
+    public @Nullable String getTimezone() {
+      return timezone;
+    }
+
+    public void setTimezone(@Nullable String timezone) {
+      this.timezone = timezone;
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2584,45 +2584,45 @@ public class SentryOptions {
   }
 
   public static final class Cron {
-    private @Nullable String checkinMargin;
-    private @Nullable String maxRuntime;
-    private @Nullable String timezone;
+    private @Nullable Long defaultCheckinMargin;
+    private @Nullable Long defaultMaxRuntime;
+    private @Nullable String defaultTimezone;
 
     public Cron(
-        final @Nullable String checkinMargin,
-        final @Nullable String maxRuntime,
+        final @Nullable Long checkinMargin,
+        final @Nullable Long maxRuntime,
         final @Nullable String timezone) {
-      this.checkinMargin = checkinMargin;
-      this.maxRuntime = maxRuntime;
-      this.timezone = timezone;
+      this.defaultCheckinMargin = checkinMargin;
+      this.defaultMaxRuntime = maxRuntime;
+      this.defaultTimezone = timezone;
     }
 
     public Cron() {
       this(null, null, null);
     }
 
-    public @Nullable String getCheckinMargin() {
-      return checkinMargin;
+    public @Nullable Long getDefaultCheckinMargin() {
+      return defaultCheckinMargin;
     }
 
-    public void setCheckinMargin(@Nullable String checkinMargin) {
-      this.checkinMargin = checkinMargin;
+    public void setDefaultCheckinMargin(@Nullable Long defaultCheckinMargin) {
+      this.defaultCheckinMargin = defaultCheckinMargin;
     }
 
-    public @Nullable String getMaxRuntime() {
-      return maxRuntime;
+    public @Nullable Long getDefaultMaxRuntime() {
+      return defaultMaxRuntime;
     }
 
-    public void setMaxRuntime(@Nullable String maxRuntime) {
-      this.maxRuntime = maxRuntime;
+    public void setDefaultMaxRuntime(@Nullable Long defaultMaxRuntime) {
+      this.defaultMaxRuntime = defaultMaxRuntime;
     }
 
-    public @Nullable String getTimezone() {
-      return timezone;
+    public @Nullable String getDefaultTimezone() {
+      return defaultTimezone;
     }
 
-    public void setTimezone(@Nullable String timezone) {
-      this.timezone = timezone;
+    public void setDefaultTimezone(@Nullable String defaultTimezone) {
+      this.defaultTimezone = defaultTimezone;
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2588,13 +2588,17 @@ public class SentryOptions {
     private @Nullable String maxRuntime;
     private @Nullable String timezone;
 
-public Cron(
+    public Cron(
         final @Nullable String checkinMargin,
         final @Nullable String maxRuntime,
         final @Nullable String timezone) {
       this.checkinMargin = checkinMargin;
       this.maxRuntime = maxRuntime;
       this.timezone = timezone;
+    }
+
+    public Cron() {
+      this(null, null, null);
     }
 
     public @Nullable String getCheckinMargin() {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2507,7 +2507,26 @@ public class SentryOptions {
     }
 
     if (options.getCron() != null) {
-      setCron(options.getCron());
+      if (getCron() == null) {
+        setCron(options.getCron());
+      } else {
+        if (options.getCron().getDefaultCheckinMargin() != null) {
+          getCron().setDefaultCheckinMargin(options.getCron().getDefaultCheckinMargin());
+        }
+        if (options.getCron().getDefaultMaxRuntime() != null) {
+          getCron().setDefaultMaxRuntime(options.getCron().getDefaultMaxRuntime());
+        }
+        if (options.getCron().getDefaultTimezone() != null) {
+          getCron().setDefaultTimezone(options.getCron().getDefaultTimezone());
+        }
+        if (options.getCron().getDefaultFailureIssueThreshold() != null) {
+          getCron()
+              .setDefaultFailureIssueThreshold(options.getCron().getDefaultFailureIssueThreshold());
+        }
+        if (options.getCron().getDefaultRecoveryThreshold() != null) {
+          getCron().setDefaultRecoveryThreshold(options.getCron().getDefaultRecoveryThreshold());
+        }
+      }
     }
   }
 
@@ -2587,18 +2606,24 @@ public class SentryOptions {
     private @Nullable Long defaultCheckinMargin;
     private @Nullable Long defaultMaxRuntime;
     private @Nullable String defaultTimezone;
+    private @Nullable Long defaultFailureIssueThreshold;
+    private @Nullable Long defaultRecoveryThreshold;
 
     public Cron(
         final @Nullable Long checkinMargin,
         final @Nullable Long maxRuntime,
-        final @Nullable String timezone) {
+        final @Nullable String timezone,
+        final @Nullable Long failureIssueThreshold,
+        final @Nullable Long recoveryThreshold) {
       this.defaultCheckinMargin = checkinMargin;
       this.defaultMaxRuntime = maxRuntime;
       this.defaultTimezone = timezone;
+      this.defaultFailureIssueThreshold = failureIssueThreshold;
+      this.defaultRecoveryThreshold = recoveryThreshold;
     }
 
     public Cron() {
-      this(null, null, null);
+      this(null, null, null, null, null);
     }
 
     public @Nullable Long getDefaultCheckinMargin() {
@@ -2623,6 +2648,22 @@ public class SentryOptions {
 
     public void setDefaultTimezone(@Nullable String defaultTimezone) {
       this.defaultTimezone = defaultTimezone;
+    }
+
+    public @Nullable Long getDefaultFailureIssueThreshold() {
+      return defaultFailureIssueThreshold;
+    }
+
+    public void setDefaultFailureIssueThreshold(@Nullable Long defaultFailureIssueThreshold) {
+      this.defaultFailureIssueThreshold = defaultFailureIssueThreshold;
+    }
+
+    public @Nullable Long getDefaultRecoveryThreshold() {
+      return defaultRecoveryThreshold;
+    }
+
+    public void setDefaultRecoveryThreshold(@Nullable Long defaultRecoveryThreshold) {
+      this.defaultRecoveryThreshold = defaultRecoveryThreshold;
     }
   }
 

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -277,10 +277,12 @@ class ExternalOptionsTest {
 
     @Test
     fun `creates options with cron defaults`() {
-        withPropertiesFile(listOf("cron.default-checkin-margin=1", "cron.default-max-runtime=30", "cron.default-timezone=America/New_York")) { options ->
+        withPropertiesFile(listOf("cron.default-checkin-margin=1", "cron.default-max-runtime=30", "cron.default-timezone=America/New_York", "cron.default-failure-issue-threshold=40", "cron.default-recovery-threshold=50")) { options ->
             assertEquals(1L, options.cron?.defaultCheckinMargin)
             assertEquals(30L, options.cron?.defaultMaxRuntime)
             assertEquals("America/New_York", options.cron?.defaultTimezone)
+            assertEquals(40L, options.cron?.defaultFailureIssueThreshold)
+            assertEquals(50L, options.cron?.defaultRecoveryThreshold)
         }
     }
 

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -275,6 +275,15 @@ class ExternalOptionsTest {
         }
     }
 
+    @Test
+    fun `creates options with cron defaults`() {
+        withPropertiesFile(listOf("cron.default-checkin-margin=1", "cron.default-max-runtime=30", "cron.default-timezone=America/New_York")) { options ->
+            assertEquals("1", options.cron?.checkinMargin)
+            assertEquals("30", options.cron?.maxRuntime)
+            assertEquals("America/New_York", options.cron?.timezone)
+        }
+    }
+
     private fun withPropertiesFile(textLines: List<String> = emptyList(), logger: ILogger = mock(), fn: (ExternalOptions) -> Unit) {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -278,9 +278,9 @@ class ExternalOptionsTest {
     @Test
     fun `creates options with cron defaults`() {
         withPropertiesFile(listOf("cron.default-checkin-margin=1", "cron.default-max-runtime=30", "cron.default-timezone=America/New_York")) { options ->
-            assertEquals("1", options.cron?.checkinMargin)
-            assertEquals("30", options.cron?.maxRuntime)
-            assertEquals("America/New_York", options.cron?.timezone)
+            assertEquals(1L, options.cron?.defaultCheckinMargin)
+            assertEquals(30L, options.cron?.defaultMaxRuntime)
+            assertEquals("America/New_York", options.cron?.defaultTimezone)
         }
     }
 

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -370,6 +370,7 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.isEnableBackpressureHandling = true
+        externalOptions.cron = SentryOptions.Cron("10", "30", "America/New_York")
 
         val options = SentryOptions()
 
@@ -400,6 +401,10 @@ class SentryOptionsTest {
         assertFalse(options.isSendModules)
         assertEquals(listOf("slug1", "slug-B"), options.ignoredCheckIns)
         assertTrue(options.isEnableBackpressureHandling)
+        assertNotNull(options.cron)
+        assertEquals("10", options.cron?.checkinMargin)
+        assertEquals("30", options.cron?.maxRuntime)
+        assertEquals("America/New_York", options.cron?.timezone)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -370,7 +370,7 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.isEnableBackpressureHandling = true
-        externalOptions.cron = SentryOptions.Cron("10", "30", "America/New_York")
+        externalOptions.cron = SentryOptions.Cron(10L, 30L, "America/New_York")
 
         val options = SentryOptions()
 
@@ -402,9 +402,9 @@ class SentryOptionsTest {
         assertEquals(listOf("slug1", "slug-B"), options.ignoredCheckIns)
         assertTrue(options.isEnableBackpressureHandling)
         assertNotNull(options.cron)
-        assertEquals("10", options.cron?.checkinMargin)
-        assertEquals("30", options.cron?.maxRuntime)
-        assertEquals("America/New_York", options.cron?.timezone)
+        assertEquals(10L, options.cron?.defaultCheckinMargin)
+        assertEquals(30L, options.cron?.defaultMaxRuntime)
+        assertEquals("America/New_York", options.cron?.defaultTimezone)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -370,7 +370,13 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.isEnableBackpressureHandling = true
-        externalOptions.cron = SentryOptions.Cron(10L, 30L, "America/New_York", 40L, 50L)
+        externalOptions.cron = SentryOptions.Cron().apply {
+            defaultCheckinMargin = 10L
+            defaultMaxRuntime = 30L
+            defaultTimezone = "America/New_York"
+            defaultFailureIssueThreshold = 40L
+            defaultRecoveryThreshold = 50L
+        }
 
         val options = SentryOptions()
 
@@ -619,7 +625,13 @@ class SentryOptionsTest {
     @Test
     fun `existing cron defaults are not overridden if not present in external options`() {
         val options = SentryOptions().apply {
-            cron = SentryOptions.Cron(1, 2, "America/New_York", 3, 4)
+            cron = SentryOptions.Cron().apply {
+                defaultCheckinMargin = 1
+                defaultMaxRuntime = 2
+                defaultTimezone = "America/New_York"
+                defaultFailureIssueThreshold = 3
+                defaultRecoveryThreshold = 4
+            }
         }
 
         val externalOptions = ExternalOptions().apply {
@@ -638,11 +650,23 @@ class SentryOptionsTest {
     @Test
     fun `all cron properties set in external options override values set in sentry options`() {
         val options = SentryOptions().apply {
-            cron = SentryOptions.Cron(1, 2, "America/New_York", 3, 4)
+            cron = SentryOptions.Cron().apply {
+                defaultCheckinMargin = 1
+                defaultMaxRuntime = 2
+                defaultTimezone = "America/New_York"
+                defaultFailureIssueThreshold = 3
+                defaultRecoveryThreshold = 4
+            }
         }
 
         val externalOptions = ExternalOptions().apply {
-            cron = SentryOptions.Cron(10, 20, "Europe/Vienna", 30, 40)
+            cron = SentryOptions.Cron().apply {
+                defaultCheckinMargin = 10
+                defaultMaxRuntime = 20
+                defaultTimezone = "Europe/Vienna"
+                defaultFailureIssueThreshold = 30
+                defaultRecoveryThreshold = 40
+            }
         }
 
         options.merge(externalOptions)

--- a/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
@@ -6,11 +6,13 @@ import io.sentry.MonitorConfig
 import io.sentry.MonitorSchedule
 import io.sentry.MonitorScheduleUnit
 import io.sentry.Sentry
+import io.sentry.SentryOptions
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.lang.AssertionError
 import java.lang.RuntimeException
 import kotlin.test.Test
@@ -56,6 +58,7 @@ class CheckInUtilsTest {
         Mockito.mockStatic(Sentry::class.java).use { sentry ->
             val hub = mock<IHub>()
             sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            whenever(hub.options).thenReturn(SentryOptions())
             val returnValue = CheckInUtils.withCheckIn("monitor-1") {
                 return@withCheckIn "test1"
             }
@@ -121,6 +124,7 @@ class CheckInUtilsTest {
         Mockito.mockStatic(Sentry::class.java).use { sentry ->
             val hub = mock<IHub>()
             sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            whenever(hub.options).thenReturn(SentryOptions())
             val monitorConfig = MonitorConfig(MonitorSchedule.interval(7, MonitorScheduleUnit.DAY))
             val returnValue = CheckInUtils.withCheckIn("monitor-1", monitorConfig) {
                 "test1"
@@ -153,6 +157,7 @@ class CheckInUtilsTest {
         Mockito.mockStatic(Sentry::class.java).use { sentry ->
             val hub = mock<IHub>()
             sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            whenever(hub.options).thenReturn(SentryOptions())
             val monitorConfig = MonitorConfig(MonitorSchedule.interval(7, MonitorScheduleUnit.DAY)).apply {
                 failureIssueThreshold = 10
                 recoveryThreshold = 20
@@ -180,6 +185,56 @@ class CheckInUtilsTest {
                 )
                 verify(hub).popScope()
             }
+        }
+    }
+
+    @Test
+    fun `sets defaults for MonitorConfig from SentryOptions`() {
+        Mockito.mockStatic(Sentry::class.java).use { sentry ->
+            val hub = mock<IHub>()
+            sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            whenever(hub.options).thenReturn(
+                SentryOptions().apply {
+                    cron = SentryOptions.Cron().apply {
+                        defaultCheckinMargin = 20
+                        defaultMaxRuntime = 50
+                        defaultTimezone = "America/New_York"
+                    }
+                }
+            )
+
+            val monitorConfig = MonitorConfig(MonitorSchedule.interval(7, MonitorScheduleUnit.DAY))
+
+            assertEquals(20, monitorConfig.checkinMargin)
+            assertEquals(50, monitorConfig.maxRuntime)
+            assertEquals("America/New_York", monitorConfig.timezone)
+        }
+    }
+
+    @Test
+    fun `defaults for MonitorConfig from SentryOptions can be overridden`() {
+        Mockito.mockStatic(Sentry::class.java).use { sentry ->
+            val hub = mock<IHub>()
+            sentry.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(hub)
+            whenever(hub.options).thenReturn(
+                SentryOptions().apply {
+                    cron = SentryOptions.Cron().apply {
+                        defaultCheckinMargin = 20
+                        defaultMaxRuntime = 50
+                        defaultTimezone = "America/New_York"
+                    }
+                }
+            )
+
+            val monitorConfig = MonitorConfig(MonitorSchedule.interval(7, MonitorScheduleUnit.DAY)).apply {
+                checkinMargin = 10
+                maxRuntime = 30
+                timezone = "America/Los_Angeles"
+            }
+
+            assertEquals(10, monitorConfig.checkinMargin)
+            assertEquals(30, monitorConfig.maxRuntime)
+            assertEquals("America/Los_Angeles", monitorConfig.timezone)
         }
     }
 }

--- a/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CheckInUtilsTest.kt
@@ -197,8 +197,10 @@ class CheckInUtilsTest {
                 SentryOptions().apply {
                     cron = SentryOptions.Cron().apply {
                         defaultCheckinMargin = 20
-                        defaultMaxRuntime = 50
+                        defaultMaxRuntime = 30
                         defaultTimezone = "America/New_York"
+                        defaultFailureIssueThreshold = 40
+                        defaultRecoveryThreshold = 50
                     }
                 }
             )
@@ -206,8 +208,10 @@ class CheckInUtilsTest {
             val monitorConfig = MonitorConfig(MonitorSchedule.interval(7, MonitorScheduleUnit.DAY))
 
             assertEquals(20, monitorConfig.checkinMargin)
-            assertEquals(50, monitorConfig.maxRuntime)
+            assertEquals(30, monitorConfig.maxRuntime)
             assertEquals("America/New_York", monitorConfig.timezone)
+            assertEquals(40, monitorConfig.failureIssueThreshold)
+            assertEquals(50, monitorConfig.recoveryThreshold)
         }
     }
 


### PR DESCRIPTION
## :scroll: Description
Allow configuring global default values for  `checkinMargin`, `maxRuntime`, `timezone`, `recoveryThreshold` and `failureIssueThreshold` of `MonitorConfig` through `SentryOptions`.


## :bulb: Motivation and Context
Fixes #3122 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
