### PR TITLE
[SR] Expose public API for flutter

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -21,6 +21,13 @@ public final class io/sentry/android/replay/GeneratedVideo {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class io/sentry/android/replay/Recorder : java/io/Closeable {
+	public abstract fun pause ()V
+	public abstract fun resume ()V
+	public abstract fun start (Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
+	public abstract fun stop ()V
+}
+
 public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/protocol/SentryId;Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
 	public final fun addFrame (Ljava/io/File;J)V
@@ -32,11 +39,15 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 
 public final class io/sentry/android/replay/ReplayIntegration : android/content/ComponentCallbacks, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, java/io/Closeable {
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
+	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
+	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
 	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
 	public fun onLowMemory ()V
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
+	public fun onScreenshotRecorded (Ljava/io/File;J)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 	public fun resume ()V
@@ -47,6 +58,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 
 public abstract interface class io/sentry/android/replay/ScreenshotRecorderCallback {
 	public abstract fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
+	public abstract fun onScreenshotRecorded (Ljava/io/File;J)V
 }
 
 public final class io/sentry/android/replay/ScreenshotRecorderConfig {

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -42,6 +42,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
+	public final fun getReplayCacheDir ()Ljava/io/File;
 	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
 	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
+    testImplementation(Config.TestLibs.awaitility)
 }
 
 tasks.withType<Detekt> {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/Recorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/Recorder.kt
@@ -1,0 +1,18 @@
+package io.sentry.android.replay
+
+import java.io.Closeable
+
+interface Recorder : Closeable {
+    /**
+     * @param recorderConfig a [ScreenshotRecorderConfig] that can be used to determine frame rate
+     * at which the screenshots should be taken, and the screenshots size/resolution, which can
+     * change e.g. in the case of orientation change or window size change
+     */
+    fun start(recorderConfig: ScreenshotRecorderConfig)
+
+    fun resume()
+
+    fun pause()
+
+    fun stop()
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -30,14 +30,14 @@ public class ReplayCache internal constructor(
     private val options: SentryOptions,
     private val replayId: SentryId,
     private val recorderConfig: ScreenshotRecorderConfig,
-    private val encoderCreator: (videoFile: File, height: Int, width: Int) -> SimpleVideoEncoder
+    private val encoderProvider: (videoFile: File, height: Int, width: Int) -> SimpleVideoEncoder
 ) : Closeable {
 
     public constructor(
         options: SentryOptions,
         replayId: SentryId,
         recorderConfig: ScreenshotRecorderConfig
-    ) : this(options, replayId, recorderConfig, encoderCreator = { videoFile, height, width ->
+    ) : this(options, replayId, recorderConfig, encoderProvider = { videoFile, height, width ->
         SimpleVideoEncoder(
             options,
             MuxerConfig(
@@ -145,7 +145,7 @@ public class ReplayCache internal constructor(
         }
 
         // TODO: reuse instance of encoder and just change file path to create a different muxer
-        encoder = synchronized(encoderLock) { encoderCreator(videoFile, height, width) }
+        encoder = synchronized(encoderLock) { encoderProvider(videoFile, height, width) }
 
         val step = 1000 / recorderConfig.frameRate.toLong()
         var frameCount = 0

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -52,6 +52,7 @@ public class ReplayIntegration(
     private val isEnabled = AtomicBoolean(false)
     private val isRecording = AtomicBoolean(false)
     private var captureStrategy: CaptureStrategy? = null
+    public val replayCacheDir: File? get() = captureStrategy?.replayCacheDir
 
     private lateinit var recorderConfig: ScreenshotRecorderConfig
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -22,17 +22,30 @@ import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion
 import java.io.Closeable
+import java.io.File
 import java.security.SecureRandom
 import java.util.concurrent.atomic.AtomicBoolean
 
-class ReplayIntegration(
+public class ReplayIntegration(
     private val context: Context,
-    private val dateProvider: ICurrentDateProvider
+    private val dateProvider: ICurrentDateProvider,
+    private val recorderProvider: (() -> Recorder)? = null,
+    private val recorderConfigProvider: ((configChanged: Boolean) -> ScreenshotRecorderConfig)? = null,
+    private val replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null
 ) : Integration, Closeable, ScreenshotRecorderCallback, ReplayController, ComponentCallbacks {
+
+    // needed for the Java's call site
+    constructor(context: Context, dateProvider: ICurrentDateProvider) : this(
+        context,
+        dateProvider,
+        null,
+        null,
+        null
+    )
 
     private lateinit var options: SentryOptions
     private var hub: IHub? = null
-    private var recorder: WindowRecorder? = null
+    private var recorder: Recorder? = null
     private val random by lazy { SecureRandom() }
 
     // TODO: probably not everything has to be thread-safe here
@@ -58,7 +71,7 @@ class ReplayIntegration(
         }
 
         this.hub = hub
-        recorder = WindowRecorder(options, this)
+        recorder = recorderProvider?.invoke() ?: WindowRecorder(options, this)
         isEnabled.set(true)
 
         try {
@@ -94,15 +107,15 @@ class ReplayIntegration(
             return
         }
 
-        recorderConfig = ScreenshotRecorderConfig.from(context, options.experimental.sessionReplay)
+        recorderConfig = recorderConfigProvider?.invoke(false) ?: ScreenshotRecorderConfig.from(context, options.experimental.sessionReplay)
         captureStrategy = if (isFullSession) {
-            SessionCaptureStrategy(options, hub, dateProvider, recorderConfig)
+            SessionCaptureStrategy(options, hub, dateProvider, recorderConfig, replayCacheProvider = replayCacheProvider)
         } else {
-            BufferCaptureStrategy(options, hub, dateProvider, recorderConfig, random)
+            BufferCaptureStrategy(options, hub, dateProvider, recorderConfig, random, replayCacheProvider)
         }
 
         captureStrategy?.start()
-        recorder?.startRecording(recorderConfig)
+        recorder?.start(recorderConfig)
     }
 
     override fun resume() {
@@ -133,6 +146,8 @@ class ReplayIntegration(
         captureStrategy = captureStrategy?.convert()
     }
 
+    override fun getReplayId(): SentryId = captureStrategy?.currentReplayId?.get() ?: SentryId.EMPTY_ID
+
     override fun pause() {
         if (!isEnabled.get() || !isRecording.get()) {
             return
@@ -147,14 +162,22 @@ class ReplayIntegration(
             return
         }
 
-        recorder?.stopRecording()
+        recorder?.stop()
         captureStrategy?.stop()
         isRecording.set(false)
         captureStrategy = null
     }
 
     override fun onScreenshotRecorded(bitmap: Bitmap) {
-        captureStrategy?.onScreenshotRecorded(bitmap)
+        captureStrategy?.onScreenshotRecorded { frameTimeStamp ->
+            addFrame(bitmap, frameTimeStamp)
+        }
+    }
+
+    override fun onScreenshotRecorded(screenshot: File, frameTimestamp: Long) {
+        captureStrategy?.onScreenshotRecorded { _ ->
+            addFrame(screenshot, frameTimestamp)
+        }
     }
 
     override fun close() {
@@ -169,6 +192,8 @@ class ReplayIntegration(
         stop()
         captureStrategy?.close()
         captureStrategy = null
+        recorder?.close()
+        recorder = null
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -176,13 +201,13 @@ class ReplayIntegration(
             return
         }
 
-        recorder?.stopRecording()
+        recorder?.stop()
 
         // refresh config based on new device configuration
-        recorderConfig = ScreenshotRecorderConfig.from(context, options.experimental.sessionReplay)
+        recorderConfig = recorderConfigProvider?.invoke(true) ?: ScreenshotRecorderConfig.from(context, options.experimental.sessionReplay)
         captureStrategy?.onConfigurationChanged(recorderConfig)
 
-        recorder?.startRecording(recorderConfig)
+        recorder?.start(recorderConfig)
     }
 
     override fun onLowMemory() = Unit

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -33,7 +33,8 @@ internal abstract class BaseCaptureStrategy(
     private val hub: IHub?,
     private val dateProvider: ICurrentDateProvider,
     protected var recorderConfig: ScreenshotRecorderConfig,
-    executor: ScheduledExecutorService? = null
+    executor: ScheduledExecutorService? = null,
+    private val replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null
 ) : CaptureStrategy {
 
     internal companion object {
@@ -72,7 +73,7 @@ internal abstract class BaseCaptureStrategy(
             }
         }
 
-        cache = ReplayCache(options, currentReplayId.get(), recorderConfig)
+        cache = replayCacheProvider?.invoke(replayId) ?: ReplayCache(options, replayId, recorderConfig)
 
         // TODO: replace it with dateProvider.currentTimeMillis to also test it
         segmentTimestamp.set(DateUtils.getCurrentDateTime())

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -46,6 +46,7 @@ internal abstract class BaseCaptureStrategy(
     protected val replayStartTimestamp = AtomicLong()
     override val currentReplayId = AtomicReference(SentryId.EMPTY_ID)
     override val currentSegment = AtomicInteger(0)
+    override val replayCacheDir: File? get() = cache?.replayCacheDir
 
     protected val replayExecutor: ScheduledExecutorService by lazy {
         executor ?: Executors.newSingleThreadScheduledExecutor(ReplayExecutorServiceThreadFactory())

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -1,8 +1,8 @@
 package io.sentry.android.replay.capture
 
-import android.graphics.Bitmap
 import io.sentry.Hint
 import io.sentry.SentryEvent
+import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.protocol.SentryId
 import java.util.concurrent.atomic.AtomicInteger
@@ -22,7 +22,7 @@ internal interface CaptureStrategy {
 
     fun sendReplayForEvent(event: SentryEvent, hint: Hint, onSegmentSent: () -> Unit)
 
-    fun onScreenshotRecorded(bitmap: Bitmap)
+    fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit)
 
     fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -5,12 +5,14 @@ import io.sentry.SentryEvent
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.protocol.SentryId
+import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 internal interface CaptureStrategy {
     val currentSegment: AtomicInteger
     val currentReplayId: AtomicReference<SentryId>
+    val replayCacheDir: File?
 
     fun start(segmentId: Int = 0, replayId: SentryId = SentryId(), cleanupOldReplays: Boolean = true)
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -41,7 +41,7 @@ class ReplayCacheTest {
             options.run {
                 cacheDirPath = dir?.newFolder()?.absolutePath
             }
-            return ReplayCache(options, replayId, recorderConfig, encoderCreator = { videoFile, height, width ->
+            return ReplayCache(options, replayId, recorderConfig, encoderProvider = { videoFile, height, width ->
                 encoder = SimpleVideoEncoder(
                     options,
                     MuxerConfig(

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -1,0 +1,231 @@
+package io.sentry.android.replay
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat.JPEG
+import android.graphics.Bitmap.Config.ARGB_8888
+import android.media.MediaCodec
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.IHub
+import io.sentry.SentryOptions
+import io.sentry.SentryReplayEvent.ReplayType
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.CLOSED
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.INITALIZED
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.PAUSED
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.RESUMED
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.STARTED
+import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState.STOPPED
+import io.sentry.android.replay.video.MuxerConfig
+import io.sentry.android.replay.video.SimpleVideoEncoder
+import io.sentry.rrweb.RRWebMetaEvent
+import io.sentry.rrweb.RRWebVideoEvent
+import io.sentry.transport.CurrentDateProvider
+import io.sentry.transport.ICurrentDateProvider
+import org.awaitility.kotlin.await
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.check
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.TimeUnit.MICROSECONDS
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [26])
+class ReplayIntegrationWithRecorderTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    internal class Fixture {
+        val options = SentryOptions()
+        val hub = mock<IHub>()
+        var encoder: SimpleVideoEncoder? = null
+
+        fun getSut(
+            context: Context,
+            recorder: Recorder,
+            recorderConfig: ScreenshotRecorderConfig,
+            dateProvider: ICurrentDateProvider = CurrentDateProvider.getInstance(),
+            framesToEncode: Int = 0
+        ): ReplayIntegration {
+            return ReplayIntegration(
+                context,
+                dateProvider,
+                recorderProvider = { recorder },
+                recorderConfigProvider = { recorderConfig },
+                // this is just needed for testing to encode a fake video
+                replayCacheProvider = { replayId ->
+                    ReplayCache(
+                        options,
+                        replayId,
+                        recorderConfig,
+                        encoderProvider = { videoFile, height, width ->
+                            encoder = SimpleVideoEncoder(
+                                options,
+                                MuxerConfig(
+                                    file = videoFile,
+                                    recordingHeight = height,
+                                    recordingWidth = width,
+                                    frameRate = recorderConfig.frameRate,
+                                    bitRate = recorderConfig.bitRate
+                                ),
+                                onClose = {
+                                    encodeFrame(
+                                        framesToEncode,
+                                        recorderConfig.frameRate,
+                                        size = 0,
+                                        flags = MediaCodec.BUFFER_FLAG_END_OF_STREAM
+                                    )
+                                }
+                            ).also { it.start() }
+                            repeat(framesToEncode) { encodeFrame(it, recorderConfig.frameRate) }
+
+                            encoder!!
+                        }
+                    )
+                }
+            )
+        }
+
+        private fun encodeFrame(index: Int, frameRate: Int, size: Int = 10, flags: Int = 0) {
+            val presentationTime = MICROSECONDS.convert(index * (1000L / frameRate), MILLISECONDS)
+            encoder!!.mediaCodec.dequeueInputBuffer(0)
+            encoder!!.mediaCodec.queueInputBuffer(
+                index,
+                index * size,
+                size,
+                presentationTime,
+                flags
+            )
+        }
+    }
+
+    private val fixture = Fixture()
+    private lateinit var context: Context
+
+    @BeforeTest
+    fun `set up`() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `works with different recorder`() {
+        val captured = AtomicBoolean(false)
+        whenever(fixture.hub.captureReplay(any(), anyOrNull())).then {
+            captured.set(true)
+        }
+        // fake current time to trigger segment creation, CurrentDateProvider.getInstance() should
+        // be used in prod
+        val dateProvider = ICurrentDateProvider {
+            System.currentTimeMillis() + fixture.options.experimental.sessionReplay.sessionSegmentDuration
+        }
+
+        fixture.options.experimental.sessionReplay.sessionSampleRate = 1.0
+        fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
+
+        val replay: ReplayIntegration
+        val recorderConfig = ScreenshotRecorderConfig(100, 200, 1f, 1f, 1, 20_000)
+        val recorder = object : Recorder {
+            var state: LifecycleState = INITALIZED
+
+            override fun start(recorderConfig: ScreenshotRecorderConfig) {
+                state = STARTED
+            }
+
+            override fun resume() {
+                state = RESUMED
+            }
+
+            override fun pause() {
+                state = PAUSED
+            }
+
+            override fun stop() {
+                state = STOPPED
+            }
+
+            override fun close() {
+                state = CLOSED
+            }
+        }
+
+        replay = fixture.getSut(context, recorder, recorderConfig, dateProvider, framesToEncode = 5)
+        replay.register(fixture.hub, fixture.options)
+
+        assertEquals(INITALIZED, recorder.state)
+
+        replay.start()
+        assertEquals(STARTED, recorder.state)
+
+        replay.resume()
+        assertEquals(RESUMED, recorder.state)
+
+        replay.pause()
+        assertEquals(PAUSED, recorder.state)
+
+        replay.stop()
+        assertEquals(STOPPED, recorder.state)
+
+        replay.close()
+        assertEquals(CLOSED, recorder.state)
+
+        // start again and capture some frames
+        replay.start()
+
+        val flutterCacheDir =
+            File(fixture.options.cacheDirPath!!, "flutter_replay").also { it.mkdirs() }
+        val screenshot = File(flutterCacheDir, "1.jpg").also { it.createNewFile() }
+
+        screenshot.outputStream().use {
+            Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)
+            it.flush()
+        }
+        replay.onScreenshotRecorded(screenshot, frameTimestamp = 1)
+
+        // verify
+        await.untilTrue(captured)
+
+        verify(fixture.hub).captureReplay(
+            check {
+                assertEquals(replay.replayId, it.replayId)
+                assertEquals(ReplayType.SESSION, it.replayType)
+                assertEquals("0.mp4", it.videoFile?.name)
+                assertEquals("replay_${replay.replayId}", it.videoFile?.parentFile?.name)
+            },
+            check {
+                val metaEvents = it.replayRecording?.payload?.filterIsInstance<RRWebMetaEvent>()
+                assertEquals(200, metaEvents?.first()?.height)
+                assertEquals(100, metaEvents?.first()?.width)
+
+                val videoEvents = it.replayRecording?.payload?.filterIsInstance<RRWebVideoEvent>()
+                assertEquals(200, videoEvents?.first()?.height)
+                assertEquals(100, videoEvents?.first()?.width)
+                assertEquals(5000, videoEvents?.first()?.durationMs)
+                assertEquals(5, videoEvents?.first()?.frameCount)
+                assertEquals(1, videoEvents?.first()?.frameRate)
+                assertEquals(0, videoEvents?.first()?.segmentId)
+            }
+        )
+    }
+
+    enum class LifecycleState {
+        INITALIZED,
+        STARTED,
+        RESUMED,
+        PAUSED,
+        STOPPED,
+        CLOSED
+    }
+}

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -184,9 +184,9 @@ class ReplayIntegrationWithRecorderTest {
         // start again and capture some frames
         replay.start()
 
-        val flutterCacheDir =
-            File(fixture.options.cacheDirPath!!, "flutter_replay").also { it.mkdirs() }
-        val screenshot = File(flutterCacheDir, "1.jpg").also { it.createNewFile() }
+        // have to access 'replayCacheDir' after calling replay.start(), BUT can already be accessed
+        // inside recorder.start()
+        val screenshot = File(replay.replayCacheDir, "1.jpg").also { it.createNewFile() }
 
         screenshot.outputStream().use {
             Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1255,6 +1255,7 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 
 public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public static fun getInstance ()Lio/sentry/NoOpReplayController;
+	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
 	public fun pause ()V
 	public fun resume ()V
@@ -1657,6 +1658,7 @@ public final class io/sentry/PropagationContext {
 }
 
 public abstract interface class io/sentry/ReplayController {
+	public abstract fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
@@ -5032,6 +5034,46 @@ public final class io/sentry/protocol/ViewHierarchyNode$JsonKeys {
 	public static final field WIDTH Ljava/lang/String;
 	public static final field X Ljava/lang/String;
 	public static final field Y Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent : io/sentry/rrweb/RRWebEvent, io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public static final field EVENT_TAG Ljava/lang/String;
+	public fun <init> ()V
+	public fun getBreadcrumbTimestamp ()J
+	public fun getBreadcrumbType ()Ljava/lang/String;
+	public fun getCategory ()Ljava/lang/String;
+	public fun getData ()Ljava/util/Map;
+	public fun getDataUnknown ()Ljava/util/Map;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getPayloadUnknown ()Ljava/util/Map;
+	public fun getTag ()Ljava/lang/String;
+	public fun getUnknown ()Ljava/util/Map;
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setBreadcrumbTimestamp (J)V
+	public fun setBreadcrumbType (Ljava/lang/String;)V
+	public fun setCategory (Ljava/lang/String;)V
+	public fun setData (Ljava/util/Map;)V
+	public fun setDataUnknown (Ljava/util/Map;)V
+	public fun setMessage (Ljava/lang/String;)V
+	public fun setPayloadUnknown (Ljava/util/Map;)V
+	public fun setTag (Ljava/lang/String;)V
+	public fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/rrweb/RRWebBreadcrumbEvent;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
+}
+
+public final class io/sentry/rrweb/RRWebBreadcrumbEvent$JsonKeys {
+	public static final field CATEGORY Ljava/lang/String;
+	public static final field DATA Ljava/lang/String;
+	public static final field MESSAGE Ljava/lang/String;
+	public static final field PAYLOAD Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
+	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V
 }
 

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.protocol.SentryId;
 import org.jetbrains.annotations.NotNull;
 
 public final class NoOpReplayController implements ReplayController {
@@ -31,4 +32,9 @@ public final class NoOpReplayController implements ReplayController {
 
   @Override
   public void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint) {}
+
+  @Override
+  public @NotNull SentryId getReplayId() {
+    return SentryId.EMPTY_ID;
+  }
 }

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.protocol.SentryId;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,4 +17,7 @@ public interface ReplayController {
   boolean isRecording();
 
   void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint);
+
+  @NotNull
+  SentryId getReplayId();
 }

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebBreadcrumbEvent.java
@@ -1,6 +1,5 @@
 package io.sentry.rrweb;
 
-import io.sentry.Breadcrumb;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
 import io.sentry.JsonSerializable;
@@ -16,7 +15,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknown, JsonSerializable {
+public final class RRWebBreadcrumbEvent extends RRWebEvent
+    implements JsonUnknown, JsonSerializable {
   public static final String EVENT_TAG = "breadcrumb";
 
   private @NotNull String tag;
@@ -30,7 +30,6 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   private @Nullable Map<String, Object> unknown;
   private @Nullable Map<String, Object> payloadUnknown;
   private @Nullable Map<String, Object> dataUnknown;
-
 
   public RRWebBreadcrumbEvent() {
     super(RRWebEventType.Custom);
@@ -128,8 +127,8 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
     public static final String MESSAGE = "message";
   }
 
-  @Override public void serialize(@NotNull ObjectWriter writer, @NotNull ILogger logger)
-    throws IOException {
+  @Override
+  public void serialize(@NotNull ObjectWriter writer, @NotNull ILogger logger) throws IOException {
     writer.beginObject();
     new RRWebEvent.Serializer().serialize(this, writer, logger);
     writer.name(JsonKeys.DATA);
@@ -145,7 +144,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   }
 
   private void serializeData(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
-    throws IOException {
+      throws IOException {
     writer.beginObject();
     writer.name(RRWebEvent.JsonKeys.TAG).value(tag);
     writer.name(JsonKeys.PAYLOAD);
@@ -161,7 +160,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
   }
 
   private void serializePayload(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
-    throws IOException {
+      throws IOException {
     writer.beginObject();
     if (breadcrumbType != null) {
       writer.name(JsonKeys.TYPE).value(breadcrumbType);
@@ -174,7 +173,7 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
       writer.name(JsonKeys.MESSAGE).value(message);
     }
     if (data != null) {
-      writer.name(Breadcrumb.JsonKeys.DATA).value(logger, data);
+      writer.name(JsonKeys.DATA).value(logger, data);
     }
     if (payloadUnknown != null) {
       for (final String key : payloadUnknown.keySet()) {
@@ -188,8 +187,9 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
 
   public static final class Deserializer implements JsonDeserializer<RRWebBreadcrumbEvent> {
 
-    @Override public @NotNull RRWebBreadcrumbEvent deserialize(@NotNull ObjectReader reader,
-      @NotNull ILogger logger) throws Exception {
+    @Override
+    public @NotNull RRWebBreadcrumbEvent deserialize(
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
       reader.beginObject();
       @Nullable Map<String, Object> unknown = null;
 
@@ -219,10 +219,10 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
     }
 
     private void deserializeData(
-      final @NotNull RRWebBreadcrumbEvent event,
-      final @NotNull ObjectReader reader,
-      final @NotNull ILogger logger)
-      throws Exception {
+        final @NotNull RRWebBreadcrumbEvent event,
+        final @NotNull ObjectReader reader,
+        final @NotNull ILogger logger)
+        throws Exception {
       @Nullable Map<String, Object> dataUnknown = null;
 
       reader.beginObject();
@@ -247,11 +247,12 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
       reader.endObject();
     }
 
-    @SuppressWarnings("unchecked") private void deserializePayload(
-      final @NotNull RRWebBreadcrumbEvent event,
-      final @NotNull ObjectReader reader,
-      final @NotNull ILogger logger)
-      throws Exception {
+    @SuppressWarnings("unchecked")
+    private void deserializePayload(
+        final @NotNull RRWebBreadcrumbEvent event,
+        final @NotNull ObjectReader reader,
+        final @NotNull ILogger logger)
+        throws Exception {
       @Nullable Map<String, Object> payloadUnknown = null;
 
       reader.beginObject();
@@ -272,8 +273,8 @@ public final class RRWebBreadcrumbEvent extends RRWebEvent implements JsonUnknow
             break;
           case JsonKeys.DATA:
             Map<String, Object> deserializedData =
-              CollectionUtils.newConcurrentHashMap(
-                (Map<String, Object>) reader.nextObjectOrNull());
+                CollectionUtils.newConcurrentHashMap(
+                    (Map<String, Object>) reader.nextObjectOrNull());
             if (deserializedData != null) {
               event.data = deserializedData;
             }


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Rework `ReplayIntegration` so it can accept a `Recorder` as a parameter and be used in e.g. Flutter by reusing most parts of the replay logic from the native layer
* Make `ReplayIntegration` testable and add a simple test with a different recorder. This is just a first step to make it testable and cover it with tests

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/63255

## :green_heart: How did you test it?
Ivan did
