### PR TITLE
Allow whitespace in metric tag values

### DIFF
--- a/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
@@ -23,7 +23,7 @@ public final class MetricsHelper {
   private static final Pattern INVALID_KEY_CHARACTERS_PATTERN =
       Pattern.compile("[^a-zA-Z0-9_/.-]+");
   private static final Pattern INVALID_VALUE_CHARACTERS_PATTERN =
-      Pattern.compile("[^\\w\\d_:/@\\.\\{\\}\\[\\]$-]+");
+      Pattern.compile("[^\\w\\d\\s_:/@\\.\\{\\}\\[\\]$-]+");
   // See
   // https://docs.sysdig.com/en/docs/sysdig-monitor/integrations/working-with-integrations/custom-integrations/integrate-statsd-metrics/#characters-allowed-for-statsd-metric-names
   private static final Pattern INVALID_METRIC_UNIT_CHARACTERS_PATTERN =

--- a/sentry/src/test/java/io/sentry/metrics/MetricsHelperTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/MetricsHelperTest.kt
@@ -70,6 +70,7 @@ class MetricsHelperTest {
         assertEquals("\$foo", MetricsHelper.sanitizeValue("%\$foo"))
         assertEquals("blah{}", MetricsHelper.sanitizeValue("blah{}"))
         assertEquals("snwmn", MetricsHelper.sanitizeValue("snöwmän"))
+        assertEquals("j e n g a", MetricsHelper.sanitizeValue("j e n g a!"))
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
see https://github.com/getsentry/develop/pull/1171
and https://github.com/getsentry/relay/pull/3174
and https://github.com/getsentry/sentry-python/pull/2775


## :bulb: Motivation and Context
Whitespace is fine.

#skip-changelog 
-- as the feature hasn't been released yet.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
