### PR TITLE
Do not always write startup crash marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - (Internal) Metrics code cleanup ([#3403](https://github.com/getsentry/sentry-java/pull/3403))
 - Fix Frame measurements in app start transactions ([#3382](https://github.com/getsentry/sentry-java/pull/3382))
 - Fix timing metric value different from span duration ([#3368](https://github.com/getsentry/sentry-java/pull/3368))
+- Do not always write startup crash marker ([#3409](https://github.com/getsentry/sentry-java/pull/3409))
+  - This may have been causing the SDK init logic to block the main thread
 
 ## 7.8.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -57,7 +57,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     if (HintUtils.hasType(hint, UncaughtExceptionHandlerIntegration.UncaughtExceptionHint.class)
         && sdkInitTimeSpan.hasStarted()) {
       long timeSinceSdkInit =
-          currentDateProvider.getCurrentTimeMillis() - sdkInitTimeSpan.getStartTimestampMs();
+          currentDateProvider.getCurrentTimeMillis() - sdkInitTimeSpan.getStartUptimeMs();
       if (timeSinceSdkInit <= options.getStartupCrashDurationThresholdMillis()) {
         options
             .getLogger()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/cache/AndroidEnvelopeCacheTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/cache/AndroidEnvelopeCacheTest.kt
@@ -51,10 +51,8 @@ class AndroidEnvelopeCacheTest {
                 AppStartMetrics.getInstance().apply {
                     if (options.isEnablePerformanceV2) {
                         appStartTimeSpan.setStartedAt(appStartMillis)
-                        appStartTimeSpan.setStartUnixTimeMs(appStartMillis)
                     } else {
                         sdkInitTimeSpan.setStartedAt(appStartMillis)
-                        sdkInitTimeSpan.setStartUnixTimeMs(appStartMillis)
                     }
                 }
             }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* We were using epoch millis for startup time, whereas `CurrentDateProvider` uses uptime millis, therefore we were always writing the crash marker file and always blocking SDK init. This is a regression from when we introduced app start spans

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found out this accidentally while testing

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
