### PR TITLE
Properly reset metric flush flag on metric emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Remove profiling timeout logic and disable profiling on API 21 ([#3478](https://github.com/getsentry/sentry-java/pull/3478))
+- Properly reset metric flush flag on metric emission ([#3493](https://github.com/getsentry/sentry-java/pull/3493))
 
 ## 7.10.0
 

--- a/sentry/src/main/java/io/sentry/MetricsAggregator.java
+++ b/sentry/src/main/java/io/sentry/MetricsAggregator.java
@@ -239,6 +239,8 @@ public final class MetricsAggregator implements IMetricsAggregator, Runnable, Cl
       force = true;
     }
 
+    flushScheduled = false;
+
     final @NotNull Set<Long> flushableBuckets = getFlushableBuckets(force);
     if (flushableBuckets.isEmpty()) {
       logger.log(SentryLevel.DEBUG, "Metrics: nothing to flush");

--- a/sentry/src/test/java/io/sentry/MetricsAggregatorTest.kt
+++ b/sentry/src/test/java/io/sentry/MetricsAggregatorTest.kt
@@ -312,6 +312,19 @@ class MetricsAggregatorTest {
 
         // there is no other metric to capture, so flush is not scheduled again
         assertFalse(fixture.executorService.hasScheduledRunnables())
+
+        // once another metric is emitted
+        aggregator.increment(
+            "name1",
+            1.0,
+            MeasurementUnit.Custom("unit0"),
+            mapOf("key0" to "value0"),
+            20_001,
+            null
+        )
+
+        // then flush should be scheduled again
+        assertTrue(fixture.executorService.hasScheduledRunnables())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
The flush schedule flag wasn't properly reset and thus metrics weren't always sent properly.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-java/issues/3472
Maybe fixes https://github.com/getsentry/sentry-java/issues/3494

## :green_heart: How did you test it?
Extended unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
