### PR TITLE
Increase gradle memory pool size from 4gb to 12gb, crash on OOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ createCoverageReports:
 
 # Run tests and lint
 check:
-	./gradlew check --debug
+	./gradlew check

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ createCoverageReports:
 
 # Run tests and lint
 check:
-	./gradlew check
+	./gradlew check --debug

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,11 +91,11 @@ allprojects {
                 TestLogEvent.PASSED,
                 TestLogEvent.FAILED
             )
-            // maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+            maxParallelForks = Runtime.getRuntime().availableProcessors() / 4
 
             // Cap JVM args per test
-            minHeapSize = "128m"
-            maxHeapSize = "1g"
+            minHeapSize = "256m"
+            maxHeapSize = "2g"
             dependsOn("cleanTest")
         }
         withType<JavaCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ allprojects {
                 TestLogEvent.PASSED,
                 TestLogEvent.FAILED
             )
-            maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+            // maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
 
             // Cap JVM args per test
             minHeapSize = "128m"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Daemons heap size
-org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=3g -XX:+CrashOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx12g -XX:MaxMetaspaceSize=4g -XX:+CrashOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.parallel=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Daemons heap size
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1536m -XX:+CrashOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.parallel=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Daemons heap size
-org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1536m -XX:+CrashOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=3g -XX:+CrashOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.parallel=true
 


### PR DESCRIPTION
## :scroll: Description

#skip-changelog

An attempt to fix CI issues where certain gradle tasks simply get stuck forever. E.g. https://github.com/getsentry/sentry-java/actions/runs/8200009043/job/22426029447?pr=3253#step:5:1524

## :bulb: Motivation and Context
Reliable CI!


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
