### PR TITLE
Hubs/Scopes Merge 33 - No longer replace global scope

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -44,6 +44,7 @@ public final class InternalSentrySdk {
   @Nullable
   public static IScope getCurrentScope() {
     final @NotNull AtomicReference<IScope> scopeRef = new AtomicReference<>();
+    // TODO [HSM] should this retrieve combined scope?
     ScopesAdapter.getInstance()
         .configureScope(
             scope -> {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -24,6 +24,10 @@ import org.jetbrains.annotations.NotNull;
 /** Sentry initialization class */
 public final class SentryAndroid {
 
+  static {
+    Sentry.getGlobalScope().replaceOptions(new SentryAndroidOptions());
+  }
+
   // SystemClock.uptimeMillis() isn't affected by phone provider or clock changes.
   private static final long sdkInitMillis = SystemClock.uptimeMillis();
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -268,6 +268,7 @@ public final class io/sentry/CombinedScopeView : io/sentry/IScope {
 	public fun removeContexts (Ljava/lang/String;)V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
+	public fun replaceOptions (Lio/sentry/SentryOptions;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Character;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V
@@ -805,6 +806,7 @@ public abstract interface class io/sentry/IScope {
 	public abstract fun removeContexts (Ljava/lang/String;)V
 	public abstract fun removeExtra (Ljava/lang/String;)V
 	public abstract fun removeTag (Ljava/lang/String;)V
+	public abstract fun replaceOptions (Lio/sentry/SentryOptions;)V
 	public abstract fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
 	public abstract fun setContexts (Ljava/lang/String;Ljava/lang/Character;)V
 	public abstract fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V
@@ -1466,6 +1468,7 @@ public final class io/sentry/NoOpScope : io/sentry/IScope {
 	public fun removeContexts (Ljava/lang/String;)V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
+	public fun replaceOptions (Lio/sentry/SentryOptions;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Character;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V
@@ -1909,6 +1912,7 @@ public final class io/sentry/Scope : io/sentry/IScope {
 	public fun removeContexts (Ljava/lang/String;)V
 	public fun removeExtra (Ljava/lang/String;)V
 	public fun removeTag (Ljava/lang/String;)V
+	public fun replaceOptions (Lio/sentry/SentryOptions;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Boolean;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Character;)V
 	public fun setContexts (Ljava/lang/String;Ljava/lang/Number;)V

--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -395,7 +396,7 @@ public final class CombinedScopeView implements IScope {
 
   @Override
   public @NotNull SentryOptions getOptions() {
-    return scope.getOptions();
+    return globalScope.getOptions();
   }
 
   @Override
@@ -473,5 +474,11 @@ public final class CombinedScopeView implements IScope {
   public void setSpanContext(
       @NotNull Throwable throwable, @NotNull ISpan span, @NotNull String transactionName) {
     globalScope.setSpanContext(throwable, span, transactionName);
+  }
+
+  @ApiStatus.Internal
+  @Override
+  public void replaceOptions(@NotNull SentryOptions options) {
+    globalScope.replaceOptions(options);
   }
 }

--- a/sentry/src/main/java/io/sentry/IScope.java
+++ b/sentry/src/main/java/io/sentry/IScope.java
@@ -396,4 +396,7 @@ public interface IScope {
       final @NotNull Throwable throwable,
       final @NotNull ISpan span,
       final @NotNull String transactionName);
+
+  @ApiStatus.Internal
+  void replaceOptions(final @NotNull SentryOptions options);
 }

--- a/sentry/src/main/java/io/sentry/NoOpScope.java
+++ b/sentry/src/main/java/io/sentry/NoOpScope.java
@@ -276,4 +276,7 @@ public final class NoOpScope implements IScope {
   @Override
   public void setSpanContext(
       @NotNull Throwable throwable, @NotNull ISpan span, @NotNull String transactionName) {}
+
+  @Override
+  public void replaceOptions(@NotNull SentryOptions options) {}
 }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -54,7 +54,7 @@ public final class Scope implements IScope {
   private @NotNull List<String> fingerprint = new ArrayList<>();
 
   /** Scope's breadcrumb queue */
-  private final @NotNull Queue<Breadcrumb> breadcrumbs;
+  private volatile @NotNull Queue<Breadcrumb> breadcrumbs;
 
   /** Scope's tags */
   private @NotNull Map<String, @NotNull String> tags = new ConcurrentHashMap<>();
@@ -66,7 +66,7 @@ public final class Scope implements IScope {
   private @NotNull List<EventProcessorAndOrder> eventProcessors = new CopyOnWriteArrayList<>();
 
   /** Scope's SentryOptions */
-  private final @NotNull SentryOptions options;
+  private volatile @NotNull SentryOptions options;
 
   // TODO Consider: Scope clone doesn't clone sessions
 
@@ -1035,6 +1035,23 @@ public final class Scope implements IScope {
     // the most inner span should be assigned to a throwable
     if (!throwableToSpan.containsKey(rootCause)) {
       throwableToSpan.put(rootCause, new Pair<>(new WeakReference<>(span), transactionName));
+    }
+  }
+
+  @ApiStatus.Internal
+  @Override
+  public void replaceOptions(final @NotNull SentryOptions options) {
+    // TODO [HSM] check if already enabled and noop in that case?
+    //    if (!isEnabled()) {}
+    this.options = options;
+    final Queue<Breadcrumb> oldBreadcrumbs = breadcrumbs;
+    breadcrumbs = createBreadcrumbsList(options.getMaxBreadcrumbs());
+    for (Breadcrumb breadcrumb : oldBreadcrumbs) {
+      /*
+      this should trigger beforeBreadcrumb
+      and notify observers for breadcrumbs added before options where customized in Sentry.init
+      */
+      addBreadcrumb(breadcrumb);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -47,7 +47,12 @@ public final class Sentry {
 
   /** The root Scopes or NoOp if Sentry is disabled. */
   private static volatile @NotNull IScopes rootScopes = NoOpScopes.getInstance();
-  // TODO [HSM] cannot pass options here
+  /**
+   * This initializes global scope with default options. Options will later be replaced on
+   * Sentry.init
+   *
+   * <p>For Android options will also be (temporarily) replaced by SentryAndroid static block.
+   */
   private static volatile @NotNull IScope globalScope = new Scope(new SentryOptions());
 
   /** Default value for globalHubMode is false */
@@ -265,14 +270,13 @@ public final class Sentry {
 
     options.getLogger().log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubMode));
     Sentry.globalHubMode = globalHubMode;
+    globalScope.replaceOptions(options);
 
     final IScopes scopes = getCurrentScopes();
     final IScope rootScope = new Scope(options);
     final IScope rootIsolationScope = new Scope(options);
-    // TODO [HSM] shouldn't replace global scope
-    globalScope = new Scope(options);
     globalScope.bindClient(new SentryClient(options));
-    rootScopes = new Scopes(rootScope, rootIsolationScope, options, "Sentry.init");
+    rootScopes = new Scopes(rootScope, rootIsolationScope, "Sentry.init");
 
     getScopesStorage().set(rootScopes);
 


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
We're now instantiating `globalScope` with default `SentryOptions`. These are replaced in a `static {}` block for `SentryAndroid` (temporarily) and then replaced on `Sentry.init` to actually use options customized by the user.

Also remove options from `Scopes` and instead use globla scope options (via `CombinedScopeView`).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before we were replacing global scope on `Sentry.init`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
