### PR TITLE
Hubs/Scopes Merge 31 - Fix `EventProcessor` ordering on `Scopes`

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -97,6 +97,7 @@ public final class io/sentry/android/core/AnrIntegrationFactory {
 
 public final class io/sentry/android/core/AnrV2EventProcessor : io/sentry/BackfillingEventProcessor {
 	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/android/core/BuildInfoProvider;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
@@ -236,6 +237,7 @@ public final class io/sentry/android/core/PhoneStateBreadcrumbsIntegration : io/
 
 public final class io/sentry/android/core/ScreenshotEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/android/core/BuildInfoProvider;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
@@ -386,6 +388,7 @@ public final class io/sentry/android/core/UserInteractionIntegration : android/a
 
 public final class io/sentry/android/core/ViewHierarchyEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 	public static fun snapshotViewHierarchy (Landroid/app/Activity;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -429,6 +429,11 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
   }
   // endregion
 
+  @Override
+  public @Nullable Long getOrder() {
+    return 12000L;
+  }
+
   // region static values
   private void setStaticValues(final @NotNull SentryEvent event) {
     mergeUser(event);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -303,4 +303,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
     return transaction;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 8000L;
+  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -254,4 +254,9 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         null,
         defaultSpanData);
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 9000L;
+  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -98,4 +98,9 @@ public final class ScreenshotEventProcessor implements EventProcessor {
     hint.set(ANDROID_ACTIVITY, activity);
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 10000L;
+  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -284,4 +284,9 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
 
     return node;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 11000L;
+  }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
@@ -1,5 +1,6 @@
 public final class io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor : io/sentry/EventProcessor {
 	public fun <init> ()V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryLinkErrorEventProcessor.java
@@ -99,4 +99,9 @@ public final class OpenTelemetryLinkErrorEventProcessor implements EventProcesso
 
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 6000L;
+  }
 }

--- a/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet-jakarta/src/main/java/io/sentry/servlet/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -56,4 +56,9 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   private static @Nullable String toString(final @Nullable Enumeration<String> enumeration) {
     return enumeration != null ? String.join(",", Collections.list(enumeration)) : null;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 4000L;
+  }
 }

--- a/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-servlet/src/main/java/io/sentry/servlet/SentryRequestHttpServletRequestProcessor.java
@@ -56,4 +56,9 @@ final class SentryRequestHttpServletRequestProcessor implements EventProcessor {
   private static @Nullable String toString(final @Nullable Enumeration<String> enumeration) {
     return enumeration != null ? String.join(",", Collections.list(enumeration)) : null;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 4000L;
+  }
 }

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -5,6 +5,7 @@ public final class io/sentry/spring/jakarta/BuildConfig {
 
 public final class io/sentry/spring/jakarta/ContextTagsEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 
@@ -43,6 +44,7 @@ public class io/sentry/spring/jakarta/SentryInitBeanPostProcessor : org/springfr
 
 public class io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/spring/jakarta/tracing/TransactionNameProvider;Ljakarta/servlet/http/HttpServletRequest;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/ContextTagsEventProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/ContextTagsEventProcessor.java
@@ -38,4 +38,9 @@ public final class ContextTagsEventProcessor implements EventProcessor {
     }
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 14000L;
+  }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessor.java
@@ -8,6 +8,7 @@ import io.sentry.spring.jakarta.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
 import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Attaches transaction name from the HTTP request to {@link SentryEvent}. */
 @Open
@@ -29,5 +30,10 @@ public class SentryRequestHttpServletRequestProcessor implements EventProcessor 
       event.setTransaction(transactionNameProvider.provideTransactionName(request));
     }
     return event;
+  }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 5000L;
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringFilter.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -156,6 +157,11 @@ public class SentrySpringFilter extends OncePerRequestFilter {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }
       return event;
+    }
+
+    @Override
+    public @Nullable Long getOrder() {
+      return 3000L;
     }
   }
 }

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -5,6 +5,7 @@ public final class io/sentry/spring/BuildConfig {
 
 public final class io/sentry/spring/ContextTagsEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 
@@ -43,6 +44,7 @@ public class io/sentry/spring/SentryInitBeanPostProcessor : org/springframework/
 
 public class io/sentry/spring/SentryRequestHttpServletRequestProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/spring/tracing/TransactionNameProvider;Ljavax/servlet/http/HttpServletRequest;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/ContextTagsEventProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/ContextTagsEventProcessor.java
@@ -38,4 +38,9 @@ public final class ContextTagsEventProcessor implements EventProcessor {
     }
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 14000L;
+  }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentryRequestHttpServletRequestProcessor.java
@@ -8,6 +8,7 @@ import io.sentry.spring.tracing.TransactionNameProvider;
 import io.sentry.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Attaches transaction name from the HTTP request to {@link SentryEvent}. */
 @Open
