### PR TITLE
Add ttid/ttfd contribution flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add start_type to app context ([#3379](https://github.com/getsentry/sentry-java/pull/3379))
+- Add ttid/ttfd contribution flags ([#3386](https://github.com/getsentry/sentry-java/pull/3386))
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -98,9 +98,12 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         transaction.getMeasurements().put(appStartKey, value);
 
         attachColdAppStartSpans(AppStartMetrics.getInstance(), transaction);
+
         sentStartMeasurement = true;
       }
     }
+
+    setContributingFlags(transaction);
 
     final SentryId eventId = transaction.getEventId();
     final SpanContext spanContext = transaction.getContexts().getTrace();
@@ -119,6 +122,60 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
     }
 
     return transaction;
+  }
+
+  private void setContributingFlags(SentryTransaction transaction) {
+
+    @Nullable SentrySpan ttidSpan = null;
+    @Nullable SentrySpan ttfdSpan = null;
+    for (final @NotNull SentrySpan span : transaction.getSpans()) {
+      if (ActivityLifecycleIntegration.TTID_OP.equals(span.getOp())) {
+        ttidSpan = span;
+      } else if (ActivityLifecycleIntegration.TTFD_OP.equals(span.getOp())) {
+        ttfdSpan = span;
+      }
+      // once both are found we can early exit
+      if (ttidSpan != null && ttfdSpan != null) {
+        break;
+      }
+    }
+
+    if (ttidSpan == null && ttfdSpan == null) {
+      return;
+    }
+
+    for (final @NotNull SentrySpan span : transaction.getSpans()) {
+      // as ttid and ttfd spans are artificially created, we don't want to set the flags on them
+      if (span == ttidSpan || span == ttfdSpan) {
+        continue;
+      }
+
+      // TODO should we only consider spans running on the main thread?
+      final boolean withinTtid =
+          (ttidSpan != null) && isTimestampWithinSpan(span.getStartTimestamp(), ttidSpan);
+      final boolean withinTtfd =
+          (ttfdSpan != null) && isTimestampWithinSpan(span.getStartTimestamp(), ttfdSpan);
+
+      if (withinTtid || withinTtfd) {
+        @Nullable Map<String, Object> data = span.getData();
+        if (data == null) {
+          data = new ConcurrentHashMap<>();
+          span.setData(data);
+        }
+        if (withinTtid) {
+          data.put(SpanDataConvention.CONTRIBUTES_TTID, true);
+        }
+        if (withinTtfd) {
+          data.put(SpanDataConvention.CONTRIBUTES_TTFD, true);
+        }
+      }
+    }
+  }
+
+  private static boolean isTimestampWithinSpan(
+      final double timestamp, final @NotNull SentrySpan target) {
+    return timestamp >= target.getStartTimestamp()
+        && (target.getTimestamp() == null || timestamp <= target.getTimestamp());
   }
 
   private boolean hasAppStartSpan(final @NotNull SentryTransaction txn) {
@@ -238,6 +295,9 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
     final Map<String, Object> defaultSpanData = new HashMap<>(2);
     defaultSpanData.put(SpanDataConvention.THREAD_ID, Looper.getMainLooper().getThread().getId());
     defaultSpanData.put(SpanDataConvention.THREAD_NAME, "main");
+
+    defaultSpanData.put(SpanDataConvention.CONTRIBUTES_TTID, true);
+    defaultSpanData.put(SpanDataConvention.CONTRIBUTES_TTFD, true);
 
     return new SentrySpan(
         span.getStartTimestampSecs(),

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -163,9 +163,20 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
         continue;
       }
 
-      // TODO should we only consider spans running on the main thread?
+      // let's assume main thread, unless it's set differently
+      boolean spanOnMainThread = true;
+      final @Nullable Map<String, Object> spanData = span.getData();
+      if (spanData != null) {
+        final @Nullable Object threadName = spanData.get(SpanDataConvention.THREAD_NAME);
+        spanOnMainThread = threadName == null || "main".equals(threadName);
+      }
+
+      // for ttid, only main thread spans are relevant
       final boolean withinTtid =
-          (ttidSpan != null) && isTimestampWithinSpan(span.getStartTimestamp(), ttidSpan);
+          (ttidSpan != null)
+              && isTimestampWithinSpan(span.getStartTimestamp(), ttidSpan)
+              && spanOnMainThread;
+
       final boolean withinTtfd =
           (ttfdSpan != null) && isTimestampWithinSpan(span.getStartTimestamp(), ttfdSpan);
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -7,6 +7,7 @@ import io.sentry.IHub
 import io.sentry.MeasurementUnit
 import io.sentry.SentryTracer
 import io.sentry.SpanContext
+import io.sentry.SpanDataConvention
 import io.sentry.SpanId
 import io.sentry.SpanStatus
 import io.sentry.TracesSamplingDecision
@@ -27,6 +28,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -462,6 +464,164 @@ class PerformanceAndroidEventProcessorTest {
                     it.data!!.containsKey("thread.id")
             }
         }
