### PR TITLE
Fix Frame measurements in app start transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix Frame measurements in app start transactions ([#3382](https://github.com/getsentry/sentry-java/pull/3382))
 - Fix timing metric value different from span duration ([#3368](https://github.com/getsentry/sentry-java/pull/3368))
 
 ## 7.8.0

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -560,7 +560,7 @@ public final class ActivityLifecycleIntegration
       if (ttfdSpan != null && ttfdSpan.isFinished()) {
         ttfdSpan.updateEndDate(endDate);
         // If the ttfd span was finished before the first frame we adjust the measurement, too
-        ttidSpan.setMeasurement(
+        ttfdSpan.setMeasurement(
             MeasurementValue.KEY_TIME_TO_FULL_DISPLAY, durationMillis, MILLISECOND);
       }
       finishSpan(ttidSpan, endDate);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -560,7 +560,7 @@ public final class ActivityLifecycleIntegration
       if (ttfdSpan != null && ttfdSpan.isFinished()) {
         ttfdSpan.updateEndDate(endDate);
         // If the ttfd span was finished before the first frame we adjust the measurement, too
-        ttfdSpan.setMeasurement(
+        ttidSpan.setMeasurement(
             MeasurementValue.KEY_TIME_TO_FULL_DISPLAY, durationMillis, MILLISECOND);
       }
       finishSpan(ttidSpan, endDate);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -144,7 +144,7 @@ public class SpanFrameMetricsCollector
         return;
       }
       // Note: The comparison between two values obtained by realNanos() works only if both are the
-      // same kind of dates (both SentryNanotimeDate or both SentryLongDate)
+      // same kind of dates (both are SentryNanotimeDate or both SentryLongDate)
       final long spanEndNanos = realNanos(spanFinishDate);
 
       final @NotNull SentryFrameMetrics frameMetrics = new SentryFrameMetrics();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -7,6 +7,7 @@ import io.sentry.NoOpSpan;
 import io.sentry.NoOpTransaction;
 import io.sentry.SentryDate;
 import io.sentry.SentryNanotimeDate;
+import io.sentry.SentryTracer;
 import io.sentry.SpanDataConvention;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.protocol.MeasurementValue;
@@ -135,11 +136,15 @@ public class SpanFrameMetricsCollector
         return;
       }
 
-      // ignore spans with no finish date
-      final @Nullable SentryDate spanFinishDate = span.getFinishDate();
+      // Ignore spans with no finish date, but SentryTracer is not finished when executing this
+      // callback, yet, so in that case we use the current timestamp.
+      final @Nullable SentryDate spanFinishDate =
+          span instanceof SentryTracer ? new SentryNanotimeDate() : span.getFinishDate();
       if (spanFinishDate == null) {
         return;
       }
+      // Note: The comparison between two values obtained by realNanos() works only if both are the
+      // same kind of dates (both SentryNanotimeDate or both SentryLongDate)
       final long spanEndNanos = realNanos(spanFinishDate);
 
       final @NotNull SentryFrameMetrics frameMetrics = new SentryFrameMetrics();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -5,12 +5,11 @@ import io.sentry.DateUtils;
 import io.sentry.SentryDate;
 import io.sentry.SentryLongDate;
 import io.sentry.SentryNanotimeDate;
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * A measurement for time critical components on a macro (ms) level. Based on {@link

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -10,6 +10,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A measurement for time critical components on a macro (ms) level. Based on {@link
  * SystemClock#uptimeMillis()} to ensure linear time progression (as opposed to a syncable clock).
@@ -22,6 +24,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
 
   private @Nullable String description;
 
+  private long startSystemNanos;
   private long startUnixTimeMs;
   private long startUptimeMs;
   private long stopUptimeMs;
@@ -30,6 +33,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
   public void start() {
     startUptimeMs = SystemClock.uptimeMillis();
     startUnixTimeMs = System.currentTimeMillis();
+    startSystemNanos = System.nanoTime();
   }
 
   /**
@@ -41,6 +45,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
 
     final long shiftMs = SystemClock.uptimeMillis() - startUptimeMs;
     startUnixTimeMs = System.currentTimeMillis() - shiftMs;
+    startSystemNanos = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(shiftMs);
   }
 
   /** Stops the time span */
@@ -92,7 +97,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
   public @Nullable SentryDate getStartTimestamp() {
     if (hasStarted()) {
       return new SentryNanotimeDate(
-          DateUtils.nanosToDate(DateUtils.millisToNanos(getStartTimestampMs())), System.nanoTime());
+          DateUtils.nanosToDate(DateUtils.millisToNanos(getStartTimestampMs())), startSystemNanos);
     }
     return null;
   }
@@ -164,6 +169,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
     startUptimeMs = 0;
     stopUptimeMs = 0;
     startUnixTimeMs = 0;
+    startSystemNanos = 0;
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -4,6 +4,7 @@ import android.os.SystemClock;
 import io.sentry.DateUtils;
 import io.sentry.SentryDate;
 import io.sentry.SentryLongDate;
+import io.sentry.SentryNanotimeDate;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -90,7 +91,8 @@ public class TimeSpan implements Comparable<TimeSpan> {
    */
   public @Nullable SentryDate getStartTimestamp() {
     if (hasStarted()) {
-      return new SentryLongDate(DateUtils.millisToNanos(getStartTimestampMs()));
+      return new SentryNanotimeDate(
+          DateUtils.nanosToDate(DateUtils.millisToNanos(getStartTimestampMs())), System.nanoTime());
     }
     return null;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
@@ -40,9 +40,7 @@ class SpanFrameMetricsCollectorTest {
             options.frameMetricsCollector = frameMetricsCollector
             options.isEnableFramesTracking = enabled
             options.isEnablePerformanceV2 = enabled
-            options.setDateProvider {
-                SentryLongDate(timeNanos)
-            }
+            options.dateProvider = SentryAndroidDateProvider()
 
             return SpanFrameMetricsCollector(options, frameMetricsCollector)
         }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
@@ -14,6 +14,7 @@ import io.sentry.android.core.SentryAndroidOptions
 import io.sentry.assertEnvelopeTransaction
 import io.sentry.protocol.MeasurementValue
 import io.sentry.protocol.SentryTransaction
+import org.junit.Assume
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -86,6 +87,8 @@ class AutomaticSpansTest : BaseUiTest() {
                 val slowFrames = measurements[MeasurementValue.KEY_FRAMES_SLOW]?.value?.toInt() ?: 0
                 val totalFrames = measurements[MeasurementValue.KEY_FRAMES_TOTAL]?.value?.toInt() ?: 0
                 assertEquals("ProfilingSampleActivity", transactionItem.transaction)
+                // AGP matrix tests have no frames
+                Assume.assumeTrue(totalFrames > 0)
                 assertNotEquals(totalFrames, 0)
                 assertTrue(totalFrames > slowFrames + frozenFrames, "Expected total frames ($totalFrames) to be higher than the sum of slow ($slowFrames) and frozen ($frozenFrames) frames.")
             }
@@ -120,6 +123,8 @@ class AutomaticSpansTest : BaseUiTest() {
                 val slowFrames = measurements[MeasurementValue.KEY_FRAMES_SLOW]?.value?.toInt() ?: 0
                 val totalFrames = measurements[MeasurementValue.KEY_FRAMES_TOTAL]?.value?.toInt() ?: 0
                 assertEquals("ProfilingSampleActivity", transactionItem.transaction)
+                // AGP matrix tests have no frames
+                Assume.assumeTrue(totalFrames > 0)
                 assertNotEquals(totalFrames, 0)
                 assertTrue(totalFrames > slowFrames + frozenFrames, "Expected total frames ($totalFrames) to be higher than the sum of slow ($slowFrames) and frozen ($frozenFrames) frames.")
             }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/AutomaticSpansTest.kt
@@ -2,13 +2,22 @@ package io.sentry.uitest.android
 
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.launchActivity
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.Sentry
 import io.sentry.SentryLevel
+import io.sentry.android.core.AndroidLogger
 import io.sentry.android.core.SentryAndroidOptions
+import io.sentry.assertEnvelopeTransaction
+import io.sentry.protocol.MeasurementValue
 import io.sentry.protocol.SentryTransaction
 import org.junit.runner.RunWith
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -47,6 +56,82 @@ class AutomaticSpansTest : BaseUiTest() {
                     }
                 }
             }
+        }
+    }
+
+    @Test
+    fun checkAppStartFramesMeasurements() {
+        initSentry(true) { options: SentryAndroidOptions ->
+            options.tracesSampleRate = 1.0
+            options.isEnableTimeToFullDisplayTracing = true
+            options.isEnablePerformanceV2 = false
+        }
+
+        IdlingRegistry.getInstance().register(ProfilingSampleActivity.scrollingIdlingResource)
+        val sampleScenario = launchActivity<ProfilingSampleActivity>()
+        swipeList(3)
+        Sentry.reportFullyDisplayed()
+        sampleScenario.moveToState(Lifecycle.State.DESTROYED)
+        IdlingRegistry.getInstance().unregister(ProfilingSampleActivity.scrollingIdlingResource)
+        relayIdlingResource.increment()
+
+        relay.assert {
+            findEnvelope {
+                assertEnvelopeTransaction(it.items.toList(), AndroidLogger()).transaction == "ProfilingSampleActivity"
+            }.assert {
+                val transactionItem: SentryTransaction = it.assertTransaction()
+                it.assertNoOtherItems()
+                val measurements = transactionItem.measurements
+                val frozenFrames = measurements[MeasurementValue.KEY_FRAMES_FROZEN]?.value?.toInt() ?: 0
+                val slowFrames = measurements[MeasurementValue.KEY_FRAMES_SLOW]?.value?.toInt() ?: 0
+                val totalFrames = measurements[MeasurementValue.KEY_FRAMES_TOTAL]?.value?.toInt() ?: 0
+                assertEquals("ProfilingSampleActivity", transactionItem.transaction)
+                assertNotEquals(totalFrames, 0)
+                assertTrue(totalFrames > slowFrames + frozenFrames, "Expected total frames ($totalFrames) to be higher than the sum of slow ($slowFrames) and frozen ($frozenFrames) frames.")
+            }
+            assertNoOtherEnvelopes()
+        }
+    }
+
+    @Test
+    fun checkAppStartFramesMeasurementsPerfV2() {
+        initSentry(true) { options: SentryAndroidOptions ->
+            options.tracesSampleRate = 1.0
+            options.isEnableTimeToFullDisplayTracing = true
+            options.isEnablePerformanceV2 = true
+        }
+
+        IdlingRegistry.getInstance().register(ProfilingSampleActivity.scrollingIdlingResource)
+        val sampleScenario = launchActivity<ProfilingSampleActivity>()
+        swipeList(3)
+        Sentry.reportFullyDisplayed()
+        sampleScenario.moveToState(Lifecycle.State.DESTROYED)
+        IdlingRegistry.getInstance().unregister(ProfilingSampleActivity.scrollingIdlingResource)
+        relayIdlingResource.increment()
+
+        relay.assert {
+            findEnvelope {
+                assertEnvelopeTransaction(it.items.toList(), AndroidLogger()).transaction == "ProfilingSampleActivity"
+            }.assert {
+                val transactionItem: SentryTransaction = it.assertTransaction()
+                it.assertNoOtherItems()
+                val measurements = transactionItem.measurements
+                val frozenFrames = measurements[MeasurementValue.KEY_FRAMES_FROZEN]?.value?.toInt() ?: 0
+                val slowFrames = measurements[MeasurementValue.KEY_FRAMES_SLOW]?.value?.toInt() ?: 0
+                val totalFrames = measurements[MeasurementValue.KEY_FRAMES_TOTAL]?.value?.toInt() ?: 0
+                assertEquals("ProfilingSampleActivity", transactionItem.transaction)
+                assertNotEquals(totalFrames, 0)
+                assertTrue(totalFrames > slowFrames + frozenFrames, "Expected total frames ($totalFrames) to be higher than the sum of slow ($slowFrames) and frozen ($frozenFrames) frames.")
+            }
+            assertNoOtherEnvelopes()
+        }
+    }
+
+    private fun swipeList(times: Int) {
+        repeat(times) {
+            Thread.sleep(100)
+            Espresso.onView(ViewMatchers.withId(R.id.profiling_sample_list)).perform(ViewActions.swipeUp())
+            Espresso.onIdle()
         }
     }
 }

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -157,7 +157,7 @@ class EnvelopeTests : BaseUiTest() {
                     // Timestamps of measurements should differ at least 10 milliseconds from each other
                     (1 until values.size).forEach { i ->
                         assertTrue(
-                            values[i].relativeStartNs.toLong() > values[i - 1].relativeStartNs.toLong() + TimeUnit.MILLISECONDS.toNanos(
+                            values[i].relativeStartNs.toLong() >= values[i - 1].relativeStartNs.toLong() + TimeUnit.MILLISECONDS.toNanos(
                                 10
                             ),
                             "Measurement value timestamp for '$name' does not differ at least 10ms"

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -87,9 +87,9 @@ public final class SentryTracer implements ITransaction {
       this.baggage = new Baggage(hub.getOptions().getLogger());
     }
 
-    // We are currently sending the performance data only in profiles, so there's no point in
-    // collecting them if a profile is not sampled
-    if (transactionPerformanceCollector != null && Boolean.TRUE.equals(isProfileSampled())) {
+    // We are currently sending the performance data only in profiles, but we are always sending
+    // performance measurements.
+    if (transactionPerformanceCollector != null) {
       transactionPerformanceCollector.start(this);
     }
 

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -1005,9 +1005,9 @@ class SentryTracerTest {
     }
 
     @Test
-    fun `when transaction is created, but not profiled, transactionPerformanceCollector is not started`() {
+    fun `when transaction is created, but not profiled, transactionPerformanceCollector is started anyway`() {
         val transaction = fixture.getSut()
-        verify(fixture.transactionPerformanceCollector, never()).start(anyOrNull())
+        verify(fixture.transactionPerformanceCollector).start(anyOrNull())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
performance collectors are called independently from profiling (now transactions get frames measurements)
`TimeSpan.getStartTimestamp` is now a `SentryNanotimeDate`, to fix `FrameMetricsCollector` on app start transactions


## :bulb: Motivation and Context
`FrameMetricsCollector` checks the start and end timestamp with a difference to a common date. The issue is that using a `SentryLongDate` and a `SentryNanotimeDate` gives different results. We always use `SentryNanotimeDate` on Android, except for app start timestamps, which are then propagated to app start transaction, TTID and TTFD.
Also, `SentryTracer` was not added to the `PerformaceCollectors` when profiling was disabled, due to previous constraints


## :green_heart: How did you test it?
Added UI test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
