### PR TITLE
[SR] Allow RRWeb breadcrumb customization from hybrid SDKs

### DIFF
--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -75,6 +75,6 @@
 
 ##---------------Begin: proguard configuration for sentry-android-replay  ----------
 -dontwarn io.sentry.android.replay.ReplayIntegration
--dontwarn io.sentry.android.replay.ReplayIntegrationKt
+-dontwarn io.sentry.android.replay.DefaultReplayBreadcrumbConverter
 -keepnames class io.sentry.android.replay.ReplayIntegration
 ##---------------End: proguard configuration for sentry-android-replay  ----------

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -22,6 +22,7 @@ import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
+import io.sentry.android.replay.DefaultReplayBreadcrumbConverter;
 import io.sentry.android.replay.ReplayIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
 import io.sentry.cache.PersistingOptionsObserver;
@@ -308,6 +309,7 @@ final class AndroidOptionsInitializer {
     if (isReplayAvailable) {
       final ReplayIntegration replay =
           new ReplayIntegration(context, CurrentDateProvider.getInstance());
+      replay.setBreadcrumbConverter(new DefaultReplayBreadcrumbConverter());
       options.addIntegration(replay);
       options.setReplayController(replay);
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -36,8 +36,6 @@ public final class SentryAndroid {
   static final String SENTRY_REPLAY_INTEGRATION_CLASS_NAME =
       "io.sentry.android.replay.ReplayIntegration";
 
-  private static boolean isReplayAvailable = false;
-
   private static final String TIMBER_CLASS_NAME = "timber.log.Timber";
   private static final String FRAGMENT_CLASS_NAME =
       "androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks";
@@ -104,7 +102,7 @@ public final class SentryAndroid {
             final boolean isTimberAvailable =
                 (isTimberUpstreamAvailable
                     && classLoader.isClassAvailable(SENTRY_TIMBER_INTEGRATION_CLASS_NAME, options));
-            isReplayAvailable =
+            final boolean isReplayAvailable =
                 classLoader.isClassAvailable(SENTRY_REPLAY_INTEGRATION_CLASS_NAME, options);
 
             final BuildInfoProvider buildInfoProvider = new BuildInfoProvider(logger);

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -6,6 +6,11 @@ public final class io/sentry/android/replay/BuildConfig {
 	public fun <init> ()V
 }
 
+public class io/sentry/android/replay/DefaultReplayBreadcrumbConverter : io/sentry/ReplayBreadcrumbConverter {
+	public fun <init> ()V
+	public fun convert (Lio/sentry/Breadcrumb;)Lio/sentry/rrweb/RRWebEvent;
+}
+
 public final class io/sentry/android/replay/GeneratedVideo {
 	public fun <init> (Ljava/io/File;IJ)V
 	public final fun component1 ()Ljava/io/File;
@@ -42,6 +47,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
+	public fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public final fun getReplayCacheDir ()Ljava/io/File;
 	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
@@ -55,6 +61,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun resume ()V
 	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
+	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V
 	public fun stop ()V
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -7,10 +7,11 @@ import io.sentry.SpanDataConvention
 import io.sentry.rrweb.RRWebBreadcrumbEvent
 import io.sentry.rrweb.RRWebEvent
 import io.sentry.rrweb.RRWebSpanEvent
+import kotlin.LazyThreadSafetyMode.NONE
 
 public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
     internal companion object {
-        private val snakecasePattern = "_[a-z]".toRegex()
+        private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
         private val supportedNetworkData = setOf(
             "status_code",
             "method",

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -1,0 +1,148 @@
+package io.sentry.android.replay
+
+import io.sentry.Breadcrumb
+import io.sentry.ReplayBreadcrumbConverter
+import io.sentry.SentryLevel
+import io.sentry.SpanDataConvention
+import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebEvent
+import io.sentry.rrweb.RRWebSpanEvent
+
+public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
+    internal companion object {
+        private val snakecasePattern = "_[a-z]".toRegex()
+        private val supportedNetworkData = setOf(
+            "status_code",
+            "method",
+            "response_content_length",
+            "request_content_length",
+            "http.response_content_length",
+            "http.request_content_length"
+        )
+    }
+
+    override fun convert(breadcrumb: Breadcrumb): RRWebEvent? {
+        var rrwebBreadcrumb: RRWebBreadcrumbEvent? = null
+
+        var breadcrumbMessage: String? = null
+        var breadcrumbCategory: String? = null
+        var breadcrumbLevel: SentryLevel? = null
+        val breadcrumbData = mutableMapOf<String, Any?>()
+        when {
+            breadcrumb.category == "http" -> {
+                return if (breadcrumb.isValidForRRWebSpan()) breadcrumb.toRRWebSpanEvent() else null
+            }
+
+            breadcrumb.type == "navigation" &&
+                breadcrumb.category == "app.lifecycle" -> {
+                breadcrumbCategory = "app.${breadcrumb.data["state"]}"
+            }
+
+            breadcrumb.type == "navigation" &&
+                breadcrumb.category == "device.orientation" -> {
+                breadcrumbCategory = breadcrumb.category!!
+                val position = breadcrumb.data["position"]
+                if (position == "landscape" || position == "portrait") {
+                    breadcrumbData["position"] = position
+                } else {
+                    return null
+                }
+            }
+
+            breadcrumb.type == "navigation" -> {
+                breadcrumbCategory = "navigation"
+                breadcrumbData["to"] = when {
+                    breadcrumb.data["state"] == "resumed" -> (breadcrumb.data["screen"] as? String)?.substringAfterLast('.')
+                    "to" in breadcrumb.data -> breadcrumb.data["to"] as? String
+                    else -> null
+                } ?: return null
+            }
+
+            breadcrumb.category == "ui.click" -> {
+                breadcrumbCategory = "ui.tap"
+                breadcrumbMessage = (
+                    breadcrumb.data["view.id"]
+                        ?: breadcrumb.data["view.tag"]
+                        ?: breadcrumb.data["view.class"]
+                    ) as? String ?: return null
+                breadcrumbData.putAll(breadcrumb.data)
+            }
+
+            breadcrumb.type == "system" && breadcrumb.category == "network.event" -> {
+                breadcrumbCategory = "device.connectivity"
+                breadcrumbData["state"] = when {
+                    breadcrumb.data["action"] == "NETWORK_LOST" -> "offline"
+                    "network_type" in breadcrumb.data -> if (!(breadcrumb.data["network_type"] as? String).isNullOrEmpty()) {
+                        breadcrumb.data["network_type"]
+                    } else {
+                        return null
+                    }
+
+                    else -> return null
+                }
+            }
+
+            breadcrumb.data["action"] == "BATTERY_CHANGED" -> {
+                breadcrumbCategory = "device.battery"
+                breadcrumbData.putAll(
+                    breadcrumb.data.filterKeys { it == "level" || it == "charging" }
+                )
+            }
+
+            else -> {
+                breadcrumbCategory = breadcrumb.category
+                breadcrumbMessage = breadcrumb.message
+                breadcrumbLevel = breadcrumb.level
+                breadcrumbData.putAll(breadcrumb.data)
+            }
+        }
+        if (!breadcrumbCategory.isNullOrEmpty()) {
+            rrwebBreadcrumb = RRWebBreadcrumbEvent().apply {
+                timestamp = breadcrumb.timestamp.time
+                breadcrumbTimestamp = breadcrumb.timestamp.time / 1000.0
+                breadcrumbType = "default"
+                category = breadcrumbCategory
+                message = breadcrumbMessage
+                level = breadcrumbLevel
+                data = breadcrumbData
+            }
+        }
+        return rrwebBreadcrumb
+    }
+
+    private fun Breadcrumb.isValidForRRWebSpan(): Boolean {
+        return !(data["url"] as? String).isNullOrEmpty() &&
+            SpanDataConvention.HTTP_START_TIMESTAMP in data &&
+            SpanDataConvention.HTTP_END_TIMESTAMP in data
+    }
+
+    private fun String.snakeToCamelCase(): String {
+        return replace(snakecasePattern) { it.value.last().uppercase() }
+    }
+
+    private fun Breadcrumb.toRRWebSpanEvent(): RRWebSpanEvent {
+        val breadcrumb = this
+        return RRWebSpanEvent().apply {
+            timestamp = breadcrumb.timestamp.time
+            op = "resource.http"
+            description = breadcrumb.data["url"] as String
+            startTimestamp =
+                (breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP] as Long) / 1000.0
+            endTimestamp =
+                (breadcrumb.data[SpanDataConvention.HTTP_END_TIMESTAMP] as Long) / 1000.0
+
+            val breadcrumbData = mutableMapOf<String, Any?>()
+            for ((key, value) in breadcrumb.data) {
+                if (key in supportedNetworkData) {
+                    breadcrumbData[
+                        key
+                            .replace("content_length", "body_size")
+                            .substringAfter(".")
+                            .snakeToCamelCase()
+                    ] = value
+                }
+            }
+            data = breadcrumbData
+        }
+    }
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -23,8 +23,6 @@ public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
     }
 
     override fun convert(breadcrumb: Breadcrumb): RRWebEvent? {
-        var rrwebBreadcrumb: RRWebBreadcrumbEvent? = null
-
         var breadcrumbMessage: String? = null
         var breadcrumbCategory: String? = null
         var breadcrumbLevel: SentryLevel? = null
@@ -97,8 +95,8 @@ public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
                 breadcrumbData.putAll(breadcrumb.data)
             }
         }
-        if (!breadcrumbCategory.isNullOrEmpty()) {
-            rrwebBreadcrumb = RRWebBreadcrumbEvent().apply {
+        return if (!breadcrumbCategory.isNullOrEmpty()) {
+            RRWebBreadcrumbEvent().apply {
                 timestamp = breadcrumb.timestamp.time
                 breadcrumbTimestamp = breadcrumb.timestamp.time / 1000.0
                 breadcrumbType = "default"
@@ -107,8 +105,9 @@ public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
                 level = breadcrumbLevel
                 data = breadcrumbData
             }
+        } else {
+            null
         }
-        return rrwebBreadcrumb
     }
 
     private fun Breadcrumb.isValidForRRWebSpan(): Boolean {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -9,6 +9,8 @@ import android.view.MotionEvent
 import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.Integration
+import io.sentry.NoOpReplayBreadcrumbConverter
+import io.sentry.ReplayBreadcrumbConverter
 import io.sentry.ReplayController
 import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
@@ -54,6 +56,7 @@ public class ReplayIntegration(
     private val isRecording = AtomicBoolean(false)
     private var captureStrategy: CaptureStrategy? = null
     public val replayCacheDir: File? get() = captureStrategy?.replayCacheDir
+    private var replayBreadcrumbConverter: ReplayBreadcrumbConverter = NoOpReplayBreadcrumbConverter.getInstance()
 
     private lateinit var recorderConfig: ScreenshotRecorderConfig
 
@@ -157,6 +160,12 @@ public class ReplayIntegration(
     }
 
     override fun getReplayId(): SentryId = captureStrategy?.currentReplayId?.get() ?: SentryId.EMPTY_ID
+
+    override fun setBreadcrumbConverter(converter: ReplayBreadcrumbConverter) {
+        replayBreadcrumbConverter = converter
+    }
+
+    override fun getBreadcrumbConverter(): ReplayBreadcrumbConverter = replayBreadcrumbConverter
 
     override fun pause() {
         if (!isEnabled.get() || !isRecording.get()) {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverterTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverterTest.kt
@@ -1,0 +1,217 @@
+package io.sentry.android.replay
+
+import io.sentry.Breadcrumb
+import io.sentry.SentryLevel
+import io.sentry.SpanDataConvention
+import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebSpanEvent
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import java.util.Date
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class DefaultReplayBreadcrumbConverterTest {
+    class Fixture {
+        fun getSut(): DefaultReplayBreadcrumbConverter {
+            return DefaultReplayBreadcrumbConverter()
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `returns null when no category`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            message = "message"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        assertNull(rrwebEvent)
+    }
+
+    @Test
+    fun `convert RRWebSpanEvent`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "http"
+            data["url"] = "http://example.com"
+            data["status_code"] = 404
+            data["method"] = "GET"
+            data[SpanDataConvention.HTTP_START_TIMESTAMP] = 1234L
+            data[SpanDataConvention.HTTP_END_TIMESTAMP] = 2234L
+            data["http.response_content_length"] = 300
+            data["http.request_content_length"] = 400
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebSpanEvent)
+        assertEquals("resource.http", rrwebEvent.op)
+        assertEquals("http://example.com", rrwebEvent.description)
+        assertEquals(123L, rrwebEvent.timestamp)
+        assertEquals(1.234, rrwebEvent.startTimestamp)
+        assertEquals(2.234, rrwebEvent.endTimestamp)
+        assertEquals(404, rrwebEvent.data!!["statusCode"])
+        assertEquals("GET", rrwebEvent.data!!["method"])
+        assertEquals(300, rrwebEvent.data!!["responseBodySize"])
+        assertEquals(400, rrwebEvent.data!!["requestBodySize"])
+    }
+
+    @Test
+    fun `returns null if not eligible for RRWebSpanEvent`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "http"
+            data["status_code"] = 404
+            data["method"] = "GET"
+            data[SpanDataConvention.HTTP_START_TIMESTAMP] = 1234L
+            data[SpanDataConvention.HTTP_END_TIMESTAMP] = 2234L
+            data["http.response_content_length"] = 300
+            data["http.request_content_length"] = 400
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        assertNull(rrwebEvent)
+    }
+
+    @Test
+    fun `converts app lifecycle breadcrumbs`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "app.lifecycle"
+            type = "navigation"
+            data["state"] = "background"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebBreadcrumbEvent)
+        assertEquals("app.background", rrwebEvent.category)
+        assertEquals(123L, rrwebEvent.timestamp)
+        assertEquals(0.123, rrwebEvent.breadcrumbTimestamp)
+        assertEquals("default", rrwebEvent.breadcrumbType)
+    }
+
+    @Test
+    fun `converts device orientation breadcrumbs`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "device.orientation"
+            type = "navigation"
+            data["position"] = "landscape"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebBreadcrumbEvent)
+        assertEquals("device.orientation", rrwebEvent.category)
+        assertEquals("landscape", rrwebEvent.data!!["position"])
+        assertEquals(123L, rrwebEvent.timestamp)
+        assertEquals(0.123, rrwebEvent.breadcrumbTimestamp)
+        assertEquals("default", rrwebEvent.breadcrumbType)
+    }
+
+    @Test
+    fun `returns null if no position for orientation breadcrumbs`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "device.orientation"
+            type = "navigation"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        assertNull(rrwebEvent)
+    }
+
+    @Test
+    fun `converts navigation breadcrumbs`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "navigation"
+            type = "navigation"
+            data["state"] = "resumed"
+            data["screen"] = "io.sentry.MainActivity"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebBreadcrumbEvent)
+        assertEquals("navigation", rrwebEvent.category)
+        assertEquals("MainActivity", rrwebEvent.data!!["to"])
+        assertEquals(123L, rrwebEvent.timestamp)
+        assertEquals(0.123, rrwebEvent.breadcrumbTimestamp)
+        assertEquals("default", rrwebEvent.breadcrumbType)
+    }
+
+    @Test
+    fun `converts navigation breadcrumbs with destination`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "navigation"
+            type = "navigation"
+            data["to"] = "/github"
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebBreadcrumbEvent)
+        assertEquals("navigation", rrwebEvent.category)
+        assertEquals("/github", rrwebEvent.data!!["to"])
+        assertEquals(123L, rrwebEvent.timestamp)
+        assertEquals(0.123, rrwebEvent.breadcrumbTimestamp)
+        assertEquals("default", rrwebEvent.breadcrumbType)
+    }
+
+//    @Test
+//    fun `test convert with navigation and app lifecycle`() {
+//        val breadcrumb = Breadcrumb().apply {
+//            message = "message"
+//            category = "navigation"
+//            type = "navigation"
+//            level = SentryLevel.ERROR
+//            data["state"] = "resumed"
+//            data["screen"] = "screen"
+//        }
+//
+//        val result = DefaultReplayBreadcrumbConverter().convert(breadcrumb)
+//
+//        assertTrue(result is RRWebBreadcrumbEvent)
+//        assertEquals("navigation", result.category)
+//        assertEquals("navigation", result.type)
+//        assertEquals(SentryLevel.ERROR, result.level)
+//        assertEquals("resumed", result.data["state"])
+//        assertEquals("screen", result.data["screen"])
+//    }
+//
+//    @Test
+//    fun `test convert with navigation and device orientation`() {
+//        val breadcrumb = Breadcrumb().apply {
+//            message = "message"
+//            category = "navigation"
+//            type = "navigation"
+//            level = SentryLevel.ERROR
+//            data["position"] = "landscape"
+//        }
+//
+//        val result = DefaultReplayBreadcrumbConverter().convert(breadcrumb)
+//
+//        assertTrue(result is RRWebBreadcrumbEvent)
+//        assertEquals("navigation", result.category)
+//        assertEquals("navigation", result.type)
+//        assertEquals(SentryLevel.ERROR, result.level)
+//        assertEquals("landscape", result.data["position"])
+//    }
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1251,7 +1251,13 @@ public final class io/sentry/NoOpLogger : io/sentry/ILogger {
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/Throwable;Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public final class io/sentry/NoOpReplayBreadcrumbConverter : io/sentry/ReplayBreadcrumbConverter {
+	public fun convert (Lio/sentry/Breadcrumb;)Lio/sentry/rrweb/RRWebEvent;
+	public static fun getInstance ()Lio/sentry/NoOpReplayBreadcrumbConverter;
+}
+
 public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
+	public fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public static fun getInstance ()Lio/sentry/NoOpReplayController;
 	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
@@ -1259,6 +1265,7 @@ public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public fun resume ()V
 	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
+	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V
 	public fun stop ()V
 }
