### PR TITLE
Move fragment auto span finish to onFragmentStarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Move fragment auto span finish to onFragmentStarted ([#3424](https://github.com/getsentry/sentry-java/pull/3424))
+
 ## 7.9.0
 
 ### Features

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -96,12 +96,13 @@ class SentryFragmentLifecycleCallbacks(
 
     override fun onFragmentStarted(fragmentManager: FragmentManager, fragment: Fragment) {
         addBreadcrumb(fragment, FragmentLifecycleState.STARTED)
+
+        // ViewPager2 locks background fragments to STARTED state
+        stopTracing(fragment)
     }
 
     override fun onFragmentResumed(fragmentManager: FragmentManager, fragment: Fragment) {
         addBreadcrumb(fragment, FragmentLifecycleState.RESUMED)
-
-        stopTracing(fragment)
     }
 
     override fun onFragmentPaused(fragmentManager: FragmentManager, fragment: Fragment) {

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -229,11 +229,11 @@ class SentryFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    fun `When fragment is resumed, it should stop tracing if enabled`() {
+    fun `When fragment is started, it should stop tracing if enabled`() {
         val sut = fixture.getSut(enableAutoFragmentLifecycleTracing = true)
 
         sut.onFragmentCreated(fixture.fragmentManager, fixture.fragment, savedInstanceState = null)
-        sut.onFragmentResumed(fixture.fragmentManager, fixture.fragment)
+        sut.onFragmentStarted(fixture.fragmentManager, fixture.fragment)
 
         verify(fixture.span).finish(
             check {
@@ -243,12 +243,12 @@ class SentryFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    fun `When fragment is resumed, it should stop tracing if enabled but keep status`() {
+    fun `When fragment is started, it should stop tracing if enabled but keep status`() {
         val sut = fixture.getSut(enableAutoFragmentLifecycleTracing = true)
 
         whenever(fixture.span.status).thenReturn(SpanStatus.ABORTED)
         sut.onFragmentCreated(fixture.fragmentManager, fixture.fragment, savedInstanceState = null)
-        sut.onFragmentResumed(fixture.fragmentManager, fixture.fragment)
+        sut.onFragmentStarted(fixture.fragmentManager, fixture.fragment)
 
         verify(fixture.span).finish(
             check {


### PR DESCRIPTION
## :scroll: Description
moved fragment auto span finish to onFragmentStarted instead of onFragmentResumed to account for ViewPager2 behaviour

Other options considered, but failed:
* [getUserVisibleHint()](https://developer.android.com/reference/androidx/fragment/app/Fragment.html#getUserVisibleHint()): it's deprecated and returns true for all fragments
* [mMaxState](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:fragment/fragment/src/main/java/androidx/fragment/app/Fragment.java;l=297): only accessible through reflection and returns the current max state achieved (in onFragmentStarted it will be STARTED, while in onFragmentResumed it will be RESUMED
* [isVisible](https://developer.android.com/reference/androidx/fragment/app/Fragment.html#isVisible()): returns true for all fragments

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3269


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
