### PR TITLE
Move onFinishCallback before span or transaction is finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Move onFinishCallback before span or transaction is finished ([#3459](https://github.com/getsentry/sentry-java/pull/3459))
 - Move fragment auto span finish to onFragmentStarted ([#3424](https://github.com/getsentry/sentry-java/pull/3424))
 - Remove profiling timeout logic and disable profiling on API 21 ([#3478](https://github.com/getsentry/sentry-java/pull/3478))
 - Properly reset metric flush flag on metric emission ([#3493](https://github.com/getsentry/sentry-java/pull/3493))
@@ -16,7 +17,6 @@
 
 ### Fixes
 
-- Move onFinishCallback before span or transaction is finished ([#3459](https://github.com/getsentry/sentry-java/pull/3459))
 - Fix faulty `span.frame_delay` calculation for early app start spans ([#3427](https://github.com/getsentry/sentry-java/pull/3427))
 - Fix crash when installing `ShutdownHookIntegration` and the VM is shutting down ([#3456](https://github.com/getsentry/sentry-java/pull/3456))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Move onFinishCallback before span or transaction is finished ([#3459](https://github.com/getsentry/sentry-java/pull/3459))
 - Fix faulty `span.frame_delay` calculation for early app start spans ([#3427](https://github.com/getsentry/sentry-java/pull/3427))
 - Fix crash when installing `ShutdownHookIntegration` and the VM is shutting down ([#3456](https://github.com/getsentry/sentry-java/pull/3456))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -131,26 +131,12 @@ public class SpanFrameMetricsCollector
   private void captureFrameMetrics(@NotNull final ISpan span) {
     // TODO lock still required?
     synchronized (lock) {
-      String x = "";
-      for (ISpan runningSpan : runningSpans) {
-        x += runningSpan.getOperation() + " - " + runningSpan.getDescription() + ", ";
-      }
-      System.out.println(
-          "SpanFrameMetricsCollector.onSpanFinished - "
-              + span.getOperation()
-              + " - "
-              + span.getDescription()
-              + " ---> \ncurrent spans: "
-              + x);
-
       boolean removed = runningSpans.remove(span);
-      System.out.println(removed);
       if (!removed) {
         return;
       }
 
       final @Nullable SentryDate spanFinishDate = span.getFinishDate();
-      System.out.println("spanFinishDate == null: " + (spanFinishDate == null));
       if (spanFinishDate == null) {
         return;
       }
@@ -158,7 +144,6 @@ public class SpanFrameMetricsCollector
       final long spanStartNanos = toNanoTime(span.getStartDate());
       final long spanEndNanos = toNanoTime(spanFinishDate);
       final long spanDurationNanos = spanEndNanos - spanStartNanos;
-      System.out.println("spanDurationNanos: " + spanDurationNanos);
       if (spanDurationNanos <= 0) {
         return;
       }
@@ -208,7 +193,6 @@ public class SpanFrameMetricsCollector
       }
 
       int totalFrameCount = frameMetrics.getTotalFrameCount();
-      System.out.println("totalFrameCount: " + totalFrameCount);
 
       final long nextScheduledFrameNanos = frameMetricsCollector.getLastKnownFrameStartTimeNanos();
       // nextScheduledFrameNanos might be -1 if no frames have been scheduled for drawing yet
@@ -224,14 +208,12 @@ public class SpanFrameMetricsCollector
           frameMetrics.getSlowFrameDelayNanos() + frameMetrics.getFrozenFrameDelayNanos();
       final double frameDelayInSeconds = frameDelayNanos / 1e9d;
 
-      System.out.println("totalFrameCount: " + totalFrameCount);
       span.setData(SpanDataConvention.FRAMES_TOTAL, totalFrameCount);
       span.setData(SpanDataConvention.FRAMES_SLOW, frameMetrics.getSlowFrameCount());
       span.setData(SpanDataConvention.FRAMES_FROZEN, frameMetrics.getFrozenFrameCount());
       span.setData(SpanDataConvention.FRAMES_DELAY, frameDelayInSeconds);
 
       if (span instanceof ITransaction) {
-        System.out.println("TTTT - totalFrameCount: " + totalFrameCount);
         span.setMeasurement(MeasurementValue.KEY_FRAMES_TOTAL, totalFrameCount);
         span.setMeasurement(MeasurementValue.KEY_FRAMES_SLOW, frameMetrics.getSlowFrameCount());
         span.setMeasurement(MeasurementValue.KEY_FRAMES_FROZEN, frameMetrics.getFrozenFrameCount());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SpanFrameMetricsCollector.java
@@ -131,12 +131,26 @@ public class SpanFrameMetricsCollector
   private void captureFrameMetrics(@NotNull final ISpan span) {
     // TODO lock still required?
     synchronized (lock) {
+      String x = "";
+      for (ISpan runningSpan : runningSpans) {
+        x += runningSpan.getOperation() + " - " + runningSpan.getDescription() + ", ";
+      }
+      System.out.println(
+          "SpanFrameMetricsCollector.onSpanFinished - "
+              + span.getOperation()
+              + " - "
+              + span.getDescription()
+              + " ---> \ncurrent spans: "
+              + x);
+
       boolean removed = runningSpans.remove(span);
+      System.out.println(removed);
       if (!removed) {
         return;
       }
 
       final @Nullable SentryDate spanFinishDate = span.getFinishDate();
+      System.out.println("spanFinishDate == null: " + (spanFinishDate == null));
       if (spanFinishDate == null) {
         return;
       }
@@ -144,6 +158,7 @@ public class SpanFrameMetricsCollector
       final long spanStartNanos = toNanoTime(span.getStartDate());
       final long spanEndNanos = toNanoTime(spanFinishDate);
       final long spanDurationNanos = spanEndNanos - spanStartNanos;
+      System.out.println("spanDurationNanos: " + spanDurationNanos);
       if (spanDurationNanos <= 0) {
         return;
       }
@@ -193,6 +208,7 @@ public class SpanFrameMetricsCollector
       }
 
       int totalFrameCount = frameMetrics.getTotalFrameCount();
+      System.out.println("totalFrameCount: " + totalFrameCount);
 
       final long nextScheduledFrameNanos = frameMetricsCollector.getLastKnownFrameStartTimeNanos();
       // nextScheduledFrameNanos might be -1 if no frames have been scheduled for drawing yet
@@ -208,12 +224,14 @@ public class SpanFrameMetricsCollector
           frameMetrics.getSlowFrameDelayNanos() + frameMetrics.getFrozenFrameDelayNanos();
       final double frameDelayInSeconds = frameDelayNanos / 1e9d;
 
+      System.out.println("totalFrameCount: " + totalFrameCount);
       span.setData(SpanDataConvention.FRAMES_TOTAL, totalFrameCount);
       span.setData(SpanDataConvention.FRAMES_SLOW, frameMetrics.getSlowFrameCount());
       span.setData(SpanDataConvention.FRAMES_FROZEN, frameMetrics.getFrozenFrameCount());
       span.setData(SpanDataConvention.FRAMES_DELAY, frameDelayInSeconds);
 
       if (span instanceof ITransaction) {
+        System.out.println("TTTT - totalFrameCount: " + totalFrameCount);
         span.setMeasurement(MeasurementValue.KEY_FRAMES_TOTAL, totalFrameCount);
         span.setMeasurement(MeasurementValue.KEY_FRAMES_SLOW, frameMetrics.getSlowFrameCount());
         span.setMeasurement(MeasurementValue.KEY_FRAMES_FROZEN, frameMetrics.getFrozenFrameCount());

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -303,7 +303,7 @@ class ActivityLifecycleIntegrationTest {
         sut.ttidSpanMap.values.first().finish()
         sut.ttfdSpanMap.values.first().finish()
 
-        // then transaction should not be immediatelly finished
+        // then transaction should not be immediately finished
         verify(fixture.hub, never())
             .captureTransaction(
                 anyOrNull(),

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -1378,4 +1378,15 @@ class SentryTracerTest {
 
         assertEquals(5, tracer.children.size)
     }
+
+    @Test
+    fun `tracer is not finished when finishCallback is called`() {
+        val transaction = fixture.getSut(transactionFinishedCallback = {
+            assertFalse(it.isFinished)
+            assertNotNull(it.finishDate)
+        })
+        assertFalse(transaction.isFinished)
+        assertNull(transaction.finishDate)
+        transaction.finish()
+    }
 }

--- a/sentry/src/test/java/io/sentry/SpanTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanTest.kt
@@ -495,6 +495,19 @@ class SpanTest {
         assertSame(span.localMetricsAggregator, span.localMetricsAggregator)
     }
 
+    // test to ensure that the span is not finished when the finishCallback is called
+    @Test
+    fun `span is not finished when finishCallback is called`() {
+        val span = fixture.getSut()
+        span.setSpanFinishedCallback {
+            assertFalse(span.isFinished)
+            assertNotNull(span.finishDate)
+        }
+        assertFalse(span.isFinished)
+        assertNull(span.finishDate)
+        span.finish()
+    }
+
     private fun getTransaction(transactionContext: TransactionContext = TransactionContext("name", "op")): SentryTracer {
         return SentryTracer(transactionContext, fixture.hub)
     }


### PR DESCRIPTION
## :scroll: Description
moved span and transaction finish callback before they are actually finished


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/3228
This fixes and aligns the behaviour among spans and transactions.


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
