### PR TITLE
Add rate limit to Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add rate limit to Metrics ([#3334](https://github.com/getsentry/sentry-java/pull/3334))
+
 ## 7.7.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -224,6 +224,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static final field Attachment Lio/sentry/DataCategory;
 	public static final field Default Lio/sentry/DataCategory;
 	public static final field Error Lio/sentry/DataCategory;
+	public static final field MetricBucket Lio/sentry/DataCategory;
 	public static final field Monitor Lio/sentry/DataCategory;
 	public static final field Profile Lio/sentry/DataCategory;
 	public static final field Security Lio/sentry/DataCategory;
@@ -4925,6 +4926,7 @@ public final class io/sentry/util/ClassLoaderUtils {
 }
 
 public final class io/sentry/util/CollectionUtils {
+	public static fun contains ([Ljava/lang/Object;Ljava/lang/Object;)Z
 	public static fun filterListEntries (Ljava/util/List;Lio/sentry/util/CollectionUtils$Predicate;)Ljava/util/List;
 	public static fun filterMapEntries (Ljava/util/Map;Lio/sentry/util/CollectionUtils$Predicate;)Ljava/util/Map;
 	public static fun map (Ljava/util/List;Lio/sentry/util/CollectionUtils$Mapper;)Ljava/util/List;
@@ -5092,6 +5094,7 @@ public final class io/sentry/util/SampleRateUtils {
 public final class io/sentry/util/StringUtils {
 	public static fun byteCountToString (J)Ljava/lang/String;
 	public static fun calculateStringHash (Ljava/lang/String;Lio/sentry/ILogger;)Ljava/lang/String;
+	public static fun camelCase (Ljava/lang/String;)Ljava/lang/String;
 	public static fun capitalize (Ljava/lang/String;)Ljava/lang/String;
 	public static fun countOf (Ljava/lang/String;C)I
 	public static fun getStringAfterDot (Ljava/lang/String;)Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/DataCategory.java
+++ b/sentry/src/main/java/io/sentry/DataCategory.java
@@ -12,6 +12,7 @@ public enum DataCategory {
   Attachment("attachment"),
   Monitor("monitor"),
   Profile("profile"),
+  MetricBucket("metric_bucket"),
   Transaction("transaction"),
   Security("security"),
   UserReport("user_report"),

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -146,6 +146,9 @@ public final class ClientReportRecorder implements IClientReportRecorder {
     if (SentryItemType.Profile.equals(itemType)) {
       return DataCategory.Profile;
     }
+    if (SentryItemType.Statsd.equals(itemType)) {
+      return DataCategory.MetricBucket;
+    }
     if (SentryItemType.Attachment.equals(itemType)) {
       return DataCategory.Attachment;
     }

--- a/sentry/src/main/java/io/sentry/util/CollectionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CollectionUtils.java
@@ -153,8 +153,8 @@ public final class CollectionUtils {
    * @return true if the element is present in the array, false otherwise.
    */
   public static <T> boolean contains(final @NotNull T[] array, final @NotNull T element) {
-    for (T t : array) {
-      if (t.equals(element)) {
+    for (final T t : array) {
+      if (element.equals(t)) {
         return true;
       }
     }

--- a/sentry/src/main/java/io/sentry/util/CollectionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CollectionUtils.java
@@ -146,6 +146,22 @@ public final class CollectionUtils {
   }
 
   /**
+   * Returns true if the element is present in the array, false otherwise.
+   *
+   * @param array - the array
+   * @param element - the element
+   * @return true if the element is present in the array, false otherwise.
+   */
+  public static <T> boolean contains(final @NotNull T[] array, final @NotNull T element) {
+    for (T t : array) {
+      if (t.equals(element)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * A simplified copy of Java 8 Predicate.
    *
    * @param <T> the type

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -10,6 +10,7 @@ import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Iterator;
 import java.util.Locale;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -21,6 +22,7 @@ public final class StringUtils {
 
   private static final String CORRUPTED_NIL_UUID = "0000-0000";
   private static final String PROPER_NIL_UUID = "00000000-0000-0000-0000-000000000000";
+  private static final @NotNull Pattern wordsPattern = Pattern.compile("[\\W_]+");
 
   private StringUtils() {}
 
@@ -48,6 +50,25 @@ public final class StringUtils {
     }
 
     return str.substring(0, 1).toUpperCase(Locale.ROOT) + str.substring(1).toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Converts a String to CamelCase format. E.g. metric_bucket => MetricBucket;
+   *
+   * @param str the String to convert
+   * @return the camel case converted String or itself if empty or null
+   */
+  public static @Nullable String camelCase(final @Nullable String str) {
+    if (str == null || str.isEmpty()) {
+      return str;
+    }
+
+    String[] words = wordsPattern.split(str, -1);
+    StringBuilder builder = new StringBuilder();
+    for (String w : words) {
+      builder.append(capitalize(w));
+    }
+    return builder.toString();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -22,7 +22,7 @@ public final class StringUtils {
 
   private static final String CORRUPTED_NIL_UUID = "0000-0000";
   private static final String PROPER_NIL_UUID = "00000000-0000-0000-0000-000000000000";
-  private static final @NotNull Pattern wordsPattern = Pattern.compile("[\\W_]+");
+  private static final @NotNull Pattern PATTERN_WORD_SNAKE_CASE = Pattern.compile("[\\W_]+");
 
   private StringUtils() {}
 
@@ -63,7 +63,7 @@ public final class StringUtils {
       return str;
     }
 
-    String[] words = wordsPattern.split(str, -1);
+    String[] words = PATTERN_WORD_SNAKE_CASE.split(str, -1);
     StringBuilder builder = new StringBuilder();
     for (String w : words) {
       builder.append(capitalize(w));

--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
@@ -23,6 +23,7 @@ import io.sentry.UncaughtExceptionHandlerIntegration.UncaughtExceptionHint
 import io.sentry.UserFeedback
 import io.sentry.dsnString
 import io.sentry.hints.Retryable
+import io.sentry.metrics.EncodedMetrics
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
@@ -67,13 +68,14 @@ class ClientReportTest {
             SentryEnvelopeItem.fromUserFeedback(opts.serializer, UserFeedback(SentryId(UUID.randomUUID()))),
             SentryEnvelopeItem.fromAttachment(opts.serializer, NoOpLogger.getInstance(), Attachment("{ \"number\": 10 }".toByteArray(), "log.json"), 1000),
             SentryEnvelopeItem.fromProfilingTrace(ProfilingTraceData(File(""), transaction), 1000, opts.serializer),
-            SentryEnvelopeItem.fromCheckIn(opts.serializer, CheckIn("monitor-slug-1", CheckInStatus.ERROR))
+            SentryEnvelopeItem.fromCheckIn(opts.serializer, CheckIn("monitor-slug-1", CheckInStatus.ERROR)),
+            SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
         )
 
         clientReportRecorder.recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope)
 
         val clientReportAtEnd = clientReportRecorder.resetCountsAndGenerateClientReport()
-        testHelper.assertTotalCount(12, clientReportAtEnd)
+        testHelper.assertTotalCount(13, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.SAMPLE_RATE, DataCategory.Error, 3, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.BEFORE_SEND, DataCategory.Error, 2, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.QUEUE_OVERFLOW, DataCategory.Transaction, 1, clientReportAtEnd)
@@ -83,6 +85,7 @@ class ClientReportTest {
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Attachment, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Profile, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Monitor, 1, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.MetricBucket, 1, clientReportAtEnd)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -20,6 +20,7 @@ import io.sentry.TransactionContext
 import io.sentry.UserFeedback
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.IClientReportRecorder
+import io.sentry.metrics.EncodedMetrics
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
@@ -102,13 +103,14 @@ class RateLimiterTest {
         val eventItem = SentryEnvelopeItem.fromEvent(fixture.serializer, SentryEvent())
         val transaction = SentryTransaction(SentryTracer(TransactionContext("name", "op"), hub))
         val transactionItem = SentryEnvelopeItem.fromEvent(fixture.serializer, transaction)
-        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, transactionItem))
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, transactionItem, statsdItem))
 
-        rateLimiter.updateRetryAfterLimits("1:transaction:key, 1:default;error;security:organization", null, 1)
+        rateLimiter.updateRetryAfterLimits("1:transaction:key, 1:default;error;metric_bucket;security:organization", null, 1)
 
         val result = rateLimiter.filter(envelope, Hint())
         assertNotNull(result)
-        assertEquals(2, result.items.count())
+        assertEquals(3, result.items.count())
     }
 
     @Test
@@ -199,8 +201,9 @@ class RateLimiterTest {
         val attachmentItem = SentryEnvelopeItem.fromAttachment(fixture.serializer, NoOpLogger.getInstance(), Attachment("{ \"number\": 10 }".toByteArray(), "log.json"), 1000)
         val profileItem = SentryEnvelopeItem.fromProfilingTrace(ProfilingTraceData(File(""), transaction), 1000, fixture.serializer)
         val checkInItem = SentryEnvelopeItem.fromCheckIn(fixture.serializer, CheckIn("monitor-slug-1", CheckInStatus.ERROR))
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
 
-        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, userFeedbackItem, sessionItem, attachmentItem, profileItem, checkInItem))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, userFeedbackItem, sessionItem, attachmentItem, profileItem, checkInItem, statsdItem))
 
         rateLimiter.updateRetryAfterLimits(null, null, 429)
         val result = rateLimiter.filter(envelope, Hint())
@@ -213,6 +216,7 @@ class RateLimiterTest {
         verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(attachmentItem))
         verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(profileItem))
         verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(checkInItem))
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(statsdItem))
         verifyNoMoreInteractions(fixture.clientReportRecorder)
     }
 
@@ -269,6 +273,71 @@ class RateLimiterTest {
         assertEquals(1, result.items.toList().size)
 
         verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(profileItem))
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `drop metrics items as lost`() {
+        val rateLimiter = fixture.getSUT()
+        val hub = mock<IHub>()
+        whenever(hub.options).thenReturn(SentryOptions())
+
+        val eventItem = SentryEnvelopeItem.fromEvent(fixture.serializer, SentryEvent())
+        val f = File.createTempFile("test", "trace")
+        val transaction = SentryTracer(TransactionContext("name", "op"), hub)
+        val profileItem = SentryEnvelopeItem.fromProfilingTrace(ProfilingTraceData(f, transaction), 1000, fixture.serializer)
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(eventItem, profileItem, statsdItem))
+
+        rateLimiter.updateRetryAfterLimits("60:metric_bucket:key", null, 1)
+        val result = rateLimiter.filter(envelope, Hint())
+
+        assertNotNull(result)
+        assertEquals(2, result.items.toList().size)
+
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(statsdItem))
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `drop metrics items if namespace is custom`() {
+        val rateLimiter = fixture.getSUT()
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(statsdItem))
+
+        rateLimiter.updateRetryAfterLimits("60:metric_bucket:key:quota_exceeded:custom", null, 1)
+        val result = rateLimiter.filter(envelope, Hint())
+        assertNull(result)
+
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(statsdItem))
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `drop metrics items if namespaces is empty`() {
+        val rateLimiter = fixture.getSUT()
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(statsdItem))
+
+        rateLimiter.updateRetryAfterLimits("60:metric_bucket:key:quota_exceeded::", null, 1)
+        val result = rateLimiter.filter(envelope, Hint())
+        assertNull(result)
+
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(statsdItem))
+        verifyNoMoreInteractions(fixture.clientReportRecorder)
+    }
+
+    @Test
+    fun `drop metrics items if namespaces is not present`() {
+        val rateLimiter = fixture.getSUT()
+        val statsdItem = SentryEnvelopeItem.fromMetrics(EncodedMetrics(emptyMap()))
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(statsdItem))
+
+        rateLimiter.updateRetryAfterLimits("60:metric_bucket:key:quota_exceeded", null, 1)
+        val result = rateLimiter.filter(envelope, Hint())
+        assertNull(result)
+
+        verify(fixture.clientReportRecorder, times(1)).recordLostEnvelopeItem(eq(DiscardReason.RATELIMIT_BACKOFF), same(statsdItem))
         verifyNoMoreInteractions(fixture.clientReportRecorder)
     }
 

--- a/sentry/src/test/java/io/sentry/util/CollectionUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CollectionUtilsTest.kt
@@ -4,6 +4,8 @@ import io.sentry.JsonObjectReader
 import java.io.StringReader
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CollectionUtilsTest {
 
@@ -61,5 +63,20 @@ class CollectionUtilsTest {
         assertEquals(2, result?.size)
         assertEquals("value1", result?.get("key1"))
         assertEquals("value3", result?.get("key3"))
+    }
+
+    @Test
+    fun `contains returns false for empty arrays`() {
+        assertFalse(CollectionUtils.contains(emptyArray<String>(), ""))
+    }
+
+    @Test
+    fun `contains returns true if element is present`() {
+        assertTrue(CollectionUtils.contains(arrayOf("one", "two", "three"), "two"))
+    }
+
+    @Test
+    fun `contains returns false if element is not present`() {
+        assertFalse(CollectionUtils.contains(arrayOf("one", "two", "three"), "four"))
     }
 }

--- a/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/StringUtilsTest.kt
@@ -58,6 +58,31 @@ class StringUtilsTest {
     }
 
     @Test
+    fun `camelCase string`() {
+        assertEquals("TestCase", StringUtils.camelCase("test_case"))
+    }
+
+    @Test
+    fun `camelCase string even if its uppercase`() {
+        assertEquals("TestCase", StringUtils.camelCase("TEST CASE"))
+    }
+
+    @Test
+    fun `camelCase do not throw if only 1 char`() {
+        assertEquals("T", StringUtils.camelCase("t"))
+    }
+
+    @Test
+    fun `camelCase returns itself if null`() {
+        assertNull(StringUtils.camelCase(null))
+    }
+
+    @Test
+    fun `camelCase returns itself if empty`() {
+        assertEquals("", StringUtils.camelCase(""))
+    }
+
+    @Test
     fun `removeSurrounding returns null if argument is null`() {
         assertNull(StringUtils.removeSurrounding(null, "\""))
     }


### PR DESCRIPTION
## :scroll: Description
add rate limiting to metrics
added metric_bucket data category


## :bulb: Motivation and Context
Implements https://github.com/getsentry/sentry-java/issues/3292


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
