### PR TITLE
reverted app start span timestamp to SentryLongDate

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -1,11 +1,13 @@
 package io.sentry.android.core;
 
+import io.sentry.DateUtils;
 import io.sentry.IPerformanceContinuousCollector;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.NoOpSpan;
 import io.sentry.NoOpTransaction;
 import io.sentry.SentryDate;
+import io.sentry.SentryLongDate;
 import io.sentry.SentryNanotimeDate;
 import io.sentry.SentryTracer;
 import io.sentry.SpanDataConvention;
@@ -143,8 +145,6 @@ public class SpanFrameMetricsCollector
       if (spanFinishDate == null) {
         return;
       }
-      // Note: The comparison between two values obtained by realNanos() works only if both are the
-      // same kind of dates (both are SentryNanotimeDate or both SentryLongDate)
       final long spanEndNanos = realNanos(spanFinishDate);
 
       final @NotNull SentryFrameMetrics frameMetrics = new SentryFrameMetrics();
@@ -308,7 +308,16 @@ public class SpanFrameMetricsCollector
    * @return a timestamp in nano precision
    */
   private static long realNanos(final @NotNull SentryDate date) {
-    return date.diff(UNIX_START_DATE);
+    // SentryNanotimeDate nanotime is based on System.nanotime(), like UNIX_START_DATE
+    if (date instanceof SentryNanotimeDate) {
+      return date.diff(UNIX_START_DATE);
+    }
+
+    // SentryLongDate nanotime is based on current date converted to nanoseconds, which is a
+    // different order than frames based System.nanotime(). So we have to convert the nanotime of
+    // the SentryLongDate to a System.nanotime() compatible one.
+    return date.diff(new SentryLongDate(DateUtils.millisToNanos(System.currentTimeMillis())))
+        + System.nanoTime();
   }
 
   private static class Frame implements Comparable<Frame> {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -4,7 +4,6 @@ import android.os.SystemClock;
 import io.sentry.DateUtils;
 import io.sentry.SentryDate;
 import io.sentry.SentryLongDate;
-import io.sentry.SentryNanotimeDate;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -95,8 +94,7 @@ public class TimeSpan implements Comparable<TimeSpan> {
    */
   public @Nullable SentryDate getStartTimestamp() {
     if (hasStarted()) {
-      return new SentryNanotimeDate(
-          DateUtils.nanosToDate(DateUtils.millisToNanos(getStartTimestampMs())), startSystemNanos);
+      return new SentryLongDate(DateUtils.millisToNanos(getStartTimestampMs()));
     }
     return null;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SpanFrameMetricsCollectorTest.kt
@@ -4,7 +4,6 @@ import io.sentry.ISpan
 import io.sentry.ITransaction
 import io.sentry.NoOpSpan
 import io.sentry.NoOpTransaction
-import io.sentry.SentryLongDate
 import io.sentry.SentryNanotimeDate
 import io.sentry.SpanContext
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector
@@ -53,10 +52,16 @@ class SpanFrameMetricsCollectorTest {
         val span = mock<ISpan>()
         val spanContext = SpanContext("op.fake")
         whenever(span.spanContext).thenReturn(spanContext)
-        whenever(span.startDate).thenReturn(SentryLongDate(startTimeStampNanos))
+        whenever(span.startDate).thenReturn(
+            SentryNanotimeDate(
+                Date(),
+                startTimeStampNanos
+            )
+        )
         whenever(span.finishDate).thenReturn(
             if (endTimeStampNanos != null) {
-                SentryLongDate(
+                SentryNanotimeDate(
+                    Date(),
                     endTimeStampNanos
                 )
             } else {
@@ -73,10 +78,16 @@ class SpanFrameMetricsCollectorTest {
         val span = mock<ITransaction>()
         val spanContext = SpanContext("op.fake")
         whenever(span.spanContext).thenReturn(spanContext)
-        whenever(span.startDate).thenReturn(SentryLongDate(startTimeStampNanos))
+        whenever(span.startDate).thenReturn(
+            SentryNanotimeDate(
+                Date(),
+                startTimeStampNanos
+            )
+        )
         whenever(span.finishDate).thenReturn(
             if (endTimeStampNanos != null) {
-                SentryLongDate(
+                SentryNanotimeDate(
+                    Date(),
                     endTimeStampNanos
                 )
             } else {


### PR DESCRIPTION
## :scroll: Description
reverted TimeSpan.getStartTimestamp to SentryLongDate, to not break hybrid sdks
fixed SpanFrameMetricsCollector.realNanos (it now checks the date type and reacts accordingly)
improves https://github.com/getsentry/sentry-java/pull/3382

#skip-changelog

## :bulb: Motivation and Context
Hybrid SDKs read the start timestamp of the app start spans as it's the current timestamp (like the `SentryLongDate`).
Reverting this before it gets to hybrid SDKs


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
