### PR TITLE
[SR] Fix crashing MediaCodec and use density to determine recording resolution

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -49,26 +49,28 @@ public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallb
 
 public final class io/sentry/android/replay/ScreenshotRecorderConfig {
 	public static final field Companion Lio/sentry/android/replay/ScreenshotRecorderConfig$Companion;
-	public fun <init> (IIFII)V
+	public fun <init> (IIFFII)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun component3 ()F
-	public final fun component4 ()I
+	public final fun component4 ()F
 	public final fun component5 ()I
-	public final fun copy (IIFII)Lio/sentry/android/replay/ScreenshotRecorderConfig;
-	public static synthetic fun copy$default (Lio/sentry/android/replay/ScreenshotRecorderConfig;IIFIIILjava/lang/Object;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public final fun component6 ()I
+	public final fun copy (IIFFII)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public static synthetic fun copy$default (Lio/sentry/android/replay/ScreenshotRecorderConfig;IIFFIIILjava/lang/Object;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBitRate ()I
 	public final fun getFrameRate ()I
 	public final fun getRecordingHeight ()I
 	public final fun getRecordingWidth ()I
-	public final fun getScaleFactor ()F
+	public final fun getScaleFactorX ()F
+	public final fun getScaleFactorY ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/sentry/android/replay/ScreenshotRecorderConfig$Companion {
-	public final fun from (Landroid/content/Context;ILio/sentry/SentryReplayOptions;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public final fun from (Landroid/content/Context;Lio/sentry/SentryReplayOptions;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
 }
 
 public abstract interface class io/sentry/android/replay/video/SimpleFrameMuxer {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -70,7 +70,6 @@ class ReplayIntegration(
     private val recorderConfig by lazy(NONE) {
         ScreenshotRecorderConfig.from(
             context,
-            targetHeight = 720,
             options.experimental.sessionReplayOptions
         )
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -55,11 +55,6 @@ internal class WindowRecorder(
             return
         }
 
-//    val (height, width) = (wm.currentWindowMetrics.bounds.bottom /
-//        context.resources.displayMetrics.density).roundToInt() to
-//        (wm.currentWindowMetrics.bounds.right /
-//            context.resources.displayMetrics.density).roundToInt()
-
         recorder = ScreenshotRecorder(recorderConfig, options, screenshotRecorderCallback)
         rootViewsSpy.listeners += onRootViewsChangedListener
         capturingTask = capturer.scheduleAtFixedRateSafely(

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -221,13 +221,17 @@ internal class SimpleVideoEncoder(
     }
 
     fun release() {
-        onClose?.invoke()
-        drainCodec(true)
-        mediaCodec.stop()
-        mediaCodec.release()
-        surface?.release()
+        try {
+            onClose?.invoke()
+            drainCodec(true)
+            mediaCodec.stop()
+            mediaCodec.release()
+            surface?.release()
 
-        frameMuxer.release()
+            frameMuxer.release()
+        } catch (e: Throwable) {
+            options.logger.log(DEBUG, "Failed to properly release video encoder", e)
+        }
     }
 }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -58,17 +58,22 @@ internal class SimpleVideoEncoder(
     }
 
     private val mediaFormat: MediaFormat by lazy(NONE) {
-        val videoCapabilities = mediaCodec.codecInfo
-            .getCapabilitiesForType(muxerConfig.mimeType)
-            .videoCapabilities
-
         var bitRate = muxerConfig.recorderConfig.bitRate
-        if (!videoCapabilities.bitrateRange.contains(bitRate)) {
-            options.logger.log(
-                DEBUG,
-                "Encoder doesn't support the provided bitRate: $bitRate, the value will be clamped to the closest one"
-            )
-            bitRate = videoCapabilities.bitrateRange.clamp(bitRate)
+
+        try {
+            val videoCapabilities = mediaCodec.codecInfo
+                .getCapabilitiesForType(muxerConfig.mimeType)
+                .videoCapabilities
+
+            if (!videoCapabilities.bitrateRange.contains(bitRate)) {
+                options.logger.log(
+                    DEBUG,
+                    "Encoder doesn't support the provided bitRate: $bitRate, the value will be clamped to the closest one"
+                )
+                bitRate = videoCapabilities.bitrateRange.clamp(bitRate)
+            }
+        } catch (e: Throwable) {
+            options.logger.log(DEBUG, "Could not retrieve MediaCodec info", e)
         }
 
         // TODO: if this ever becomes a problem, move this to ScreenshotRecorderConfig.from()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -37,7 +37,7 @@ class ReplayCacheTest {
             frameRate: Int,
             framesToEncode: Int = 0
         ): ReplayCache {
-            val recorderConfig = ScreenshotRecorderConfig(100, 200, 1f, frameRate = frameRate, bitRate = 20_000)
+            val recorderConfig = ScreenshotRecorderConfig(100, 200, 1f, 1f, frameRate = frameRate, bitRate = 20_000)
             options.run {
                 cacheDirPath = dir?.newFolder()?.absolutePath
             }

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -24,7 +24,7 @@ public final class SentryReplayOptions {
    * Defines the quality of the session replay. Higher bit rates have better replay quality, but
    * also affect the final payload size to transfer, defaults to 20kbps.
    */
-  private int bitRate = 20_000;
+  private int bitRate = 100_000;
 
   /**
    * Number of frames per second of the replay. The bigger the number, the more accurate the replay

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -22,7 +22,7 @@ public final class SentryReplayOptions {
 
   /**
    * Defines the quality of the session replay. Higher bit rates have better replay quality, but
-   * also affect the final payload size to transfer, defaults to 20kbps.
+   * also affect the final payload size to transfer, defaults to 100kbps.
    */
   private int bitRate = 100_000;
 


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Moves away from using a static height, but rather determine the recording size based on density (use 1x=mdpi for now, which means 2280x1080 will translate to something like 840x400)
* Fixes crashing MediaCodec on some devices, because we were not rounding height and width so they're divisible by 16 (pixel block size, which codecs work on)
* Increases default bitrate because 20k bps is of very low quality (we'll introduce different quality levels in the future, so it's easier for customers to chose from low|medium|high rather than picking arbitrary values)
* Fixes out-of-sync viewHierarchy in some cases by setting it to null immediately so it's not used for a later (maybe irrelevant) screenshot

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
