### PR TITLE
[SR] Add `sendReplay` method for Hybrid SDKs

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -52,6 +52,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 	public fun resume ()V
+	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public fun start ()V
 	public fun stop ()V

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -138,12 +138,20 @@ public class ReplayIntegration(
             return
         }
 
-        if (SentryId.EMPTY_ID.equals(captureStrategy?.currentReplayId?.get())) {
-            options.logger.log(DEBUG, "Replay id is not set, not capturing for event %s", event.eventId)
+        sendReplay(event.isCrashed, event.eventId.toString(), hint)
+    }
+
+    override fun sendReplay(isCrashed: Boolean?, eventId: String?, hint: Hint?) {
+        if (!isEnabled.get() || !isRecording.get()) {
             return
         }
 
-        captureStrategy?.sendReplayForEvent(event, hint, onSegmentSent = { captureStrategy?.currentSegment?.getAndIncrement() })
+        if (SentryId.EMPTY_ID.equals(captureStrategy?.currentReplayId?.get())) {
+            options.logger.log(DEBUG, "Replay id is not set, not capturing for event %s", eventId)
+            return
+        }
+
+        captureStrategy?.sendReplayForEvent(isCrashed == true, eventId, hint, onSegmentSent = { captureStrategy?.currentSegment?.getAndIncrement() })
         captureStrategy = captureStrategy?.convert()
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.replay.capture
 
 import io.sentry.Hint
-import io.sentry.SentryEvent
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.protocol.SentryId
@@ -22,7 +21,7 @@ internal interface CaptureStrategy {
 
     fun resume()
 
-    fun sendReplayForEvent(event: SentryEvent, hint: Hint, onSegmentSent: () -> Unit)
+    fun sendReplayForEvent(isCrashed: Boolean, eventId: String?, hint: Hint?, onSegmentSent: () -> Unit)
 
     fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -3,7 +3,6 @@ package io.sentry.android.replay.capture
 import io.sentry.DateUtils
 import io.sentry.Hint
 import io.sentry.IHub
-import io.sentry.SentryEvent
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
 import io.sentry.SentryOptions
@@ -58,16 +57,14 @@ internal class SessionCaptureStrategy(
         super.stop()
     }
 
-    override fun sendReplayForEvent(event: SentryEvent, hint: Hint, onSegmentSent: () -> Unit) {
-        // don't ask me why
-        event.setTag("replayId", currentReplayId.get().toString())
-        if (!event.isCrashed) {
-            options.logger.log(DEBUG, "Replay is already running in 'session' mode, not capturing for event %s", event.eventId)
+    override fun sendReplayForEvent(isCrashed: Boolean, eventId: String?, hint: Hint?, onSegmentSent: () -> Unit) {
+        if (!isCrashed) {
+            options.logger.log(DEBUG, "Replay is already running in 'session' mode, not capturing for event %s", eventId)
         } else {
-            options.logger.log(DEBUG, "Replay is already running in 'session' mode, capturing last segment for crashed event %s", event.eventId)
+            options.logger.log(DEBUG, "Replay is already running in 'session' mode, capturing last segment for crashed event %s", eventId)
             createCurrentSegment("send_replay_for_event") { segment ->
                 if (segment is ReplaySegment.Created) {
-                    segment.capture(hub, hint)
+                    segment.capture(hub, hint ?: Hint())
                 }
             }
         }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1259,6 +1259,7 @@ public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public fun isRecording ()Z
 	public fun pause ()V
 	public fun resume ()V
+	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public fun start ()V
 	public fun stop ()V
@@ -1662,6 +1663,7 @@ public abstract interface class io/sentry/ReplayController {
 	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
+	public abstract fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public abstract fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public abstract fun start ()V
 	public abstract fun stop ()V

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.protocol.SentryId;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class NoOpReplayController implements ReplayController {
 
@@ -32,6 +33,10 @@ public final class NoOpReplayController implements ReplayController {
 
   @Override
   public void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint) {}
+
+  @Override
+  public void sendReplay(
+      @Nullable Boolean isCrashed, @Nullable String eventId, @Nullable Hint hint) {}
 
   @Override
   public @NotNull SentryId getReplayId() {

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -3,6 +3,7 @@ package io.sentry;
 import io.sentry.protocol.SentryId;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public interface ReplayController {
@@ -17,6 +18,8 @@ public interface ReplayController {
   boolean isRecording();
 
   void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint);
+
+  void sendReplay(@Nullable Boolean isCrashed, @Nullable String eventId, @Nullable Hint hint);
 
   @NotNull
   SentryId getReplayId();


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds `sendReplay` method which is not depending on the Event class and so can be used by the hybrid SDKs to capture Replay for hybrid errors (JS errors).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/getsentry/sentry-react-native/pull/3714

## :green_heart: How did you test it?
Tested with the RN Sample app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
