### PR TITLE
Don't wait on main thread when SDK restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add new threshold parameters to monitor config ([#3181](https://github.com/getsentry/sentry-java/pull/3181))
 
+### Fixes
+
+- Don't wait on main thread when SDK restarts ([#3200](https://github.com/getsentry/sentry-java/pull/3200))
+
 ## 7.3.0
 
 ### Features

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -54,6 +54,10 @@ class InternalSentrySdkTest {
                 options.dsn = "https://key@host/proj"
                 options.setTransportFactory { _, _ ->
                     object : ITransport {
+                        override fun close(isRestarting: Boolean) {
+                            // no-op
+                        }
+
                         override fun close() {
                             // no-op
                         }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
@@ -133,6 +133,10 @@ class SessionTrackingIntegrationTest {
             TODO("Not yet implemented")
         }
 
+        override fun close(isRestarting: Boolean) {
+            TODO("Not yet implemented")
+        }
+
         override fun close() {
             TODO("Not yet implemented")
         }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -1,6 +1,5 @@
 package io.sentry.uitest.android
 
-import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso
@@ -199,7 +198,6 @@ class EnvelopeTests : BaseUiTest() {
 
         relay.assert {
             findEnvelope {
-                Log.e("ITEMS", it.items.joinToString { item -> item.header.type.itemType })
                 assertEnvelopeTransaction(it.items.toList(), AndroidLogger()).transaction == "timedOutProfile"
             }.assert {
                 val transactionItem: SentryTransaction = it.assertTransaction()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -136,6 +136,7 @@ class SdkInitTests : BaseUiTest() {
 
         initSentry(true) { options: SentryAndroidOptions ->
             options.tracesSampleRate = 1.0
+            options.flushTimeoutMillis = 3000
         }
 
         Sentry.startTransaction("beforeRestart", "emptyTransaction").finish()
@@ -154,7 +155,7 @@ class SdkInitTests : BaseUiTest() {
         val restartMs = afterRestart - beforeRestart
 
         Sentry.startTransaction("afterRestart", "emptyTransaction").finish()
-        assertTrue(restartMs > 2000, "Expected more than 2000 ms for SDK close and restart. Got $restartMs ms")
+        assertTrue(restartMs > 3000, "Expected more than 3000 ms for SDK close and restart. Got $restartMs ms")
 
         relay.assert {
             findEnvelope {

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -104,7 +104,8 @@ class SdkInitTests : BaseUiTest() {
         val restartMs = afterRestart - beforeRestart
 
         Sentry.startTransaction("afterRestart", "emptyTransaction").finish()
-        assertTrue(restartMs < 250, "Expected less than 250 ms for SDK restart. Got $restartMs ms")
+        // We assert for less than 1 second just to account for slow devices in saucelabs or headless emulator
+        assertTrue(restartMs < 1000, "Expected less than 1000 ms for SDK restart. Got $restartMs ms")
 
         relay.assert {
             findEnvelope {

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/SdkInitTests.kt
@@ -91,6 +91,9 @@ class SdkInitTests : BaseUiTest() {
 
         Sentry.startTransaction("beforeRestart", "emptyTransaction").finish()
 
+        // We want the SDK to start sending the event. If we don't wait, it's possible we don't send anything before the SDK is restarted
+        Thread.sleep(500)
+
         val beforeRestart = System.currentTimeMillis()
         // We restart the SDK. This shouldn't block the main thread, but new options (e.g. profiling) should work
         initSentry(false) { options: SentryAndroidOptions ->
@@ -140,6 +143,9 @@ class SdkInitTests : BaseUiTest() {
         }
 
         Sentry.startTransaction("beforeRestart", "emptyTransaction").finish()
+
+        // We want the SDK to start sending the event. If we don't wait, it's possible we don't send anything before the SDK is restarted
+        Thread.sleep(500)
 
         val beforeRestart = System.currentTimeMillis()
         Sentry.close()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -6,6 +6,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import okhttp3.mockwebserver.SocketPolicy
 import kotlin.test.assertNotNull
 
 /** Mocks a relay server. */
@@ -32,21 +33,21 @@ class MockRelay(
     init {
         relay.dispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
-                // If a request with a body size of 0 is received, we drop it.
-                // This shouldn't happen in reality, but it rarely happens in tests.
-                if (request.bodySize == 0L || request.failure != null) {
-                    return MockResponse()
-                }
                 // We check if there is any custom response previously set to return to this request,
                 // otherwise we return a successful MockResponse.
-                val response = responses.asSequence()
-                    .mapNotNull { it(request) }
-                    .firstOrNull()
-                    ?: MockResponse()
+                val response = responses.removeFirstOrNull()?.let { it(request) } ?: MockResponse()
 
                 // We should receive only envelopes on this path.
                 if (request.path == envelopePath) {
                     val relayResponse = RelayAsserter.RelayResponse(request, response)
+                    // If we reply with NO_RESPONSE, we can ignore the request, so we can return here
+                    if (relayResponse.envelope == null || response.socketPolicy == SocketPolicy.NO_RESPONSE) {
+                        // If we are waiting for requests to be received, we decrement the associated counter.
+                        if (waitForRequests) {
+                            relayIdlingResource.decrement()
+                        }
+                        return response
+                    }
                     assertNotNull(relayResponse.envelope)
                     val envelopeId: String = relayResponse.envelope!!.header.eventId!!.toString()
                     // If we already received the envelope (e.g. retrying mechanism) we drop it
@@ -88,6 +89,13 @@ class MockRelay(
         // Responses are added to the beginning of the list so they'll take precedence over
         // previously added ones.
         responses.add(0, response)
+    }
+
+    /** Add a custom response to be returned at the next request received. */
+    fun addTimeoutResponse() {
+        addResponse {
+            MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)
+        }
     }
 
     /** Add a custom response to be returned at the next request received, if it satisfies the [filter]. */

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/MockRelay.kt
@@ -50,7 +50,7 @@ class MockRelay(
                     }
                     assertNotNull(relayResponse.envelope)
                     val envelopeId: String = relayResponse.envelope!!.header.eventId!!.toString()
-                    // If we already received the envelope (e.g. retrying mechanism) we drop it
+                    // If we already received the envelope (e.g. retrying mechanism) we ignore it
                     if (receivedEnvelopes.contains(envelopeId)) {
                         return MockResponse()
                     }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/RelayAsserter.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/RelayAsserter.kt
@@ -40,7 +40,11 @@ class RelayAsserter(
         filter: (envelope: SentryEnvelope) -> Boolean = { true }
     ): RelayResponse {
         val relayResponseIndex = unassertedEnvelopes.indexOfFirst { it.envelope?.let(filter) ?: false }
-        if (relayResponseIndex == -1) throw AssertionError("No envelope request found with specified filter")
+        if (relayResponseIndex == -1) {
+            throw AssertionError("No envelope request found with specified filter.\n" +
+                "There was a total of ${originalUnassertedEnvelopes.size} envelopes: " +
+                originalUnassertedEnvelopes.joinToString { describeEnvelope(it.envelope!!) })
+        }
         return unassertedEnvelopes.removeAt(relayResponseIndex)
     }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/RelayAsserter.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/mockservers/RelayAsserter.kt
@@ -41,9 +41,11 @@ class RelayAsserter(
     ): RelayResponse {
         val relayResponseIndex = unassertedEnvelopes.indexOfFirst { it.envelope?.let(filter) ?: false }
         if (relayResponseIndex == -1) {
-            throw AssertionError("No envelope request found with specified filter.\n" +
-                "There was a total of ${originalUnassertedEnvelopes.size} envelopes: " +
-                originalUnassertedEnvelopes.joinToString { describeEnvelope(it.envelope!!) })
+            throw AssertionError(
+                "No envelope request found with specified filter.\n" +
+                    "There was a total of ${originalUnassertedEnvelopes.size} envelopes: " +
+                    originalUnassertedEnvelopes.joinToString { describeEnvelope(it.envelope!!) }
+            )
         }
         return unassertedEnvelopes.removeAt(relayResponseIndex)
     }

--- a/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
+++ b/sentry-apache-http-client-5/api/sentry-apache-http-client-5.api
@@ -1,6 +1,7 @@
 public final class io/sentry/transport/apache/ApacheHttpClientTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/RequestDetails;Lorg/apache/hc/client5/http/impl/async/CloseableHttpAsyncClient;Lio/sentry/transport/RateLimiter;)V
 	public fun close ()V
+	public fun close (Z)V
 	public fun flush (J)V
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V

--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransport.java
@@ -196,9 +196,14 @@ public final class ApacheHttpClientTransport implements ITransport {
 
   @Override
   public void close() throws IOException {
+    close(false);
+  }
+
+  @Override
+  public void close(final boolean isRestarting) throws IOException {
     options.getLogger().log(DEBUG, "Shutting down");
     try {
-      httpclient.awaitShutdown(TimeValue.ofSeconds(1));
+      httpclient.awaitShutdown(TimeValue.ofSeconds(isRestarting ? 0 : 1));
     } catch (InterruptedException e) {
       options.getLogger().log(DEBUG, "Thread interrupted while closing the connection.");
       Thread.currentThread().interrupt();

--- a/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
+++ b/sentry-apache-http-client-5/src/test/kotlin/io/sentry/transport/apache/ApacheHttpClientTransportTest.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class ApacheHttpClientTransportTest {
 
@@ -116,7 +117,21 @@ class ApacheHttpClientTransportTest {
     fun `close waits for shutdown`() {
         val sut = fixture.getSut()
         sut.close()
-        verify(fixture.client).awaitShutdown(any())
+        verify(fixture.client).awaitShutdown(check { assertNotEquals(0L, it.duration) })
+    }
+
+    @Test
+    fun `close with isRestarting false waits for shutdown`() {
+        val sut = fixture.getSut()
+        sut.close(false)
+        verify(fixture.client).awaitShutdown(check { assertNotEquals(0L, it.duration) })
+    }
+
+    @Test
+    fun `close with isRestarting true does not wait for shutdown`() {
+        val sut = fixture.getSut()
+        sut.close(true)
+        verify(fixture.client).awaitShutdown(check { assertEquals(0L, it.duration) })
     }
 
     @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -427,6 +427,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun clone ()Lio/sentry/IHub;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun close ()V
+	public fun close (Z)V
 	public fun configureScope (Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
@@ -477,6 +478,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun clone ()Lio/sentry/IHub;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun close ()V
+	public fun close (Z)V
 	public fun configureScope (Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
@@ -567,6 +569,7 @@ public abstract interface class io/sentry/IHub {
 	public abstract fun clearBreadcrumbs ()V
 	public abstract fun clone ()Lio/sentry/IHub;
 	public abstract fun close ()V
+	public abstract fun close (Z)V
 	public abstract fun configureScope (Lio/sentry/ScopeCallback;)V
 	public abstract fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public abstract fun endSession ()V
@@ -732,6 +735,7 @@ public abstract interface class io/sentry/ISentryClient {
 	public abstract fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/IScope;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public abstract fun close ()V
+	public abstract fun close (Z)V
 	public abstract fun flush (J)V
 	public abstract fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public abstract fun isEnabled ()Z
@@ -1131,6 +1135,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun clone ()Lio/sentry/IHub;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun close ()V
+	public fun close (Z)V
 	public fun configureScope (Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
@@ -1849,6 +1854,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/IScope;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun close ()V
+	public fun close (Z)V
 	public fun flush (J)V
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun isEnabled ()Z
@@ -4536,6 +4542,7 @@ public final class io/sentry/transport/AsyncHttpTransport : io/sentry/transport/
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/RequestDetails;)V
 	public fun <init> (Lio/sentry/transport/QueuedThreadPoolExecutor;Lio/sentry/SentryOptions;Lio/sentry/transport/RateLimiter;Lio/sentry/transport/ITransportGate;Lio/sentry/transport/HttpConnection;)V
 	public fun close ()V
+	public fun close (Z)V
 	public fun flush (J)V
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun isHealthy ()Z
@@ -4552,6 +4559,7 @@ public abstract interface class io/sentry/transport/ICurrentDateProvider {
 }
 
 public abstract interface class io/sentry/transport/ITransport : java/io/Closeable {
+	public abstract fun close (Z)V
 	public abstract fun flush (J)V
 	public abstract fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun isHealthy ()Z
@@ -4573,6 +4581,7 @@ public final class io/sentry/transport/NoOpEnvelopeCache : io/sentry/cache/IEnve
 
 public final class io/sentry/transport/NoOpTransport : io/sentry/transport/ITransport {
 	public fun close ()V
+	public fun close (Z)V
 	public fun flush (J)V
 	public static fun getInstance ()Lio/sentry/transport/NoOpTransport;
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
@@ -4606,6 +4615,7 @@ public final class io/sentry/transport/ReusableCountLatch {
 public final class io/sentry/transport/StdoutTransport : io/sentry/transport/ITransport {
 	public fun <init> (Lio/sentry/ISerializer;)V
 	public fun close ()V
+	public fun close (Z)V
 	public fun flush (J)V
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun send (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -331,6 +331,12 @@ public final class Hub implements IHub {
 
   @Override
   public void close() {
+    close(false);
+  }
+
+  @Override
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void close(final boolean isRestarting) {
     if (!isEnabled()) {
       options
           .getLogger()
@@ -352,12 +358,17 @@ public final class Hub implements IHub {
         configureScope(scope -> scope.clear());
         options.getTransactionProfiler().close();
         options.getTransactionPerformanceCollector().close();
-        options.getExecutorService().close(options.getShutdownTimeoutMillis());
+        final @NotNull ISentryExecutorService executorService = options.getExecutorService();
+        if (isRestarting) {
+          executorService.submit(() -> executorService.close(options.getShutdownTimeoutMillis()));
+        } else {
+          executorService.close(options.getShutdownTimeoutMillis());
+        }
 
         // Close the top-most client
         final StackItem item = stack.peek();
         // TODO: should we end session before closing client?
-        item.getClient().close();
+        item.getClient().close(isRestarting);
       } catch (Throwable e) {
         options.getLogger().log(SentryLevel.ERROR, "Error while closing the Hub.", e);
       }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -79,6 +79,11 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
+  public void close(final boolean isRestarting) {
+    Sentry.close();
+  }
+
+  @Override
   public void close() {
     Sentry.close();
   }

--- a/sentry/src/main/java/io/sentry/IHub.java
+++ b/sentry/src/main/java/io/sentry/IHub.java
@@ -192,6 +192,13 @@ public interface IHub {
   void close();
 
   /**
+   * Flushes out the queue for up to timeout seconds and disable the Hub.
+   *
+   * @param isRestarting if true, avoids locking the main thread when finishing the queue.
+   */
+  void close(boolean isRestarting);
+
+  /**
    * Adds a breadcrumb to the current Scope
    *
    * @param breadcrumb the breadcrumb

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -33,6 +33,13 @@ public interface ISentryClient {
   void close();
 
   /**
+   * Flushes out the queue for up to timeout seconds and disable the client.
+   *
+   * @param isRestarting if true, avoids locking the main thread when finishing the queue.
+   */
+  void close(boolean isRestarting);
+
+  /**
    * Flushes events queued up, but keeps the client enabled. Not implemented yet.
    *
    * @param timeoutMillis time in milliseconds

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -77,6 +77,9 @@ public final class NoOpHub implements IHub {
   public void close() {}
 
   @Override
+  public void close(final boolean isRestarting) {}
+
+  @Override
   public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hint hint) {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -29,6 +29,9 @@ final class NoOpSentryClient implements ISentryClient {
   }
 
   @Override
+  public void close(final boolean isRestarting) {}
+
+  @Override
   public void close() {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -237,7 +237,7 @@ public final class Sentry {
 
     currentHub.set(mainHub);
 
-    hub.close();
+    hub.close(true);
 
     // If the executorService passed in the init is the same that was previously closed, we have to
     // set a new one
@@ -484,7 +484,7 @@ public final class Sentry {
     mainHub = NoOpHub.getInstance();
     // remove thread local to avoid memory leak
     currentHub.remove();
-    hub.close();
+    hub.close(false);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -903,11 +903,16 @@ public final class SentryClient implements ISentryClient {
 
   @Override
   public void close() {
+    close(false);
+  }
+
+  @Override
+  public void close(final boolean isRestarting) {
     options.getLogger().log(SentryLevel.INFO, "Closing SentryClient.");
 
     try {
-      flush(options.getShutdownTimeoutMillis());
-      transport.close();
+      flush(isRestarting ? 0 : options.getShutdownTimeoutMillis());
+      transport.close(isRestarting);
     } catch (IOException e) {
       options
           .getLogger()

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -163,10 +163,16 @@ public final class AsyncHttpTransport implements ITransport {
 
   @Override
   public void close() throws IOException {
+    close(false);
+  }
+
+  @Override
+  public void close(final boolean isRestarting) throws IOException {
     executor.shutdown();
     options.getLogger().log(SentryLevel.DEBUG, "Shutting down");
     try {
-      if (!executor.awaitTermination(options.getFlushTimeoutMillis(), TimeUnit.MILLISECONDS)) {
+      if (!executor.awaitTermination(
+          isRestarting ? 0 : options.getFlushTimeoutMillis(), TimeUnit.MILLISECONDS)) {
         options
             .getLogger()
             .log(

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -171,13 +171,14 @@ public final class AsyncHttpTransport implements ITransport {
     executor.shutdown();
     options.getLogger().log(SentryLevel.DEBUG, "Shutting down");
     try {
-      if (!executor.awaitTermination(
-          isRestarting ? 0 : options.getFlushTimeoutMillis(), TimeUnit.MILLISECONDS)) {
+      // We need a small timeout to be able to save to disk any rejected envelope
+      long timeout = isRestarting ? 200 : options.getFlushTimeoutMillis();
+      if (!executor.awaitTermination(timeout, TimeUnit.MILLISECONDS)) {
         options
             .getLogger()
             .log(
                 SentryLevel.WARNING,
-                "Failed to shutdown the async connection async sender within 1 minute. Trying to force it now.");
+                "Failed to shutdown the async connection async sender  within " + timeout + " ms. Trying to force it now.");
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {

--- a/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/AsyncHttpTransport.java
@@ -178,7 +178,9 @@ public final class AsyncHttpTransport implements ITransport {
             .getLogger()
             .log(
                 SentryLevel.WARNING,
-                "Failed to shutdown the async connection async sender  within " + timeout + " ms. Trying to force it now.");
+                "Failed to shutdown the async connection async sender  within "
+                    + timeout
+                    + " ms. Trying to force it now.");
         executor.shutdownNow();
       }
     } catch (InterruptedException e) {

--- a/sentry/src/main/java/io/sentry/transport/ITransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ITransport.java
@@ -28,4 +28,11 @@ public interface ITransport extends Closeable {
 
   @Nullable
   RateLimiter getRateLimiter();
+
+  /**
+   * Closes the transport.
+   *
+   * @param isRestarting if true, avoids locking the main thread by dropping the current connection.
+   */
+  void close(boolean isRestarting) throws IOException;
 }

--- a/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/NoOpTransport.java
@@ -32,4 +32,7 @@ public final class NoOpTransport implements ITransport {
 
   @Override
   public void close() throws IOException {}
+
+  @Override
+  public void close(final boolean isRestarting) throws IOException {}
 }

--- a/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
+++ b/sentry/src/main/java/io/sentry/transport/StdoutTransport.java
@@ -41,4 +41,7 @@ public final class StdoutTransport implements ITransport {
 
   @Override
   public void close() {}
+
+  @Override
+  public void close(final boolean isRestarting) {}
 }

--- a/sentry/src/test/java/io/sentry/HubAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/HubAdapterTest.kt
@@ -93,7 +93,17 @@ class HubAdapterTest {
 
     @Test fun `close calls Hub`() {
         HubAdapter.getInstance().close()
-        verify(hub).close()
+        verify(hub).close(false)
+    }
+
+    @Test fun `close with isRestarting true calls Hub with isRestarting false`() {
+        HubAdapter.getInstance().close(true)
+        verify(hub).close(false)
+    }
+
+    @Test fun `close with isRestarting false calls Hub with isRestarting false`() {
+        HubAdapter.getInstance().close(false)
+        verify(hub).close(false)
     }
 
     @Test fun `addBreadcrumb calls Hub`() {

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -10,6 +10,7 @@ import io.sentry.hints.SessionStartHint
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.test.DeferredExecutorService
 import io.sentry.test.callMethod
 import io.sentry.util.HintUtils
 import io.sentry.util.StringUtils
@@ -774,7 +775,7 @@ class HubTest {
         sut.close()
 
         sut.close()
-        verify(mockClient).close() // 1 to close, but next one wont be recorded
+        verify(mockClient).close(eq(false)) // 1 to close, but next one wont be recorded
     }
 
     @Test
@@ -782,7 +783,23 @@ class HubTest {
         val (sut, mockClient) = getEnabledHub()
 
         sut.close()
-        verify(mockClient).close()
+        verify(mockClient).close(eq(false))
+    }
+
+    @Test
+    fun `when close is called with isRestarting false and client is alive, close on the client should be called with isRestarting false`() {
+        val (sut, mockClient) = getEnabledHub()
+
+        sut.close(false)
+        verify(mockClient).close(eq(false))
+    }
+
+    @Test
+    fun `when close is called with isRestarting true and client is alive, close on the client should be called with isRestarting true`() {
+        val (sut, mockClient) = getEnabledHub()
+
+        sut.close(true)
+        verify(mockClient).close(eq(true))
     }
     //endregion
 
@@ -1650,6 +1667,32 @@ class HubTest {
         verify(executor).close(any())
         verify(profiler).close()
         verify(performanceCollector).close()
+    }
+
+    @Test
+    fun `Hub with isRestarting true should close the sentry executor in the background`() {
+        val executor = spy(DeferredExecutorService())
+        val options = SentryOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+            executorService = executor
+        }
+        val sut = Hub(options)
+        sut.close(true)
+        verify(executor, never()).close(any())
+        executor.runAll()
+        verify(executor).close(any())
+    }
+
+    @Test
+    fun `Hub with isRestarting false should close the sentry executor in the background`() {
+        val executor = mock<ISentryExecutorService>()
+        val options = SentryOptions().apply {
+            dsn = "https://key@sentry.io/proj"
+            executorService = executor
+        }
+        val sut = Hub(options)
+        sut.close(false)
+        verify(executor).close(any())
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -47,6 +47,18 @@ class NoOpHubTest {
     }
 
     @Test
+    fun `close with isRestarting true does not affect captureEvent`() {
+        sut.close(true)
+        assertEquals(SentryId.EMPTY_ID, sut.captureEvent(SentryEvent()))
+    }
+
+    @Test
+    fun `close with isRestarting false does not affect captureEvent`() {
+        sut.close(false)
+        assertEquals(SentryId.EMPTY_ID, sut.captureEvent(SentryEvent()))
+    }
+
+    @Test
     fun `close does not affect captureException`() {
         sut.close()
         assertEquals(SentryId.EMPTY_ID, sut.captureException(RuntimeException()))

--- a/sentry/src/test/java/io/sentry/NoOpSentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpSentryClientTest.kt
@@ -36,6 +36,18 @@ class NoOpSentryClientTest {
     }
 
     @Test
+    fun `close with isRestarting true does not affect captureEvent`() {
+        sut.close(true)
+        assertEquals(SentryId.EMPTY_ID, sut.callMethod("captureEvent", SentryEvent::class.java, null))
+    }
+
+    @Test
+    fun `close with isRestarting false does not affect captureEvent`() {
+        sut.close(false)
+        assertEquals(SentryId.EMPTY_ID, sut.callMethod("captureEvent", SentryEvent::class.java, null))
+    }
+
+    @Test
     fun `close does not affect captureException`() {
         sut.close()
         assertEquals(SentryId.EMPTY_ID, sut.callMethod("captureException", Throwable::class.java, null))

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -139,6 +139,25 @@ class SentryClientTest {
     }
 
     @Test
+    fun `when client is closed with isRestarting false, transport waits`() {
+        val sut = fixture.getSut()
+        assertTrue(sut.isEnabled)
+        sut.close(false)
+        assertNotEquals(0, fixture.sentryOptions.shutdownTimeoutMillis)
+        verify(fixture.transport).flush(eq(fixture.sentryOptions.shutdownTimeoutMillis))
+        verify(fixture.transport).close(eq(false))
+    }
+
+    @Test
+    fun `when client is closed with isRestarting true, transport does not wait`() {
+        val sut = fixture.getSut()
+        assertTrue(sut.isEnabled)
+        sut.close(true)
+        verify(fixture.transport).flush(eq(0))
+        verify(fixture.transport).close(eq(true))
+    }
+
+    @Test
     fun `when client is closed, client gets disabled`() {
         val sut = fixture.getSut()
         assertTrue(sut.isEnabled)

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -63,6 +63,30 @@ class SentryTest {
     }
 
     @Test
+    fun `init multiple times calls hub close with isRestarting true`() {
+        val hub = mock<IHub>()
+        Sentry.init {
+            it.dsn = dsn
+        }
+        Sentry.setCurrentHub(hub)
+        Sentry.init {
+            it.dsn = dsn
+        }
+        verify(hub).close(eq(true))
+    }
+
+    @Test
+    fun `close calls hub close with isRestarting false`() {
+        val hub = mock<IHub>()
+        Sentry.init {
+            it.dsn = dsn
+        }
+        Sentry.setCurrentHub(hub)
+        Sentry.close()
+        verify(hub).close(eq(false))
+    }
+
+    @Test
     fun `outboxPath should be created at initialization`() {
         var sentryOptions: SentryOptions? = null
         Sentry.init {

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -337,6 +337,24 @@ class AsyncHttpTransportTest {
     }
 
     @Test
+    fun `close with isRestarting false uses flushTimeoutMillis option to schedule termination`() {
+        fixture.sentryOptions.flushTimeoutMillis = 123
+        val sut = fixture.getSUT()
+        sut.close(false)
+
+        verify(fixture.executor).awaitTermination(eq(123), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `close with isRestarting true does not await termination`() {
+        fixture.sentryOptions.flushTimeoutMillis = 123
+        val sut = fixture.getSUT()
+        sut.close(true)
+
+        verify(fixture.executor).awaitTermination(eq(0), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
     fun `when DiskFlushNotification is not flushable, does not flush`() {
         // given
         val ev = SentryEvent()

--- a/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/AsyncHttpTransportTest.kt
@@ -351,7 +351,7 @@ class AsyncHttpTransportTest {
         val sut = fixture.getSUT()
         sut.close(true)
 
-        verify(fixture.executor).awaitTermination(eq(0), eq(TimeUnit.MILLISECONDS))
+        verify(fixture.executor).awaitTermination(eq(200), eq(TimeUnit.MILLISECONDS))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
added new methods to close instances with isRestarting flag:
- IHub.close(Boolean)
- ISentryClient.close(Boolean)
- ITransport.close(Boolean)

when the SDK restarts 
- the executor service is now closed in the background
- current network connections are dropped. This is not a problem, as data will be sent anyway after the SDK restarts

We still wait for any processing that is happening, as that's more complex, but the biggest slowdown when restarting the SDK is waiting for the network to send data.


## :bulb: Motivation and Context
When the SDK is initialized multiple times, it closes the old instance, waiting for any task to be completed.
This PR aims to reduce the wait time by dropping network connections and let any job scheduled to the executor to be finished in the background.
Relates to https://github.com/getsentry/sentry-java/issues/3162


## :green_heart: How did you test it?
Unit tests
Added Ui test to check it waits for network to timeout on Sentry.close and doesn't wait on multiple Sentry.init()


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
