### PR TITLE
[SR] Introduce MapObjectReader

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -136,8 +136,8 @@ public final class io/sentry/Breadcrumb : io/sentry/JsonSerializable, io/sentry/
 
 public final class io/sentry/Breadcrumb$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/Breadcrumb;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/Breadcrumb;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/Breadcrumb$JsonKeys {
@@ -181,8 +181,8 @@ public final class io/sentry/CheckIn : io/sentry/JsonSerializable, io/sentry/Jso
 
 public final class io/sentry/CheckIn$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/CheckIn;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/CheckIn;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/CheckIn$JsonKeys {
@@ -226,6 +226,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static final field Error Lio/sentry/DataCategory;
 	public static final field Monitor Lio/sentry/DataCategory;
 	public static final field Profile Lio/sentry/DataCategory;
+	public static final field Replay Lio/sentry/DataCategory;
 	public static final field Security Lio/sentry/DataCategory;
 	public static final field Session Lio/sentry/DataCategory;
 	public static final field Transaction Lio/sentry/DataCategory;
@@ -300,6 +301,7 @@ public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
 
 public abstract interface class io/sentry/EventProcessor {
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/SentryReplayEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
 
@@ -387,12 +389,14 @@ public final class io/sentry/Hint {
 	public fun get (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getAs (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
 	public fun getAttachments ()Ljava/util/List;
+	public fun getReplayRecording ()Lio/sentry/ReplayRecording;
 	public fun getScreenshot ()Lio/sentry/Attachment;
 	public fun getThreadDump ()Lio/sentry/Attachment;
 	public fun getViewHierarchy ()Lio/sentry/Attachment;
 	public fun remove (Ljava/lang/String;)V
 	public fun replaceAttachments (Ljava/util/List;)V
 	public fun set (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun setReplayRecording (Lio/sentry/ReplayRecording;)V
 	public fun setScreenshot (Lio/sentry/Attachment;)V
 	public fun setThreadDump (Lio/sentry/Attachment;)V
 	public fun setViewHierarchy (Lio/sentry/Attachment;)V
@@ -421,6 +425,7 @@ public final class io/sentry/Hub : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public fun captureReplay (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -471,6 +476,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public fun captureReplay (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -559,6 +565,7 @@ public abstract interface class io/sentry/IHub {
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureReplay (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
@@ -723,6 +730,7 @@ public abstract interface class io/sentry/ISentryClient {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/IScope;)Lio/sentry/protocol/SentryId;
+	public abstract fun captureReplayEvent (Lio/sentry/SentryReplayEvent;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;)V
 	public abstract fun captureSession (Lio/sentry/Session;Lio/sentry/Hint;)V
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;)Lio/sentry/protocol/SentryId;
@@ -843,7 +851,7 @@ public final class io/sentry/JavaMemoryCollector : io/sentry/IPerformanceSnapsho
 }
 
 public abstract interface class io/sentry/JsonDeserializer {
-	public abstract fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public abstract fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/JsonObjectDeserializer {
@@ -851,23 +859,38 @@ public final class io/sentry/JsonObjectDeserializer {
 	public fun deserialize (Lio/sentry/JsonObjectReader;)Ljava/lang/Object;
 }
 
-public final class io/sentry/JsonObjectReader : io/sentry/vendor/gson/stream/JsonReader {
+public final class io/sentry/JsonObjectReader : io/sentry/ObjectReader {
 	public fun <init> (Ljava/io/Reader;)V
-	public static fun dateOrNull (Ljava/lang/String;Lio/sentry/ILogger;)Ljava/util/Date;
+	public fun beginArray ()V
+	public fun beginObject ()V
+	public fun close ()V
+	public fun endArray ()V
+	public fun endObject ()V
+	public fun hasNext ()Z
+	public fun nextBoolean ()Z
 	public fun nextBooleanOrNull ()Ljava/lang/Boolean;
 	public fun nextDateOrNull (Lio/sentry/ILogger;)Ljava/util/Date;
+	public fun nextDouble ()D
 	public fun nextDoubleOrNull ()Ljava/lang/Double;
-	public fun nextFloat ()Ljava/lang/Float;
+	public fun nextFloat ()F
 	public fun nextFloatOrNull ()Ljava/lang/Float;
+	public fun nextInt ()I
 	public fun nextIntegerOrNull ()Ljava/lang/Integer;
 	public fun nextListOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/List;
+	public fun nextLong ()J
 	public fun nextLongOrNull ()Ljava/lang/Long;
 	public fun nextMapOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/Map;
+	public fun nextName ()Ljava/lang/String;
+	public fun nextNull ()V
 	public fun nextObjectOrNull ()Ljava/lang/Object;
 	public fun nextOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/lang/Object;
+	public fun nextString ()Ljava/lang/String;
 	public fun nextStringOrNull ()Ljava/lang/String;
 	public fun nextTimeZoneOrNull (Lio/sentry/ILogger;)Ljava/util/TimeZone;
 	public fun nextUnknown (Lio/sentry/ILogger;Ljava/util/Map;Ljava/lang/String;)V
+	public fun peek ()Lio/sentry/vendor/gson/stream/JsonToken;
+	public fun setLenient (Z)V
+	public fun skipValue ()V
 }
 
 public final class io/sentry/JsonObjectSerializer {
@@ -887,11 +910,13 @@ public final class io/sentry/JsonObjectWriter : io/sentry/ObjectWriter {
 	public synthetic fun endArray ()Lio/sentry/ObjectWriter;
 	public fun endObject ()Lio/sentry/JsonObjectWriter;
 	public synthetic fun endObject ()Lio/sentry/ObjectWriter;
+	public fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public fun name (Ljava/lang/String;)Lio/sentry/JsonObjectWriter;
 	public synthetic fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public fun nullValue ()Lio/sentry/JsonObjectWriter;
 	public synthetic fun nullValue ()Lio/sentry/ObjectWriter;
 	public fun setIndent (Ljava/lang/String;)V
+	public fun setLenient (Z)V
 	public fun value (D)Lio/sentry/JsonObjectWriter;
 	public synthetic fun value (D)Lio/sentry/ObjectWriter;
 	public fun value (J)Lio/sentry/JsonObjectWriter;
@@ -936,6 +961,7 @@ public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor, java
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close ()V
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
+	public fun process (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/SentryReplayEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
 
@@ -1018,8 +1044,8 @@ public final class io/sentry/MonitorConfig : io/sentry/JsonSerializable, io/sent
 
 public final class io/sentry/MonitorConfig$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorConfig;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorConfig;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/MonitorConfig$JsonKeys {
@@ -1040,8 +1066,8 @@ public final class io/sentry/MonitorContexts : java/util/concurrent/ConcurrentHa
 
 public final class io/sentry/MonitorContexts$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorContexts;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorContexts;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/MonitorSchedule : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -1063,8 +1089,8 @@ public final class io/sentry/MonitorSchedule : io/sentry/JsonSerializable, io/se
 
 public final class io/sentry/MonitorSchedule$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorSchedule;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/MonitorSchedule;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/MonitorSchedule$JsonKeys {
@@ -1119,6 +1145,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun captureException (Ljava/lang/Throwable;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public fun captureReplay (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public fun clearBreadcrumbs ()V
@@ -1331,13 +1358,48 @@ public final class io/sentry/NoOpTransportFactory : io/sentry/ITransportFactory 
 	public static fun getInstance ()Lio/sentry/NoOpTransportFactory;
 }
 
+public abstract interface class io/sentry/ObjectReader : java/io/Closeable {
+	public abstract fun beginArray ()V
+	public abstract fun beginObject ()V
+	public static fun dateOrNull (Ljava/lang/String;Lio/sentry/ILogger;)Ljava/util/Date;
+	public abstract fun endArray ()V
+	public abstract fun endObject ()V
+	public abstract fun hasNext ()Z
+	public abstract fun nextBoolean ()Z
+	public abstract fun nextBooleanOrNull ()Ljava/lang/Boolean;
+	public abstract fun nextDateOrNull (Lio/sentry/ILogger;)Ljava/util/Date;
+	public abstract fun nextDouble ()D
+	public abstract fun nextDoubleOrNull ()Ljava/lang/Double;
+	public abstract fun nextFloat ()F
+	public abstract fun nextFloatOrNull ()Ljava/lang/Float;
+	public abstract fun nextInt ()I
+	public abstract fun nextIntegerOrNull ()Ljava/lang/Integer;
+	public abstract fun nextListOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/List;
+	public abstract fun nextLong ()J
+	public abstract fun nextLongOrNull ()Ljava/lang/Long;
+	public abstract fun nextMapOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/Map;
+	public abstract fun nextName ()Ljava/lang/String;
+	public abstract fun nextNull ()V
+	public abstract fun nextObjectOrNull ()Ljava/lang/Object;
+	public abstract fun nextOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/lang/Object;
+	public abstract fun nextString ()Ljava/lang/String;
+	public abstract fun nextStringOrNull ()Ljava/lang/String;
+	public abstract fun nextTimeZoneOrNull (Lio/sentry/ILogger;)Ljava/util/TimeZone;
+	public abstract fun nextUnknown (Lio/sentry/ILogger;Ljava/util/Map;Ljava/lang/String;)V
+	public abstract fun peek ()Lio/sentry/vendor/gson/stream/JsonToken;
+	public abstract fun setLenient (Z)V
+	public abstract fun skipValue ()V
+}
+
 public abstract interface class io/sentry/ObjectWriter {
 	public abstract fun beginArray ()Lio/sentry/ObjectWriter;
 	public abstract fun beginObject ()Lio/sentry/ObjectWriter;
 	public abstract fun endArray ()Lio/sentry/ObjectWriter;
 	public abstract fun endObject ()Lio/sentry/ObjectWriter;
+	public abstract fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public abstract fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public abstract fun nullValue ()Lio/sentry/ObjectWriter;
+	public abstract fun setLenient (Z)V
 	public abstract fun value (D)Lio/sentry/ObjectWriter;
 	public abstract fun value (J)Lio/sentry/ObjectWriter;
 	public abstract fun value (Lio/sentry/ILogger;Ljava/lang/Object;)Lio/sentry/ObjectWriter;
@@ -1426,8 +1488,8 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 
 public final class io/sentry/ProfilingTraceData$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/ProfilingTraceData;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/ProfilingTraceData;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/ProfilingTraceData$JsonKeys {
@@ -1484,8 +1546,8 @@ public final class io/sentry/ProfilingTransactionData : io/sentry/JsonSerializab
 
 public final class io/sentry/ProfilingTransactionData$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/ProfilingTransactionData;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/ProfilingTransactionData;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/ProfilingTransactionData$JsonKeys {
@@ -1517,6 +1579,30 @@ public final class io/sentry/PropagationContext {
 	public fun setSpanId (Lio/sentry/SpanId;)V
 	public fun setTraceId (Lio/sentry/protocol/SentryId;)V
 	public fun traceContext ()Lio/sentry/TraceContext;
+}
+
+public final class io/sentry/ReplayRecording : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPayload ()Ljava/util/List;
+	public fun getSegmentId ()Ljava/lang/Integer;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setPayload (Ljava/util/List;)V
+	public fun setSegmentId (Ljava/lang/Integer;)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/ReplayRecording$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/ReplayRecording;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/ReplayRecording$JsonKeys {
+	public static final field SEGMENT_ID Ljava/lang/String;
+	public fun <init> ()V
 }
 
 public final class io/sentry/RequestDetails {
@@ -1669,6 +1755,7 @@ public final class io/sentry/Sentry {
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;
 	public static fun captureMessage (Ljava/lang/String;Lio/sentry/SentryLevel;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public static fun captureReplay (Lio/sentry/SentryReplayEvent;Lio/sentry/Hint;)V
 	public static fun captureUserFeedback (Lio/sentry/UserFeedback;)V
 	public static fun clearBreadcrumbs ()V
 	public static fun cloneMainHub ()Lio/sentry/IHub;
@@ -1742,8 +1829,8 @@ public final class io/sentry/SentryAppStartProfilingOptions : io/sentry/JsonSeri
 
 public final class io/sentry/SentryAppStartProfilingOptions$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryAppStartProfilingOptions;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryAppStartProfilingOptions;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
@@ -1809,7 +1896,7 @@ public abstract class io/sentry/SentryBaseEvent {
 
 public final class io/sentry/SentryBaseEvent$Deserializer {
 	public fun <init> ()V
-	public fun deserializeValue (Lio/sentry/SentryBaseEvent;Ljava/lang/String;Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Z
+	public fun deserializeValue (Lio/sentry/SentryBaseEvent;Ljava/lang/String;Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Z
 }
 
 public final class io/sentry/SentryBaseEvent$JsonKeys {
@@ -1839,6 +1926,7 @@ public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun captureCheckIn (Lio/sentry/CheckIn;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun captureReplayEvent (Lio/sentry/SentryReplayEvent;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureSession (Lio/sentry/Session;Lio/sentry/Hint;)V
 	public fun captureTransaction (Lio/sentry/protocol/SentryTransaction;Lio/sentry/TraceContext;Lio/sentry/IScope;Lio/sentry/Hint;Lio/sentry/ProfilingTraceData;)Lio/sentry/protocol/SentryId;
 	public fun captureUserFeedback (Lio/sentry/UserFeedback;)V
@@ -1899,8 +1987,8 @@ public final class io/sentry/SentryEnvelopeHeader : io/sentry/JsonSerializable, 
 
 public final class io/sentry/SentryEnvelopeHeader$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEnvelopeHeader;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEnvelopeHeader;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryEnvelopeHeader$JsonKeys {
@@ -1917,6 +2005,7 @@ public final class io/sentry/SentryEnvelopeItem {
 	public static fun fromClientReport (Lio/sentry/ISerializer;Lio/sentry/clientreport/ClientReport;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromEvent (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromProfilingTrace (Lio/sentry/ProfilingTraceData;JLio/sentry/ISerializer;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromReplay (Lio/sentry/ISerializer;Lio/sentry/ILogger;Lio/sentry/SentryReplayEvent;Lio/sentry/ReplayRecording;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromSession (Lio/sentry/ISerializer;Lio/sentry/Session;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromUserFeedback (Lio/sentry/ISerializer;Lio/sentry/UserFeedback;)Lio/sentry/SentryEnvelopeItem;
 	public fun getClientReport (Lio/sentry/ISerializer;)Lio/sentry/clientreport/ClientReport;
@@ -1940,8 +2029,8 @@ public final class io/sentry/SentryEnvelopeItemHeader : io/sentry/JsonSerializab
 
 public final class io/sentry/SentryEnvelopeItemHeader$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEnvelopeItemHeader;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEnvelopeItemHeader;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryEnvelopeItemHeader$JsonKeys {
@@ -1987,8 +2076,8 @@ public final class io/sentry/SentryEvent : io/sentry/SentryBaseEvent, io/sentry/
 
 public final class io/sentry/SentryEvent$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEvent;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryEvent$JsonKeys {
@@ -2047,6 +2136,7 @@ public final class io/sentry/SentryItemType : java/lang/Enum, io/sentry/JsonSeri
 	public static final field Profile Lio/sentry/SentryItemType;
 	public static final field ReplayEvent Lio/sentry/SentryItemType;
 	public static final field ReplayRecording Lio/sentry/SentryItemType;
+	public static final field ReplayVideo Lio/sentry/SentryItemType;
 	public static final field Session Lio/sentry/SentryItemType;
 	public static final field Transaction Lio/sentry/SentryItemType;
 	public static final field Unknown Lio/sentry/SentryItemType;
@@ -2097,8 +2187,8 @@ public final class io/sentry/SentryLockReason : io/sentry/JsonSerializable, io/s
 
 public final class io/sentry/SentryLockReason$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryLockReason;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryLockReason;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryLockReason$JsonKeys {
@@ -2374,6 +2464,70 @@ public abstract interface class io/sentry/SentryOptions$TracesSamplerCallback {
 	public abstract fun sample (Lio/sentry/SamplingContext;)Ljava/lang/Double;
 }
 
+public final class io/sentry/SentryReplayEvent : io/sentry/SentryBaseEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field REPLAY_EVENT_TYPE Ljava/lang/String;
+	public static final field REPLAY_VIDEO_MAX_SIZE J
+	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getErrorIds ()Ljava/util/List;
+	public fun getReplayId ()Lio/sentry/protocol/SentryId;
+	public fun getReplayStartTimestamp ()Ljava/util/Date;
+	public fun getReplayType ()Lio/sentry/SentryReplayEvent$ReplayType;
+	public fun getSegmentId ()I
+	public fun getTimestamp ()Ljava/util/Date;
+	public fun getTraceIds ()Ljava/util/List;
+	public fun getType ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun getUrls ()Ljava/util/List;
+	public fun getVideoFile ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setErrorIds (Ljava/util/List;)V
+	public fun setReplayId (Lio/sentry/protocol/SentryId;)V
+	public fun setReplayStartTimestamp (Ljava/util/Date;)V
+	public fun setReplayType (Lio/sentry/SentryReplayEvent$ReplayType;)V
+	public fun setSegmentId (I)V
+	public fun setTimestamp (Ljava/util/Date;)V
+	public fun setTraceIds (Ljava/util/List;)V
+	public fun setType (Ljava/lang/String;)V
+	public fun setUnknown (Ljava/util/Map;)V
+	public fun setUrls (Ljava/util/List;)V
+	public fun setVideoFile (Ljava/io/File;)V
+}
+
+public final class io/sentry/SentryReplayEvent$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryReplayEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/SentryReplayEvent$JsonKeys {
+	public static final field ERROR_IDS Ljava/lang/String;
+	public static final field REPLAY_ID Ljava/lang/String;
+	public static final field REPLAY_START_TIMESTAMP Ljava/lang/String;
+	public static final field REPLAY_TYPE Ljava/lang/String;
+	public static final field SEGMENT_ID Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
+	public static final field TRACE_IDS Ljava/lang/String;
+	public static final field TYPE Ljava/lang/String;
+	public static final field URLS Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/SentryReplayEvent$ReplayType : java/lang/Enum, io/sentry/JsonSerializable {
+	public static final field BUFFER Lio/sentry/SentryReplayEvent$ReplayType;
+	public static final field SESSION Lio/sentry/SentryReplayEvent$ReplayType;
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryReplayEvent$ReplayType;
+	public static fun values ()[Lio/sentry/SentryReplayEvent$ReplayType;
+}
+
+public final class io/sentry/SentryReplayEvent$ReplayType$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryReplayEvent$ReplayType;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
 public final class io/sentry/SentrySpanStorage {
 	public fun get (Ljava/lang/String;)Lio/sentry/ISpan;
 	public static fun getInstance ()Lio/sentry/SentrySpanStorage;
@@ -2495,8 +2649,8 @@ public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/Jso
 
 public final class io/sentry/Session$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/Session;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/Session;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/Session$JsonKeys {
@@ -2617,8 +2771,8 @@ public class io/sentry/SpanContext : io/sentry/JsonSerializable, io/sentry/JsonU
 
 public final class io/sentry/SpanContext$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanContext;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanContext;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SpanContext$JsonKeys {
@@ -2662,8 +2816,8 @@ public final class io/sentry/SpanId : io/sentry/JsonSerializable {
 
 public final class io/sentry/SpanId$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanId;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanId;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public class io/sentry/SpanOptions {
@@ -2704,8 +2858,8 @@ public final class io/sentry/SpanStatus : java/lang/Enum, io/sentry/JsonSerializ
 
 public final class io/sentry/SpanStatus$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanStatus;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SpanStatus;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SystemOutLogger : io/sentry/ILogger {
@@ -2733,8 +2887,8 @@ public final class io/sentry/TraceContext : io/sentry/JsonSerializable, io/sentr
 
 public final class io/sentry/TraceContext$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/TraceContext;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/TraceContext;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/TraceContext$JsonKeys {
@@ -2893,8 +3047,8 @@ public final class io/sentry/UserFeedback : io/sentry/JsonSerializable, io/sentr
 
 public final class io/sentry/UserFeedback$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/UserFeedback;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/UserFeedback;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/UserFeedback$JsonKeys {
@@ -3005,8 +3159,8 @@ public final class io/sentry/clientreport/ClientReport : io/sentry/JsonSerializa
 
 public final class io/sentry/clientreport/ClientReport$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/clientreport/ClientReport;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/clientreport/ClientReport;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/clientreport/ClientReport$JsonKeys {
@@ -3050,8 +3204,8 @@ public final class io/sentry/clientreport/DiscardedEvent : io/sentry/JsonSeriali
 
 public final class io/sentry/clientreport/DiscardedEvent$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/clientreport/DiscardedEvent;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/clientreport/DiscardedEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/clientreport/DiscardedEvent$JsonKeys {
@@ -3344,8 +3498,8 @@ public final class io/sentry/profilemeasurements/ProfileMeasurement : io/sentry/
 
 public final class io/sentry/profilemeasurements/ProfileMeasurement$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/profilemeasurements/ProfileMeasurement;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/profilemeasurements/ProfileMeasurement;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/profilemeasurements/ProfileMeasurement$JsonKeys {
@@ -3368,8 +3522,8 @@ public final class io/sentry/profilemeasurements/ProfileMeasurementValue : io/se
 
 public final class io/sentry/profilemeasurements/ProfileMeasurementValue$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/profilemeasurements/ProfileMeasurementValue;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/profilemeasurements/ProfileMeasurementValue;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/profilemeasurements/ProfileMeasurementValue$JsonKeys {
@@ -3410,8 +3564,8 @@ public final class io/sentry/protocol/App : io/sentry/JsonSerializable, io/sentr
 
 public final class io/sentry/protocol/App$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/App;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/App;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/App$JsonKeys {
@@ -3444,8 +3598,8 @@ public final class io/sentry/protocol/Browser : io/sentry/JsonSerializable, io/s
 
 public final class io/sentry/protocol/Browser$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Browser;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Browser;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Browser$JsonKeys {
@@ -3479,8 +3633,8 @@ public final class io/sentry/protocol/Contexts : java/util/concurrent/Concurrent
 
 public final class io/sentry/protocol/Contexts$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Contexts;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Contexts;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/DebugImage : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -3513,8 +3667,8 @@ public final class io/sentry/protocol/DebugImage : io/sentry/JsonSerializable, i
 
 public final class io/sentry/protocol/DebugImage$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/DebugImage;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/DebugImage;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/DebugImage$JsonKeys {
@@ -3543,8 +3697,8 @@ public final class io/sentry/protocol/DebugMeta : io/sentry/JsonSerializable, io
 
 public final class io/sentry/protocol/DebugMeta$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/DebugMeta;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/DebugMeta;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/DebugMeta$JsonKeys {
@@ -3633,8 +3787,8 @@ public final class io/sentry/protocol/Device : io/sentry/JsonSerializable, io/se
 
 public final class io/sentry/protocol/Device$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Device;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Device;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Device$DeviceOrientation : java/lang/Enum, io/sentry/JsonSerializable {
@@ -3647,8 +3801,8 @@ public final class io/sentry/protocol/Device$DeviceOrientation : java/lang/Enum,
 
 public final class io/sentry/protocol/Device$DeviceOrientation$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Device$DeviceOrientation;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Device$DeviceOrientation;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Device$JsonKeys {
@@ -3706,8 +3860,8 @@ public final class io/sentry/protocol/Geo : io/sentry/JsonSerializable, io/sentr
 
 public final class io/sentry/protocol/Geo$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Geo;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Geo;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Geo$JsonKeys {
@@ -3747,8 +3901,8 @@ public final class io/sentry/protocol/Gpu : io/sentry/JsonSerializable, io/sentr
 
 public final class io/sentry/protocol/Gpu$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Gpu;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Gpu;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Gpu$JsonKeys {
@@ -3783,8 +3937,8 @@ public final class io/sentry/protocol/MeasurementValue : io/sentry/JsonSerializa
 
 public final class io/sentry/protocol/MeasurementValue$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/MeasurementValue;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/MeasurementValue;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/MeasurementValue$JsonKeys {
@@ -3817,8 +3971,8 @@ public final class io/sentry/protocol/Mechanism : io/sentry/JsonSerializable, io
 
 public final class io/sentry/protocol/Mechanism$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Mechanism;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Mechanism;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Mechanism$JsonKeys {
@@ -3847,8 +4001,8 @@ public final class io/sentry/protocol/Message : io/sentry/JsonSerializable, io/s
 
 public final class io/sentry/protocol/Message$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Message;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Message;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Message$JsonKeys {
@@ -3882,8 +4036,8 @@ public final class io/sentry/protocol/OperatingSystem : io/sentry/JsonSerializab
 
 public final class io/sentry/protocol/OperatingSystem$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/OperatingSystem;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/OperatingSystem;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/OperatingSystem$JsonKeys {
@@ -3930,8 +4084,8 @@ public final class io/sentry/protocol/Request : io/sentry/JsonSerializable, io/s
 
 public final class io/sentry/protocol/Request$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Request;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Request;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Request$JsonKeys {
@@ -3970,8 +4124,8 @@ public final class io/sentry/protocol/Response : io/sentry/JsonSerializable, io/
 
 public final class io/sentry/protocol/Response$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Response;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/Response;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/Response$JsonKeys {
@@ -4000,8 +4154,8 @@ public final class io/sentry/protocol/SdkInfo : io/sentry/JsonSerializable, io/s
 
 public final class io/sentry/protocol/SdkInfo$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SdkInfo;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SdkInfo;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SdkInfo$JsonKeys {
@@ -4034,8 +4188,8 @@ public final class io/sentry/protocol/SdkVersion : io/sentry/JsonSerializable, i
 
 public final class io/sentry/protocol/SdkVersion$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SdkVersion;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SdkVersion;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SdkVersion$JsonKeys {
@@ -4067,8 +4221,8 @@ public final class io/sentry/protocol/SentryException : io/sentry/JsonSerializab
 
 public final class io/sentry/protocol/SentryException$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryException;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryException;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryException$JsonKeys {
@@ -4094,8 +4248,8 @@ public final class io/sentry/protocol/SentryId : io/sentry/JsonSerializable {
 
 public final class io/sentry/protocol/SentryId$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryId;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryId;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryPackage : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -4113,8 +4267,8 @@ public final class io/sentry/protocol/SentryPackage : io/sentry/JsonSerializable
 
 public final class io/sentry/protocol/SentryPackage$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryPackage;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryPackage;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryPackage$JsonKeys {
@@ -4139,8 +4293,8 @@ public final class io/sentry/protocol/SentryRuntime : io/sentry/JsonSerializable
 
 public final class io/sentry/protocol/SentryRuntime$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryRuntime;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryRuntime;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryRuntime$JsonKeys {
@@ -4173,8 +4327,8 @@ public final class io/sentry/protocol/SentrySpan : io/sentry/JsonSerializable, i
 
 public final class io/sentry/protocol/SentrySpan$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentrySpan;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentrySpan;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentrySpan$JsonKeys {
@@ -4243,8 +4397,8 @@ public final class io/sentry/protocol/SentryStackFrame : io/sentry/JsonSerializa
 
 public final class io/sentry/protocol/SentryStackFrame$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryStackFrame;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryStackFrame;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryStackFrame$JsonKeys {
@@ -4284,8 +4438,8 @@ public final class io/sentry/protocol/SentryStackTrace : io/sentry/JsonSerializa
 
 public final class io/sentry/protocol/SentryStackTrace$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryStackTrace;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryStackTrace;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryStackTrace$JsonKeys {
@@ -4324,8 +4478,8 @@ public final class io/sentry/protocol/SentryThread : io/sentry/JsonSerializable,
 
 public final class io/sentry/protocol/SentryThread$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryThread;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryThread;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryThread$JsonKeys {
@@ -4362,8 +4516,8 @@ public final class io/sentry/protocol/SentryTransaction : io/sentry/SentryBaseEv
 
 public final class io/sentry/protocol/SentryTransaction$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryTransaction;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/SentryTransaction;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/SentryTransaction$JsonKeys {
@@ -4386,8 +4540,8 @@ public final class io/sentry/protocol/TransactionInfo : io/sentry/JsonSerializab
 
 public final class io/sentry/protocol/TransactionInfo$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/TransactionInfo;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/TransactionInfo;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/TransactionInfo$JsonKeys {
@@ -4438,8 +4592,8 @@ public final class io/sentry/protocol/User : io/sentry/JsonSerializable, io/sent
 
 public final class io/sentry/protocol/User$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/User;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/User;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/User$JsonKeys {
@@ -4466,8 +4620,8 @@ public final class io/sentry/protocol/ViewHierarchy : io/sentry/JsonSerializable
 
 public final class io/sentry/protocol/ViewHierarchy$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/ViewHierarchy$JsonKeys {
@@ -4507,8 +4661,8 @@ public final class io/sentry/protocol/ViewHierarchyNode : io/sentry/JsonSerializ
 
 public final class io/sentry/protocol/ViewHierarchyNode$Deserializer : io/sentry/JsonDeserializer {
 	public fun <init> ()V
-	public fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchyNode;
-	public synthetic fun deserialize (Lio/sentry/JsonObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchyNode;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/protocol/ViewHierarchyNode$JsonKeys {
@@ -4523,6 +4677,152 @@ public final class io/sentry/protocol/ViewHierarchyNode$JsonKeys {
 	public static final field WIDTH Ljava/lang/String;
 	public static final field X Ljava/lang/String;
 	public static final field Y Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public abstract class io/sentry/rrweb/RRWebEvent {
+	protected fun <init> ()V
+	protected fun <init> (Lio/sentry/rrweb/RRWebEventType;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTimestamp ()J
+	public fun getType ()Lio/sentry/rrweb/RRWebEventType;
+	public fun hashCode ()I
+	public fun setTimestamp (J)V
+	public fun setType (Lio/sentry/rrweb/RRWebEventType;)V
+}
+
+public final class io/sentry/rrweb/RRWebEvent$Deserializer {
+	public fun <init> ()V
+	public fun deserializeValue (Lio/sentry/rrweb/RRWebEvent;Ljava/lang/String;Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Z
+}
+
+public final class io/sentry/rrweb/RRWebEvent$JsonKeys {
+	public static final field TAG Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/rrweb/RRWebEvent$Serializer {
+	public fun <init> ()V
+	public fun serialize (Lio/sentry/rrweb/RRWebEvent;Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+}
+
+public final class io/sentry/rrweb/RRWebEventType : java/lang/Enum, io/sentry/JsonSerializable {
+	public static final field Custom Lio/sentry/rrweb/RRWebEventType;
+	public static final field DomContentLoaded Lio/sentry/rrweb/RRWebEventType;
+	public static final field FullSnapshot Lio/sentry/rrweb/RRWebEventType;
+	public static final field IncrementalSnapshot Lio/sentry/rrweb/RRWebEventType;
+	public static final field Load Lio/sentry/rrweb/RRWebEventType;
+	public static final field Meta Lio/sentry/rrweb/RRWebEventType;
+	public static final field Plugin Lio/sentry/rrweb/RRWebEventType;
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/rrweb/RRWebEventType;
+	public static fun values ()[Lio/sentry/rrweb/RRWebEventType;
+}
+
+public final class io/sentry/rrweb/RRWebEventType$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/rrweb/RRWebEventType;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/rrweb/RRWebMetaEvent : io/sentry/rrweb/RRWebEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDataUnknown ()Ljava/util/Map;
+	public fun getHeight ()I
+	public fun getHref ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun getWidth ()I
+	public fun hashCode ()I
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setDataUnknown (Ljava/util/Map;)V
+	public fun setHeight (I)V
+	public fun setHref (Ljava/lang/String;)V
+	public fun setUnknown (Ljava/util/Map;)V
+	public fun setWidth (I)V
+}
+
+public final class io/sentry/rrweb/RRWebMetaEvent$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/rrweb/RRWebMetaEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/rrweb/RRWebMetaEvent$JsonKeys {
+	public static final field DATA Ljava/lang/String;
+	public static final field HEIGHT Ljava/lang/String;
+	public static final field HREF Ljava/lang/String;
+	public static final field WIDTH Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/rrweb/RRWebVideoEvent : io/sentry/rrweb/RRWebEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field EVENT_TAG Ljava/lang/String;
+	public static final field REPLAY_CONTAINER Ljava/lang/String;
+	public static final field REPLAY_ENCODING Ljava/lang/String;
+	public static final field REPLAY_FRAME_RATE_TYPE_CONSTANT Ljava/lang/String;
+	public static final field REPLAY_FRAME_RATE_TYPE_VARIABLE Ljava/lang/String;
+	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContainer ()Ljava/lang/String;
+	public fun getDataUnknown ()Ljava/util/Map;
+	public fun getDuration ()I
+	public fun getEncoding ()Ljava/lang/String;
+	public fun getFrameCount ()I
+	public fun getFrameRate ()I
+	public fun getFrameRateType ()Ljava/lang/String;
+	public fun getHeight ()I
+	public fun getLeft ()I
+	public fun getPayloadUnknown ()Ljava/util/Map;
+	public fun getSegmentId ()I
+	public fun getSize ()J
+	public fun getTag ()Ljava/lang/String;
+	public fun getTop ()I
+	public fun getUnknown ()Ljava/util/Map;
+	public fun getWidth ()I
+	public fun hashCode ()I
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setContainer (Ljava/lang/String;)V
+	public fun setDataUnknown (Ljava/util/Map;)V
+	public fun setDuration (I)V
+	public fun setEncoding (Ljava/lang/String;)V
+	public fun setFrameCount (I)V
+	public fun setFrameRate (I)V
+	public fun setFrameRateType (Ljava/lang/String;)V
+	public fun setHeight (I)V
+	public fun setLeft (I)V
+	public fun setPayloadUnknown (Ljava/util/Map;)V
+	public fun setSegmentId (I)V
+	public fun setSize (J)V
+	public fun setTag (Ljava/lang/String;)V
+	public fun setTop (I)V
+	public fun setUnknown (Ljava/util/Map;)V
+	public fun setWidth (I)V
+}
+
+public final class io/sentry/rrweb/RRWebVideoEvent$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/rrweb/RRWebVideoEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/rrweb/RRWebVideoEvent$JsonKeys {
+	public static final field CONTAINER Ljava/lang/String;
+	public static final field DATA Ljava/lang/String;
+	public static final field DURATION Ljava/lang/String;
+	public static final field ENCODING Ljava/lang/String;
+	public static final field FRAME_COUNT Ljava/lang/String;
+	public static final field FRAME_RATE Ljava/lang/String;
+	public static final field FRAME_RATE_TYPE Ljava/lang/String;
+	public static final field HEIGHT Ljava/lang/String;
+	public static final field LEFT Ljava/lang/String;
+	public static final field PAYLOAD Ljava/lang/String;
+	public static final field SEGMENT_ID Ljava/lang/String;
+	public static final field SIZE Ljava/lang/String;
+	public static final field TOP Ljava/lang/String;
+	public static final field WIDTH Ljava/lang/String;
 	public fun <init> ()V
 }
 
@@ -4727,6 +5027,40 @@ public final class io/sentry/util/LogUtils {
 	public static fun logNotInstanceOf (Ljava/lang/Class;Ljava/lang/Object;Lio/sentry/ILogger;)V
 }
 
+public final class io/sentry/util/MapObjectReader : io/sentry/ObjectReader {
+	public fun <init> (Ljava/util/Map;)V
+	public fun beginArray ()V
+	public fun beginObject ()V
+	public fun close ()V
+	public fun endArray ()V
+	public fun endObject ()V
+	public fun hasNext ()Z
+	public fun nextBoolean ()Z
+	public fun nextBooleanOrNull ()Ljava/lang/Boolean;
+	public fun nextDateOrNull (Lio/sentry/ILogger;)Ljava/util/Date;
+	public fun nextDouble ()D
+	public fun nextDoubleOrNull ()Ljava/lang/Double;
+	public fun nextFloat ()F
+	public fun nextFloatOrNull ()Ljava/lang/Float;
+	public fun nextInt ()I
+	public fun nextIntegerOrNull ()Ljava/lang/Integer;
+	public fun nextListOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/List;
+	public fun nextLong ()J
+	public fun nextLongOrNull ()Ljava/lang/Long;
+	public fun nextMapOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/util/Map;
+	public fun nextName ()Ljava/lang/String;
+	public fun nextNull ()V
+	public fun nextObjectOrNull ()Ljava/lang/Object;
+	public fun nextOrNull (Lio/sentry/ILogger;Lio/sentry/JsonDeserializer;)Ljava/lang/Object;
+	public fun nextString ()Ljava/lang/String;
+	public fun nextStringOrNull ()Ljava/lang/String;
+	public fun nextTimeZoneOrNull (Lio/sentry/ILogger;)Ljava/util/TimeZone;
+	public fun nextUnknown (Lio/sentry/ILogger;Ljava/util/Map;Ljava/lang/String;)V
+	public fun peek ()Lio/sentry/vendor/gson/stream/JsonToken;
+	public fun setLenient (Z)V
+	public fun skipValue ()V
+}
+
 public final class io/sentry/util/MapObjectWriter : io/sentry/ObjectWriter {
 	public fun <init> (Ljava/util/Map;)V
 	public synthetic fun beginArray ()Lio/sentry/ObjectWriter;
@@ -4737,10 +5071,12 @@ public final class io/sentry/util/MapObjectWriter : io/sentry/ObjectWriter {
 	public fun endArray ()Lio/sentry/util/MapObjectWriter;
 	public synthetic fun endObject ()Lio/sentry/ObjectWriter;
 	public fun endObject ()Lio/sentry/util/MapObjectWriter;
+	public fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public synthetic fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public fun name (Ljava/lang/String;)Lio/sentry/util/MapObjectWriter;
 	public synthetic fun nullValue ()Lio/sentry/ObjectWriter;
 	public fun nullValue ()Lio/sentry/util/MapObjectWriter;
+	public fun setLenient (Z)V
 	public synthetic fun value (D)Lio/sentry/ObjectWriter;
 	public fun value (D)Lio/sentry/util/MapObjectWriter;
 	public synthetic fun value (J)Lio/sentry/ObjectWriter;

--- a/sentry/src/main/java/io/sentry/Breadcrumb.java
+++ b/sentry/src/main/java/io/sentry/Breadcrumb.java
@@ -86,8 +86,7 @@ public final class Breadcrumb implements JsonUnknown, JsonSerializable {
       switch (entry.getKey()) {
         case JsonKeys.TIMESTAMP:
           if (value instanceof String) {
-            Date deserializedDate =
-                JsonObjectReader.dateOrNull((String) value, options.getLogger());
+            Date deserializedDate = ObjectReader.dateOrNull((String) value, options.getLogger());
             if (deserializedDate != null) {
               timestamp = deserializedDate;
             }
@@ -700,8 +699,8 @@ public final class Breadcrumb implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<Breadcrumb> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Breadcrumb deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull Breadcrumb deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
       @NotNull Date timestamp = DateUtils.getCurrentDateTime();
       String message = null;

--- a/sentry/src/main/java/io/sentry/CheckIn.java
+++ b/sentry/src/main/java/io/sentry/CheckIn.java
@@ -170,7 +170,7 @@ public final class CheckIn implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<CheckIn> {
     @Override
-    public @NotNull CheckIn deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull CheckIn deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       SentryId sentryId = null;
       MonitorConfig monitorConfig = null;

--- a/sentry/src/main/java/io/sentry/JsonDeserializer.java
+++ b/sentry/src/main/java/io/sentry/JsonDeserializer.java
@@ -6,5 +6,5 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 public interface JsonDeserializer<T> {
   @NotNull
-  T deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception;
+  T deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception;
 }

--- a/sentry/src/main/java/io/sentry/JsonObjectReader.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectReader.java
@@ -15,64 +15,74 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class JsonObjectReader extends JsonReader {
+public final class JsonObjectReader implements ObjectReader {
+
+  private final @NotNull JsonReader jsonReader;
 
   public JsonObjectReader(Reader in) {
-    super(in);
+    this.jsonReader = new JsonReader(in);
   }
 
+  @Override
   public @Nullable String nextStringOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return nextString();
+    return jsonReader.nextString();
   }
 
+  @Override
   public @Nullable Double nextDoubleOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return nextDouble();
+    return jsonReader.nextDouble();
   }
 
+  @Override
   public @Nullable Float nextFloatOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
     return nextFloat();
   }
 
-  public @NotNull Float nextFloat() throws IOException {
-    return (float) nextDouble();
+  @Override
+  public float nextFloat() throws IOException {
+    return (float) jsonReader.nextDouble();
   }
 
+  @Override
   public @Nullable Long nextLongOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return nextLong();
+    return jsonReader.nextLong();
   }
 
+  @Override
   public @Nullable Integer nextIntegerOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return nextInt();
+    return jsonReader.nextInt();
   }
 
+  @Override
   public @Nullable Boolean nextBooleanOrNull() throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return nextBoolean();
+    return jsonReader.nextBoolean();
   }
 
+  @Override
   public void nextUnknown(ILogger logger, Map<String, Object> unknown, String name) {
     try {
       unknown.put(name, nextObjectOrNull());
@@ -81,90 +91,79 @@ public final class JsonObjectReader extends JsonReader {
     }
   }
 
+  @Override
   public <T> @Nullable List<T> nextListOrNull(
       @NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer) throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    beginArray();
+    jsonReader.beginArray();
     List<T> list = new ArrayList<>();
-    if (hasNext()) {
+    if (jsonReader.hasNext()) {
       do {
         try {
           list.add(deserializer.deserialize(this, logger));
         } catch (Exception e) {
           logger.log(SentryLevel.WARNING, "Failed to deserialize object in list.", e);
         }
-      } while (peek() == JsonToken.BEGIN_OBJECT);
+      } while (jsonReader.peek() == JsonToken.BEGIN_OBJECT);
     }
-    endArray();
+    jsonReader.endArray();
     return list;
   }
 
+  @Override
   public <T> @Nullable Map<String, T> nextMapOrNull(
       @NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer) throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    beginObject();
+    jsonReader.beginObject();
     Map<String, T> map = new HashMap<>();
-    if (hasNext()) {
+    if (jsonReader.hasNext()) {
       do {
         try {
-          String key = nextName();
+          String key = jsonReader.nextName();
           map.put(key, deserializer.deserialize(this, logger));
         } catch (Exception e) {
           logger.log(SentryLevel.WARNING, "Failed to deserialize object in map.", e);
         }
-      } while (peek() == JsonToken.BEGIN_OBJECT || peek() == JsonToken.NAME);
+      } while (jsonReader.peek() == JsonToken.BEGIN_OBJECT || jsonReader.peek() == JsonToken.NAME);
     }
 
-    endObject();
+    jsonReader.endObject();
     return map;
   }
 
+  @Override
   public <T> @Nullable T nextOrNull(
       @NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer) throws Exception {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
     return deserializer.deserialize(this, logger);
   }
 
+  @Override
   public @Nullable Date nextDateOrNull(ILogger logger) throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
-    return JsonObjectReader.dateOrNull(nextString(), logger);
+    return ObjectReader.dateOrNull(jsonReader.nextString(), logger);
   }
 
-  public static @Nullable Date dateOrNull(@Nullable String dateString, ILogger logger) {
-    if (dateString == null) {
-      return null;
-    }
-    try {
-      return DateUtils.getDateTime(dateString);
-    } catch (Exception ignored) {
-      try {
-        return DateUtils.getDateTimeWithMillisPrecision(dateString);
-      } catch (Exception e) {
-        logger.log(SentryLevel.ERROR, "Error when deserializing millis timestamp format.", e);
-      }
-    }
-    return null;
-  }
-
+  @Override
   public @Nullable TimeZone nextTimeZoneOrNull(ILogger logger) throws IOException {
-    if (peek() == JsonToken.NULL) {
-      nextNull();
+    if (jsonReader.peek() == JsonToken.NULL) {
+      jsonReader.nextNull();
       return null;
     }
     try {
-      return TimeZone.getTimeZone(nextString());
+      return TimeZone.getTimeZone(jsonReader.nextString());
     } catch (Exception e) {
       logger.log(SentryLevel.ERROR, "Error when deserializing TimeZone", e);
     }
@@ -177,7 +176,88 @@ public final class JsonObjectReader extends JsonReader {
    *
    * @return The deserialized object from json.
    */
+  @Override
   public @Nullable Object nextObjectOrNull() throws IOException {
     return new JsonObjectDeserializer().deserialize(this);
+  }
+
+  @Override
+  public @NotNull JsonToken peek() throws IOException {
+    return jsonReader.peek();
+  }
+
+  @Override
+  public @NotNull String nextName() throws IOException {
+    return jsonReader.nextName();
+  }
+
+  @Override
+  public void beginObject() throws IOException {
+    jsonReader.beginObject();
+  }
+
+  @Override
+  public void endObject() throws IOException {
+    jsonReader.endObject();
+  }
+
+  @Override
+  public void beginArray() throws IOException {
+    jsonReader.beginArray();
+  }
+
+  @Override
+  public void endArray() throws IOException {
+    jsonReader.endArray();
+  }
+
+  @Override
+  public boolean hasNext() throws IOException {
+    return jsonReader.hasNext();
+  }
+
+  @Override
+  public int nextInt() throws IOException {
+    return jsonReader.nextInt();
+  }
+
+  @Override
+  public long nextLong() throws IOException {
+    return jsonReader.nextLong();
+  }
+
+  @Override
+  public String nextString() throws IOException {
+    return jsonReader.nextString();
+  }
+
+  @Override
+  public boolean nextBoolean() throws IOException {
+    return jsonReader.nextBoolean();
+  }
+
+  @Override
+  public double nextDouble() throws IOException {
+    return jsonReader.nextDouble();
+  }
+
+  @Override
+  public void nextNull() throws IOException {
+    jsonReader.nextNull();
+  }
+
+  @Override
+  public void setLenient(boolean lenient) {
+    jsonReader.setLenient(lenient);
+  }
+
+  @Override
+  public void skipValue() throws IOException {
+    jsonReader.skipValue();
+  }
+
+  @Override
+  public void close() throws IOException {
+    jsonReader.close();
   }
 }

--- a/sentry/src/main/java/io/sentry/MonitorConfig.java
+++ b/sentry/src/main/java/io/sentry/MonitorConfig.java
@@ -105,8 +105,8 @@ public final class MonitorConfig implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<MonitorConfig> {
     @Override
-    public @NotNull MonitorConfig deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull MonitorConfig deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       MonitorSchedule schedule = null;
       Long checkinMargin = null;
       Long maxRuntime = null;

--- a/sentry/src/main/java/io/sentry/MonitorContexts.java
+++ b/sentry/src/main/java/io/sentry/MonitorContexts.java
@@ -66,7 +66,7 @@ public final class MonitorContexts extends ConcurrentHashMap<String, Object>
 
     @Override
     public @NotNull MonitorContexts deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       final MonitorContexts contexts = new MonitorContexts();
       reader.beginObject();
       while (reader.peek() == JsonToken.NAME) {

--- a/sentry/src/main/java/io/sentry/MonitorSchedule.java
+++ b/sentry/src/main/java/io/sentry/MonitorSchedule.java
@@ -123,7 +123,7 @@ public final class MonitorSchedule implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<MonitorSchedule> {
     @Override
     public @NotNull MonitorSchedule deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       String type = null;
       String value = null;
       String unit = null;

--- a/sentry/src/main/java/io/sentry/ObjectReader.java
+++ b/sentry/src/main/java/io/sentry/ObjectReader.java
@@ -11,7 +11,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface ObjectReader extends Closeable {
-  static @Nullable Date dateOrNull(@Nullable String dateString, final @NotNull ILogger logger) {
+  static @Nullable Date dateOrNull(
+      final @Nullable String dateString, final @NotNull ILogger logger) {
     if (dateString == null) {
       return null;
     }

--- a/sentry/src/main/java/io/sentry/ObjectReader.java
+++ b/sentry/src/main/java/io/sentry/ObjectReader.java
@@ -1,0 +1,101 @@
+package io.sentry;
+
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface ObjectReader extends Closeable {
+  static @Nullable Date dateOrNull(@Nullable String dateString, final @NotNull ILogger logger) {
+    if (dateString == null) {
+      return null;
+    }
+    try {
+      return DateUtils.getDateTime(dateString);
+    } catch (Exception ignored) {
+      try {
+        return DateUtils.getDateTimeWithMillisPrecision(dateString);
+      } catch (Exception e) {
+        logger.log(SentryLevel.ERROR, "Error when deserializing millis timestamp format.", e);
+      }
+    }
+    return null;
+  }
+
+  void nextUnknown(ILogger logger, Map<String, Object> unknown, String name);
+
+  <T> @Nullable List<T> nextListOrNull(
+      @NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer) throws IOException;
+
+  <T> @Nullable Map<String, T> nextMapOrNull(
+      @NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer) throws IOException;
+
+  <T> @Nullable T nextOrNull(@NotNull ILogger logger, @NotNull JsonDeserializer<T> deserializer)
+      throws Exception;
+
+  @Nullable
+  Date nextDateOrNull(ILogger logger) throws IOException;
+
+  @Nullable
+  TimeZone nextTimeZoneOrNull(ILogger logger) throws IOException;
+
+  @Nullable
+  Object nextObjectOrNull() throws IOException;
+
+  @NotNull
+  JsonToken peek() throws IOException;
+
+  @NotNull
+  String nextName() throws IOException;
+
+  void beginObject() throws IOException;
+
+  void endObject() throws IOException;
+
+  void beginArray() throws IOException;
+
+  void endArray() throws IOException;
+
+  boolean hasNext() throws IOException;
+
+  int nextInt() throws IOException;
+
+  @Nullable
+  Integer nextIntegerOrNull() throws IOException;
+
+  long nextLong() throws IOException;
+
+  @Nullable
+  Long nextLongOrNull() throws IOException;
+
+  String nextString() throws IOException;
+
+  @Nullable
+  String nextStringOrNull() throws IOException;
+
+  boolean nextBoolean() throws IOException;
+
+  @Nullable
+  Boolean nextBooleanOrNull() throws IOException;
+
+  double nextDouble() throws IOException;
+
+  @Nullable
+  Double nextDoubleOrNull() throws IOException;
+
+  float nextFloat() throws IOException;
+
+  @Nullable
+  Float nextFloatOrNull() throws IOException;
+
+  void nextNull() throws IOException;
+
+  void setLenient(boolean lenient);
+
+  void skipValue() throws IOException;
+}

--- a/sentry/src/main/java/io/sentry/ProfilingTraceData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTraceData.java
@@ -448,7 +448,7 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
     @SuppressWarnings("unchecked")
     @Override
     public @NotNull ProfilingTraceData deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       ProfilingTraceData data = new ProfilingTraceData();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTransactionData.java
@@ -179,7 +179,7 @@ public final class ProfilingTransactionData implements JsonUnknown, JsonSerializ
 
     @Override
     public @NotNull ProfilingTransactionData deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       ProfilingTransactionData data = new ProfilingTransactionData();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
@@ -151,7 +151,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
 
     @Override
     public @NotNull SentryAppStartProfilingOptions deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       SentryAppStartProfilingOptions options = new SentryAppStartProfilingOptions();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/SentryBaseEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryBaseEvent.java
@@ -395,7 +395,7 @@ public abstract class SentryBaseEvent {
     public boolean deserializeValue(
         @NotNull SentryBaseEvent baseEvent,
         @NotNull String nextName,
-        @NotNull JsonObjectReader reader,
+        @NotNull ObjectReader reader,
         @NotNull ILogger logger)
         throws Exception {
       switch (nextName) {

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeHeader.java
@@ -117,7 +117,7 @@ public final class SentryEnvelopeHeader implements JsonSerializable, JsonUnknown
   public static final class Deserializer implements JsonDeserializer<SentryEnvelopeHeader> {
     @Override
     public @NotNull SentryEnvelopeHeader deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
       SentryId eventId = null;

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
@@ -130,7 +130,7 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
   public static final class Deserializer implements JsonDeserializer<SentryEnvelopeItemHeader> {
     @Override
     public @NotNull SentryEnvelopeItemHeader deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
       String contentType = null;

--- a/sentry/src/main/java/io/sentry/SentryEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryEvent.java
@@ -311,8 +311,8 @@ public final class SentryEvent extends SentryBaseEvent implements JsonUnknown, J
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull SentryEvent deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentryEvent deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
       SentryEvent event = new SentryEvent();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/SentryItemType.java
+++ b/sentry/src/main/java/io/sentry/SentryItemType.java
@@ -65,7 +65,7 @@ public enum SentryItemType implements JsonSerializable {
 
     @Override
     public @NotNull SentryItemType deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       return SentryItemType.valueOfLabel(reader.nextString().toLowerCase(Locale.ROOT));
     }
   }

--- a/sentry/src/main/java/io/sentry/SentryLevel.java
+++ b/sentry/src/main/java/io/sentry/SentryLevel.java
@@ -21,8 +21,8 @@ public enum SentryLevel implements JsonSerializable {
   static final class Deserializer implements JsonDeserializer<SentryLevel> {
 
     @Override
-    public @NotNull SentryLevel deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentryLevel deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       return SentryLevel.valueOf(reader.nextString().toUpperCase(Locale.ROOT));
     }
   }

--- a/sentry/src/main/java/io/sentry/SentryLockReason.java
+++ b/sentry/src/main/java/io/sentry/SentryLockReason.java
@@ -147,7 +147,7 @@ public final class SentryLockReason implements JsonUnknown, JsonSerializable {
 
     @Override
     public @NotNull SentryLockReason deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       final SentryLockReason sentryLockReason = new SentryLockReason();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -426,7 +426,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Session deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Session deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
 

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -292,8 +292,8 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<SpanContext> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull SpanContext deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SpanContext deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
       SentryId traceId = null;
       SpanId spanId = null;

--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -53,7 +53,7 @@ public final class SpanId implements JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SpanId> {
     @Override
-    public @NotNull SpanId deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull SpanId deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       return new SpanId(reader.nextString());
     }

--- a/sentry/src/main/java/io/sentry/SpanStatus.java
+++ b/sentry/src/main/java/io/sentry/SpanStatus.java
@@ -114,8 +114,8 @@ public enum SpanStatus implements JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<SpanStatus> {
 
     @Override
-    public @NotNull SpanStatus deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SpanStatus deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       return SpanStatus.valueOf(reader.nextString().toUpperCase(Locale.ROOT));
     }
   }

--- a/sentry/src/main/java/io/sentry/TraceContext.java
+++ b/sentry/src/main/java/io/sentry/TraceContext.java
@@ -141,7 +141,7 @@ public final class TraceContext implements JsonUnknown, JsonSerializable {
     public static final class Deserializer implements JsonDeserializer<TraceContextUser> {
       @Override
       public @NotNull TraceContextUser deserialize(
-          @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+          @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
         reader.beginObject();
 
         String id = null;
@@ -239,8 +239,8 @@ public final class TraceContext implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<TraceContext> {
     @Override
-    public @NotNull TraceContext deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull TraceContext deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
 
       SentryId traceId = null;

--- a/sentry/src/main/java/io/sentry/UserFeedback.java
+++ b/sentry/src/main/java/io/sentry/UserFeedback.java
@@ -174,8 +174,8 @@ public final class UserFeedback implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<UserFeedback> {
     @Override
-    public @NotNull UserFeedback deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull UserFeedback deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       SentryId sentryId = null;
       String name = null;
       String email = null;

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReport.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReport.java
@@ -3,9 +3,9 @@ package io.sentry.clientreport;
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -74,8 +74,8 @@ public final class ClientReport implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<ClientReport> {
     @Override
-    public @NotNull ClientReport deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull ClientReport deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       Date timestamp = null;
       List<DiscardedEvent> discardedEvents = new ArrayList<>();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/clientreport/DiscardedEvent.java
+++ b/sentry/src/main/java/io/sentry/clientreport/DiscardedEvent.java
@@ -2,9 +2,9 @@ package io.sentry.clientreport;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -93,7 +93,7 @@ public final class DiscardedEvent implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<DiscardedEvent> {
     @Override
     public @NotNull DiscardedEvent deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       String reason = null;
       String category = null;
       Long quanity = null;

--- a/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurement.java
+++ b/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurement.java
@@ -2,9 +2,9 @@ package io.sentry.profilemeasurements;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.Objects;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -118,7 +118,7 @@ public final class ProfileMeasurement implements JsonUnknown, JsonSerializable {
 
     @Override
     public @NotNull ProfileMeasurement deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       ProfileMeasurement data = new ProfileMeasurement();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
@@ -2,9 +2,9 @@ package io.sentry.profilemeasurements;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.Objects;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -92,7 +92,7 @@ public final class ProfileMeasurementValue implements JsonUnknown, JsonSerializa
 
     @Override
     public @NotNull ProfileMeasurementValue deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       ProfileMeasurementValue data = new ProfileMeasurementValue();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/App.java
+++ b/sentry/src/main/java/io/sentry/protocol/App.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -255,7 +255,7 @@ public final class App implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<App> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull App deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull App deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       App app = new App();

--- a/sentry/src/main/java/io/sentry/protocol/Browser.java
+++ b/sentry/src/main/java/io/sentry/protocol/Browser.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -102,7 +102,7 @@ public final class Browser implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<Browser> {
     @Override
-    public @NotNull Browser deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Browser deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       Browser browser = new Browser();

--- a/sentry/src/main/java/io/sentry/protocol/Contexts.java
+++ b/sentry/src/main/java/io/sentry/protocol/Contexts.java
@@ -2,8 +2,8 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SpanContext;
 import io.sentry.util.HintUtils;
@@ -160,7 +160,7 @@ public final class Contexts extends ConcurrentHashMap<String, Object> implements
 
     @Override
     public @NotNull Contexts deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       final Contexts contexts = new Contexts();
       reader.beginObject();
       while (reader.peek() == JsonToken.NAME) {

--- a/sentry/src/main/java/io/sentry/protocol/DebugImage.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugImage.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -314,8 +314,8 @@ public final class DebugImage implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<DebugImage> {
     @Override
-    public @NotNull DebugImage deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull DebugImage deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
 
       DebugImage debugImage = new DebugImage();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
+++ b/sentry/src/main/java/io/sentry/protocol/DebugMeta.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -95,7 +95,7 @@ public final class DebugMeta implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<DebugMeta> {
     @Override
-    public @NotNull DebugMeta deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull DebugMeta deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
 
       DebugMeta debugMeta = new DebugMeta();

--- a/sentry/src/main/java/io/sentry/protocol/Device.java
+++ b/sentry/src/main/java/io/sentry/protocol/Device.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -544,7 +544,7 @@ public final class Device implements JsonUnknown, JsonSerializable {
     public static final class Deserializer implements JsonDeserializer<DeviceOrientation> {
       @Override
       public @NotNull DeviceOrientation deserialize(
-          @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+          @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
         return DeviceOrientation.valueOf(reader.nextString().toUpperCase(Locale.ROOT));
       }
     }
@@ -726,7 +726,7 @@ public final class Device implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<Device> {
 
     @Override
-    public @NotNull Device deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Device deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       Device device = new Device();

--- a/sentry/src/main/java/io/sentry/protocol/Geo.java
+++ b/sentry/src/main/java/io/sentry/protocol/Geo.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -161,7 +161,7 @@ public final class Geo implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<Geo> {
 
     @Override
-    public Geo deserialize(JsonObjectReader reader, ILogger logger) throws Exception {
+    public Geo deserialize(@NotNull ObjectReader reader, ILogger logger) throws Exception {
       reader.beginObject();
       final Geo geo = new Geo();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/Gpu.java
+++ b/sentry/src/main/java/io/sentry/protocol/Gpu.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -229,7 +229,7 @@ public final class Gpu implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<Gpu> {
     @Override
-    public @NotNull Gpu deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Gpu deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       Gpu gpu = new Gpu();

--- a/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/protocol/MeasurementValue.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -101,7 +101,7 @@ public final class MeasurementValue implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<MeasurementValue> {
     @Override
     public @NotNull MeasurementValue deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
       String unit = null;

--- a/sentry/src/main/java/io/sentry/protocol/Mechanism.java
+++ b/sentry/src/main/java/io/sentry/protocol/Mechanism.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -205,7 +205,7 @@ public final class Mechanism implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<Mechanism> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Mechanism deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Mechanism deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       Mechanism mechanism = new Mechanism();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/Message.java
+++ b/sentry/src/main/java/io/sentry/protocol/Message.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -131,7 +131,7 @@ public final class Message implements JsonUnknown, JsonSerializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Message deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Message deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       Message message = new Message();

--- a/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
+++ b/sentry/src/main/java/io/sentry/protocol/OperatingSystem.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -180,7 +180,7 @@ public final class OperatingSystem implements JsonUnknown, JsonSerializable {
 
     @Override
     public @NotNull OperatingSystem deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       OperatingSystem operatingSystem = new OperatingSystem();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/Request.java
+++ b/sentry/src/main/java/io/sentry/protocol/Request.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
@@ -326,7 +326,7 @@ public final class Request implements JsonUnknown, JsonSerializable {
   @SuppressWarnings("unchecked")
   public static final class Deserializer implements JsonDeserializer<Request> {
     @Override
-    public @NotNull Request deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull Request deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       Request request = new Request();

--- a/sentry/src/main/java/io/sentry/protocol/Response.java
+++ b/sentry/src/main/java/io/sentry/protocol/Response.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -154,7 +154,7 @@ public final class Response implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<Response> {
     @Override
     public @NotNull Response deserialize(
-        final @NotNull JsonObjectReader reader, final @NotNull ILogger logger) throws Exception {
+        final @NotNull ObjectReader reader, final @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       final Response response = new Response();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/SdkInfo.java
+++ b/sentry/src/main/java/io/sentry/protocol/SdkInfo.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -116,7 +116,7 @@ public final class SdkInfo implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SdkInfo> {
     @Override
-    public @NotNull SdkInfo deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull SdkInfo deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
 
       SdkInfo sdkInfo = new SdkInfo();

--- a/sentry/src/main/java/io/sentry/protocol/SdkVersion.java
+++ b/sentry/src/main/java/io/sentry/protocol/SdkVersion.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryLevel;
@@ -224,8 +224,8 @@ public final class SdkVersion implements JsonUnknown, JsonSerializable {
   @SuppressWarnings("unchecked")
   public static final class Deserializer implements JsonDeserializer<SdkVersion> {
     @Override
-    public @NotNull SdkVersion deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SdkVersion deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
 
       String name = null;
       String version = null;

--- a/sentry/src/main/java/io/sentry/protocol/SentryException.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryException.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -223,7 +223,7 @@ public final class SentryException implements JsonUnknown, JsonSerializable {
     @SuppressWarnings("unchecked")
     @Override
     public @NotNull SentryException deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       SentryException sentryException = new SentryException();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/protocol/SentryId.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryId.java
@@ -2,8 +2,8 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.StringUtils;
 import java.io.IOException;
@@ -82,7 +82,7 @@ public final class SentryId implements JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SentryId> {
     @Override
-    public @NotNull SentryId deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull SentryId deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       return new SentryId(reader.nextString());
     }

--- a/sentry/src/main/java/io/sentry/protocol/SentryPackage.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryPackage.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.util.Objects;
@@ -100,8 +100,8 @@ public final class SentryPackage implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SentryPackage> {
     @Override
-    public @NotNull SentryPackage deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentryPackage deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
 
       String name = null;
       String version = null;

--- a/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryRuntime.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -110,8 +110,8 @@ public final class SentryRuntime implements JsonUnknown, JsonSerializable {
 
   public static final class Deserializer implements JsonDeserializer<SentryRuntime> {
     @Override
-    public @NotNull SentryRuntime deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentryRuntime deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
       SentryRuntime runtime = new SentryRuntime();
       Map<String, Object> unknown = null;

--- a/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
@@ -3,9 +3,9 @@ package io.sentry.protocol;
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.Span;
@@ -218,8 +218,8 @@ public final class SentrySpan implements JsonUnknown, JsonSerializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull SentrySpan deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentrySpan deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       reader.beginObject();
 
       Double startTimestamp = null;

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLockReason;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -398,7 +398,7 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<SentryStackFrame> {
     @Override
     public @NotNull SentryStackFrame deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       SentryStackFrame sentryStackFrame = new SentryStackFrame();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackTrace.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -154,7 +154,7 @@ public final class SentryStackTrace implements JsonUnknown, JsonSerializable {
     @SuppressWarnings("unchecked")
     @Override
     public @NotNull SentryStackTrace deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       SentryStackTrace sentryStackTrace = new SentryStackTrace();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLockReason;
 import io.sentry.vendor.gson.stream.JsonToken;
@@ -303,8 +303,8 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<SentryThread> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull SentryThread deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull SentryThread deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
       SentryThread sentryThread = new SentryThread();
       Map<String, Object> unknown = null;
       reader.beginObject();

--- a/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
@@ -3,9 +3,9 @@ package io.sentry.protocol;
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryBaseEvent;
 import io.sentry.SentryTracer;
@@ -231,7 +231,7 @@ public final class SentryTransaction extends SentryBaseEvent
     @SuppressWarnings({"unchecked", "JavaUtilDate"})
     @Override
     public @NotNull SentryTransaction deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
       // Init with placeholders.

--- a/sentry/src/main/java/io/sentry/protocol/TransactionInfo.java
+++ b/sentry/src/main/java/io/sentry/protocol/TransactionInfo.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -62,7 +62,7 @@ public final class TransactionInfo implements JsonSerializable, JsonUnknown {
 
     @Override
     public @NotNull TransactionInfo deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
 
       String source = null;

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
@@ -418,7 +418,7 @@ public final class User implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<User> {
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull User deserialize(@NotNull JsonObjectReader reader, @NotNull ILogger logger)
+    public @NotNull User deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
         throws Exception {
       reader.beginObject();
       User user = new User();

--- a/sentry/src/main/java/io/sentry/protocol/ViewHierarchy.java
+++ b/sentry/src/main/java/io/sentry/protocol/ViewHierarchy.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -73,8 +73,8 @@ public final class ViewHierarchy implements JsonUnknown, JsonSerializable {
   public static final class Deserializer implements JsonDeserializer<ViewHierarchy> {
 
     @Override
-    public @NotNull ViewHierarchy deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+    public @NotNull ViewHierarchy deserialize(@NotNull ObjectReader reader, @NotNull ILogger logger)
+        throws Exception {
 
       @Nullable String renderingSystem = null;
       @Nullable List<ViewHierarchyNode> windows = null;

--- a/sentry/src/main/java/io/sentry/protocol/ViewHierarchyNode.java
+++ b/sentry/src/main/java/io/sentry/protocol/ViewHierarchyNode.java
@@ -2,9 +2,9 @@ package io.sentry.protocol;
 
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
-import io.sentry.JsonObjectReader;
 import io.sentry.JsonSerializable;
 import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
@@ -205,7 +205,7 @@ public final class ViewHierarchyNode implements JsonUnknown, JsonSerializable {
 
     @Override
     public @NotNull ViewHierarchyNode deserialize(
-        @NotNull JsonObjectReader reader, @NotNull ILogger logger) throws Exception {
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       @Nullable Map<String, Object> unknown = null;
       @NotNull final ViewHierarchyNode node = new ViewHierarchyNode();
 

--- a/sentry/src/main/java/io/sentry/util/MapObjectReader.java
+++ b/sentry/src/main/java/io/sentry/util/MapObjectReader.java
@@ -28,7 +28,8 @@ public final class MapObjectReader implements ObjectReader {
   }
 
   @Override
-  public void nextUnknown(final @NotNull ILogger logger, Map<String, Object> unknown, String name) {
+  public void nextUnknown(
+      final @NotNull ILogger logger, final Map<String, Object> unknown, final String name) {
     try {
       unknown.put(name, nextObjectOrNull());
     } catch (Exception exception) {
@@ -63,14 +64,14 @@ public final class MapObjectReader implements ObjectReader {
   @Nullable
   @Override
   public Date nextDateOrNull(final @NotNull ILogger logger) throws IOException {
-    String dateString = nextStringOrNull();
+    final String dateString = nextStringOrNull();
     return ObjectReader.dateOrNull(dateString, logger);
   }
 
   @Nullable
   @Override
   public TimeZone nextTimeZoneOrNull(final @NotNull ILogger logger) throws IOException {
-    String timeZoneId = nextStringOrNull();
+    final String timeZoneId = nextStringOrNull();
     return timeZoneId != null ? TimeZone.getTimeZone(timeZoneId) : null;
   }
 
@@ -87,7 +88,7 @@ public final class MapObjectReader implements ObjectReader {
       return JsonToken.END_DOCUMENT;
     }
 
-    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    final Map.Entry<String, Object> currentEntry = stack.peekLast();
     if (currentEntry == null) {
       return JsonToken.END_DOCUMENT;
     }
@@ -96,7 +97,7 @@ public final class MapObjectReader implements ObjectReader {
       return JsonToken.NAME;
     }
 
-    Object value = currentEntry.getValue();
+    final Object value = currentEntry.getValue();
 
     if (value instanceof Map) {
       return JsonToken.BEGIN_OBJECT;
@@ -118,7 +119,7 @@ public final class MapObjectReader implements ObjectReader {
   @NotNull
   @Override
   public String nextName() throws IOException {
-    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    final Map.Entry<String, Object> currentEntry = stack.peekLast();
     if (currentEntry != null && currentEntry.getKey() != null) {
       return currentEntry.getKey();
     }
@@ -127,11 +128,11 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public void beginObject() throws IOException {
-    Map.Entry<String, Object> currentEntry = stack.removeLast();
+    final Map.Entry<String, Object> currentEntry = stack.removeLast();
     if (currentEntry == null) {
       throw new IOException("No more entries");
     }
-    Object value = currentEntry.getValue();
+    final Object value = currentEntry.getValue();
     if (value instanceof Map) {
       // insert a dummy entry to indicate end of an object
       stack.addLast(new AbstractMap.SimpleEntry<>(null, JsonToken.END_OBJECT));
@@ -153,17 +154,17 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public void beginArray() throws IOException {
-    Map.Entry<String, Object> currentEntry = stack.removeLast();
+    final Map.Entry<String, Object> currentEntry = stack.removeLast();
     if (currentEntry == null) {
       throw new IOException("No more entries");
     }
-    Object value = currentEntry.getValue();
+    final Object value = currentEntry.getValue();
     if (value instanceof List) {
       // insert a dummy entry to indicate end of an object
       stack.addLast(new AbstractMap.SimpleEntry<>(null, JsonToken.END_ARRAY));
       // extract map entries onto the stack
       for (int i = ((List<?>) value).size() - 1; i >= 0; i--) {
-        Object entry = ((List<?>) value).get(i);
+        final Object entry = ((List<?>) value).get(i);
         stack.addLast(new AbstractMap.SimpleEntry<>(null, entry));
       }
     } else {
@@ -185,7 +186,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public int nextInt() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).intValue();
     } else {
@@ -196,7 +197,7 @@ public final class MapObjectReader implements ObjectReader {
   @Nullable
   @Override
   public Integer nextIntegerOrNull() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).intValue();
     }
@@ -205,7 +206,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public long nextLong() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).longValue();
     } else {
@@ -216,7 +217,7 @@ public final class MapObjectReader implements ObjectReader {
   @Nullable
   @Override
   public Long nextLongOrNull() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).longValue();
     }
@@ -225,7 +226,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public String nextString() throws IOException {
-    String value = nextValueOrNull();
+    final String value = nextValueOrNull();
     if (value != null) {
       return value;
     } else {
@@ -241,7 +242,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public boolean nextBoolean() throws IOException {
-    Boolean value = nextValueOrNull();
+    final Boolean value = nextValueOrNull();
     if (value != null) {
       return value;
     } else {
@@ -257,7 +258,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public double nextDouble() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).doubleValue();
     } else {
@@ -268,7 +269,7 @@ public final class MapObjectReader implements ObjectReader {
   @Nullable
   @Override
   public Double nextDoubleOrNull() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).doubleValue();
     }
@@ -278,7 +279,7 @@ public final class MapObjectReader implements ObjectReader {
   @Nullable
   @Override
   public Float nextFloatOrNull() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).floatValue();
     }
@@ -287,7 +288,7 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public float nextFloat() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value instanceof Number) {
       return ((Number) value).floatValue();
     } else {
@@ -297,14 +298,14 @@ public final class MapObjectReader implements ObjectReader {
 
   @Override
   public void nextNull() throws IOException {
-    Object value = nextValueOrNull();
+    final Object value = nextValueOrNull();
     if (value != null) {
       throw new IOException("Expected null but was " + peek());
     }
   }
 
   @Override
-  public void setLenient(boolean lenient) {}
+  public void setLenient(final boolean lenient) {}
 
   @Override
   public void skipValue() throws IOException {}
@@ -324,17 +325,17 @@ public final class MapObjectReader implements ObjectReader {
   private <T> T nextValueOrNull(
       final @Nullable ILogger logger, final @Nullable JsonDeserializer<T> deserializer)
       throws Exception {
-    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    final Map.Entry<String, Object> currentEntry = stack.peekLast();
     if (currentEntry == null) {
       return null;
     }
-    T value = (T) currentEntry.getValue();
+    final T value = (T) currentEntry.getValue();
     if (deserializer != null && logger != null) {
       return deserializer.deserialize(this, logger);
     } else if (value instanceof List) {
       List<Object> list = new ArrayList<>((List<Object>) value);
       if (!list.isEmpty()) {
-        T next = (T) list.remove(0);
+        final T next = (T) list.remove(0);
         if (next instanceof Map) {
           stack.addLast(new AbstractMap.SimpleEntry<>(null, next));
         }

--- a/sentry/src/main/java/io/sentry/util/MapObjectReader.java
+++ b/sentry/src/main/java/io/sentry/util/MapObjectReader.java
@@ -1,0 +1,350 @@
+package io.sentry.util;
+
+import io.sentry.ILogger;
+import io.sentry.JsonDeserializer;
+import io.sentry.ObjectReader;
+import io.sentry.SentryLevel;
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayDeque;
+import java.util.Date;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings("unchecked")
+public final class MapObjectReader implements ObjectReader {
+
+  private final Deque<Map.Entry<String, Object>> stack;
+
+  public MapObjectReader(final Map<String, Object> root) {
+    stack = new ArrayDeque<>();
+    stack.addLast(new AbstractMap.SimpleEntry<>(null, root));
+  }
+
+  @Override
+  public void nextUnknown(final @NotNull ILogger logger, Map<String, Object> unknown, String name) {
+    try {
+      unknown.put(name, nextObjectOrNull());
+    } catch (Exception exception) {
+      logger.log(SentryLevel.ERROR, exception, "Error deserializing unknown key: %s", name);
+    }
+  }
+
+  @Nullable
+  @Override
+  public <T> List<T> nextListOrNull(
+      final @NotNull ILogger logger, final @NotNull JsonDeserializer<T> deserializer)
+      throws IOException {
+    return nextValueOrNull();
+  }
+
+  @Nullable
+  @Override
+  public <T> Map<String, T> nextMapOrNull(
+      final @NotNull ILogger logger, final @NotNull JsonDeserializer<T> deserializer)
+      throws IOException {
+    return nextValueOrNull();
+  }
+
+  @Nullable
+  @Override
+  public <T> T nextOrNull(
+      final @NotNull ILogger logger, final @NotNull JsonDeserializer<T> deserializer)
+      throws Exception {
+    return nextValueOrNull(logger, deserializer);
+  }
+
+  @Nullable
+  @Override
+  public Date nextDateOrNull(final @NotNull ILogger logger) throws IOException {
+    String dateString = nextStringOrNull();
+    return ObjectReader.dateOrNull(dateString, logger);
+  }
+
+  @Nullable
+  @Override
+  public TimeZone nextTimeZoneOrNull(final @NotNull ILogger logger) throws IOException {
+    String timeZoneId = nextStringOrNull();
+    return timeZoneId != null ? TimeZone.getTimeZone(timeZoneId) : null;
+  }
+
+  @Nullable
+  @Override
+  public Object nextObjectOrNull() throws IOException {
+    return nextValueOrNull();
+  }
+
+  @NotNull
+  @Override
+  public JsonToken peek() throws IOException {
+    if (stack.isEmpty()) {
+      return JsonToken.END_DOCUMENT;
+    }
+
+    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    if (currentEntry == null) {
+      return JsonToken.END_DOCUMENT;
+    }
+
+    if (currentEntry.getKey() != null) {
+      return JsonToken.NAME;
+    }
+
+    Object value = currentEntry.getValue();
+
+    if (value instanceof Map) {
+      return JsonToken.BEGIN_OBJECT;
+    } else if (value instanceof List) {
+      return JsonToken.BEGIN_ARRAY;
+    } else if (value instanceof String) {
+      return JsonToken.STRING;
+    } else if (value instanceof Number) {
+      return JsonToken.NUMBER;
+    } else if (value instanceof Boolean) {
+      return JsonToken.BOOLEAN;
+    } else if (value instanceof JsonToken) {
+      return (JsonToken) value;
+    } else {
+      return JsonToken.END_DOCUMENT;
+    }
+  }
+
+  @NotNull
+  @Override
+  public String nextName() throws IOException {
+    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    if (currentEntry != null && currentEntry.getKey() != null) {
+      return currentEntry.getKey();
+    }
+    throw new IOException("Expected a name but was " + peek());
+  }
+
+  @Override
+  public void beginObject() throws IOException {
+    Map.Entry<String, Object> currentEntry = stack.removeLast();
+    if (currentEntry == null) {
+      throw new IOException("No more entries");
+    }
+    Object value = currentEntry.getValue();
+    if (value instanceof Map) {
+      // insert a dummy entry to indicate end of an object
+      stack.addLast(new AbstractMap.SimpleEntry<>(null, JsonToken.END_OBJECT));
+      // extract map entries onto the stack
+      for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
+        stack.addLast(entry);
+      }
+    } else {
+      throw new IOException("Current token is not an object");
+    }
+  }
+
+  @Override
+  public void endObject() throws IOException {
+    if (stack.size() > 1) {
+      stack.removeLast(); // Pop the current map from stack
+    }
+  }
+
+  @Override
+  public void beginArray() throws IOException {
+    Map.Entry<String, Object> currentEntry = stack.removeLast();
+    if (currentEntry == null) {
+      throw new IOException("No more entries");
+    }
+    Object value = currentEntry.getValue();
+    if (value instanceof List) {
+      // insert a dummy entry to indicate end of an object
+      stack.addLast(new AbstractMap.SimpleEntry<>(null, JsonToken.END_ARRAY));
+      // extract map entries onto the stack
+      for (Object entry : (List<?>) value) {
+        stack.addLast(new AbstractMap.SimpleEntry<>(null, entry));
+      }
+    } else {
+      throw new IOException("Current token is not an object");
+    }
+  }
+
+  @Override
+  public void endArray() throws IOException {
+    if (stack.size() > 1) {
+      stack.removeLast(); // Pop the current array from stack
+    }
+  }
+
+  @Override
+  public boolean hasNext() throws IOException {
+    return !stack.isEmpty();
+  }
+
+  @Override
+  public int nextInt() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    } else {
+      throw new IOException("Expected int");
+    }
+  }
+
+  @Nullable
+  @Override
+  public Integer nextIntegerOrNull() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    }
+    return null;
+  }
+
+  @Override
+  public long nextLong() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    } else {
+      throw new IOException("Expected long");
+    }
+  }
+
+  @Nullable
+  @Override
+  public Long nextLongOrNull() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    return null;
+  }
+
+  @Override
+  public String nextString() throws IOException {
+    String value = nextValueOrNull();
+    if (value != null) {
+      return value;
+    } else {
+      throw new IOException("Expected string");
+    }
+  }
+
+  @Nullable
+  @Override
+  public String nextStringOrNull() throws IOException {
+    return nextValueOrNull();
+  }
+
+  @Override
+  public boolean nextBoolean() throws IOException {
+    Boolean value = nextValueOrNull();
+    if (value != null) {
+      return value;
+    } else {
+      throw new IOException("Expected boolean");
+    }
+  }
+
+  @Nullable
+  @Override
+  public Boolean nextBooleanOrNull() throws IOException {
+    return nextValueOrNull();
+  }
+
+  @Override
+  public double nextDouble() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).doubleValue();
+    } else {
+      throw new IOException("Expected double");
+    }
+  }
+
+  @Nullable
+  @Override
+  public Double nextDoubleOrNull() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).doubleValue();
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Float nextFloatOrNull() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).floatValue();
+    }
+    return null;
+  }
+
+  @Override
+  public float nextFloat() throws IOException {
+    Object value = nextValueOrNull();
+    if (value instanceof Number) {
+      return ((Number) value).floatValue();
+    } else {
+      throw new IOException("Expected float");
+    }
+  }
+
+  @Override
+  public void nextNull() throws IOException {
+    nextValueOrNull();
+  }
+
+  @Override
+  public void setLenient(boolean lenient) {}
+
+  @Override
+  public void skipValue() throws IOException {}
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  @Nullable
+  private <T> T nextValueOrNull() throws IOException {
+    try {
+      return nextValueOrNull(null, null);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  @Nullable
+  private <T> T nextValueOrNull(
+      final @Nullable ILogger logger, final @Nullable JsonDeserializer<T> deserializer)
+      throws Exception {
+    Map.Entry<String, Object> currentEntry = stack.peekLast();
+    if (currentEntry == null) {
+      return null;
+    }
+    T value = (T) currentEntry.getValue();
+    if (deserializer != null && logger != null) {
+      return deserializer.deserialize(this, logger);
+    } else if (value instanceof List) {
+      List<Object> list = (List<Object>) value;
+      if (!list.isEmpty()) {
+        T next = (T) list.remove(0);
+        if (next instanceof Map) {
+          stack.addLast(new AbstractMap.SimpleEntry<>(null, next));
+        }
+        return next;
+      }
+    } else if (value instanceof Map) {
+      stack.addLast(new AbstractMap.SimpleEntry<>(null, value));
+      return value;
+    }
+    stack.removeLast();
+    return value;
+  }
+
+  @Override
+  public void close() throws IOException {
+    stack.clear();
+  }
+}

--- a/sentry/src/main/java/io/sentry/util/MapObjectWriter.java
+++ b/sentry/src/main/java/io/sentry/util/MapObjectWriter.java
@@ -121,6 +121,11 @@ public final class MapObjectWriter implements ObjectWriter {
   }
 
   @Override
+  public void setLenient(boolean lenient) {
+    // no-op
+  }
+
+  @Override
   public MapObjectWriter beginArray() throws IOException {
     stack.add(new ArrayList<>());
     return this;
@@ -148,6 +153,12 @@ public final class MapObjectWriter implements ObjectWriter {
   @Override
   public MapObjectWriter value(final @Nullable String value) throws IOException {
     postValue(value);
+    return this;
+  }
+
+  @Override
+  public ObjectWriter jsonValue(@Nullable String value) throws IOException {
+    // no-op
     return this;
   }
 

--- a/sentry/src/test/java/io/sentry/JsonObjectReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonObjectReaderTest.kt
@@ -285,7 +285,7 @@ class JsonObjectReaderTest {
         var bar: String? = null
     ) {
         class Deserializer : JsonDeserializer<Deserializable> {
-            override fun deserialize(reader: JsonObjectReader, logger: ILogger): Deserializable {
+            override fun deserialize(reader: ObjectReader, logger: ILogger): Deserializable {
                 return Deserializable().apply {
                     reader.beginObject()
                     reader.nextName()

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -1,6 +1,8 @@
 package io.sentry
 
 import io.sentry.exception.SentryEnvelopeException
+import io.sentry.protocol.ReplayRecordingSerializationTest
+import io.sentry.protocol.SentryReplayEventSerializationTest
 import io.sentry.protocol.User
 import io.sentry.protocol.ViewHierarchy
 import io.sentry.test.injectForField
@@ -10,12 +12,15 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.msgpack.core.MessagePack
 import java.io.BufferedWriter
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
+import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.nio.charset.Charset
+import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -66,7 +71,12 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with bytes`() {
         val attachment = Attachment(fixture.bytesAllowed, fixture.filename)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertAttachment(attachment, fixture.bytesAllowed, item)
     }
@@ -78,7 +88,12 @@ class SentryEnvelopeItemTest {
 
         val attachment = Attachment(viewHierarchy, fixture.filename, "text/plain", null, false)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertAttachment(attachment, viewHierarchySerialized, item)
     }
@@ -87,7 +102,12 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with attachmentType`() {
         val attachment = Attachment(fixture.pathname, fixture.filename, "", true, "event.minidump")
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertEquals("event.minidump", item.header.attachmentType)
     }
@@ -98,7 +118,12 @@ class SentryEnvelopeItemTest {
         file.writeBytes(fixture.bytesAllowed)
         val attachment = Attachment(file.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertAttachment(attachment, fixture.bytesAllowed, item)
     }
@@ -110,7 +135,12 @@ class SentryEnvelopeItemTest {
         file.writeBytes(twoMB)
         val attachment = Attachment(file.absolutePath)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertAttachment(attachment, twoMB, item)
     }
@@ -119,7 +149,12 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with non existent file`() {
         val attachment = Attachment("I don't exist", "file.txt")
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertFailsWith<IOException>(
             "Reading the attachment ${attachment.pathname} failed, because the file located at " +
@@ -139,7 +174,12 @@ class SentryEnvelopeItemTest {
         if (changedFileReadPermission) {
             val attachment = Attachment(file.path, "file.txt")
 
-            val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+            val item = SentryEnvelopeItem.fromAttachment(
+                fixture.serializer,
+                fixture.options.logger,
+                attachment,
+                fixture.maxAttachmentSize
+            )
 
             assertFailsWith<IOException>(
                 "Reading the attachment ${attachment.pathname} failed, " +
@@ -162,7 +202,12 @@ class SentryEnvelopeItemTest {
         val securityManager = DenyReadFileSecurityManager(fixture.pathname)
         System.setSecurityManager(securityManager)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertFailsWith<SecurityException>("Reading the attachment ${attachment.pathname} failed.") {
             item.data
@@ -181,7 +226,12 @@ class SentryEnvelopeItemTest {
         // reflection instead.
         attachment.injectForField("pathname", null)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertFailsWith<SentryEnvelopeException>(
             "Couldn't attach the attachment ${attachment.filename}.\n" +
@@ -196,7 +246,12 @@ class SentryEnvelopeItemTest {
         val image = this::class.java.classLoader.getResource("Tongariro.jpg")!!
         val attachment = Attachment(image.path)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.serializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
         assertAttachment(attachment, image.readBytes(), item)
     }
 
@@ -204,7 +259,12 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with bytes too big`() {
         val attachment = Attachment(fixture.bytesTooBig, fixture.filename)
         val exception = assertFailsWith<SentryEnvelopeException> {
-            SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize).data
+            SentryEnvelopeItem.fromAttachment(
+                fixture.serializer,
+                fixture.options.logger,
+                attachment,
+                fixture.maxAttachmentSize
+            ).data
         }
 
         assertEquals(
@@ -227,7 +287,12 @@ class SentryEnvelopeItemTest {
 
         val attachment = Attachment(serializable, fixture.filename, "text/plain", null, false)
         val exception = assertFailsWith<SentryEnvelopeException> {
-            SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize).data
+            SentryEnvelopeItem.fromAttachment(
+                fixture.serializer,
+                fixture.options.logger,
+                attachment,
+                fixture.maxAttachmentSize
+            ).data
         }
 
         assertEquals(
@@ -246,7 +311,12 @@ class SentryEnvelopeItemTest {
         val attachment = Attachment(file.path)
 
         val exception = assertFailsWith<IOException> {
-            SentryEnvelopeItem.fromAttachment(fixture.serializer, fixture.options.logger, attachment, fixture.maxAttachmentSize).data
+            SentryEnvelopeItem.fromAttachment(
+                fixture.serializer,
+                fixture.options.logger,
+                attachment,
+                fixture.maxAttachmentSize
+            ).data
         }
 
         assertEquals(
@@ -261,7 +331,12 @@ class SentryEnvelopeItemTest {
     fun `fromAttachment with bytesFrom serializable are null`() {
         val attachment = Attachment(mock<JsonSerializable>(), "mock-file-name", null, null, false)
 
-        val item = SentryEnvelopeItem.fromAttachment(fixture.errorSerializer, fixture.options.logger, attachment, fixture.maxAttachmentSize)
+        val item = SentryEnvelopeItem.fromAttachment(
+            fixture.errorSerializer,
+            fixture.options.logger,
+            attachment,
+            fixture.maxAttachmentSize
+        )
 
         assertFailsWith<SentryEnvelopeException>(
             "Couldn't attach the attachment ${attachment.filename}.\n" +
@@ -279,8 +354,13 @@ class SentryEnvelopeItemTest {
         }
 
         file.writeBytes(fixture.bytes)
-        SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, fixture.serializer).data
-        verify(profilingTraceData).sampledProfile = Base64.encodeToString(fixture.bytes, Base64.NO_WRAP or Base64.NO_PADDING)
+        SentryEnvelopeItem.fromProfilingTrace(
+            profilingTraceData,
+            fixture.maxAttachmentSize,
+            fixture.serializer
+        ).data
+        verify(profilingTraceData).sampledProfile =
+            Base64.encodeToString(fixture.bytes, Base64.NO_WRAP or Base64.NO_PADDING)
     }
 
     @Test
@@ -292,7 +372,11 @@ class SentryEnvelopeItemTest {
 
         file.writeBytes(fixture.bytes)
         assert(file.exists())
-        val traceData = SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())
+        val traceData = SentryEnvelopeItem.fromProfilingTrace(
+            profilingTraceData,
+            fixture.maxAttachmentSize,
+            mock()
+        )
         assert(file.exists())
         traceData.data
         assertFalse(file.exists())
@@ -306,7 +390,11 @@ class SentryEnvelopeItemTest {
         }
 
         assertFailsWith<SentryEnvelopeException>("Dropping profiling trace data, because the file ${file.path} doesn't exists") {
-            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
+            SentryEnvelopeItem.fromProfilingTrace(
+                profilingTraceData,
+                fixture.maxAttachmentSize,
+                mock()
+            ).data
         }
     }
 
@@ -319,7 +407,11 @@ class SentryEnvelopeItemTest {
         file.writeBytes(fixture.bytes)
         file.setReadable(false)
         assertFailsWith<IOException>("Dropping profiling trace data, because the file ${file.path} doesn't exists") {
-            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
+            SentryEnvelopeItem.fromProfilingTrace(
+                profilingTraceData,
+                fixture.maxAttachmentSize,
+                mock()
+            ).data
         }
     }
 
@@ -331,7 +423,11 @@ class SentryEnvelopeItemTest {
             whenever(it.traceFile).thenReturn(file)
         }
 
-        val traceData = SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock())
+        val traceData = SentryEnvelopeItem.fromProfilingTrace(
+            profilingTraceData,
+            fixture.maxAttachmentSize,
+            mock()
+        )
         assertFailsWith<SentryEnvelopeException>("Profiling trace file is empty") {
             traceData.data
         }
@@ -346,7 +442,11 @@ class SentryEnvelopeItemTest {
         }
 
         val exception = assertFailsWith<IOException> {
-            SentryEnvelopeItem.fromProfilingTrace(profilingTraceData, fixture.maxAttachmentSize, mock()).data
+            SentryEnvelopeItem.fromProfilingTrace(
+                profilingTraceData,
+                fixture.maxAttachmentSize,
+                mock()
+            ).data
         }
 
         assertEquals(
@@ -355,6 +455,58 @@ class SentryEnvelopeItemTest {
                 "allowed size of ${fixture.maxAttachmentSize} bytes.",
             exception.message
         )
+    }
+
+    @Test
+    fun `fromReplay encodes payload into msgpack`() {
+        val file = Files.createTempFile("replay", "").toFile()
+        val videoBytes =
+            this::class.java.classLoader.getResource("Tongariro.jpg")!!.readBytes()
+        file.writeBytes(videoBytes)
+
+        val replayEvent = SentryReplayEventSerializationTest.Fixture().getSut().apply {
+            videoFile = file
+        }
+        val replayRecording = ReplayRecordingSerializationTest.Fixture().getSut()
+        val replayItem = SentryEnvelopeItem
+            .fromReplay(fixture.serializer, fixture.options.logger, replayEvent, replayRecording)
+
+        assertEquals(SentryItemType.ReplayVideo, replayItem.header.type)
+
+        assertPayload(replayItem, replayEvent, replayRecording, videoBytes)
+    }
+
+    @Test
+    fun `fromReplay does not add video item when no bytes`() {
+        val file = File(fixture.pathname)
+        file.writeBytes(ByteArray(0))
+
+        val replayEvent = SentryReplayEventSerializationTest.Fixture().getSut().apply {
+            videoFile = file
+        }
+
+        val replayItem = SentryEnvelopeItem
+            .fromReplay(fixture.serializer, fixture.options.logger, replayEvent, null)
+        replayItem.data
+        assertPayload(replayItem, replayEvent, null, ByteArray(0)) { mapSize ->
+            assertEquals(1, mapSize)
+        }
+    }
+
+    @Test
+    fun `fromReplay deletes file only after reading data`() {
+        val file = File(fixture.pathname)
+        val replayEvent = SentryReplayEventSerializationTest.Fixture().getSut().apply {
+            videoFile = file
+        }
+
+        file.writeBytes(fixture.bytes)
+        assert(file.exists())
+        val replayItem = SentryEnvelopeItem
+            .fromReplay(fixture.serializer, fixture.options.logger, replayEvent, null)
+        assert(file.exists())
+        replayItem.data
+        assertFalse(file.exists())
     }
 
     private fun createSession(): Session {
@@ -378,5 +530,46 @@ class SentryEnvelopeItemTest {
                 return stream.toByteArray()
             }
         }
+    }
+
+    private fun assertPayload(
+        replayItem: SentryEnvelopeItem,
+        replayEvent: SentryReplayEvent,
+        replayRecording: ReplayRecording?,
+        videoBytes: ByteArray,
+        mapSizeAsserter: (mapSize: Int) -> Unit = {}
+    ) {
+        val unpacker = MessagePack.newDefaultUnpacker(replayItem.data)
+        val mapSize = unpacker.unpackMapHeader()
+        mapSizeAsserter(mapSize)
+        for (i in 0 until mapSize) {
+            val key = unpacker.unpackString()
+            when (key) {
+                SentryItemType.ReplayEvent.itemType -> {
+                    val replayEventLength = unpacker.unpackBinaryHeader()
+                    val replayEventBytes = unpacker.readPayload(replayEventLength)
+                    val actualReplayEvent = fixture.serializer.deserialize(
+                        InputStreamReader(replayEventBytes.inputStream()),
+                        SentryReplayEvent::class.java
+                    )
+                    assertEquals(replayEvent, actualReplayEvent)
+                }
+                SentryItemType.ReplayRecording.itemType -> {
+                    val replayRecordingLength = unpacker.unpackBinaryHeader()
+                    val replayRecordingBytes = unpacker.readPayload(replayRecordingLength)
+                    val actualReplayRecording = fixture.serializer.deserialize(
+                        InputStreamReader(replayRecordingBytes.inputStream()),
+                        ReplayRecording::class.java
+                    )
+                    assertEquals(replayRecording, actualReplayRecording)
+                }
+                SentryItemType.ReplayVideo.itemType -> {
+                    val videoLength = unpacker.unpackBinaryHeader()
+                    val actualBytes = unpacker.readPayload(videoLength)
+                    assertArrayEquals(videoBytes, actualBytes)
+                }
+            }
+        }
+        unpacker.close()
     }
 }

--- a/sentry/src/test/java/io/sentry/protocol/SentryBaseEventSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryBaseEventSerializationTest.kt
@@ -2,8 +2,8 @@ package io.sentry.protocol
 
 import io.sentry.ILogger
 import io.sentry.JsonDeserializer
-import io.sentry.JsonObjectReader
 import io.sentry.JsonSerializable
+import io.sentry.ObjectReader
 import io.sentry.ObjectWriter
 import io.sentry.SentryBaseEvent
 import io.sentry.SentryIntegrationPackageStorage
@@ -27,7 +27,7 @@ class SentryBaseEventSerializationTest {
         }
 
         class Deserializer : JsonDeserializer<Sut> {
-            override fun deserialize(reader: JsonObjectReader, logger: ILogger): Sut {
+            override fun deserialize(reader: ObjectReader, logger: ILogger): Sut {
                 val sut = Sut()
                 reader.beginObject()
 

--- a/sentry/src/test/java/io/sentry/protocol/SentryReplayEventSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryReplayEventSerializationTest.kt
@@ -27,6 +27,10 @@ class SentryReplayEventSerializationTest {
             errorIds = listOf("ab3a347a4cc14fd4b4cf1dc56b670c5b")
             traceIds = listOf("340cfef948204549ac07c3b353c81c50")
             SentryBaseEventSerializationTest.Fixture().update(this)
+            // irrelevant for replay
+            serverName = null
+            breadcrumbs = null
+            extras = null
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/java/io/sentry/util/MapObjectReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/util/MapObjectReaderTest.kt
@@ -1,0 +1,131 @@
+package io.sentry.util
+
+import io.sentry.ILogger
+import io.sentry.JsonDeserializer
+import io.sentry.JsonSerializable
+import io.sentry.NoOpLogger
+import io.sentry.ObjectReader
+import io.sentry.ObjectWriter
+import io.sentry.vendor.gson.stream.JsonToken
+import java.math.BigDecimal
+import java.net.URI
+import java.util.Currency
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MapObjectReaderTest {
+
+    enum class BasicEnum {
+        A
+    }
+
+    data class BasicSerializable(var test: String = "string") : JsonSerializable {
+
+        override fun serialize(writer: ObjectWriter, logger: ILogger) {
+            writer.beginObject()
+                .name("test")
+                .value(test)
+                .endObject()
+        }
+
+        class Deserializer : JsonDeserializer<BasicSerializable> {
+            override fun deserialize(reader: ObjectReader, logger: ILogger): BasicSerializable {
+                val basicSerializable = BasicSerializable()
+                reader.beginObject()
+                if (reader.nextName() == "test") {
+                    basicSerializable.test = reader.nextString()
+                }
+                reader.endObject()
+                return basicSerializable
+            }
+        }
+    }
+
+    @Test
+    fun `deserializes data correctly`() {
+        val logger = NoOpLogger.getInstance()
+        val data = mutableMapOf<String, Any>()
+        val writer = MapObjectWriter(data)
+
+        writer.name("null").nullValue()
+        writer.name("int").value(1)
+        writer.name("boolean").value(true)
+        writer.name("long").value(Long.MAX_VALUE)
+        writer.name("double").value(Double.MAX_VALUE)
+        writer.name("number").value(BigDecimal(123))
+        writer.name("date").value(logger, Date(0))
+        writer.name("string").value("string")
+
+        writer.name("TimeZone").value(logger, TimeZone.getTimeZone("Vienna"))
+        writer.name("JsonSerializable").value(
+            logger,
+            BasicSerializable()
+        )
+        writer.name("Collection").value(logger, listOf("a", "b"))
+        writer.name("Arrays").value(logger, arrayOf("b", "c"))
+        writer.name("Map").value(logger, mapOf(kotlin.Pair("key", "value")))
+        writer.name("Locale").value(logger, Locale.US)
+        writer.name("URI").value(logger, URI.create("http://www.example.com"))
+        writer.name("UUID").value(logger, UUID.fromString("00000000-1111-2222-3333-444444444444"))
+        writer.name("Currency").value(logger, Currency.getInstance("EUR"))
+        writer.name("Enum").value(logger, MapObjectWriterTest.BasicEnum.A)
+
+        val reader = MapObjectReader(data)
+        reader.beginObject()
+        assertEquals(JsonToken.NAME, reader.peek())
+        assertEquals("Enum", reader.nextName())
+        assertEquals(BasicEnum.A, BasicEnum.valueOf(reader.nextString()))
+        assertEquals("Currency", reader.nextName())
+        assertEquals(Currency.getInstance("EUR"), Currency.getInstance(reader.nextString()))
+        assertEquals("UUID", reader.nextName())
+        assertEquals(
+            UUID.fromString("00000000-1111-2222-3333-444444444444"),
+            UUID.fromString(reader.nextString())
+        )
+        assertEquals("URI", reader.nextName())
+        assertEquals(URI.create("http://www.example.com"), URI.create(reader.nextString()))
+        assertEquals("Locale", reader.nextName())
+        assertEquals(Locale.US.toString(), reader.nextString())
+        assertEquals("Map", reader.nextName())
+        // nested object
+        reader.beginObject()
+        assertEquals("key", reader.nextName())
+        assertEquals("value", reader.nextStringOrNull())
+        reader.endObject()
+        assertEquals("Arrays", reader.nextName())
+        reader.beginArray()
+        assertEquals("b", reader.nextString())
+        assertEquals("c", reader.nextString())
+        reader.endArray()
+        assertEquals("Collection", reader.nextName())
+        reader.beginArray()
+        assertEquals("a", reader.nextString())
+        assertEquals("b", reader.nextString())
+        reader.endArray()
+        assertEquals("JsonSerializable", reader.nextName())
+        assertEquals(BasicSerializable(), reader.nextOrNull(logger, BasicSerializable.Deserializer()))
+        assertEquals("TimeZone", reader.nextName())
+        assertEquals(TimeZone.getTimeZone("Vienna"), reader.nextTimeZoneOrNull(logger))
+        assertEquals("string", reader.nextName())
+        assertEquals("string", reader.nextString())
+        assertEquals("date", reader.nextName())
+        assertEquals(Date(0), reader.nextDateOrNull(logger))
+        assertEquals("number", reader.nextName())
+        assertEquals(BigDecimal(123), reader.nextObjectOrNull())
+        assertEquals("double", reader.nextName())
+        assertEquals(Double.MAX_VALUE, reader.nextDoubleOrNull())
+        assertEquals("long", reader.nextName())
+        assertEquals(Long.MAX_VALUE, reader.nextLongOrNull())
+        assertEquals("boolean", reader.nextName())
+        assertEquals(true, reader.nextBoolean())
+        assertEquals("int", reader.nextName())
+        assertEquals(1, reader.nextInt())
+        assertEquals("null", reader.nextName())
+        reader.nextNull()
+        reader.endObject()
+    }
+}


### PR DESCRIPTION
_#skip-changelog_

Add new sentry-android-replay module## :scroll: Description
<!--- Describe your changes in detail -->
* Extract an interface `ObjectReader` from `JsonObjecteReader` and introduce a new `MapObjectReader` analogous to what @markushi has done for the hybrid SDKs in https://github.com/getsentry/sentry-java/pull/2814
  * This is necessary to transform object from Maps to typed object for RRWebEvents since we hold a list of generics and lose their type at runtime.
* I also think this probably will be useful in the future if hybrid sdks will pass the data to the native ones in form of dictionaries (probably gonna be the case for Flutter session replay)

There are still some rough edges I believe, but it works for the current replay usecase, and I think it should be fine. I'll add some tests but won't cover everything (will fix stuff along-the-way if I find something).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Next Steps
Add some tests for the MapObjectReader
