### PR TITLE
[SR] Handle orientation change

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -25,15 +25,17 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/protocol/SentryId;Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
 	public final fun addFrame (Ljava/io/File;J)V
 	public fun close ()V
-	public final fun createVideoOf (JJILjava/io/File;)Lio/sentry/android/replay/GeneratedVideo;
-	public static synthetic fun createVideoOf$default (Lio/sentry/android/replay/ReplayCache;JJILjava/io/File;ILjava/lang/Object;)Lio/sentry/android/replay/GeneratedVideo;
+	public final fun createVideoOf (JJIIILjava/io/File;)Lio/sentry/android/replay/GeneratedVideo;
+	public static synthetic fun createVideoOf$default (Lio/sentry/android/replay/ReplayCache;JJIIILjava/io/File;ILjava/lang/Object;)Lio/sentry/android/replay/GeneratedVideo;
 	public final fun rotate (J)V
 }
 
-public final class io/sentry/android/replay/ReplayIntegration : io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, java/io/Closeable {
+public final class io/sentry/android/replay/ReplayIntegration : android/content/ComponentCallbacks, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
 	public fun close ()V
 	public fun isRecording ()Z
+	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
+	public fun onLowMemory ()V
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -1,6 +1,8 @@
 package io.sentry.android.replay
 
+import android.content.ComponentCallbacks
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.os.Build
 import io.sentry.DateUtils
@@ -41,7 +43,7 @@ import kotlin.LazyThreadSafetyMode.NONE
 class ReplayIntegration(
     private val context: Context,
     private val dateProvider: ICurrentDateProvider
-) : Integration, Closeable, ScreenshotRecorderCallback, ReplayController {
+) : Integration, Closeable, ScreenshotRecorderCallback, ReplayController, ComponentCallbacks {
 
     internal companion object {
         private const val TAG = "ReplayIntegration"
@@ -391,6 +393,12 @@ class ReplayIntegration(
         stop()
         replayExecutor.gracefullyShutdown(options)
     }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+
+    }
+
+    override fun onLowMemory() = Unit
 
     private class ReplayExecutorServiceThreadFactory : ThreadFactory {
         private var cnt = 0

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -17,7 +17,6 @@ import kotlin.LazyThreadSafetyMode.NONE
 @TargetApi(26)
 internal class WindowRecorder(
     private val options: SentryOptions,
-    private val recorderConfig: ScreenshotRecorderConfig,
     private val screenshotRecorderCallback: ScreenshotRecorderCallback
 ) : Closeable {
 
@@ -50,7 +49,7 @@ internal class WindowRecorder(
         }
     }
 
-    fun startRecording() {
+    fun startRecording(recorderConfig: ScreenshotRecorderConfig) {
         if (isRecording.getAndSet(true)) {
             return
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -37,7 +37,6 @@ import android.media.MediaFormat
 import android.view.Surface
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryOptions
-import io.sentry.android.replay.ScreenshotRecorderConfig
 import java.io.File
 import java.nio.ByteBuffer
 import kotlin.LazyThreadSafetyMode.NONE

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -62,7 +62,7 @@ internal class SimpleVideoEncoder(
             .getCapabilitiesForType(muxerConfig.mimeType)
             .videoCapabilities
 
-        var bitRate = muxerConfig.recorderConfig.bitRate
+        var bitRate = muxerConfig.bitRate
         if (!videoCapabilities.bitrateRange.contains(bitRate)) {
             options.logger.log(
                 DEBUG,
@@ -96,8 +96,8 @@ internal class SimpleVideoEncoder(
 
         val format = MediaFormat.createVideoFormat(
             muxerConfig.mimeType,
-            muxerConfig.recorderConfig.recordingWidth,
-            muxerConfig.recorderConfig.recordingHeight
+            muxerConfig.recordingWidth,
+            muxerConfig.recordingHeight
         )
 
         // this allows reducing bitrate on newer devices, where they enforce higher quality in VBR
@@ -115,14 +115,14 @@ internal class SimpleVideoEncoder(
             MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface
         )
         format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
-        format.setFloat(MediaFormat.KEY_FRAME_RATE, muxerConfig.recorderConfig.frameRate.toFloat())
+        format.setFloat(MediaFormat.KEY_FRAME_RATE, muxerConfig.frameRate.toFloat())
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 10)
 
         format
     }
 
     private val bufferInfo: MediaCodec.BufferInfo = MediaCodec.BufferInfo()
-    private val frameMuxer = SimpleMp4FrameMuxer(muxerConfig.file.absolutePath, muxerConfig.recorderConfig.frameRate.toFloat())
+    private val frameMuxer = SimpleMp4FrameMuxer(muxerConfig.file.absolutePath, muxerConfig.frameRate.toFloat())
     val duration get() = frameMuxer.getVideoTime()
 
     private var surface: Surface? = null
@@ -229,6 +229,9 @@ internal class SimpleVideoEncoder(
 @TargetApi(24)
 internal data class MuxerConfig(
     val file: File,
-    val recorderConfig: ScreenshotRecorderConfig,
+    var recordingWidth: Int,
+    var recordingHeight: Int,
+    val frameRate: Int,
+    val bitRate: Int,
     val mimeType: String = MediaFormat.MIMETYPE_VIDEO_AVC
 )

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -41,12 +41,15 @@ class ReplayCacheTest {
             options.run {
                 cacheDirPath = dir?.newFolder()?.absolutePath
             }
-            return ReplayCache(options, replayId, recorderConfig, encoderCreator = { videoFile ->
+            return ReplayCache(options, replayId, recorderConfig, encoderCreator = { videoFile, height, width ->
                 encoder = SimpleVideoEncoder(
                     options,
                     MuxerConfig(
                         file = videoFile,
-                        recorderConfig = recorderConfig
+                        recordingHeight = height,
+                        recordingWidth = width,
+                        frameRate = recorderConfig.frameRate,
+                        bitRate = recorderConfig.bitRate
                     ),
                     onClose = {
                         encodeFrame(framesToEncode, frameRate, size = 0, flags = MediaCodec.BUFFER_FLAG_END_OF_STREAM)
@@ -107,7 +110,7 @@ class ReplayCacheTest {
             frameRate = 1
         )
 
-        val video = replayCache.createVideoOf(5000L, 0, 0)
+        val video = replayCache.createVideoOf(5000L, 0, 0, 100, 200)
 
         assertNull(video)
     }
@@ -125,7 +128,7 @@ class ReplayCacheTest {
         replayCache.addFrame(bitmap, 1001)
         replayCache.addFrame(bitmap, 2001)
 
-        val segment0 = replayCache.createVideoOf(3000L, 0, 0)
+        val segment0 = replayCache.createVideoOf(3000L, 0, 0, 100, 200)
         assertEquals(3, segment0!!.frameCount)
         assertEquals(3000, segment0.duration)
         assertTrue { segment0.video.exists() && segment0.video.length() > 0 }
@@ -146,7 +149,7 @@ class ReplayCacheTest {
         val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
         replayCache.addFrame(bitmap, 1)
 
-        val segment0 = replayCache.createVideoOf(5000L, 0, 0)
+        val segment0 = replayCache.createVideoOf(5000L, 0, 0, 100, 200)
         assertEquals(5, segment0!!.frameCount)
         assertEquals(5000, segment0.duration)
         assertTrue { segment0.video.exists() && segment0.video.length() > 0 }
@@ -165,7 +168,7 @@ class ReplayCacheTest {
         replayCache.addFrame(bitmap, 1)
         replayCache.addFrame(bitmap, 3001)
 
-        val segment0 = replayCache.createVideoOf(5000L, 0, 0)
+        val segment0 = replayCache.createVideoOf(5000L, 0, 0, 100, 200)
         assertEquals(5, segment0!!.frameCount)
         assertEquals(5000, segment0.duration)
         assertTrue { segment0.video.exists() && segment0.video.length() > 0 }
@@ -184,12 +187,12 @@ class ReplayCacheTest {
         replayCache.addFrame(bitmap, 1)
         replayCache.addFrame(bitmap, 5001)
 
-        val segment0 = replayCache.createVideoOf(5000L, 0, 0)
+        val segment0 = replayCache.createVideoOf(5000L, 0, 0, 100, 200)
         assertEquals(5, segment0!!.frameCount)
         assertEquals(5000, segment0.duration)
         assertEquals(File(replayCache.replayCacheDir, "0.mp4"), segment0.video)
 
-        val segment1 = replayCache.createVideoOf(5000L, 5000L, 1)
+        val segment1 = replayCache.createVideoOf(5000L, 5000L, 1, 100, 200)
         assertEquals(5, segment1!!.frameCount)
         assertEquals(5000, segment1.duration)
         assertTrue { segment0.video.exists() && segment0.video.length() > 0 }
@@ -209,7 +212,7 @@ class ReplayCacheTest {
         replayCache.addFrame(bitmap, 1001)
         replayCache.addFrame(bitmap, 1501)
 
-        val segment0 = replayCache.createVideoOf(3000L, 0, 0)
+        val segment0 = replayCache.createVideoOf(3000L, 0, 0, 100, 200)
         assertEquals(6, segment0!!.frameCount)
         assertEquals(3000, segment0.duration)
         assertTrue { segment0.video.exists() && segment0.video.length() > 0 }
@@ -235,7 +238,7 @@ class ReplayCacheTest {
         }
         replayCache.addFrame(screenshot, frameTimestamp = 1)
 
-        val segment0 = replayCache.createVideoOf(5000L, 0, 0, videoFile = video)
+        val segment0 = replayCache.createVideoOf(5000L, 0, 0, 100, 200, videoFile = video)
         assertEquals(5, segment0!!.frameCount)
         assertEquals(5000, segment0.duration)
 

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -157,6 +157,7 @@
       <meta-data android:name="io.sentry.performance-v2.enable" android:value="true" />
 
       <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
+      <meta-data android:name="io.sentry.session-replay.redact-all-text" android:value="false" />
 
     </application>
 </manifest>


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Observe device configuration changes to stop and restart the replay with new config
  * This is only support in full `session` mode for now, to support this in `buffer` mode we'd have to split the buffered video into multiple segments (as many as the number of orientation changes), but this will come later 
* Fix bug where we were not tagging events with `replayId` in `session` mode

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255
