### PR TITLE
Add timestamp when a profile starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Fix faulty `span.frame_delay` calculation for early app start spans ([#3427](https://github.com/getsentry/sentry-java/pull/3427))
+- Add timestamp when a profile starts ([#3442](https://github.com/getsentry/sentry-java/pull/3442))
 
 ## 7.9.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -81,7 +81,8 @@ public class io/sentry/android/core/AndroidProfiler$ProfileEndData {
 public class io/sentry/android/core/AndroidProfiler$ProfileStartData {
 	public final field startCpuMillis J
 	public final field startNanos J
-	public fun <init> (JJ)V
+	public final field startTimestamp Ljava/util/Date;
+	public fun <init> (JJLjava/util/Date;)V
 }
 
 public final class io/sentry/android/core/AnrIntegration : io/sentry/Integration, java/io/Closeable {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -6,6 +6,7 @@ import android.os.Debug;
 import android.os.Process;
 import android.os.SystemClock;
 import io.sentry.CpuCollectionData;
+import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.ISentryExecutorService;
 import io.sentry.MemoryCollectionData;
@@ -17,6 +18,7 @@ import io.sentry.profilemeasurements.ProfileMeasurementValue;
 import io.sentry.util.Objects;
 import java.io.File;
 import java.util.ArrayDeque;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +35,13 @@ public class AndroidProfiler {
   public static class ProfileStartData {
     public final long startNanos;
     public final long startCpuMillis;
+    public final @NotNull Date startTimestamp;
 
-    public ProfileStartData(final long startNanos, final long startCpuMillis) {
+    public ProfileStartData(
+        final long startNanos, final long startCpuMillis, final @NotNull Date startTimestamp) {
       this.startNanos = startNanos;
       this.startCpuMillis = startCpuMillis;
+      this.startTimestamp = startTimestamp;
     }
   }
 
@@ -192,6 +197,7 @@ public class AndroidProfiler {
     }
 
     profileStartNanos = SystemClock.elapsedRealtimeNanos();
+    final @NotNull Date profileStartTimestamp = DateUtils.getCurrentDateTime();
     long profileStartCpuMillis = Process.getElapsedCpuTime();
 
     // We don't make any check on the file existence or writeable state, because we don't want to
@@ -203,7 +209,7 @@ public class AndroidProfiler {
       // tests)
       Debug.startMethodTracingSampling(traceFile.getPath(), BUFFER_SIZE_BYTES, intervalUs);
       isRunning = true;
-      return new ProfileStartData(profileStartNanos, profileStartCpuMillis);
+      return new ProfileStartData(profileStartNanos, profileStartCpuMillis, profileStartTimestamp);
     } catch (Throwable e) {
       endAndCollect(false, null);
       logger.log(SentryLevel.ERROR, "Unable to start a profile: ", e);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.os.Build;
 import android.os.Process;
 import android.os.SystemClock;
+import io.sentry.DateUtils;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ILogger;
@@ -24,6 +25,7 @@ import io.sentry.android.core.internal.util.CpuInfoUtils;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,6 +46,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   private @Nullable AndroidProfiler profiler = null;
   private long profileStartNanos;
   private long profileStartCpuMillis;
+  private @NotNull Date profileStartTimestamp;
 
   /**
    * @deprecated please use a constructor that doesn't takes a {@link IHub} instead, as it would be
@@ -95,6 +98,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     this.profilingTracesHz = profilingTracesHz;
     this.executorService =
         Objects.requireNonNull(executorService, "The ISentryExecutorService is required.");
+    this.profileStartTimestamp = DateUtils.getCurrentDateTime();
   }
 
   private void init() {
@@ -164,6 +168,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     }
     profileStartNanos = startData.startNanos;
     profileStartCpuMillis = startData.startCpuMillis;
+    profileStartTimestamp = startData.startTimestamp;
     return true;
   }
 
@@ -274,6 +279,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
     // done in the background when the trace file is read
     return new ProfilingTraceData(
         endData.traceFile,
+        profileStartTimestamp,
         transactionList,
         transactionName,
         transactionId,

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
@@ -178,6 +178,7 @@ class AndroidProfilerTest {
         val endData = profiler.endAndCollect(false, null)
         assertNotNull(startData?.startNanos)
         assertNotNull(startData?.startCpuMillis)
+        assertNotNull(startData?.startTimestamp)
         assertNotNull(endData?.endNanos)
         assertNotNull(endData?.endCpuMillis)
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1420,7 +1420,7 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 	public static final field TRUNCATION_REASON_NORMAL Ljava/lang/String;
 	public static final field TRUNCATION_REASON_TIMEOUT Ljava/lang/String;
 	public fun <init> (Ljava/io/File;Lio/sentry/ITransaction;)V
-	public fun <init> (Ljava/io/File;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Ljava/io/File;Ljava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun getAndroidApiLevel ()I
 	public fun getBuildId ()Ljava/lang/String;
 	public fun getCpuArchitecture ()Ljava/lang/String;
@@ -1439,6 +1439,7 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 	public fun getProfileId ()Ljava/lang/String;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getSampledProfile ()Ljava/lang/String;
+	public fun getTimestamp ()Ljava/util/Date;
 	public fun getTraceFile ()Ljava/io/File;
 	public fun getTraceId ()Ljava/lang/String;
 	public fun getTransactionId ()Ljava/lang/String;
@@ -1465,6 +1466,7 @@ public final class io/sentry/ProfilingTraceData : io/sentry/JsonSerializable, io
 	public fun setProfileId (Ljava/lang/String;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setSampledProfile (Ljava/lang/String;)V
+	public fun setTimestamp (Ljava/util/Date;)V
 	public fun setTraceId (Ljava/lang/String;)V
 	public fun setTransactionId (Ljava/lang/String;)V
 	public fun setTransactionName (Ljava/lang/String;)V
@@ -1499,6 +1501,7 @@ public final class io/sentry/ProfilingTraceData$JsonKeys {
 	public static final field PROFILE_ID Ljava/lang/String;
 	public static final field RELEASE Ljava/lang/String;
 	public static final field SAMPLED_PROFILE Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
 	public static final field TRACE_ID Ljava/lang/String;
 	public static final field TRANSACTION_ID Ljava/lang/String;
 	public static final field TRANSACTION_LIST Ljava/lang/String;

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -492,6 +492,7 @@ class JsonSerializerTest {
     @Test
     fun `serializes profilingTraceData`() {
         val profilingTraceData = ProfilingTraceData(fixture.traceFile, NoOpTransaction.getInstance())
+        val now = Date()
         profilingTraceData.androidApiLevel = 21
         profilingTraceData.deviceLocale = "deviceLocale"
         profilingTraceData.deviceManufacturer = "deviceManufacturer"
@@ -503,6 +504,7 @@ class JsonSerializerTest {
         profilingTraceData.deviceCpuFrequencies = listOf(1, 2, 3, 4)
         profilingTraceData.devicePhysicalMemoryBytes = "2000000"
         profilingTraceData.buildId = "buildId"
+        profilingTraceData.timestamp = now
         profilingTraceData.transactions = listOf(
             ProfilingTransactionData(NoOpTransaction.getInstance(), 1, 2),
             ProfilingTransactionData(NoOpTransaction.getInstance(), 2, 3)
@@ -559,6 +561,7 @@ class JsonSerializerTest {
         assertEquals("2000000", element["device_physical_memory_bytes"] as String)
         assertEquals("android", element["platform"] as String)
         assertEquals("buildId", element["build_id"] as String)
+        assertEquals(DateUtils.getTimestamp(now), element["timestamp"] as String)
         assertEquals(
             listOf(
                 mapOf(
@@ -655,6 +658,7 @@ class JsonSerializerTest {
                             "device_physical_memory_bytes":"2000000",
                             "platform":"android",
                             "build_id":"buildId",
+                            "timestamp":"2024-05-24T12:52:03.561Z",
                             "transactions":[
                                 {
                                     "id":"id",
@@ -729,6 +733,7 @@ class JsonSerializerTest {
         assertEquals("2000000", profilingTraceData.devicePhysicalMemoryBytes)
         assertEquals("android", profilingTraceData.platform)
         assertEquals("buildId", profilingTraceData.buildId)
+        assertEquals(DateUtils.getDateTime("2024-05-24T12:52:03.561Z"), profilingTraceData.timestamp)
         val expectedTransactions = listOf(
             ProfilingTransactionData().apply {
                 id = "id"


### PR DESCRIPTION
## :scroll: Description
added start timestamp in ProfileStartData when a profile starts
added the timestamp in ProfilingTraceData and send it in the json payload

Example of [wrong profile](https://demo.sentry.io/profiling/profile/android/625533174daa4b7b964d8ac08b7ab75b/flamegraph/?colorCoding=by+system+vs+application+frame&fov=0%2C5%2C10353642496%2C13&query=&sorting=call+order&tid=8734&view=top+down) (before)
Example of [correct profile](https://sentry-sdks.sentry.io/profiling/profile/sentry-android/dc544fbc9c4b496a88ec4b62cfe0a3e0/flamegraph/?colorCoding=by+system+vs+application+frame&fov=0%2C0%2C2867905792%2C19&query=&sorting=call+order&tid=8998&view=top+down) (after)

## :bulb: Motivation and Context
Profiles are a not aligned to spans, especially when we change the transaction start timestamp. In that case, it is assumed that the profile and the transaction starts at the same time, which is wrong. I added a `timestamp` field set when the profile starts.


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
