### PR TITLE
Kw/app start span for hybrid SDKs

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -204,6 +204,7 @@ public abstract interface class io/sentry/android/core/IDebugImagesLoader {
 public final class io/sentry/android/core/InternalSentrySdk {
 	public fun <init> ()V
 	public static fun captureEnvelope ([B)Lio/sentry/protocol/SentryId;
+	public static fun getAppStartMeasurement ()Ljava/util/Map;
 	public static fun getCurrentScope ()Lio/sentry/IScope;
 	public static fun serializeScope (Landroid/content/Context;Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/IScope;)Ljava/util/Map;
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -201,38 +201,38 @@ public final class InternalSentrySdk {
 
     final @NotNull Map<String, Object> processInitSpan = new HashMap<>();
     processInitSpan.put("description", "Process Initialization");
-    processInitSpan.put("startTimestampMs", metrics.getAppStartTimeSpan().getStartTimestampMs());
-    processInitSpan.put("endTimestampMs", metrics.getClassLoadedUptimeMs());
+    processInitSpan.put("start_timestamp_ms", metrics.getAppStartTimeSpan().getstart_timestamp_ms());
+    processInitSpan.put("end_timestamp_ms", metrics.getClassLoadedUptimeMs());
     spans.add(processInitSpan);
 
     final @NotNull Map<String, Object> applicationOnCreateSpan = new HashMap<>();
     applicationOnCreateSpan.put("description", "Process Initialization");
     applicationOnCreateSpan.put(
-        "startTimestampMs", metrics.getAppStartTimeSpan().getStartTimestampMs());
+        "start_timestamp_ms", metrics.getAppStartTimeSpan().getstart_timestamp_ms());
     applicationOnCreateSpan.put(
-        "endTimestampMs", metrics.getAppStartTimeSpan().getProjectedStopTimestampMs());
+        "end_timestamp_ms", metrics.getAppStartTimeSpan().getProjectedStopTimestampMs());
     spans.add(applicationOnCreateSpan);
 
     for (final TimeSpan span : metrics.getContentProviderOnCreateTimeSpans()) {
       final @NotNull Map<String, Object> serializedSpan = new HashMap<>();
       serializedSpan.put("description", span.getDescription());
-      serializedSpan.put("startTimestampMs", span.getStartTimestampMs());
-      serializedSpan.put("endTimestampMs", span.getProjectedStopTimestampMs());
+      serializedSpan.put("start_timestamp_ms", span.getstart_timestamp_ms());
+      serializedSpan.put("end_timestamp_ms", span.getProjectedStopTimestampMs());
       spans.add(serializedSpan);
     }
 
     for (final ActivityLifecycleTimeSpan span : metrics.getActivityLifecycleTimeSpans()) {
       final @NotNull Map<String, Object> serializedOnCreateSpan = new HashMap<>();
       serializedOnCreateSpan.put("description", span.getOnCreate().getDescription());
-      serializedOnCreateSpan.put("startTimestampMs", span.getOnCreate().getStartTimestampMs());
+      serializedOnCreateSpan.put("start_timestamp_ms", span.getOnCreate().getstart_timestamp_ms());
       serializedOnCreateSpan.put(
-          "endTimestampMs", span.getOnCreate().getProjectedStopTimestampMs());
+          "end_timestamp_ms", span.getOnCreate().getProjectedStopTimestampMs());
       spans.add(serializedOnCreateSpan);
 
       final @NotNull Map<String, Object> serializedOnStartSpan = new HashMap<>();
       serializedOnStartSpan.put("description", span.getOnStart().getDescription());
-      serializedOnStartSpan.put("startTimestampMs", span.getOnStart().getStartTimestampMs());
-      serializedOnStartSpan.put("endTimestampMs", span.getOnStart().getProjectedStopTimestampMs());
+      serializedOnStartSpan.put("start_timestamp_ms", span.getOnStart().getstart_timestamp_ms());
+      serializedOnStartSpan.put("end_timestamp_ms", span.getOnStart().getProjectedStopTimestampMs());
       spans.add(serializedOnStartSpan);
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -201,14 +201,14 @@ public final class InternalSentrySdk {
 
     final @NotNull Map<String, Object> processInitSpan = new HashMap<>();
     processInitSpan.put("description", "Process Initialization");
-    processInitSpan.put("start_timestamp_ms", metrics.getAppStartTimeSpan().getstart_timestamp_ms());
+    processInitSpan.put("start_timestamp_ms", metrics.getAppStartTimeSpan().getStartTimestampMs());
     processInitSpan.put("end_timestamp_ms", metrics.getClassLoadedUptimeMs());
     spans.add(processInitSpan);
 
     final @NotNull Map<String, Object> applicationOnCreateSpan = new HashMap<>();
     applicationOnCreateSpan.put("description", "Process Initialization");
     applicationOnCreateSpan.put(
-        "start_timestamp_ms", metrics.getAppStartTimeSpan().getstart_timestamp_ms());
+        "start_timestamp_ms", metrics.getAppStartTimeSpan().getStartTimestampMs());
     applicationOnCreateSpan.put(
         "end_timestamp_ms", metrics.getAppStartTimeSpan().getProjectedStopTimestampMs());
     spans.add(applicationOnCreateSpan);
@@ -216,7 +216,7 @@ public final class InternalSentrySdk {
     for (final TimeSpan span : metrics.getContentProviderOnCreateTimeSpans()) {
       final @NotNull Map<String, Object> serializedSpan = new HashMap<>();
       serializedSpan.put("description", span.getDescription());
-      serializedSpan.put("start_timestamp_ms", span.getstart_timestamp_ms());
+      serializedSpan.put("start_timestamp_ms", span.getStartTimestampMs());
       serializedSpan.put("end_timestamp_ms", span.getProjectedStopTimestampMs());
       spans.add(serializedSpan);
     }
@@ -224,14 +224,14 @@ public final class InternalSentrySdk {
     for (final ActivityLifecycleTimeSpan span : metrics.getActivityLifecycleTimeSpans()) {
       final @NotNull Map<String, Object> serializedOnCreateSpan = new HashMap<>();
       serializedOnCreateSpan.put("description", span.getOnCreate().getDescription());
-      serializedOnCreateSpan.put("start_timestamp_ms", span.getOnCreate().getstart_timestamp_ms());
+      serializedOnCreateSpan.put("start_timestamp_ms", span.getOnCreate().getStartTimestampMs());
       serializedOnCreateSpan.put(
           "end_timestamp_ms", span.getOnCreate().getProjectedStopTimestampMs());
       spans.add(serializedOnCreateSpan);
 
       final @NotNull Map<String, Object> serializedOnStartSpan = new HashMap<>();
       serializedOnStartSpan.put("description", span.getOnStart().getDescription());
-      serializedOnStartSpan.put("start_timestamp_ms", span.getOnStart().getstart_timestamp_ms());
+      serializedOnStartSpan.put("start_timestamp_ms", span.getOnStart().getStartTimestampMs());
       serializedOnStartSpan.put("end_timestamp_ms", span.getOnStart().getProjectedStopTimestampMs());
       spans.add(serializedOnStartSpan);
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.ApiStatus;
@@ -219,7 +220,7 @@ public final class InternalSentrySdk {
 
     final @NotNull Map<String, Object> result = new HashMap<>();
     result.put("spans", spans);
-    result.put("type", metrics.getAppStartType().toString().toLowerCase());
+    result.put("type", metrics.getAppStartType().toString().toLowerCase(Locale.ROOT));
     if (metrics.getAppStartTimeSpan().hasStarted()) {
       result.put("app_start_timestamp_ms", metrics.getAppStartTimeSpan().getStartTimestampMs());
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -1,5 +1,7 @@
 package io.sentry.android.core
 
+import android.app.Application
+import android.content.ContentProvider
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -17,6 +19,8 @@ import io.sentry.SentryExceptionFactory
 import io.sentry.SentryItemType
 import io.sentry.SentryOptions
 import io.sentry.Session
+import io.sentry.android.core.performance.ActivityLifecycleTimeSpan
+import io.sentry.android.core.performance.AppStartMetrics
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.App
 import io.sentry.protocol.Contexts
@@ -100,6 +104,61 @@ class InternalSentrySdkTest {
             val data = outputStream.toByteArray()
 
             InternalSentrySdk.captureEnvelope(data)
+        }
+
+        fun mockFinishedAppStart() {
+            val metrics = AppStartMetrics.getInstance()
+
+            metrics.appStartType = AppStartMetrics.AppStartType.WARM
+
+            metrics.appStartTimeSpan.setStartedAt(20) // Can't be 0, as that's the default value if not set
+            metrics.appStartTimeSpan.setStartUnixTimeMs(20) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            metrics.appStartTimeSpan.setStoppedAt(200)
+            metrics.classLoadedUptimeMs = 100
+
+            AppStartMetrics.onApplicationCreate(mock<Application>())
+            metrics.applicationOnCreateTimeSpan.description = "Application created"
+            metrics.applicationOnCreateTimeSpan.setStartedAt(30) // Can't be 0, as that's the default value if not set
+            metrics.applicationOnCreateTimeSpan.setStartUnixTimeMs(30) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            metrics.applicationOnCreateTimeSpan.setStoppedAt(40)
+
+            val activityLifecycleSpan = ActivityLifecycleTimeSpan()
+            activityLifecycleSpan.onCreate.description = "Test Activity Lifecycle onCreate"
+            activityLifecycleSpan.onCreate.setStartedAt(50) // Can't be 0, as that's the default value if not set
+            activityLifecycleSpan.onCreate.setStartUnixTimeMs(50) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            activityLifecycleSpan.onCreate.setStoppedAt(60)
+
+            activityLifecycleSpan.onStart.description = "Test Activity Lifecycle onStart"
+            activityLifecycleSpan.onStart.setStartedAt(70) // Can't be 0, as that's the default value if not set
+            activityLifecycleSpan.onStart.setStartUnixTimeMs(70) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            activityLifecycleSpan.onStart.setStoppedAt(80)
+            metrics.addActivityLifecycleTimeSpans(activityLifecycleSpan)
+
+            AppStartMetrics.onContentProviderCreate(mock<ContentProvider>())
+            metrics.contentProviderOnCreateTimeSpans[0].description = "Test Content Provider created"
+            metrics.contentProviderOnCreateTimeSpans[0].setStartedAt(90)
+            metrics.contentProviderOnCreateTimeSpans[0].setStartUnixTimeMs(90)
+            metrics.contentProviderOnCreateTimeSpans[0].setStoppedAt(100)
+
+            metrics.appStartProfiler = mock()
+            metrics.appStartSamplingDecision = mock()
+        }
+
+        fun mockMinimumFinishedAppStart() {
+            val metrics = AppStartMetrics.getInstance()
+
+            metrics.appStartType = AppStartMetrics.AppStartType.WARM
+
+            metrics.appStartTimeSpan.setStartedAt(20) // Can't be 0, as that's the default value if not set
+            metrics.appStartTimeSpan.setStartUnixTimeMs(20) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            metrics.appStartTimeSpan.setStoppedAt(200)
+            metrics.classLoadedUptimeMs = 100
+
+            AppStartMetrics.onApplicationCreate(mock<Application>())
+            metrics.applicationOnCreateTimeSpan.description = "Application created"
+            metrics.applicationOnCreateTimeSpan.setStartedAt(30) // Can't be 0, as that's the default value if not set
+            metrics.applicationOnCreateTimeSpan.setStartUnixTimeMs(30) // The order matters, unix time must be set after started at in tests to avoid overwrite
+            metrics.applicationOnCreateTimeSpan.setStoppedAt(40)
         }
     }
 
@@ -301,5 +360,64 @@ class InternalSentrySdkTest {
             scopeRef.set(scope)
         }
         assertEquals(Session.State.Crashed, scopeRef.get().session!!.status)
+    }
+
+    @Test
+    fun `getAppStartMeasurement returns correct serialized data from the app start instance`() {
+        Fixture().mockFinishedAppStart()
+
+        val serializedAppStart = InternalSentrySdk.getAppStartMeasurement()
+
+        assertEquals("warm", serializedAppStart["type"])
+        assertEquals(20.0, serializedAppStart["app_start_timestamp_ms"])
+
+        val actualSpans = serializedAppStart["spans"] as List<*>
+
+        val actualProcessSpan = actualSpans[0] as Map<*, *>
+        assertEquals("Process Initialization", actualProcessSpan["description"])
+        assertEquals(20.toLong(), actualProcessSpan["start_timestamp_ms"])
+        assertEquals(100.toLong(), actualProcessSpan["end_timestamp_ms"])
+
+        val actualAppSpan = actualSpans[1] as Map<*, *>
+        assertEquals("Application created", actualAppSpan["description"])
+        assertEquals(30.toLong(), actualAppSpan["start_timestamp_ms"])
+        assertEquals(40.toLong(), actualAppSpan["end_timestamp_ms"])
+
+        val actualContentProviderSpan = actualSpans[2] as Map<*, *>
+        assertEquals("Test Content Provider created", actualContentProviderSpan["description"])
+        assertEquals(90.toLong(), actualContentProviderSpan["start_timestamp_ms"])
+        assertEquals(100.toLong(), actualContentProviderSpan["end_timestamp_ms"])
+
+        val actualActivityOnCreateSpan = actualSpans[3] as Map<*, *>
+        assertEquals("Test Activity Lifecycle onCreate", actualActivityOnCreateSpan["description"])
+        assertEquals(50.toLong(), actualActivityOnCreateSpan["start_timestamp_ms"])
+        assertEquals(60.toLong(), actualActivityOnCreateSpan["end_timestamp_ms"])
+
+        val actualActivityOnStartSpan = actualSpans[4] as Map<*, *>
+        assertEquals("Test Activity Lifecycle onStart", actualActivityOnStartSpan["description"])
+        assertEquals(70.toLong(), actualActivityOnStartSpan["start_timestamp_ms"])
+        assertEquals(80.toLong(), actualActivityOnStartSpan["end_timestamp_ms"])
+    }
+
+    @Test
+    fun `getAppStartMeasurement returns correct serialized data from the minimum app start instance`() {
+        Fixture().mockMinimumFinishedAppStart()
+
+        val serializedAppStart = InternalSentrySdk.getAppStartMeasurement()
+
+        assertEquals("warm", serializedAppStart["type"])
+        assertEquals(20.0, serializedAppStart["app_start_timestamp_ms"])
+
+        val actualSpans = serializedAppStart["spans"] as List<*>
+
+        val actualProcessSpan = actualSpans[0] as Map<*, *>
+        assertEquals("Process Initialization", actualProcessSpan["description"])
+        assertEquals(20.toLong(), actualProcessSpan["start_timestamp_ms"])
+        assertEquals(100.toLong(), actualProcessSpan["end_timestamp_ms"])
+
+        val actualAppSpan = actualSpans[1] as Map<*, *>
+        assertEquals("Application created", actualAppSpan["description"])
+        assertEquals(30.toLong(), actualAppSpan["start_timestamp_ms"])
+        assertEquals(40.toLong(), actualAppSpan["end_timestamp_ms"])
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds a new method to the HybridSDKs interface which returns serializable app start data including span structures.

This can be used in Flutter (replacing current custom impl), React Native and other hybrid SDKs like Unity, Capacitor and others.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- https://github.com/getsentry/sentry-react-native/issues/3445

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

#skip-changelog 