@@ -29,5 +30,10 @@ public class SentryRequestHttpServletRequestProcessor implements EventProcessor 
       event.setTransaction(transactionNameProvider.provideTransactionName(request));
     }
     return event;
+  }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 5000L;
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -156,6 +157,11 @@ public class SentrySpringFilter extends OncePerRequestFilter {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }
       return event;
+    }
+
+    @Override
+    public @Nullable Long getOrder() {
+      return 3000L;
     }
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -255,6 +255,7 @@ public final class io/sentry/CombinedScopeView : io/sentry/IScope {
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getOrderedEventProcessors ()Ljava/util/List;
 	public fun getPropagationContext ()Lio/sentry/PropagationContext;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getScreen ()Ljava/lang/String;
@@ -342,6 +343,7 @@ public final class io/sentry/DateUtils {
 
 public final class io/sentry/DeduplicateMultithreadedEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 
@@ -377,6 +379,7 @@ public final class io/sentry/DsnUtil {
 
 public final class io/sentry/DuplicateEventDetectionEventProcessor : io/sentry/EventProcessor {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 }
 
@@ -392,6 +395,7 @@ public final class io/sentry/EnvelopeSender : io/sentry/IEnvelopeSender {
 }
 
 public abstract interface class io/sentry/EventProcessor {
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
@@ -788,6 +792,7 @@ public abstract interface class io/sentry/IScope {
 	public abstract fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getLevel ()Lio/sentry/SentryLevel;
 	public abstract fun getOptions ()Lio/sentry/SentryOptions;
+	public abstract fun getOrderedEventProcessors ()Ljava/util/List;
 	public abstract fun getPropagationContext ()Lio/sentry/PropagationContext;
 	public abstract fun getRequest ()Lio/sentry/protocol/Request;
 	public abstract fun getScreen ()Ljava/lang/String;
@@ -1160,6 +1165,7 @@ public abstract interface class io/sentry/JsonUnknown {
 public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor, java/io/Closeable {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close ()V
+	public fun getOrder ()Ljava/lang/Long;
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 }
@@ -1447,6 +1453,7 @@ public final class io/sentry/NoOpScope : io/sentry/IScope {
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getOrderedEventProcessors ()Ljava/util/List;
 	public fun getPropagationContext ()Lio/sentry/PropagationContext;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getScreen ()Ljava/lang/String;
@@ -1889,6 +1896,7 @@ public final class io/sentry/Scope : io/sentry/IScope {
 	public fun getLastEventId ()Lio/sentry/protocol/SentryId;
 	public fun getLevel ()Lio/sentry/SentryLevel;
 	public fun getOptions ()Lio/sentry/SentryOptions;
+	public fun getOrderedEventProcessors ()Ljava/util/List;
 	public fun getPropagationContext ()Lio/sentry/PropagationContext;
 	public fun getRequest ()Lio/sentry/protocol/Request;
 	public fun getScreen ()Ljava/lang/String;
@@ -1958,6 +1966,7 @@ public abstract class io/sentry/ScopeObserverAdapter : io/sentry/IScopeObserver 
 }
 
 public final class io/sentry/ScopeType : java/lang/Enum {
+	public static final field COMBINED Lio/sentry/ScopeType;
 	public static final field CURRENT Lio/sentry/ScopeType;
 	public static final field GLOBAL Lio/sentry/ScopeType;
 	public static final field ISOLATION Lio/sentry/ScopeType;
@@ -3805,6 +3814,14 @@ public final class io/sentry/internal/debugmeta/ResourcesDebugMetaLoader : io/se
 	public fun loadDebugMeta ()Ljava/util/List;
 }
 
+public final class io/sentry/internal/eventprocessor/EventProcessorAndOrder : java/lang/Comparable {
+	public fun <init> (Lio/sentry/EventProcessor;Ljava/lang/Long;)V
+	public fun compareTo (Lio/sentry/internal/eventprocessor/EventProcessorAndOrder;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun getEventProcessor ()Lio/sentry/EventProcessor;
+	public fun getOrder ()Ljava/lang/Long;
+}
+
 public abstract interface class io/sentry/internal/gestures/GestureTargetLocator {
 	public abstract fun locate (Ljava/lang/Object;FFLio/sentry/internal/gestures/UiElement$Type;)Lio/sentry/internal/gestures/UiElement;
 }
@@ -5379,6 +5396,11 @@ public final class io/sentry/util/DebugMetaPropertiesApplier {
 	public fun <init> ()V
 	public static fun applyToOptions (Lio/sentry/SentryOptions;Ljava/util/List;)V
 	public static fun getProguardUuid (Ljava/util/Properties;)Ljava/lang/String;
+}
+
+public final class io/sentry/util/EventProcessorUtils {
+	public fun <init> ()V
+	public static fun unwrap (Ljava/util/List;)Ljava/util/List;
 }
 
 public final class io/sentry/util/ExceptionUtils {

--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -1,9 +1,11 @@
 package io.sentry;
 
+import io.sentry.internal.eventprocessor.EventProcessorAndOrder;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
+import io.sentry.util.EventProcessorUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -341,13 +343,18 @@ public final class CombinedScopeView implements IScope {
   }
 
   @Override
-  public @NotNull List<EventProcessor> getEventProcessors() {
-    // TODO [HSM] mechanism for ordering event processors
-    final @NotNull List<EventProcessor> allEventProcessors = new CopyOnWriteArrayList<>();
-    allEventProcessors.addAll(globalScope.getEventProcessors());
-    allEventProcessors.addAll(isolationScope.getEventProcessors());
-    allEventProcessors.addAll(scope.getEventProcessors());
+  public @NotNull List<EventProcessorAndOrder> getOrderedEventProcessors() {
+    final @NotNull List<EventProcessorAndOrder> allEventProcessors = new CopyOnWriteArrayList<>();
+    allEventProcessors.addAll(globalScope.getOrderedEventProcessors());
+    allEventProcessors.addAll(isolationScope.getOrderedEventProcessors());
+    allEventProcessors.addAll(scope.getOrderedEventProcessors());
+    Collections.sort(allEventProcessors);
     return allEventProcessors;
+  }
+
+  @Override
+  public @NotNull List<EventProcessor> getEventProcessors() {
+    return EventProcessorUtils.unwrap(getOrderedEventProcessors());
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/DeduplicateMultithreadedEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DeduplicateMultithreadedEventProcessor.java
@@ -62,4 +62,9 @@ public final class DeduplicateMultithreadedEventProcessor implements EventProces
     processedEvents.put(type, currentEventTid);
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 7000L;
+  }
 }

--- a/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/DuplicateEventDetectionEventProcessor.java
@@ -62,4 +62,9 @@ public final class DuplicateEventDetectionEventProcessor implements EventProcess
     }
     return causes;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 1000L;
+  }
 }

--- a/sentry/src/main/java/io/sentry/EventProcessor.java
+++ b/sentry/src/main/java/io/sentry/EventProcessor.java
@@ -32,4 +32,15 @@ public interface EventProcessor {
   default SentryTransaction process(@NotNull SentryTransaction transaction, @NotNull Hint hint) {
     return transaction;
   }
+
+  /**
+   * Controls when this EventProcessor is invoked.
+   *
+   * @return order higher number = later, lower number = earlier (negative values may also be
+   *     passed), null = latest (note: multiple event processors using null may lead to random
+   *     ordering)
+   */
+  default @Nullable Long getOrder() {
+    return null;
+  }
 }

--- a/sentry/src/main/java/io/sentry/IScope.java
+++ b/sentry/src/main/java/io/sentry/IScope.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.internal.eventprocessor.EventProcessorAndOrder;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
@@ -303,8 +304,13 @@ public interface IScope {
    *
    * @return the event processors list
    */
+  @ApiStatus.Internal
   @NotNull
   List<EventProcessor> getEventProcessors();
+
+  @ApiStatus.Internal
+  @NotNull
+  List<EventProcessorAndOrder> getOrderedEventProcessors();
 
   /**
    * Adds an event processor to the Scope's event processors list

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -307,4 +307,9 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
   HostnameCache getHostnameCache() {
     return hostnameCache;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 0L;
+  }
 }

--- a/sentry/src/main/java/io/sentry/NoOpScope.java
+++ b/sentry/src/main/java/io/sentry/NoOpScope.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.internal.eventprocessor.EventProcessorAndOrder;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.Request;
 import io.sentry.protocol.SentryId;
@@ -180,6 +181,12 @@ public final class NoOpScope implements IScope {
   @ApiStatus.Internal
   @Override
   public @NotNull List<EventProcessor> getEventProcessors() {
+    return new ArrayList<>();
+  }
+
+  @ApiStatus.Internal
+  @Override
+  public @NotNull List<EventProcessorAndOrder> getOrderedEventProcessors() {
     return new ArrayList<>();
   }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -139,6 +139,7 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
       }
     }
 
+    // TODO [HSM] EventProcessors from options are always executed after those from scopes
     event = processEvent(event, hint, options.getEventProcessors());
 
     if (event != null) {

--- a/sentry/src/main/java/io/sentry/SentryRuntimeEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/SentryRuntimeEventProcessor.java
@@ -42,4 +42,9 @@ final class SentryRuntimeEventProcessor implements EventProcessor {
     }
     return event;
   }
+
+  @Override
+  public @Nullable Long getOrder() {
+    return 2000L;
+  }
 }

--- a/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
+++ b/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
@@ -1,0 +1,34 @@
+package io.sentry.internal.eventprocessor;
+
+import io.sentry.EventProcessor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class EventProcessorAndOrder implements Comparable<EventProcessorAndOrder> {
+
+  private final @NotNull EventProcessor eventProcessor;
+  private final @NotNull Long order;
+
+  public EventProcessorAndOrder(
+      final @NotNull EventProcessor eventProcessor, final @Nullable Long order) {
+    this.eventProcessor = eventProcessor;
+    if (order == null) {
+      this.order = System.nanoTime();
+    } else {
+      this.order = order;
+    }
+  }
+
+  public @NotNull EventProcessor getEventProcessor() {
+    return eventProcessor;
+  }
+
+  public @NotNull Long getOrder() {
+    return order;
+  }
+
+  @Override
+  public int compareTo(@NotNull EventProcessorAndOrder o) {
+    return order.compareTo(o.order);
+  }
+}

--- a/sentry/src/main/java/io/sentry/util/EventProcessorUtils.java
+++ b/sentry/src/main/java/io/sentry/util/EventProcessorUtils.java
@@ -1,0 +1,23 @@
+package io.sentry.util;
+
+import io.sentry.EventProcessor;
+import io.sentry.internal.eventprocessor.EventProcessorAndOrder;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jetbrains.annotations.Nullable;
+
+public final class EventProcessorUtils {
+
+  public static List<EventProcessor> unwrap(
+      final @Nullable List<EventProcessorAndOrder> orderedEventProcessor) {
+    final List<EventProcessor> eventProcessors = new CopyOnWriteArrayList<>();
+
+    if (orderedEventProcessor != null) {
+      for (EventProcessorAndOrder eventProcessorAndOrder : orderedEventProcessor) {
+        eventProcessors.add(eventProcessorAndOrder.getEventProcessor());
+      }
+    }
+
+    return eventProcessors;
+  }
+}

--- a/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
+++ b/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
@@ -69,4 +69,46 @@ class CombinedScopeViewTest {
         assertEquals("current 3", breadcrumbs2.poll().message)
         assertEquals("current 4", breadcrumbs2.poll().message)
     }
+
+    @Test
+    fun `event processors from options are not returned`() {
+        val options = SentryOptions().also {
+            it.addEventProcessor(MainEventProcessor(it))
+        }
+
+        val globalScope = Scope(options)
+        val isolationScope = Scope(options)
+        val scope = Scope(options)
+
+        val combined = CombinedScopeView(globalScope, isolationScope, scope)
+
+        assertEquals(0, combined.eventProcessors.size)
+    }
+
+    @Test
+    fun `event processors from options and all scopes in order`() {
+        val options = SentryOptions()
+
+        val globalScope = Scope(options)
+        val isolationScope = Scope(options)
+        val scope = Scope(options)
+
+        val first = TestEventProcessor(0).also { scope.addEventProcessor(it) }
+        val second = TestEventProcessor(1000).also { globalScope.addEventProcessor(it) }
+        val third = TestEventProcessor(2000).also { isolationScope.addEventProcessor(it) }
+        val fourth = TestEventProcessor(3000).also { scope.addEventProcessor(it) }
+
+        val combined = CombinedScopeView(globalScope, isolationScope, scope)
+
+        val eventProcessors = combined.eventProcessors
+
+        assertEquals(first, eventProcessors.get(0))
+        assertEquals(second, eventProcessors.get(1))
+        assertEquals(third, eventProcessors.get(2))
+        assertEquals(fourth, eventProcessors.get(3))
+    }
+
+    class TestEventProcessor(val orderNumber: Long?) : EventProcessor {
+        override fun getOrder() = orderNumber
+    }
 }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to now having multiple scopes (current, isolation and global) event processor ordering could no longer rely on insertion order into a single list.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
