### PR TITLE
Reverse order for Android RuntimeException

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -3,6 +3,7 @@ package io.sentry.android.core;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import androidx.annotation.NonNull;
 import io.sentry.DateUtils;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
@@ -15,11 +16,16 @@ import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.protocol.App;
 import io.sentry.protocol.OperatingSystem;
+import io.sentry.protocol.SentryException;
+import io.sentry.protocol.SentryStackFrame;
+import io.sentry.protocol.SentryStackTrace;
 import io.sentry.protocol.SentryThread;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -68,7 +74,49 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     setCommons(event, true, applyScopeData);
 
+    fixExceptionOrder(event);
+
     return event;
+  }
+
+  /**
+   * The last exception is usually used for picking the issue title, but the convention is to send
+   * inner exceptions first, e.g. [inner, outer] This doesn't work very well on Android, as some
+   * hooks like Application.onCreate is wrapped by Android framework with a RuntimeException. Thus,
+   * if the last exception is a RuntimeInit$MethodAndArgsCaller, reverse the order to get a better
+   * issue title. This is a quick fix, for more details see: <a
+   * href="https://github.com/getsentry/sentry/issues/64074">#64074</a> <a
+   * href="https://github.com/getsentry/sentry/issues/59679">#59679</a> <a
+   * href="https://github.com/getsentry/sentry/issues/64088">#64088</a>
+   *
+   * @param event the event to process
+   */
+  private static void fixExceptionOrder(final @NonNull SentryEvent event) {
+    boolean reverseExceptions = false;
+
+    final @Nullable List<SentryException> exceptions = event.getExceptions();
+    if (exceptions != null && exceptions.size() > 1) {
+      final @NotNull SentryException lastException = exceptions.get(exceptions.size() - 1);
+      if ("java.lang".equals(lastException.getModule())) {
+        final @Nullable SentryStackTrace stacktrace = lastException.getStacktrace();
+        if (stacktrace != null) {
+          final @Nullable List<SentryStackFrame> frames = stacktrace.getFrames();
+          if (frames != null) {
+            for (SentryStackFrame frame : frames) {
+              if ("com.android.internal.os.RuntimeInit$MethodAndArgsCaller"
+                  .equals(frame.getModule())) {
+                reverseExceptions = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (reverseExceptions) {
+      Collections.reverse(exceptions);
+    }
   }
 
   private void setCommons(


### PR DESCRIPTION
## :scroll: Description

Based on https://github.com/getsentry/sentry-java/pull/3184, as a quick fix we want to reverse the order (similar to e.g. RN) of the exception list. This applies to Android only, and only to RuntimeExceptions.

## :bulb: Motivation and Context
Improve https://github.com/getsentry/sentry/issues/64074

## :green_heart: How did you test it?
Added unit tests, did a quick manual test with our demo app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
