### PR TITLE
Fix java.lang.ClassNotFoundException: org.springframework.web.servlet.HandlerMapping in Spring Boot Servlet mode without WebMVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Add rate limit to Metrics ([#3334](https://github.com/getsentry/sentry-java/pull/3334))
+- Fix java.lang.ClassNotFoundException: org.springframework.web.servlet.HandlerMapping in Spring Boot Servlet mode without WebMVC ([#3336](https://github.com/getsentry/sentry-java/pull/3336))
 
 ## 7.7.0
 

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -268,12 +268,6 @@ public class SentryAutoConfiguration {
       }
 
       @Bean
-      @ConditionalOnMissingBean(TransactionNameProvider.class)
-      public @NotNull TransactionNameProvider transactionNameProvider() {
-        return new SpringMvcTransactionNameProvider();
-      }
-
-      @Bean
       @ConditionalOnMissingBean(name = "sentrySpringFilter")
       public @NotNull FilterRegistrationBean<SentrySpringFilter> sentrySpringFilter(
           final @NotNull IHub hub,
@@ -300,7 +294,7 @@ public class SentryAutoConfiguration {
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
-      static class SentryExceptionResolverConfigurationWrapper {
+      static class SentryNonServletOnlyModeConfig {
 
         @Bean
         @ConditionalOnMissingBean
@@ -310,6 +304,12 @@ public class SentryAutoConfiguration {
             final @NotNull SentryProperties options) {
           return new SentryExceptionResolver(
               sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+        }
+
+        @Bean
+        @ConditionalOnMissingBean(TransactionNameProvider.class)
+        public @NotNull TransactionNameProvider transactionNameProvider() {
+          return new SpringMvcTransactionNameProvider();
         }
       }
     }

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -294,7 +294,7 @@ public class SentryAutoConfiguration {
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
-      static class SentryNonServletOnlyModeConfig {
+      static class SentryMvcModeConfig {
 
         @Bean
         @ConditionalOnMissingBean

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -33,6 +33,7 @@ import io.sentry.spring.jakarta.tracing.SentrySpanPointcutConfiguration;
 import io.sentry.spring.jakarta.tracing.SentryTracingFilter;
 import io.sentry.spring.jakarta.tracing.SentryTransactionPointcutConfiguration;
 import io.sentry.spring.jakarta.tracing.SpringMvcTransactionNameProvider;
+import io.sentry.spring.jakarta.tracing.SpringServletTransactionNameProvider;
 import io.sentry.spring.jakarta.tracing.TransactionNameProvider;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.apache.ApacheHttpClientTransportFactory;
@@ -49,6 +50,7 @@ import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
@@ -290,7 +292,6 @@ public class SentryAutoConfiguration {
         return filter;
       }
 
-      /** Wraps exception resolver @Bean because the return type is loaded too early otherwise */
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
@@ -310,6 +311,18 @@ public class SentryAutoConfiguration {
         @ConditionalOnMissingBean(TransactionNameProvider.class)
         public @NotNull TransactionNameProvider transactionNameProvider() {
           return new SpringMvcTransactionNameProvider();
+        }
+      }
+
+      @Configuration(proxyBeanMethods = false)
+      @ConditionalOnMissingClass("org.springframework.web.servlet.HandlerExceptionResolver")
+      @Open
+      static class SentryServletModeConfig {
+
+        @Bean
+        @ConditionalOnMissingBean(TransactionNameProvider.class)
+        public @NotNull TransactionNameProvider transactionNameProvider() {
+          return new SpringServletTransactionNameProvider();
         }
       }
     }

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -26,6 +26,8 @@ import io.sentry.spring.jakarta.SentryUserFilter
 import io.sentry.spring.jakarta.SentryUserProvider
 import io.sentry.spring.jakarta.SpringSecuritySentryUserProvider
 import io.sentry.spring.jakarta.tracing.SentryTracingFilter
+import io.sentry.spring.jakarta.tracing.SpringServletTransactionNameProvider
+import io.sentry.spring.jakarta.tracing.TransactionNameProvider
 import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
 import io.sentry.transport.apache.ApacheHttpClientTransportFactory
@@ -442,6 +444,15 @@ class SentryAutoConfigurationTest {
             .withClassLoader(FilteredClassLoader(HandlerExceptionResolver::class.java))
             .run {
                 assertThat(it).doesNotHaveBean(SentryExceptionResolver::class.java)
+            }
+    }
+
+    @Test
+    fun `when Spring MVC is not on the classpath, fallback TransactionNameProvider is configured`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true")
+            .withClassLoader(FilteredClassLoader(HandlerExceptionResolver::class.java))
+            .run {
+                assertThat(it.getBean(TransactionNameProvider::class.java)).isInstanceOf(SpringServletTransactionNameProvider::class.java)
             }
     }
 

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -292,7 +292,7 @@ public class SentryAutoConfiguration {
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
-      static class SentryNonServletOnlyModeConfig {
+      static class SentryMvcModeConfig {
 
         @Bean
         @ConditionalOnMissingBean

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -266,12 +266,6 @@ public class SentryAutoConfiguration {
       }
 
       @Bean
-      @ConditionalOnMissingBean(TransactionNameProvider.class)
-      public @NotNull TransactionNameProvider transactionNameProvider() {
-        return new SpringMvcTransactionNameProvider();
-      }
-
-      @Bean
       @ConditionalOnMissingBean(name = "sentrySpringFilter")
       public @NotNull FilterRegistrationBean<SentrySpringFilter> sentrySpringFilter(
           final @NotNull IHub hub,
@@ -298,7 +292,7 @@ public class SentryAutoConfiguration {
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
-      static class SentryExceptionResolverConfigurationWrapper {
+      static class SentryNonServletOnlyModeConfig {
 
         @Bean
         @ConditionalOnMissingBean
@@ -308,6 +302,12 @@ public class SentryAutoConfiguration {
             final @NotNull SentryProperties options) {
           return new SentryExceptionResolver(
               sentryHub, transactionNameProvider, options.getExceptionResolverOrder());
+        }
+
+        @Bean
+        @ConditionalOnMissingBean(TransactionNameProvider.class)
+        public @NotNull TransactionNameProvider transactionNameProvider() {
+          return new SpringMvcTransactionNameProvider();
         }
       }
     }

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -33,6 +33,7 @@ import io.sentry.spring.tracing.SentrySpanPointcutConfiguration;
 import io.sentry.spring.tracing.SentryTracingFilter;
 import io.sentry.spring.tracing.SentryTransactionPointcutConfiguration;
 import io.sentry.spring.tracing.SpringMvcTransactionNameProvider;
+import io.sentry.spring.tracing.SpringServletTransactionNameProvider;
 import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.apache.ApacheHttpClientTransportFactory;
@@ -49,6 +50,7 @@ import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
@@ -288,7 +290,6 @@ public class SentryAutoConfiguration {
         return filter;
       }
 
-      /** Wraps exception resolver @Bean because the return type is loaded too early otherwise */
       @Configuration(proxyBeanMethods = false)
       @ConditionalOnClass(HandlerExceptionResolver.class)
       @Open
@@ -308,6 +309,18 @@ public class SentryAutoConfiguration {
         @ConditionalOnMissingBean(TransactionNameProvider.class)
         public @NotNull TransactionNameProvider transactionNameProvider() {
           return new SpringMvcTransactionNameProvider();
+        }
+      }
+
+      @Configuration(proxyBeanMethods = false)
+      @ConditionalOnMissingClass("org.springframework.web.servlet.HandlerExceptionResolver")
+      @Open
+      static class SentryServletModeConfig {
+
+        @Bean
+        @ConditionalOnMissingBean(TransactionNameProvider.class)
+        public @NotNull TransactionNameProvider transactionNameProvider() {
+          return new SpringServletTransactionNameProvider();
         }
       }
     }

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -26,6 +26,8 @@ import io.sentry.spring.SentryUserFilter
 import io.sentry.spring.SentryUserProvider
 import io.sentry.spring.SpringSecuritySentryUserProvider
 import io.sentry.spring.tracing.SentryTracingFilter
+import io.sentry.spring.tracing.SpringServletTransactionNameProvider
+import io.sentry.spring.tracing.TransactionNameProvider
 import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
 import io.sentry.transport.apache.ApacheHttpClientTransportFactory
@@ -441,6 +443,17 @@ class SentryAutoConfigurationTest {
             .withClassLoader(FilteredClassLoader(HandlerExceptionResolver::class.java))
             .run {
                 assertThat(it).doesNotHaveBean(SentryExceptionResolver::class.java)
+            }
+    }
+
+    @Test
+    fun `when Spring MVC is not on the classpath, fallback TransactionNameProvider is configured`() {
+        contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj", "sentry.send-default-pii=true")
+            .withClassLoader(FilteredClassLoader(HandlerExceptionResolver::class.java))
+            .run {
+                assertThat(it.getBean(TransactionNameProvider::class.java)).isInstanceOf(
+                    SpringServletTransactionNameProvider::class.java
+                )
             }
     }
 

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -261,6 +261,12 @@ public final class io/sentry/spring/jakarta/tracing/SpringMvcTransactionNameProv
 	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;
 }
 
+public final class io/sentry/spring/jakarta/tracing/SpringServletTransactionNameProvider : io/sentry/spring/jakarta/tracing/TransactionNameProvider {
+	public fun <init> ()V
+	public fun provideTransactionName (Ljakarta/servlet/http/HttpServletRequest;)Ljava/lang/String;
+	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;
+}
+
 public abstract interface class io/sentry/spring/jakarta/tracing/TransactionNameProvider {
 	public abstract fun provideTransactionName (Ljakarta/servlet/http/HttpServletRequest;)Ljava/lang/String;
 	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SpringServletTransactionNameProvider.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/tracing/SpringServletTransactionNameProvider.java
@@ -1,0 +1,22 @@
+package io.sentry.spring.jakarta.tracing;
+
+import io.sentry.protocol.TransactionNameSource;
+import jakarta.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Fallback TransactionNameProvider when Spring is used in servlet mode (without MVC). */
+@ApiStatus.Internal
+public final class SpringServletTransactionNameProvider implements TransactionNameProvider {
+  @Override
+  public @Nullable String provideTransactionName(final @NotNull HttpServletRequest request) {
+    return request.getMethod() + " " + request.getRequestURI();
+  }
+
+  @Override
+  @ApiStatus.Internal
+  public @NotNull TransactionNameSource provideTransactionSource() {
+    return TransactionNameSource.URL;
+  }
+}

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -260,6 +260,12 @@ public final class io/sentry/spring/tracing/SpringMvcTransactionNameProvider : i
 	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;
 }
 
+public final class io/sentry/spring/tracing/SpringServletTransactionNameProvider : io/sentry/spring/tracing/TransactionNameProvider {
+	public fun <init> ()V
+	public fun provideTransactionName (Ljavax/servlet/http/HttpServletRequest;)Ljava/lang/String;
+	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;
+}
+
 public abstract interface class io/sentry/spring/tracing/TransactionNameProvider {
 	public abstract fun provideTransactionName (Ljavax/servlet/http/HttpServletRequest;)Ljava/lang/String;
 	public fun provideTransactionSource ()Lio/sentry/protocol/TransactionNameSource;

--- a/sentry-spring/src/main/java/io/sentry/spring/tracing/SpringServletTransactionNameProvider.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/tracing/SpringServletTransactionNameProvider.java
@@ -1,0 +1,22 @@
+package io.sentry.spring.tracing;
+
+import io.sentry.protocol.TransactionNameSource;
+import javax.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Fallback TransactionNameProvider when Spring is used in servlet mode (without MVC). */
+@ApiStatus.Internal
+public final class SpringServletTransactionNameProvider implements TransactionNameProvider {
+  @Override
+  public @Nullable String provideTransactionName(final @NotNull HttpServletRequest request) {
+    return request.getMethod() + " " + request.getRequestURI();
+  }
+
+  @Override
+  @ApiStatus.Internal
+  public @NotNull TransactionNameSource provideTransactionSource() {
+    return TransactionNameSource.URL;
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
HandlerMapping is used by `SpringMvcTransactionNameProvider`. We now provide a fallback `TransactionNameProvider` which uses the `requestURI` as transaction name. This means we're not using the route which contains placeholders for IDs (e.g. `/todo/{id}`) but instead use e.g. `/todo/100`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix-es #1863 (2nd part)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
