### PR TITLE
Show warning if incompatible spring boot version is detected

### DIFF
--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpringVersionChecker.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpringVersionChecker.java
@@ -1,0 +1,30 @@
+package io.sentry.spring.boot.jakarta;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
+import org.springframework.context.ApplicationListener;
+
+final class SentrySpringVersionChecker
+    implements ApplicationListener<ApplicationContextInitializedEvent> {
+
+  private static final Log logger = LogFactory.getLog(SentrySpringVersionChecker.class);
+
+  @Override
+  public void onApplicationEvent(ApplicationContextInitializedEvent event) {
+
+    if (!SpringBootVersion.getVersion().startsWith("3")) {
+      logger.warn("############################### WARNING ###############################");
+      logger.warn("##                                                                   ##");
+      logger.warn("##            !Incompatible Spring Boot Version detected!            ##");
+      logger.warn("##              Please see the sentry docs linked below              ##");
+      logger.warn("##                Choose your Spring Boot version and                ##");
+      logger.warn("##                  install the matching dependency                  ##");
+      logger.warn("##                                                                   ##");
+      logger.warn("## https://docs.sentry.io/platforms/java/guides/spring-boot/#install ##");
+      logger.warn("##                                                                   ##");
+      logger.warn("#######################################################################");
+    }
+  }
+}

--- a/sentry-spring-boot-jakarta/src/main/resources/META-INF/spring.factories
+++ b/sentry-spring-boot-jakarta/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.context.ApplicationListener=io.sentry.spring.boot.jakarta.SentrySpringVersionChecker

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpringVersionChecker.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpringVersionChecker.java
@@ -1,0 +1,30 @@
+package io.sentry.spring.boot;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
+import org.springframework.context.ApplicationListener;
+
+final class SentrySpringVersionChecker
+    implements ApplicationListener<ApplicationContextInitializedEvent> {
+
+  private static final Log logger = LogFactory.getLog(SentrySpringVersionChecker.class);
+
+  @Override
+  public void onApplicationEvent(ApplicationContextInitializedEvent event) {
+
+    if (!SpringBootVersion.getVersion().startsWith("2")) {
+      logger.warn("############################### WARNING ###############################");
+      logger.warn("##                                                                   ##");
+      logger.warn("##            !Incompatible Spring Boot Version detected!            ##");
+      logger.warn("##              Please see the sentry docs linked below              ##");
+      logger.warn("##                Choose your Spring Boot version and                ##");
+      logger.warn("##                  install the matching dependency                  ##");
+      logger.warn("##                                                                   ##");
+      logger.warn("## https://docs.sentry.io/platforms/java/guides/spring-boot/#install ##");
+      logger.warn("##                                                                   ##");
+      logger.warn("#######################################################################");
+    }
+  }
+}

--- a/sentry-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/sentry-spring-boot/src/main/resources/META-INF/spring.factories
@@ -2,3 +2,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.sentry.spring.boot.SentryAutoConfiguration,\
 io.sentry.spring.boot.SentryLogbackAppenderAutoConfiguration,\
 io.sentry.spring.boot.SentryWebfluxAutoConfiguration
+
+org.springframework.context.ApplicationListener=io.sentry.spring.boot.SentrySpringVersionChecker


### PR DESCRIPTION
## :scroll: Description
Check for spring boot version on startup and show warning if an incompatible spring boot version is detected.


## :bulb: Motivation and Context
Fixes #2914 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
