### PR TITLE
Extend Proxy options with proxy type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add support for Spring Rest Client ([#3199](https://github.com/getsentry/sentry-java/pull/3199))
+- Extend Proxy options with proxy type ([#3326](https://github.com/getsentry/sentry-java/pull/3326))
 
 ### Fixes
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2447,13 +2447,17 @@ public final class io/sentry/SentryOptions$Proxy {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/Proxy$Type;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/net/Proxy$Type;Ljava/lang/String;Ljava/lang/String;)V
 	public fun getHost ()Ljava/lang/String;
 	public fun getPass ()Ljava/lang/String;
 	public fun getPort ()Ljava/lang/String;
+	public fun getType ()Ljava/net/Proxy$Type;
 	public fun getUser ()Ljava/lang/String;
 	public fun setHost (Ljava/lang/String;)V
 	public fun setPass (Ljava/lang/String;)V
 	public fun setPort (Ljava/lang/String;)V
+	public fun setType (Ljava/net/Proxy$Type;)V
 	public fun setUser (Ljava/lang/String;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -25,6 +25,7 @@ import io.sentry.util.StringUtils;
 import io.sentry.util.thread.IMainThreadChecker;
 import io.sentry.util.thread.NoOpMainThreadChecker;
 import java.io.File;
+import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -2676,17 +2677,7 @@ public class SentryOptions {
     private @Nullable String port;
     private @Nullable String user;
     private @Nullable String pass;
-
-    public Proxy(
-        final @Nullable String host,
-        final @Nullable String port,
-        final @Nullable String user,
-        final @Nullable String pass) {
-      this.host = host;
-      this.port = port;
-      this.user = user;
-      this.pass = pass;
-    }
+    private @Nullable java.net.Proxy.Type type;
 
     public Proxy() {
       this(null, null, null, null);
@@ -2694,6 +2685,31 @@ public class SentryOptions {
 
     public Proxy(@Nullable String host, @Nullable String port) {
       this(host, port, null, null);
+    }
+
+    public Proxy(@Nullable String host, @Nullable String port, @Nullable java.net.Proxy.Type type) {
+      this(host, port, type, null, null);
+    }
+
+    public Proxy(
+        final @Nullable String host,
+        final @Nullable String port,
+        final @Nullable String user,
+        final @Nullable String pass) {
+      this(host, port, null, user, pass);
+    }
+
+    public Proxy(
+        final @Nullable String host,
+        final @Nullable String port,
+        final @Nullable java.net.Proxy.Type type,
+        final @Nullable String user,
+        final @Nullable String pass) {
+      this.host = host;
+      this.port = port;
+      this.type = type;
+      this.user = user;
+      this.pass = pass;
     }
 
     public @Nullable String getHost() {
@@ -2726,6 +2742,14 @@ public class SentryOptions {
 
     public void setPass(final @Nullable String pass) {
       this.pass = pass;
+    }
+
+    public @Nullable java.net.Proxy.Type getType() {
+      return type;
+    }
+
+    public void setType(final @Nullable java.net.Proxy.Type type) {
+      this.type = type;
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2680,11 +2680,11 @@ public class SentryOptions {
     private @Nullable java.net.Proxy.Type type;
 
     public Proxy() {
-      this(null, null, null, null);
+      this(null, null, null, null, null);
     }
 
     public Proxy(@Nullable String host, @Nullable String port) {
-      this(host, port, null, null);
+      this(host, port, null, null, null);
     }
 
     public Proxy(@Nullable String host, @Nullable String port, @Nullable java.net.Proxy.Type type) {

--- a/sentry/src/main/java/io/sentry/transport/HttpConnection.java
+++ b/sentry/src/main/java/io/sentry/transport/HttpConnection.java
@@ -78,8 +78,14 @@ final class HttpConnection {
       final String host = optionsProxy.getHost();
       if (port != null && host != null) {
         try {
+          final @NotNull Proxy.Type type;
+          if (optionsProxy.getType() != null) {
+            type = optionsProxy.getType();
+          } else {
+            type = Proxy.Type.HTTP;
+          }
           InetSocketAddress proxyAddr = new InetSocketAddress(host, Integer.parseInt(port));
-          proxy = new Proxy(Proxy.Type.HTTP, proxyAddr);
+          proxy = new Proxy(type, proxyAddr);
         } catch (NumberFormatException e) {
           options
               .getLogger()

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -4,6 +4,7 @@ import io.sentry.backpressure.NoOpBackpressureMonitor
 import io.sentry.util.StringUtils
 import org.mockito.kotlin.mock
 import java.io.File
+import java.net.Proxy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -350,7 +351,7 @@ class SentryOptionsTest {
         externalOptions.environment = "environment"
         externalOptions.release = "release"
         externalOptions.serverName = "serverName"
-        externalOptions.proxy = SentryOptions.Proxy("example.com", "8090")
+        externalOptions.proxy = SentryOptions.Proxy("example.com", "8090", Proxy.Type.SOCKS)
         externalOptions.setTag("tag1", "value1")
         externalOptions.setTag("tag2", "value2")
         externalOptions.enableUncaughtExceptionHandler = false
@@ -391,6 +392,7 @@ class SentryOptionsTest {
         assertNotNull(options.proxy)
         assertEquals("example.com", options.proxy!!.host)
         assertEquals("8090", options.proxy!!.port)
+        assertEquals(java.net.Proxy.Type.SOCKS, options.proxy!!.type)
         assertEquals(mapOf("tag1" to "value1", "tag2" to "value2"), options.tags)
         assertFalse(options.isEnableUncaughtExceptionHandler)
         assertEquals(true, options.enableTracing)

--- a/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
@@ -231,7 +231,7 @@ class HttpConnectionTest {
     }
 
     @Test
-    fun `When Proxy type is not set, iot defaults to HTTP`() {
+    fun `When Proxy type is not set, it defaults to HTTP`() {
         fixture.proxy = Proxy("proxy.example.com", "8080")
         val transport = fixture.getSUT()
 

--- a/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/HttpConnectionTest.kt
@@ -231,6 +231,28 @@ class HttpConnectionTest {
     }
 
     @Test
+    fun `When Proxy type is not set, iot defaults to HTTP`() {
+        fixture.proxy = Proxy("proxy.example.com", "8080")
+        val transport = fixture.getSUT()
+
+        transport.send(createEnvelope())
+
+        assertEquals(Type.HTTP, transport.proxy!!.type())
+    }
+
+    @Test
+    fun `When Proxy type is set to SOCKS, HTTP connection uses it`() {
+        fixture.proxy = Proxy("proxy.example.com", "8080").apply {
+            type = Type.SOCKS
+        }
+        val transport = fixture.getSUT()
+
+        transport.send(createEnvelope())
+
+        assertEquals(Type.SOCKS, transport.proxy!!.type())
+    }
+
+    @Test
     fun `sets common headers and on http connection`() {
         val transport = fixture.getSUT()
 


### PR DESCRIPTION
## :scroll: Description
Until now the proxy type was hardcoded to HTTP, let's allow other types (e.g. SOCKS) as well. 

## :bulb: Motivation and Context
Customer feedback

## :green_heart: How did you test it?
Added unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
