### PR TITLE
[SR] Cleanups and session deadline

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -27,7 +27,6 @@ import io.sentry.android.core.cache.AndroidEnvelopeCache
 import io.sentry.android.core.performance.AppStartMetrics
 import io.sentry.android.fragment.FragmentLifecycleIntegration
 import io.sentry.android.replay.ReplayIntegration
-import io.sentry.android.replay.getReplayIntegration
 import io.sentry.android.timber.SentryTimberIntegration
 import io.sentry.cache.IEnvelopeCache
 import io.sentry.cache.PersistingOptionsObserver
@@ -319,7 +318,7 @@ class SentryAndroidTest {
     @Config(sdk = [26])
     fun `init starts session replay if app is in foreground`() {
         initSentryWithForegroundImportance(true) { _ ->
-            assertTrue(Sentry.getCurrentHub().getReplayIntegration()!!.isRecording())
+            assertTrue(Sentry.getCurrentHub().options.replayController.isRecording())
         }
     }
 
@@ -327,7 +326,7 @@ class SentryAndroidTest {
     @Config(sdk = [26])
     fun `init does not start session replay if the app is in background`() {
         initSentryWithForegroundImportance(false) { _ ->
-            assertFalse(Sentry.getCurrentHub().getReplayIntegration()!!.isRecording())
+            assertFalse(Sentry.getCurrentHub().options.replayController.isRecording())
         }
     }
 

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -33,7 +33,7 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
 	public fun close ()V
-	public final fun isRecording ()Z
+	public fun isRecording ()Z
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
@@ -44,8 +44,7 @@ public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integr
 }
 
 public final class io/sentry/android/replay/ReplayIntegrationKt {
-	public static final fun getReplayIntegration (Lio/sentry/IHub;)Lio/sentry/android/replay/ReplayIntegration;
-	public static final fun gracefullyShutdown (Ljava/util/concurrent/ExecutorService;Lio/sentry/SentryOptions;)V
+	public static final fun submitSafely (Ljava/util/concurrent/ExecutorService;Lio/sentry/ILogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 }
 
 public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallback {

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -43,10 +43,6 @@ public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integr
 	public fun stop ()V
 }
 
-public final class io/sentry/android/replay/ReplayIntegrationKt {
-	public static final fun submitSafely (Ljava/util/concurrent/ExecutorService;Lio/sentry/ILogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
-}
-
 public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallback {
 	public abstract fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
@@ -1,0 +1,67 @@
+package io.sentry.android.replay.util
+
+import io.sentry.SentryLevel.ERROR
+import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+internal fun ExecutorService.gracefullyShutdown(options: SentryOptions) {
+    synchronized(this) {
+        if (!isShutdown) {
+            shutdown()
+        }
+        try {
+            if (!awaitTermination(options.shutdownTimeoutMillis, MILLISECONDS)) {
+                shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            shutdownNow()
+            Thread.currentThread().interrupt()
+        }
+    }
+}
+
+internal fun ExecutorService.submitSafely(
+    options: SentryOptions,
+    taskName: String,
+    task: Runnable
+): Future<*>? {
+    return try {
+        submit {
+            try {
+                task.run()
+            } catch (e: Throwable) {
+                options.logger.log(ERROR, "Failed to execute task $taskName", e)
+            }
+        }
+    } catch (e: Throwable) {
+        options.logger.log(ERROR, "Failed to submit task $taskName to executor", e)
+        null
+    }
+}
+
+internal fun ScheduledExecutorService.scheduleAtFixedRateSafely(
+    options: SentryOptions,
+    taskName: String,
+    initialDelay: Long,
+    period: Long,
+    unit: TimeUnit,
+    task: Runnable
+): ScheduledFuture<*>? {
+    return try {
+        scheduleAtFixedRate({
+            try {
+                task.run()
+            } catch (e: Throwable) {
+                options.logger.log(ERROR, "Failed to execute task $taskName", e)
+            }
+        }, initialDelay, period, unit)
+    } catch (e: Throwable) {
+        options.logger.log(ERROR, "Failed to submit task $taskName to executor", e)
+        null
+    }
+}

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -156,5 +156,7 @@
 
       <meta-data android:name="io.sentry.performance-v2.enable" android:value="true" />
 
+      <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
+
     </application>
 </manifest>

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2569,6 +2569,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getErrorReplayDuration ()J
 	public fun getErrorSampleRate ()Ljava/lang/Double;
 	public fun getFrameRate ()I
+	public fun getSessionDuration ()J
 	public fun getSessionSampleRate ()Ljava/lang/Double;
 	public fun getSessionSegmentDuration ()J
 	public fun isSessionReplayEnabled ()Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1206,6 +1206,7 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 
 public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public static fun getInstance ()Lio/sentry/NoOpReplayController;
+	public fun isRecording ()Z
 	public fun pause ()V
 	public fun resume ()V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
@@ -1604,6 +1605,7 @@ public final class io/sentry/PropagationContext {
 }
 
 public abstract interface class io/sentry/ReplayController {
+	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
 	public abstract fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -25,5 +25,10 @@ public final class NoOpReplayController implements ReplayController {
   public void resume() {}
 
   @Override
+  public boolean isRecording() {
+    return false;
+  }
+
+  @Override
   public void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint) {}
 }

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -13,5 +13,7 @@ public interface ReplayController {
 
   void resume();
 
+  boolean isRecording();
+
   void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint);
 }

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -22,21 +22,24 @@ public final class SentryReplayOptions {
 
   /**
    * Defines the quality of the session replay. Higher bit rates have better replay quality, but
-   * also affect the final payload size to transfer. The default value is 20kbps;
+   * also affect the final payload size to transfer, defaults to 20kbps.
    */
   private int bitRate = 20_000;
 
   /**
    * Number of frames per second of the replay. The bigger the number, the more accurate the replay
-   * will be, but also more data to transfer and more CPU load.
+   * will be, but also more data to transfer and more CPU load, defaults to 1fps.
    */
   private int frameRate = 1;
 
-  /** The maximum duration of replays for error events. */
+  /** The maximum duration of replays for error events, defaults to 30s. */
   private long errorReplayDuration = 30_000L;
 
-  /** The maximum duration of the segment of a session replay. */
+  /** The maximum duration of the segment of a session replay, defaults to 5s. */
   private long sessionSegmentDuration = 5000L;
+
+  /** The maximum duration of a full session replay, defaults to 1h. */
+  private long sessionDuration = 60 * 60 * 1000L;
 
   public SentryReplayOptions() {}
 
@@ -102,5 +105,10 @@ public final class SentryReplayOptions {
   @ApiStatus.Internal
   public long getSessionSegmentDuration() {
     return sessionSegmentDuration;
+  }
+
+  @ApiStatus.Internal
+  public long getSessionDuration() {
+    return sessionDuration;
   }
 }


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
A few improvements this PR does:
* Cleans up older replay folders when starting a new one
* Adds deadline of 1 hour for full session recordings
* Adds safe wrappers for executors that handle failures gracefully when submitting or executing tasks

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
