### PR TITLE
Hubs/Scopes Merge 9 - Replace `IHub` with `IScopes` in more integrations

### DIFF
--- a/sentry-jdbc/api/sentry-jdbc.api
+++ b/sentry-jdbc/api/sentry-jdbc.api
@@ -16,7 +16,7 @@ public final class io/sentry/jdbc/DatabaseUtils$DatabaseDetails {
 
 public class io/sentry/jdbc/SentryJdbcEventListener : com/p6spy/engine/event/SimpleJdbcEventListener {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun onAfterAnyExecute (Lcom/p6spy/engine/common/StatementInformation;JLjava/sql/SQLException;)V
 	public fun onBeforeAnyExecute (Lcom/p6spy/engine/common/StatementInformation;)V
 }

--- a/sentry-kotlin-extensions/api/sentry-kotlin-extensions.api
+++ b/sentry-kotlin-extensions/api/sentry-kotlin-extensions.api
@@ -1,16 +1,16 @@
 public final class io/sentry/kotlin/SentryContext : kotlin/coroutines/AbstractCoroutineContextElement, kotlinx/coroutines/CopyableThreadContextElement {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
-	public synthetic fun <init> (Lio/sentry/IHub;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public synthetic fun <init> (Lio/sentry/IScopes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun copyForChild ()Lkotlinx/coroutines/CopyableThreadContextElement;
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
 	public fun mergeForChild (Lkotlin/coroutines/CoroutineContext$Element;)Lkotlin/coroutines/CoroutineContext;
 	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
 	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
-	public fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Lio/sentry/IHub;)V
+	public fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Lio/sentry/IScopes;)V
 	public synthetic fun restoreThreadContext (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Object;)V
-	public fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Lio/sentry/IHub;
+	public fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Lio/sentry/IScopes;
 	public synthetic fun updateThreadContext (Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
 }
 

--- a/sentry-kotlin-extensions/src/main/java/io/sentry/kotlin/SentryContext.kt
+++ b/sentry-kotlin-extensions/src/main/java/io/sentry/kotlin/SentryContext.kt
@@ -1,6 +1,6 @@
 package io.sentry.kotlin
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import kotlinx.coroutines.CopyableThreadContextElement
 import kotlin.coroutines.AbstractCoroutineContextElement
@@ -9,26 +9,32 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Sentry context element for [CoroutineContext].
  */
-public class SentryContext(private val hub: IHub = Sentry.getCurrentHub().clone()) :
-    CopyableThreadContextElement<IHub>, AbstractCoroutineContextElement(Key) {
+@SuppressWarnings("deprecation")
+// TODO fork instead
+public class SentryContext(private val scopes: IScopes = Sentry.getCurrentScopes().clone()) :
+    CopyableThreadContextElement<IScopes>, AbstractCoroutineContextElement(Key) {
 
     private companion object Key : CoroutineContext.Key<SentryContext>
 
-    override fun copyForChild(): CopyableThreadContextElement<IHub> {
-        return SentryContext(hub.clone())
+    @SuppressWarnings("deprecation")
+    override fun copyForChild(): CopyableThreadContextElement<IScopes> {
+        // TODO fork instead
+        return SentryContext(scopes.clone())
     }
 
+    @SuppressWarnings("deprecation")
     override fun mergeForChild(overwritingElement: CoroutineContext.Element): CoroutineContext {
-        return overwritingElement[Key] ?: SentryContext(hub.clone())
+        // TODO fork instead?
+        return overwritingElement[Key] ?: SentryContext(scopes.clone())
     }
 
-    override fun updateThreadContext(context: CoroutineContext): IHub {
-        val oldState = Sentry.getCurrentHub()
-        Sentry.setCurrentHub(hub)
+    override fun updateThreadContext(context: CoroutineContext): IScopes {
+        val oldState = Sentry.getCurrentScopes()
+        Sentry.setCurrentScopes(scopes)
         return oldState
     }
 
-    override fun restoreThreadContext(context: CoroutineContext, oldState: IHub) {
-        Sentry.setCurrentHub(oldState)
+    override fun restoreThreadContext(context: CoroutineContext, oldState: IScopes) {
+        Sentry.setCurrentScopes(oldState)
     }
 }

--- a/sentry-kotlin-extensions/src/test/java/io/sentry/kotlin/SentryContextTest.kt
+++ b/sentry-kotlin-extensions/src/test/java/io/sentry/kotlin/SentryContextTest.kt
@@ -119,7 +119,7 @@ class SentryContextTest {
 
             val c2 = launch(
                 SentryContext(
-                    Sentry.getCurrentHub().clone().also {
+                    Sentry.getCurrentScopes().clone().also {
                         it.setTag("cloned", "clonedValue")
                     }
                 )
@@ -145,7 +145,7 @@ class SentryContextTest {
     @Test
     fun `mergeForChild returns copy of initial context if Key not present`() {
         val initialContextElement = SentryContext(
-            Sentry.getCurrentHub().clone().also {
+            Sentry.getCurrentScopes().clone().also {
                 it.setTag("cloned", "clonedValue")
             }
         )
@@ -158,7 +158,7 @@ class SentryContextTest {
     @Test
     fun `mergeForChild returns passed context`() {
         val initialContextElement = SentryContext(
-            Sentry.getCurrentHub().clone().also {
+            Sentry.getCurrentScopes().clone().also {
                 it.setTag("cloned", "clonedValue")
             }
         )

--- a/sentry-openfeign/api/sentry-openfeign.api
+++ b/sentry-openfeign/api/sentry-openfeign.api
@@ -1,12 +1,12 @@
 public final class io/sentry/openfeign/SentryCapability : feign/Capability {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
 	public fun <init> (Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
 	public fun enrich (Lfeign/Client;)Lfeign/Client;
 }
 
 public final class io/sentry/openfeign/SentryFeignClient : feign/Client {
-	public fun <init> (Lfeign/Client;Lio/sentry/IHub;Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
+	public fun <init> (Lfeign/Client;Lio/sentry/IScopes;Lio/sentry/openfeign/SentryFeignClient$BeforeSpanCallback;)V
 	public fun execute (Lfeign/Request;Lfeign/Request$Options;)Lfeign/Response;
 }
 

--- a/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryCapability.java
+++ b/sentry-openfeign/src/main/java/io/sentry/openfeign/SentryCapability.java
@@ -2,33 +2,34 @@ package io.sentry.openfeign;
 
 import feign.Capability;
 import feign.Client;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Adds Sentry tracing capability to Feign clients. */
 public final class SentryCapability implements Capability {
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private final @Nullable SentryFeignClient.BeforeSpanCallback beforeSpan;
 
   public SentryCapability(
-      final @NotNull IHub hub, final @Nullable SentryFeignClient.BeforeSpanCallback beforeSpan) {
-    this.hub = hub;
+      final @NotNull IScopes scopes,
+      final @Nullable SentryFeignClient.BeforeSpanCallback beforeSpan) {
+    this.scopes = scopes;
     this.beforeSpan = beforeSpan;
   }
 
   public SentryCapability(final @Nullable SentryFeignClient.BeforeSpanCallback beforeSpan) {
-    this(HubAdapter.getInstance(), beforeSpan);
+    this(ScopesAdapter.getInstance(), beforeSpan);
   }
 
   public SentryCapability() {
-    this(HubAdapter.getInstance(), null);
+    this(ScopesAdapter.getInstance(), null);
   }
 
   @Override
   public @NotNull Client enrich(final @NotNull Client client) {
-    return new SentryFeignClient(client, hub, beforeSpan);
+    return new SentryFeignClient(client, scopes, beforeSpan);
   }
 }

--- a/sentry-quartz/api/sentry-quartz.api
+++ b/sentry-quartz/api/sentry-quartz.api
@@ -7,7 +7,7 @@ public final class io/sentry/quartz/SentryJobListener : org/quartz/JobListener {
 	public static final field SENTRY_CHECK_IN_ID_KEY Ljava/lang/String;
 	public static final field SENTRY_SLUG_KEY Ljava/lang/String;
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun getName ()Ljava/lang/String;
 	public fun jobExecutionVetoed (Lorg/quartz/JobExecutionContext;)V
 	public fun jobToBeExecuted (Lorg/quartz/JobExecutionContext;)V

--- a/sentry-quartz/src/main/java/io/sentry/quartz/SentryJobListener.java
+++ b/sentry-quartz/src/main/java/io/sentry/quartz/SentryJobListener.java
@@ -3,8 +3,8 @@ package io.sentry.quartz;
 import io.sentry.BuildConfig;
 import io.sentry.CheckIn;
 import io.sentry.CheckInStatus;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
@@ -24,14 +24,14 @@ public final class SentryJobListener implements JobListener {
   public static final String SENTRY_CHECK_IN_ID_KEY = "sentry-checkin-id";
   public static final String SENTRY_SLUG_KEY = "sentry-slug";
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryJobListener() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentryJobListener(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryJobListener(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
     SentryIntegrationPackageStorage.getInstance().addIntegration("Quartz");
     SentryIntegrationPackageStorage.getInstance()
         .addPackage("maven:io.sentry:sentry-quartz", BuildConfig.VERSION_NAME);
@@ -49,15 +49,16 @@ public final class SentryJobListener implements JobListener {
       if (maybeSlug == null) {
         return;
       }
-      hub.pushScope();
-      TracingUtils.startNewTrace(hub);
+      scopes.pushScope();
+      TracingUtils.startNewTrace(scopes);
       final @NotNull String slug = maybeSlug;
       final @NotNull CheckIn checkIn = new CheckIn(slug, CheckInStatus.IN_PROGRESS);
-      final @NotNull SentryId checkInId = hub.captureCheckIn(checkIn);
+      final @NotNull SentryId checkInId = scopes.captureCheckIn(checkIn);
       context.put(SENTRY_CHECK_IN_ID_KEY, checkInId);
       context.put(SENTRY_SLUG_KEY, slug);
     } catch (Throwable t) {
-      hub.getOptions()
+      scopes
+          .getOptions()
           .getLogger()
           .log(SentryLevel.ERROR, "Unable to capture check-in in jobToBeExecuted.", t);
     }
@@ -94,14 +95,15 @@ public final class SentryJobListener implements JobListener {
       if (slug != null) {
         final boolean isFailed = jobException != null;
         final @NotNull CheckInStatus status = isFailed ? CheckInStatus.ERROR : CheckInStatus.OK;
-        hub.captureCheckIn(new CheckIn(checkInId, slug, status));
+        scopes.captureCheckIn(new CheckIn(checkInId, slug, status));
       }
     } catch (Throwable t) {
-      hub.getOptions()
+      scopes
+          .getOptions()
           .getLogger()
           .log(SentryLevel.ERROR, "Unable to capture check-in in jobWasExecuted.", t);
     } finally {
-      hub.popScope();
+      scopes.popScope();
     }
   }
 }

--- a/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
+++ b/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
@@ -10,7 +10,7 @@ public class io/sentry/servlet/jakarta/SentryServletContainerInitializer : jakar
 
 public class io/sentry/servlet/jakarta/SentryServletRequestListener : jakarta/servlet/ServletRequestListener {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun requestDestroyed (Ljakarta/servlet/ServletRequestEvent;)V
 	public fun requestInitialized (Ljakarta/servlet/ServletRequestEvent;)V
 }

--- a/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletRequestListenerTest.kt
+++ b/sentry-servlet-jakarta/src/test/kotlin/io/sentry/servlet/jakarta/SentryServletRequestListenerTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.servlet.jakarta
 
 import io.sentry.Breadcrumb
-import io.sentry.IHub
+import io.sentry.IScopes
 import jakarta.servlet.ServletRequestEvent
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.check
@@ -13,9 +13,9 @@ import kotlin.test.assertEquals
 
 class SentryServletRequestListenerTest {
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val listener =
-            SentryServletRequestListener(hub)
+            SentryServletRequestListener(scopes)
         val request = mockRequest(
             url = "http://localhost:8080/some-uri",
             method = "POST"
@@ -33,14 +33,14 @@ class SentryServletRequestListenerTest {
     fun `pushes scope when request gets initialized`() {
         fixture.listener.requestInitialized(fixture.event)
 
-        verify(fixture.hub).pushScope()
+        verify(fixture.scopes).pushScope()
     }
 
     @Test
     fun `adds breadcrumb when request gets initialized`() {
         fixture.listener.requestInitialized(fixture.event)
 
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check { it: Breadcrumb ->
                 assertEquals("/some-uri", it.getData("url"))
                 assertEquals("POST", it.getData("method"))
@@ -54,6 +54,6 @@ class SentryServletRequestListenerTest {
     fun `pops scope when request gets destroyed`() {
         fixture.listener.requestDestroyed(fixture.event)
 
-        verify(fixture.hub).popScope()
+        verify(fixture.scopes).popScope()
     }
 }

--- a/sentry-servlet/api/sentry-servlet.api
+++ b/sentry-servlet/api/sentry-servlet.api
@@ -10,7 +10,7 @@ public class io/sentry/servlet/SentryServletContainerInitializer : javax/servlet
 
 public class io/sentry/servlet/SentryServletRequestListener : javax/servlet/ServletRequestListener {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun requestDestroyed (Ljavax/servlet/ServletRequestEvent;)V
 	public fun requestInitialized (Ljavax/servlet/ServletRequestEvent;)V
 }

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -5,8 +5,8 @@ import static io.sentry.TypeCheckHint.SERVLET_REQUEST;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.util.Objects;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
@@ -21,24 +21,24 @@ import org.jetbrains.annotations.NotNull;
 @Open
 public class SentryServletRequestListener implements ServletRequestListener {
 
-  private final IHub hub;
+  private final IScopes scopes;
 
-  public SentryServletRequestListener(@NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryServletRequestListener(@NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   public SentryServletRequestListener() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
   @Override
   public void requestDestroyed(@NotNull ServletRequestEvent servletRequestEvent) {
-    hub.popScope();
+    scopes.popScope();
   }
 
   @Override
   public void requestInitialized(@NotNull ServletRequestEvent servletRequestEvent) {
-    hub.pushScope();
+    scopes.pushScope();
 
     final ServletRequest servletRequest = servletRequestEvent.getServletRequest();
     if (servletRequest instanceof HttpServletRequest) {
@@ -47,10 +47,10 @@ public class SentryServletRequestListener implements ServletRequestListener {
       final Hint hint = new Hint();
       hint.set(SERVLET_REQUEST, httpRequest);
 
-      hub.addBreadcrumb(
+      scopes.addBreadcrumb(
           Breadcrumb.http(httpRequest.getRequestURI(), httpRequest.getMethod()), hint);
 
-      hub.configureScope(
+      scopes.configureScope(
           scope -> {
             scope.addEventProcessor(new SentryRequestHttpServletRequestProcessor(httpRequest));
           });

--- a/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryServletRequestListenerTest.kt
+++ b/sentry-servlet/src/test/kotlin/io/sentry/servlet/SentryServletRequestListenerTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.servlet
 
 import io.sentry.Breadcrumb
-import io.sentry.IHub
+import io.sentry.IScopes
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.check
@@ -14,8 +14,8 @@ import kotlin.test.Test
 
 class SentryServletRequestListenerTest {
     private class Fixture {
-        val hub = mock<IHub>()
-        val listener = SentryServletRequestListener(hub)
+        val scopes = mock<IScopes>()
+        val listener = SentryServletRequestListener(scopes)
         val request = MockHttpServletRequest()
         val event = mock<ServletRequestEvent>()
 
@@ -32,14 +32,14 @@ class SentryServletRequestListenerTest {
     fun `pushes scope when request gets initialized`() {
         fixture.listener.requestInitialized(fixture.event)
 
-        verify(fixture.hub).pushScope()
+        verify(fixture.scopes).pushScope()
     }
 
     @Test
     fun `adds breadcrumb when request gets initialized`() {
         fixture.listener.requestInitialized(fixture.event)
 
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check { it: Breadcrumb ->
                 assertThat(it.getData("url")).isEqualTo("http://localhost:8080/some-uri")
                 assertThat(it.getData("method")).isEqualTo("POST")
@@ -53,6 +53,6 @@ class SentryServletRequestListenerTest {
     fun `pops scope when request gets destroyed`() {
         fixture.listener.requestDestroyed(fixture.event)
 
-        verify(fixture.hub).popScope()
+        verify(fixture.scopes).popScope()
     }
 }

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -32,6 +32,7 @@ public final class io/sentry/test/ImmediateExecutorService : io/sentry/ISentryEx
 }
 
 public final class io/sentry/test/ReflectionKt {
+	public static final fun collectInterfaceHierarchy (Ljava/lang/Class;)Ljava/util/List;
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Z
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/Class;)Z
 	public static final fun getCtor (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor;

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Reflection.kt
@@ -12,16 +12,23 @@ inline fun <reified T : Any> T.callMethod(name: String, parameterTypes: Class<*>
     val declaredMethod = try {
         T::class.java.getDeclaredMethod(name, parameterTypes)
     } catch (e: NoSuchMethodException) {
-        T::class.java.interfaces.first { it.containsMethod(name, parameterTypes) }.getDeclaredMethod(name, parameterTypes)
+        collectInterfaceHierarchy(T::class.java).first { it.containsMethod(name, parameterTypes) }.getDeclaredMethod(name, parameterTypes)
     }
     return declaredMethod.invoke(this, value)
+}
+
+fun collectInterfaceHierarchy(clazz: Class<*>): List<Class<*>> {
+    if (clazz.interfaces.isEmpty()) {
+        return listOf(clazz)
+    }
+    return clazz.interfaces.flatMap { iface -> collectInterfaceHierarchy(iface) }.also { it.toMutableList().add(clazz) }
 }
 
 inline fun <reified T : Any> T.callMethod(name: String, parameterTypes: Array<Class<*>>, vararg value: Any?): Any? {
     val declaredMethod = try {
         T::class.java.getDeclaredMethod(name, *parameterTypes)
     } catch (e: NoSuchMethodException) {
-        T::class.java.interfaces.first { it.containsMethod(name, parameterTypes) }.getDeclaredMethod(name, *parameterTypes)
+        collectInterfaceHierarchy(T::class.java).first { it.containsMethod(name, parameterTypes) }.getDeclaredMethod(name, *parameterTypes)
     }
     return declaredMethod.invoke(this, *value)
 }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Follow up for https://github.com/getsentry/sentry-java/pull/3297 changing JDBC, OpenFeign, Kotlin, Quartz, Servlet integrations as well as test support.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
