### PR TITLE
Do not crash when installing shutdown hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Fix faulty `span.frame_delay` calculation for early app start spans ([#3427](https://github.com/getsentry/sentry-java/pull/3427))
+- Fix crash when installing `ShutdownHookIntegration` and the VM is shutting down ([#3456](https://github.com/getsentry/sentry-java/pull/3456))
 
 ## 7.9.0
 

--- a/sentry/src/test/java/io/sentry/ShutdownHookIntegrationTest.kt
+++ b/sentry/src/test/java/io/sentry/ShutdownHookIntegrationTest.kt
@@ -93,6 +93,16 @@ class ShutdownHookIntegrationTest {
     }
 
     @Test
+    fun `shutdown in progress is handled gracefully for registration`() {
+        val integration = fixture.getSut()
+        whenever(fixture.runtime.addShutdownHook(any())).thenThrow(java.lang.IllegalStateException("VM already shutting down"))
+
+        integration.register(fixture.hub, fixture.options)
+
+        verify(fixture.runtime).addShutdownHook(any())
+    }
+
+    @Test
     fun `non shutdown in progress during removeShutdownHook is rethrown`() {
         val integration = fixture.getSut()
         whenever(fixture.runtime.removeShutdownHook(any())).thenThrow(java.lang.IllegalStateException())


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* There was a report from the SDK console (See below), so I've just wrapped the `addShutdownHook` method analogous to what we do when removing the hook

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Google Play SDK console yield this crash:

```
Exception java.lang.IllegalStateException: VM already shutting down
  at java.lang.Runtime.addShutdownHook (Runtime.java:280)
  at io.sentry.ShutdownHookIntegration.register (ShutdownHookIntegration.java:34)
  at io.sentry.Sentry.init (Sentry.java:237)
  at io.sentry.Sentry.init (Sentry.java:147)
  at io.sentry.android.core.SentryAndroid.init (SentryAndroid.java:89)
  at io.sentry.android.core.SentryAndroid.init (SentryAndroid.java:70)
  at <private>
  at java.lang.reflect.Method.invoke
  at <private>
  at android.os.Handler.handleCallback (Handler.java:1000)
  at android.os.Handler.dispatchMessage (Handler.java:104)
  at <private>
  at android.os.Looper.loopOnce (Looper.java:242)
  at android.os.Looper.loop (Looper.java:362)
  at <private>
  at java.lang.Thread.run (Thread.java:1012)
```

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
