### PR TITLE
Fix timing metric value different from span duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix timing metric value different from span duration ([#3368](https://github.com/getsentry/sentry-java/pull/3368))
+
 ## 7.8.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -634,7 +634,6 @@ public abstract interface class io/sentry/IMetricsAggregator : java/io/Closeable
 	public abstract fun increment (Ljava/lang/String;DLio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
 	public abstract fun set (Ljava/lang/String;ILio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
 	public abstract fun set (Ljava/lang/String;Ljava/lang/String;Lio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
-	public abstract fun timing (Ljava/lang/String;Ljava/lang/Runnable;Lio/sentry/MeasurementUnit$Duration;Ljava/util/Map;Lio/sentry/metrics/LocalMetricsAggregator;)V
 }
 
 public abstract interface class io/sentry/IOptionsObserver {
@@ -1039,7 +1038,6 @@ public final class io/sentry/MetricsAggregator : io/sentry/IMetricsAggregator, j
 	public fun run ()V
 	public fun set (Ljava/lang/String;ILio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun set (Ljava/lang/String;Ljava/lang/String;Lio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
-	public fun timing (Ljava/lang/String;Ljava/lang/Runnable;Lio/sentry/MeasurementUnit$Duration;Ljava/util/Map;Lio/sentry/metrics/LocalMetricsAggregator;)V
 }
 
 public final class io/sentry/MonitorConfig : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
@@ -3561,7 +3559,6 @@ public final class io/sentry/metrics/NoopMetricsAggregator : io/sentry/IMetricsA
 	public fun set (Ljava/lang/String;ILio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun set (Ljava/lang/String;Ljava/lang/String;Lio/sentry/MeasurementUnit;Ljava/util/Map;JLio/sentry/metrics/LocalMetricsAggregator;)V
 	public fun startSpanForMetric (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ISpan;
-	public fun timing (Ljava/lang/String;Ljava/lang/Runnable;Lio/sentry/MeasurementUnit$Duration;Ljava/util/Map;Lio/sentry/metrics/LocalMetricsAggregator;)V
 }
 
 public final class io/sentry/metrics/SetMetric : io/sentry/metrics/Metric {

--- a/sentry/src/main/java/io/sentry/IMetricsAggregator.java
+++ b/sentry/src/main/java/io/sentry/IMetricsAggregator.java
@@ -103,21 +103,5 @@ public interface IMetricsAggregator extends Closeable {
       final long timestampMs,
       final @Nullable LocalMetricsAggregator localMetricsAggregator);
 
-  /**
-   * Emits a distribution with the time it takes to run a given code block.
-   *
-   * @param key A unique key identifying the metric
-   * @param callback The code block to measure
-   * @param unit An optional unit, see {@link MeasurementUnit.Duration}, defaults to seconds
-   * @param tags Optional Tags to associate with the metric
-   * @param localMetricsAggregator The local metrics aggregator for creating span summaries
-   */
-  void timing(
-      final @NotNull String key,
-      final @NotNull Runnable callback,
-      final @NotNull MeasurementUnit.Duration unit,
-      final @Nullable Map<String, String> tags,
-      final @Nullable LocalMetricsAggregator localMetricsAggregator);
-
   void flush(boolean force);
 }

--- a/sentry/src/main/java/io/sentry/MetricsAggregator.java
+++ b/sentry/src/main/java/io/sentry/MetricsAggregator.java
@@ -141,24 +141,6 @@ public final class MetricsAggregator implements IMetricsAggregator, Runnable, Cl
     add(MetricType.Set, key, intValue, unit, tags, timestampMs, localMetricsAggregator);
   }
 
-  @Override
-  public void timing(
-      final @NotNull String key,
-      final @NotNull Runnable callback,
-      final @NotNull MeasurementUnit.Duration unit,
-      final @Nullable Map<String, String> tags,
-      final @Nullable LocalMetricsAggregator localMetricsAggregator) {
-    final long startMs = nowMillis();
-    final long startNanos = System.nanoTime();
-    try {
-      callback.run();
-    } finally {
-      final long durationNanos = (System.nanoTime() - startNanos);
-      final double value = MetricsHelper.convertNanosTo(unit, durationNanos);
-      add(MetricType.Distribution, key, value, unit, tags, startMs, localMetricsAggregator);
-    }
-  }
-
   @SuppressWarnings({"FutureReturnValueIgnored", "UnusedVariable"})
   private void add(
       final @NotNull MetricType type,

--- a/sentry/src/main/java/io/sentry/metrics/NoopMetricsAggregator.java
+++ b/sentry/src/main/java/io/sentry/metrics/NoopMetricsAggregator.java
@@ -76,16 +76,6 @@ public final class NoopMetricsAggregator
   }
 
   @Override
-  public void timing(
-      final @NotNull String key,
-      final @NotNull Runnable callback,
-      final @NotNull MeasurementUnit.Duration unit,
-      final @Nullable Map<String, String> tags,
-      final @Nullable LocalMetricsAggregator localMetricsAggregator) {
-    callback.run();
-  }
-
-  @Override
   public void flush(final boolean force) {
     // no-op
   }

--- a/sentry/src/test/java/io/sentry/MetricsAggregatorTest.kt
+++ b/sentry/src/test/java/io/sentry/MetricsAggregatorTest.kt
@@ -268,21 +268,12 @@ class MetricsAggregatorTest {
             20_001,
             null
         )
-        aggregator.timing(
-            "name0",
-            {
-                Thread.sleep(2)
-            },
-            MeasurementUnit.Duration.SECOND,
-            mapOf("key0" to "value0"),
-            null
-        )
 
         aggregator.flush(true)
         verify(fixture.client).captureMetrics(
             check {
                 val metrics = MetricsHelperTest.parseMetrics(it.encodeToStatsd())
-                assertEquals(6, metrics.size)
+                assertEquals(5, metrics.size)
             }
         )
     }


### PR DESCRIPTION
## :scroll: Description
removed timing from IMetricsAggregator
duration of timing metric of MetricsApi now equals span duration
local metrics aggregator is fetch directly from the span in the timing api


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3289 and https://github.com/getsentry/sentry-java/issues/3290


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
