### PR TITLE
Force flush metrics when weight is too high

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1023,7 +1023,7 @@ public final class io/sentry/MemoryCollectionData {
 
 public final class io/sentry/MetricsAggregator : io/sentry/IMetricsAggregator, java/io/Closeable, java/lang/Runnable {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/metrics/IMetricsClient;)V
-	public fun <init> (Lio/sentry/metrics/IMetricsClient;Lio/sentry/ILogger;Lio/sentry/SentryDateProvider;Lio/sentry/ISentryExecutorService;)V
+	public fun <init> (Lio/sentry/metrics/IMetricsClient;Lio/sentry/ILogger;Lio/sentry/SentryDateProvider;ILio/sentry/ISentryExecutorService;)V
 	public fun close ()V
 	public fun distribution (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;JI)V
 	public fun flush (Z)V
@@ -3395,15 +3395,15 @@ public final class io/sentry/metrics/CounterMetric : io/sentry/metrics/Metric {
 	public fun <init> (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;Ljava/lang/Long;)V
 	public fun add (D)V
 	public fun getValue ()D
-	public fun getValues ()Ljava/lang/Iterable;
 	public fun getWeight ()I
+	public fun serialize ()Ljava/lang/Iterable;
 }
 
 public final class io/sentry/metrics/DistributionMetric : io/sentry/metrics/Metric {
 	public fun <init> (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;Ljava/lang/Long;)V
 	public fun add (D)V
-	public fun getValues ()Ljava/lang/Iterable;
 	public fun getWeight ()I
+	public fun serialize ()Ljava/lang/Iterable;
 }
 
 public final class io/sentry/metrics/EncodedMetrics {
@@ -3414,8 +3414,8 @@ public final class io/sentry/metrics/EncodedMetrics {
 public final class io/sentry/metrics/GaugeMetric : io/sentry/metrics/Metric {
 	public fun <init> (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;Ljava/lang/Long;)V
 	public fun add (D)V
-	public fun getValues ()Ljava/lang/Iterable;
 	public fun getWeight ()I
+	public fun serialize ()Ljava/lang/Iterable;
 }
 
 public abstract interface class io/sentry/metrics/IMetricsClient {
@@ -3430,8 +3430,8 @@ public abstract class io/sentry/metrics/Metric {
 	public fun getTimeStampMs ()Ljava/lang/Long;
 	public fun getType ()Lio/sentry/metrics/MetricType;
 	public fun getUnit ()Lio/sentry/MeasurementUnit;
-	public abstract fun getValues ()Ljava/lang/Iterable;
 	public abstract fun getWeight ()I
+	public abstract fun serialize ()Ljava/lang/Iterable;
 }
 
 public final class io/sentry/metrics/MetricResourceIdentifier {
@@ -3494,6 +3494,7 @@ public abstract interface class io/sentry/metrics/MetricsApi$IMetricsInterface {
 
 public final class io/sentry/metrics/MetricsHelper {
 	public static final field FLUSHER_SLEEP_TIME_MS I
+	public static final field MAX_TOTAL_WEIGHT I
 	public fun <init> ()V
 	public static fun convertNanosTo (Lio/sentry/MeasurementUnit$Duration;J)D
 	public static fun encodeMetrics (JLjava/util/Collection;Ljava/lang/StringBuilder;)V
@@ -3543,8 +3544,8 @@ public final class io/sentry/metrics/SentryMetric$JsonKeys {
 public final class io/sentry/metrics/SetMetric : io/sentry/metrics/Metric {
 	public fun <init> (Ljava/lang/String;Lio/sentry/MeasurementUnit;Ljava/util/Map;Ljava/lang/Long;)V
 	public fun add (D)V
-	public fun getValues ()Ljava/lang/Iterable;
 	public fun getWeight ()I
+	public fun serialize ()Ljava/lang/Iterable;
 }
 
 public final class io/sentry/profilemeasurements/ProfileMeasurement : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/metrics/CounterMetric.java
+++ b/sentry/src/main/java/io/sentry/metrics/CounterMetric.java
@@ -37,7 +37,7 @@ public final class CounterMetric extends Metric {
   }
 
   @Override
-  public @NotNull Iterable<?> getValues() {
+  public @NotNull Iterable<?> serialize() {
     return Collections.singletonList(value);
   }
 }

--- a/sentry/src/main/java/io/sentry/metrics/DistributionMetric.java
+++ b/sentry/src/main/java/io/sentry/metrics/DistributionMetric.java
@@ -34,7 +34,7 @@ public final class DistributionMetric extends Metric {
   }
 
   @Override
-  public @NotNull Iterable<?> getValues() {
+  public @NotNull Iterable<?> serialize() {
     return values;
   }
 }

--- a/sentry/src/main/java/io/sentry/metrics/GaugeMetric.java
+++ b/sentry/src/main/java/io/sentry/metrics/GaugeMetric.java
@@ -47,7 +47,7 @@ public final class GaugeMetric extends Metric {
   }
 
   @Override
-  public @NotNull Iterable<?> getValues() {
+  public @NotNull Iterable<?> serialize() {
     return Arrays.asList(last, min, max, sum, count);
   }
 }

--- a/sentry/src/main/java/io/sentry/metrics/Metric.java
+++ b/sentry/src/main/java/io/sentry/metrics/Metric.java
@@ -68,5 +68,5 @@ public abstract class Metric {
     return timestampMs;
   }
 
-  public abstract @NotNull Iterable<?> getValues();
+  public abstract @NotNull Iterable<?> serialize();
 }

--- a/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
@@ -184,7 +184,7 @@ public final class MetricsHelper {
       final String sanitizeUnitName = sanitizeUnit(unitName);
       writer.append(sanitizeUnitName);
 
-      for (final @NotNull Object value : metric.getValues()) {
+      for (final @NotNull Object value : metric.serialize()) {
         writer.append(":");
         writer.append(value);
       }

--- a/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.TestOnly;
 @ApiStatus.Internal
 public final class MetricsHelper {
   public static final int FLUSHER_SLEEP_TIME_MS = 5000;
+  public static final int MAX_TOTAL_WEIGHT = 100000;
   private static final int ROLLUP_IN_SECONDS = 10;
 
   private static final Pattern INVALID_KEY_CHARACTERS_PATTERN =

--- a/sentry/src/main/java/io/sentry/metrics/SentryMetric.java
+++ b/sentry/src/main/java/io/sentry/metrics/SentryMetric.java
@@ -42,7 +42,7 @@ public final class SentryMetric implements JsonSerializable {
     this.unit = metric.getUnit();
     this.tags = metric.getTags();
     this.timestampMs = metric.getTimeStampMs();
-    this.values = metric.getValues();
+    this.values = metric.serialize();
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/metrics/SetMetric.java
+++ b/sentry/src/main/java/io/sentry/metrics/SetMetric.java
@@ -38,7 +38,7 @@ public final class SetMetric extends Metric {
   }
 
   @Override
-  public @NotNull Iterable<?> getValues() {
+  public @NotNull Iterable<?> serialize() {
     return values;
   }
 }

--- a/sentry/src/test/java/io/sentry/metrics/CounterMetricTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/CounterMetricTest.kt
@@ -71,12 +71,12 @@ class CounterMetricTest {
             System.currentTimeMillis()
         )
 
-        val values0 = metric.values.toList()
+        val values0 = metric.serialize().toList()
         assertEquals(1, values0.size)
         assertEquals(1.0, values0[0] as Double)
 
         metric.add(1.0)
-        val values1 = metric.values.toList()
+        val values1 = metric.serialize().toList()
         assertEquals(1, values1.size)
         assertEquals(2.0, values1[0] as Double)
     }

--- a/sentry/src/test/java/io/sentry/metrics/DistributionMetricTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/DistributionMetricTest.kt
@@ -14,11 +14,11 @@ class DistributionMetricTest {
             null,
             System.currentTimeMillis()
         )
-        assertEquals(listOf(1.0), metric.values.toList())
+        assertEquals(listOf(1.0), metric.serialize().toList())
 
         metric.add(1.0)
         metric.add(2.0)
-        assertEquals(listOf(1.0, 1.0, 2.0), metric.values.toList())
+        assertEquals(listOf(1.0, 1.0, 2.0), metric.serialize().toList())
     }
 
     @Test
@@ -59,7 +59,7 @@ class DistributionMetricTest {
         )
         metric.add(2.0)
 
-        val values = metric.values.toList()
+        val values = metric.serialize().toList()
         assertEquals(2, values.size)
         assertEquals(listOf(1.0, 2.0), values)
     }

--- a/sentry/src/test/java/io/sentry/metrics/GaugeMetricTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/GaugeMetricTest.kt
@@ -22,7 +22,7 @@ class GaugeMetricTest {
                 1.0,
                 1
             ),
-            metric.values.toList()
+            metric.serialize().toList()
         )
 
         metric.add(5.0)
@@ -38,7 +38,7 @@ class GaugeMetricTest {
                 16.0, // sum
                 6 // count
             ),
-            metric.values.toList()
+            metric.serialize().toList()
         )
     }
 

--- a/sentry/src/test/java/io/sentry/metrics/SetMetricTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/SetMetricTest.kt
@@ -14,18 +14,18 @@ class SetMetricTest {
             null,
             System.currentTimeMillis()
         )
-        assertTrue(metric.values.toList().isEmpty())
+        assertTrue(metric.serialize().toList().isEmpty())
 
         metric.add(1.0)
         metric.add(2.0)
         metric.add(3.0)
 
-        assertEquals(3, metric.values.toList().size)
+        assertEquals(3, metric.serialize().toList().size)
 
         // when an already existing item is added
         // size stays the same
         metric.add(3.0)
-        assertEquals(3, metric.values.toList().size)
+        assertEquals(3, metric.serialize().toList().size)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Implement the force flush behavior described here: https://develop.sentry.dev/sdk/metrics/#aggregator-behavior
Details like max_weight taken from https://github.com/getsentry/sentry-python/blame/master/sentry_sdk/metrics.py

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Added unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
