### PR TITLE
[SR] More gates

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/Windows.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/Windows.kt
@@ -136,18 +136,17 @@ internal fun interface OnRootViewsChangedListener {
  */
 internal class RootViewsSpy private constructor() {
 
-    val listeners = CopyOnWriteArrayList<OnRootViewsChangedListener>()
-
-    private val delegatingViewList = object : ArrayList<View>() {
-        override fun addAll(elements: Collection<View>): Boolean {
-            listeners.forEach { listener ->
-                elements.forEach { element ->
-                    listener.onRootViewsChanged(element, true)
-                }
+    val listeners: CopyOnWriteArrayList<OnRootViewsChangedListener> = object : CopyOnWriteArrayList<OnRootViewsChangedListener>() {
+        override fun add(element: OnRootViewsChangedListener?): Boolean {
+            // notify listener about existing root views immediately
+            delegatingViewList.forEach {
+                element?.onRootViewsChanged(it, true)
             }
-            return super.addAll(elements)
+            return super.add(element)
         }
+    }
 
+    private val delegatingViewList: ArrayList<View> = object : ArrayList<View>() {
         override fun add(element: View): Boolean {
             listeners.forEach { it.onRootViewsChanged(element, true) }
             return super.add(element)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Just adding more gates for the methods that shouldn't be called until we introduce replay lifecycle state
* Changed RootViewsSpy so that whenever we add a new listener to the list, we notify it immediately about any existing root views. This way we can ensure in the future if `start()` is called manually in the middle of app flow, we get the current root views to track