### PR TITLE
Hubs/Scopes Merge 25 - Use new API in Servlet integrations

### DIFF
--- a/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
+++ b/sentry-servlet-jakarta/api/sentry-servlet-jakarta.api
@@ -9,6 +9,7 @@ public class io/sentry/servlet/jakarta/SentryServletContainerInitializer : jakar
 }
 
 public class io/sentry/servlet/jakarta/SentryServletRequestListener : jakarta/servlet/ServletRequestListener {
+	public static final field SENTRY_LIFECYCLE_TOKEN_KEY Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun requestDestroyed (Ljakarta/servlet/ServletRequestEvent;)V

--- a/sentry-servlet/api/sentry-servlet.api
+++ b/sentry-servlet/api/sentry-servlet.api
@@ -9,6 +9,7 @@ public class io/sentry/servlet/SentryServletContainerInitializer : javax/servlet
 }
 
 public class io/sentry/servlet/SentryServletRequestListener : javax/servlet/ServletRequestListener {
+	public static final field SENTRY_LIFECYCLE_TOKEN_KEY Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun requestDestroyed (Ljavax/servlet/ServletRequestEvent;)V

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryServletRequestListener.java
@@ -6,7 +6,9 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ScopesAdapter;
+import io.sentry.util.LifecycleHelper;
 import io.sentry.util.Objects;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestEvent;
@@ -21,6 +23,8 @@ import org.jetbrains.annotations.NotNull;
 @Open
 public class SentryServletRequestListener implements ServletRequestListener {
 
+  public static final String SENTRY_LIFECYCLE_TOKEN_KEY = "sentry-lifecycle";
+
   private final IScopes scopes;
 
   public SentryServletRequestListener(@NotNull IScopes scopes) {
@@ -33,14 +37,16 @@ public class SentryServletRequestListener implements ServletRequestListener {
 
   @Override
   public void requestDestroyed(@NotNull ServletRequestEvent servletRequestEvent) {
-    scopes.popScope();
+    final ServletRequest servletRequest = servletRequestEvent.getServletRequest();
+    LifecycleHelper.close(servletRequest.getAttribute(SENTRY_LIFECYCLE_TOKEN_KEY));
   }
 
   @Override
   public void requestInitialized(@NotNull ServletRequestEvent servletRequestEvent) {
-    scopes.pushScope();
+    final @NotNull ISentryLifecycleToken lifecycleToken = scopes.pushIsolationScope();
 
     final ServletRequest servletRequest = servletRequestEvent.getServletRequest();
+    servletRequest.setAttribute(SENTRY_LIFECYCLE_TOKEN_KEY, lifecycleToken);
     if (servletRequest instanceof HttpServletRequest) {
       final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
