### PR TITLE
Fix hub restore in async wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Ensure performance measurement collection is not taken too frequently ([#3221](https://github.com/getsentry/sentry-java/pull/3221))
 - Fix old profiles deletion on SDK init ([#3216](https://github.com/getsentry/sentry-java/pull/3216))
+- Fix hub restore point in wrappers: SentryWrapper, SentryTaskDecorator and SentryScheduleHook ([#3225](https://github.com/getsentry/sentry-java/pull/3225))
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ensure performance measurement collection is not taken too frequently ([#3221](https://github.com/getsentry/sentry-java/pull/3221))
 - Fix old profiles deletion on SDK init ([#3216](https://github.com/getsentry/sentry-java/pull/3216))
 - Fix hub restore point in wrappers: SentryWrapper, SentryTaskDecorator and SentryScheduleHook ([#3225](https://github.com/getsentry/sentry-java/pull/3225))
+  - We now reset the hub to its previous value on the thread where the `Runnable`/`Callable`/`Supplier` is executed instead of setting it to the hub that was used on the thread where the `Runnable`/`Callable`/`Supplier` was created.
 
 ## 7.4.0
 

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -63,11 +63,6 @@ public class io/sentry/spring/jakarta/SentrySpringServletContainerInitializer : 
 	public fun onStartup (Ljava/util/Set;Ljakarta/servlet/ServletContext;)V
 }
 
-public final class io/sentry/spring/jakarta/SentryTaskDecorator : org/springframework/core/task/TaskDecorator {
-	public fun <init> ()V
-	public fun decorate (Ljava/lang/Runnable;)Ljava/lang/Runnable;
-}
-
 public class io/sentry/spring/jakarta/SentryUserFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
 	protected fun doFilterInternal (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljakarta/servlet/FilterChain;)V

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -63,6 +63,11 @@ public class io/sentry/spring/jakarta/SentrySpringServletContainerInitializer : 
 	public fun onStartup (Ljava/util/Set;Ljakarta/servlet/ServletContext;)V
 }
 
+public final class io/sentry/spring/jakarta/SentryTaskDecorator : org/springframework/core/task/TaskDecorator {
+	public fun <init> ()V
+	public fun decorate (Ljava/lang/Runnable;)Ljava/lang/Runnable;
+}
+
 public class io/sentry/spring/jakarta/SentryUserFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
 	protected fun doFilterInternal (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljakarta/servlet/FilterChain;)V

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryTaskDecorator.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryTaskDecorator.java
@@ -15,9 +15,10 @@ import org.springframework.scheduling.annotation.Async;
 public final class SentryTaskDecorator implements TaskDecorator {
   @Override
   public @NotNull Runnable decorate(final @NotNull Runnable runnable) {
-    final IHub oldState = Sentry.getCurrentHub();
     final IHub newHub = Sentry.getCurrentHub().clone();
+
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         runnable.run();

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryScheduleHook.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryScheduleHook.java
@@ -14,9 +14,10 @@ import org.jetbrains.annotations.NotNull;
 public final class SentryScheduleHook implements Function<Runnable, Runnable> {
   @Override
   public Runnable apply(final @NotNull Runnable runnable) {
-    final IHub oldState = Sentry.getCurrentHub();
     final IHub newHub = Sentry.getCurrentHub().clone();
+
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         runnable.run();

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
@@ -1,8 +1,7 @@
 package io.sentry.spring.jakarta
 
 import io.sentry.Sentry
-import io.sentry.SentryCrashLastRunState
-import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -12,22 +11,23 @@ import kotlin.test.assertNotEquals
 
 class SentryTaskDecoratorTest {
     private val dsn = "http://key@localhost/proj"
-    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var executor: ExecutorService
 
     @BeforeTest
-    @AfterTest
     fun beforeTest() {
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterTest
+    fun afterTest() {
         Sentry.close()
-        SentryCrashLastRunState.getInstance().reset()
+        executor.shutdown()
     }
 
     @Test
     fun `hub is reset to its state within the thread after decoration is done`() {
         Sentry.init {
             it.dsn = dsn
-            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
-                event
-            }
         }
 
         val sut = SentryTaskDecorator()

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
@@ -1,0 +1,59 @@
+package io.sentry.spring.jakarta
+
+import io.sentry.Sentry
+import io.sentry.SentryCrashLastRunState
+import io.sentry.SentryOptions
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SentryTaskDecoratorTest {
+    private val dsn = "http://key@localhost/proj"
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @BeforeTest
+    @AfterTest
+    fun beforeTest() {
+        Sentry.close()
+        SentryCrashLastRunState.getInstance().reset()
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after decoration is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val sut = SentryTaskDecorator()
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            executor.submit(
+                sut.decorate {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                }
+            )
+
+        callableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
+    }
+}

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
@@ -1,8 +1,7 @@
 package io.sentry.spring.jakarta.webflux
 
 import io.sentry.Sentry
-import io.sentry.SentryCrashLastRunState
-import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -13,22 +12,23 @@ import kotlin.test.assertNotEquals
 class SentryScheduleHookTest {
 
     private val dsn = "http://key@localhost/proj"
-    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var executor: ExecutorService
 
     @BeforeTest
-    @AfterTest
     fun beforeTest() {
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterTest
+    fun afterTest() {
         Sentry.close()
-        SentryCrashLastRunState.getInstance().reset()
+        executor.shutdown()
     }
 
     @Test
     fun `hub is reset to its state within the thread after hook is done`() {
         Sentry.init {
             it.dsn = dsn
-            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
-                event
-            }
         }
 
         val sut = SentryScheduleHook()

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
@@ -1,0 +1,60 @@
+package io.sentry.spring.jakarta.webflux
+
+import io.sentry.Sentry
+import io.sentry.SentryCrashLastRunState
+import io.sentry.SentryOptions
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SentryScheduleHookTest {
+
+    private val dsn = "http://key@localhost/proj"
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @BeforeTest
+    @AfterTest
+    fun beforeTest() {
+        Sentry.close()
+        SentryCrashLastRunState.getInstance().reset()
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after hook is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val sut = SentryScheduleHook()
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            executor.submit(
+                sut.apply {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                }
+            )
+
+        callableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
+    }
+}

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryTaskDecorator.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryTaskDecorator.java
@@ -15,9 +15,10 @@ import org.springframework.scheduling.annotation.Async;
 public final class SentryTaskDecorator implements TaskDecorator {
   @Override
   public @NotNull Runnable decorate(final @NotNull Runnable runnable) {
-    final IHub oldState = Sentry.getCurrentHub();
     final IHub newHub = Sentry.getCurrentHub().clone();
+
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         runnable.run();

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryScheduleHook.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryScheduleHook.java
@@ -14,9 +14,10 @@ import org.jetbrains.annotations.NotNull;
 public final class SentryScheduleHook implements Function<Runnable, Runnable> {
   @Override
   public Runnable apply(final @NotNull Runnable runnable) {
-    final IHub oldState = Sentry.getCurrentHub();
     final IHub newHub = Sentry.getCurrentHub().clone();
+
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         runnable.run();

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
@@ -1,8 +1,7 @@
 package io.sentry.spring
 
 import io.sentry.Sentry
-import io.sentry.SentryCrashLastRunState
-import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -12,22 +11,23 @@ import kotlin.test.assertNotEquals
 
 class SentryTaskDecoratorTest {
     private val dsn = "http://key@localhost/proj"
-    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var executor: ExecutorService
 
     @BeforeTest
-    @AfterTest
     fun beforeTest() {
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterTest
+    fun afterTest() {
         Sentry.close()
-        SentryCrashLastRunState.getInstance().reset()
+        executor.shutdown()
     }
 
     @Test
     fun `hub is reset to its state within the thread after decoration is done`() {
         Sentry.init {
             it.dsn = dsn
-            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
-                event
-            }
         }
 
         val sut = SentryTaskDecorator()

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
@@ -1,0 +1,59 @@
+package io.sentry.spring
+
+import io.sentry.Sentry
+import io.sentry.SentryCrashLastRunState
+import io.sentry.SentryOptions
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SentryTaskDecoratorTest {
+    private val dsn = "http://key@localhost/proj"
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @BeforeTest
+    @AfterTest
+    fun beforeTest() {
+        Sentry.close()
+        SentryCrashLastRunState.getInstance().reset()
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after decoration is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val sut = SentryTaskDecorator()
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            executor.submit(
+                sut.decorate {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                }
+            )
+
+        callableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
+    }
+}

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
@@ -1,8 +1,7 @@
 package io.sentry.spring.webflux
 
 import io.sentry.Sentry
-import io.sentry.SentryCrashLastRunState
-import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -13,22 +12,23 @@ import kotlin.test.assertNotEquals
 class SentryScheduleHookTest {
 
     private val dsn = "http://key@localhost/proj"
-    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var executor: ExecutorService
 
     @BeforeTest
-    @AfterTest
     fun beforeTest() {
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterTest
+    fun afterTest() {
         Sentry.close()
-        SentryCrashLastRunState.getInstance().reset()
+        executor.shutdown()
     }
 
     @Test
     fun `hub is reset to its state within the thread after hook is done`() {
         Sentry.init {
             it.dsn = dsn
-            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
-                event
-            }
         }
 
         val sut = SentryScheduleHook()

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
@@ -1,0 +1,60 @@
+package io.sentry.spring.webflux
+
+import io.sentry.Sentry
+import io.sentry.SentryCrashLastRunState
+import io.sentry.SentryOptions
+import java.util.concurrent.Executors
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SentryScheduleHookTest {
+
+    private val dsn = "http://key@localhost/proj"
+    private val executor = Executors.newSingleThreadExecutor()
+
+    @BeforeTest
+    @AfterTest
+    fun beforeTest() {
+        Sentry.close()
+        SentryCrashLastRunState.getInstance().reset()
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after hook is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val sut = SentryScheduleHook()
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            executor.submit(
+                sut.apply {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                }
+            )
+
+        callableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
+    }
+}

--- a/sentry/src/main/java/io/sentry/SentryWrapper.java
+++ b/sentry/src/main/java/io/sentry/SentryWrapper.java
@@ -28,10 +28,10 @@ public final class SentryWrapper {
    * @param <U> - the result type of the {@link Callable}
    */
   public static <U> Callable<U> wrapCallable(final @NotNull Callable<U> callable) {
-    final IHub oldState = Sentry.getCurrentHub();
-    final IHub newHub = oldState.clone();
+    final IHub newHub = Sentry.getCurrentHub().clone();
 
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         return callable.call();
@@ -52,10 +52,11 @@ public final class SentryWrapper {
    * @param <U> - the result type of the {@link Supplier}
    */
   public static <U> Supplier<U> wrapSupplier(final @NotNull Supplier<U> supplier) {
-    final IHub oldState = Sentry.getCurrentHub();
-    final IHub newHub = oldState.clone();
+
+    final IHub newHub = Sentry.getCurrentHub().clone();
 
     return () -> {
+      final IHub oldState = Sentry.getCurrentHub();
       Sentry.setCurrentHub(newHub);
       try {
         return supplier.get();

--- a/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class SentryWrapperTest {
 
@@ -17,6 +18,42 @@ class SentryWrapperTest {
     fun beforeTest() {
         Sentry.close()
         SentryCrashLastRunState.getInstance().reset()
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after supply is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            CompletableFuture.supplyAsync(
+                SentryWrapper.wrapSupplier {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    "Result 1"
+                },
+                executor
+            )
+
+        callableFuture.join()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
     }
 
     @Test
@@ -118,5 +155,40 @@ class SentryWrapperTest {
         assertEquals(2, mainEvent?.breadcrumbs?.size)
         assertEquals(2, clonedEvent?.breadcrumbs?.size)
         assertEquals(2, clonedEvent2?.breadcrumbs?.size)
+    }
+
+    @Test
+    fun `hub is reset to its state within the thread after callable is done`() {
+        Sentry.init {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                event
+            }
+        }
+
+        val mainHub = Sentry.getCurrentHub()
+        val threadedHub = Sentry.getCurrentHub().clone()
+
+        executor.submit {
+            Sentry.setCurrentHub(threadedHub)
+        }.get()
+
+        assertEquals(mainHub, Sentry.getCurrentHub())
+
+        val callableFuture =
+            executor.submit(
+                SentryWrapper.wrapCallable {
+                    assertNotEquals(mainHub, Sentry.getCurrentHub())
+                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    "Result 1"
+                }
+            )
+
+        callableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainHub, Sentry.getCurrentHub())
+            assertEquals(threadedHub, Sentry.getCurrentHub())
+        }.get()
     }
 }

--- a/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -11,11 +12,16 @@ import kotlin.test.assertNotEquals
 class SentryWrapperTest {
 
     private val dsn = "http://key@localhost/proj"
-    private val executor = Executors.newSingleThreadExecutor()
+    private lateinit var executor: ExecutorService
 
     @BeforeTest
-    @AfterTest
     fun beforeTest() {
+        executor = Executors.newSingleThreadExecutor()
+    }
+
+    @AfterTest
+    fun afterTest() {
+        executor.shutdown()
         Sentry.close()
         SentryCrashLastRunState.getInstance().reset()
     }
@@ -161,9 +167,6 @@ class SentryWrapperTest {
     fun `hub is reset to its state within the thread after callable is done`() {
         Sentry.init {
             it.dsn = dsn
-            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
-                event
-            }
         }
 
         val mainHub = Sentry.getCurrentHub()


### PR DESCRIPTION
## :scroll: Description
Fix restore point for hub in async wrappers
- SentryWrapper
- SentryScheduleHook
- SentryTaskDecorator


## :bulb: Motivation and Context
Fixes #3177 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
