### PR TITLE
Hubs/Scopes Merge 11 - Replace `IHub` with `IScopes` in Spring integrations

### DIFF
--- a/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
+++ b/sentry-spring-boot-jakarta/api/sentry-spring-boot-jakarta.api
@@ -62,7 +62,7 @@ public class io/sentry/spring/boot/jakarta/SentryProperties$Reactive {
 
 public class io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration {
 	public fun <init> ()V
-	public fun sentryWebExceptionHandler (Lio/sentry/IHub;)Lio/sentry/spring/jakarta/webflux/SentryWebExceptionHandler;
+	public fun sentryWebExceptionHandler (Lio/sentry/IScopes;)Lio/sentry/spring/jakarta/webflux/SentryWebExceptionHandler;
 }
 
 public class io/sentry/spring/boot/jakarta/graphql/SentryGraphqlAutoConfiguration {

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -3,10 +3,10 @@ package io.sentry.spring.boot.jakarta;
 import com.jakewharton.nopen.annotation.Open;
 import graphql.GraphQLError;
 import io.sentry.EventProcessor;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransportFactory;
 import io.sentry.Integration;
+import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
@@ -116,7 +116,7 @@ public class SentryAutoConfiguration {
     }
 
     @Bean
-    public @NotNull IHub sentryHub(
+    public @NotNull IScopes sentryHub(
         final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<GitProperties> gitProperties) {
@@ -139,7 +139,7 @@ public class SentryAutoConfiguration {
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
       Sentry.init(options);
-      return HubAdapter.getInstance();
+      return ScopesAdapter.getInstance();
     }
 
     @Configuration(proxyBeanMethods = false)
@@ -239,7 +239,7 @@ public class SentryAutoConfiguration {
        * HttpServletRequest#getUserPrincipal()}. If Spring Security is auto-configured, its order is
        * set to run after Spring Security.
        *
-       * @param hub the Sentry hub
+       * @param scopes the Sentry scopes
        * @param sentryProperties the Sentry properties
        * @param sentryUserProvider the user provider
        * @return {@link SentryUserFilter} registration bean
@@ -247,11 +247,11 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnBean(SentryUserProvider.class)
       public @NotNull FilterRegistrationBean<SentryUserFilter> sentryUserFilter(
-          final @NotNull IHub hub,
+          final @NotNull IScopes scopes,
           final @NotNull SentryProperties sentryProperties,
           final @NotNull List<SentryUserProvider> sentryUserProvider) {
         final FilterRegistrationBean<SentryUserFilter> filter = new FilterRegistrationBean<>();
-        filter.setFilter(new SentryUserFilter(hub, sentryUserProvider));
+        filter.setFilter(new SentryUserFilter(scopes, sentryUserProvider));
         filter.setOrder(resolveUserFilterOrder(sentryProperties));
         return filter;
       }
@@ -263,8 +263,8 @@ public class SentryAutoConfiguration {
       }
 
       @Bean
-      public @NotNull SentryRequestResolver sentryRequestResolver(final @NotNull IHub hub) {
-        return new SentryRequestResolver(hub);
+      public @NotNull SentryRequestResolver sentryRequestResolver(final @NotNull IScopes scopes) {
+        return new SentryRequestResolver(scopes);
       }
 
       @Bean
@@ -276,12 +276,12 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnMissingBean(name = "sentrySpringFilter")
       public @NotNull FilterRegistrationBean<SentrySpringFilter> sentrySpringFilter(
-          final @NotNull IHub hub,
+          final @NotNull IScopes scopes,
           final @NotNull SentryRequestResolver requestResolver,
           final @NotNull TransactionNameProvider transactionNameProvider) {
         FilterRegistrationBean<SentrySpringFilter> filter =
             new FilterRegistrationBean<>(
-                new SentrySpringFilter(hub, requestResolver, transactionNameProvider));
+                new SentrySpringFilter(scopes, requestResolver, transactionNameProvider));
         filter.setOrder(SENTRY_SPRING_FILTER_PRECEDENCE);
         return filter;
       }
@@ -289,9 +289,10 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnMissingBean(name = "sentryTracingFilter")
       public FilterRegistrationBean<SentryTracingFilter> sentryTracingFilter(
-          final @NotNull IHub hub, final @NotNull TransactionNameProvider transactionNameProvider) {
+          final @NotNull IScopes scopes,
+          final @NotNull TransactionNameProvider transactionNameProvider) {
         FilterRegistrationBean<SentryTracingFilter> filter =
-            new FilterRegistrationBean<>(new SentryTracingFilter(hub, transactionNameProvider));
+            new FilterRegistrationBean<>(new SentryTracingFilter(scopes, transactionNameProvider));
         filter.setOrder(SENTRY_SPRING_FILTER_PRECEDENCE + 1); // must run after SentrySpringFilter
         return filter;
       }
@@ -300,11 +301,11 @@ public class SentryAutoConfiguration {
       @ConditionalOnMissingBean
       @ConditionalOnClass(HandlerExceptionResolver.class)
       public @NotNull SentryExceptionResolver sentryExceptionResolver(
-          final @NotNull IHub sentryHub,
+          final @NotNull IScopes scopes,
           final @NotNull TransactionNameProvider transactionNameProvider,
           final @NotNull SentryProperties options) {
         return new SentryExceptionResolver(
-            sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+            scopes, transactionNameProvider, options.getExceptionResolverOrder());
       }
     }
 
@@ -354,8 +355,8 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryPerformanceRestTemplateConfiguration {
       @Bean
-      public SentrySpanRestTemplateCustomizer sentrySpanRestTemplateCustomizer(IHub hub) {
-        return new SentrySpanRestTemplateCustomizer(hub);
+      public SentrySpanRestTemplateCustomizer sentrySpanRestTemplateCustomizer(IScopes scopes) {
+        return new SentrySpanRestTemplateCustomizer(scopes);
       }
     }
 
@@ -365,8 +366,8 @@ public class SentryAutoConfiguration {
     @Open
     static class SentrySpanRestClientConfiguration {
       @Bean
-      public SentrySpanRestClientCustomizer sentrySpanRestClientCustomizer(IHub hub) {
-        return new SentrySpanRestClientCustomizer(hub);
+      public SentrySpanRestClientCustomizer sentrySpanRestClientCustomizer(IScopes scopes) {
+        return new SentrySpanRestClientCustomizer(scopes);
       }
     }
 
@@ -376,8 +377,8 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryPerformanceWebClientConfiguration {
       @Bean
-      public SentrySpanWebClientCustomizer sentrySpanWebClientCustomizer(IHub hub) {
-        return new SentrySpanWebClientCustomizer(hub);
+      public SentrySpanWebClientCustomizer sentrySpanWebClientCustomizer(IScopes scopes) {
+        return new SentrySpanWebClientCustomizer(scopes);
       }
     }
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanRestClientCustomizer.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanRestClientCustomizer.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.boot.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.web.client.RestClientCustomizer;
@@ -11,8 +11,8 @@ import org.springframework.web.client.RestClient;
 class SentrySpanRestClientCustomizer implements RestClientCustomizer {
   private final @NotNull SentrySpanClientHttpRequestInterceptor interceptor;
 
-  public SentrySpanRestClientCustomizer(final @NotNull IHub hub) {
-    this.interceptor = new SentrySpanClientHttpRequestInterceptor(hub, false);
+  public SentrySpanRestClientCustomizer(final @NotNull IScopes scopes) {
+    this.interceptor = new SentrySpanClientHttpRequestInterceptor(scopes, false);
   }
 
   @Override

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanRestTemplateCustomizer.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanRestTemplateCustomizer.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.boot.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +14,8 @@ import org.springframework.web.client.RestTemplate;
 class SentrySpanRestTemplateCustomizer implements RestTemplateCustomizer {
   private final @NotNull SentrySpanClientHttpRequestInterceptor interceptor;
 
-  public SentrySpanRestTemplateCustomizer(final @NotNull IHub hub) {
-    this.interceptor = new SentrySpanClientHttpRequestInterceptor(hub);
+  public SentrySpanRestTemplateCustomizer(final @NotNull IScopes scopes) {
+    this.interceptor = new SentrySpanClientHttpRequestInterceptor(scopes);
   }
 
   @Override

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanWebClientCustomizer.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentrySpanWebClientCustomizer.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.boot.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.tracing.SentrySpanClientWebRequestFilter;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
@@ -11,8 +11,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 class SentrySpanWebClientCustomizer implements WebClientCustomizer {
   private final @NotNull SentrySpanClientWebRequestFilter filter;
 
-  public SentrySpanWebClientCustomizer(final @NotNull IHub hub) {
-    this.filter = new SentrySpanClientWebRequestFilter(hub);
+  public SentrySpanWebClientCustomizer(final @NotNull IScopes scopes) {
+    this.filter = new SentrySpanClientWebRequestFilter(scopes);
   }
 
   @Override

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.boot.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.webflux.SentryScheduleHook;
 import io.sentry.spring.jakarta.webflux.SentryWebExceptionHandler;
 import io.sentry.spring.jakarta.webflux.SentryWebFilter;
@@ -28,7 +28,7 @@ import reactor.core.scheduler.Schedulers;
 /** Configures Sentry integration for Spring Webflux and Project Reactor. */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
-@ConditionalOnBean(IHub.class)
+@ConditionalOnBean(IScopes.class)
 @ConditionalOnClass(Schedulers.class)
 @Open
 @ApiStatus.Experimental
@@ -44,14 +44,14 @@ public class SentryWebfluxAutoConfiguration {
      * Configures a filter that sets up Sentry {@link IScope} for each request.
      *
      * <p>Makes use of newer reactor-core and context-propagation library feature
-     * ThreadLocalAccessor to propagate the Sentry hub.
+     * ThreadLocalAccessor to propagate the Sentry scopes.
      */
     @Bean
     @Order(SENTRY_SPRING_FILTER_PRECEDENCE)
     public @NotNull SentryWebFilterWithThreadLocalAccessor sentryWebFilterWithContextPropagation(
-        final @NotNull IHub hub) {
+        final @NotNull IScopes scopes) {
       Hooks.enableAutomaticContextPropagation();
-      return new SentryWebFilterWithThreadLocalAccessor(hub);
+      return new SentryWebFilterWithThreadLocalAccessor(scopes);
     }
   }
 
@@ -60,7 +60,7 @@ public class SentryWebfluxAutoConfiguration {
   @Open
   static class SentryWebfluxFilterConfiguration {
 
-    /** Configures hook that sets correct hub on the executing thread. */
+    /** Configures hook that sets correct scopes on the executing thread. */
     @Bean
     public @NotNull ApplicationRunner sentryScheduleHookApplicationRunner() {
       return args -> {
@@ -71,15 +71,16 @@ public class SentryWebfluxAutoConfiguration {
     /** Configures a filter that sets up Sentry {@link IScope} for each request. */
     @Bean
     @Order(SENTRY_SPRING_FILTER_PRECEDENCE)
-    public @NotNull SentryWebFilter sentryWebFilter(final @NotNull IHub hub) {
-      return new SentryWebFilter(hub);
+    public @NotNull SentryWebFilter sentryWebFilter(final @NotNull IScopes scopes) {
+      return new SentryWebFilter(scopes);
     }
   }
 
   /** Configures exception handler that handles unhandled exceptions and sends them to Sentry. */
   @Bean
-  public @NotNull SentryWebExceptionHandler sentryWebExceptionHandler(final @NotNull IHub hub) {
-    return new SentryWebExceptionHandler(hub);
+  public @NotNull SentryWebExceptionHandler sentryWebExceptionHandler(
+      final @NotNull IScopes scopes) {
+    return new SentryWebExceptionHandler(scopes);
   }
 
   static final class SentryLegacyFilterConfigurationCondition extends AnyNestedCondition {

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -5,7 +5,7 @@ import io.sentry.AsyncHttpTransportFactory
 import io.sentry.Breadcrumb
 import io.sentry.EventProcessor
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Integration
 import io.sentry.NoOpTransportFactory
@@ -77,18 +77,18 @@ class SentryAutoConfigurationTest {
         .withConfiguration(AutoConfigurations.of(SentryAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
 
     @Test
-    fun `hub is not created when auto-configuration dsn is not set`() {
+    fun `scopes is not created when auto-configuration dsn is not set`() {
         contextRunner
             .run {
-                assertThat(it).doesNotHaveBean(IHub::class.java)
+                assertThat(it).doesNotHaveBean(IScopes::class.java)
             }
     }
 
     @Test
-    fun `hub is created when dsn is provided`() {
+    fun `scopes is created when dsn is provided`() {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
             .run {
-                assertThat(it).hasSingleBean(IHub::class.java)
+                assertThat(it).hasSingleBean(IScopes::class.java)
             }
     }
 
@@ -961,7 +961,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomIntegration : Integration {
-        override fun register(hub: IHub, options: SentryOptions) {}
+        override fun register(scopes: IScopes, options: SentryOptions) {}
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentrySpanRestClientCustomizerTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentrySpanRestClientCustomizerTest.kt
@@ -2,7 +2,7 @@ package io.sentry.spring.boot.jakarta
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -36,18 +36,18 @@ import kotlin.test.assertTrue
 class SentrySpanRestClientCustomizerTest {
     class Fixture {
         val sentryOptions = SentryOptions()
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val restClientBuilder = RestClient.builder()
         var mockServer = MockWebServer()
         val transaction: SentryTracer
-        internal val customizer = SentrySpanRestClientCustomizer(hub)
+        internal val customizer = SentrySpanRestClientCustomizer(scopes)
         val url = mockServer.url("/test/123").toString()
         val scope = Scope(sentryOptions)
 
         init {
-            whenever(hub.options).thenReturn(sentryOptions)
-            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(hub).configureScope(any())
-            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), hub)
+            whenever(scopes.options).thenReturn(sentryOptions)
+            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(scopes).configureScope(any())
+            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), scopes)
         }
 
         fun getSut(
@@ -75,7 +75,7 @@ class SentrySpanRestClientCustomizerTest {
             )
 
             if (isTransactionActive) {
-                whenever(hub.span).thenReturn(transaction)
+                whenever(scopes.span).thenReturn(transaction)
             }
 
             return restClientBuilder.apply {
@@ -247,7 +247,7 @@ class SentrySpanRestClientCustomizerTest {
             .body("content")
             .retrieve()
             .toEntity(String::class.java)
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -269,7 +269,7 @@ class SentrySpanRestClientCustomizerTest {
                 .toEntity(String::class.java)
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -287,7 +287,7 @@ class SentrySpanRestClientCustomizerTest {
             .body("content")
             .retrieve()
             .toEntity(String::class.java)
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -309,7 +309,7 @@ class SentrySpanRestClientCustomizerTest {
                 .toEntity(String::class.java)
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentrySpanWebClientCustomizerTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentrySpanWebClientCustomizerTest.kt
@@ -2,8 +2,8 @@ package io.sentry.spring.boot.jakarta
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.IHub
 import io.sentry.IScope
+import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -39,10 +39,10 @@ class SentrySpanWebClientCustomizerTest {
     class Fixture {
         lateinit var sentryOptions: SentryOptions
         lateinit var scope: IScope
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         var mockServer = MockWebServer()
         lateinit var transaction: SentryTracer
-        private val customizer = SentrySpanWebClientCustomizer(hub)
+        private val customizer = SentrySpanWebClientCustomizer(scopes)
 
         fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, throwIOException: Boolean = false, includeMockServerInTracingOrigins: Boolean = true): WebClient {
             sentryOptions = SentryOptions().apply {
@@ -54,9 +54,9 @@ class SentrySpanWebClientCustomizerTest {
                 dsn = "http://key@localhost/proj"
             }
             scope = Scope(sentryOptions)
-            whenever(hub.options).thenReturn(sentryOptions)
-            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(hub).configureScope(any())
-            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), hub)
+            whenever(scopes.options).thenReturn(sentryOptions)
+            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(scopes).configureScope(any())
+            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), scopes)
             val webClientBuilder = WebClient.builder()
             customizer.customize(webClientBuilder)
             val webClient = webClientBuilder.build()
@@ -64,7 +64,7 @@ class SentrySpanWebClientCustomizerTest {
             if (isTransactionActive) {
                 val scope = Scope(sentryOptions)
                 scope.transaction = transaction
-                whenever(hub.span).thenReturn(transaction)
+                whenever(scopes.span).thenReturn(transaction)
             }
 
             val dispatcher: Dispatcher = object : Dispatcher() {
@@ -236,7 +236,7 @@ class SentrySpanWebClientCustomizerTest {
             .retrieve()
             .bodyToMono(String::class.java)
             .block()
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(uri.toString(), it.data["url"])
@@ -259,7 +259,7 @@ class SentrySpanWebClientCustomizerTest {
                 .block()
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(uri.toString(), it.data["url"])
@@ -279,7 +279,7 @@ class SentrySpanWebClientCustomizerTest {
             .retrieve()
             .bodyToMono(String::class.java)
             .block()
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(uri.toString(), it.data["url"])
@@ -302,7 +302,7 @@ class SentrySpanWebClientCustomizerTest {
                 .block()
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(uri.toString(), it.data["url"])

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/it/SentrySpringIntegrationTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.boot.jakarta.it
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.checkEvent
@@ -60,7 +60,7 @@ class SentrySpringIntegrationTest {
     lateinit var transport: ITransport
 
     @SpyBean
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @LocalServerPort
     var port: Int? = null
@@ -188,7 +188,7 @@ class SentrySpringIntegrationTest {
 
         restTemplate.getForEntity("http://localhost:$port/throws-handled", String::class.java)
 
-        verify(hub, never()).captureEvent(any())
+        verify(scopes, never()).captureEvent(any())
     }
 
     @Test

--- a/sentry-spring-boot/api/sentry-spring-boot.api
+++ b/sentry-spring-boot/api/sentry-spring-boot.api
@@ -53,8 +53,8 @@ public class io/sentry/spring/boot/SentryProperties$Logging {
 public class io/sentry/spring/boot/SentryWebfluxAutoConfiguration {
 	public fun <init> ()V
 	public fun sentryScheduleHookApplicationRunner ()Lorg/springframework/boot/ApplicationRunner;
-	public fun sentryWebExceptionHandler (Lio/sentry/IHub;)Lio/sentry/spring/webflux/SentryWebExceptionHandler;
-	public fun sentryWebFilter (Lio/sentry/IHub;)Lio/sentry/spring/webflux/SentryWebFilter;
+	public fun sentryWebExceptionHandler (Lio/sentry/IScopes;)Lio/sentry/spring/webflux/SentryWebExceptionHandler;
+	public fun sentryWebFilter (Lio/sentry/IScopes;)Lio/sentry/spring/webflux/SentryWebFilter;
 }
 
 public class io/sentry/spring/boot/graphql/SentryGraphqlAutoConfiguration {

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -3,10 +3,10 @@ package io.sentry.spring.boot;
 import com.jakewharton.nopen.annotation.Open;
 import graphql.GraphQLError;
 import io.sentry.EventProcessor;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransportFactory;
 import io.sentry.Integration;
+import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
@@ -114,7 +114,7 @@ public class SentryAutoConfiguration {
     }
 
     @Bean
-    public @NotNull IHub sentryHub(
+    public @NotNull IScopes sentryHub(
         final @NotNull List<Sentry.OptionsConfiguration<SentryOptions>> optionsConfigurations,
         final @NotNull SentryProperties options,
         final @NotNull ObjectProvider<GitProperties> gitProperties) {
@@ -137,7 +137,7 @@ public class SentryAutoConfiguration {
       // here we make sure that only classes that extend throwable are set on this field
       options.getIgnoredExceptionsForType().removeIf(it -> !Throwable.class.isAssignableFrom(it));
       Sentry.init(options);
-      return HubAdapter.getInstance();
+      return ScopesAdapter.getInstance();
     }
 
     @Configuration(proxyBeanMethods = false)
@@ -237,7 +237,7 @@ public class SentryAutoConfiguration {
        * HttpServletRequest#getUserPrincipal()}. If Spring Security is auto-configured, its order is
        * set to run after Spring Security.
        *
-       * @param hub the Sentry hub
+       * @param scopes the Sentry scopes
        * @param sentryProperties the Sentry properties
        * @param sentryUserProvider the user provider
        * @return {@link SentryUserFilter} registration bean
@@ -245,11 +245,11 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnBean(SentryUserProvider.class)
       public @NotNull FilterRegistrationBean<SentryUserFilter> sentryUserFilter(
-          final @NotNull IHub hub,
+          final @NotNull IScopes scopes,
           final @NotNull SentryProperties sentryProperties,
           final @NotNull List<SentryUserProvider> sentryUserProvider) {
         final FilterRegistrationBean<SentryUserFilter> filter = new FilterRegistrationBean<>();
-        filter.setFilter(new SentryUserFilter(hub, sentryUserProvider));
+        filter.setFilter(new SentryUserFilter(scopes, sentryUserProvider));
         filter.setOrder(resolveUserFilterOrder(sentryProperties));
         return filter;
       }
@@ -261,8 +261,8 @@ public class SentryAutoConfiguration {
       }
 
       @Bean
-      public @NotNull SentryRequestResolver sentryRequestResolver(final @NotNull IHub hub) {
-        return new SentryRequestResolver(hub);
+      public @NotNull SentryRequestResolver sentryRequestResolver(final @NotNull IScopes scopes) {
+        return new SentryRequestResolver(scopes);
       }
 
       @Bean
@@ -274,12 +274,12 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnMissingBean(name = "sentrySpringFilter")
       public @NotNull FilterRegistrationBean<SentrySpringFilter> sentrySpringFilter(
-          final @NotNull IHub hub,
+          final @NotNull IScopes scopes,
           final @NotNull SentryRequestResolver requestResolver,
           final @NotNull TransactionNameProvider transactionNameProvider) {
         FilterRegistrationBean<SentrySpringFilter> filter =
             new FilterRegistrationBean<>(
-                new SentrySpringFilter(hub, requestResolver, transactionNameProvider));
+                new SentrySpringFilter(scopes, requestResolver, transactionNameProvider));
         filter.setOrder(SENTRY_SPRING_FILTER_PRECEDENCE);
         return filter;
       }
@@ -287,9 +287,10 @@ public class SentryAutoConfiguration {
       @Bean
       @ConditionalOnMissingBean(name = "sentryTracingFilter")
       public FilterRegistrationBean<SentryTracingFilter> sentryTracingFilter(
-          final @NotNull IHub hub, final @NotNull TransactionNameProvider transactionNameProvider) {
+          final @NotNull IScopes scopes,
+          final @NotNull TransactionNameProvider transactionNameProvider) {
         FilterRegistrationBean<SentryTracingFilter> filter =
-            new FilterRegistrationBean<>(new SentryTracingFilter(hub, transactionNameProvider));
+            new FilterRegistrationBean<>(new SentryTracingFilter(scopes, transactionNameProvider));
         filter.setOrder(SENTRY_SPRING_FILTER_PRECEDENCE + 1); // must run after SentrySpringFilter
         return filter;
       }
@@ -298,11 +299,11 @@ public class SentryAutoConfiguration {
       @ConditionalOnMissingBean
       @ConditionalOnClass(HandlerExceptionResolver.class)
       public @NotNull SentryExceptionResolver sentryExceptionResolver(
-          final @NotNull IHub sentryHub,
+          final @NotNull IScopes scopes,
           final @NotNull TransactionNameProvider transactionNameProvider,
           final @NotNull SentryProperties options) {
         return new SentryExceptionResolver(
-            sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+            scopes, transactionNameProvider, options.getExceptionResolverOrder());
       }
     }
 
@@ -348,8 +349,8 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryPerformanceRestTemplateConfiguration {
       @Bean
-      public SentrySpanRestTemplateCustomizer sentrySpanRestTemplateCustomizer(IHub hub) {
-        return new SentrySpanRestTemplateCustomizer(hub);
+      public SentrySpanRestTemplateCustomizer sentrySpanRestTemplateCustomizer(IScopes scopes) {
+        return new SentrySpanRestTemplateCustomizer(scopes);
       }
     }
 
@@ -359,8 +360,8 @@ public class SentryAutoConfiguration {
     @Open
     static class SentryPerformanceWebClientConfiguration {
       @Bean
-      public SentrySpanWebClientCustomizer sentrySpanWebClientCustomizer(IHub hub) {
-        return new SentrySpanWebClientCustomizer(hub);
+      public SentrySpanWebClientCustomizer sentrySpanWebClientCustomizer(IScopes scopes) {
+        return new SentrySpanWebClientCustomizer(scopes);
       }
     }
 

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpanRestTemplateCustomizer.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpanRestTemplateCustomizer.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.boot;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.spring.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,8 +14,8 @@ import org.springframework.web.client.RestTemplate;
 class SentrySpanRestTemplateCustomizer implements RestTemplateCustomizer {
   private final @NotNull SentrySpanClientHttpRequestInterceptor interceptor;
 
-  public SentrySpanRestTemplateCustomizer(final @NotNull IHub hub) {
-    this.interceptor = new SentrySpanClientHttpRequestInterceptor(hub);
+  public SentrySpanRestTemplateCustomizer(final @NotNull IScopes scopes) {
+    this.interceptor = new SentrySpanClientHttpRequestInterceptor(scopes);
   }
 
   @Override

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpanWebClientCustomizer.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentrySpanWebClientCustomizer.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.boot;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.spring.tracing.SentrySpanClientWebRequestFilter;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
@@ -11,8 +11,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 class SentrySpanWebClientCustomizer implements WebClientCustomizer {
   private final @NotNull SentrySpanClientWebRequestFilter filter;
 
-  public SentrySpanWebClientCustomizer(final @NotNull IHub hub) {
-    this.filter = new SentrySpanClientWebRequestFilter(hub);
+  public SentrySpanWebClientCustomizer(final @NotNull IScopes scopes) {
+    this.filter = new SentrySpanClientWebRequestFilter(scopes);
   }
 
   @Override

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryWebfluxAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryWebfluxAutoConfiguration.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.boot;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.spring.webflux.SentryScheduleHook;
 import io.sentry.spring.webflux.SentryWebExceptionHandler;
 import io.sentry.spring.webflux.SentryWebFilter;
@@ -21,14 +21,14 @@ import reactor.core.scheduler.Schedulers;
 /** Configures Sentry integration for Spring Webflux and Project Reactor. */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
-@ConditionalOnBean(IHub.class)
+@ConditionalOnBean(IScopes.class)
 @ConditionalOnClass(Schedulers.class)
 @Open
 @ApiStatus.Experimental
 public class SentryWebfluxAutoConfiguration {
   private static final int SENTRY_SPRING_FILTER_PRECEDENCE = Ordered.HIGHEST_PRECEDENCE;
 
-  /** Configures hook that sets correct hub on the executing thread. */
+  /** Configures hook that sets correct scopes on the executing thread. */
   @Bean
   public @NotNull ApplicationRunner sentryScheduleHookApplicationRunner() {
     return args -> {
@@ -39,13 +39,14 @@ public class SentryWebfluxAutoConfiguration {
   /** Configures a filter that sets up Sentry {@link IScope} for each request. */
   @Bean
   @Order(SENTRY_SPRING_FILTER_PRECEDENCE)
-  public @NotNull SentryWebFilter sentryWebFilter(final @NotNull IHub hub) {
-    return new SentryWebFilter(hub);
+  public @NotNull SentryWebFilter sentryWebFilter(final @NotNull IScopes scopes) {
+    return new SentryWebFilter(scopes);
   }
 
   /** Configures exception handler that handles unhandled exceptions and sends them to Sentry. */
   @Bean
-  public @NotNull SentryWebExceptionHandler sentryWebExceptionHandler(final @NotNull IHub hub) {
-    return new SentryWebExceptionHandler(hub);
+  public @NotNull SentryWebExceptionHandler sentryWebExceptionHandler(
+      final @NotNull IScopes scopes) {
+    return new SentryWebExceptionHandler(scopes);
   }
 }

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -5,7 +5,7 @@ import io.sentry.AsyncHttpTransportFactory
 import io.sentry.Breadcrumb
 import io.sentry.EventProcessor
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Integration
 import io.sentry.NoOpTransportFactory
@@ -76,18 +76,18 @@ class SentryAutoConfigurationTest {
         .withConfiguration(AutoConfigurations.of(SentryAutoConfiguration::class.java, WebMvcAutoConfiguration::class.java))
 
     @Test
-    fun `hub is not created when auto-configuration dsn is not set`() {
+    fun `scopes is not created when auto-configuration dsn is not set`() {
         contextRunner
             .run {
-                assertThat(it).doesNotHaveBean(IHub::class.java)
+                assertThat(it).doesNotHaveBean(IScopes::class.java)
             }
     }
 
     @Test
-    fun `hub is created when dsn is provided`() {
+    fun `scopes is created when dsn is provided`() {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
             .run {
-                assertThat(it).hasSingleBean(IHub::class.java)
+                assertThat(it).hasSingleBean(IScopes::class.java)
             }
     }
 
@@ -943,7 +943,7 @@ class SentryAutoConfigurationTest {
     }
 
     class CustomIntegration : Integration {
-        override fun register(hub: IHub, options: SentryOptions) {}
+        override fun register(scopes: IScopes, options: SentryOptions) {}
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentrySpanRestTemplateCustomizerTest.kt
@@ -2,7 +2,7 @@ package io.sentry.spring.boot
 
 import io.sentry.BaggageHeader
 import io.sentry.Breadcrumb
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -37,23 +37,23 @@ import kotlin.test.assertTrue
 class SentrySpanRestTemplateCustomizerTest {
     class Fixture {
         val sentryOptions = SentryOptions()
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val restTemplate = RestTemplateBuilder()
             .setConnectTimeout(Duration.ofSeconds(2))
             .setReadTimeout(Duration.ofSeconds(2))
             .build()
         var mockServer = MockWebServer()
         val transaction: SentryTracer
-        internal val customizer = SentrySpanRestTemplateCustomizer(hub)
+        internal val customizer = SentrySpanRestTemplateCustomizer(scopes)
         val url = mockServer.url("/test/123").toString()
         val scope = Scope(sentryOptions)
 
         init {
-            whenever(hub.options).thenReturn(sentryOptions)
-            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(hub).configureScope(
+            whenever(scopes.options).thenReturn(sentryOptions)
+            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(scopes).configureScope(
                 any()
             )
-            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), hub)
+            transaction = SentryTracer(TransactionContext("aTransaction", "op", TracesSamplingDecision(true)), scopes)
         }
 
         fun getSut(isTransactionActive: Boolean, status: HttpStatus = HttpStatus.OK, socketPolicy: SocketPolicy = SocketPolicy.KEEP_OPEN, includeMockServerInTracingOrigins: Boolean = true): RestTemplate {
@@ -76,7 +76,7 @@ class SentrySpanRestTemplateCustomizerTest {
             )
 
             if (isTransactionActive) {
-                whenever(hub.span).thenReturn(transaction)
+                whenever(scopes.span).thenReturn(transaction)
             }
 
             return restTemplate
@@ -211,7 +211,7 @@ class SentrySpanRestTemplateCustomizerTest {
     @Test
     fun `when transaction is active adds breadcrumb when http calls succeeds`() {
         fixture.getSut(isTransactionActive = true).postForObject(fixture.url, "content", String::class.java)
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -229,7 +229,7 @@ class SentrySpanRestTemplateCustomizerTest {
             fixture.getSut(isTransactionActive = true, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -242,7 +242,7 @@ class SentrySpanRestTemplateCustomizerTest {
     @Test
     fun `when transaction is not active adds breadcrumb when http calls succeeds`() {
         fixture.getSut(isTransactionActive = false).postForObject(fixture.url, "content", String::class.java)
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])
@@ -260,7 +260,7 @@ class SentrySpanRestTemplateCustomizerTest {
             fixture.getSut(isTransactionActive = false, status = HttpStatus.INTERNAL_SERVER_ERROR).getForObject(fixture.url, String::class.java)
         } catch (e: Throwable) {
         }
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check<Breadcrumb> {
                 assertEquals("http", it.type)
                 assertEquals(fixture.url, it.data["url"])

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/it/SentrySpringIntegrationTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.boot.it
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.checkEvent
@@ -60,7 +60,7 @@ class SentrySpringIntegrationTest {
     lateinit var transport: ITransport
 
     @SpyBean
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @LocalServerPort
     var port: Int? = null
@@ -188,7 +188,7 @@ class SentrySpringIntegrationTest {
 
         restTemplate.getForEntity("http://localhost:$port/throws-handled", String::class.java)
 
-        verify(hub, never()).captureEvent(any())
+        verify(scopes, never()).captureEvent(any())
     }
 
     @Test

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -22,7 +22,7 @@ public final class io/sentry/spring/jakarta/HttpServletRequestSentryUserProvider
 
 public class io/sentry/spring/jakarta/SentryExceptionResolver : org/springframework/core/Ordered, org/springframework/web/servlet/HandlerExceptionResolver {
 	public static final field MECHANISM_TYPE Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;I)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;I)V
 	protected fun createEvent (Ljakarta/servlet/http/HttpServletRequest;Ljava/lang/Exception;)Lio/sentry/SentryEvent;
 	protected fun createHint (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;)Lio/sentry/Hint;
 	public fun getOrder ()I
@@ -47,14 +47,14 @@ public class io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessor :
 }
 
 public class io/sentry/spring/jakarta/SentryRequestResolver {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Ljakarta/servlet/http/HttpServletRequest;)Lio/sentry/protocol/Request;
 }
 
 public class io/sentry/spring/jakarta/SentrySpringFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/jakarta/SentryRequestResolver;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/jakarta/SentryRequestResolver;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;)V
 	protected fun doFilterInternal (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljakarta/servlet/FilterChain;)V
 }
 
@@ -69,7 +69,7 @@ public final class io/sentry/spring/jakarta/SentryTaskDecorator : org/springfram
 }
 
 public class io/sentry/spring/jakarta/SentryUserFilter : org/springframework/web/filter/OncePerRequestFilter {
-	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
+	public fun <init> (Lio/sentry/IScopes;Ljava/util/List;)V
 	protected fun doFilterInternal (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljakarta/servlet/FilterChain;)V
 	public fun getSentryUserProviders ()Ljava/util/List;
 }
@@ -96,7 +96,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/checkin/Sent
 
 public class io/sentry/spring/jakarta/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor, org/springframework/context/EmbeddedValueResolverAware {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 	public fun setEmbeddedValueResolver (Lorg/springframework/util/StringValueResolver;)V
 }
@@ -127,7 +127,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/exception/Se
 
 public class io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -169,7 +169,7 @@ public final class io/sentry/spring/jakarta/graphql/SentryDataFetcherExceptionRe
 
 public final class io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler : io/sentry/graphql/SentrySubscriptionHandler {
 	public fun <init> ()V
-	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
+	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IScopes;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
 public final class io/sentry/spring/jakarta/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor, org/springframework/core/PriorityOrdered {
@@ -188,7 +188,7 @@ public class io/sentry/spring/jakarta/graphql/SentryGraphqlConfiguration {
 
 public final class io/sentry/spring/jakarta/graphql/SentrySpringSubscriptionHandler : io/sentry/graphql/SentrySubscriptionHandler {
 	public fun <init> ()V
-	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
+	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IScopes;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/jakarta/tracing/SentryAdviceConfiguration {
@@ -207,18 +207,18 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 
 public class io/sentry/spring/jakarta/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/jakarta/tracing/SentrySpanClientHttpRequestInterceptor : org/springframework/http/client/ClientHttpRequestInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
-	public fun <init> (Lio/sentry/IHub;Z)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public fun <init> (Lio/sentry/IScopes;Z)V
 	public fun intercept (Lorg/springframework/http/HttpRequest;[BLorg/springframework/http/client/ClientHttpRequestExecution;)Lorg/springframework/http/client/ClientHttpResponse;
 }
 
 public class io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter : org/springframework/web/reactive/function/client/ExchangeFilterFunction {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun filter (Lorg/springframework/web/reactive/function/client/ClientRequest;Lorg/springframework/web/reactive/function/client/ExchangeFunction;)Lreactor/core/publisher/Mono;
 }
 
@@ -233,8 +233,8 @@ public class io/sentry/spring/jakarta/tracing/SentryTracingConfiguration {
 
 public class io/sentry/spring/jakarta/tracing/SentryTracingFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;)V
 	protected fun doFilterInternal (Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;Ljakarta/servlet/FilterChain;)V
 }
 
@@ -246,7 +246,7 @@ public abstract interface annotation class io/sentry/spring/jakarta/tracing/Sent
 
 public class io/sentry/spring/jakarta/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -268,21 +268,22 @@ public abstract interface class io/sentry/spring/jakarta/tracing/TransactionName
 
 public abstract class io/sentry/spring/jakarta/webflux/AbstractSentryWebFilter : org/springframework/web/server/WebFilter {
 	public static final field SENTRY_HUB_KEY Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;)V
-	protected fun doFinally (Lorg/springframework/web/server/ServerWebExchange;Lio/sentry/IHub;Lio/sentry/ITransaction;)V
-	protected fun doFirst (Lorg/springframework/web/server/ServerWebExchange;Lio/sentry/IHub;)V
+	public static final field SENTRY_SCOPES_KEY Ljava/lang/String;
+	public fun <init> (Lio/sentry/IScopes;)V
+	protected fun doFinally (Lorg/springframework/web/server/ServerWebExchange;Lio/sentry/IScopes;Lio/sentry/ITransaction;)V
+	protected fun doFirst (Lorg/springframework/web/server/ServerWebExchange;Lio/sentry/IScopes;)V
 	protected fun doOnError (Lio/sentry/ITransaction;Ljava/lang/Throwable;)V
-	protected fun maybeStartTransaction (Lio/sentry/IHub;Lorg/springframework/http/server/reactive/ServerHttpRequest;)Lio/sentry/ITransaction;
-	protected fun shouldTraceRequest (Lio/sentry/IHub;Lorg/springframework/http/server/reactive/ServerHttpRequest;)Z
-	protected fun startTransaction (Lio/sentry/IHub;Lorg/springframework/http/server/reactive/ServerHttpRequest;Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
+	protected fun maybeStartTransaction (Lio/sentry/IScopes;Lorg/springframework/http/server/reactive/ServerHttpRequest;)Lio/sentry/ITransaction;
+	protected fun shouldTraceRequest (Lio/sentry/IScopes;Lorg/springframework/http/server/reactive/ServerHttpRequest;)Z
+	protected fun startTransaction (Lio/sentry/IScopes;Lorg/springframework/http/server/reactive/ServerHttpRequest;Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
 }
 
 public final class io/sentry/spring/jakarta/webflux/ReactorUtils {
 	public fun <init> ()V
 	public static fun withSentry (Lreactor/core/publisher/Flux;)Lreactor/core/publisher/Flux;
 	public static fun withSentry (Lreactor/core/publisher/Mono;)Lreactor/core/publisher/Mono;
-	public static fun withSentryHub (Lreactor/core/publisher/Flux;Lio/sentry/IHub;)Lreactor/core/publisher/Flux;
-	public static fun withSentryHub (Lreactor/core/publisher/Mono;Lio/sentry/IHub;)Lreactor/core/publisher/Mono;
+	public static fun withSentryHub (Lreactor/core/publisher/Flux;Lio/sentry/IScopes;)Lreactor/core/publisher/Flux;
+	public static fun withSentryHub (Lreactor/core/publisher/Mono;Lio/sentry/IScopes;)Lreactor/core/publisher/Mono;
 	public static fun withSentryNewMainHubClone (Lreactor/core/publisher/Flux;)Lreactor/core/publisher/Flux;
 	public static fun withSentryNewMainHubClone (Lreactor/core/publisher/Mono;)Lreactor/core/publisher/Mono;
 }
@@ -290,16 +291,16 @@ public final class io/sentry/spring/jakarta/webflux/ReactorUtils {
 public final class io/sentry/spring/jakarta/webflux/SentryReactorThreadLocalAccessor : io/micrometer/context/ThreadLocalAccessor {
 	public static final field KEY Ljava/lang/String;
 	public fun <init> ()V
-	public fun getValue ()Lio/sentry/IHub;
+	public fun getValue ()Lio/sentry/IScopes;
 	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun key ()Ljava/lang/Object;
 	public fun reset ()V
-	public fun setValue (Lio/sentry/IHub;)V
+	public fun setValue (Lio/sentry/IScopes;)V
 	public synthetic fun setValue (Ljava/lang/Object;)V
 }
 
 public class io/sentry/spring/jakarta/webflux/SentryRequestResolver {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Lorg/springframework/http/server/reactive/ServerHttpRequest;)Lio/sentry/protocol/Request;
 }
 
@@ -311,18 +312,18 @@ public final class io/sentry/spring/jakarta/webflux/SentryScheduleHook : java/ut
 
 public final class io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler : org/springframework/web/server/WebExceptionHandler {
 	public static final field MECHANISM_TYPE Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun handle (Lorg/springframework/web/server/ServerWebExchange;Ljava/lang/Throwable;)Lreactor/core/publisher/Mono;
 }
 
 public class io/sentry/spring/jakarta/webflux/SentryWebFilter : io/sentry/spring/jakarta/webflux/AbstractSentryWebFilter {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun filter (Lorg/springframework/web/server/ServerWebExchange;Lorg/springframework/web/server/WebFilterChain;)Lreactor/core/publisher/Mono;
 }
 
 public final class io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor : io/sentry/spring/jakarta/webflux/AbstractSentryWebFilter {
 	public static final field TRACE_ORIGIN Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun filter (Lorg/springframework/web/server/ServerWebExchange;Lorg/springframework/web/server/WebFilterChain;)Lreactor/core/publisher/Mono;
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/EnableSentry.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/EnableSentry.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Import;
  *
  * <ul>
  *   <li>creates bean of type {@link io.sentry.SentryOptions}
- *   <li>registers {@link io.sentry.IHub} for sending Sentry events
+ *   <li>registers {@link io.sentry.IScopes} for sending Sentry events
  *   <li>registers {@link SentryExceptionResolver} to send Sentry event for any uncaught exception
  *       in Spring MVC flow.
  * </ul>

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryExceptionResolver.java
@@ -5,7 +5,7 @@ import static io.sentry.TypeCheckHint.SPRING_RESOLVER_RESPONSE;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Hint;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
@@ -29,15 +29,15 @@ import org.springframework.web.servlet.ModelAndView;
 public class SentryExceptionResolver implements HandlerExceptionResolver, Ordered {
   public static final String MECHANISM_TYPE = "Spring6ExceptionResolver";
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private final @NotNull TransactionNameProvider transactionNameProvider;
   private final int order;
 
   public SentryExceptionResolver(
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull TransactionNameProvider transactionNameProvider,
       final int order) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
     this.transactionNameProvider =
         Objects.requireNonNull(transactionNameProvider, "transactionNameProvider is required");
     this.order = order;
@@ -53,7 +53,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
     final SentryEvent event = createEvent(request, ex);
     final Hint hint = createHint(request, response);
 
-    hub.captureEvent(event, hint);
+    scopes.captureEvent(event, hint);
 
     // null = run other HandlerExceptionResolvers to actually handle the exception
     return null;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryHubRegistrar.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryHubRegistrar.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
@@ -60,7 +60,7 @@ public class SentryHubRegistrar implements ImportBeanDefinitionRegistrar {
 
   private void registerSentryHubBean(final @NotNull BeanDefinitionRegistry registry) {
     final BeanDefinitionBuilder builder =
-        BeanDefinitionBuilder.genericBeanDefinition(HubAdapter.class);
+        BeanDefinitionBuilder.genericBeanDefinition(ScopesAdapter.class);
     builder.setInitMethodName("getInstance");
 
     registry.registerBeanDefinition("sentryHub", builder.getBeanDefinition());

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryInitBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryInitBeanPostProcessor.java
@@ -2,10 +2,10 @@ package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.EventProcessor;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransportFactory;
 import io.sentry.Integration;
+import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.SentryOptions.TracesSamplerCallback;
@@ -27,15 +27,15 @@ public class SentryInitBeanPostProcessor
     implements BeanPostProcessor, ApplicationContextAware, DisposableBean {
   private @Nullable ApplicationContext applicationContext;
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryInitBeanPostProcessor() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  SentryInitBeanPostProcessor(final @NotNull IHub hub) {
-    Objects.requireNonNull(hub, "hub is required");
-    this.hub = hub;
+  SentryInitBeanPostProcessor(final @NotNull IScopes scopes) {
+    Objects.requireNonNull(scopes, "Scopes are required");
+    this.scopes = scopes;
   }
 
   @Override
@@ -86,6 +86,6 @@ public class SentryInitBeanPostProcessor
 
   @Override
   public void destroy() {
-    hub.close();
+    scopes.close();
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
@@ -20,11 +20,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Open
 public class SentryRequestResolver {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private volatile @Nullable List<String> extraSecurityCookies;
 
-  public SentryRequestResolver(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "options is required");
+  public SentryRequestResolver(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "options is required");
   }
 
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
@@ -40,7 +40,7 @@ public class SentryRequestResolver {
         extractSecurityCookieNamesOrUseCached(httpRequest);
     sentryRequest.setHeaders(resolveHeadersMap(httpRequest, additionalSecurityCookieNames));
 
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       String cookieName = HttpUtils.COOKIE_HEADER_NAME;
       final @Nullable List<String> filteredHeaders =
           HttpUtils.filterOutSecurityCookiesFromHeader(
@@ -57,7 +57,8 @@ public class SentryRequestResolver {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
-      if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
+      if (scopes.getOptions().isSendDefaultPii()
+          || !HttpUtils.containsSensitiveHeader(headerName)) {
         final @Nullable List<String> filteredHeaders =
             HttpUtils.filterOutSecurityCookiesFromHeader(
                 request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
@@ -94,7 +95,8 @@ public class SentryRequestResolver {
         }
       }
     } catch (Throwable t) {
-      hub.getOptions()
+      scopes
+          .getOptions()
           .getLogger()
           .log(SentryLevel.WARNING, "Failed to extract session cookie name from request.", t);
     }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryTaskDecorator.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryTaskDecorator.java
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta;
 
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.Sentry;
 import java.util.concurrent.Callable;
 import org.jetbrains.annotations.NotNull;
@@ -8,22 +8,24 @@ import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.Async;
 
 /**
- * Sets a current hub on a thread running a {@link Runnable} given by parameter. Used to propagate
- * the current {@link IHub} on the thread executing async task - like MVC controller methods
- * returning a {@link Callable} or Spring beans methods annotated with {@link Async}.
+ * Sets a current scopes on a thread running a {@link Runnable} given by parameter. Used to
+ * propagate the current {@link IScopes} on the thread executing async task - like MVC controller
+ * methods returning a {@link Callable} or Spring beans methods annotated with {@link Async}.
  */
 public final class SentryTaskDecorator implements TaskDecorator {
   @Override
+  @SuppressWarnings("deprecation")
   public @NotNull Runnable decorate(final @NotNull Runnable runnable) {
-    final IHub newHub = Sentry.getCurrentHub().clone();
+    // TODO fork
+    final IScopes newHub = Sentry.getCurrentScopes().clone();
 
     return () -> {
-      final IHub oldState = Sentry.getCurrentHub();
-      Sentry.setCurrentHub(newHub);
+      final IScopes oldState = Sentry.getCurrentScopes();
+      Sentry.setCurrentScopes(newHub);
       try {
         runnable.run();
       } finally {
-        Sentry.setCurrentHub(oldState);
+        Sentry.setCurrentScopes(oldState);
       }
     };
   }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryUserFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryUserFilter.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.IpAddressUtils;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
@@ -26,12 +26,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 @Open
 public class SentryUserFilter extends OncePerRequestFilter {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private final @NotNull List<SentryUserProvider> sentryUserProviders;
 
   public SentryUserFilter(
-      final @NotNull IHub hub, final @NotNull List<SentryUserProvider> sentryUserProviders) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+      final @NotNull IScopes scopes, final @NotNull List<SentryUserProvider> sentryUserProviders) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
     this.sentryUserProviders =
         Objects.requireNonNull(sentryUserProviders, "sentryUserProviders list is required");
   }
@@ -46,13 +46,13 @@ public class SentryUserFilter extends OncePerRequestFilter {
     for (final SentryUserProvider provider : sentryUserProviders) {
       apply(user, provider.provideUser());
     }
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       if (IpAddressUtils.isDefault(user.getIpAddress())) {
         // unset {{auto}} as it would set the server's ip address as a user ip address
         user.setIpAddress(null);
       }
     }
-    hub.setUser(user);
+    scopes.setUser(user);
     chain.doFilter(request, response);
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.jakarta.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
 import io.sentry.util.Objects;
@@ -22,14 +22,14 @@ import org.springframework.core.annotation.AnnotationUtils;
 @Open
 public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor {
   private static final String MECHANISM_TYPE = "SentrySpring6CaptureExceptionParameterAdvice";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryCaptureExceptionParameterAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCaptureExceptionParameterAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @Override
@@ -58,6 +58,6 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
     mechanism.setHandled(true);
     final Throwable mechanismException =
         new ExceptionMechanismException(mechanism, throwable, Thread.currentThread());
-    hub.captureException(mechanismException);
+    scopes.captureException(mechanismException);
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryBatchLoaderRegistry.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryBatchLoaderRegistry.java
@@ -1,11 +1,11 @@
 package io.sentry.spring.jakarta.graphql;
 
-import static io.sentry.graphql.SentryInstrumentation.SENTRY_HUB_CONTEXT_KEY;
+import static io.sentry.graphql.SentryInstrumentation.SENTRY_SCOPES_CONTEXT_KEY;
 
 import graphql.GraphQLContext;
 import io.sentry.Breadcrumb;
-import io.sentry.IHub;
-import io.sentry.NoOpHub;
+import io.sentry.IScopes;
+import io.sentry.NoOpScopes;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +89,7 @@ public final class SentryBatchLoaderRegistry implements BatchLoaderRegistry {
     public void registerBatchLoader(BiFunction<List<K>, BatchLoaderEnvironment, Flux<V>> loader) {
       delegate.registerBatchLoader(
           (keys, batchLoaderEnvironment) -> {
-            hubFromContext(batchLoaderEnvironment)
+            scopesFromContext(batchLoaderEnvironment)
                 .addBreadcrumb(Breadcrumb.graphqlDataLoader(keys, keyType, valueType, name));
             return loader.apply(keys, batchLoaderEnvironment);
           });
@@ -100,20 +100,20 @@ public final class SentryBatchLoaderRegistry implements BatchLoaderRegistry {
         BiFunction<Set<K>, BatchLoaderEnvironment, Mono<Map<K, V>>> loader) {
       delegate.registerMappedBatchLoader(
           (keys, batchLoaderEnvironment) -> {
-            hubFromContext(batchLoaderEnvironment)
+            scopesFromContext(batchLoaderEnvironment)
                 .addBreadcrumb(Breadcrumb.graphqlDataLoader(keys, keyType, valueType, name));
             return loader.apply(keys, batchLoaderEnvironment);
           });
     }
 
-    private @NotNull IHub hubFromContext(final @NotNull BatchLoaderEnvironment environment) {
+    private @NotNull IScopes scopesFromContext(final @NotNull BatchLoaderEnvironment environment) {
       Object context = environment.getContext();
       if (context instanceof GraphQLContext) {
         GraphQLContext graphqlContext = (GraphQLContext) context;
-        return graphqlContext.getOrDefault(SENTRY_HUB_CONTEXT_KEY, NoOpHub.getInstance());
+        return graphqlContext.getOrDefault(SENTRY_SCOPES_CONTEXT_KEY, NoOpScopes.getInstance());
       }
 
-      return NoOpHub.getInstance();
+      return NoOpScopes.getInstance();
     }
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentryDgsSubscriptionHandler.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta.graphql;
 
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.graphql.ExceptionReporter;
 import io.sentry.graphql.SentrySubscriptionHandler;
@@ -17,7 +17,7 @@ public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHan
   @Override
   public @NotNull Object onSubscriptionResult(
       final @NotNull Object result,
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull ExceptionReporter exceptionReporter,
       final @NotNull InstrumentationFieldFetchParameters parameters) {
     if (result instanceof Flux) {
@@ -25,7 +25,7 @@ public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHan
       return flux.doOnError(
           throwable -> {
             final @NotNull ExceptionReporter.ExceptionDetails exceptionDetails =
-                new ExceptionReporter.ExceptionDetails(hub, parameters.getEnvironment(), true);
+                new ExceptionReporter.ExceptionDetails(scopes, parameters.getEnvironment(), true);
             exceptionReporter.captureThrowable(throwable, exceptionDetails, null);
           });
     }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentrySpringSubscriptionHandler.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/graphql/SentrySpringSubscriptionHandler.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta.graphql;
 
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.graphql.ExceptionReporter;
 import io.sentry.graphql.SentrySubscriptionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +13,7 @@ public final class SentrySpringSubscriptionHandler implements SentrySubscription
   @Override
   public @NotNull Object onSubscriptionResult(
       final @NotNull Object result,
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull ExceptionReporter exceptionReporter,
       final @NotNull InstrumentationFieldFetchParameters parameters) {
     if (result instanceof Flux) {
@@ -21,7 +21,7 @@ public final class SentrySpringSubscriptionHandler implements SentrySubscription
       return flux.doOnError(
           throwable -> {
             final @NotNull ExceptionReporter.ExceptionDetails exceptionDetails =
-                new ExceptionReporter.ExceptionDetails(hub, parameters.getEnvironment(), true);
+                new ExceptionReporter.ExceptionDetails(scopes, parameters.getEnvironment(), true);
             if (throwable instanceof SubscriptionPublisherException
                 && throwable.getCause() != null) {
               exceptionReporter.captureThrowable(throwable.getCause(), exceptionDetails, null);

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanAdvice.java
@@ -1,9 +1,9 @@
 package io.sentry.spring.jakarta.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ISpan;
+import io.sentry.ScopesAdapter;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.lang.reflect.Method;
@@ -22,20 +22,20 @@ import org.springframework.util.StringUtils;
 @Open
 public class SentrySpanAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring_jakarta.advice";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentrySpanAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentrySpanAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentrySpanAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public Object invoke(final @NotNull MethodInvocation invocation) throws Throwable {
-    final ISpan activeSpan = hub.getSpan();
+    final ISpan activeSpan = scopes.getSpan();
 
     if (activeSpan == null || activeSpan.isNoOp()) {
       // there is no active transaction, we do not start new span

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentrySpanClientWebRequestFilter.java
@@ -7,7 +7,7 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ISpan;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
@@ -25,16 +25,16 @@ import reactor.core.publisher.Mono;
 @Open
 public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction {
   private static final String TRACE_ORIGIN = "auto.http.spring_jakarta.webclient";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
-  public SentrySpanClientWebRequestFilter(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentrySpanClientWebRequestFilter(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "Scopes are required");
   }
 
   @Override
   public @NotNull Mono<ClientResponse> filter(
       final @NotNull ClientRequest request, final @NotNull ExchangeFunction next) {
-    final ISpan activeSpan = hub.getSpan();
+    final ISpan activeSpan = scopes.getSpan();
     if (activeSpan == null) {
       final @NotNull ClientRequest modifiedRequest = maybeAddTracingHeaders(request, null);
       addBreadcrumb(modifiedRequest, null);
@@ -74,7 +74,7 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
 
     final @Nullable TracingUtils.TracingHeaders tracingHeaders =
         TracingUtils.traceIfAllowed(
-            hub,
+            scopes,
             request.url().toString(),
             request.headers().get(BaggageHeader.BAGGAGE_HEADER),
             span);
@@ -111,6 +111,6 @@ public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction 
       hint.set(SPRING_EXCHANGE_FILTER_RESPONSE, response);
     }
 
-    hub.addBreadcrumb(breadcrumb, hint);
+    scopes.addBreadcrumb(breadcrumb, hint);
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTracingFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SentryTracingFilter.java
@@ -3,9 +3,9 @@ package io.sentry.spring.jakarta.tracing;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.CustomSamplingContext;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransaction;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
@@ -38,7 +38,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
   private static final String TRACE_ORIGIN = "auto.http.spring_jakarta.webmvc";
 
   private final @NotNull TransactionNameProvider transactionNameProvider;
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   /**
    * Creates filter that resolves transaction name using {@link SpringMvcTransactionNameProvider}.
@@ -49,25 +49,26 @@ public class SentryTracingFilter extends OncePerRequestFilter {
    * jakarta.servlet.Filter}.
    */
   public SentryTracingFilter() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
   /**
    * Creates filter that resolves transaction name using transaction name provider given by
    * parameter.
    *
-   * @param hub - the hub
+   * @param scopes - the scopes
    * @param transactionNameProvider - transaction name provider.
    */
   public SentryTracingFilter(
-      final @NotNull IHub hub, final @NotNull TransactionNameProvider transactionNameProvider) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+      final @NotNull IScopes scopes,
+      final @NotNull TransactionNameProvider transactionNameProvider) {
+    this.scopes = Objects.requireNonNull(scopes, "Scopes are required");
     this.transactionNameProvider =
         Objects.requireNonNull(transactionNameProvider, "transactionNameProvider is required");
   }
 
-  public SentryTracingFilter(final @NotNull IHub hub) {
-    this(hub, new SpringMvcTransactionNameProvider());
+  public SentryTracingFilter(final @NotNull IScopes scopes) {
+    this(scopes, new SpringMvcTransactionNameProvider());
   }
 
   @Override
@@ -76,14 +77,14 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       final @NotNull HttpServletResponse httpResponse,
       final @NotNull FilterChain filterChain)
       throws ServletException, IOException {
-    if (hub.isEnabled()) {
+    if (scopes.isEnabled()) {
       final @Nullable String sentryTraceHeader =
           httpRequest.getHeader(SentryTraceHeader.SENTRY_TRACE_HEADER);
       final @Nullable List<String> baggageHeader =
           Collections.list(httpRequest.getHeaders(BaggageHeader.BAGGAGE_HEADER));
       final @Nullable TransactionContext transactionContext =
-          hub.continueTrace(sentryTraceHeader, baggageHeader);
-      if (hub.getOptions().isTracingEnabled() && shouldTraceRequest(httpRequest)) {
+          scopes.continueTrace(sentryTraceHeader, baggageHeader);
+      if (scopes.getOptions().isTracingEnabled() && shouldTraceRequest(httpRequest)) {
         doFilterWithTransaction(httpRequest, httpResponse, filterChain, transactionContext);
       } else {
         filterChain.doFilter(httpRequest, httpResponse);
@@ -130,7 +131,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
   }
 
   private boolean shouldTraceRequest(final @NotNull HttpServletRequest request) {
-    return hub.getOptions().isTraceOptionsRequests()
+    return scopes.getOptions().isTraceOptionsRequests()
         || !HttpMethod.OPTIONS.name().equals(request.getMethod());
   }
 
@@ -152,14 +153,14 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       transactionOptions.setCustomSamplingContext(customSamplingContext);
       transactionOptions.setBindToScope(true);
 
-      return hub.startTransaction(transactionContext, transactionOptions);
+      return scopes.startTransaction(transactionContext, transactionOptions);
     }
 
     final TransactionOptions transactionOptions = new TransactionOptions();
     transactionOptions.setCustomSamplingContext(customSamplingContext);
     transactionOptions.setBindToScope(true);
 
-    return hub.startTransaction(
+    return scopes.startTransaction(
         new TransactionContext(name, TransactionNameSource.URL, "http.server"), transactionOptions);
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/ReactorUtils.java
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta.webflux;
 
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.Sentry;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -8,11 +8,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
+// TODO deprecate and replace with "withSentryScopes" etc.
 @ApiStatus.Experimental
 public final class ReactorUtils {
 
   /**
-   * Writes the current Sentry {@link IHub} to the {@link Context} and uses {@link
+   * Writes the current Sentry {@link IScopes} to the {@link Context} and uses {@link
    * io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -20,14 +21,16 @@ public final class ReactorUtils {
    * having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
+  @SuppressWarnings("deprecation")
   public static <T> Mono<T> withSentry(final @NotNull Mono<T> mono) {
-    final @NotNull IHub oldHub = Sentry.getCurrentHub();
-    final @NotNull IHub clonedHub = oldHub.clone();
+    final @NotNull IScopes oldHub = Sentry.getCurrentScopes();
+    // TODO fork
+    final @NotNull IScopes clonedHub = oldHub.clone();
     return withSentryHub(mono, clonedHub);
   }
 
   /**
-   * Writes a new Sentry {@link IHub} cloned from the main hub to the {@link Context} and uses
+   * Writes a new Sentry {@link IScopes} cloned from the main hub to the {@link Context} and uses
    * {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -36,12 +39,12 @@ public final class ReactorUtils {
    */
   @ApiStatus.Experimental
   public static <T> Mono<T> withSentryNewMainHubClone(final @NotNull Mono<T> mono) {
-    final @NotNull IHub hub = Sentry.cloneMainHub();
+    final @NotNull IScopes hub = Sentry.cloneMainHub();
     return withSentryHub(mono, hub);
   }
 
   /**
-   * Writes the given Sentry {@link IHub} to the {@link Context} and uses {@link
+   * Writes the given Sentry {@link IScopes} to the {@link Context} and uses {@link
    * io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -49,7 +52,7 @@ public final class ReactorUtils {
    * having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Mono<T> withSentryHub(final @NotNull Mono<T> mono, final @NotNull IHub hub) {
+  public static <T> Mono<T> withSentryHub(final @NotNull Mono<T> mono, final @NotNull IScopes hub) {
     /**
      * WARNING: Cannot set the hub as current. It would be used by others to clone again causing
      * shared hubs and scopes and thus leading to issues like unrelated breadcrumbs showing up in
@@ -62,7 +65,7 @@ public final class ReactorUtils {
   }
 
   /**
-   * Writes the current Sentry {@link IHub} to the {@link Context} and uses {@link
+   * Writes the current Sentry {@link IScopes} to the {@link Context} and uses {@link
    * io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -70,15 +73,17 @@ public final class ReactorUtils {
    * having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
+  @SuppressWarnings("deprecation")
   public static <T> Flux<T> withSentry(final @NotNull Flux<T> flux) {
-    final @NotNull IHub oldHub = Sentry.getCurrentHub();
-    final @NotNull IHub clonedHub = oldHub.clone();
+    final @NotNull IScopes oldHub = Sentry.getCurrentScopes();
+    // TODO fork
+    final @NotNull IScopes clonedHub = oldHub.clone();
 
     return withSentryHub(flux, clonedHub);
   }
 
   /**
-   * Writes a new Sentry {@link IHub} cloned from the main hub to the {@link Context} and uses
+   * Writes a new Sentry {@link IScopes} cloned from the main hub to the {@link Context} and uses
    * {@link io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -87,12 +92,12 @@ public final class ReactorUtils {
    */
   @ApiStatus.Experimental
   public static <T> Flux<T> withSentryNewMainHubClone(final @NotNull Flux<T> flux) {
-    final @NotNull IHub hub = Sentry.cloneMainHub();
+    final @NotNull IScopes hub = Sentry.cloneMainHub();
     return withSentryHub(flux, hub);
   }
 
   /**
-   * Writes the given Sentry {@link IHub} to the {@link Context} and uses {@link
+   * Writes the given Sentry {@link IScopes} to the {@link Context} and uses {@link
    * io.micrometer.context.ThreadLocalAccessor} to propagate it.
    *
    * <p>This requires - reactor.core.publisher.Hooks#enableAutomaticContextPropagation() to be
@@ -100,7 +105,7 @@ public final class ReactorUtils {
    * having `io.projectreactor:reactor-core:3.5.3+` (provided by Spring Boot 3.0.3+)
    */
   @ApiStatus.Experimental
-  public static <T> Flux<T> withSentryHub(final @NotNull Flux<T> flux, final @NotNull IHub hub) {
+  public static <T> Flux<T> withSentryHub(final @NotNull Flux<T> flux, final @NotNull IScopes hub) {
     /**
      * WARNING: Cannot set the hub as current. It would be used by others to clone again causing
      * shared hubs and scopes and thus leading to issues like unrelated breadcrumbs showing up in

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryReactorThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryReactorThreadLocalAccessor.java
@@ -1,15 +1,15 @@
 package io.sentry.spring.jakarta.webflux;
 
 import io.micrometer.context.ThreadLocalAccessor;
-import io.sentry.IHub;
-import io.sentry.NoOpHub;
+import io.sentry.IScopes;
+import io.sentry.NoOpScopes;
 import io.sentry.Sentry;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Experimental
-public final class SentryReactorThreadLocalAccessor implements ThreadLocalAccessor<IHub> {
+public final class SentryReactorThreadLocalAccessor implements ThreadLocalAccessor<IScopes> {
 
-  public static final String KEY = "sentry-hub";
+  public static final String KEY = "sentry-scopes";
 
   @Override
   public Object key() {
@@ -17,18 +17,18 @@ public final class SentryReactorThreadLocalAccessor implements ThreadLocalAccess
   }
 
   @Override
-  public IHub getValue() {
-    return Sentry.getCurrentHub();
+  public IScopes getValue() {
+    return Sentry.getCurrentScopes();
   }
 
   @Override
-  public void setValue(IHub value) {
-    Sentry.setCurrentHub(value);
+  public void setValue(IScopes value) {
+    Sentry.setCurrentScopes(value);
   }
 
   @Override
   @SuppressWarnings("deprecation")
   public void reset() {
-    Sentry.setCurrentHub(NoOpHub.getInstance());
+    Sentry.setCurrentScopes(NoOpScopes.getInstance());
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryRequestResolver.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta.webflux;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
@@ -20,10 +20,10 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 @Open
 @ApiStatus.Experimental
 public class SentryRequestResolver {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
-  public SentryRequestResolver(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "options is required");
+  public SentryRequestResolver(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   public @NotNull Request resolveSentryRequest(final @NotNull ServerHttpRequest httpRequest) {
@@ -36,7 +36,7 @@ public class SentryRequestResolver {
     urlDetails.applyToRequest(sentryRequest);
     sentryRequest.setHeaders(resolveHeadersMap(httpRequest.getHeaders()));
 
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       String headerName = HttpUtils.COOKIE_HEADER_NAME;
       sentryRequest.setCookies(
           toString(
@@ -52,7 +52,8 @@ public class SentryRequestResolver {
     for (Map.Entry<String, List<String>> entry : request.entrySet()) {
       // do not copy personal information identifiable headers
       String headerName = entry.getKey();
-      if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
+      if (scopes.getOptions().isSendDefaultPii()
+          || !HttpUtils.containsSensitiveHeader(headerName)) {
         headersMap.put(
             headerName,
             toString(

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryScheduleHook.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryScheduleHook.java
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta.webflux;
 
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.Sentry;
 import java.util.function.Function;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,16 +13,18 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Experimental
 public final class SentryScheduleHook implements Function<Runnable, Runnable> {
   @Override
+  @SuppressWarnings("deprecation")
   public Runnable apply(final @NotNull Runnable runnable) {
-    final IHub newHub = Sentry.getCurrentHub().clone();
+    // TODO fork instead
+    final IScopes newHub = Sentry.getCurrentScopes().clone();
 
     return () -> {
-      final IHub oldState = Sentry.getCurrentHub();
-      Sentry.setCurrentHub(newHub);
+      final IScopes oldState = Sentry.getCurrentScopes();
+      Sentry.setCurrentScopes(newHub);
       try {
         runnable.run();
       } finally {
-        Sentry.setCurrentHub(oldState);
+        Sentry.setCurrentScopes(oldState);
       }
     };
   }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebExceptionHandler.java
@@ -5,7 +5,7 @@ import static io.sentry.TypeCheckHint.WEBFLUX_EXCEPTION_HANDLER_REQUEST;
 import static io.sentry.TypeCheckHint.WEBFLUX_EXCEPTION_HANDLER_RESPONSE;
 
 import io.sentry.Hint;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
@@ -27,18 +27,18 @@ import reactor.core.publisher.Mono;
 @ApiStatus.Experimental
 public final class SentryWebExceptionHandler implements WebExceptionHandler {
   public static final String MECHANISM_TYPE = "Spring6WebFluxExceptionResolver";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
-  public SentryWebExceptionHandler(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryWebExceptionHandler(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @Override
   public @NotNull Mono<Void> handle(
       final @NotNull ServerWebExchange serverWebExchange, final @NotNull Throwable ex) {
-    final @Nullable IHub requestHub =
-        serverWebExchange.getAttributeOrDefault(SentryWebFilter.SENTRY_HUB_KEY, null);
-    final @NotNull IHub hubToUse = requestHub != null ? requestHub : hub;
+    final @Nullable IScopes requestScopes =
+        serverWebExchange.getAttributeOrDefault(SentryWebFilter.SENTRY_SCOPES_KEY, null);
+    final @NotNull IScopes scopesToUse = requestScopes != null ? requestScopes : scopes;
 
     return ReactorUtils.withSentryHub(
             Mono.just(ex)
@@ -61,12 +61,12 @@ public final class SentryWebExceptionHandler implements WebExceptionHandler {
                             WEBFLUX_EXCEPTION_HANDLER_RESPONSE, serverWebExchange.getResponse());
                         hint.set(WEBFLUX_EXCEPTION_HANDLER_EXCHANGE, serverWebExchange);
 
-                        hub.captureEvent(event, hint);
+                        scopes.captureEvent(event, hint);
                       }
 
                       return it;
                     }),
-            hubToUse)
+            scopesToUse)
         .flatMap(it -> Mono.error(ex));
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilter.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.jakarta.webflux;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
 import org.jetbrains.annotations.ApiStatus;
@@ -20,28 +20,28 @@ public class SentryWebFilter extends AbstractSentryWebFilter {
 
   private static final String TRACE_ORIGIN = "auto.spring_jakarta.webflux";
 
-  public SentryWebFilter(final @NotNull IHub hub) {
-    super(hub);
+  public SentryWebFilter(final @NotNull IScopes scopes) {
+    super(scopes);
   }
 
   @Override
   public Mono<Void> filter(
       final @NotNull ServerWebExchange serverWebExchange,
       final @NotNull WebFilterChain webFilterChain) {
-    @NotNull IHub requestHub = Sentry.cloneMainHub();
+    @NotNull IScopes requestScopes = Sentry.cloneMainHub();
     final ServerHttpRequest request = serverWebExchange.getRequest();
-    final @Nullable ITransaction transaction = maybeStartTransaction(requestHub, request);
+    final @Nullable ITransaction transaction = maybeStartTransaction(requestScopes, request);
     if (transaction != null) {
       transaction.getSpanContext().setOrigin(TRACE_ORIGIN);
     }
     return webFilterChain
         .filter(serverWebExchange)
-        .doFinally(__ -> doFinally(serverWebExchange, requestHub, transaction))
+        .doFinally(__ -> doFinally(serverWebExchange, requestScopes, transaction))
         .doOnError(e -> doOnError(transaction, e))
         .doFirst(
             () -> {
-              Sentry.setCurrentHub(requestHub);
-              doFirst(serverWebExchange, requestHub);
+              Sentry.setCurrentScopes(requestScopes);
+              doFirst(serverWebExchange, requestScopes);
             });
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta.webflux;
 
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.ITransaction;
 import io.sentry.Sentry;
 import org.jetbrains.annotations.ApiStatus;
@@ -17,8 +17,8 @@ public final class SentryWebFilterWithThreadLocalAccessor extends AbstractSentry
 
   public static final String TRACE_ORIGIN = "auto.spring_jakarta.webflux";
 
-  public SentryWebFilterWithThreadLocalAccessor(final @NotNull IHub hub) {
-    super(hub);
+  public SentryWebFilterWithThreadLocalAccessor(final @NotNull IScopes scopes) {
+    super(scopes);
   }
 
   @Override
@@ -33,14 +33,15 @@ public final class SentryWebFilterWithThreadLocalAccessor extends AbstractSentry
                 __ ->
                     doFinally(
                         serverWebExchange,
-                        Sentry.getCurrentHub(),
+                        Sentry.getCurrentScopes(),
                         transactionContainer.transaction))
             .doOnError(e -> doOnError(transactionContainer.transaction, e))
             .doFirst(
                 () -> {
-                  doFirst(serverWebExchange, Sentry.getCurrentHub());
+                  doFirst(serverWebExchange, Sentry.getCurrentScopes());
                   final ITransaction transaction =
-                      maybeStartTransaction(Sentry.getCurrentHub(), serverWebExchange.getRequest());
+                      maybeStartTransaction(
+                          Sentry.getCurrentScopes(), serverWebExchange.getRequest());
                   transactionContainer.transaction = transaction;
                   if (transaction != null) {
                     transaction.getSpanContext().setOrigin(TRACE_ORIGIN);

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/EnableSentryTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/EnableSentryTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta
 
 import io.sentry.EventProcessor
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Integration
 import io.sentry.Sentry
@@ -67,7 +67,7 @@ class EnableSentryTest {
     @Test
     fun `creates Sentry Hub`() {
         contextRunner.run {
-            assertThat(it).hasSingleBean(IHub::class.java)
+            assertThat(it).hasSingleBean(IScopes::class.java)
         }
     }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryCheckInAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryCheckInAdviceTest.kt
@@ -2,7 +2,7 @@ package io.sentry.spring.jakarta
 
 import io.sentry.CheckIn
 import io.sentry.CheckInStatus
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
@@ -54,19 +54,19 @@ class SentryCheckInAdviceTest {
     lateinit var sampleServiceSpringProperties: SampleServiceSpringProperties
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
-        whenever(hub.options).thenReturn(SentryOptions())
+        reset(scopes)
+        whenever(scopes.options).thenReturn(SentryOptions())
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn, every method call creates two check-ins`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleService.hello()
         assertEquals(1, result)
         assertEquals(2, checkInCaptor.allValues.size)
@@ -79,17 +79,17 @@ class SentryCheckInAdviceTest {
         assertEquals("monitor_slug_1", doneCheckIn.monitorSlug)
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub, times(2)).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes, times(2)).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn, every method call creates two check-ins error`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         assertThrows<RuntimeException> {
             sampleService.oops()
         }
@@ -103,17 +103,17 @@ class SentryCheckInAdviceTest {
         assertEquals("monitor_slug_1e", doneCheckIn.monitorSlug)
         assertEquals(CheckInStatus.ERROR.apiName(), doneCheckIn.status)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub, times(2)).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes, times(2)).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn and heartbeat only, every method call creates only one check-in at the end`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceHeartbeat.hello()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -123,17 +123,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn and heartbeat only, every method call creates only one check-in at the end with error`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         assertThrows<RuntimeException> {
             sampleServiceHeartbeat.oops()
         }
@@ -144,31 +144,31 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.ERROR.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn but slug is missing, does not create check-in`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceNoSlug.hello()
         assertEquals(1, result)
         assertEquals(0, checkInCaptor.allValues.size)
 
-        verify(hub, never()).pushScope()
-        verify(hub, never()).captureCheckIn(any())
-        verify(hub, never()).popScope()
+        verify(scopes, never()).pushScope()
+        verify(scopes, never()).captureCheckIn(any())
+        verify(scopes, never()).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property it is resolved correctly`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.hello()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -178,17 +178,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property that does not exist, raw value is used`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.helloUnresolvedProperty()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -198,17 +198,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property that causes an exception, raw value is used`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.helloExceptionProperty()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -218,10 +218,10 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Configuration
@@ -242,10 +242,10 @@ class SentryCheckInAdviceTest {
         open fun sampleServiceSpringProperties() = SampleServiceSpringProperties()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
 
         companion object {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryExceptionResolverTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.exception.ExceptionMechanismException
@@ -17,7 +17,7 @@ import org.mockito.kotlin.whenever
 import kotlin.test.Test
 
 class SentryExceptionResolverTest {
-    private val hub = mock<IHub>()
+    private val scopes = mock<IScopes>()
     private val transactionNameProvider = mock<TransactionNameProvider>()
 
     private val request = mock<HttpServletRequest>()
@@ -26,10 +26,10 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, sets wrapped exception for event`() {
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
         val expectedCause = RuntimeException("test")
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, expectedCause)
 
         assertThat(eventCaptor.firstValue.throwable).isEqualTo(expectedCause)
@@ -46,9 +46,9 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, sets fatal level for event`() {
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         assertThat(eventCaptor.firstValue.level).isEqualTo(SentryLevel.FATAL)
@@ -59,9 +59,9 @@ class SentryExceptionResolverTest {
         val expectedTransactionName = "test-transaction"
         whenever(transactionNameProvider.provideTransactionName(any())).thenReturn(expectedTransactionName)
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         assertThat(eventCaptor.firstValue.transaction).isEqualTo(expectedTransactionName)
@@ -71,9 +71,9 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, provides spring resolver hint`() {
         val hintCaptor = argumentCaptor<Hint>()
-        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+        whenever(scopes.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         with(hintCaptor.firstValue) {
@@ -86,8 +86,8 @@ class SentryExceptionResolverTest {
     fun `when custom create event method provided, uses it to capture event`() {
         val expectedEvent = SentryEvent()
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
-        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(scopes, transactionNameProvider, 1) {
             override fun createEvent(request: HttpServletRequest, ex: Exception) = expectedEvent
         }
 
@@ -100,8 +100,8 @@ class SentryExceptionResolverTest {
     fun `when custom create hint method provided, uses it to capture event`() {
         val expectedHint = Hint()
         val hintCaptor = argumentCaptor<Hint>()
-        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
-        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+        whenever(scopes.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(scopes, transactionNameProvider, 1) {
             override fun createHint(request: HttpServletRequest, response: HttpServletResponse) = expectedHint
         }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryInitBeanPostProcessorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryInitBeanPostProcessorTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -13,18 +13,18 @@ class SentryInitBeanPostProcessorTest {
     @Test
     fun closesSentryOnApplicationContextDestroy() {
         val ctx = AnnotationConfigApplicationContext(TestConfig::class.java)
-        val hub = ctx.getBean(IHub::class.java)
+        val scopes = ctx.getBean(IScopes::class.java)
         ctx.close()
-        verify(hub).close()
+        verify(scopes).close()
     }
 
     @Configuration
     open class TestConfig {
 
         @Bean(destroyMethod = "")
-        open fun hub() = mock<IHub>()
+        open fun scopes() = mock<IScopes>()
 
         @Bean
-        open fun sentryInitBeanPostProcessor() = SentryInitBeanPostProcessor(hub())
+        open fun sentryInitBeanPostProcessor() = SentryInitBeanPostProcessor(scopes())
     }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessorTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.spring.jakarta.tracing.SpringMvcTransactionNameProvider
@@ -19,10 +19,10 @@ import kotlin.test.assertNotNull
 class SentryRequestHttpServletRequestProcessorTest {
 
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
 
         fun getSut(request: HttpServletRequest, options: SentryOptions = SentryOptions()): SentryRequestHttpServletRequestProcessor {
-            whenever(hub.options).thenReturn(options)
+            whenever(scopes.options).thenReturn(options)
             return SentryRequestHttpServletRequestProcessor(SpringMvcTransactionNameProvider(), request)
         }
     }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryTaskDecoratorTest.kt
@@ -32,28 +32,28 @@ class SentryTaskDecoratorTest {
 
         val sut = SentryTaskDecorator()
 
-        val mainHub = Sentry.getCurrentHub()
-        val threadedHub = Sentry.getCurrentHub().clone()
+        val mainHub = Sentry.getCurrentScopes()
+        val threadedHub = Sentry.getCurrentScopes().clone()
 
         executor.submit {
-            Sentry.setCurrentHub(threadedHub)
+            Sentry.setCurrentScopes(threadedHub)
         }.get()
 
-        assertEquals(mainHub, Sentry.getCurrentHub())
+        assertEquals(mainHub, Sentry.getCurrentScopes())
 
         val callableFuture =
             executor.submit(
                 sut.decorate {
-                    assertNotEquals(mainHub, Sentry.getCurrentHub())
-                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    assertNotEquals(mainHub, Sentry.getCurrentScopes())
+                    assertNotEquals(threadedHub, Sentry.getCurrentScopes())
                 }
             )
 
         callableFuture.get()
 
         executor.submit {
-            assertNotEquals(mainHub, Sentry.getCurrentHub())
-            assertEquals(threadedHub, Sentry.getCurrentHub())
+            assertNotEquals(mainHub, Sentry.getCurrentScopes())
+            assertEquals(threadedHub, Sentry.getCurrentScopes())
         }.get()
     }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryUserFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentryUserFilterTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryOptions
 import io.sentry.protocol.User
 import jakarta.servlet.FilterChain
@@ -16,7 +16,7 @@ import kotlin.test.assertNull
 
 class SentryUserFilterTest {
     class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val request = MockHttpServletRequest()
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
@@ -25,8 +25,8 @@ class SentryUserFilterTest {
             val options = SentryOptions().apply {
                 this.isSendDefaultPii = isSendDefaultPii
             }
-            whenever(hub.options).thenReturn(options)
-            return SentryUserFilter(hub, userProviders)
+            whenever(scopes.options).thenReturn(options)
+            return SentryUserFilter(scopes, userProviders)
         }
     }
 
@@ -52,7 +52,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -72,7 +72,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -92,7 +92,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -118,7 +118,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(mapOf("key" to "value", "new-key" to "new-value"), it.others)
             }
@@ -140,7 +140,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals("192.168.0.1", it.ipAddress)
             }
@@ -162,7 +162,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertNull(it.ipAddress)
             }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/exception/SentryCaptureExceptionParameterAdviceTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.jakarta.exception
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.exception.ExceptionMechanismException
 import org.junit.runner.RunWith
@@ -30,18 +30,18 @@ class SentryCaptureExceptionParameterAdviceTest {
     lateinit var sampleService: SampleService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
+        reset(scopes)
     }
 
     @Test
     fun `captures exception passed to method annotated with @SentryCaptureException`() {
         val exception = RuntimeException("test exception")
         sampleService.methodTakingAnException(exception)
-        verify(hub).captureException(
+        verify(scopes).captureException(
             check {
                 assertTrue(it is ExceptionMechanismException)
                 assertEquals(exception, it.throwable)
@@ -60,10 +60,10 @@ class SentryCaptureExceptionParameterAdviceTest {
         open fun sampleService() = SampleService()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
     }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/mvc/SentrySpringIntegrationTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta.mvc
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.SentryOptions
@@ -104,7 +104,7 @@ class SentrySpringIntegrationTest {
     lateinit var anotherService: AnotherService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @LocalServerPort
     var port: Int? = null
@@ -260,7 +260,7 @@ class SentrySpringIntegrationTest {
         try {
             someService.aMethodThrowing()
         } catch (e: Exception) {
-            hub.captureException(e)
+            scopes.captureException(e)
         }
         verify(transport).send(
             checkEvent {
@@ -276,7 +276,7 @@ class SentrySpringIntegrationTest {
         try {
             someService.aMethodWithInnerSpanThrowing()
         } catch (e: Exception) {
-            hub.captureException(e)
+            scopes.captureException(e)
         }
         verify(transport).send(
             checkEvent {
@@ -370,20 +370,20 @@ open class App {
     open fun springSecuritySentryUserProvider(sentryOptions: SentryOptions) = SpringSecuritySentryUserProvider(sentryOptions)
 
     @Bean
-    open fun sentryUserFilter(hub: IHub, @Lazy sentryUserProviders: List<SentryUserProvider>) = FilterRegistrationBean<SentryUserFilter>().apply {
-        this.filter = SentryUserFilter(hub, sentryUserProviders)
+    open fun sentryUserFilter(scopes: IScopes, @Lazy sentryUserProviders: List<SentryUserProvider>) = FilterRegistrationBean<SentryUserFilter>().apply {
+        this.filter = SentryUserFilter(scopes, sentryUserProviders)
         this.order = Ordered.LOWEST_PRECEDENCE
     }
 
     @Bean
-    open fun sentrySpringFilter(hub: IHub) = FilterRegistrationBean<SentrySpringFilter>().apply {
-        this.filter = SentrySpringFilter(hub)
+    open fun sentrySpringFilter(scopes: IScopes) = FilterRegistrationBean<SentrySpringFilter>().apply {
+        this.filter = SentrySpringFilter(scopes)
         this.order = Ordered.HIGHEST_PRECEDENCE
     }
 
     @Bean
-    open fun sentryTracingFilter(hub: IHub) = FilterRegistrationBean<SentryTracingFilter>().apply {
-        this.filter = SentryTracingFilter(hub)
+    open fun sentryTracingFilter(scopes: IScopes) = FilterRegistrationBean<SentryTracingFilter>().apply {
+        this.filter = SentryTracingFilter(scopes)
         this.order = Ordered.HIGHEST_PRECEDENCE + 1 // must run after SentrySpringFilter
     }
 
@@ -391,13 +391,13 @@ open class App {
     open fun sentryTaskDecorator() = SentryTaskDecorator()
 
     @Bean
-    open fun webClient(hub: IHub): WebClient {
+    open fun webClient(scopes: IScopes): WebClient {
         return WebClient.builder()
             .filter(
                 ExchangeFilterFunctions
                     .basicAuthentication("user", "password")
             )
-            .filter(SentrySpanClientWebRequestFilter(hub)).build()
+            .filter(SentrySpanClientWebRequestFilter(scopes)).build()
     }
 }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentrySpanAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentrySpanAdviceTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta.tracing
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.Sentry
 import io.sentry.SentryOptions
@@ -37,20 +37,20 @@ class SentrySpanAdviceTest {
     lateinit var classAnnotatedWithOperationSampleService: ClassAnnotatedWithOperationSampleService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        whenever(hub.options).thenReturn(SentryOptions())
+        whenever(scopes.options).thenReturn(SentryOptions())
     }
 
     @Test
     fun `when class is annotated with @SentrySpan, every method call attaches span to existing transaction`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         val result = classAnnotatedSampleService.hello()
         assertEquals(1, result)
         assertEquals(1, tx.spans.size)
@@ -62,10 +62,10 @@ class SentrySpanAdviceTest {
     @Test
     fun `when class is annotated with @SentrySpan with operation set, every method call attaches span to existing transaction`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         val result = classAnnotatedWithOperationSampleService.hello()
         assertEquals(1, result)
         assertEquals(1, tx.spans.size)
@@ -76,10 +76,10 @@ class SentrySpanAdviceTest {
     @Test
     fun `when method is annotated with @SentrySpan with properties set, attaches span to existing transaction`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         val result = sampleService.methodWithSpanDescriptionSet()
         assertEquals(1, result)
         assertEquals(1, tx.spans.size)
@@ -90,10 +90,10 @@ class SentrySpanAdviceTest {
     @Test
     fun `when method is annotated with @SentrySpan without properties set, attaches span to existing transaction and sets Span description as className dot methodName`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         val result = sampleService.methodWithoutSpanDescriptionSet()
         assertEquals(2, result)
         assertEquals(1, tx.spans.size)
@@ -104,10 +104,10 @@ class SentrySpanAdviceTest {
     @Test
     fun `when method is annotated with @SentrySpan and returns, attached span has status OK`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         sampleService.methodWithSpanDescriptionSet()
         assertEquals(SpanStatus.OK, tx.spans.first().status)
     }
@@ -115,10 +115,10 @@ class SentrySpanAdviceTest {
     @Test
     fun `when method is annotated with @SentrySpan and throws exception, attached span has throwable set and INTERNAL_ERROR status`() {
         val scope = Scope(SentryOptions())
-        val tx = SentryTracer(TransactionContext("aTransaction", "op"), hub)
+        val tx = SentryTracer(TransactionContext("aTransaction", "op"), scopes)
         scope.setTransaction(tx)
 
-        whenever(hub.span).thenReturn(tx)
+        whenever(scopes.span).thenReturn(tx)
         var throwable: Throwable? = null
         try {
             sampleService.methodThrowingException()
@@ -131,7 +131,7 @@ class SentrySpanAdviceTest {
 
     @Test
     fun `when method is annotated with @SentrySpan and there is no active transaction, span is not created and method is executed`() {
-        whenever(hub.span).thenReturn(null)
+        whenever(scopes.span).thenReturn(null)
         val result = sampleService.methodWithSpanDescriptionSet()
         assertEquals(1, result)
     }
@@ -151,10 +151,10 @@ class SentrySpanAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
     }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/tracing/SentryTransactionAdviceTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.jakarta.tracing
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -44,13 +44,13 @@ class SentryTransactionAdviceTest {
     lateinit var classAnnotatedWithOperationSampleService: ClassAnnotatedWithOperationSampleService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
-        whenever(hub.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
-        whenever(hub.options).thenReturn(
+        reset(scopes)
+        whenever(scopes.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
+        whenever(scopes.options).thenReturn(
             SentryOptions().apply {
                 dsn = "https://key@sentry.io/proj"
             }
@@ -60,7 +60,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `creates transaction around method annotated with @SentryTransaction`() {
         sampleService.methodWithTransactionNameSet()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("customName")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("bean")
@@ -76,7 +76,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `when method annotated with @SentryTransaction throws exception, sets error status on transaction`() {
         assertThrows<RuntimeException> { sampleService.methodThrowingException() }
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
             },
@@ -89,7 +89,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `when @SentryTransaction has no name set, sets transaction name as className dot methodName`() {
         sampleService.methodWithoutTransactionNameSet()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("SampleService.methodWithoutTransactionNameSet")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("op")
@@ -102,18 +102,18 @@ class SentryTransactionAdviceTest {
 
     @Test
     fun `when transaction is already active, does not start new transaction`() {
-        whenever(hub.options).thenReturn(SentryOptions())
-        whenever(hub.span).then { SentryTracer(TransactionContext("aTransaction", "op"), hub) }
+        whenever(scopes.options).thenReturn(SentryOptions())
+        whenever(scopes.span).then { SentryTracer(TransactionContext("aTransaction", "op"), scopes) }
 
         sampleService.methodWithTransactionNameSet()
 
-        verify(hub, times(0)).captureTransaction(any(), any<TraceContext>())
+        verify(scopes, times(0)).captureTransaction(any(), any<TraceContext>())
     }
 
     @Test
     fun `creates transaction around method in class annotated with @SentryTransaction`() {
         classAnnotatedSampleService.hello()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("ClassAnnotatedSampleService.hello")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("op")
@@ -127,7 +127,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `creates transaction with operation set around method in class annotated with @SentryTransaction`() {
         classAnnotatedWithOperationSampleService.hello()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("ClassAnnotatedWithOperationSampleService.hello")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("my-op")
@@ -141,13 +141,13 @@ class SentryTransactionAdviceTest {
     @Test
     fun `pushes the scope when advice starts`() {
         classAnnotatedSampleService.hello()
-        verify(hub).pushScope()
+        verify(scopes).pushScope()
     }
 
     @Test
     fun `pops the scope when advice finishes`() {
         classAnnotatedSampleService.hello()
-        verify(hub).popScope()
+        verify(scopes).popScope()
     }
 
     @Configuration
@@ -165,10 +165,10 @@ class SentryTransactionAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
     }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/ReactorUtilsTest.kt
@@ -1,7 +1,8 @@
 package io.sentry.spring.jakarta.webflux
 
 import io.sentry.IHub
-import io.sentry.NoOpHub
+import io.sentry.IScopes
+import io.sentry.NoOpScopes
 import io.sentry.Sentry
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -26,18 +27,18 @@ class ReactorUtilsTest {
 
     @AfterTest
     fun teardown() {
-        Sentry.setCurrentHub(NoOpHub.getInstance())
+        Sentry.setCurrentScopes(NoOpScopes.getInstance())
     }
 
     @Test
     fun `propagates hub inside mono`() {
-        val hubToUse = mock<IHub>()
-        var hubInside: IHub? = null
+        val hubToUse = mock<IScopes>()
+        var hubInside: IScopes? = null
         val mono = ReactorUtils.withSentryHub(
             Mono.just("hello")
                 .publishOn(Schedulers.boundedElastic())
                 .map { it ->
-                    hubInside = Sentry.getCurrentHub()
+                    hubInside = Sentry.getCurrentScopes()
                     it
                 },
             hubToUse
@@ -49,13 +50,13 @@ class ReactorUtilsTest {
 
     @Test
     fun `propagates hub inside flux`() {
-        val hubToUse = mock<IHub>()
-        var hubInside: IHub? = null
+        val hubToUse = mock<IScopes>()
+        var hubInside: IScopes? = null
         val flux = ReactorUtils.withSentryHub(
             Flux.just("hello")
                 .publishOn(Schedulers.boundedElastic())
                 .map { it ->
-                    hubInside = Sentry.getCurrentHub()
+                    hubInside = Sentry.getCurrentScopes()
                     it
                 },
             hubToUse
@@ -67,12 +68,12 @@ class ReactorUtilsTest {
 
     @Test
     fun `without reactive utils hub is not propagated to mono`() {
-        val hubToUse = mock<IHub>()
-        var hubInside: IHub? = null
+        val hubToUse = mock<IScopes>()
+        var hubInside: IScopes? = null
         val mono = Mono.just("hello")
             .publishOn(Schedulers.boundedElastic())
             .map { it ->
-                hubInside = Sentry.getCurrentHub()
+                hubInside = Sentry.getCurrentScopes()
                 it
             }
 
@@ -82,12 +83,12 @@ class ReactorUtilsTest {
 
     @Test
     fun `without reactive utils hub is not propagated to flux`() {
-        val hubToUse = mock<IHub>()
-        var hubInside: IHub? = null
+        val hubToUse = mock<IScopes>()
+        var hubInside: IScopes? = null
         val flux = Flux.just("hello")
             .publishOn(Schedulers.boundedElastic())
             .map { it ->
-                hubInside = Sentry.getCurrentHub()
+                hubInside = Sentry.getCurrentScopes()
                 it
             }
 
@@ -97,21 +98,21 @@ class ReactorUtilsTest {
 
     @Test
     fun `clones hub for mono`() {
-        val mockHub = mock<IHub>()
-        whenever(mockHub.clone()).thenReturn(mock<IHub>())
-        Sentry.setCurrentHub(mockHub)
+        val mockScopes = mock<IScopes>()
+        whenever(mockScopes.clone()).thenReturn(mock<IHub>())
+        Sentry.setCurrentScopes(mockScopes)
         ReactorUtils.withSentry(Mono.just("hello")).block()
 
-        verify(mockHub).clone()
+        verify(mockScopes).clone()
     }
 
     @Test
     fun `clones hub for flux`() {
-        val mockHub = mock<IHub>()
-        whenever(mockHub.clone()).thenReturn(mock<IHub>())
-        Sentry.setCurrentHub(mockHub)
+        val mockScopes = mock<IScopes>()
+        whenever(mockScopes.clone()).thenReturn(mock<IHub>())
+        Sentry.setCurrentScopes(mockScopes)
         ReactorUtils.withSentry(Flux.just("hello")).blockFirst()
 
-        verify(mockHub).clone()
+        verify(mockScopes).clone()
     }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryScheduleHookTest.kt
@@ -33,28 +33,28 @@ class SentryScheduleHookTest {
 
         val sut = SentryScheduleHook()
 
-        val mainHub = Sentry.getCurrentHub()
-        val threadedHub = Sentry.getCurrentHub().clone()
+        val mainHub = Sentry.getCurrentScopes()
+        val threadedHub = Sentry.getCurrentScopes().clone()
 
         executor.submit {
-            Sentry.setCurrentHub(threadedHub)
+            Sentry.setCurrentScopes(threadedHub)
         }.get()
 
-        assertEquals(mainHub, Sentry.getCurrentHub())
+        assertEquals(mainHub, Sentry.getCurrentScopes())
 
         val callableFuture =
             executor.submit(
                 sut.apply {
-                    assertNotEquals(mainHub, Sentry.getCurrentHub())
-                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    assertNotEquals(mainHub, Sentry.getCurrentScopes())
+                    assertNotEquals(threadedHub, Sentry.getCurrentScopes())
                 }
             )
 
         callableFuture.get()
 
         executor.submit {
-            assertNotEquals(mainHub, Sentry.getCurrentHub())
-            assertEquals(threadedHub, Sentry.getCurrentHub())
+            assertNotEquals(mainHub, Sentry.getCurrentScopes())
+            assertEquals(threadedHub, Sentry.getCurrentScopes())
         }.get()
     }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebFluxTracingFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebFluxTracingFilterTest.kt
@@ -2,8 +2,9 @@ package io.sentry.spring.jakarta.webflux
 
 import io.sentry.Breadcrumb
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.HubScopesWrapper
 import io.sentry.ILogger
+import io.sentry.IScopes
 import io.sentry.PropagationContext
 import io.sentry.ScopeCallback
 import io.sentry.Sentry
@@ -17,7 +18,7 @@ import io.sentry.TransactionOptions
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.TransactionNameSource
-import io.sentry.spring.jakarta.webflux.AbstractSentryWebFilter.SENTRY_HUB_KEY
+import io.sentry.spring.jakarta.webflux.AbstractSentryWebFilter.SENTRY_SCOPES_KEY
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -47,7 +48,7 @@ import kotlin.test.fail
 
 class SentryWebFluxTracingFilterTest {
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         lateinit var request: MockServerHttpRequest
         lateinit var exchange: MockServerWebExchange
         val chain = mock<WebFilterChain>()
@@ -58,45 +59,47 @@ class SentryWebFluxTracingFilterTest {
         val logger = mock<ILogger>()
 
         init {
-            whenever(hub.options).thenReturn(options)
+            whenever(scopes.options).thenReturn(options)
         }
 
         fun getSut(isEnabled: Boolean = true, status: HttpStatus = HttpStatus.OK, sentryTraceHeader: String? = null, baggageHeaders: List<String>? = null, method: HttpMethod = HttpMethod.POST): SentryWebFilter {
             var requestBuilder = MockServerHttpRequest.method(method, "/product/{id}", 12)
             if (sentryTraceHeader != null) {
                 requestBuilder = requestBuilder.header("sentry-trace", sentryTraceHeader)
-                whenever(hub.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
+                whenever(scopes.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
             }
             if (baggageHeaders != null) {
                 requestBuilder = requestBuilder.header("baggage", *baggageHeaders.toTypedArray())
             }
             request = requestBuilder.build()
             exchange = MockServerWebExchange.builder(request).build()
-            exchange.attributes.put(SENTRY_HUB_KEY, hub)
+            exchange.attributes.put(SENTRY_SCOPES_KEY, scopes)
             exchange.attributes.put(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, PathPatternParser().parse("/product/{id}"))
             exchange.response.statusCode = status
-            whenever(hub.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
-            whenever(hub.isEnabled).thenReturn(isEnabled)
+            whenever(scopes.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
+            whenever(scopes.isEnabled).thenReturn(isEnabled)
             whenever(chain.filter(any())).thenReturn(Mono.create { s -> s.success() })
-            whenever(hub.continueTrace(anyOrNull(), anyOrNull())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
-            return SentryWebFilter(hub)
+            whenever(scopes.continueTrace(anyOrNull(), anyOrNull())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
+            return SentryWebFilter(scopes)
         }
     }
 
     private val fixture = Fixture()
 
-    fun withMockHub(closure: () -> Unit) = Mockito.mockStatic(Sentry::class.java).use {
-        it.`when`<Any> { Sentry.cloneMainHub() }.thenReturn(fixture.hub)
+    fun withMockScopes(closure: () -> Unit) = Mockito.mockStatic(Sentry::class.java).use {
+        it.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(HubScopesWrapper(fixture.scopes))
+        it.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(fixture.scopes)
+        it.`when`<Any> { Sentry.cloneMainHub() }.thenReturn(fixture.scopes)
         closure.invoke()
     }
 
     @Test
     fun `creates transaction around the request`() {
         val filter = fixture.getSut()
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).startTransaction(
+            verify(fixture.scopes).startTransaction(
                 check<TransactionContext> {
                     assertEquals("POST /product/12", it.name)
                     assertEquals(TransactionNameSource.URL, it.transactionNameSource)
@@ -109,7 +112,7 @@ class SentryWebFluxTracingFilterTest {
                 }
             )
             verify(fixture.chain).filter(fixture.exchange)
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.transaction).isEqualTo("POST /product/{id}")
                     assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.OK)
@@ -128,10 +131,10 @@ class SentryWebFluxTracingFilterTest {
     fun `sets correct span status based on the response status`() {
         val filter = fixture.getSut(status = HttpStatus.INTERNAL_SERVER_ERROR)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
                     assertThat(it.contexts.response!!.statusCode).isEqualTo(500)
@@ -147,10 +150,10 @@ class SentryWebFluxTracingFilterTest {
     fun `does not set span status for response status that dont match predefined span statuses`() {
         val filter = fixture.getSut(status = HttpStatus.FOUND)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.status).isNull()
                 },
@@ -165,10 +168,10 @@ class SentryWebFluxTracingFilterTest {
     fun `when sentry trace is not present, transaction does not have parentSpanId set`() {
         val filter = fixture.getSut()
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -184,10 +187,10 @@ class SentryWebFluxTracingFilterTest {
         val parentSpanId = SpanId()
         val filter = fixture.getSut(sentryTraceHeader = "${SentryId()}-$parentSpanId-1")
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isEqualTo(parentSpanId)
                 },
@@ -199,16 +202,16 @@ class SentryWebFluxTracingFilterTest {
     }
 
     @Test
-    fun `when hub is disabled, components are not invoked`() {
+    fun `when scopes is disabled, components are not invoked`() {
         val filter = fixture.getSut(isEnabled = false)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub, times(3)).isEnabled
-            verifyNoMoreInteractions(fixture.hub)
+            verify(fixture.scopes, times(3)).isEnabled
+            verifyNoMoreInteractions(fixture.scopes)
         }
     }
 
@@ -216,7 +219,7 @@ class SentryWebFluxTracingFilterTest {
     fun `sets status to internal server error when chain throws exception`() {
         val filter = fixture.getSut()
 
-        withMockHub {
+        withMockScopes {
             whenever(fixture.chain.filter(any())).thenReturn(Mono.error(RuntimeException("error")))
 
             try {
@@ -224,7 +227,7 @@ class SentryWebFluxTracingFilterTest {
                 fail("filter is expected to rethrow exception")
             } catch (_: Exception) {
             }
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
                 },
@@ -239,21 +242,21 @@ class SentryWebFluxTracingFilterTest {
     fun `does not track OPTIONS request with traceOptionsRequests=false`() {
         val filter = fixture.getSut(method = HttpMethod.OPTIONS)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = false
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub, times(3)).isEnabled
-            verify(fixture.hub, times(2)).options
-            verify(fixture.hub).continueTrace(anyOrNull(), anyOrNull())
-            verify(fixture.hub).pushScope()
-            verify(fixture.hub).addBreadcrumb(any<Breadcrumb>(), any<Hint>())
-            verify(fixture.hub).configureScope(any<ScopeCallback>())
-            verify(fixture.hub).popScope()
-            verifyNoMoreInteractions(fixture.hub)
+            verify(fixture.scopes, times(3)).isEnabled
+            verify(fixture.scopes, times(2)).options
+            verify(fixture.scopes).continueTrace(anyOrNull(), anyOrNull())
+            verify(fixture.scopes).pushScope()
+            verify(fixture.scopes).addBreadcrumb(any<Breadcrumb>(), any<Hint>())
+            verify(fixture.scopes).configureScope(any<ScopeCallback>())
+            verify(fixture.scopes).popScope()
+            verifyNoMoreInteractions(fixture.scopes)
         }
     }
 
@@ -261,14 +264,14 @@ class SentryWebFluxTracingFilterTest {
     fun `tracks OPTIONS request with traceOptionsRequests=true`() {
         val filter = fixture.getSut(method = HttpMethod.OPTIONS)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = true
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -283,14 +286,14 @@ class SentryWebFluxTracingFilterTest {
     fun `tracks POST request with traceOptionsRequests=false`() {
         val filter = fixture.getSut(method = HttpMethod.POST)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = false
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -309,19 +312,19 @@ class SentryWebFluxTracingFilterTest {
         fixture.options.enableTracing = false
         val filter = fixture.getSut(sentryTraceHeader = sentryTraceHeaderString, baggageHeaders = baggageHeaderStrings)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub, never()).captureTransaction(
+            verify(fixture.scopes, never()).captureTransaction(
                 anyOrNull<SentryTransaction>(),
                 anyOrNull<TraceContext>(),
                 anyOrNull(),
                 anyOrNull()
             )
 
-            verify(fixture.hub).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
+            verify(fixture.scopes).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
         }
     }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.spring.jakarta.webflux
 
-import io.sentry.HubAdapter
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
+import io.sentry.ScopesAdapter
 import io.sentry.Sentry
 import io.sentry.checkEvent
 import io.sentry.checkTransaction
@@ -160,13 +160,13 @@ open class App {
     open fun mockTransport() = transport
 
     @Bean
-    open fun hub() = HubAdapter.getInstance()
+    open fun scopes() = ScopesAdapter.getInstance()
 
     @Bean
-    open fun sentryFilter(hub: IHub) = SentryWebFilter(hub)
+    open fun sentryFilter(scopes: IScopes) = SentryWebFilter(scopes)
 
     @Bean
-    open fun sentryWebExceptionHandler(hub: IHub) = SentryWebExceptionHandler(hub)
+    open fun sentryWebExceptionHandler(scopes: IScopes) = SentryWebExceptionHandler(scopes)
 
     @Bean
     open fun sentryScheduleHookRegistrar() = ApplicationRunner {

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -22,7 +22,7 @@ public final class io/sentry/spring/HttpServletRequestSentryUserProvider : io/se
 
 public class io/sentry/spring/SentryExceptionResolver : org/springframework/core/Ordered, org/springframework/web/servlet/HandlerExceptionResolver {
 	public static final field MECHANISM_TYPE Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/tracing/TransactionNameProvider;I)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/tracing/TransactionNameProvider;I)V
 	protected fun createEvent (Ljavax/servlet/http/HttpServletRequest;Ljava/lang/Exception;)Lio/sentry/SentryEvent;
 	protected fun createHint (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;)Lio/sentry/Hint;
 	public fun getOrder ()I
@@ -47,14 +47,14 @@ public class io/sentry/spring/SentryRequestHttpServletRequestProcessor : io/sent
 }
 
 public class io/sentry/spring/SentryRequestResolver {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Ljavax/servlet/http/HttpServletRequest;)Lio/sentry/protocol/Request;
 }
 
 public class io/sentry/spring/SentrySpringFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/SentryRequestResolver;Lio/sentry/spring/tracing/TransactionNameProvider;)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/SentryRequestResolver;Lio/sentry/spring/tracing/TransactionNameProvider;)V
 	protected fun doFilterInternal (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljavax/servlet/FilterChain;)V
 }
 
@@ -69,7 +69,7 @@ public final class io/sentry/spring/SentryTaskDecorator : org/springframework/co
 }
 
 public class io/sentry/spring/SentryUserFilter : org/springframework/web/filter/OncePerRequestFilter {
-	public fun <init> (Lio/sentry/IHub;Ljava/util/List;)V
+	public fun <init> (Lio/sentry/IScopes;Ljava/util/List;)V
 	protected fun doFilterInternal (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljavax/servlet/FilterChain;)V
 	public fun getSentryUserProviders ()Ljava/util/List;
 }
@@ -96,7 +96,7 @@ public abstract interface annotation class io/sentry/spring/checkin/SentryCheckI
 
 public class io/sentry/spring/checkin/SentryCheckInAdvice : org/aopalliance/intercept/MethodInterceptor, org/springframework/context/EmbeddedValueResolverAware {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 	public fun setEmbeddedValueResolver (Lorg/springframework/util/StringValueResolver;)V
 }
@@ -127,7 +127,7 @@ public abstract interface annotation class io/sentry/spring/exception/SentryCapt
 
 public class io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -169,7 +169,7 @@ public final class io/sentry/spring/graphql/SentryDataFetcherExceptionResolverAd
 
 public final class io/sentry/spring/graphql/SentryDgsSubscriptionHandler : io/sentry/graphql/SentrySubscriptionHandler {
 	public fun <init> ()V
-	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
+	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IScopes;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
 public final class io/sentry/spring/graphql/SentryGraphqlBeanPostProcessor : org/springframework/beans/factory/config/BeanPostProcessor, org/springframework/core/PriorityOrdered {
@@ -188,7 +188,7 @@ public class io/sentry/spring/graphql/SentryGraphqlConfiguration {
 
 public final class io/sentry/spring/graphql/SentrySpringSubscriptionHandler : io/sentry/graphql/SentrySubscriptionHandler {
 	public fun <init> ()V
-	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IHub;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
+	public fun onSubscriptionResult (Ljava/lang/Object;Lio/sentry/IScopes;Lio/sentry/graphql/ExceptionReporter;Lgraphql/execution/instrumentation/parameters/InstrumentationFieldFetchParameters;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/tracing/SentryAdviceConfiguration {
@@ -207,17 +207,17 @@ public abstract interface annotation class io/sentry/spring/tracing/SentrySpan :
 
 public class io/sentry/spring/tracing/SentrySpanAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
 public class io/sentry/spring/tracing/SentrySpanClientHttpRequestInterceptor : org/springframework/http/client/ClientHttpRequestInterceptor {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun intercept (Lorg/springframework/http/HttpRequest;[BLorg/springframework/http/client/ClientHttpRequestExecution;)Lorg/springframework/http/client/ClientHttpResponse;
 }
 
 public class io/sentry/spring/tracing/SentrySpanClientWebRequestFilter : org/springframework/web/reactive/function/client/ExchangeFilterFunction {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun filter (Lorg/springframework/web/reactive/function/client/ClientRequest;Lorg/springframework/web/reactive/function/client/ExchangeFunction;)Lreactor/core/publisher/Mono;
 }
 
@@ -232,8 +232,8 @@ public class io/sentry/spring/tracing/SentryTracingConfiguration {
 
 public class io/sentry/spring/tracing/SentryTracingFilter : org/springframework/web/filter/OncePerRequestFilter {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
-	public fun <init> (Lio/sentry/IHub;Lio/sentry/spring/tracing/TransactionNameProvider;)V
+	public fun <init> (Lio/sentry/IScopes;)V
+	public fun <init> (Lio/sentry/IScopes;Lio/sentry/spring/tracing/TransactionNameProvider;)V
 	protected fun doFilterInternal (Ljavax/servlet/http/HttpServletRequest;Ljavax/servlet/http/HttpServletResponse;Ljavax/servlet/FilterChain;)V
 }
 
@@ -245,7 +245,7 @@ public abstract interface annotation class io/sentry/spring/tracing/SentryTransa
 
 public class io/sentry/spring/tracing/SentryTransactionAdvice : org/aopalliance/intercept/MethodInterceptor {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun invoke (Lorg/aopalliance/intercept/MethodInvocation;)Ljava/lang/Object;
 }
 
@@ -266,7 +266,7 @@ public abstract interface class io/sentry/spring/tracing/TransactionNameProvider
 }
 
 public class io/sentry/spring/webflux/SentryRequestResolver {
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Lorg/springframework/http/server/reactive/ServerHttpRequest;)Lio/sentry/protocol/Request;
 }
 
@@ -278,13 +278,14 @@ public final class io/sentry/spring/webflux/SentryScheduleHook : java/util/funct
 
 public final class io/sentry/spring/webflux/SentryWebExceptionHandler : org/springframework/web/server/WebExceptionHandler {
 	public static final field MECHANISM_TYPE Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;)V
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun handle (Lorg/springframework/web/server/ServerWebExchange;Ljava/lang/Throwable;)Lreactor/core/publisher/Mono;
 }
 
 public final class io/sentry/spring/webflux/SentryWebFilter : org/springframework/web/server/WebFilter {
 	public static final field SENTRY_HUB_KEY Ljava/lang/String;
-	public fun <init> (Lio/sentry/IHub;)V
+	public static final field SENTRY_SCOPES_KEY Ljava/lang/String;
+	public fun <init> (Lio/sentry/IScopes;)V
 	public fun filter (Lorg/springframework/web/server/ServerWebExchange;Lorg/springframework/web/server/WebFilterChain;)Lreactor/core/publisher/Mono;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryExceptionResolver.java
@@ -5,7 +5,7 @@ import static io.sentry.TypeCheckHint.SPRING_RESOLVER_RESPONSE;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Hint;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
@@ -29,15 +29,15 @@ import org.springframework.web.servlet.ModelAndView;
 public class SentryExceptionResolver implements HandlerExceptionResolver, Ordered {
   public static final String MECHANISM_TYPE = "Spring5ExceptionResolver";
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private final @NotNull TransactionNameProvider transactionNameProvider;
   private final int order;
 
   public SentryExceptionResolver(
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull TransactionNameProvider transactionNameProvider,
       final int order) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
     this.transactionNameProvider =
         Objects.requireNonNull(transactionNameProvider, "transactionNameProvider is required");
     this.order = order;
@@ -53,7 +53,7 @@ public class SentryExceptionResolver implements HandlerExceptionResolver, Ordere
     final SentryEvent event = createEvent(request, ex);
     final Hint hint = createHint(request, response);
 
-    hub.captureEvent(event, hint);
+    scopes.captureEvent(event, hint);
 
     // null = run other HandlerExceptionResolvers to actually handle the exception
     return null;

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryHubRegistrar.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryHubRegistrar.java
@@ -1,7 +1,7 @@
 package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
@@ -60,7 +60,7 @@ public class SentryHubRegistrar implements ImportBeanDefinitionRegistrar {
 
   private void registerSentryHubBean(final @NotNull BeanDefinitionRegistry registry) {
     final BeanDefinitionBuilder builder =
-        BeanDefinitionBuilder.genericBeanDefinition(HubAdapter.class);
+        BeanDefinitionBuilder.genericBeanDefinition(ScopesAdapter.class);
     builder.setInitMethodName("getInstance");
 
     registry.registerBeanDefinition("sentryHub", builder.getBeanDefinition());

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryInitBeanPostProcessor.java
@@ -2,10 +2,10 @@ package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.EventProcessor;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransportFactory;
 import io.sentry.Integration;
+import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryOptions;
 import io.sentry.SentryOptions.TracesSamplerCallback;
@@ -27,15 +27,15 @@ public class SentryInitBeanPostProcessor
     implements BeanPostProcessor, ApplicationContextAware, DisposableBean {
   private @Nullable ApplicationContext applicationContext;
 
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryInitBeanPostProcessor() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  SentryInitBeanPostProcessor(final @NotNull IHub hub) {
-    Objects.requireNonNull(hub, "hub is required");
-    this.hub = hub;
+  SentryInitBeanPostProcessor(final @NotNull IScopes scopes) {
+    Objects.requireNonNull(scopes, "scopes are required");
+    this.scopes = scopes;
   }
 
   @Override
@@ -86,6 +86,6 @@ public class SentryInitBeanPostProcessor
 
   @Override
   public void destroy() {
-    hub.close();
+    scopes.close();
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestResolver.java
@@ -1,7 +1,7 @@
 package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
@@ -20,11 +20,11 @@ import org.jetbrains.annotations.Nullable;
 
 @Open
 public class SentryRequestResolver {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private volatile @Nullable List<String> extraSecurityCookies;
 
-  public SentryRequestResolver(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "options is required");
+  public SentryRequestResolver(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   // httpRequest.getRequestURL() returns StringBuffer which is considered an obsolete class.
@@ -40,7 +40,7 @@ public class SentryRequestResolver {
         extractSecurityCookieNamesOrUseCached(httpRequest);
     sentryRequest.setHeaders(resolveHeadersMap(httpRequest, additionalSecurityCookieNames));
 
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       String cookieName = HttpUtils.COOKIE_HEADER_NAME;
       final @Nullable List<String> filteredHeaders =
           HttpUtils.filterOutSecurityCookiesFromHeader(
@@ -57,7 +57,8 @@ public class SentryRequestResolver {
     final Map<String, String> headersMap = new HashMap<>();
     for (String headerName : Collections.list(request.getHeaderNames())) {
       // do not copy personal information identifiable headers
-      if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
+      if (scopes.getOptions().isSendDefaultPii()
+          || !HttpUtils.containsSensitiveHeader(headerName)) {
         final @Nullable List<String> filteredHeaders =
             HttpUtils.filterOutSecurityCookiesFromHeader(
                 request.getHeaders(headerName), headerName, additionalSecurityCookieNames);
@@ -94,7 +95,8 @@ public class SentryRequestResolver {
         }
       }
     } catch (Throwable t) {
-      hub.getOptions()
+      scopes
+          .getOptions()
           .getLogger()
           .log(SentryLevel.WARNING, "Failed to extract session cookie name from request.", t);
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryTaskDecorator.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryTaskDecorator.java
@@ -1,6 +1,6 @@
 package io.sentry.spring;
 
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.Sentry;
 import java.util.concurrent.Callable;
 import org.jetbrains.annotations.NotNull;
@@ -9,21 +9,23 @@ import org.springframework.scheduling.annotation.Async;
 
 /**
  * Sets a current hub on a thread running a {@link Runnable} given by parameter. Used to propagate
- * the current {@link IHub} on the thread executing async task - like MVC controller methods
+ * the current {@link IScopes} on the thread executing async task - like MVC controller methods
  * returning a {@link Callable} or Spring beans methods annotated with {@link Async}.
  */
 public final class SentryTaskDecorator implements TaskDecorator {
   @Override
+  @SuppressWarnings("deprecation")
   public @NotNull Runnable decorate(final @NotNull Runnable runnable) {
-    final IHub newHub = Sentry.getCurrentHub().clone();
+    // TODO fork instead
+    final IScopes newHub = Sentry.getCurrentScopes().clone();
 
     return () -> {
-      final IHub oldState = Sentry.getCurrentHub();
-      Sentry.setCurrentHub(newHub);
+      final IScopes oldState = Sentry.getCurrentScopes();
+      Sentry.setCurrentScopes(newHub);
       try {
         runnable.run();
       } finally {
-        Sentry.setCurrentHub(oldState);
+        Sentry.setCurrentScopes(oldState);
       }
     };
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryUserFilter.java
@@ -1,8 +1,8 @@
 package io.sentry.spring;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
 import io.sentry.IScope;
+import io.sentry.IScopes;
 import io.sentry.IpAddressUtils;
 import io.sentry.protocol.User;
 import io.sentry.util.Objects;
@@ -26,12 +26,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 @Open
 public class SentryUserFilter extends OncePerRequestFilter {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
   private final @NotNull List<SentryUserProvider> sentryUserProviders;
 
   public SentryUserFilter(
-      final @NotNull IHub hub, final @NotNull List<SentryUserProvider> sentryUserProviders) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+      final @NotNull IScopes scopes, final @NotNull List<SentryUserProvider> sentryUserProviders) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
     this.sentryUserProviders =
         Objects.requireNonNull(sentryUserProviders, "sentryUserProviders list is required");
   }
@@ -46,13 +46,13 @@ public class SentryUserFilter extends OncePerRequestFilter {
     for (final SentryUserProvider provider : sentryUserProviders) {
       apply(user, provider.provideUser());
     }
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       if (IpAddressUtils.isDefault(user.getIpAddress())) {
         // unset {{auto}} as it would set the server's ip address as a user ip address
         user.setIpAddress(null);
       }
     }
-    hub.setUser(user);
+    scopes.setUser(user);
     chain.doFilter(request, response);
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -4,8 +4,8 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.CheckIn;
 import io.sentry.CheckInStatus;
 import io.sentry.DateUtils;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.SentryId;
 import io.sentry.util.Objects;
@@ -30,16 +30,16 @@ import org.springframework.util.StringValueResolver;
 @ApiStatus.Experimental
 @Open
 public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueResolverAware {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   private @Nullable StringValueResolver resolver;
 
   public SentryCheckInAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentryCheckInAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCheckInAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @Override
@@ -69,7 +69,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
         // Sentry should alert the user about missed checkins in this case since the monitor slug
         // won't match
         // what is configured in Sentry.
-        hub.getOptions()
+        scopes
+            .getOptions()
             .getLogger()
             .log(
                 SentryLevel.WARNING,
@@ -79,7 +80,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
     }
 
     if (ObjectUtils.isEmpty(monitorSlug)) {
-      hub.getOptions()
+      scopes
+          .getOptions()
           .getLogger()
           .log(
               SentryLevel.WARNING,
@@ -87,8 +89,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       return invocation.proceed();
     }
 
-    hub.pushScope();
-    TracingUtils.startNewTrace(hub);
+    scopes.pushScope();
+    TracingUtils.startNewTrace(scopes);
 
     @Nullable SentryId checkInId = null;
     final long startTime = System.currentTimeMillis();
@@ -96,7 +98,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
 
     try {
       if (!isHeartbeatOnly) {
-        checkInId = hub.captureCheckIn(new CheckIn(monitorSlug, CheckInStatus.IN_PROGRESS));
+        checkInId = scopes.captureCheckIn(new CheckIn(monitorSlug, CheckInStatus.IN_PROGRESS));
       }
       return invocation.proceed();
     } catch (Throwable e) {
@@ -106,8 +108,8 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
       CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
       checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
-      hub.captureCheckIn(checkIn);
-      hub.popScope();
+      scopes.captureCheckIn(checkIn);
+      scopes.popScope();
     }
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/exception/SentryCaptureExceptionParameterAdvice.java
@@ -1,8 +1,8 @@
 package io.sentry.spring.exception;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.protocol.Mechanism;
 import io.sentry.util.Objects;
@@ -22,14 +22,14 @@ import org.springframework.core.annotation.AnnotationUtils;
 @Open
 public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor {
   private static final String MECHANISM_TYPE = "SentrySpring5CaptureExceptionParameterAdvice";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryCaptureExceptionParameterAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentryCaptureExceptionParameterAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryCaptureExceptionParameterAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @Override
@@ -58,6 +58,6 @@ public class SentryCaptureExceptionParameterAdvice implements MethodInterceptor 
     mechanism.setHandled(true);
     final Throwable mechanismException =
         new ExceptionMechanismException(mechanism, throwable, Thread.currentThread());
-    hub.captureException(mechanismException);
+    scopes.captureException(mechanismException);
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryBatchLoaderRegistry.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryBatchLoaderRegistry.java
@@ -1,11 +1,11 @@
 package io.sentry.spring.graphql;
 
-import static io.sentry.graphql.SentryInstrumentation.SENTRY_HUB_CONTEXT_KEY;
+import static io.sentry.graphql.SentryInstrumentation.SENTRY_SCOPES_CONTEXT_KEY;
 
 import graphql.GraphQLContext;
 import io.sentry.Breadcrumb;
-import io.sentry.IHub;
-import io.sentry.NoOpHub;
+import io.sentry.IScopes;
+import io.sentry.NoOpScopes;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,7 +89,7 @@ public final class SentryBatchLoaderRegistry implements BatchLoaderRegistry {
     public void registerBatchLoader(BiFunction<List<K>, BatchLoaderEnvironment, Flux<V>> loader) {
       delegate.registerBatchLoader(
           (keys, batchLoaderEnvironment) -> {
-            hubFromContext(batchLoaderEnvironment)
+            scopesFromContext(batchLoaderEnvironment)
                 .addBreadcrumb(Breadcrumb.graphqlDataLoader(keys, keyType, valueType, name));
             return loader.apply(keys, batchLoaderEnvironment);
           });
@@ -100,20 +100,20 @@ public final class SentryBatchLoaderRegistry implements BatchLoaderRegistry {
         BiFunction<Set<K>, BatchLoaderEnvironment, Mono<Map<K, V>>> loader) {
       delegate.registerMappedBatchLoader(
           (keys, batchLoaderEnvironment) -> {
-            hubFromContext(batchLoaderEnvironment)
+            scopesFromContext(batchLoaderEnvironment)
                 .addBreadcrumb(Breadcrumb.graphqlDataLoader(keys, keyType, valueType, name));
             return loader.apply(keys, batchLoaderEnvironment);
           });
     }
 
-    private @NotNull IHub hubFromContext(final @NotNull BatchLoaderEnvironment environment) {
+    private @NotNull IScopes scopesFromContext(final @NotNull BatchLoaderEnvironment environment) {
       Object context = environment.getContext();
       if (context instanceof GraphQLContext) {
         GraphQLContext graphqlContext = (GraphQLContext) context;
-        return graphqlContext.getOrDefault(SENTRY_HUB_CONTEXT_KEY, NoOpHub.getInstance());
+        return graphqlContext.getOrDefault(SENTRY_SCOPES_CONTEXT_KEY, NoOpScopes.getInstance());
       }
 
-      return NoOpHub.getInstance();
+      return NoOpScopes.getInstance();
     }
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDgsSubscriptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentryDgsSubscriptionHandler.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.graphql;
 
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.graphql.ExceptionReporter;
 import io.sentry.graphql.SentrySubscriptionHandler;
@@ -17,7 +17,7 @@ public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHan
   @Override
   public @NotNull Object onSubscriptionResult(
       final @NotNull Object result,
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull ExceptionReporter exceptionReporter,
       final @NotNull InstrumentationFieldFetchParameters parameters) {
     if (result instanceof Flux) {
@@ -25,7 +25,7 @@ public final class SentryDgsSubscriptionHandler implements SentrySubscriptionHan
       return flux.doOnError(
           throwable -> {
             final @NotNull ExceptionReporter.ExceptionDetails exceptionDetails =
-                new ExceptionReporter.ExceptionDetails(hub, parameters.getEnvironment(), true);
+                new ExceptionReporter.ExceptionDetails(scopes, parameters.getEnvironment(), true);
             exceptionReporter.captureThrowable(throwable, exceptionDetails, null);
           });
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/graphql/SentrySpringSubscriptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/graphql/SentrySpringSubscriptionHandler.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.graphql;
 
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.graphql.ExceptionReporter;
 import io.sentry.graphql.SentrySubscriptionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +13,7 @@ public final class SentrySpringSubscriptionHandler implements SentrySubscription
   @Override
   public @NotNull Object onSubscriptionResult(
       final @NotNull Object result,
-      final @NotNull IHub hub,
+      final @NotNull IScopes scopes,
       final @NotNull ExceptionReporter exceptionReporter,
       final @NotNull InstrumentationFieldFetchParameters parameters) {
     if (result instanceof Flux) {
@@ -21,7 +21,7 @@ public final class SentrySpringSubscriptionHandler implements SentrySubscription
       return flux.doOnError(
           throwable -> {
             final @NotNull ExceptionReporter.ExceptionDetails exceptionDetails =
-                new ExceptionReporter.ExceptionDetails(hub, parameters.getEnvironment(), true);
+                new ExceptionReporter.ExceptionDetails(scopes, parameters.getEnvironment(), true);
             if (throwable instanceof SubscriptionPublisherException
                 && throwable.getCause() != null) {
               exceptionReporter.captureThrowable(throwable.getCause(), exceptionDetails, null);

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentrySpanAdvice.java
@@ -1,9 +1,9 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ISpan;
+import io.sentry.ScopesAdapter;
 import io.sentry.SpanStatus;
 import io.sentry.util.Objects;
 import java.lang.reflect.Method;
@@ -22,20 +22,20 @@ import org.springframework.util.StringUtils;
 @Open
 public class SentrySpanAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring.advice";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentrySpanAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentrySpanAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentrySpanAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public Object invoke(final @NotNull MethodInvocation invocation) throws Throwable {
-    final ISpan activeSpan = hub.getSpan();
+    final ISpan activeSpan = scopes.getSpan();
 
     if (activeSpan == null || activeSpan.isNoOp()) {
       // there is no active transaction, we do not start new span

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTracingFilter.java
@@ -3,9 +3,9 @@ package io.sentry.spring.tracing;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.BaggageHeader;
 import io.sentry.CustomSamplingContext;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransaction;
+import io.sentry.ScopesAdapter;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
@@ -35,7 +35,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
   private static final String TRACE_ORIGIN = "auto.http.spring.webmvc";
 
   private final @NotNull TransactionNameProvider transactionNameProvider;
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   /**
    * Creates filter that resolves transaction name using {@link SpringMvcTransactionNameProvider}.
@@ -46,25 +46,26 @@ public class SentryTracingFilter extends OncePerRequestFilter {
    * javax.servlet.Filter}.
    */
   public SentryTracingFilter() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
   /**
    * Creates filter that resolves transaction name using transaction name provider given by
    * parameter.
    *
-   * @param hub - the hub
+   * @param scopes - the scopes
    * @param transactionNameProvider - transaction name provider.
    */
   public SentryTracingFilter(
-      final @NotNull IHub hub, final @NotNull TransactionNameProvider transactionNameProvider) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+      final @NotNull IScopes scopes,
+      final @NotNull TransactionNameProvider transactionNameProvider) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes is required");
     this.transactionNameProvider =
         Objects.requireNonNull(transactionNameProvider, "transactionNameProvider is required");
   }
 
-  public SentryTracingFilter(final @NotNull IHub hub) {
-    this(hub, new SpringMvcTransactionNameProvider());
+  public SentryTracingFilter(final @NotNull IScopes scopes) {
+    this(scopes, new SpringMvcTransactionNameProvider());
   }
 
   @Override
@@ -74,15 +75,15 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       final @NotNull FilterChain filterChain)
       throws ServletException, IOException {
 
-    if (hub.isEnabled()) {
+    if (scopes.isEnabled()) {
       final @Nullable String sentryTraceHeader =
           httpRequest.getHeader(SentryTraceHeader.SENTRY_TRACE_HEADER);
       final @Nullable List<String> baggageHeader =
           Collections.list(httpRequest.getHeaders(BaggageHeader.BAGGAGE_HEADER));
       final @Nullable TransactionContext transactionContext =
-          hub.continueTrace(sentryTraceHeader, baggageHeader);
+          scopes.continueTrace(sentryTraceHeader, baggageHeader);
 
-      if (hub.getOptions().isTracingEnabled() && shouldTraceRequest(httpRequest)) {
+      if (scopes.getOptions().isTracingEnabled() && shouldTraceRequest(httpRequest)) {
         doFilterWithTransaction(httpRequest, httpResponse, filterChain, transactionContext);
       } else {
         filterChain.doFilter(httpRequest, httpResponse);
@@ -129,7 +130,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
   }
 
   private boolean shouldTraceRequest(final @NotNull HttpServletRequest request) {
-    return hub.getOptions().isTraceOptionsRequests()
+    return scopes.getOptions().isTraceOptionsRequests()
         || !HttpMethod.OPTIONS.name().equals(request.getMethod());
   }
 
@@ -151,14 +152,14 @@ public class SentryTracingFilter extends OncePerRequestFilter {
       transactionOptions.setCustomSamplingContext(customSamplingContext);
       transactionOptions.setBindToScope(true);
 
-      return hub.startTransaction(transactionContext, transactionOptions);
+      return scopes.startTransaction(transactionContext, transactionOptions);
     }
 
     final TransactionOptions transactionOptions = new TransactionOptions();
     transactionOptions.setCustomSamplingContext(customSamplingContext);
     transactionOptions.setBindToScope(true);
 
-    return hub.startTransaction(
+    return scopes.startTransaction(
         new TransactionContext(name, TransactionNameSource.URL, "http.server"), transactionOptions);
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SentryTransactionAdvice.java
@@ -1,9 +1,9 @@
 package io.sentry.spring.tracing;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.HubAdapter;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.ITransaction;
+import io.sentry.ScopesAdapter;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
@@ -27,14 +27,14 @@ import org.springframework.util.StringUtils;
 @Open
 public class SentryTransactionAdvice implements MethodInterceptor {
   private static final String TRACE_ORIGIN = "auto.function.spring.advice";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
   public SentryTransactionAdvice() {
-    this(HubAdapter.getInstance());
+    this(ScopesAdapter.getInstance());
   }
 
-  public SentryTransactionAdvice(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryTransactionAdvice(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @SuppressWarnings("deprecation")
@@ -67,11 +67,11 @@ public class SentryTransactionAdvice implements MethodInterceptor {
       } else {
         operation = "bean";
       }
-      hub.pushScope();
+      scopes.pushScope();
       final TransactionOptions transactionOptions = new TransactionOptions();
       transactionOptions.setBindToScope(true);
       final ITransaction transaction =
-          hub.startTransaction(
+          scopes.startTransaction(
               new TransactionContext(nameAndSource.name, nameAndSource.source, operation),
               transactionOptions);
       transaction.getSpanContext().setOrigin(TRACE_ORIGIN);
@@ -85,7 +85,7 @@ public class SentryTransactionAdvice implements MethodInterceptor {
         throw e;
       } finally {
         transaction.finish();
-        hub.popScope();
+        scopes.popScope();
       }
     }
   }
@@ -105,7 +105,7 @@ public class SentryTransactionAdvice implements MethodInterceptor {
   }
 
   private boolean isTransactionActive() {
-    return hub.getSpan() != null;
+    return scopes.getSpan() != null;
   }
 
   private static class TransactionNameAndSource {

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryRequestResolver.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryRequestResolver.java
@@ -1,7 +1,7 @@
 package io.sentry.spring.webflux;
 
 import com.jakewharton.nopen.annotation.Open;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.protocol.Request;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
@@ -20,10 +20,10 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 @Open
 @ApiStatus.Experimental
 public class SentryRequestResolver {
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
-  public SentryRequestResolver(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "options is required");
+  public SentryRequestResolver(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   public @NotNull Request resolveSentryRequest(final @NotNull ServerHttpRequest httpRequest) {
@@ -36,7 +36,7 @@ public class SentryRequestResolver {
     urlDetails.applyToRequest(sentryRequest);
     sentryRequest.setHeaders(resolveHeadersMap(httpRequest.getHeaders()));
 
-    if (hub.getOptions().isSendDefaultPii()) {
+    if (scopes.getOptions().isSendDefaultPii()) {
       String headerName = HttpUtils.COOKIE_HEADER_NAME;
       sentryRequest.setCookies(
           toString(
@@ -52,7 +52,8 @@ public class SentryRequestResolver {
     for (Map.Entry<String, List<String>> entry : request.entrySet()) {
       // do not copy personal information identifiable headers
       String headerName = entry.getKey();
-      if (hub.getOptions().isSendDefaultPii() || !HttpUtils.containsSensitiveHeader(headerName)) {
+      if (scopes.getOptions().isSendDefaultPii()
+          || !HttpUtils.containsSensitiveHeader(headerName)) {
         headersMap.put(
             headerName,
             toString(

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryScheduleHook.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryScheduleHook.java
@@ -1,6 +1,6 @@
 package io.sentry.spring.webflux;
 
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.Sentry;
 import java.util.function.Function;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,16 +13,18 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Experimental
 public final class SentryScheduleHook implements Function<Runnable, Runnable> {
   @Override
+  @SuppressWarnings("deprecation")
   public Runnable apply(final @NotNull Runnable runnable) {
-    final IHub newHub = Sentry.getCurrentHub().clone();
+    // TODO fork instead
+    final IScopes newHub = Sentry.getCurrentScopes().clone();
 
     return () -> {
-      final IHub oldState = Sentry.getCurrentHub();
-      Sentry.setCurrentHub(newHub);
+      final IScopes oldState = Sentry.getCurrentScopes();
+      Sentry.setCurrentScopes(newHub);
       try {
         runnable.run();
       } finally {
-        Sentry.setCurrentHub(oldState);
+        Sentry.setCurrentScopes(oldState);
       }
     };
   }

--- a/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/webflux/SentryWebExceptionHandler.java
@@ -5,7 +5,7 @@ import static io.sentry.TypeCheckHint.WEBFLUX_EXCEPTION_HANDLER_REQUEST;
 import static io.sentry.TypeCheckHint.WEBFLUX_EXCEPTION_HANDLER_RESPONSE;
 
 import io.sentry.Hint;
-import io.sentry.IHub;
+import io.sentry.IScopes;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.exception.ExceptionMechanismException;
@@ -26,10 +26,10 @@ import reactor.core.publisher.Mono;
 @ApiStatus.Experimental
 public final class SentryWebExceptionHandler implements WebExceptionHandler {
   public static final String MECHANISM_TYPE = "Spring5WebFluxExceptionResolver";
-  private final @NotNull IHub hub;
+  private final @NotNull IScopes scopes;
 
-  public SentryWebExceptionHandler(final @NotNull IHub hub) {
-    this.hub = Objects.requireNonNull(hub, "hub is required");
+  public SentryWebExceptionHandler(final @NotNull IScopes scopes) {
+    this.scopes = Objects.requireNonNull(scopes, "scopes are required");
   }
 
   @Override
@@ -50,7 +50,7 @@ public final class SentryWebExceptionHandler implements WebExceptionHandler {
       hint.set(WEBFLUX_EXCEPTION_HANDLER_RESPONSE, serverWebExchange.getResponse());
       hint.set(WEBFLUX_EXCEPTION_HANDLER_EXCHANGE, serverWebExchange);
 
-      hub.captureEvent(event, hint);
+      scopes.captureEvent(event, hint);
     }
     return Mono.error(ex);
   }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/EnableSentryTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring
 
 import io.sentry.EventProcessor
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Integration
 import io.sentry.Sentry
@@ -65,9 +65,9 @@ class EnableSentryTest {
     }
 
     @Test
-    fun `creates Sentry Hub`() {
+    fun `creates Sentry Scopes`() {
         contextRunner.run {
-            assertThat(it).hasSingleBean(IHub::class.java)
+            assertThat(it).hasSingleBean(IScopes::class.java)
         }
     }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryCheckInAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryCheckInAdviceTest.kt
@@ -2,7 +2,7 @@ package io.sentry.spring
 
 import io.sentry.CheckIn
 import io.sentry.CheckInStatus
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.protocol.SentryId
@@ -55,19 +55,19 @@ class SentryCheckInAdviceTest {
     lateinit var sampleServiceSpringProperties: SampleServiceSpringProperties
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
-        whenever(hub.options).thenReturn(SentryOptions())
+        reset(scopes)
+        whenever(scopes.options).thenReturn(SentryOptions())
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn, every method call creates two check-ins`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleService.hello()
         assertEquals(1, result)
         assertEquals(2, checkInCaptor.allValues.size)
@@ -80,17 +80,17 @@ class SentryCheckInAdviceTest {
         assertEquals("monitor_slug_1", doneCheckIn.monitorSlug)
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub, times(2)).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes, times(2)).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn, every method call creates two check-ins error`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         assertThrows<RuntimeException> {
             sampleService.oops()
         }
@@ -104,17 +104,17 @@ class SentryCheckInAdviceTest {
         assertEquals("monitor_slug_1e", doneCheckIn.monitorSlug)
         assertEquals(CheckInStatus.ERROR.apiName(), doneCheckIn.status)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub, times(2)).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes, times(2)).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn and heartbeat only, every method call creates only one check-in at the end`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceHeartbeat.hello()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -124,17 +124,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn and heartbeat only, every method call creates only one check-in at the end with error`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         assertThrows<RuntimeException> {
             sampleServiceHeartbeat.oops()
         }
@@ -145,31 +145,31 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.ERROR.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when method is annotated with @SentryCheckIn but slug is missing, does not create check-in`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceNoSlug.hello()
         assertEquals(1, result)
         assertEquals(0, checkInCaptor.allValues.size)
 
-        verify(hub, never()).pushScope()
-        verify(hub, never()).captureCheckIn(any())
-        verify(hub, never()).popScope()
+        verify(scopes, never()).pushScope()
+        verify(scopes, never()).captureCheckIn(any())
+        verify(scopes, never()).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property it is resolved correctly`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.hello()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -179,17 +179,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property that does not exist, raw value is used`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.helloUnresolvedProperty()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -199,17 +199,17 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Test
     fun `when @SentryCheckIn is passed a spring property that causes an exception, raw value is used`() {
         val checkInId = SentryId()
         val checkInCaptor = argumentCaptor<CheckIn>()
-        whenever(hub.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
+        whenever(scopes.captureCheckIn(checkInCaptor.capture())).thenReturn(checkInId)
         val result = sampleServiceSpringProperties.helloExceptionProperty()
         assertEquals(1, result)
         assertEquals(1, checkInCaptor.allValues.size)
@@ -219,10 +219,10 @@ class SentryCheckInAdviceTest {
         assertEquals(CheckInStatus.OK.apiName(), doneCheckIn.status)
         assertNotNull(doneCheckIn.duration)
 
-        val order = inOrder(hub)
-        order.verify(hub).pushScope()
-        order.verify(hub).captureCheckIn(any())
-        order.verify(hub).popScope()
+        val order = inOrder(scopes)
+        order.verify(scopes).pushScope()
+        order.verify(scopes).captureCheckIn(any())
+        order.verify(scopes).popScope()
     }
 
     @Configuration
@@ -243,10 +243,10 @@ class SentryCheckInAdviceTest {
         open fun sampleServiceSpringProperties() = SampleServiceSpringProperties()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
 
         companion object {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryExceptionResolverTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.exception.ExceptionMechanismException
@@ -17,7 +17,7 @@ import javax.servlet.http.HttpServletResponse
 import kotlin.test.Test
 
 class SentryExceptionResolverTest {
-    private val hub = mock<IHub>()
+    private val scopes = mock<IScopes>()
     private val transactionNameProvider = mock<TransactionNameProvider>()
 
     private val request = mock<HttpServletRequest>()
@@ -26,10 +26,10 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, sets wrapped exception for event`() {
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
         val expectedCause = RuntimeException("test")
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, expectedCause)
 
         assertThat(eventCaptor.firstValue.throwable).isEqualTo(expectedCause)
@@ -46,9 +46,9 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, sets fatal level for event`() {
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         assertThat(eventCaptor.firstValue.level).isEqualTo(SentryLevel.FATAL)
@@ -59,9 +59,9 @@ class SentryExceptionResolverTest {
         val expectedTransactionName = "test-transaction"
         whenever(transactionNameProvider.provideTransactionName(any())).thenReturn(expectedTransactionName)
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         assertThat(eventCaptor.firstValue.transaction).isEqualTo(expectedTransactionName)
@@ -71,9 +71,9 @@ class SentryExceptionResolverTest {
     @Test
     fun `when handles exception, provides spring resolver hint`() {
         val hintCaptor = argumentCaptor<Hint>()
-        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+        whenever(scopes.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
 
-        SentryExceptionResolver(hub, transactionNameProvider, 1)
+        SentryExceptionResolver(scopes, transactionNameProvider, 1)
             .resolveException(request, response, null, RuntimeException("test"))
 
         with(hintCaptor.firstValue) {
@@ -86,8 +86,8 @@ class SentryExceptionResolverTest {
     fun `when custom create event method provided, uses it to capture event`() {
         val expectedEvent = SentryEvent()
         val eventCaptor = argumentCaptor<SentryEvent>()
-        whenever(hub.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
-        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+        whenever(scopes.captureEvent(eventCaptor.capture(), any<Hint>())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(scopes, transactionNameProvider, 1) {
             override fun createEvent(request: HttpServletRequest, ex: Exception) = expectedEvent
         }
 
@@ -100,8 +100,8 @@ class SentryExceptionResolverTest {
     fun `when custom create hint method provided, uses it to capture event`() {
         val expectedHint = Hint()
         val hintCaptor = argumentCaptor<Hint>()
-        whenever(hub.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
-        val resolver = object : SentryExceptionResolver(hub, transactionNameProvider, 1) {
+        whenever(scopes.captureEvent(any(), hintCaptor.capture())).thenReturn(null)
+        val resolver = object : SentryExceptionResolver(scopes, transactionNameProvider, 1) {
             override fun createHint(request: HttpServletRequest, response: HttpServletResponse) = expectedHint
         }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryInitBeanPostProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryInitBeanPostProcessorTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -13,18 +13,18 @@ class SentryInitBeanPostProcessorTest {
     @Test
     fun closesSentryOnApplicationContextDestroy() {
         val ctx = AnnotationConfigApplicationContext(TestConfig::class.java)
-        val hub = ctx.getBean(IHub::class.java)
+        val scopes = ctx.getBean(IScopes::class.java)
         ctx.close()
-        verify(hub).close()
+        verify(scopes).close()
     }
 
     @Configuration
     open class TestConfig {
 
         @Bean(destroyMethod = "")
-        open fun hub() = mock<IHub>()
+        open fun scopes() = mock<IScopes>()
 
         @Bean
-        open fun sentryInitBeanPostProcessor() = SentryInitBeanPostProcessor(hub())
+        open fun sentryInitBeanPostProcessor() = SentryInitBeanPostProcessor(scopes())
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryRequestHttpServletRequestProcessorTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.spring.tracing.SpringMvcTransactionNameProvider
@@ -19,10 +19,10 @@ import kotlin.test.assertNotNull
 class SentryRequestHttpServletRequestProcessorTest {
 
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
 
         fun getSut(request: HttpServletRequest, options: SentryOptions = SentryOptions()): SentryRequestHttpServletRequestProcessor {
-            whenever(hub.options).thenReturn(options)
+            whenever(scopes.options).thenReturn(options)
             return SentryRequestHttpServletRequestProcessor(SpringMvcTransactionNameProvider(), request)
         }
     }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.spring
 
 import io.sentry.Breadcrumb
-import io.sentry.IHub
 import io.sentry.IScope
+import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
@@ -37,7 +37,7 @@ import kotlin.test.fail
 
 class SentrySpringFilterTest {
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
         lateinit var scope: IScope
@@ -45,15 +45,15 @@ class SentrySpringFilterTest {
 
         fun getSut(request: HttpServletRequest? = null, options: SentryOptions = SentryOptions()): SentrySpringFilter {
             scope = Scope(options)
-            whenever(hub.options).thenReturn(options)
-            whenever(hub.isEnabled).thenReturn(true)
-            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(hub).configureScope(any())
+            whenever(scopes.options).thenReturn(options)
+            whenever(scopes.isEnabled).thenReturn(true)
+            doAnswer { (it.arguments[0] as ScopeCallback).run(scope) }.whenever(scopes).configureScope(any())
             this.request = request
                 ?: MockHttpServletRequest().apply {
                     this.requestURI = "http://localhost:8080/some-uri"
                     this.method = "post"
                 }
-            return SentrySpringFilter(hub)
+            return SentrySpringFilter(scopes)
         }
     }
 
@@ -64,7 +64,7 @@ class SentrySpringFilterTest {
         val listener = fixture.getSut()
         listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).pushScope()
+        verify(fixture.scopes).pushScope()
     }
 
     @Test
@@ -72,7 +72,7 @@ class SentrySpringFilterTest {
         val listener = fixture.getSut()
         listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).addBreadcrumb(
+        verify(fixture.scopes).addBreadcrumb(
             check { it: Breadcrumb ->
                 Assertions.assertThat(it.getData("url")).isEqualTo("http://localhost:8080/some-uri")
                 Assertions.assertThat(it.getData("method")).isEqualTo("POST")
@@ -87,7 +87,7 @@ class SentrySpringFilterTest {
         val listener = fixture.getSut()
         listener.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).popScope()
+        verify(fixture.scopes).popScope()
     }
 
     @Test
@@ -99,7 +99,7 @@ class SentrySpringFilterTest {
             listener.doFilter(fixture.request, fixture.response, fixture.chain)
             fail()
         } catch (e: Exception) {
-            verify(fixture.hub).popScope()
+            verify(fixture.scopes).popScope()
         }
     }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryTaskDecoratorTest.kt
@@ -32,28 +32,28 @@ class SentryTaskDecoratorTest {
 
         val sut = SentryTaskDecorator()
 
-        val mainHub = Sentry.getCurrentHub()
-        val threadedHub = Sentry.getCurrentHub().clone()
+        val mainHub = Sentry.getCurrentScopes()
+        val threadedHub = Sentry.getCurrentScopes().clone()
 
         executor.submit {
-            Sentry.setCurrentHub(threadedHub)
+            Sentry.setCurrentScopes(threadedHub)
         }.get()
 
-        assertEquals(mainHub, Sentry.getCurrentHub())
+        assertEquals(mainHub, Sentry.getCurrentScopes())
 
         val callableFuture =
             executor.submit(
                 sut.decorate {
-                    assertNotEquals(mainHub, Sentry.getCurrentHub())
-                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    assertNotEquals(mainHub, Sentry.getCurrentScopes())
+                    assertNotEquals(threadedHub, Sentry.getCurrentScopes())
                 }
             )
 
         callableFuture.get()
 
         executor.submit {
-            assertNotEquals(mainHub, Sentry.getCurrentHub())
-            assertEquals(threadedHub, Sentry.getCurrentHub())
+            assertNotEquals(mainHub, Sentry.getCurrentScopes())
+            assertEquals(threadedHub, Sentry.getCurrentScopes())
         }.get()
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentryUserFilterTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.SentryOptions
 import io.sentry.protocol.User
 import org.mockito.kotlin.check
@@ -16,7 +16,7 @@ import kotlin.test.assertNull
 
 class SentryUserFilterTest {
     class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val request = MockHttpServletRequest()
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
@@ -25,8 +25,8 @@ class SentryUserFilterTest {
             val options = SentryOptions().apply {
                 this.isSendDefaultPii = isSendDefaultPii
             }
-            whenever(hub.options).thenReturn(options)
-            return SentryUserFilter(hub, userProviders)
+            whenever(scopes.options).thenReturn(options)
+            return SentryUserFilter(scopes, userProviders)
         }
     }
 
@@ -52,7 +52,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -72,7 +72,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -92,7 +92,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(sampleUser, it)
             }
@@ -118,7 +118,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals(mapOf("key" to "value", "new-key" to "new-value"), it.others)
             }
@@ -140,7 +140,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertEquals("192.168.0.1", it.ipAddress)
             }
@@ -162,7 +162,7 @@ class SentryUserFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).setUser(
+        verify(fixture.scopes).setUser(
             check {
                 assertNull(it.ipAddress)
             }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.exception
 
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.exception.ExceptionMechanismException
 import org.junit.runner.RunWith
@@ -30,18 +30,18 @@ class SentryCaptureExceptionParameterAdviceTest {
     lateinit var sampleService: SampleService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
+        reset(scopes)
     }
 
     @Test
     fun `captures exception passed to method annotated with @SentryCaptureException`() {
         val exception = RuntimeException("test exception")
         sampleService.methodTakingAnException(exception)
-        verify(hub).captureException(
+        verify(scopes).captureException(
             check {
                 assertTrue(it is ExceptionMechanismException)
                 assertEquals(exception, it.throwable)
@@ -60,10 +60,10 @@ class SentryCaptureExceptionParameterAdviceTest {
         open fun sampleService() = SampleService()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
     }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/graphql/SentrySpringSubscriptionHandlerTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/graphql/SentrySpringSubscriptionHandlerTest.kt
@@ -4,7 +4,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchPar
 import graphql.language.Document
 import graphql.language.OperationDefinition
 import graphql.schema.DataFetchingEnvironment
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.graphql.ExceptionReporter
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.anyOrNull
@@ -23,7 +23,7 @@ class SentrySpringSubscriptionHandlerTest {
     @Test
     fun `reports exception`() {
         val exception = IllegalStateException("some exception")
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val exceptionReporter = mock<ExceptionReporter>()
         val parameters = mock<InstrumentationFieldFetchParameters>()
         val dataFetchingEnvironment = mock<DataFetchingEnvironment>()
@@ -32,7 +32,7 @@ class SentrySpringSubscriptionHandlerTest {
             .build()
         whenever(dataFetchingEnvironment.document).thenReturn(document)
         whenever(parameters.environment).thenReturn(dataFetchingEnvironment)
-        val resultObject = SentrySpringSubscriptionHandler().onSubscriptionResult(Flux.error<Any?>(exception), hub, exceptionReporter, parameters)
+        val resultObject = SentrySpringSubscriptionHandler().onSubscriptionResult(Flux.error<Any?>(exception), scopes, exceptionReporter, parameters)
         assertThrows<IllegalStateException> {
             (resultObject as Flux<Any?>).blockFirst()
         }
@@ -41,7 +41,7 @@ class SentrySpringSubscriptionHandlerTest {
             same(exception),
             org.mockito.kotlin.check {
                 assertEquals(true, it.isSubscription)
-                assertSame(hub, it.hub)
+                assertSame(scopes, it.scopes)
                 assertEquals("query testQuery\n", it.query)
             },
             anyOrNull()
@@ -52,7 +52,7 @@ class SentrySpringSubscriptionHandlerTest {
     fun `unwraps SubscriptionPublisherException and reports cause`() {
         val exception = IllegalStateException("some exception")
         val wrappedException = SubscriptionPublisherException(emptyList(), exception)
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val exceptionReporter = mock<ExceptionReporter>()
         val parameters = mock<InstrumentationFieldFetchParameters>()
         val dataFetchingEnvironment = mock<DataFetchingEnvironment>()
@@ -61,7 +61,7 @@ class SentrySpringSubscriptionHandlerTest {
             .build()
         whenever(dataFetchingEnvironment.document).thenReturn(document)
         whenever(parameters.environment).thenReturn(dataFetchingEnvironment)
-        val resultObject = SentrySpringSubscriptionHandler().onSubscriptionResult(Flux.error<Any?>(wrappedException), hub, exceptionReporter, parameters)
+        val resultObject = SentrySpringSubscriptionHandler().onSubscriptionResult(Flux.error<Any?>(wrappedException), scopes, exceptionReporter, parameters)
         assertThrows<SubscriptionPublisherException> {
             (resultObject as Flux<Any?>).blockFirst()
         }
@@ -70,7 +70,7 @@ class SentrySpringSubscriptionHandlerTest {
             same(exception),
             org.mockito.kotlin.check {
                 assertEquals(true, it.isSubscription)
-                assertSame(hub, it.hub)
+                assertSame(scopes, it.scopes)
                 assertEquals("query testQuery\n", it.query)
             },
             anyOrNull()

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/mvc/SentrySpringIntegrationTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.mvc
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
 import io.sentry.Sentry
 import io.sentry.SentryOptions
@@ -104,7 +104,7 @@ class SentrySpringIntegrationTest {
     lateinit var anotherService: AnotherService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @LocalServerPort
     var port: Int? = null
@@ -260,7 +260,7 @@ class SentrySpringIntegrationTest {
         try {
             someService.aMethodThrowing()
         } catch (e: Exception) {
-            hub.captureException(e)
+            scopes.captureException(e)
         }
         verify(transport).send(
             checkEvent {
@@ -276,7 +276,7 @@ class SentrySpringIntegrationTest {
         try {
             someService.aMethodWithInnerSpanThrowing()
         } catch (e: Exception) {
-            hub.captureException(e)
+            scopes.captureException(e)
         }
         verify(transport).send(
             checkEvent {
@@ -370,20 +370,20 @@ open class App {
     open fun springSecuritySentryUserProvider(sentryOptions: SentryOptions) = SpringSecuritySentryUserProvider(sentryOptions)
 
     @Bean
-    open fun sentryUserFilter(hub: IHub, @Lazy sentryUserProviders: List<SentryUserProvider>) = FilterRegistrationBean<SentryUserFilter>().apply {
-        this.filter = SentryUserFilter(hub, sentryUserProviders)
+    open fun sentryUserFilter(scopes: IScopes, @Lazy sentryUserProviders: List<SentryUserProvider>) = FilterRegistrationBean<SentryUserFilter>().apply {
+        this.filter = SentryUserFilter(scopes, sentryUserProviders)
         this.order = Ordered.LOWEST_PRECEDENCE
     }
 
     @Bean
-    open fun sentrySpringFilter(hub: IHub) = FilterRegistrationBean<SentrySpringFilter>().apply {
-        this.filter = SentrySpringFilter(hub)
+    open fun sentrySpringFilter(scopes: IScopes) = FilterRegistrationBean<SentrySpringFilter>().apply {
+        this.filter = SentrySpringFilter(scopes)
         this.order = Ordered.HIGHEST_PRECEDENCE
     }
 
     @Bean
-    open fun sentryTracingFilter(hub: IHub) = FilterRegistrationBean<SentryTracingFilter>().apply {
-        this.filter = SentryTracingFilter(hub)
+    open fun sentryTracingFilter(scopes: IScopes) = FilterRegistrationBean<SentryTracingFilter>().apply {
+        this.filter = SentryTracingFilter(scopes)
         this.order = Ordered.HIGHEST_PRECEDENCE + 1 // must run after SentrySpringFilter
     }
 
@@ -391,13 +391,13 @@ open class App {
     open fun sentryTaskDecorator() = SentryTaskDecorator()
 
     @Bean
-    open fun webClient(hub: IHub): WebClient {
+    open fun webClient(scopes: IScopes): WebClient {
         return WebClient.builder()
             .filter(
                 ExchangeFilterFunctions
                     .basicAuthentication("user", "password")
             )
-            .filter(SentrySpanClientWebRequestFilter(hub)).build()
+            .filter(SentrySpanClientWebRequestFilter(scopes)).build()
     }
 }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTracingFilterTest.kt
@@ -1,7 +1,7 @@
 package io.sentry.spring.tracing
 
-import io.sentry.IHub
 import io.sentry.ILogger
+import io.sentry.IScopes
 import io.sentry.PropagationContext
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -38,7 +38,7 @@ import kotlin.test.fail
 
 class SentryTracingFilterTest {
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         val request = MockHttpServletRequest()
         val response = MockHttpServletResponse()
         val chain = mock<FilterChain>()
@@ -50,7 +50,7 @@ class SentryTracingFilterTest {
         val logger = mock<ILogger>()
 
         init {
-            whenever(hub.options).thenReturn(options)
+            whenever(scopes.options).thenReturn(options)
         }
 
         fun getSut(isEnabled: Boolean = true, status: Int = 200, sentryTraceHeader: String? = null, baggageHeaders: List<String>? = null): SentryTracingFilter {
@@ -61,16 +61,16 @@ class SentryTracingFilterTest {
             whenever(transactionNameProvider.provideTransactionSource()).thenReturn(TransactionNameSource.CUSTOM)
             if (sentryTraceHeader != null) {
                 request.addHeader("sentry-trace", sentryTraceHeader)
-                whenever(hub.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
+                whenever(scopes.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
             }
             if (baggageHeaders != null) {
                 request.addHeader("baggage", baggageHeaders)
             }
             response.status = status
-            whenever(hub.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
-            whenever(hub.isEnabled).thenReturn(isEnabled)
-            whenever(hub.continueTrace(any(), any())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
-            return SentryTracingFilter(hub, transactionNameProvider)
+            whenever(scopes.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
+            whenever(scopes.isEnabled).thenReturn(isEnabled)
+            whenever(scopes.continueTrace(any(), any())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
+            return SentryTracingFilter(scopes, transactionNameProvider)
         }
     }
 
@@ -82,7 +82,7 @@ class SentryTracingFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).startTransaction(
+        verify(fixture.scopes).startTransaction(
             check<TransactionContext> {
                 assertEquals("POST /product/12", it.name)
                 assertEquals(TransactionNameSource.URL, it.transactionNameSource)
@@ -95,7 +95,7 @@ class SentryTracingFilterTest {
             }
         )
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("POST /product/{id}")
                 assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.OK)
@@ -114,7 +114,7 @@ class SentryTracingFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
             },
@@ -130,7 +130,7 @@ class SentryTracingFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.status).isNull()
             },
@@ -146,7 +146,7 @@ class SentryTracingFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.parentSpanId).isNull()
             },
@@ -163,7 +163,7 @@ class SentryTracingFilterTest {
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.parentSpanId).isEqualTo(parentSpanId)
             },
@@ -174,15 +174,15 @@ class SentryTracingFilterTest {
     }
 
     @Test
-    fun `when hub is disabled, components are not invoked`() {
+    fun `when scopes is disabled, components are not invoked`() {
         val filter = fixture.getSut(isEnabled = false)
 
         filter.doFilter(fixture.request, fixture.response, fixture.chain)
 
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
 
-        verify(fixture.hub).isEnabled
-        verifyNoMoreInteractions(fixture.hub)
+        verify(fixture.scopes).isEnabled
+        verifyNoMoreInteractions(fixture.scopes)
         verify(fixture.transactionNameProvider, never()).provideTransactionName(any())
     }
 
@@ -196,7 +196,7 @@ class SentryTracingFilterTest {
             fail("filter is expected to rethrow exception")
         } catch (_: Exception) {
         }
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
             },
@@ -216,10 +216,10 @@ class SentryTracingFilterTest {
 
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
 
-        verify(fixture.hub).isEnabled
-        verify(fixture.hub, times(2)).options
-        verify(fixture.hub).continueTrace(anyOrNull(), anyOrNull())
-        verifyNoMoreInteractions(fixture.hub)
+        verify(fixture.scopes).isEnabled
+        verify(fixture.scopes, times(2)).options
+        verify(fixture.scopes).continueTrace(anyOrNull(), anyOrNull())
+        verifyNoMoreInteractions(fixture.scopes)
         verify(fixture.transactionNameProvider, never()).provideTransactionName(any())
     }
 
@@ -233,7 +233,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.parentSpanId).isNull()
             },
@@ -253,7 +253,7 @@ class SentryTracingFilterTest {
 
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
 
-        verify(fixture.hub).captureTransaction(
+        verify(fixture.scopes).captureTransaction(
             check {
                 assertThat(it.contexts.trace!!.parentSpanId).isNull()
             },
@@ -275,9 +275,9 @@ class SentryTracingFilterTest {
 
         verify(fixture.chain).doFilter(fixture.request, fixture.response)
 
-        verify(fixture.hub).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
+        verify(fixture.scopes).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
 
-        verify(fixture.hub, never()).captureTransaction(
+        verify(fixture.scopes, never()).captureTransaction(
             anyOrNull<SentryTransaction>(),
             anyOrNull<TraceContext>(),
             anyOrNull(),

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/tracing/SentryTransactionAdviceTest.kt
@@ -1,6 +1,6 @@
 package io.sentry.spring.tracing
 
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
@@ -44,13 +44,13 @@ class SentryTransactionAdviceTest {
     lateinit var classAnnotatedWithOperationSampleService: ClassAnnotatedWithOperationSampleService
 
     @Autowired
-    lateinit var hub: IHub
+    lateinit var scopes: IScopes
 
     @BeforeTest
     fun setup() {
-        reset(hub)
-        whenever(hub.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
-        whenever(hub.options).thenReturn(
+        reset(scopes)
+        whenever(scopes.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
+        whenever(scopes.options).thenReturn(
             SentryOptions().apply {
                 dsn = "https://key@sentry.io/proj"
             }
@@ -60,7 +60,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `creates transaction around method annotated with @SentryTransaction`() {
         sampleService.methodWithTransactionNameSet()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("customName")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("bean")
@@ -76,7 +76,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `when method annotated with @SentryTransaction throws exception, sets error status on transaction`() {
         assertThrows<RuntimeException> { sampleService.methodThrowingException() }
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
             },
@@ -89,7 +89,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `when @SentryTransaction has no name set, sets transaction name as className dot methodName`() {
         sampleService.methodWithoutTransactionNameSet()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("SampleService.methodWithoutTransactionNameSet")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("op")
@@ -102,18 +102,18 @@ class SentryTransactionAdviceTest {
 
     @Test
     fun `when transaction is already active, does not start new transaction`() {
-        whenever(hub.options).thenReturn(SentryOptions())
-        whenever(hub.span).then { SentryTracer(TransactionContext("aTransaction", "op"), hub) }
+        whenever(scopes.options).thenReturn(SentryOptions())
+        whenever(scopes.span).then { SentryTracer(TransactionContext("aTransaction", "op"), scopes) }
 
         sampleService.methodWithTransactionNameSet()
 
-        verify(hub, times(0)).captureTransaction(any(), any<TraceContext>())
+        verify(scopes, times(0)).captureTransaction(any(), any<TraceContext>())
     }
 
     @Test
     fun `creates transaction around method in class annotated with @SentryTransaction`() {
         classAnnotatedSampleService.hello()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("ClassAnnotatedSampleService.hello")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("op")
@@ -127,7 +127,7 @@ class SentryTransactionAdviceTest {
     @Test
     fun `creates transaction with operation set around method in class annotated with @SentryTransaction`() {
         classAnnotatedWithOperationSampleService.hello()
-        verify(hub).captureTransaction(
+        verify(scopes).captureTransaction(
             check {
                 assertThat(it.transaction).isEqualTo("ClassAnnotatedWithOperationSampleService.hello")
                 assertThat(it.contexts.trace!!.operation).isEqualTo("my-op")
@@ -141,13 +141,13 @@ class SentryTransactionAdviceTest {
     @Test
     fun `pushes the scope when advice starts`() {
         classAnnotatedSampleService.hello()
-        verify(hub).pushScope()
+        verify(scopes).pushScope()
     }
 
     @Test
     fun `pops the scope when advice finishes`() {
         classAnnotatedSampleService.hello()
-        verify(hub).popScope()
+        verify(scopes).popScope()
     }
 
     @Configuration
@@ -165,10 +165,10 @@ class SentryTransactionAdviceTest {
         open fun classAnnotatedWithOperationSampleService() = ClassAnnotatedWithOperationSampleService()
 
         @Bean
-        open fun hub(): IHub {
-            val hub = mock<IHub>()
-            Sentry.setCurrentHub(hub)
-            return hub
+        open fun scopes(): IScopes {
+            val scopes = mock<IScopes>()
+            Sentry.setCurrentScopes(scopes)
+            return scopes
         }
     }
 

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryScheduleHookTest.kt
@@ -33,28 +33,28 @@ class SentryScheduleHookTest {
 
         val sut = SentryScheduleHook()
 
-        val mainHub = Sentry.getCurrentHub()
-        val threadedHub = Sentry.getCurrentHub().clone()
+        val mainHub = Sentry.getCurrentScopes()
+        val threadedHub = Sentry.getCurrentScopes().clone()
 
         executor.submit {
             Sentry.setCurrentHub(threadedHub)
         }.get()
 
-        assertEquals(mainHub, Sentry.getCurrentHub())
+        assertEquals(mainHub, Sentry.getCurrentScopes())
 
         val callableFuture =
             executor.submit(
                 sut.apply {
-                    assertNotEquals(mainHub, Sentry.getCurrentHub())
-                    assertNotEquals(threadedHub, Sentry.getCurrentHub())
+                    assertNotEquals(mainHub, Sentry.getCurrentScopes())
+                    assertNotEquals(threadedHub, Sentry.getCurrentScopes())
                 }
             )
 
         callableFuture.get()
 
         executor.submit {
-            assertNotEquals(mainHub, Sentry.getCurrentHub())
-            assertEquals(threadedHub, Sentry.getCurrentHub())
+            assertNotEquals(mainHub, Sentry.getCurrentScopes())
+            assertEquals(threadedHub, Sentry.getCurrentScopes())
         }.get()
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebFluxTracingFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebFluxTracingFilterTest.kt
@@ -2,8 +2,9 @@ package io.sentry.spring.webflux
 
 import io.sentry.Breadcrumb
 import io.sentry.Hint
-import io.sentry.IHub
+import io.sentry.HubScopesWrapper
 import io.sentry.ILogger
+import io.sentry.IScopes
 import io.sentry.PropagationContext
 import io.sentry.ScopeCallback
 import io.sentry.Sentry
@@ -17,7 +18,7 @@ import io.sentry.TransactionOptions
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.TransactionNameSource
-import io.sentry.spring.webflux.SentryWebFilter.SENTRY_HUB_KEY
+import io.sentry.spring.webflux.SentryWebFilter.SENTRY_SCOPES_KEY
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -47,7 +48,7 @@ import kotlin.test.fail
 
 class SentryWebFluxTracingFilterTest {
     private class Fixture {
-        val hub = mock<IHub>()
+        val scopes = mock<IScopes>()
         lateinit var request: MockServerHttpRequest
         lateinit var exchange: MockServerWebExchange
         val chain = mock<WebFilterChain>()
@@ -58,35 +59,37 @@ class SentryWebFluxTracingFilterTest {
         val logger = mock<ILogger>()
 
         init {
-            whenever(hub.options).thenReturn(options)
+            whenever(scopes.options).thenReturn(options)
         }
 
         fun getSut(isEnabled: Boolean = true, status: HttpStatus = HttpStatus.OK, sentryTraceHeader: String? = null, baggageHeaders: List<String>? = null, method: HttpMethod = HttpMethod.POST): SentryWebFilter {
             var requestBuilder = MockServerHttpRequest.method(method, "/product/{id}", 12)
             if (sentryTraceHeader != null) {
                 requestBuilder = requestBuilder.header("sentry-trace", sentryTraceHeader)
-                whenever(hub.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
+                whenever(scopes.startTransaction(any(), check<TransactionOptions> { it.isBindToScope })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
             }
             if (baggageHeaders != null) {
                 requestBuilder = requestBuilder.header("baggage", *baggageHeaders.toTypedArray())
             }
             request = requestBuilder.build()
             exchange = MockServerWebExchange.builder(request).build()
-            exchange.attributes.put(SENTRY_HUB_KEY, hub)
+            exchange.attributes.put(SENTRY_SCOPES_KEY, scopes)
             exchange.attributes.put(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, PathPatternParser().parse("/product/{id}"))
             exchange.response.statusCode = status
-            whenever(hub.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, hub) }
-            whenever(hub.isEnabled).thenReturn(isEnabled)
+            whenever(scopes.startTransaction(any(), check<TransactionOptions> { assertTrue(it.isBindToScope) })).thenAnswer { SentryTracer(it.arguments[0] as TransactionContext, scopes) }
+            whenever(scopes.isEnabled).thenReturn(isEnabled)
             whenever(chain.filter(any())).thenReturn(Mono.create { s -> s.success() })
-            whenever(hub.continueTrace(anyOrNull(), anyOrNull())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
-            return SentryWebFilter(hub)
+            whenever(scopes.continueTrace(anyOrNull(), anyOrNull())).thenAnswer { TransactionContext.fromPropagationContext(PropagationContext.fromHeaders(logger, it.arguments[0] as String?, it.arguments[1] as List<String>?)) }
+            return SentryWebFilter(scopes)
         }
     }
 
     private val fixture = Fixture()
 
-    fun withMockHub(closure: () -> Unit) = Mockito.mockStatic(Sentry::class.java).use {
-        it.`when`<Any> { Sentry.cloneMainHub() }.thenReturn(fixture.hub)
+    fun withMockScopes(closure: () -> Unit) = Mockito.mockStatic(Sentry::class.java).use {
+        it.`when`<Any> { Sentry.getCurrentHub() }.thenReturn(HubScopesWrapper(fixture.scopes))
+        it.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(fixture.scopes)
+        it.`when`<Any> { Sentry.cloneMainHub() }.thenReturn(fixture.scopes)
         closure.invoke()
     }
 
@@ -94,10 +97,10 @@ class SentryWebFluxTracingFilterTest {
     fun `creates transaction around the request`() {
         val filter = fixture.getSut()
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).startTransaction(
+            verify(fixture.scopes).startTransaction(
                 check<TransactionContext> {
                     assertEquals("POST /product/12", it.name)
                     assertEquals(TransactionNameSource.URL, it.transactionNameSource)
@@ -110,7 +113,7 @@ class SentryWebFluxTracingFilterTest {
                 }
             )
             verify(fixture.chain).filter(fixture.exchange)
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.transaction).isEqualTo("POST /product/{id}")
                     assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.OK)
@@ -129,10 +132,10 @@ class SentryWebFluxTracingFilterTest {
     fun `sets correct span status based on the response status`() {
         val filter = fixture.getSut(status = HttpStatus.INTERNAL_SERVER_ERROR)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
                     assertThat(it.contexts.response!!.statusCode).isEqualTo(500)
@@ -148,10 +151,10 @@ class SentryWebFluxTracingFilterTest {
     fun `does not set span status for response status that dont match predefined span statuses`() {
         val filter = fixture.getSut(status = HttpStatus.FOUND)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.status).isNull()
                 },
@@ -166,10 +169,10 @@ class SentryWebFluxTracingFilterTest {
     fun `when sentry trace is not present, transaction does not have parentSpanId set`() {
         val filter = fixture.getSut()
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -185,10 +188,10 @@ class SentryWebFluxTracingFilterTest {
         val parentSpanId = SpanId()
         val filter = fixture.getSut(sentryTraceHeader = "${SentryId()}-$parentSpanId-1")
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isEqualTo(parentSpanId)
                 },
@@ -200,16 +203,16 @@ class SentryWebFluxTracingFilterTest {
     }
 
     @Test
-    fun `when hub is disabled, components are not invoked`() {
+    fun `when scopes is disabled, components are not invoked`() {
         val filter = fixture.getSut(isEnabled = false)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).isEnabled
-            verifyNoMoreInteractions(fixture.hub)
+            verify(fixture.scopes).isEnabled
+            verifyNoMoreInteractions(fixture.scopes)
         }
     }
 
@@ -217,7 +220,7 @@ class SentryWebFluxTracingFilterTest {
     fun `sets status to internal server error when chain throws exception`() {
         val filter = fixture.getSut()
 
-        withMockHub {
+        withMockScopes {
             whenever(fixture.chain.filter(any())).thenReturn(Mono.error(RuntimeException("error")))
 
             try {
@@ -225,7 +228,7 @@ class SentryWebFluxTracingFilterTest {
                 fail("filter is expected to rethrow exception")
             } catch (_: Exception) {
             }
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.status).isEqualTo(SpanStatus.INTERNAL_ERROR)
                 },
@@ -240,21 +243,21 @@ class SentryWebFluxTracingFilterTest {
     fun `does not track OPTIONS request with traceOptionsRequests=false`() {
         val filter = fixture.getSut(method = HttpMethod.OPTIONS)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = false
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).isEnabled
-            verify(fixture.hub, times(2)).options
-            verify(fixture.hub).continueTrace(anyOrNull(), anyOrNull())
-            verify(fixture.hub).pushScope()
-            verify(fixture.hub).addBreadcrumb(any<Breadcrumb>(), any<Hint>())
-            verify(fixture.hub).configureScope(any<ScopeCallback>())
-            verify(fixture.hub).popScope()
-            verifyNoMoreInteractions(fixture.hub)
+            verify(fixture.scopes).isEnabled
+            verify(fixture.scopes, times(2)).options
+            verify(fixture.scopes).continueTrace(anyOrNull(), anyOrNull())
+            verify(fixture.scopes).pushScope()
+            verify(fixture.scopes).addBreadcrumb(any<Breadcrumb>(), any<Hint>())
+            verify(fixture.scopes).configureScope(any<ScopeCallback>())
+            verify(fixture.scopes).popScope()
+            verifyNoMoreInteractions(fixture.scopes)
         }
     }
 
@@ -262,14 +265,14 @@ class SentryWebFluxTracingFilterTest {
     fun `tracks OPTIONS request with traceOptionsRequests=true`() {
         val filter = fixture.getSut(method = HttpMethod.OPTIONS)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = true
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -284,14 +287,14 @@ class SentryWebFluxTracingFilterTest {
     fun `tracks POST request with traceOptionsRequests=false`() {
         val filter = fixture.getSut(method = HttpMethod.POST)
 
-        withMockHub {
+        withMockScopes {
             fixture.options.isTraceOptionsRequests = false
 
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub).captureTransaction(
+            verify(fixture.scopes).captureTransaction(
                 check {
                     assertThat(it.contexts.trace!!.parentSpanId).isNull()
                 },
@@ -310,19 +313,19 @@ class SentryWebFluxTracingFilterTest {
         fixture.options.enableTracing = false
         val filter = fixture.getSut(sentryTraceHeader = sentryTraceHeaderString, baggageHeaders = baggageHeaderStrings)
 
-        withMockHub {
+        withMockScopes {
             filter.filter(fixture.exchange, fixture.chain).block()
 
             verify(fixture.chain).filter(fixture.exchange)
 
-            verify(fixture.hub, never()).captureTransaction(
+            verify(fixture.scopes, never()).captureTransaction(
                 anyOrNull<SentryTransaction>(),
                 anyOrNull<TraceContext>(),
                 anyOrNull(),
                 anyOrNull()
             )
 
-            verify(fixture.hub).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
+            verify(fixture.scopes).continueTrace(eq(sentryTraceHeaderString), eq(baggageHeaderStrings))
         }
     }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.spring.webflux
 
-import io.sentry.HubAdapter
-import io.sentry.IHub
+import io.sentry.IScopes
 import io.sentry.ITransportFactory
+import io.sentry.ScopesAdapter
 import io.sentry.Sentry
 import io.sentry.checkEvent
 import io.sentry.checkTransaction
@@ -160,13 +160,13 @@ open class App {
     open fun mockTransport() = transport
 
     @Bean
-    open fun hub() = HubAdapter.getInstance()
+    open fun scopes() = ScopesAdapter.getInstance()
 
     @Bean
-    open fun sentryFilter(hub: IHub) = SentryWebFilter(hub)
+    open fun sentryFilter(scopes: IScopes) = SentryWebFilter(scopes)
 
     @Bean
-    open fun sentryWebExceptionHandler(hub: IHub) = SentryWebExceptionHandler(hub)
+    open fun sentryWebExceptionHandler(scopes: IScopes) = SentryWebExceptionHandler(scopes)
 
     @Bean
     open fun sentryScheduleHookRegistrar() = ApplicationRunner {


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Follow up for https://github.com/getsentry/sentry-java/pull/3297 changing Spring integrations.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
