### PR TITLE
[SR] Capture breadcrumbs (temporary)

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -170,10 +170,8 @@ internal abstract class BaseCaptureStrategy(
 
         hub?.configureScope { scope ->
             scope.breadcrumbs.forEach { breadcrumb ->
-                if (breadcrumb.timestamp.after(segmentTimestamp) && breadcrumb.timestamp.before(
-                        endTimestamp
-                    )
-                ) {
+                if (breadcrumb.timestamp.after(segmentTimestamp) &&
+                    breadcrumb.timestamp.before(endTimestamp)) {
                     // TODO: rework this later when aligned with iOS and frontend
                     var breadcrumbMessage: String? = null
                     val breadcrumbCategory: String?

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -220,7 +220,7 @@ internal abstract class BaseCaptureStrategy(
                             breadcrumbType = "default"
                             category = breadcrumbCategory
                             message = breadcrumbMessage
-                            data = if (breadcrumbData.isEmpty()) null else breadcrumbData
+                            data = breadcrumbData
                         }
                     }
                 }
@@ -229,7 +229,7 @@ internal abstract class BaseCaptureStrategy(
 
         val recording = ReplayRecording().apply {
             this.segmentId = segmentId
-            payload = recordingPayload
+            payload = recordingPayload.sortedBy { it.timestamp }
         }
 
         return ReplaySegment.Created(

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -171,7 +171,8 @@ internal abstract class BaseCaptureStrategy(
         hub?.configureScope { scope ->
             scope.breadcrumbs.forEach { breadcrumb ->
                 if (breadcrumb.timestamp.after(segmentTimestamp) &&
-                    breadcrumb.timestamp.before(endTimestamp)) {
+                    breadcrumb.timestamp.before(endTimestamp)
+                ) {
                     // TODO: rework this later when aligned with iOS and frontend
                     var breadcrumbMessage: String? = null
                     val breadcrumbCategory: String?

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -23,7 +23,7 @@ internal class BufferCaptureStrategy(
     private val dateProvider: ICurrentDateProvider,
     recorderConfig: ScreenshotRecorderConfig,
     private val random: SecureRandom
-) : BaseCaptureStrategy(options, dateProvider, recorderConfig) {
+) : BaseCaptureStrategy(options, hub, dateProvider, recorderConfig) {
 
     private val bufferedSegments = mutableListOf<ReplaySegment.Created>()
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -21,7 +21,7 @@ internal class SessionCaptureStrategy(
     private val dateProvider: ICurrentDateProvider,
     recorderConfig: ScreenshotRecorderConfig,
     executor: ScheduledExecutorService? = null
-) : BaseCaptureStrategy(options, dateProvider, recorderConfig, executor) {
+) : BaseCaptureStrategy(options, hub, dateProvider, recorderConfig, executor) {
 
     internal companion object {
         private const val TAG = "SessionCaptureStrategy"

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5038,7 +5038,7 @@ public final class io/sentry/protocol/ViewHierarchyNode$JsonKeys {
 public final class io/sentry/rrweb/RRWebBreadcrumbEvent : io/sentry/rrweb/RRWebEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public static final field EVENT_TAG Ljava/lang/String;
 	public fun <init> ()V
-	public fun getBreadcrumbTimestamp ()J
+	public fun getBreadcrumbTimestamp ()D
 	public fun getBreadcrumbType ()Ljava/lang/String;
 	public fun getCategory ()Ljava/lang/String;
 	public fun getData ()Ljava/util/Map;
@@ -5048,7 +5048,7 @@ public final class io/sentry/rrweb/RRWebBreadcrumbEvent : io/sentry/rrweb/RRWebE
 	public fun getTag ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
-	public fun setBreadcrumbTimestamp (J)V
+	public fun setBreadcrumbTimestamp (D)V
 	public fun setBreadcrumbType (Ljava/lang/String;)V
 	public fun setCategory (Ljava/lang/String;)V
 	public fun setData (Ljava/util/Map;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5035,6 +5035,46 @@ public final class io/sentry/protocol/ViewHierarchyNode$JsonKeys {
 	public fun <init> ()V
 }
 
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent : io/sentry/rrweb/RRWebEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field EVENT_TAG Ljava/lang/String;
+	public fun <init> ()V
+	public fun getBreadcrumbTimestamp ()J
+	public fun getBreadcrumbType ()Ljava/lang/String;
+	public fun getCategory ()Ljava/lang/String;
+	public fun getData ()Ljava/util/Map;
+	public fun getDataUnknown ()Ljava/util/Map;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getPayloadUnknown ()Ljava/util/Map;
+	public fun getTag ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setBreadcrumbTimestamp (J)V
+	public fun setBreadcrumbType (Ljava/lang/String;)V
+	public fun setCategory (Ljava/lang/String;)V
+	public fun setData (Ljava/util/Map;)V
+	public fun setDataUnknown (Ljava/util/Map;)V
+	public fun setMessage (Ljava/lang/String;)V
+	public fun setPayloadUnknown (Ljava/util/Map;)V
+	public fun setTag (Ljava/lang/String;)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/rrweb/RRWebBreadcrumbEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent$JsonKeys {
+	public static final field CATEGORY Ljava/lang/String;
+	public static final field DATA Ljava/lang/String;
+	public static final field MESSAGE Ljava/lang/String;
+	public static final field PAYLOAD Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
+	public static final field TYPE Ljava/lang/String;
+	public fun <init> ()V
+}
+
 public abstract class io/sentry/rrweb/RRWebEvent {
 	protected fun <init> ()V
 	protected fun <init> (Lio/sentry/rrweb/RRWebEventType;)V

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
@@ -1,0 +1,293 @@
+package io.sentry.rrweb;
+
+import io.sentry.Breadcrumb;
+import io.sentry.ILogger;
+import io.sentry.JsonDeserializer;
+import io.sentry.JsonSerializable;
+import io.sentry.JsonUnknown;
+import io.sentry.ObjectReader;
+import io.sentry.ObjectWriter;
+import io.sentry.util.CollectionUtils;
+import io.sentry.vendor.gson.stream.JsonToken;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknown, JsonSerializable {
+  public static final String EVENT_TAG = "breadcrumb";
+
+  private @NotNull String tag;
+  private long breadcrumbTimestamp;
+  private @Nullable String breadcrumbType;
+  private @Nullable String category;
+  private @Nullable String message;
+  private @Nullable Map<String, Object> data;
+  // to support unknown json attributes with nesting, we have to have unknown map for each of the
+  // nested object in json: { ..., "data": { ..., "payload": { ... } } }
+  private @Nullable Map<String, Object> unknown;
+  private @Nullable Map<String, Object> payloadUnknown;
+  private @Nullable Map<String, Object> dataUnknown;
+
+
+  public RRWebBreadcrumbEvent() {
+    super(RRWebEventType.Custom);
+    tag = EVENT_TAG;
+  }
+
+  @NotNull
+  public String getTag() {
+    return tag;
+  }
+
+  public void setTag(final @NotNull String tag) {
+    this.tag = tag;
+  }
+
+  public long getBreadcrumbTimestamp() {
+    return breadcrumbTimestamp;
+  }
+
+  public void setBreadcrumbTimestamp(final long breadcrumbTimestamp) {
+    this.breadcrumbTimestamp = breadcrumbTimestamp;
+  }
+
+  @Nullable
+  public String getBreadcrumbType() {
+    return breadcrumbType;
+  }
+
+  public void setBreadcrumbType(final @Nullable String breadcrumbType) {
+    this.breadcrumbType = breadcrumbType;
+  }
+
+  @Nullable
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(final @Nullable String category) {
+    this.category = category;
+  }
+
+  @Nullable
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final @Nullable String message) {
+    this.message = message;
+  }
+
+  @Nullable
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  public void setData(final @Nullable Map<String, Object> data) {
+    this.data = data == null ? null : new ConcurrentHashMap<>(data);
+  }
+
+  public @Nullable Map<String, Object> getPayloadUnknown() {
+    return payloadUnknown;
+  }
+
+  public void setPayloadUnknown(final @Nullable Map<String, Object> payloadUnknown) {
+    this.payloadUnknown = payloadUnknown;
+  }
+
+  public @Nullable Map<String, Object> getDataUnknown() {
+    return dataUnknown;
+  }
+
+  public void setDataUnknown(final @Nullable Map<String, Object> dataUnknown) {
+    this.dataUnknown = dataUnknown;
+  }
+
+  @Override
+  public @Nullable Map<String, Object> getUnknown() {
+    return unknown;
+  }
+
+  @Override
+  public void setUnknown(final @Nullable Map<String, Object> unknown) {
+    this.unknown = unknown;
+  }
+
+  // region json
+
+  // rrweb uses camelCase hence the json keys are in camelCase here
+  public static final class JsonKeys {
+    public static final String DATA = "data";
+    public static final String PAYLOAD = "payload";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String TYPE = "type";
+    public static final String CATEGORY = "category";
+    public static final String MESSAGE = "message";
+  }
+
+  @Override public void serialize(@NotNull ObjectWriter writer, @NotNull ILogger logger)
+    throws IOException {
+    writer.beginObject();
+    new RRWebEvent.Serializer().serialize(this, writer, logger);
+    writer.name(JsonKeys.DATA);
+    serializeData(writer, logger);
+    if (unknown != null) {
+      for (final String key : unknown.keySet()) {
+        final Object value = unknown.get(key);
+        writer.name(key);
+        writer.value(logger, value);
+      }
+    }
+    writer.endObject();
+  }
+
+  private void serializeData(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
+    throws IOException {
+    writer.beginObject();
+    writer.name(RRWebEvent.JsonKeys.TAG).value(tag);
+    writer.name(JsonKeys.PAYLOAD);
+    serializePayload(writer, logger);
+    if (dataUnknown != null) {
+      for (String key : dataUnknown.keySet()) {
+        Object value = dataUnknown.get(key);
+        writer.name(key);
+        writer.value(logger, value);
+      }
+    }
+    writer.endObject();
+  }
+
+  private void serializePayload(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
+    throws IOException {
+    writer.beginObject();
+    if (breadcrumbType != null) {
+      writer.name(JsonKeys.TYPE).value(breadcrumbType);
+    }
+    writer.name(JsonKeys.TIMESTAMP).value(breadcrumbTimestamp);
+    if (category != null) {
+      writer.name(JsonKeys.CATEGORY).value(category);
+    }
+    if (message != null) {
+      writer.name(JsonKeys.MESSAGE).value(message);
+    }
+    if (data != null) {
+      writer.name(Breadcrumb.JsonKeys.DATA).value(logger, data);
+    }
+    if (payloadUnknown != null) {
+      for (final String key : payloadUnknown.keySet()) {
+        final Object value = payloadUnknown.get(key);
+        writer.name(key);
+        writer.value(logger, value);
+      }
+    }
+    writer.endObject();
+  }
+
+  public static final class Deserializer implements JsonDeserializer<RRWebBreadcrumbEvent> {
+
+    @Override public @NotNull RRWebBreadcrumbEvent deserialize(@NotNull ObjectReader reader,
+      @NotNull ILogger logger) throws Exception {
+      reader.beginObject();
+      @Nullable Map<String, Object> unknown = null;
+
+      final RRWebBreadcrumbEvent event = new RRWebBreadcrumbEvent();
+      final RRWebEvent.Deserializer baseEventDeserializer = new RRWebEvent.Deserializer();
+
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.DATA:
+            deserializeData(event, reader, logger);
+            break;
+          default:
+            if (!baseEventDeserializer.deserializeValue(event, nextName, reader, logger)) {
+              if (unknown == null) {
+                unknown = new HashMap<>();
+              }
+              reader.nextUnknown(logger, unknown, nextName);
+            }
+            break;
+        }
+      }
+
+      event.setUnknown(unknown);
+      reader.endObject();
+      return event;
+    }
+
+    private void deserializeData(
+      final @NotNull RRWebBreadcrumbEvent event,
+      final @NotNull ObjectReader reader,
+      final @NotNull ILogger logger)
+      throws Exception {
+      @Nullable Map<String, Object> dataUnknown = null;
+
+      reader.beginObject();
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case RRWebEvent.JsonKeys.TAG:
+            final String tag = reader.nextStringOrNull();
+            event.tag = tag == null ? "" : tag;
+            break;
+          case JsonKeys.PAYLOAD:
+            deserializePayload(event, reader, logger);
+            break;
+          default:
+            if (dataUnknown == null) {
+              dataUnknown = new ConcurrentHashMap<>();
+            }
+            reader.nextUnknown(logger, dataUnknown, nextName);
+        }
+      }
+      event.setDataUnknown(dataUnknown);
+      reader.endObject();
+    }
+
+    @SuppressWarnings("unchecked") private void deserializePayload(
+      final @NotNull RRWebBreadcrumbEvent event,
+      final @NotNull ObjectReader reader,
+      final @NotNull ILogger logger)
+      throws Exception {
+      @Nullable Map<String, Object> payloadUnknown = null;
+
+      reader.beginObject();
+      while (reader.peek() == JsonToken.NAME) {
+        final String nextName = reader.nextName();
+        switch (nextName) {
+          case JsonKeys.TYPE:
+            event.breadcrumbType = reader.nextStringOrNull();
+            break;
+          case JsonKeys.TIMESTAMP:
+            event.breadcrumbTimestamp = reader.nextLong();
+            break;
+          case JsonKeys.CATEGORY:
+            event.category = reader.nextStringOrNull();
+            break;
+          case JsonKeys.MESSAGE:
+            event.message = reader.nextStringOrNull();
+            break;
+          case JsonKeys.DATA:
+            Map<String, Object> deserializedData =
+              CollectionUtils.newConcurrentHashMap(
+                (Map<String, Object>) reader.nextObjectOrNull());
+            if (deserializedData != null) {
+              event.data = deserializedData;
+            }
+            break;
+          default:
+            if (payloadUnknown == null) {
+              payloadUnknown = new ConcurrentHashMap<>();
+            }
+            reader.nextUnknown(logger, payloadUnknown, nextName);
+        }
+      }
+      event.setPayloadUnknown(payloadUnknown);
+      reader.endObject();
+    }
+  }
+  // endregion json
+}

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
@@ -9,6 +9,7 @@ import io.sentry.ObjectWriter;
 import io.sentry.util.CollectionUtils;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,7 +21,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent
   public static final String EVENT_TAG = "breadcrumb";
 
   private @NotNull String tag;
-  private long breadcrumbTimestamp;
+  private double breadcrumbTimestamp;
   private @Nullable String breadcrumbType;
   private @Nullable String category;
   private @Nullable String message;
@@ -45,11 +46,11 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent
     this.tag = tag;
   }
 
-  public long getBreadcrumbTimestamp() {
+  public double getBreadcrumbTimestamp() {
     return breadcrumbTimestamp;
   }
 
-  public void setBreadcrumbTimestamp(final long breadcrumbTimestamp) {
+  public void setBreadcrumbTimestamp(final double breadcrumbTimestamp) {
     this.breadcrumbTimestamp = breadcrumbTimestamp;
   }
 
@@ -165,7 +166,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent
     if (breadcrumbType != null) {
       writer.name(JsonKeys.TYPE).value(breadcrumbType);
     }
-    writer.name(JsonKeys.TIMESTAMP).value(breadcrumbTimestamp);
+    writer.name(JsonKeys.TIMESTAMP).value(logger, BigDecimal.valueOf(breadcrumbTimestamp));
     if (category != null) {
       writer.name(JsonKeys.CATEGORY).value(category);
     }
@@ -263,7 +264,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent
             event.breadcrumbType = reader.nextStringOrNull();
             break;
           case JsonKeys.TIMESTAMP:
-            event.breadcrumbTimestamp = reader.nextLong();
+            event.breadcrumbTimestamp = reader.nextDouble();
             break;
           case JsonKeys.CATEGORY:
             event.category = reader.nextStringOrNull();

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
@@ -16,7 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknown, JsonSerializable {
+public final class RRWebBreadcrumbEvent extends RRWebEvent
+    implements JsonUnknown, JsonSerializable {
   public static final String EVENT_TAG = "breadcrumb";
 
   private @NotNull String tag;
@@ -30,7 +31,6 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   private @Nullable Map<String, Object> unknown;
   private @Nullable Map<String, Object> payloadUnknown;
   private @Nullable Map<String, Object> dataUnknown;
-
 
   public RRWebBreadcrumbEvent() {
     super(RRWebEventType.Custom);
@@ -128,8 +128,8 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
     public static final String MESSAGE = "message";
   }
 
-  @Override public void serialize(@NotNull ObjectWriter writer, @NotNull ILogger logger)
-    throws IOException {
+  @Override
+  public void serialize(@NotNull ObjectWriter writer, @NotNull ILogger logger) throws IOException {
     writer.beginObject();
     new RRWebEvent.Serializer().serialize(this, writer, logger);
     writer.name(JsonKeys.DATA);
@@ -145,7 +145,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   }
 
   private void serializeData(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
-    throws IOException {
+      throws IOException {
     writer.beginObject();
     writer.name(RRWebEvent.JsonKeys.TAG).value(tag);
     writer.name(JsonKeys.PAYLOAD);
@@ -161,7 +161,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   }
 
   private void serializePayload(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
-    throws IOException {
+      throws IOException {
     writer.beginObject();
     if (breadcrumbType != null) {
       writer.name(JsonKeys.TYPE).value(breadcrumbType);
@@ -188,8 +188,9 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
 
   public static final class Deserializer implements JsonDeserializer<RRWebBreadcrumbEvent> {
 
-    @Override public @NotNull RRWebBreadcrumbEvent deserialize(@NotNull ObjectReader reader,
-      @NotNull ILogger logger) throws Exception {
+    @Override
+    public @NotNull RRWebBreadcrumbEvent deserialize(
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       @Nullable Map<String, Object> unknown = null;
 
@@ -219,10 +220,10 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
     }
 
     private void deserializeData(
-      final @NotNull RRWebBreadcrumbEvent event,
-      final @NotNull ObjectReader reader,
-      final @NotNull ILogger logger)
-      throws Exception {
+        final @NotNull RRWebBreadcrumbEvent event,
+        final @NotNull ObjectReader reader,
+        final @NotNull ILogger logger)
+        throws Exception {
       @Nullable Map<String, Object> dataUnknown = null;
 
       reader.beginObject();
@@ -247,11 +248,12 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
       reader.endObject();
     }
 
-    @SuppressWarnings("unchecked") private void deserializePayload(
-      final @NotNull RRWebBreadcrumbEvent event,
-      final @NotNull ObjectReader reader,
-      final @NotNull ILogger logger)
-      throws Exception {
+    @SuppressWarnings("unchecked")
+    private void deserializePayload(
+        final @NotNull RRWebBreadcrumbEvent event,
+        final @NotNull ObjectReader reader,
+        final @NotNull ILogger logger)
+        throws Exception {
       @Nullable Map<String, Object> payloadUnknown = null;
 
       reader.beginObject();
@@ -272,8 +274,8 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
             break;
           case JsonKeys.DATA:
             Map<String, Object> deserializedData =
-              CollectionUtils.newConcurrentHashMap(
-                (Map<String, Object>) reader.nextObjectOrNull());
+                CollectionUtils.newConcurrentHashMap(
+                    (Map<String, Object>) reader.nextObjectOrNull());
             if (deserializedData != null) {
               event.data = deserializedData;
             }

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
@@ -1,6 +1,5 @@
 package io.sentry.rrweb;
 
-import io.sentry.Breadcrumb;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
 import io.sentry.JsonSerializable;
@@ -174,7 +173,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent
       writer.name(JsonKeys.MESSAGE).value(message);
     }
     if (data != null) {
-      writer.name(Breadcrumb.JsonKeys.DATA).value(logger, data);
+      writer.name(JsonKeys.DATA).value(logger, data);
     }
     if (payloadUnknown != null) {
       for (final String key : payloadUnknown.keySet()) {

--- a/sentry/src/test/java/io/sentry/rrweb/RRWebBreadcrumbEventSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/rrweb/RRWebBreadcrumbEventSerializationTest.kt
@@ -1,0 +1,43 @@
+package io.sentry.rrweb
+
+import io.sentry.ILogger
+import io.sentry.protocol.SerializationUtils
+import org.junit.Test
+import org.mockito.kotlin.mock
+import kotlin.test.assertEquals
+
+class RRWebBreadcrumbEventSerializationTest {
+    class Fixture {
+        val logger = mock<ILogger>()
+
+        fun getSut() = RRWebBreadcrumbEvent().apply {
+            timestamp = 12345678901
+            breadcrumbType = "default"
+            breadcrumbTimestamp = 12345678.901
+            category = "navigation"
+            message = "message"
+            data = mapOf(
+                "screen" to "MainActivity",
+                "state" to "resumed"
+            )
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun serialize() {
+        val expected = SerializationUtils.sanitizedFile("json/rrweb_breadcrumb_event.json")
+        val actual = SerializationUtils.serializeToString(fixture.getSut(), fixture.logger)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deserialize() {
+        val expectedJson = SerializationUtils.sanitizedFile("json/rrweb_breadcrumb_event.json")
+        val actual =
+            SerializationUtils.deserializeJson(expectedJson, RRWebBreadcrumbEvent.Deserializer(), fixture.logger)
+        val actualJson = SerializationUtils.serializeToString(actual, fixture.logger)
+        assertEquals(expectedJson, actualJson)
+    }
+}

--- a/sentry/src/test/resources/json/rrweb_breadcrumb_event.json
+++ b/sentry/src/test/resources/json/rrweb_breadcrumb_event.json
@@ -1,0 +1,17 @@
+{
+  "type": 5,
+  "timestamp": 12345678901,
+  "data": {
+    "tag": "breadcrumb",
+    "payload": {
+      "type": "default",
+      "timestamp": 12345678.901,
+      "category": "navigation",
+      "message": "message",
+      "data": {
+        "screen": "MainActivity",
+        "state": "resumed"
+      }
+    }
+  }
+}


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Adds RRWebBreadcrumbEvents and transforms our breadcrumbs from the scope to these, filtered by the replay segment timespan
* There's still some things TBD and TODO so will be addressed in follow-up PRs for sure

![image](https://github.com/getsentry/sentry-java/assets/4999776/22c93c14-d05f-48f5-9144-4da92a999b20)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255