### PR TITLE
Hubs/Scopes Merge 40 - `Scopes.isEnabled` now checks `getClient().isEnabled()`

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -2,14 +2,12 @@ package io.sentry.android.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
-import io.sentry.IScope
 import io.sentry.IScopes
-import io.sentry.Scope
-import io.sentry.Scopes
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.test.DeferredExecutorService
 import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.createTestScopes
 import org.junit.runner.RunWith
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -74,9 +72,7 @@ class EnvelopeFileObserverIntegrationTest {
         options.cacheDirPath = file.absolutePath
         options.addIntegration(integrationMock)
         options.setSerializer(mock())
-        val globalScope = Scope(options)
-        val scopes = Scopes(mock<IScope>(), mock<IScope>(), globalScope, "test")
-//        verify(integrationMock).register(expected, options)
+        val scopes = createTestScopes(options)
         scopes.close()
         verify(integrationMock).close()
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -8,7 +8,6 @@ import io.sentry.Hint
 import io.sentry.IScope
 import io.sentry.Scope
 import io.sentry.ScopeType
-import io.sentry.Scopes
 import io.sentry.Sentry
 import io.sentry.SentryEnvelope
 import io.sentry.SentryEnvelopeHeader
@@ -24,6 +23,7 @@ import io.sentry.protocol.Contexts
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
+import io.sentry.test.createTestScopes
 import io.sentry.transport.ITransport
 import io.sentry.transport.RateLimiter
 import org.junit.runner.RunWith
@@ -106,13 +106,14 @@ class InternalSentrySdkTest {
 
     @BeforeTest
     fun `set up`() {
+        Sentry.close()
         context = ApplicationProvider.getApplicationContext()
         DeviceInfoUtil.resetInstance()
     }
 
     @Test
     fun `current scope returns null when scopes is no-op`() {
-        Sentry.getCurrentScopes().close()
+        Sentry.setCurrentScopes(createTestScopes(enabled = false))
         val scope = InternalSentrySdk.getCurrentScope()
         assertNull(scope)
     }
@@ -122,9 +123,7 @@ class InternalSentrySdkTest {
         val options = SentryOptions().apply {
             dsn = "https://key@uri/1234567"
         }
-        Sentry.setCurrentScopes(
-            Scopes(Scope(options), Scope(options), Scope(options), "test")
-        )
+        Sentry.setCurrentScopes(createTestScopes(options))
         val scope = InternalSentrySdk.getCurrentScope()
         assertNotNull(scope)
     }
@@ -134,9 +133,7 @@ class InternalSentrySdkTest {
         val options = SentryOptions().apply {
             dsn = "https://key@uri/1234567"
         }
-        Sentry.setCurrentScopes(
-            Scopes(Scope(options), Scope(options), Scope(options), "test")
-        )
+        Sentry.setCurrentScopes(createTestScopes(options))
         Sentry.addBreadcrumb("test")
         Sentry.configureScope(ScopeType.CURRENT) { scope -> scope.addBreadcrumb(Breadcrumb("currentBreadcrumb")) }
         Sentry.configureScope(ScopeType.ISOLATION) { scope -> scope.addBreadcrumb(Breadcrumb("isolationBreadcrumb")) }

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -35,17 +35,18 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SentryAppenderTest {
-    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, contextTags: List<String>? = null, encoder: Encoder<ILoggingEvent>? = null, sendDefaultPii: Boolean = false) {
+    private class Fixture(dsn: String? = "http://key@localhost/proj", minimumBreadcrumbLevel: Level? = null, minimumEventLevel: Level? = null, contextTags: List<String>? = null, encoder: Encoder<ILoggingEvent>? = null, sendDefaultPii: Boolean = false, options: SentryOptions = SentryOptions(), startLater: Boolean = false) {
         val logger: Logger = LoggerFactory.getLogger(SentryAppenderTest::class.java)
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
         val transportFactory = mock<ITransportFactory>()
         val transport = mock<ITransport>()
         val utcTimeZone: ZoneId = ZoneId.of("UTC")
+        val appender = SentryAppender()
+        var encoder: Encoder<ILoggingEvent>? = null
 
         init {
             whenever(this.transportFactory.create(any(), any())).thenReturn(transport)
-            val appender = SentryAppender()
-            val options = SentryOptions()
+            this.encoder = encoder
             options.dsn = dsn
             options.isSendDefaultPii = sendDefaultPii
             contextTags?.forEach { options.addContextTag(it) }
@@ -59,6 +60,12 @@ class SentryAppenderTest {
             val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
             rootLogger.level = Level.TRACE
             rootLogger.addAppender(appender)
+            if (!startLater) {
+                start()
+            }
+        }
+
+        fun start() {
             appender.start()
             encoder?.start()
             loggerContext.start()
@@ -82,17 +89,25 @@ class SentryAppenderTest {
 
     @Test
     fun `does not initialize Sentry if Sentry is already enabled`() {
-        fixture = Fixture()
+        fixture = Fixture(
+            startLater = true,
+            options = SentryOptions().also {
+                it.setTag("only-present-if-logger-init-was-run", "another-value")
+            }
+        )
         Sentry.init {
             it.dsn = "http://key@localhost/proj"
             it.environment = "manual-environment"
             it.setTransportFactory(fixture.transportFactory)
+            it.setTag("tag-from-first-init", "some-value")
         }
+        fixture.start()
+
         fixture.logger.error("testing environment field")
 
         verify(fixture.transport).send(
             checkEvent { event ->
-                assertEquals("manual-environment", event.environment)
+                assertNull(event.tags?.get("only-present-if-logger-init-was-run"))
             },
             anyOrNull()
         )

--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -31,6 +31,13 @@ public final class io/sentry/test/ImmediateExecutorService : io/sentry/ISentryEx
 	public fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
 }
 
+public final class io/sentry/test/MocksKt {
+	public static final fun createSentryClientMock (Z)Lio/sentry/ISentryClient;
+	public static synthetic fun createSentryClientMock$default (ZILjava/lang/Object;)Lio/sentry/ISentryClient;
+	public static final fun createTestScopes (Lio/sentry/SentryOptions;ZLio/sentry/IScope;Lio/sentry/IScope;Lio/sentry/IScope;)Lio/sentry/Scopes;
+	public static synthetic fun createTestScopes$default (Lio/sentry/SentryOptions;ZLio/sentry/IScope;Lio/sentry/IScope;Lio/sentry/IScope;ILjava/lang/Object;)Lio/sentry/Scopes;
+}
+
 public final class io/sentry/test/ReflectionKt {
 	public static final fun collectInterfaceHierarchy (Ljava/lang/Class;)Ljava/util/List;
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Z

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -1,11 +1,19 @@
 // ktlint-disable filename
 package io.sentry.test
 
+import io.sentry.IScope
+import io.sentry.ISentryClient
 import io.sentry.ISentryExecutorService
+import io.sentry.Scope
+import io.sentry.Scopes
+import io.sentry.SentryOptions
 import io.sentry.backpressure.IBackpressureMonitor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
 
 class ImmediateExecutorService : ISentryExecutorService {
     override fun submit(runnable: Runnable): Future<*> {
@@ -64,4 +72,23 @@ class DeferredExecutorService : ISentryExecutorService {
     override fun isClosed(): Boolean = false
 
     fun hasScheduledRunnables(): Boolean = scheduledRunnables.isNotEmpty()
+}
+
+fun createSentryClientMock(enabled: Boolean = true) = mock<ISentryClient>().also {
+    val isEnabled = AtomicBoolean(enabled)
+    whenever(it.isEnabled).then { isEnabled.get() }
+    whenever(it.close()).then { isEnabled.set(false) }
+    whenever(it.close(any())).then { isEnabled.set(false) }
+}
+
+fun createTestScopes(options: SentryOptions? = null, enabled: Boolean = true, scope: IScope? = null, isolationScope: IScope? = null, globalScope: IScope? = null): Scopes {
+    val optionsToUse = options ?: SentryOptions().also { it.dsn = "https://key@sentry.io/proj" }
+    val scopeToUse = scope ?: Scope(optionsToUse)
+    val isolationScopeToUse = isolationScope ?: Scope(optionsToUse)
+    val globalScopeToUse = globalScope ?: Scope(optionsToUse)
+    return Scopes(scopeToUse, isolationScopeToUse, globalScopeToUse, "test").also {
+        if (enabled) {
+            it.bindClient(createSentryClientMock())
+        }
+    }
 }

--- a/sentry/src/main/java/io/sentry/CombinedContextsView.java
+++ b/sentry/src/main/java/io/sentry/CombinedContextsView.java
@@ -248,7 +248,6 @@ public final class CombinedContextsView extends Contexts {
 
   @Override
   public @Nullable Object remove(final @NotNull Object key) {
-    // TODO [HSM] should this remove from all contexts?
     return getDefaultContexts().remove(key);
   }
 

--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -231,7 +231,6 @@ public final class CombinedScopeView implements IScope {
 
   @Override
   public void removeTag(@NotNull String key) {
-    // TODO [HSM] should this go to all scopes?
     getDefaultWriteScope().removeTag(key);
   }
 
@@ -251,7 +250,6 @@ public final class CombinedScopeView implements IScope {
 
   @Override
   public void removeExtra(@NotNull String key) {
-    // TODO [HSM] should this go to all scopes?
     getDefaultWriteScope().removeExtra(key);
   }
 
@@ -301,7 +299,6 @@ public final class CombinedScopeView implements IScope {
 
   @Override
   public void removeContexts(@NotNull String key) {
-    // TODO [HSM] should this go to all scopes?
     getDefaultWriteScope().removeContexts(key);
   }
 

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -780,7 +780,6 @@ public final class Scope implements IScope {
   @NotNull
   @Override
   public List<EventProcessorAndOrder> getEventProcessorsWithOrder() {
-    // TODO [HSM] This isn't actually ordered but only gets ordered in CombinedScopeView
     return eventProcessors;
   }
 
@@ -1041,17 +1040,17 @@ public final class Scope implements IScope {
   @ApiStatus.Internal
   @Override
   public void replaceOptions(final @NotNull SentryOptions options) {
-    // TODO [HSM] check if already enabled and noop in that case?
-    //    if (!isEnabled()) {}
-    this.options = options;
-    final Queue<Breadcrumb> oldBreadcrumbs = breadcrumbs;
-    breadcrumbs = createBreadcrumbsList(options.getMaxBreadcrumbs());
-    for (Breadcrumb breadcrumb : oldBreadcrumbs) {
-      /*
-      this should trigger beforeBreadcrumb
-      and notify observers for breadcrumbs added before options where customized in Sentry.init
-      */
-      addBreadcrumb(breadcrumb);
+    if (!getClient().isEnabled()) {
+      this.options = options;
+      final Queue<Breadcrumb> oldBreadcrumbs = breadcrumbs;
+      breadcrumbs = createBreadcrumbsList(options.getMaxBreadcrumbs());
+      for (Breadcrumb breadcrumb : oldBreadcrumbs) {
+        /*
+        this should trigger beforeBreadcrumb
+        and notify observers for breadcrumbs added before options where customized in Sentry.init
+        */
+        addBreadcrumb(breadcrumb);
+      }
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/EventProcessorUtils.java
+++ b/sentry/src/main/java/io/sentry/util/EventProcessorUtils.java
@@ -2,6 +2,7 @@ package io.sentry.util;
 
 import io.sentry.EventProcessor;
 import io.sentry.internal.eventprocessor.EventProcessorAndOrder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.jetbrains.annotations.Nullable;
@@ -10,7 +11,7 @@ public final class EventProcessorUtils {
 
   public static List<EventProcessor> unwrap(
       final @Nullable List<EventProcessorAndOrder> orderedEventProcessor) {
-    final List<EventProcessor> eventProcessors = new CopyOnWriteArrayList<>();
+    final List<EventProcessor> eventProcessors = new ArrayList<>();
 
     if (orderedEventProcessor != null) {
       for (EventProcessorAndOrder eventProcessorAndOrder : orderedEventProcessor) {
@@ -18,6 +19,6 @@ public final class EventProcessorUtils {
       }
     }
 
-    return eventProcessors;
+    return new CopyOnWriteArrayList<>(eventProcessors);
   }
 }

--- a/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
+++ b/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
@@ -4,6 +4,7 @@ import io.sentry.protocol.Device
 import io.sentry.protocol.Request
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
+import io.sentry.test.createTestScopes
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Assert.assertNotEquals
@@ -38,7 +39,7 @@ class CombinedScopeViewTest {
             globalScope = Scope(options)
             isolationScope = Scope(options)
             scope = Scope(options)
-            scopes = Scopes(scope, isolationScope, globalScope, "test")
+            scopes = createTestScopes(options, scope = scope, isolationScope = isolationScope, globalScope = globalScope)
 
             return CombinedScopeView(globalScope, isolationScope, scope)
         }
@@ -801,6 +802,9 @@ class CombinedScopeViewTest {
     @Test
     fun `uses isolation scope client if noop on current scope`() {
         val combined = fixture.getSut()
+        fixture.scope.bindClient(NoOpSentryClient.getInstance())
+        fixture.isolationScope.bindClient(NoOpSentryClient.getInstance())
+        fixture.globalScope.bindClient(NoOpSentryClient.getInstance())
 
         val isolationClient = SentryClient(fixture.options)
         fixture.isolationScope.bindClient(isolationClient)
@@ -814,6 +818,9 @@ class CombinedScopeViewTest {
     @Test
     fun `uses global scope client if noop on current and isolation scope`() {
         val combined = fixture.getSut()
+        fixture.scope.bindClient(NoOpSentryClient.getInstance())
+        fixture.isolationScope.bindClient(NoOpSentryClient.getInstance())
+        fixture.globalScope.bindClient(NoOpSentryClient.getInstance())
 
         val globalClient = SentryClient(fixture.options)
         fixture.globalScope.bindClient(globalClient)
@@ -824,6 +831,10 @@ class CombinedScopeViewTest {
     @Test
     fun `binds client to default scope`() {
         val combined = fixture.getSut()
+        fixture.scope.bindClient(NoOpSentryClient.getInstance())
+        fixture.isolationScope.bindClient(NoOpSentryClient.getInstance())
+        fixture.globalScope.bindClient(NoOpSentryClient.getInstance())
+
         val client = SentryClient(fixture.options)
         combined.bindClient(client)
 
@@ -880,7 +891,7 @@ class CombinedScopeViewTest {
         whenever(globalScope.options).thenReturn(options)
 
         val exception = RuntimeException("someEx")
-        val transaction = createTransaction("aTransaction", Scopes(scope, isolationScope, globalScope, "test"))
+        val transaction = createTransaction("aTransaction", createTestScopes(options = options, scope = scope, isolationScope = isolationScope, globalScope = globalScope))
         combined.setSpanContext(exception, transaction, "aTransaction")
 
         verify(scope, never()).setSpanContext(any(), any(), any())

--- a/sentry/src/test/java/io/sentry/HubAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/HubAdapterTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.test.createSentryClientMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -190,7 +191,7 @@ class HubAdapterTest {
     }
 
     @Test fun `bindClient calls Hub`() {
-        val client = mock<ISentryClient>()
+        val client = createSentryClientMock()
         HubAdapter.getInstance().bindClient(client)
         verify(scopes).bindClient(eq(client))
     }

--- a/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.test.createSentryClientMock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
@@ -190,7 +191,7 @@ class ScopesAdapterTest {
     }
 
     @Test fun `bindClient calls Scopes`() {
-        val client = mock<ISentryClient>()
+        val client = createSentryClientMock()
         ScopesAdapter.getInstance().bindClient(client)
         verify(scopes).bindClient(eq(client))
     }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -15,6 +15,7 @@ import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryThread
 import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.createSentryClientMock
 import io.sentry.util.PlatformTestManipulator
 import io.sentry.util.thread.IMainThreadChecker
 import io.sentry.util.thread.MainThreadChecker
@@ -266,7 +267,7 @@ class SentryTest {
     fun `captureUserFeedback gets forwarded to client`() {
         Sentry.init { it.dsn = dsn }
 
-        val client = mock<ISentryClient>()
+        val client = createSentryClientMock()
         Sentry.getCurrentScopes().bindClient(client)
 
         val userFeedback = UserFeedback(SentryId.EMPTY_ID)
@@ -860,7 +861,7 @@ class SentryTest {
     fun `captureCheckIn gets forwarded to client`() {
         Sentry.init { it.dsn = dsn }
 
-        val client = mock<ISentryClient>()
+        val client = createSentryClientMock()
         Sentry.getCurrentScopes().bindClient(client)
 
         val checkIn = CheckIn("some_slug", CheckInStatus.OK)

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -2,6 +2,7 @@ package io.sentry
 
 import io.sentry.protocol.TransactionNameSource
 import io.sentry.protocol.User
+import io.sentry.test.createTestScopes
 import io.sentry.util.thread.IMainThreadChecker
 import org.awaitility.kotlin.await
 import org.mockito.kotlin.any
@@ -36,9 +37,8 @@ class SentryTracerTest {
             options.dsn = "https://key@sentry.io/proj"
             options.environment = "environment"
             options.release = "release@3.0.0"
-            scopes = spy(Scopes(Scope(options), Scope(options), Scope(options), "test"))
+            scopes = spy(createTestScopes(options))
             transactionPerformanceCollector = spy(DefaultTransactionPerformanceCollector(options))
-            scopes.bindClient(mock())
         }
 
         fun getSut(

--- a/sentry/src/test/java/io/sentry/StackTest.kt
+++ b/sentry/src/test/java/io/sentry/StackTest.kt
@@ -1,6 +1,7 @@
 package io.sentry
 
 import io.sentry.Stack.StackItem
+import io.sentry.test.createSentryClientMock
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,7 +11,7 @@ class StackTest {
 
     private class Fixture {
         val options = SentryOptions()
-        val client = mock<ISentryClient>()
+        val client = createSentryClientMock()
         val scope = Scope(options)
 
         lateinit var rootItem: StackItem

--- a/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.sentry.exception.ExceptionMechanismException
 import io.sentry.hints.DiskFlushNotification
 import io.sentry.hints.EventDropReason.MULTITHREADED_DEDUPLICATION
 import io.sentry.protocol.SentryId
+import io.sentry.test.createTestScopes
 import io.sentry.util.HintUtils
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -105,7 +106,7 @@ class UncaughtExceptionHandlerIntegrationTest {
         options.addIntegration(integrationMock)
         options.cacheDirPath = fixture.file.absolutePath
         options.setSerializer(mock())
-        val scopes = Scopes(Scope(options), Scope(options), Scope(options), "test")
+        val scopes = createTestScopes(options)
         scopes.close()
         verify(integrationMock).close()
     }

--- a/sentry/src/test/java/io/sentry/metrics/MetricsIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/metrics/MetricsIntegrationTest.kt
@@ -70,6 +70,7 @@ class MetricsIntegrationTest {
         Sentry.init(options)
 
         val client = mock<SentryClient>()
+        whenever(client.isEnabled).thenReturn(true)
         val aggregator = MetricsAggregator(options, client)
         whenever(client.metricsAggregator).thenReturn(aggregator)
         Sentry.bindClient(client)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since `Scopes` are forked much more frequently than `Hub` was, we can no longer store `isEnabled` as a property on `Scopes` as it would only affect a very limited scope (:D). By asking client we should by default now have the same state globally unless a customer sets a different client.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
