### PR TITLE
[SR] Add redact options and align naming

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -104,6 +104,10 @@ final class ManifestMetadataReader {
 
   static final String REPLAYS_ERROR_SAMPLE_RATE = "io.sentry.session-replay.error-sample-rate";
 
+  static final String REPLAYS_REDACT_ALL_TEXT = "io.sentry.session-replay.redact-all-text";
+
+  static final String REPLAYS_REDACT_ALL_IMAGES = "io.sentry.session-replay.redact-all-images";
+
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
 
@@ -376,23 +380,40 @@ final class ManifestMetadataReader {
             readBool(
                 metadata, logger, ENABLE_APP_START_PROFILING, options.isEnableAppStartProfiling()));
 
-        if (options.getExperimental().getSessionReplayOptions().getSessionSampleRate() == null) {
+        if (options.getExperimental().getSessionReplay().getSessionSampleRate() == null) {
           final Double sessionSampleRate =
               readDouble(metadata, logger, REPLAYS_SESSION_SAMPLE_RATE);
           if (sessionSampleRate != -1) {
-            options
-                .getExperimental()
-                .getSessionReplayOptions()
-                .setSessionSampleRate(sessionSampleRate);
+            options.getExperimental().getSessionReplay().setSessionSampleRate(sessionSampleRate);
           }
         }
 
-        if (options.getExperimental().getSessionReplayOptions().getErrorSampleRate() == null) {
+        if (options.getExperimental().getSessionReplay().getErrorSampleRate() == null) {
           final Double errorSampleRate = readDouble(metadata, logger, REPLAYS_ERROR_SAMPLE_RATE);
           if (errorSampleRate != -1) {
-            options.getExperimental().getSessionReplayOptions().setErrorSampleRate(errorSampleRate);
+            options.getExperimental().getSessionReplay().setErrorSampleRate(errorSampleRate);
           }
         }
+
+        options
+            .getExperimental()
+            .getSessionReplay()
+            .setRedactAllText(
+                readBool(
+                    metadata,
+                    logger,
+                    REPLAYS_REDACT_ALL_TEXT,
+                    options.getExperimental().getSessionReplay().getRedactAllText()));
+
+        options
+            .getExperimental()
+            .getSessionReplay()
+            .setRedactAllImages(
+                readBool(
+                    metadata,
+                    logger,
+                    REPLAYS_REDACT_ALL_IMAGES,
+                    options.getExperimental().getSessionReplay().getRedactAllImages()));
       }
 
       options

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1383,14 +1383,14 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplayOptions.errorSampleRate)
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.errorSampleRate)
     }
 
     @Test
     fun `applyMetadata does not override replays errorSampleRate from options`() {
         // Arrange
         val expectedSampleRate = 0.99f
-        fixture.options.experimental.sessionReplayOptions.errorSampleRate = expectedSampleRate.toDouble()
+        fixture.options.experimental.sessionReplay.errorSampleRate = expectedSampleRate.toDouble()
         val bundle = bundleOf(ManifestMetadataReader.REPLAYS_ERROR_SAMPLE_RATE to 0.1f)
         val context = fixture.getContext(metaData = bundle)
 
@@ -1398,7 +1398,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplayOptions.errorSampleRate)
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.errorSampleRate)
     }
 
     @Test
