### PR TITLE
Add support for span creating mode in metrics.timing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Experimental: Add span summaries for metrics ([#3238](https://github.com/getsentry/sentry-java/pull/3238))
+- Experimental: Implement span creating mode in metrics.timing API ([#3248](https://github.com/getsentry/sentry-java/pull/3248))
 
 ## 7.5.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -461,6 +461,7 @@ public final class io/sentry/Hub : io/sentry/IHub, io/sentry/metrics/MetricsApi$
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
 	public fun startSession ()V
+	public fun startSpanForMetric (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
@@ -3536,6 +3537,7 @@ public abstract interface class io/sentry/metrics/MetricsApi$IMetricsInterface {
 	public abstract fun getDefaultTagsForMetrics ()Ljava/util/Map;
 	public abstract fun getLocalMetricsAggregator ()Lio/sentry/metrics/LocalMetricsAggregator;
 	public abstract fun getMetricsAggregator ()Lio/sentry/IMetricsAggregator;
+	public abstract fun startSpanForMetric (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 }
 
 public final class io/sentry/metrics/MetricsHelper {
@@ -3570,6 +3572,7 @@ public final class io/sentry/metrics/NoopMetricsAggregator : io/sentry/IMetricsA
 	public fun increment (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;JILio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun set (Ljava/lang/String;ILio/sentry/MeasurementUnit;Ljava/util/Map;JILio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun set (Ljava/lang/String;Ljava/lang/String;Lio/sentry/MeasurementUnit;Ljava/util/Map;JILio/sentry/metrics/LocalMetricsAggregator;)V
+	public fun startSpanForMetric (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
 	public fun timing (Ljava/lang/String;Ljava/lang/Runnable;Lio/sentry/MeasurementUnit$Duration;Ljava/util/Map;ILio/sentry/metrics/LocalMetricsAggregator;)V
 }
 

--- a/sentry/src/main/java/io/sentry/Hub.java
+++ b/sentry/src/main/java/io/sentry/Hub.java
@@ -979,6 +979,15 @@ public final class Hub implements IHub, MetricsApi.IMetricsInterface {
   }
 
   @Override
+  public @Nullable ISpan startSpanForMetric(@NotNull String op, @NotNull String description) {
+    final @Nullable ISpan span = getSpan();
+    if (span != null) {
+      return span.startChild(op, description);
+    }
+    return null;
+  }
+
+  @Override
   public @Nullable LocalMetricsAggregator getLocalMetricsAggregator() {
     if (!options.isEnableSpanLocalMetricAggregation()) {
       return null;

--- a/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
@@ -559,6 +559,11 @@ public final class MetricsApi {
         aggregator.getLocalMetricsAggregator();
 
     final @Nullable ISpan span = aggregator.startSpanForMetric("metric.timing", key);
+    if (span != null && tags != null) {
+      for (final @NotNull Map.Entry<String, String> entry : tags.entrySet()) {
+        span.setTag(entry.getKey(), entry.getValue());
+      }
+    }
     try {
       aggregator
           .getMetricsAggregator()

--- a/sentry/src/main/java/io/sentry/metrics/NoopMetricsAggregator.java
+++ b/sentry/src/main/java/io/sentry/metrics/NoopMetricsAggregator.java
@@ -1,6 +1,7 @@
 package io.sentry.metrics;
 
 import io.sentry.IMetricsAggregator;
+import io.sentry.ISpan;
 import io.sentry.MeasurementUnit;
 import java.io.IOException;
 import java.util.Collections;
@@ -101,5 +102,10 @@ public final class NoopMetricsAggregator
   @Override
   public @NotNull Map<String, String> getDefaultTagsForMetrics() {
     return Collections.emptyMap();
+  }
+
+  @Override
+  public @Nullable ISpan startSpanForMetric(@NotNull String op, @NotNull String description) {
+    return null;
   }
 }

--- a/sentry/src/test/java/io/sentry/HubTest.kt
+++ b/sentry/src/test/java/io/sentry/HubTest.kt
@@ -2075,6 +2075,27 @@ class HubTest {
         assertNotNull(hub.localMetricsAggregator)
     }
 
+    @Test
+    fun `hub startSpanForMetric starts a child span`() {
+        val hub = generateHub {
+            it.isEnableMetrics = true
+            it.isEnableSpanLocalMetricAggregation = true
+            it.sampleRate = 1.0
+        } as Hub
+
+        val txn = hub.startTransaction(
+            "name.txn",
+            "op.txn",
+            TransactionOptions().apply { isBindToScope = true }
+        )
+
+        val span = hub.startSpanForMetric("op", "key")!!
+
+        assertEquals("op", span.spanContext.op)
+        assertEquals("key", span.spanContext.description)
+        assertEquals(span.spanContext.parentSpanId, txn.spanContext.spanId)
+    }
+
     private val dsnTest = "https://key@sentry.io/proj"
 
     private fun generateHub(optionsConfiguration: Sentry.OptionsConfiguration<SentryOptions>? = null): IHub {

--- a/sentry/src/test/java/io/sentry/metrics/MetricsApiTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/MetricsApiTest.kt
@@ -2,11 +2,13 @@ package io.sentry.metrics
 
 import io.sentry.IMetricsAggregator
 import io.sentry.ISpan
+import io.sentry.MeasurementUnit
 import io.sentry.metrics.MetricsApi.IMetricsInterface
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -317,6 +319,27 @@ class MetricsApiTest {
         assertEquals("key", fixture.lastDescription)
 
         verify(fixture.lastSpan!!).finish()
+    }
+
+    @Test
+    fun `timing applies metric tags as span tags`() {
+        val span = mock<ISpan>()
+        val api = fixture.getSut(
+            spanProvider = {
+                span
+            },
+            defaultTags = mapOf(
+                "release" to "1.0"
+            )
+        )
+        // when timing is called
+        api.timing("key", {
+            // no-op
+        }, MeasurementUnit.Duration.NANOSECOND, mapOf("a" to "b"))
+
+        // the last span should have the metric tags, without the default ones
+        verify(fixture.lastSpan!!, never()).setTag("release", "1.0")
+        verify(fixture.lastSpan!!).setTag("a", "b")
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
As described in the RFC: https://github.com/getsentry/rfcs/edit/main/text/0123-metrics-correlation.md
We want `.timing()` to be in span-creating mode, meaning a span is automatically created.

## :green_heart: How did you test it?
Added unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
