### PR TITLE
Hubs/Scopes Merge 20 - Use separate scope for current, isolation and global scope

### DIFF
--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -422,7 +422,7 @@ class SentryTest {
         assertNotNull(scopes)
         assertFalse(Sentry.getCurrentScopes().isNoOp)
 
-        val newMainHubClone = Sentry.cloneMainHub()
+        val newMainHubClone = Sentry.forkedRootScopes("test")
         newMainHubClone.addBreadcrumb("breadcrumbMainClone")
 
         scopes.captureMessage("messageCurrent")
@@ -473,7 +473,7 @@ class SentryTest {
         assertNotNull(scopes)
         assertFalse(scopes.isNoOp)
 
-        val newMainHubClone = Sentry.cloneMainHub()
+        val newMainHubClone = Sentry.forkedRootScopes("test")
         newMainHubClone.addBreadcrumb("breadcrumbMainClone")
 
         scopes.captureMessage("messageCurrent")
@@ -921,7 +921,7 @@ class SentryTest {
     }
 
     @Test
-    fun `getSpan calls returns root span if globalscopes mode is enabled on Android`() {
+    fun `getSpan calls returns root span if globalHubMode is enabled on Android`() {
         PlatformTestManipulator.pretendIsAndroid(true)
         Sentry.init({
             it.dsn = dsn
@@ -938,7 +938,7 @@ class SentryTest {
     }
 
     @Test
-    fun `getSpan calls returns child span if globalscopes mode is enabled, but the platform is not Android`() {
+    fun `getSpan calls returns child span if globalHubMode is enabled, but the platform is not Android`() {
         PlatformTestManipulator.pretendIsAndroid(false)
         Sentry.init({
             it.dsn = dsn
@@ -954,7 +954,7 @@ class SentryTest {
     }
 
     @Test
-    fun `getSpan calls returns child span if globalscopes mode is disabled`() {
+    fun `getSpan calls returns child span if globalHubMode is disabled`() {
         Sentry.init({
             it.dsn = dsn
             it.enableTracing = true


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
- Use separate scope for current, isolation and global scope
- Rename `mainScopes` to `rootScopes`
- Rename `cloneMainHub` to `forkedRootScopes`

TODO: We need to figure out how to deal with global scope. It should already be available before `Sentry.init` is called but `Scope` requires `SentryOptions` e.g. to set some limits. At the moment we're replacing global scope on `init` but that should be changed in a follow up PR.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
