### PR TITLE
chore: bump Spring Boot from 2.7.5 to 2.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove profiling timeout logic and disable profiling on API 21 ([#3478](https://github.com/getsentry/sentry-java/pull/3478))
 
+### Dependencies
+
+- Bump Spring Boot from 2.7.5 to 2.7.18
+
 ## 7.10.0
 
 ### Features

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -6,7 +6,7 @@ object Config {
     val kotlinVersion = "1.8.0"
     val kotlinStdLib = "stdlib-jdk8"
 
-    val springBootVersion = "2.7.5"
+    val springBootVersion = "2.7.18"
     val springBoot3Version = "3.2.0"
     val kotlinCompatibleLanguageVersion = "1.4"
 


### PR DESCRIPTION
## :scroll: Description

This update patches at least 13 vulnerabilities according to Maven Central [1].

Additionally, this is the final open-source, vendor-supported version in the Spring Boot 2 release line.

[1] https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
[2] https://spring.io/blog/2023/11/23/spring-boot-2-7-18-available-now#end-of-open-source-support-for-spring-boot-2x


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