@@ -1656,13 +1663,19 @@ public final class io/sentry/PropagationContext {
 	public fun traceContext ()Lio/sentry/TraceContext;
 }
 
+public abstract interface class io/sentry/ReplayBreadcrumbConverter {
+	public abstract fun convert (Lio/sentry/Breadcrumb;)Lio/sentry/rrweb/RRWebEvent;
+}
+
 public abstract interface class io/sentry/ReplayController {
+	public abstract fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public abstract fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
 	public abstract fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
 	public abstract fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
+	public abstract fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public abstract fun start ()V
 	public abstract fun stop ()V
 }

--- a/sentry/src/main/java/io/sentry/NoOpReplayBreadcrumbConverter.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayBreadcrumbConverter.java
@@ -1,0 +1,21 @@
+package io.sentry;
+
+import io.sentry.rrweb.RRWebEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpReplayBreadcrumbConverter implements ReplayBreadcrumbConverter {
+
+  private static final NoOpReplayBreadcrumbConverter instance = new NoOpReplayBreadcrumbConverter();
+
+  public static NoOpReplayBreadcrumbConverter getInstance() {
+    return instance;
+  }
+
+  private NoOpReplayBreadcrumbConverter() {}
+
+  @Override
+  public @Nullable RRWebEvent convert(final @NotNull Breadcrumb breadcrumb) {
+    return null;
+  }
+}

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -42,4 +42,12 @@ public final class NoOpReplayController implements ReplayController {
   public @NotNull SentryId getReplayId() {
     return SentryId.EMPTY_ID;
   }
+
+  @Override
+  public void setBreadcrumbConverter(@NotNull ReplayBreadcrumbConverter converter) {}
+
+  @Override
+  public @NotNull ReplayBreadcrumbConverter getBreadcrumbConverter() {
+    return NoOpReplayBreadcrumbConverter.getInstance();
+  }
 }

--- a/sentry/src/main/java/io/sentry/ReplayBreadcrumbConverter.java
+++ b/sentry/src/main/java/io/sentry/ReplayBreadcrumbConverter.java
@@ -1,0 +1,12 @@
+package io.sentry;
+
+import io.sentry.rrweb.RRWebEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@ApiStatus.Internal
+public interface ReplayBreadcrumbConverter {
+  @Nullable
+  RRWebEvent convert(@NotNull Breadcrumb breadcrumb);
+}

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -23,4 +23,9 @@ public interface ReplayController {
 
   @NotNull
   SentryId getReplayId();
+
+  void setBreadcrumbConverter(@NotNull ReplayBreadcrumbConverter converter);
+
+  @NotNull
+  ReplayBreadcrumbConverter getBreadcrumbConverter();
 }


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Extract breadcrumb conversion to a separate class, so the hybrid SDKs can override the logic
* Also make the default converter public and open, so others can delegate to it to do the conversion for some categories
