### PR TITLE
Ensure performance measurement collection is not taken too frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Ensure performance measurement collection is not taken too frequently ([#3221](https://github.com/getsentry/sentry-java/pull/3221))
 - Fix old profiles deletion on SDK init ([#3216](https://github.com/getsentry/sentry-java/pull/3216))
 
 ## 7.4.0

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -14,6 +14,7 @@ import io.sentry.util.FileUtils;
 import io.sentry.util.Objects;
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,6 +43,7 @@ public final class AndroidCpuCollector implements IPerformanceSnapshotCollector 
   private final @NotNull ILogger logger;
   private final @NotNull BuildInfoProvider buildInfoProvider;
   private boolean isEnabled = false;
+  private final @NotNull Pattern newLinePattern = Pattern.compile("[\n\t\r ]");
 
   public AndroidCpuCollector(
       final @NotNull ILogger logger, final @NotNull BuildInfoProvider buildInfoProvider) {
@@ -102,7 +104,7 @@ public final class AndroidCpuCollector implements IPerformanceSnapshotCollector 
     }
     if (stat != null) {
       stat = stat.trim();
-      String[] stats = stat.split("[\n\t\r ]");
+      String[] stats = newLinePattern.split(stat);
       try {
         // Amount of clock ticks this process has been scheduled in user mode
         long uTime = Long.parseLong(stats[13]);


### PR DESCRIPTION
## :scroll: Description
performance measurement collection now waits at least 10ms between collections
compiled regex in AndroidCpuCollector to parse the cpu file, to improve speed


## :bulb: Motivation and Context
Some UI tests are failing. Also, measurements taken too quickly (1ms) caused issues when the backend parsed the data. It was resolved in the backend, but it's something we should avoid in the first place


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
