### PR TITLE
Fix Compose widgets are not being correctly identified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add new threshold parameters to monitor config ([#3181](https://github.com/getsentry/sentry-java/pull/3181))
 - Report process init time as a span for app start performance ([#3159](https://github.com/getsentry/sentry-java/pull/3159))
 
+## Fixes
+
+- Fix Jetpack Compose widgets are not being correctly identified for user interaction tracing ([#3209](https://github.com/getsentry/sentry-java/pull/3209))
+
 ## 7.3.0
 
 ### Features

--- a/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
+++ b/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
@@ -48,8 +48,6 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
       }
     }
 
-    @Nullable String targetTag = null;
-
     if (!(root instanceof Owner)) {
       return null;
     }
@@ -57,6 +55,11 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
     final @NotNull Queue<LayoutNode> queue = new LinkedList<>();
     queue.add(((Owner) root).getRoot());
 
+    // the final tag to return
+    @Nullable String targetTag = null;
+
+    // the last known tag when iterating the node tree
+    @Nullable String lastKnownTag = null;
     while (!queue.isEmpty()) {
       final @Nullable LayoutNode node = queue.poll();
       if (node == null) {
@@ -66,7 +69,6 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
       if (node.isPlaced() && layoutNodeBoundsContain(composeHelper, node, x, y)) {
         boolean isClickable = false;
         boolean isScrollable = false;
-        @Nullable String testTag = null;
 
         final List<ModifierInfo> modifiers = node.getModifierInfo();
         for (ModifierInfo modifierInfo : modifiers) {
@@ -83,7 +85,7 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
                 isClickable = true;
               } else if ("SentryTag".equals(key) || "TestTag".equals(key)) {
                 if (entry.getValue() instanceof String) {
-                  testTag = (String) entry.getValue();
+                  lastKnownTag = (String) entry.getValue();
                 }
               }
             }
@@ -100,10 +102,10 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
         }
 
         if (isClickable && targetType == UiElement.Type.CLICKABLE) {
-          targetTag = testTag;
+          targetTag = lastKnownTag;
         }
         if (isScrollable && targetType == UiElement.Type.SCROLLABLE) {
-          targetTag = testTag;
+          targetTag = lastKnownTag;
           // skip any children for scrollable targets
           break;
         }


### PR DESCRIPTION
## :scroll: Description

Using the latest version of Compose, the compiler plugin sometimes does not fold `SentryTraced` into the same UI Node element anymore. This causes our `SentryTag` semantic to be inside the parent node, but the `Clickable` semantic ends up in the child node.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3208


## :green_heart: How did you test it?
I was able to reproduce the issue locally, did some manual tests.

We definitely need to get better at automating this, right now it's super painful as newer versions of Compose require a newer versions of Kotlin. This in turn requires bumping some plugins (e.g. detekt), which then in turn emit new build time errors.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
