### PR TITLE
Fix release pipeline being unable to fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
+          # Needs to be set, otherwise git describe --tags will fail with: No names found, cannot describe anything
+          fetch-depth: 0
           submodules: 'recursive'
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1


### PR DESCRIPTION
## :scroll: Description

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
