### PR TITLE
8.x Cleanup

### DIFF
--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/webflux/SentryWebfluxIntegrationTest.kt
@@ -95,7 +95,7 @@ class SentryWebfluxIntegrationTest {
             checkEvent { event ->
                 assertEquals("GET /throws", event.transaction)
                 assertNotNull(event.exceptions) {
-                    val ex = it.first()
+                    val ex = it.last()
                     assertEquals("something went wrong", ex.value)
                     assertNotNull(ex.mechanism) {
                         assertThat(it.isHandled).isFalse()

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/webflux/SentryWebfluxIntegrationTest.kt
@@ -95,7 +95,7 @@ class SentryWebfluxIntegrationTest {
             checkEvent { event ->
                 assertEquals("GET /throws", event.transaction)
                 assertNotNull(event.exceptions) {
-                    val ex = it.first()
+                    val ex = it.last()
                     assertEquals("something went wrong", ex.value)
                     assertNotNull(ex.mechanism) {
                         assertThat(it.isHandled).isFalse()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2958,9 +2958,7 @@ public final class io/sentry/SentryTracer : io/sentry/ITransaction {
 public final class io/sentry/SentryWrapper {
 	public fun <init> ()V
 	public static fun wrapCallable (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Callable;
-	public static fun wrapCallableIsolated (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Callable;
 	public static fun wrapSupplier (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
-	public static fun wrapSupplierIsolated (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
 }
 
 public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/DefaultScopesStorage.java
+++ b/sentry/src/main/java/io/sentry/DefaultScopesStorage.java
@@ -21,8 +21,6 @@ public final class DefaultScopesStorage implements IScopesStorage {
 
   @Override
   public void close() {
-    // TODO [HSM] prevent further storing? would this cause problems if singleton, closed and
-    // re-initialized?
     currentScopes.remove();
   }
 

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -92,8 +92,6 @@ public final class Scope implements IScope {
 
   private @NotNull ISentryClient client = NoOpSentryClient.getInstance();
 
-  // TODO [HSM] intended only for global scope
-  // TODO [HSM] test for memory leak
   private final @NotNull Map<Throwable, Pair<WeakReference<ISpan>, String>> throwableToSpan =
       Collections.synchronizedMap(new WeakHashMap<>());
 

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -87,7 +87,6 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
     return globalScope;
   }
 
-  // TODO [HSM] add to IScopes interface?
   public boolean isAncestorOf(final @Nullable Scopes otherScopes) {
     if (otherScopes == null) {
       return false;
@@ -623,7 +622,6 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
     }
   }
 
-  // TODO [HSM] lots of testing required to see how ThreadLocal is affected
   @Override
   public void withScope(final @NotNull ScopeCallback callback) {
     if (!isEnabled()) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -53,8 +53,7 @@ public final class Sentry {
    *
    * <p>For Android options will also be (temporarily) replaced by SentryAndroid static block.
    */
-  // TODO [HSM] use SentryOptions.empty and address
-  // https://github.com/getsentry/sentry-java/issues/2541
+  // TODO https://github.com/getsentry/sentry-java/issues/2541
   private static final @NotNull IScope globalScope = new Scope(SentryOptions.empty());
 
   /** Default value for globalHubMode is false */

--- a/sentry/src/main/java/io/sentry/SentryWrapper.java
+++ b/sentry/src/main/java/io/sentry/SentryWrapper.java
@@ -16,29 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * scope(s) are forked, depends on the method used here. This prevents reused threads (e.g. from
  * thread-pools) from getting an incorrect state.
  */
-// TODO [HSM] only deliver isolated variant as default for now
 public final class SentryWrapper {
-
-  /**
-   * Helper method to wrap {@link Callable}
-   *
-   * <p>Forks current scope before execution and restores previous state afterwards. This prevents
-   * reused threads (e.g. from thread-pools) from getting an incorrect state.
-   *
-   * @param callable - the {@link Callable} to be wrapped
-   * @return the wrapped {@link Callable}
-   * @param <U> - the result type of the {@link Callable}
-   */
-  public static <U> Callable<U> wrapCallable(final @NotNull Callable<U> callable) {
-    final IScopes newScopes =
-        Sentry.getCurrentScopes().forkedCurrentScope("SentryWrapper.wrapCallable");
-
-    return () -> {
-      try (ISentryLifecycleToken ignored = newScopes.makeCurrent()) {
-        return callable.call();
-      }
-    };
-  }
 
   /**
    * Helper method to wrap {@link Callable}
@@ -50,7 +28,7 @@ public final class SentryWrapper {
    * @return the wrapped {@link Callable}
    * @param <U> - the result type of the {@link Callable}
    */
-  public static <U> Callable<U> wrapCallableIsolated(final @NotNull Callable<U> callable) {
+  public static <U> Callable<U> wrapCallable(final @NotNull Callable<U> callable) {
     final IScopes newScopes = Sentry.getCurrentScopes().forkedScopes("SentryWrapper.wrapCallable");
 
     return () -> {
@@ -63,26 +41,6 @@ public final class SentryWrapper {
   /**
    * Helper method to wrap {@link Supplier}
    *
-   * <p>Forks current scope before execution and restores previous state afterwards. This prevents
-   * reused threads (e.g. from thread-pools) from getting an incorrect state.
-   *
-   * @param supplier - the {@link Supplier} to be wrapped
-   * @return the wrapped {@link Supplier}
-   * @param <U> - the result type of the {@link Supplier}
-   */
-  public static <U> Supplier<U> wrapSupplier(final @NotNull Supplier<U> supplier) {
-    final IScopes newScopes = Sentry.forkedCurrentScope("SentryWrapper.wrapSupplier");
-
-    return () -> {
-      try (ISentryLifecycleToken ignore = newScopes.makeCurrent()) {
-        return supplier.get();
-      }
-    };
-  }
-
-  /**
-   * Helper method to wrap {@link Supplier}
-   *
    * <p>Forks current and isolation scope before execution and restores previous state afterwards.
    * This prevents reused threads (e.g. from thread-pools) from getting an incorrect state.
    *
@@ -90,7 +48,7 @@ public final class SentryWrapper {
    * @return the wrapped {@link Supplier}
    * @param <U> - the result type of the {@link Supplier}
    */
-  public static <U> Supplier<U> wrapSupplierIsolated(final @NotNull Supplier<U> supplier) {
+  public static <U> Supplier<U> wrapSupplier(final @NotNull Supplier<U> supplier) {
     final IScopes newScopes = Sentry.forkedScopes("SentryWrapper.wrapSupplier");
 
     return () -> {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Isolate `wrapCallable` and `wrapSupplier` by default and remove non isolated variant for now. We can add it back if customers ask for it.
- Fix webflux tests that now report suppressed exceptions
- Remove old TODOs

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
