### PR TITLE
Replace `ThreadLocal` with scope storage

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -259,6 +259,13 @@ public final class io/sentry/DeduplicateMultithreadedEventProcessor : io/sentry/
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 
+public final class io/sentry/DefaultScopesStorage : io/sentry/IScopesStorage {
+	public fun <init> ()V
+	public fun close ()V
+	public fun get ()Lio/sentry/IScopes;
+	public fun set (Lio/sentry/IScopes;)Lio/sentry/ISentryLifecycleToken;
+}
+
 public final class io/sentry/DefaultTransactionPerformanceCollector : io/sentry/TransactionPerformanceCollector {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close ()V
@@ -792,6 +799,12 @@ public abstract interface class io/sentry/IScopes {
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
 
+public abstract interface class io/sentry/IScopesStorage {
+	public abstract fun close ()V
+	public abstract fun get ()Lio/sentry/IScopes;
+	public abstract fun set (Lio/sentry/IScopes;)Lio/sentry/ISentryLifecycleToken;
+}
+
 public abstract interface class io/sentry/ISentryClient {
 	public abstract fun captureCheckIn (Lio/sentry/CheckIn;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
@@ -829,6 +842,10 @@ public abstract interface class io/sentry/ISentryExecutorService {
 	public abstract fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
+}
+
+public abstract interface class io/sentry/ISentryLifecycleToken : java/lang/AutoCloseable {
+	public abstract fun close ()V
 }
 
 public abstract interface class io/sentry/ISerializer {
@@ -1388,6 +1405,13 @@ public final class io/sentry/NoOpScopes : io/sentry/IScopes {
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun traceHeaders ()Lio/sentry/SentryTraceHeader;
 	public fun withScope (Lio/sentry/ScopeCallback;)V
+}
+
+public final class io/sentry/NoOpScopesStorage : io/sentry/IScopesStorage {
+	public fun close ()V
+	public fun get ()Lio/sentry/IScopes;
+	public static fun getInstance ()Lio/sentry/NoOpScopesStorage;
+	public fun set (Lio/sentry/IScopes;)Lio/sentry/ISentryLifecycleToken;
 }
 
 public final class io/sentry/NoOpSpan : io/sentry/ISpan {

--- a/sentry/src/main/java/io/sentry/DefaultScopesStorage.java
+++ b/sentry/src/main/java/io/sentry/DefaultScopesStorage.java
@@ -1,0 +1,42 @@
+package io.sentry;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class DefaultScopesStorage implements IScopesStorage {
+
+  private static final @NotNull ThreadLocal<IScopes> currentScopes = new ThreadLocal<>();
+
+  @Override
+  public ISentryLifecycleToken set(@Nullable IScopes scopes) {
+    final @Nullable IScopes oldScopes = get();
+    currentScopes.set(scopes);
+    return new DefaultScopesLifecycleToken(oldScopes);
+  }
+
+  @Override
+  public @Nullable IScopes get() {
+    return currentScopes.get();
+  }
+
+  @Override
+  public void close() {
+    // TODO prevent further storing? would this cause problems if singleton, closed and
+    // re-initialized?
+    currentScopes.remove();
+  }
+
+  static final class DefaultScopesLifecycleToken implements ISentryLifecycleToken {
+
+    private final @Nullable IScopes oldValue;
+
+    DefaultScopesLifecycleToken(final @Nullable IScopes scopes) {
+      this.oldValue = scopes;
+    }
+
+    @Override
+    public void close() {
+      currentScopes.set(oldValue);
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/IScopesStorage.java
+++ b/sentry/src/main/java/io/sentry/IScopesStorage.java
@@ -1,0 +1,13 @@
+package io.sentry;
+
+import org.jetbrains.annotations.Nullable;
+
+public interface IScopesStorage {
+
+  ISentryLifecycleToken set(final @Nullable IScopes scopes);
+
+  @Nullable
+  IScopes get();
+
+  void close();
+}

--- a/sentry/src/main/java/io/sentry/ISentryLifecycleToken.java
+++ b/sentry/src/main/java/io/sentry/ISentryLifecycleToken.java
@@ -1,0 +1,8 @@
+package io.sentry;
+
+public interface ISentryLifecycleToken extends AutoCloseable {
+
+  // overridden to not have a checked exception on the method.
+  @Override
+  void close();
+}

--- a/sentry/src/main/java/io/sentry/NoOpScopesStorage.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopesStorage.java
@@ -1,0 +1,40 @@
+package io.sentry;
+
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpScopesStorage implements IScopesStorage {
+  private static final NoOpScopesStorage instance = new NoOpScopesStorage();
+
+  private NoOpScopesStorage() {}
+
+  public static NoOpScopesStorage getInstance() {
+    return instance;
+  }
+
+  @Override
+  public ISentryLifecycleToken set(@Nullable IScopes scopes) {
+    return NoOpScopesLifecycleToken.getInstance();
+  }
+
+  @Override
+  public @Nullable IScopes get() {
+    return NoOpScopes.getInstance();
+  }
+
+  @Override
+  public void close() {}
+
+  static final class NoOpScopesLifecycleToken implements ISentryLifecycleToken {
+
+    private static final NoOpScopesLifecycleToken instance = new NoOpScopesLifecycleToken();
+
+    private NoOpScopesLifecycleToken() {}
+
+    public static NoOpScopesLifecycleToken getInstance() {
+      return instance;
+    }
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Replace `ThreadLocal` in `Sentry` with scopes storage.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Can use token to clean up forked `Scopes`. Can configure store to use OpenTelemetry `Context` under the hood (in a follow up PR).

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