+    }
+
+    @Test
+    fun `adds ttid and ttfd contributing span data`() {
+        val sut = fixture.getSut()
+
+        val context = TransactionContext("Activity", UI_LOAD_OP)
+        val tracer = SentryTracer(context, fixture.hub)
+        val tr = SentryTransaction(tracer)
+
+        // given a ttid from 0.0 -> 1.0
+        //   and a ttfd from 0.0 -> 2.0
+        val ttid = SentrySpan(
+            0.0,
+            1.0,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            ActivityLifecycleIntegration.TTID_OP,
+            "App Start",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            null
+        )
+
+        val ttfd = SentrySpan(
+            0.0,
+            2.0,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            ActivityLifecycleIntegration.TTFD_OP,
+            "App Start",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            null
+        )
+        tr.spans.add(ttid)
+        tr.spans.add(ttfd)
+
+        // and 3 spans
+        // one from 0.0 -> 0.5
+        val ttidContrib = SentrySpan(
+            0.0,
+            0.5,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            "example.op",
+            "",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            null
+        )
+
+        // and another from 1.5 -> 3.5
+        val ttfdContrib = SentrySpan(
+            1.5,
+            3.5,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            "example.op",
+            "",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            null
+        )
+
+        // and another from 2.1 -> 2.2
+        val outsideSpan = SentrySpan(
+            2.1,
+            2.2,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            "example.op",
+            "",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            mutableMapOf<String, Any>(
+                "tag" to "value"
+            )
+        )
+
+        tr.spans.add(ttidContrib)
+        tr.spans.add(ttfdContrib)
+
+        // when the processor processes the txn
+        sut.process(tr, Hint())
+
+        // then the ttid/ttfd spans themselves should have no flags set
+        assertNull(ttid.data?.get(SpanDataConvention.CONTRIBUTES_TTID))
+        assertNull(ttid.data?.get(SpanDataConvention.CONTRIBUTES_TTFD))
+
+        assertNull(ttfd.data?.get(SpanDataConvention.CONTRIBUTES_TTID))
+        assertNull(ttfd.data?.get(SpanDataConvention.CONTRIBUTES_TTFD))
+
+        // then the first span should have ttid and ttfd contributing flags
+        assertTrue(ttidContrib.data?.get(SpanDataConvention.CONTRIBUTES_TTID) == true)
+        assertTrue(ttidContrib.data?.get(SpanDataConvention.CONTRIBUTES_TTFD) == true)
+
+        // and the second one should contribute to ttfd only
+        assertNull(ttfdContrib.data?.get(SpanDataConvention.CONTRIBUTES_TTID))
+        assertTrue(ttfdContrib.data?.get(SpanDataConvention.CONTRIBUTES_TTFD) == true)
+
+        // and the third span should have no flags attached, as it's outside ttid/ttfd
+        assertNull(outsideSpan.data?.get(SpanDataConvention.CONTRIBUTES_TTID))
+        assertNull(outsideSpan.data?.get(SpanDataConvention.CONTRIBUTES_TTFD))
+    }
+
+    @Test
+    fun `adds no ttid and ttfd contributing span data if txn contains no ttid or ttfd`() {
+        val sut = fixture.getSut()
+
+        val context = TransactionContext("Activity", UI_LOAD_OP)
+        val tracer = SentryTracer(context, fixture.hub)
+        val tr = SentryTransaction(tracer)
+
+        val span = SentrySpan(
+            0.0,
+            1.0,
+            tr.contexts.trace!!.traceId,
+            SpanId(),
+            null,
+            "example.op",
+            "",
+            SpanStatus.OK,
+            null,
+            emptyMap(),
+            emptyMap(),
+            null,
+            null
+        )
+
+        tr.spans.add(span)
+
+        // when the processor processes the txn
+        sut.process(tr, Hint())
+
+        // the span should have no flags attached
+        assertNull(span.data?.get(SpanDataConvention.CONTRIBUTES_TTID))
+        assertNull(span.data?.get(SpanDataConvention.CONTRIBUTES_TTFD))
     }
 
     private fun setAppStart(options: SentryAndroidOptions, coldStart: Boolean = true) {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2740,6 +2740,8 @@ public final class io/sentry/SpanContext$JsonKeys {
 public abstract interface class io/sentry/SpanDataConvention {
 	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
 	public static final field CALL_STACK_KEY Ljava/lang/String;
+	public static final field CONTRIBUTES_TTFD Ljava/lang/String;
+	public static final field CONTRIBUTES_TTID Ljava/lang/String;
 	public static final field DB_NAME_KEY Ljava/lang/String;
 	public static final field DB_SYSTEM_KEY Ljava/lang/String;
 	public static final field FRAMES_DELAY Ljava/lang/String;
@@ -4456,6 +4458,7 @@ public final class io/sentry/protocol/SentrySpan : io/sentry/JsonSerializable, i
 	public fun getUnknown ()Ljava/util/Map;
 	public fun isFinished ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setData (Ljava/util/Map;)V
 	public fun setUnknown (Ljava/util/Map;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -21,6 +21,6 @@ public interface SpanDataConvention {
   String FRAMES_SLOW = "frames.slow";
   String FRAMES_FROZEN = "frames.frozen";
   String FRAMES_DELAY = "frames.delay";
-  String CONTRIBUTES_TTID = "ui.contributes_ttid";
-  String CONTRIBUTES_TTFD = "ui.contributes_ttfd";
+  String CONTRIBUTES_TTID = "ui.contributes_to_ttid";
+  String CONTRIBUTES_TTFD = "ui.contributes_to_ttfd";
 }

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -21,6 +21,6 @@ public interface SpanDataConvention {
   String FRAMES_SLOW = "frames.slow";
   String FRAMES_FROZEN = "frames.frozen";
   String FRAMES_DELAY = "frames.delay";
-  String CONTRIBUTES_TTID = "contributes_ttid";
-  String CONTRIBUTES_TTFD = "contributes_ttfd";
+  String CONTRIBUTES_TTID = "ui.contributes_ttid";
+  String CONTRIBUTES_TTFD = "ui.contributes_ttfd";
 }

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -21,4 +21,6 @@ public interface SpanDataConvention {
   String FRAMES_SLOW = "frames.slow";
   String FRAMES_FROZEN = "frames.frozen";
   String FRAMES_DELAY = "frames.delay";
+  String CONTRIBUTES_TTID = "contributes_ttid";
+  String CONTRIBUTES_TTFD = "contributes_ttfd";
 }

--- a/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
@@ -40,7 +40,7 @@ public final class SentrySpan implements JsonUnknown, JsonSerializable {
 
   private final @Nullable String origin;
   private final @NotNull Map<String, String> tags;
-  private final @Nullable Map<String, Object> data;
+  private @Nullable Map<String, Object> data;
 
   private final @NotNull Map<String, @NotNull MeasurementValue> measurements;
   private final @Nullable Map<String, List<MetricSummary>> metricsSummaries;
@@ -157,6 +157,10 @@ public final class SentrySpan implements JsonUnknown, JsonSerializable {
 
   public @Nullable Map<String, Object> getData() {
     return data;
+  }
+
+  public void setData(final @Nullable Map<String, Object> data) {
+    this.data = data;
   }
 
   public @Nullable String getOrigin() {


### PR DESCRIPTION
## :scroll: Description

Attaches the ttid/ttfd contribution flags to all spans within a txn, if the txn contains a ttid/ttfd span. 

## :bulb: Motivation and Context

Relevant docs PR: https://github.com/getsentry/develop/pull/1250/files
Relevant discussion on Notion: https://www.notion.so/sentry/span-contribution-9b5a0979a81645789db6877593729cf4

## :green_heart: How did you test it?

Added tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
