### PR TITLE
Add before_emit_metric callback to options

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1029,7 +1029,7 @@ public final class io/sentry/MemoryCollectionData {
 
 public final class io/sentry/MetricsAggregator : io/sentry/IMetricsAggregator, java/io/Closeable, java/lang/Runnable {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/metrics/IMetricsClient;)V
-	public fun <init> (Lio/sentry/metrics/IMetricsClient;Lio/sentry/ILogger;Lio/sentry/SentryDateProvider;ILio/sentry/ISentryExecutorService;)V
+	public fun <init> (Lio/sentry/metrics/IMetricsClient;Lio/sentry/ILogger;Lio/sentry/SentryDateProvider;ILio/sentry/SentryOptions$BeforeEmitMetricCallback;Lio/sentry/ISentryExecutorService;)V
 	public fun close ()V
 	public fun distribution (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;JILio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun flush (Z)V
@@ -2203,6 +2203,7 @@ public class io/sentry/SentryOptions {
 	public static fun empty ()Lio/sentry/SentryOptions;
 	public fun getBackpressureMonitor ()Lio/sentry/backpressure/IBackpressureMonitor;
 	public fun getBeforeBreadcrumb ()Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;
+	public fun getBeforeEmitMetricCallback ()Lio/sentry/SentryOptions$BeforeEmitMetricCallback;
 	public fun getBeforeEnvelopeCallback ()Lio/sentry/SentryOptions$BeforeEnvelopeCallback;
 	public fun getBeforeSend ()Lio/sentry/SentryOptions$BeforeSendCallback;
 	public fun getBeforeSendTransaction ()Lio/sentry/SentryOptions$BeforeSendTransactionCallback;
@@ -2314,6 +2315,7 @@ public class io/sentry/SentryOptions {
 	public fun setAttachThreads (Z)V
 	public fun setBackpressureMonitor (Lio/sentry/backpressure/IBackpressureMonitor;)V
 	public fun setBeforeBreadcrumb (Lio/sentry/SentryOptions$BeforeBreadcrumbCallback;)V
+	public fun setBeforeEmitMetricCallback (Lio/sentry/SentryOptions$BeforeEmitMetricCallback;)V
 	public fun setBeforeEnvelopeCallback (Lio/sentry/SentryOptions$BeforeEnvelopeCallback;)V
 	public fun setBeforeSend (Lio/sentry/SentryOptions$BeforeSendCallback;)V
 	public fun setBeforeSendTransaction (Lio/sentry/SentryOptions$BeforeSendTransactionCallback;)V
@@ -2405,6 +2407,10 @@ public class io/sentry/SentryOptions {
 
 public abstract interface class io/sentry/SentryOptions$BeforeBreadcrumbCallback {
 	public abstract fun execute (Lio/sentry/Breadcrumb;Lio/sentry/Hint;)Lio/sentry/Breadcrumb;
+}
+
+public abstract interface class io/sentry/SentryOptions$BeforeEmitMetricCallback {
+	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;)Z
 }
 
 public abstract interface class io/sentry/SentryOptions$BeforeEnvelopeCallback {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -468,6 +468,8 @@ public class SentryOptions {
 
   private boolean enableSpanLocalMetricAggregation = true;
 
+  private @Nullable BeforeEmitMetricCallback beforeEmitMetricCallback = null;
+
   /**
    * Profiling traces rate. 101 hz means 101 traces in 1 second. Defaults to 101 to avoid possible
    * lockstep sampling. More on
@@ -2362,6 +2364,18 @@ public class SentryOptions {
     this.enableDefaultTagsForMetrics = enableDefaultTagsForMetrics;
   }
 
+  @ApiStatus.Experimental
+  @Nullable
+  public BeforeEmitMetricCallback getBeforeEmitMetricCallback() {
+    return beforeEmitMetricCallback;
+  }
+
+  @ApiStatus.Experimental
+  public void setBeforeEmitMetricCallback(
+      final @Nullable BeforeEmitMetricCallback beforeEmitMetricCallback) {
+    this.beforeEmitMetricCallback = beforeEmitMetricCallback;
+  }
+
   public @Nullable Cron getCron() {
     return cron;
   }
@@ -2453,6 +2467,20 @@ public class SentryOptions {
      * @param hint the hints
      */
     void execute(@NotNull SentryEnvelope envelope, @Nullable Hint hint);
+  }
+
+  /** The BeforeEmitMetric callback */
+  @ApiStatus.Experimental
+  public interface BeforeEmitMetricCallback {
+
+    /**
+     * A callback which gets called right before a metric is about to be emitted.
+     *
+     * @param key the metric key
+     * @param tags the metric tags
+     * @return true if the metric should be emitted, false otherwise
+     */
+    boolean execute(@NotNull String key, @Nullable Map<String, String> tags);
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SentryOptionsTest {
@@ -649,6 +650,15 @@ class SentryOptionsTest {
         assertTrue(options.isEnableMetrics)
         assertFalse(options.isEnableDefaultTagsForMetrics)
         assertFalse(options.isEnableSpanLocalMetricAggregation)
+    }
+
+    @Test
+    fun `when metric callback is set, getter returns it`() {
+        val callback = SentryOptions.BeforeEmitMetricCallback { _, _ -> false }
+        val options = SentryOptions().apply {
+            beforeEmitMetricCallback = callback
+        }
+        assertSame(options.beforeEmitMetricCallback, options.beforeEmitMetricCallback)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
