### PR TITLE
Add support for measurements at span level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for measurements at span level ([#3219](https://github.com/getsentry/sentry-java/pull/3219))
+
 ### Fixes
 
 - Fix old profiles deletion on SDK init ([#3216](https://github.com/getsentry/sentry-java/pull/3216))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -22,6 +22,8 @@ import io.sentry.util.Objects;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -241,8 +243,8 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         span.getDescription(),
         SpanStatus.OK,
         APP_METRICS_ORIGIN,
-        new HashMap<>(),
-        new HashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
         null);
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -242,6 +242,7 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         SpanStatus.OK,
         APP_METRICS_ORIGIN,
         new HashMap<>(),
+        new HashMap<>(),
         null);
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -21,6 +21,7 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentrySpan;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.util.Objects;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -250,6 +251,6 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         APP_METRICS_ORIGIN,
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
-      defaultSpanData);
+        defaultSpanData);
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -19,11 +19,9 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentrySpan;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.util.Objects;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -239,6 +239,7 @@ class PerformanceAndroidEventProcessorTest {
             SpanStatus.OK,
             null,
             emptyMap(),
+            emptyMap(),
             null
         )
         tr.spans.add(appStartSpan)
@@ -334,6 +335,7 @@ class PerformanceAndroidEventProcessorTest {
             SpanStatus.OK,
             null,
             emptyMap(),
+            emptyMap(),
             null
         )
         tr.spans.add(appStartSpan)
@@ -382,6 +384,7 @@ class PerformanceAndroidEventProcessorTest {
             "App Start",
             SpanStatus.OK,
             null,
+            emptyMap(),
             emptyMap(),
             null
         )

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -434,6 +434,7 @@ class PerformanceAndroidEventProcessorTest {
             SpanStatus.OK,
             null,
             emptyMap(),
+            emptyMap(),
             null
         )
         tr.spans.add(appStartSpan)

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -267,7 +267,10 @@ public class MainActivity extends AppCompatActivity {
     screenLoadCount++;
     final ISpan span = Sentry.getSpan();
     if (span != null) {
-      span.setMeasurement("screen_load_count", screenLoadCount, new MeasurementUnit.Custom("test"));
+      ISpan measurementSpan = span.startChild("screen_load_measurement", "test measurement");
+      measurementSpan.setMeasurement(
+          "screen_load_count", screenLoadCount, new MeasurementUnit.Custom("test"));
+      measurementSpan.finish();
     }
     Sentry.reportFullyDisplayed();
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2463,6 +2463,8 @@ public final class io/sentry/SentryTracer : io/sentry/ITransaction {
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setMeasurement (Ljava/lang/String;Ljava/lang/Number;)V
 	public fun setMeasurement (Ljava/lang/String;Ljava/lang/Number;Lio/sentry/MeasurementUnit;)V
+	public fun setMeasurementFromChild (Ljava/lang/String;Ljava/lang/Number;)V
+	public fun setMeasurementFromChild (Ljava/lang/String;Ljava/lang/Number;Lio/sentry/MeasurementUnit;)V
 	public fun setName (Ljava/lang/String;)V
 	public fun setName (Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;)V
 	public fun setOperation (Ljava/lang/String;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2565,6 +2565,7 @@ public final class io/sentry/Span : io/sentry/ISpan {
 	public fun getData (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getFinishDate ()Lio/sentry/SentryDate;
+	public fun getMeasurements ()Ljava/util/Map;
 	public fun getOperation ()Ljava/lang/String;
 	public fun getParentSpanId ()Lio/sentry/SpanId;
 	public fun getSamplingDecision ()Lio/sentry/TracesSamplingDecision;
@@ -4185,9 +4186,10 @@ public final class io/sentry/protocol/SentryRuntime$JsonKeys {
 public final class io/sentry/protocol/SentrySpan : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> (Lio/sentry/Span;)V
 	public fun <init> (Lio/sentry/Span;Ljava/util/Map;)V
-	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanStatus;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Lio/sentry/protocol/SentryId;Lio/sentry/SpanId;Lio/sentry/SpanId;Ljava/lang/String;Ljava/lang/String;Lio/sentry/SpanStatus;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public fun getData ()Ljava/util/Map;
 	public fun getDescription ()Ljava/lang/String;
+	public fun getMeasurements ()Ljava/util/Map;
 	public fun getOp ()Ljava/lang/String;
 	public fun getOrigin ()Ljava/lang/String;
 	public fun getParentSpanId ()Lio/sentry/SpanId;
@@ -4212,6 +4214,7 @@ public final class io/sentry/protocol/SentrySpan$Deserializer : io/sentry/JsonDe
 public final class io/sentry/protocol/SentrySpan$JsonKeys {
 	public static final field DATA Ljava/lang/String;
 	public static final field DESCRIPTION Ljava/lang/String;
+	public static final field MEASUREMENTS Ljava/lang/String;
 	public static final field OP Ljava/lang/String;
 	public static final field ORIGIN Ljava/lang/String;
 	public static final field PARENT_SPAN_ID Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -615,6 +615,12 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setOperation(final @NotNull String operation) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The transaction is already finished. Operation %s cannot be set",
+              operation);
       return;
     }
 
@@ -629,6 +635,12 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setDescription(final @Nullable String description) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The transaction is already finished. Description %s cannot be set",
+              description);
       return;
     }
 
@@ -643,6 +655,12 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setStatus(final @Nullable SpanStatus status) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The transaction is already finished. Status %s cannot be set",
+              status == null ? "null" : status.name());
       return;
     }
 
@@ -657,6 +675,9 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setThrowable(final @Nullable Throwable throwable) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(SentryLevel.DEBUG, "The transaction is already finished. Throwable cannot be set");
       return;
     }
 
