### PR TITLE
Hubs/Scopes Merge 41b - Use COMBINED as default scope type for callbacks

### DIFF
--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -303,10 +303,10 @@ public final class CombinedScopeView implements IScope {
   }
 
   private @NotNull IScope getDefaultWriteScope() {
-    return getSpecificScope(null);
+    return getSpecificScope(null, false);
   }
 
-  IScope getSpecificScope(final @Nullable ScopeType scopeType) {
+  IScope getSpecificScope(final @Nullable ScopeType scopeType, final boolean usedForCallback) {
     if (scopeType != null) {
       switch (scopeType) {
         case CURRENT:
@@ -320,6 +320,10 @@ public final class CombinedScopeView implements IScope {
         default:
           break;
       }
+    }
+
+    if (usedForCallback) {
+      return this;
     }
 
     switch (getOptions().getDefaultScopeType()) {

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -636,7 +636,8 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
     } else {
       final @NotNull IScopes forkedScopes = forkedCurrentScope("withScope");
       try (final @NotNull ISentryLifecycleToken ignored = forkedScopes.makeCurrent()) {
-        callback.run(forkedScopes.getScope());
+        //        callback.run(forkedScopes.getScope());
+        forkedScopes.configureScope(callback);
       } catch (Throwable e) {
         getOptions().getLogger().log(SentryLevel.ERROR, "Error in the 'withScope' callback.", e);
       }
@@ -657,7 +658,8 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
     } else {
       final @NotNull IScopes forkedScopes = forkedScopes("withIsolationScope");
       try (final @NotNull ISentryLifecycleToken ignored = forkedScopes.makeCurrent()) {
-        callback.run(forkedScopes.getIsolationScope());
+        //        callback.run(forkedScopes.getIsolationScope());
+        forkedScopes.configureScope(callback);
       } catch (Throwable e) {
         getOptions()
             .getLogger()
@@ -677,7 +679,7 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
               "Instance is disabled and this 'configureScope' call is a no-op.");
     } else {
       try {
-        callback.run(combinedScope.getSpecificScope(scopeType));
+        callback.run(combinedScope.getSpecificScope(scopeType, true));
       } catch (Throwable e) {
         getOptions()
             .getLogger()

--- a/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
+++ b/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
@@ -845,39 +845,75 @@ class CombinedScopeViewTest {
     }
 
     @Test
-    fun `getSpecificScope(null) returns scope defined in options CURRENT`() {
+    fun `getSpecificScope(null, true) returns CombinedScopeView CURRENT`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
-        assertSame(fixture.scope, combined.getSpecificScope(null))
+        assertSame(combined, combined.getSpecificScope(null, true))
     }
 
     @Test
-    fun `getSpecificScope(null) returns scope defined in options ISOLATION`() {
+    fun `getSpecificScope(null, true) returns CombinedScopeView ISOLATION`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.ISOLATION })
-        assertSame(fixture.isolationScope, combined.getSpecificScope(null))
+        assertSame(combined, combined.getSpecificScope(null, true))
     }
 
     @Test
-    fun `getSpecificScope(null) returns scope defined in options GLOBAL`() {
+    fun `getSpecificScope(null, true) returns CombinedScopeView GLOBAL`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.GLOBAL })
-        assertSame(fixture.globalScope, combined.getSpecificScope(null))
+        assertSame(combined, combined.getSpecificScope(null, true))
     }
 
     @Test
-    fun `getSpecificScope(CURRENT) returns current scope`() {
+    fun `getSpecificScope(CURRENT, true) returns current scope`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.ISOLATION })
-        assertSame(fixture.scope, combined.getSpecificScope(ScopeType.CURRENT))
+        assertSame(fixture.scope, combined.getSpecificScope(ScopeType.CURRENT, true))
     }
 
     @Test
-    fun `getSpecificScope(ISOLATION) returns isolation scope`() {
+    fun `getSpecificScope(ISOLATION, true) returns isolation scope`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
-        assertSame(fixture.isolationScope, combined.getSpecificScope(ScopeType.ISOLATION))
+        assertSame(fixture.isolationScope, combined.getSpecificScope(ScopeType.ISOLATION, true))
     }
 
     @Test
-    fun `getSpecificScope(GLOBAL) returns global scope`() {
+    fun `getSpecificScope(GLOBAL, true) returns global scope`() {
         val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
-        assertSame(fixture.globalScope, combined.getSpecificScope(ScopeType.GLOBAL))
+        assertSame(fixture.globalScope, combined.getSpecificScope(ScopeType.GLOBAL, true))
+    }
+
+    @Test
+    fun `getSpecificScope(null, false) returns scope defined in options CURRENT`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
+        assertSame(fixture.scope, combined.getSpecificScope(null, false))
+    }
+
+    @Test
+    fun `getSpecificScope(null, false) returns scope defined in options ISOLATION`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.ISOLATION })
+        assertSame(fixture.isolationScope, combined.getSpecificScope(null, false))
+    }
+
+    @Test
+    fun `getSpecificScope(null, false) returns scope defined in options GLOBAL`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.GLOBAL })
+        assertSame(fixture.globalScope, combined.getSpecificScope(null, false))
+    }
+
+    @Test
+    fun `getSpecificScope(CURRENT, false) returns current scope`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.ISOLATION })
+        assertSame(fixture.scope, combined.getSpecificScope(ScopeType.CURRENT, false))
+    }
+
+    @Test
+    fun `getSpecificScope(ISOLATION, false) returns isolation scope`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
+        assertSame(fixture.isolationScope, combined.getSpecificScope(ScopeType.ISOLATION, false))
+    }
+
+    @Test
+    fun `getSpecificScope(GLOBAL, false) returns global scope`() {
+        val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
+        assertSame(fixture.globalScope, combined.getSpecificScope(ScopeType.GLOBAL, false))
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -262,8 +262,8 @@ class ScopesTest {
         options.setSerializer(mock())
         val sut = createScopes(options)
         var breadcrumbs: Queue<Breadcrumb>? = null
-        sut.configureScope { breadcrumbs = it.breadcrumbs }
         sut.addBreadcrumb("message", "category")
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
         assertEquals("message", breadcrumbs!!.single().message)
         assertEquals("category", breadcrumbs!!.single().category)
     }
@@ -276,8 +276,8 @@ class ScopesTest {
         options.setSerializer(mock())
         val sut = createScopes(options)
         var breadcrumbs: Queue<Breadcrumb>? = null
-        sut.configureScope { breadcrumbs = it.breadcrumbs }
         sut.addBreadcrumb("message", "category")
+        sut.configureScope { breadcrumbs = it.breadcrumbs }
         assertEquals("message", breadcrumbs!!.single().message)
         assertEquals("category", breadcrumbs!!.single().category)
     }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
This is an optional PR which we may or may not merge.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `CombinedScopeView`  as default scope for callbacks used in e.g. `configureScope()` or `withScope()` should be closer to what we did when there was only a single scope.

However, this also means there can be writes that manipulate e.g. global scope. One example where this is the case would be manipulating an object on `Contexts` where `CombinedContextsView` may hand back an object instance for let's say `Device` that lives on global scope. If you now change this `Device` object, global scope is changed.

For `configureScope` changing global scope may be OK but for `withScope` customers would likely expect it to not affect anything outside the callback. Having `configureScope` and `withScope` behave differently would also be odd.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
