### PR TITLE
Remove profiling timeout logic and disable profiling on API 21

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -79,7 +79,6 @@ public class AndroidProfiler {
   private @Nullable Future<?> scheduledFinish = null;
   private @Nullable File traceFile = null;
   private @Nullable String frameMetricsCollectorId;
-  private volatile @Nullable ProfileEndData timedOutProfilingData = null;
   private final @NotNull SentryFrameMetricsCollector frameMetricsCollector;
   private final @NotNull ArrayDeque<ProfileMeasurementValue> screenFrameRateMeasurements =
       new ArrayDeque<>();
@@ -182,8 +181,7 @@ public class AndroidProfiler {
     // We stop profiling after a timeout to avoid huge profiles to be sent
     try {
       scheduledFinish =
-          executorService.schedule(
-              () -> timedOutProfilingData = endAndCollect(true, null), PROFILING_TIMEOUT_MILLIS);
+          executorService.schedule(() -> endAndCollect(true, null), PROFILING_TIMEOUT_MILLIS);
     } catch (RejectedExecutionException e) {
       logger.log(
           SentryLevel.ERROR,
@@ -216,10 +214,6 @@ public class AndroidProfiler {
   public synchronized @Nullable ProfileEndData endAndCollect(
       final boolean isTimeout,
       final @Nullable List<PerformanceCollectionData> performanceCollectionData) {
-    // check if profiling timed out
-    if (timedOutProfilingData != null) {
-      return timedOutProfilingData;
-    }
 
     if (!isRunning) {
       logger.log(SentryLevel.WARNING, "Profiler not running");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -133,8 +133,9 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
 
   @Override
   public synchronized void start() {
-    // Debug.startMethodTracingSampling() is only available since Lollipop
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return;
+    // Debug.startMethodTracingSampling() is only available since Lollipop, but Android Profiler
+    // causes crashes on api 21 -> https://github.com/getsentry/sentry-java/issues/3392
+    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return;
 
     // Let's initialize trace folder and profiling interval
     init();
@@ -204,9 +205,9 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
       return null;
     }
 
-    // onTransactionStart() is only available since Lollipop
+    // onTransactionStart() is only available since Lollipop_MR1
     // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return null;
+    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return null;
 
     // Transaction finished, but it's not in the current profile
     if (currentProfilingTransactionData == null

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
@@ -218,7 +218,7 @@ class AndroidProfilerTest {
     }
 
     @Test
-    fun `timedOutData has timeout flag`() {
+    fun `timedOutData is not recorded`() {
         val profiler = fixture.getSut()
 
         // Start and finish first transaction profiling
@@ -229,7 +229,7 @@ class AndroidProfilerTest {
 
         // First transaction finishes: timed out data is returned
         val endData = profiler.endAndCollect(false, null)
-        assert(endData!!.didTimeout)
+        assertNull(endData)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -53,7 +53,7 @@ class AndroidTransactionProfilerTest {
     private class Fixture {
         private val mockDsn = "http://key@localhost/proj"
         val buildInfo = mock<BuildInfoProvider> {
-            whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
+            whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP_MR1)
         }
         val mockLogger = mock<ILogger>()
         var lastScheduledRunnable: Runnable? = null
@@ -224,9 +224,9 @@ class AndroidTransactionProfilerTest {
     }
 
     @Test
-    fun `profiler works only on api 21+`() {
+    fun `profiler works only on api 22+`() {
         val buildInfo = mock<BuildInfoProvider> {
-            whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.KITKAT)
+            whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
         }
         val profiler = fixture.getSut(context, buildInfo)
         profiler.start()
@@ -379,7 +379,7 @@ class AndroidTransactionProfilerTest {
     }
 
     @Test
-    fun `timedOutData has timeout truncation reason`() {
+    fun `timedOutData is not recorded`() {
         val profiler = fixture.getSut(context)
 
         // Start and finish first transaction profiling
@@ -391,8 +391,7 @@ class AndroidTransactionProfilerTest {
 
         // First transaction finishes: timed out data is returned
         val profilingTraceData = profiler.onTransactionFinish(fixture.transaction1, null, fixture.options)
-        assertEquals(profilingTraceData!!.transactionId, fixture.transaction1.eventId.toString())
-        assertEquals(ProfilingTraceData.TRUNCATION_REASON_TIMEOUT, profilingTraceData.truncationReason)
+        assertNull(profilingTraceData)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
removed timeout logic from AndroidProfiler, as unused by the backend anyway, to fix potential profiling always or never running when one times out
removed API 21 from supported profiling versions, due to a crash


## :bulb: Motivation and Context
Timeout logic of AndroidProfiler could make profiling run forever, if a transaction is started after another times out without finishing.
If a profile timed out and the transaction finished, profiling was not started anymore, due to a bug in the logic.
Relay drops timed out profiles anyway, so we don't need to handle them.
Also, profiling crash on API 21, which is 10 years old, so we dropped support for it.


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
