### PR TITLE
Fix UncaughtExceptionHandlerIntegration Memory Leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix Frame measurements in app start transactions ([#3382](https://github.com/getsentry/sentry-java/pull/3382))
 - Fix timing metric value different from span duration ([#3368](https://github.com/getsentry/sentry-java/pull/3368))
+- Fix UncaughtExceptionHandlerIntegration Memory Leak ([#3398](https://github.com/getsentry/sentry-java/pull/3398))
 
 ## 7.8.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2978,7 +2978,7 @@ public final class io/sentry/TypeCheckHint {
 public final class io/sentry/UncaughtExceptionHandlerIntegration : io/sentry/Integration, java/io/Closeable, java/lang/Thread$UncaughtExceptionHandler {
 	public fun <init> ()V
 	public fun close ()V
-	public final fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
+	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 	public fun uncaughtException (Ljava/lang/Thread;Ljava/lang/Throwable;)V
 }
 

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -75,7 +75,14 @@ public final class UncaughtExceptionHandlerIntegration
                 "default UncaughtExceptionHandler class='"
                     + currentHandler.getClass().getName()
                     + "'");
-        defaultExceptionHandler = currentHandler;
+
+        if(currentHandler instanceof UncaughtExceptionHandlerIntegration) {
+          final UncaughtExceptionHandlerIntegration currentHandlerIntegration = (UncaughtExceptionHandlerIntegration) currentHandler;
+          defaultExceptionHandler = currentHandlerIntegration.defaultExceptionHandler;
+        } else {
+          defaultExceptionHandler = currentHandler;
+        }
+
       }
 
       threadAdapter.setDefaultUncaughtExceptionHandler(this);

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -43,7 +43,7 @@ public final class UncaughtExceptionHandlerIntegration
   }
 
   @Override
-  public final void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
+  public void register(final @NotNull IHub hub, final @NotNull SentryOptions options) {
     if (registered) {
       options
           .getLogger()
@@ -76,13 +76,15 @@ public final class UncaughtExceptionHandlerIntegration
                     + currentHandler.getClass().getName()
                     + "'");
 
-        if(currentHandler instanceof UncaughtExceptionHandlerIntegration) {
-          final UncaughtExceptionHandlerIntegration currentHandlerIntegration = (UncaughtExceptionHandlerIntegration) currentHandler;
+        if (currentHandler instanceof UncaughtExceptionHandlerIntegration) {
+          final UncaughtExceptionHandlerIntegration currentHandlerIntegration =
+              (UncaughtExceptionHandlerIntegration) currentHandler;
           defaultExceptionHandler = currentHandlerIntegration.defaultExceptionHandler;
         } else {
           defaultExceptionHandler = currentHandler;
         }
 
+        //        defaultExceptionHandler = currentHandler;
       }
 
       threadAdapter.setDefaultUncaughtExceptionHandler(this);

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -83,8 +83,6 @@ public final class UncaughtExceptionHandlerIntegration
         } else {
           defaultExceptionHandler = currentHandler;
         }
-
-        //        defaultExceptionHandler = currentHandler;
       }
 
       threadAdapter.setDefaultUncaughtExceptionHandler(this);

--- a/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
@@ -320,7 +320,7 @@ class UncaughtExceptionHandlerIntegrationTest {
 
     @Test
     fun `multiple registrations do not cause the build-up of a tree of UncaughtExceptionHandlerIntegrations, reset to inital`() {
-        val initialUncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, _ ->  }
+        val initialUncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, _ -> }
 
         var currentDefaultHandler: Thread.UncaughtExceptionHandler? = initialUncaughtExceptionHandler
 

--- a/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/UncaughtExceptionHandlerIntegrationTest.kt
@@ -7,6 +7,7 @@ import io.sentry.hints.EventDropReason.MULTITHREADED_DEDUPLICATION
 import io.sentry.protocol.SentryId
 import io.sentry.util.HintUtils
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.argumentCaptor
@@ -19,6 +20,7 @@ import java.io.PrintStream
 import java.nio.file.Files
 import kotlin.concurrent.thread
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -290,5 +292,29 @@ class UncaughtExceptionHandlerIntegrationTest {
                     .isFlushable(eventCaptor.firstValue.eventId)
             }
         )
+    }
+
+    @Test
+    fun `multiple registrations do not cause the build-up of a tree of UncaughtExceptionHandlerIntegrations`() {
+        var currentDefaultHandler: Thread.UncaughtExceptionHandler? = null
+
+        val handler = mock<UncaughtExceptionHandler>()
+        whenever(handler.defaultUncaughtExceptionHandler).thenAnswer { currentDefaultHandler }
+
+        whenever(handler.setDefaultUncaughtExceptionHandler(anyOrNull<Thread.UncaughtExceptionHandler>())).then {
+            currentDefaultHandler = it.getArgument(0)
+            null
+        }
+
+        val integration1 = UncaughtExceptionHandlerIntegration(handler)
+        integration1.register(fixture.hub, fixture.options)
+
+        val integration2 = UncaughtExceptionHandlerIntegration(handler)
+        integration2.register(fixture.hub, fixture.options)
+
+        assertEquals(currentDefaultHandler, integration2)
+        integration2.close()
+
+        assertEquals(null, currentDefaultHandler)
     }
 }


### PR DESCRIPTION
Upon registration check if an `UncaughtExceptionHandlerIntegration` is already set as `defaultUncaughtExceptionHandler`, if so, set its `defaultExceptionHandler` as the default of the new `UncaughtExceptionHandlerIntegration`. 

## :bulb: Motivation and Context
Fixes #3266


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