@@ -1410,6 +1410,33 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertNull(fixture.options.experimental.sessionReplayOptions.errorSampleRate)
+        assertNull(fixture.options.experimental.sessionReplay.errorSampleRate)
+    }
+
+    @Test
+    fun `applyMetadata reads session replay redact flags to options`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.REPLAYS_REDACT_ALL_TEXT to false, ManifestMetadataReader.REPLAYS_REDACT_ALL_IMAGES to false)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.experimental.sessionReplay.redactAllImages)
+        assertFalse(fixture.options.experimental.sessionReplay.redactAllText)
+    }
+
+    @Test
+    fun `applyMetadata reads session replay redact flags to options and keeps default if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.experimental.sessionReplay.redactAllImages)
+        assertTrue(fixture.options.experimental.sessionReplay.redactAllText)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -27,7 +27,6 @@ import io.sentry.android.core.cache.AndroidEnvelopeCache
 import io.sentry.android.core.performance.AppStartMetrics
 import io.sentry.android.fragment.FragmentLifecycleIntegration
 import io.sentry.android.replay.ReplayIntegration
-import io.sentry.android.replay.getReplayIntegration
 import io.sentry.android.timber.SentryTimberIntegration
 import io.sentry.cache.IEnvelopeCache
 import io.sentry.cache.PersistingOptionsObserver
@@ -319,7 +318,7 @@ class SentryAndroidTest {
     @Config(sdk = [26])
     fun `init starts session replay if app is in foreground`() {
         initSentryWithForegroundImportance(true) { _ ->
-            assertTrue(Sentry.getCurrentHub().getReplayIntegration()!!.isRecording())
+            assertTrue(Sentry.getCurrentHub().options.replayController.isRecording())
         }
     }
 
@@ -327,7 +326,7 @@ class SentryAndroidTest {
     @Config(sdk = [26])
     fun `init does not start session replay if the app is in background`() {
         initSentryWithForegroundImportance(false) { _ ->
-            assertFalse(Sentry.getCurrentHub().getReplayIntegration()!!.isRecording())
+            assertFalse(Sentry.getCurrentHub().options.replayController.isRecording())
         }
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -341,7 +341,7 @@ class SentryAndroidTest {
                 options.release = "prod"
                 options.dsn = "https://key@sentry.io/123"
                 options.isEnableAutoSessionTracking = true
-                options.experimental.sessionReplayOptions.errorSampleRate = 1.0
+                options.experimental.sessionReplay.errorSampleRate = 1.0
             }
 
             var session: Session? = null

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -33,7 +33,7 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
 	public fun close ()V
-	public final fun isRecording ()Z
+	public fun isRecording ()Z
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
@@ -44,8 +44,7 @@ public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integr
 }
 
 public final class io/sentry/android/replay/ReplayIntegrationKt {
-	public static final fun getReplayIntegration (Lio/sentry/IHub;)Lio/sentry/android/replay/ReplayIntegration;
-	public static final fun gracefullyShutdown (Ljava/util/concurrent/ExecutorService;Lio/sentry/SentryOptions;)V
+	public static final fun submitSafely (Ljava/util/concurrent/ExecutorService;Lio/sentry/ILogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 }
 
 public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallback {

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -43,10 +43,6 @@ public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integr
 	public fun stop ()V
 }
 
-public final class io/sentry/android/replay/ReplayIntegrationKt {
-	public static final fun submitSafely (Ljava/util/concurrent/ExecutorService;Lio/sentry/ILogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
-}
-
 public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallback {
 	public abstract fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 }

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -118,6 +118,6 @@ public final class io/sentry/android/replay/viewhierarchy/ViewHierarchyNode {
 }
 
 public final class io/sentry/android/replay/viewhierarchy/ViewHierarchyNode$Companion {
-	public final fun fromView (Landroid/view/View;)Lio/sentry/android/replay/viewhierarchy/ViewHierarchyNode;
+	public final fun fromView (Landroid/view/View;Lio/sentry/SentryOptions;)Lio/sentry/android/replay/viewhierarchy/ViewHierarchyNode;
 }
 

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -49,26 +49,28 @@ public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallb
 
 public final class io/sentry/android/replay/ScreenshotRecorderConfig {
 	public static final field Companion Lio/sentry/android/replay/ScreenshotRecorderConfig$Companion;
-	public fun <init> (IIFII)V
+	public fun <init> (IIFFII)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun component3 ()F
-	public final fun component4 ()I
+	public final fun component4 ()F
 	public final fun component5 ()I
-	public final fun copy (IIFII)Lio/sentry/android/replay/ScreenshotRecorderConfig;
-	public static synthetic fun copy$default (Lio/sentry/android/replay/ScreenshotRecorderConfig;IIFIIILjava/lang/Object;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public final fun component6 ()I
+	public final fun copy (IIFFII)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public static synthetic fun copy$default (Lio/sentry/android/replay/ScreenshotRecorderConfig;IIFFIIILjava/lang/Object;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBitRate ()I
 	public final fun getFrameRate ()I
 	public final fun getRecordingHeight ()I
 	public final fun getRecordingWidth ()I
-	public final fun getScaleFactor ()F
+	public final fun getScaleFactorX ()F
+	public final fun getScaleFactorY ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/sentry/android/replay/ScreenshotRecorderConfig$Companion {
-	public final fun from (Landroid/content/Context;ILio/sentry/SentryReplayOptions;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
+	public final fun from (Landroid/content/Context;Lio/sentry/SentryReplayOptions;)Lio/sentry/android/replay/ScreenshotRecorderConfig;
 }
 
 public abstract interface class io/sentry/android/replay/video/SimpleFrameMuxer {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -70,7 +70,6 @@ class ReplayIntegration(
     private val recorderConfig by lazy(NONE) {
         ScreenshotRecorderConfig.from(
             context,
-            targetHeight = 720,
             options.experimental.sessionReplayOptions
         )
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -70,7 +70,7 @@ class ReplayIntegration(
     private val recorderConfig by lazy(NONE) {
         ScreenshotRecorderConfig.from(
             context,
-            options.experimental.sessionReplayOptions
+            options.experimental.sessionReplay
         )
     }
 
@@ -89,16 +89,16 @@ class ReplayIntegration(
             return
         }
 
-        if (!options.experimental.sessionReplayOptions.isSessionReplayEnabled &&
-            !options.experimental.sessionReplayOptions.isSessionReplayForErrorsEnabled
+        if (!options.experimental.sessionReplay.isSessionReplayEnabled &&
+            !options.experimental.sessionReplay.isSessionReplayForErrorsEnabled
         ) {
             options.logger.log(INFO, "Session replay is disabled, no sample rate specified")
             return
         }
 
-        isFullSession.set(sample(options.experimental.sessionReplayOptions.sessionSampleRate))
+        isFullSession.set(sample(options.experimental.sessionReplay.sessionSampleRate))
         if (!isFullSession.get() &&
-            !options.experimental.sessionReplayOptions.isSessionReplayForErrorsEnabled
+            !options.experimental.sessionReplay.isSessionReplayForErrorsEnabled
         ) {
             options.logger.log(INFO, "Session replay is disabled, full session was not sampled and errorSampleRate is not specified")
             return
@@ -182,12 +182,12 @@ class ReplayIntegration(
             return
         }
 
-        if (!sample(options.experimental.sessionReplayOptions.errorSampleRate)) {
+        if (!sample(options.experimental.sessionReplay.errorSampleRate)) {
             options.logger.log(INFO, "Replay wasn't sampled by errorSampleRate, not capturing for event %s", event.eventId)
             return
         }
 
-        val errorReplayDuration = options.experimental.sessionReplayOptions.errorReplayDuration
+        val errorReplayDuration = options.experimental.sessionReplay.errorReplayDuration
         val now = dateProvider.currentTimeMillis
         val currentSegmentTimestamp = if (cache?.frames?.isNotEmpty() == true) {
             // in buffer mode we have to set the timestamp of the first frame as the actual start
@@ -277,7 +277,7 @@ class ReplayIntegration(
 
             val now = dateProvider.currentTimeMillis
             if (isFullSession.get() &&
-                (now - segmentTimestamp.get().time >= options.experimental.sessionReplayOptions.sessionSegmentDuration)
+                (now - segmentTimestamp.get().time >= options.experimental.sessionReplay.sessionSegmentDuration)
             ) {
                 val currentSegmentTimestamp = segmentTimestamp.get()
                 val segmentId = currentSegment.get()
@@ -285,7 +285,7 @@ class ReplayIntegration(
 
                 val videoDuration =
                     createAndCaptureSegment(
-                        options.experimental.sessionReplayOptions.sessionSegmentDuration,
+                        options.experimental.sessionReplay.sessionSegmentDuration,
                         currentSegmentTimestamp,
                         replayId,
                         segmentId
@@ -296,12 +296,12 @@ class ReplayIntegration(
                     segmentTimestamp.set(DateUtils.getDateTime(currentSegmentTimestamp.time + videoDuration))
                 }
             } else if (isFullSession.get() &&
-                (now - replayStartTimestamp.get() >= options.experimental.sessionReplayOptions.sessionDuration)
+                (now - replayStartTimestamp.get() >= options.experimental.sessionReplay.sessionDuration)
             ) {
                 stop()
                 options.logger.log(INFO, "Session replay deadline exceeded (1h), stopping recording")
             } else if (!isFullSession.get()) {
-                cache?.rotate(now - options.experimental.sessionReplayOptions.errorReplayDuration)
+                cache?.rotate(now - options.experimental.sessionReplay.errorReplayDuration)
             }
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -164,7 +164,7 @@ internal class ScreenshotRecorder(
             return
         }
 
-        val rootNode = ViewHierarchyNode.fromView(root)
+        val rootNode = ViewHierarchyNode.fromView(root, options)
         root.traverse(rootNode)
         pendingViewHierarchy.set(rootNode)
 
@@ -227,7 +227,7 @@ internal class ScreenshotRecorder(
         for (i in 0 until childCount) {
             val child = getChildAt(i)
             if (child != null) {
-                val childNode = ViewHierarchyNode.fromView(child)
+                val childNode = ViewHierarchyNode.fromView(child, options)
                 childNodes.add(childNode)
                 child.traverse(childNode)
             }
@@ -260,7 +260,7 @@ public data class ScreenshotRecorderConfig(
 
         fun from(
             context: Context,
-            sentryReplayOptions: SentryReplayOptions
+            sessionReplay: SentryReplayOptions
         ): ScreenshotRecorderConfig {
             // PixelCopy takes screenshots including system bars, so we have to get the real size here
             val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
@@ -287,8 +287,8 @@ public data class ScreenshotRecorderConfig(
                 recordingHeight = height,
                 scaleFactorX = width.toFloat() / screenBounds.width(),
                 scaleFactorY = height.toFloat() / screenBounds.height(),
-                frameRate = sentryReplayOptions.frameRate,
-                bitRate = sentryReplayOptions.bitRate
+                frameRate = sessionReplay.frameRate,
+                bitRate = sessionReplay.bitRate
             )
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -55,11 +55,6 @@ internal class WindowRecorder(
             return
         }
 
-//    val (height, width) = (wm.currentWindowMetrics.bounds.bottom /
-//        context.resources.displayMetrics.density).roundToInt() to
-//        (wm.currentWindowMetrics.bounds.right /
-//            context.resources.displayMetrics.density).roundToInt()
-
         recorder = ScreenshotRecorder(recorderConfig, options, screenshotRecorderCallback)
         rootViewsSpy.listeners += onRootViewsChangedListener
         capturingTask = capturer.scheduleAtFixedRateSafely(

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
@@ -1,0 +1,67 @@
+package io.sentry.android.replay.util
+
+import io.sentry.SentryLevel.ERROR
+import io.sentry.SentryOptions
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+internal fun ExecutorService.gracefullyShutdown(options: SentryOptions) {
+    synchronized(this) {
+        if (!isShutdown) {
+            shutdown()
+        }
+        try {
+            if (!awaitTermination(options.shutdownTimeoutMillis, MILLISECONDS)) {
+                shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            shutdownNow()
+            Thread.currentThread().interrupt()
+        }
+    }
+}
+
+internal fun ExecutorService.submitSafely(
+    options: SentryOptions,
+    taskName: String,
+    task: Runnable
+): Future<*>? {
+    return try {
+        submit {
+            try {
+                task.run()
+            } catch (e: Throwable) {
+                options.logger.log(ERROR, "Failed to execute task $taskName", e)
+            }
+        }
+    } catch (e: Throwable) {
+        options.logger.log(ERROR, "Failed to submit task $taskName to executor", e)
+        null
+    }
+}
+
+internal fun ScheduledExecutorService.scheduleAtFixedRateSafely(
+    options: SentryOptions,
+    taskName: String,
+    initialDelay: Long,
+    period: Long,
+    unit: TimeUnit,
+    task: Runnable
+): ScheduledFuture<*>? {
+    return try {
+        scheduleAtFixedRate({
+            try {
+                task.run()
+            } catch (e: Throwable) {
+                options.logger.log(ERROR, "Failed to execute task $taskName", e)
+            }
+        }, initialDelay, period, unit)
+    } catch (e: Throwable) {
+        options.logger.log(ERROR, "Failed to submit task $taskName to executor", e)
+        null
+    }
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.ImageView
 import android.widget.TextView
+import io.sentry.SentryOptions
 
 // TODO: merge with ViewHierarchyNode from sentry-core maybe?
 @TargetApi(26)
@@ -49,14 +50,14 @@ data class ViewHierarchyNode(
         // TODO: check if this works on RN
         private fun Int.toOpaque() = this or 0xFF000000.toInt()
 
-        fun fromView(view: View): ViewHierarchyNode {
+        fun fromView(view: View, options: SentryOptions): ViewHierarchyNode {
             // TODO: Extract redacting into its own class/function
             // TODO: extract redacting into a separate thread?
             var shouldRedact = false
             var dominantColor: Int? = null
             var rect: Rect? = null
-            when (view) {
-                is TextView -> {
+            when {
+                view is TextView && options.experimental.sessionReplay.redactAllText -> {
                     // TODO: API level check
                     // TODO: perhaps this is heavy, might reconsider
                     val nodeInfo = if (VERSION.SDK_INT >= VERSION_CODES.R) {
@@ -101,7 +102,7 @@ data class ViewHierarchyNode(
                     }
                 }
 
-                is ImageView -> {
+                view is ImageView && options.experimental.sessionReplay.redactAllImages -> {
                     shouldRedact = isVisible(view) && (view.drawable?.isRedactable() ?: false)
                     if (shouldRedact) {
                         rect = Rect()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -310,8 +310,8 @@ public abstract interface class io/sentry/EventProcessor {
 
 public final class io/sentry/ExperimentalOptions {
 	public fun <init> ()V
-	public fun getSessionReplayOptions ()Lio/sentry/SentryReplayOptions;
-	public fun setSessionReplayOptions (Lio/sentry/SentryReplayOptions;)V
+	public fun getSessionReplay ()Lio/sentry/SentryReplayOptions;
+	public fun setSessionReplay (Lio/sentry/SentryReplayOptions;)V
 }
 
 public final class io/sentry/ExternalOptions {
@@ -2571,12 +2571,16 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getErrorReplayDuration ()J
 	public fun getErrorSampleRate ()Ljava/lang/Double;
 	public fun getFrameRate ()I
+	public fun getRedactAllImages ()Z
+	public fun getRedactAllText ()Z
 	public fun getSessionDuration ()J
 	public fun getSessionSampleRate ()Ljava/lang/Double;
 	public fun getSessionSegmentDuration ()J
 	public fun isSessionReplayEnabled ()Z
 	public fun isSessionReplayForErrorsEnabled ()Z
 	public fun setErrorSampleRate (Ljava/lang/Double;)V
+	public fun setRedactAllImages (Z)V
+	public fun setRedactAllText (Z)V
 	public fun setSessionSampleRate (Ljava/lang/Double;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1206,6 +1206,7 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 
 public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public static fun getInstance ()Lio/sentry/NoOpReplayController;
+	public fun isRecording ()Z
 	public fun pause ()V
 	public fun resume ()V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
@@ -1604,6 +1605,7 @@ public final class io/sentry/PropagationContext {
 }
 
 public abstract interface class io/sentry/ReplayController {
+	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
 	public abstract fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -9,14 +9,14 @@ import org.jetbrains.annotations.NotNull;
  * <p>Beware that experimental options can change at any time.
  */
 public final class ExperimentalOptions {
-  private @NotNull SentryReplayOptions sessionReplayOptions = new SentryReplayOptions();
+  private @NotNull SentryReplayOptions sessionReplay = new SentryReplayOptions();
 
   @NotNull
-  public SentryReplayOptions getSessionReplayOptions() {
-    return sessionReplayOptions;
+  public SentryReplayOptions getSessionReplay() {
+    return sessionReplay;
   }
 
-  public void setSessionReplayOptions(final @NotNull SentryReplayOptions sessionReplayOptions) {
-    this.sessionReplayOptions = sessionReplayOptions;
+  public void setSessionReplay(final @NotNull SentryReplayOptions sessionReplayOptions) {
+    this.sessionReplay = sessionReplayOptions;
   }
 }

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -25,5 +25,10 @@ public final class NoOpReplayController implements ReplayController {
   public void resume() {}
 
   @Override
+  public boolean isRecording() {
+    return false;
+  }
+
+  @Override
   public void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint) {}
 }

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -13,5 +13,7 @@ public interface ReplayController {
 
   void resume();
 
+  boolean isRecording();
+
   void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint);
 }

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -21,6 +21,24 @@ public final class SentryReplayOptions {
   private @Nullable Double errorSampleRate;
 
   /**
+   * Redact all text content. Draws a rectangle of text bounds with text color on top. By default
+   * only views extending TextView are redacted.
+   *
+   * <p>Default is enabled.
+   */
+  private boolean redactAllText = true;
+
+  /**
+   * Redact all image content. Draws a rectangle of image bounds with image's dominant color on top.
+   * By default only views extending ImageView with BitmapDrawable or custom Drawable type are
+   * redacted. ColorDrawable, InsetDrawable, VectorDrawable are all considered non-PII, as they come
+   * from the apk.
+   *
+   * <p>Default is enabled.
+   */
+  private boolean redactAllImages = true;
+
+  /**
    * Defines the quality of the session replay. Higher bit rates have better replay quality, but
    * also affect the final payload size to transfer, defaults to 20kbps.
    */
@@ -85,6 +103,22 @@ public final class SentryReplayOptions {
               + " is not valid. Use null to disable or values >= 0.0 and <= 1.0.");
     }
     this.sessionSampleRate = sessionSampleRate;
+  }
+
+  public boolean getRedactAllText() {
+    return redactAllText;
+  }
+
+  public void setRedactAllText(final boolean redactAllText) {
+    this.redactAllText = redactAllText;
+  }
+
+  public boolean getRedactAllImages() {
+    return redactAllImages;
+  }
+
+  public void setRedactAllImages(final boolean redactAllImages) {
+    this.redactAllImages = redactAllImages;
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -24,7 +24,7 @@ public final class SentryReplayOptions {
    * Defines the quality of the session replay. Higher bit rates have better replay quality, but
    * also affect the final payload size to transfer, defaults to 20kbps.
    */
-  private int bitRate = 20_000;
+  private int bitRate = 100_000;
 
   /**
    * Number of frames per second of the replay. The bigger the number, the more accurate the replay


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Align naming (sessionReplay instead of sessionReplayOptions)
* Add redactAllText and redactAllImages options

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
