### PR TITLE
Fix java.lang.ClassNotFoundException: org.springframework.web.servlet.HandlerExceptionResolver in Spring Boot Servlet mode without WebMVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fixed default deadline timeout to 30s instead of 300s ([#3322](https://github.com/getsentry/sentry-java/pull/3322))
+- Fixed `Fix java.lang.ClassNotFoundException: org.springframework.web.servlet.HandlerExceptionResolver` in Spring Boot Servlet mode without WebMVC ([#3333](https://github.com/getsentry/sentry-java/pull/3333))
 
 ## 7.6.0
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -296,15 +296,21 @@ public class SentryAutoConfiguration {
         return filter;
       }
 
-      @Bean
-      @ConditionalOnMissingBean
+      /** Wraps exception resolver @Bean because the return type is loaded too early otherwise */
+      @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
-      public @NotNull SentryExceptionResolver sentryExceptionResolver(
-          final @NotNull IHub sentryHub,
-          final @NotNull TransactionNameProvider transactionNameProvider,
-          final @NotNull SentryProperties options) {
-        return new SentryExceptionResolver(
-            sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+      @Open
+      static class SentryExceptionResolverConfigurationWrapper {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public @NotNull SentryExceptionResolver sentryExceptionResolver(
+            final @NotNull IHub sentryHub,
+            final @NotNull TransactionNameProvider transactionNameProvider,
+            final @NotNull SentryProperties options) {
+          return new SentryExceptionResolver(
+              sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+        }
       }
     }
 

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -294,15 +294,21 @@ public class SentryAutoConfiguration {
         return filter;
       }
 
-      @Bean
-      @ConditionalOnMissingBean
+      /** Wraps exception resolver @Bean because the return type is loaded too early otherwise */
+      @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
-      public @NotNull SentryExceptionResolver sentryExceptionResolver(
-          final @NotNull IHub sentryHub,
-          final @NotNull TransactionNameProvider transactionNameProvider,
-          final @NotNull SentryProperties options) {
-        return new SentryExceptionResolver(
-            sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+      @Open
+      static class SentryExceptionResolverConfigurationWrapper {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public @NotNull SentryExceptionResolver sentryExceptionResolver(
+            final @NotNull IHub sentryHub,
+            final @NotNull TransactionNameProvider transactionNameProvider,
+            final @NotNull SentryProperties options) {
+          return new SentryExceptionResolver(
+              sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+        }
       }
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
When using our Spring Boot integration in servlet mode but without having `spring-webmvc` as a dependency an exception occurred during startup.

This is caused by the return type of the `@Bean` declaration already being loaded before the `@ConditionalOnClass` is checked. To avoid it we wrap the bean definition in another `@Configuration` class.

The `ConditionalOnClass` JavaDoc mentions this:

> Extra care must be taken when using `@ConditionalOnClass` on `@Bean` methods where typically the return type is the target of the condition. Before the condition on the method applies, the JVM will have loaded the class and potentially processed method references which will fail if the class is not present. To handle this scenario, a separate `@Configuration` class should be used to isolate the condition

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1863

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