@@ -676,6 +697,9 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setTag(final @NotNull String key, final @NotNull String value) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(SentryLevel.DEBUG, "The transaction is already finished. Tag %s cannot be set", key);
       return;
     }
 
@@ -695,6 +719,10 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setData(@NotNull String key, @NotNull Object value) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG, "The transaction is already finished. Data %s cannot be set", key);
       return;
     }
 
@@ -708,7 +736,10 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void setMeasurement(final @NotNull String name, final @NotNull Number value) {
-    root.setMeasurement(name, value);
+    // We don't want to overwrite the root span measurement. The span itself can still overwrite it
+    if (!root.getMeasurements().containsKey(name)) {
+      root.setMeasurement(name, value);
+    }
   }
 
   @Override
@@ -716,7 +747,10 @@ public final class SentryTracer implements ITransaction {
       final @NotNull String name,
       final @NotNull Number value,
       final @NotNull MeasurementUnit unit) {
-    root.setMeasurement(name, value, unit);
+    // We don't want to overwrite the root span measurement. The span itself can still overwrite it
+    if (!root.getMeasurements().containsKey(name)) {
+      root.setMeasurement(name, value, unit);
+    }
   }
 
   public @Nullable Map<String, Object> getData() {
@@ -747,6 +781,12 @@ public final class SentryTracer implements ITransaction {
   @Override
   public void setName(@NotNull String name, @NotNull TransactionNameSource transactionNameSource) {
     if (root.isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The transaction is already finished. Name %s cannot be set",
+              name);
       return;
     }
 

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -734,12 +734,28 @@ public final class SentryTracer implements ITransaction {
     return this.root.getData(key);
   }
 
+  @ApiStatus.Internal
+  public void setMeasurementFromChild(final @NotNull String name, final @NotNull Number value) {
+    // We don't want to overwrite the root span measurement, if it comes from a child.
+    if (!root.getMeasurements().containsKey(name)) {
+      setMeasurement(name, value);
+    }
+  }
+
+  @ApiStatus.Internal
+  public void setMeasurementFromChild(
+      final @NotNull String name,
+      final @NotNull Number value,
+      final @NotNull MeasurementUnit unit) {
+    // We don't want to overwrite the root span measurement, if it comes from a child.
+    if (!root.getMeasurements().containsKey(name)) {
+      setMeasurement(name, value, unit);
+    }
+  }
+
   @Override
   public void setMeasurement(final @NotNull String name, final @NotNull Number value) {
-    // We don't want to overwrite the root span measurement. The span itself can still overwrite it
-    if (!root.getMeasurements().containsKey(name)) {
-      root.setMeasurement(name, value);
-    }
+    root.setMeasurement(name, value);
   }
 
   @Override
@@ -747,10 +763,7 @@ public final class SentryTracer implements ITransaction {
       final @NotNull String name,
       final @NotNull Number value,
       final @NotNull MeasurementUnit unit) {
-    // We don't want to overwrite the root span measurement. The span itself can still overwrite it
-    if (!root.getMeasurements().containsKey(name)) {
-      root.setMeasurement(name, value, unit);
-    }
+    root.setMeasurement(name, value, unit);
   }
 
   public @Nullable Map<String, Object> getData() {

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -349,7 +349,7 @@ public final class Span implements ISpan {
     // We set the measurement in the transaction, too, but we have to check if this is the root span
     // of the transaction, to avoid an infinite recursion
     if (transaction.getRoot() != this) {
-      transaction.setMeasurement(name, value);
+      transaction.setMeasurementFromChild(name, value);
     }
   }
 
@@ -371,7 +371,7 @@ public final class Span implements ISpan {
     // We set the measurement in the transaction, too, but we have to check if this is the root span
     // of the transaction, to avoid an infinite recursion
     if (transaction.getRoot() != this) {
-      transaction.setMeasurement(name, value, unit);
+      transaction.setMeasurementFromChild(name, value, unit);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -325,17 +325,17 @@ public final class Span implements ISpan {
   }
 
   @Override
-  public void setData(@NotNull String key, @NotNull Object value) {
+  public void setData(final @NotNull String key, final @NotNull Object value) {
     data.put(key, value);
   }
 
   @Override
-  public @Nullable Object getData(@NotNull String key) {
+  public @Nullable Object getData(final @NotNull String key) {
     return data.get(key);
   }
 
   @Override
-  public void setMeasurement(@NotNull String name, @NotNull Number value) {
+  public void setMeasurement(final @NotNull String name, final @NotNull Number value) {
     if (isFinished()) {
       return;
     }
@@ -349,7 +349,9 @@ public final class Span implements ISpan {
 
   @Override
   public void setMeasurement(
-      @NotNull String name, @NotNull Number value, @NotNull MeasurementUnit unit) {
+      final @NotNull String name,
+      final @NotNull Number value,
+      final @NotNull MeasurementUnit unit) {
     if (isFinished()) {
       return;
     }

--- a/sentry/src/main/java/io/sentry/Span.java
+++ b/sentry/src/main/java/io/sentry/Span.java
@@ -337,6 +337,12 @@ public final class Span implements ISpan {
   @Override
   public void setMeasurement(final @NotNull String name, final @NotNull Number value) {
     if (isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The span is already finished. Measurement %s cannot be set",
+              name);
       return;
     }
     this.measurements.put(name, new MeasurementValue(value, null));
@@ -353,6 +359,12 @@ public final class Span implements ISpan {
       final @NotNull Number value,
       final @NotNull MeasurementUnit unit) {
     if (isFinished()) {
+      hub.getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "The span is already finished. Measurement %s cannot be set",
+              name);
       return;
     }
     this.measurements.put(name, new MeasurementValue(value, unit.apiName()));

--- a/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
@@ -63,7 +63,7 @@ public final class SentrySpan implements JsonUnknown, JsonSerializable {
     this.tags = tagsCopy != null ? tagsCopy : new ConcurrentHashMap<>();
     final Map<String, MeasurementValue> measurementsCopy =
         CollectionUtils.newConcurrentHashMap(span.getMeasurements());
-    this.measurements = measurementsCopy != null ? measurementsCopy : new HashMap<>();
+    this.measurements = measurementsCopy != null ? measurementsCopy : new ConcurrentHashMap<>();
     // we lose precision here, from potential nanosecond precision down to 10 microsecond precision
     this.timestamp =
         span.getFinishDate() == null

--- a/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryTransaction.java
@@ -115,6 +115,9 @@ public final class SentryTransaction extends SentryBaseEvent
     this.timestamp = timestamp;
     this.spans.addAll(spans);
     this.measurements.putAll(measurements);
+    for (SentrySpan span : spans) {
+      this.measurements.putAll(span.getMeasurements());
+    }
     this.transactionInfo = transactionInfo;
   }
 

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -1019,6 +1019,8 @@ class JsonSerializerTest {
                 assertEquals("value1", it)
             }
         }
+        assertEquals(1, deserialized?.measurements?.get("test_measurement")?.value)
+        assertEquals("test", deserialized?.measurements?.get("test_measurement")?.unit)
     }
 
     @Test
@@ -1300,6 +1302,7 @@ class JsonSerializerTest {
         }
         val tracer = SentryTracer(trace, fixture.hub)
         val span = tracer.startChild("child")
+        span.setMeasurement("test_measurement", 1, MeasurementUnit.Custom("test"))
         span.finish(SpanStatus.OK)
         tracer.finish()
         return span

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -465,7 +465,7 @@ class SentryTracerTest {
         assertEquals("desc", transaction.description)
         assertEquals("myValue", transaction.getTag("myTag"))
         assertEquals("myValue", transaction.getData("myData"))
-        assertEquals(1.0f, transaction.measurements["myMetric"]!!.value)
+        assertEquals(1.0f, transaction.root.measurements["myMetric"]!!.value)
         assertEquals("name", transaction.name)
         assertEquals(ex, transaction.throwable)
     }

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -987,6 +987,24 @@ class SentryTracerTest {
     }
 
     @Test
+    fun `setting the same measurement multiple times from a child only keeps first value`() {
+        val transaction = fixture.getSut()
+        transaction.setMeasurementFromChild("metric1", 1.0f)
+        transaction.setMeasurementFromChild("metric1", 2, MeasurementUnit.Duration.DAY)
+        transaction.finish()
+
+        verify(fixture.hub).captureTransaction(
+            check {
+                assertEquals(1.0f, it.measurements["metric1"]!!.value)
+                assertNull(it.measurements["metric1"]!!.unit)
+            },
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+    }
+
+    @Test
     fun `when transaction is created, but not profiled, transactionPerformanceCollector is not started`() {
         val transaction = fixture.getSut()
         verify(fixture.transactionPerformanceCollector, never()).start(anyOrNull())

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -1,8 +1,12 @@
 package io.sentry
 
 import io.sentry.protocol.SentryId
+import io.sentry.test.injectForField
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.Test
@@ -437,6 +441,48 @@ class SpanTest {
         assertNotNull(span.finishDate)
         assertTrue(span.updateEndDate(endDate))
         assertEquals(endDate, span.finishDate)
+    }
+
+    @Test
+    fun `setMeasurement sets a measurement`() {
+        val span = fixture.getSut()
+        span.setMeasurement("test", 1)
+        assertNotNull(span.measurements["test"])
+        assertEquals(1, span.measurements["test"]!!.value)
+    }
+
+    @Test
+    fun `setMeasurement does not set a measurement if a span is finished`() {
+        val span = fixture.getSut()
+        span.finish()
+        span.setMeasurement("test", 1)
+        assertTrue(span.measurements.isEmpty())
+    }
+
+    @Test
+    fun `setMeasurement also set a measurement to the transaction root span`() {
+        val transaction = spy(getTransaction())
+        val span = transaction.startChild("op") as Span
+        // We need to inject the mock, otherwise the span calls the real transaction object
+        span.injectForField("transaction", transaction)
+        span.setMeasurement("test", 1)
+        verify(transaction).setMeasurement(eq("test"), eq(1))
+        assertNotNull(span.measurements["test"])
+        assertEquals(1, span.measurements["test"]!!.value)
+        assertNotNull(transaction.root.measurements["test"])
+        assertEquals(1, transaction.root.measurements["test"]!!.value)
+    }
+
+    @Test
+    fun `setMeasurement on transaction root span does not call transaction setMeasurement to avoid infinite recursion`() {
+        val transaction = spy(getTransaction())
+        // We need to inject the mock, otherwise the span calls the real transaction object
+        transaction.root.injectForField("transaction", transaction)
+        transaction.root.setMeasurement("test", 1)
+        verify(transaction, never()).setMeasurement(any(), any())
+        verify(transaction, never()).setMeasurement(any(), any(), any())
+        assertNotNull(transaction.root.measurements["test"])
+        assertEquals(1, transaction.root.measurements["test"]!!.value)
     }
 
     private fun getTransaction(transactionContext: TransactionContext = TransactionContext("name", "op")): SentryTracer {

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -466,6 +466,7 @@ class SpanTest {
         // We need to inject the mock, otherwise the span calls the real transaction object
         span.injectForField("transaction", transaction)
         span.setMeasurement("test", 1)
+        verify(transaction).setMeasurementFromChild(eq("test"), eq(1))
         verify(transaction).setMeasurement(eq("test"), eq(1))
         assertNotNull(span.measurements["test"])
         assertEquals(1, span.measurements["test"]!!.value)
@@ -479,8 +480,8 @@ class SpanTest {
         // We need to inject the mock, otherwise the span calls the real transaction object
         transaction.root.injectForField("transaction", transaction)
         transaction.root.setMeasurement("test", 1)
-        verify(transaction, never()).setMeasurement(any(), any())
-        verify(transaction, never()).setMeasurement(any(), any(), any())
+        verify(transaction, never()).setMeasurementFromChild(any(), any())
+        verify(transaction, never()).setMeasurementFromChild(any(), any(), any())
         assertNotNull(transaction.root.measurements["test"])
         assertEquals(1, transaction.root.measurements["test"]!!.value)
     }

--- a/sentry/src/test/java/io/sentry/protocol/SentrySpanSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentrySpanSerializationTest.kt
@@ -29,6 +29,7 @@ class SentrySpanSerializationTest {
             SpanStatus.ALREADY_EXISTS,
             "auto.test.unit.span",
             mapOf("f1333f3a-916a-47b7-8dd6-d6d15fa96e03" to "d4a07684-5b3e-4d08-b605-f9364c398124"),
+            mapOf("test_measurement" to MeasurementValue(1, "test")),
             mapOf("518276a7-88d7-408f-ab36-af342f2d7715" to "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6")
         )
     }

--- a/sentry/src/test/java/io/sentry/protocol/SentryTransactionSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryTransactionSerializationTest.kt
@@ -53,6 +53,8 @@ class SentryTransactionSerializationTest {
         val expected = sanitizedFile("json/sentry_transaction.json")
         val actual = serialize(fixture.getSut())
         assertEquals(expected, actual)
+        // There are 1 measurement from the span and 2 from the transaction
+        assertEquals(3, fixture.getSut().measurements.size)
     }
 
     @Test

--- a/sentry/src/test/resources/json/sentry_span.json
+++ b/sentry/src/test/resources/json/sentry_span.json
@@ -15,6 +15,12 @@
   "data":
   {
     "518276a7-88d7-408f-ab36-af342f2d7715": "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6"
+  },
+  "measurements": {
+    "test_measurement": {
+      "value": 1,
+      "unit": "test"
+    }
   }
 }
 

--- a/sentry/src/test/resources/json/sentry_span_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_span_legacy_date_format.json
@@ -15,5 +15,11 @@
   "data":
   {
     "518276a7-88d7-408f-ab36-af342f2d7715": "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6"
+  },
+  "measurements": {
+    "test_measurement": {
+      "value": 1,
+      "unit": "test"
+    }
   }
 }

--- a/sentry/src/test/resources/json/sentry_transaction.json
+++ b/sentry/src/test/resources/json/sentry_transaction.json
@@ -21,6 +21,14 @@
             "data":
             {
                 "518276a7-88d7-408f-ab36-af342f2d7715": "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6"
+            },
+            "measurements":
+            {
+              "test_measurement":
+              {
+                "value": 1,
+                "unit": "test"
+              }
             }
         }
     ],
@@ -38,6 +46,11 @@
             "value": 0.4000000059604645,
             "unit": "test2",
             "new_type": "newtype"
+        },
+        "test_measurement":
+        {
+          "value": 1,
+          "unit": "test"
         }
     },
     "transaction_info": {

--- a/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
@@ -21,6 +21,14 @@
             "data":
             {
                 "518276a7-88d7-408f-ab36-af342f2d7715": "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6"
+            },
+            "measurements":
+            {
+              "test_measurement":
+              {
+                "value": 1,
+                "unit": "test"
+              }
             }
         }
     ],
@@ -38,6 +46,11 @@
         "value": 0.4000000059604645,
         "unit": "test2",
         "new_type": "newtype"
+      },
+      "test_measurement":
+      {
+        "value": 1,
+        "unit": "test"
       }
     },
     "transaction_info": {

--- a/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
+++ b/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
@@ -20,6 +20,14 @@
             "data":
             {
                 "518276a7-88d7-408f-ab36-af342f2d7715": "4a1c2d6c-3f49-41cc-b2ca-d1b36f7ea5a6"
+            },
+            "measurements":
+            {
+              "test_measurement":
+              {
+                "value": 1,
+                "unit": "test"
+              }
             }
         }
     ],
@@ -29,6 +37,11 @@
         "386384cb-1162-49e7-aea1-db913d4fca63":
         {
             "value": 0.30000001192092896
+        },
+        "test_measurement":
+        {
+          "value": 1,
+          "unit": "test"
         }
     },
     "transaction_info": {


### PR DESCRIPTION
spans forward measurements to transaction

## :scroll: Description
added measurements to spans
spans forward measurements to transaction
[Example transaction](https://sentry-sdks.sentry.io/performance/sentry-android:1cb0481f3b564ce899296156ea61dbae/?project=5428559&query=&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=1h&transaction=MainActivity&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3180


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
