### PR TITLE
Add enableScopePersistence option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add `enableScopePersistence` option to disable `PersistingScopeObserver` used for ANR reporting which may increase performance overhead. Defaults to `true` ([#3218](https://github.com/getsentry/sentry-java/pull/3218))
+  - When disabled, the SDK will not enrich ANRv2 events with scope data (e.g. breadcrumbs, user, tags, etc.)
+
 ### Fixes
 
 - Fix old profiles deletion on SDK init ([#3216](https://github.com/getsentry/sentry-java/pull/3216))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -223,7 +223,9 @@ final class AndroidOptionsInitializer {
     options.setTransactionPerformanceCollector(new DefaultTransactionPerformanceCollector(options));
 
     if (options.getCacheDirPath() != null) {
-      options.addScopeObserver(new PersistingScopeObserver(options));
+      if (options.isEnableScopePersistence()) {
+        options.addScopeObserver(new PersistingScopeObserver(options));
+      }
       options.addOptionsObserver(new PersistingOptionsObserver(options));
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -100,6 +100,8 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_APP_START_PROFILING = "io.sentry.profiling.enable-app-start";
 
+  static final String ENABLE_SCOPE_PERSISTENCE = "io.sentry.enable-scope-persistence";
+
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
 
@@ -371,6 +373,10 @@ final class ManifestMetadataReader {
         options.setEnableAppStartProfiling(
             readBool(
                 metadata, logger, ENABLE_APP_START_PROFILING, options.isEnableAppStartProfiling()));
+
+        options.setEnableScopePersistence(
+            readBool(
+                metadata, logger, ENABLE_SCOPE_PERSISTENCE, options.isEnableScopePersistence()));
       }
 
       options

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -653,4 +653,11 @@ class AndroidOptionsInitializerTest {
             fixture.sentryOptions.integrations.firstOrNull { it is AnrIntegration }
         assertNull(anrv1Integration)
     }
+
+    @Test
+    fun `PersistingScopeObserver is not set to options, if scope persistence is disabled`() {
+        fixture.initSut(configureOptions = { isEnableScopePersistence = false })
+
+        assertTrue { fixture.sentryOptions.scopeObservers.none { it is PersistingScopeObserver } }
+    }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1370,4 +1370,29 @@ class ManifestMetadataReaderTest {
         // Assert
         assertFalse(fixture.options.isEnableAppStartProfiling)
     }
+
+    @Test
+    fun `applyMetadata reads enableScopePersistence flag to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.ENABLE_SCOPE_PERSISTENCE to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.isEnableScopePersistence)
+    }
+
+    @Test
+    fun `applyMetadata reads enableScopePersistence flag to options and keeps default if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.isEnableScopePersistence)
+    }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2244,6 +2244,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableDeduplication ()Z
 	public fun isEnableExternalConfiguration ()Z
 	public fun isEnablePrettySerializationOutput ()Z
+	public fun isEnableScopePersistence ()Z
 	public fun isEnableShutdownHook ()Z
 	public fun isEnableSpotlight ()Z
 	public fun isEnableTimeToFullDisplayTracing ()Z
@@ -2284,6 +2285,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableDeduplication (Z)V
 	public fun setEnableExternalConfiguration (Z)V
 	public fun setEnablePrettySerializationOutput (Z)V
+	public fun setEnableScopePersistence (Z)V
 	public fun setEnableShutdownHook (Z)V
 	public fun setEnableSpotlight (Z)V
 	public fun setEnableTimeToFullDisplayTracing (Z)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -448,6 +448,9 @@ public class SentryOptions {
 
   private @Nullable String spotlightConnectionUrl;
 
+  /** Whether to enable scope persistence so the scope values are preserved if the process dies */
+  private boolean enableScopePersistence = true;
+
   /** Contains a list of monitor slugs for which check-ins should not be sent. */
   @ApiStatus.Experimental private @Nullable List<String> ignoredCheckIns = null;
 
@@ -2311,6 +2314,14 @@ public class SentryOptions {
   @ApiStatus.Experimental
   public void setEnableSpotlight(final boolean enableSpotlight) {
     this.enableSpotlight = enableSpotlight;
+  }
+
+  public boolean isEnableScopePersistence() {
+    return enableScopePersistence;
+  }
+
+  public void setEnableScopePersistence(boolean enableScopePersistence) {
+    this.enableScopePersistence = enableScopePersistence;
   }
 
   /** The BeforeSend callback */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2320,7 +2320,7 @@ public class SentryOptions {
     return enableScopePersistence;
   }
 
-  public void setEnableScopePersistence(boolean enableScopePersistence) {
+  public void setEnableScopePersistence(final boolean enableScopePersistence) {
     this.enableScopePersistence = enableScopePersistence;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -603,4 +603,9 @@ class SentryOptionsTest {
         assertTrue(options.isEnableSpotlight)
         assertEquals("http://localhost:8080", options.spotlightConnectionUrl)
     }
+
+    @Test
+    fun `when options are initialized, enableScopePersistence is set to true by default`() {
+        assertEquals(true, SentryOptions().isEnableScopePersistence)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
For now PersistingScopeObserver is used only for ANRv2, but it's generic enough that we can use it for other features (e.g. to address #547), hence we're introducing a new flag to disable scope persistence separately. 

We should also think how to improve its performance see #3168 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry-unity/issues/1555

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
