### PR TITLE
fixed default deadline timeout to 30s instead of 300s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for Spring Rest Client ([#3199](https://github.com/getsentry/sentry-java/pull/3199))
 
+### Fixes
+
+- Fixed default deadline timeout to 30s instead of 300s ([#3322](https://github.com/getsentry/sentry-java/pull/3322))
+
 ## 7.6.0
 
 ### Features

--- a/sentry/src/main/java/io/sentry/TransactionOptions.java
+++ b/sentry/src/main/java/io/sentry/TransactionOptions.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 /** Sentry Transaction options */
 public final class TransactionOptions extends SpanOptions {
 
-  @ApiStatus.Internal public static final long DEFAULT_DEADLINE_TIMEOUT_AUTO_TRANSACTION = 300000;
+  @ApiStatus.Internal public static final long DEFAULT_DEADLINE_TIMEOUT_AUTO_TRANSACTION = 30000;
 
   /**
    * Arbitrary data used in {@link SamplingContext} to determine if transaction is going to be


### PR DESCRIPTION
## :scroll: Description
fixed default deadline timeout to 30s instead of 300s


## :bulb: Motivation and Context
some transaction were kept alive for 5 minutes instead of 30 seconds


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
