### PR TITLE
Use SecureRandom instead of Random for Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Move fragment auto span finish to onFragmentStarted ([#3424](https://github.com/getsentry/sentry-java/pull/3424))
 - Remove profiling timeout logic and disable profiling on API 21 ([#3478](https://github.com/getsentry/sentry-java/pull/3478))
 - Properly reset metric flush flag on metric emission ([#3493](https://github.com/getsentry/sentry-java/pull/3493))
+- Use SecureRandom in favor of Random for Metrics ([#3495](https://github.com/getsentry/sentry-java/pull/3495))
 
 ## 7.10.0
 

--- a/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsHelper.java
@@ -1,11 +1,11 @@
 package io.sentry.metrics;
 
 import io.sentry.MeasurementUnit;
+import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +27,7 @@ public final class MetricsHelper {
   private static final char TAGS_ESCAPE_CHAR = '\\';
 
   private static long FLUSH_SHIFT_MS =
-      (long) (new Random().nextFloat() * (ROLLUP_IN_SECONDS * 1000f));
+      (long) (new SecureRandom().nextFloat() * (ROLLUP_IN_SECONDS * 1000f));
 
   public static long getTimeBucketKey(final long timestampMs) {
     final long seconds = timestampMs / 1000;


### PR DESCRIPTION
## :scroll: Description
In order to not get flagged by security scanners we should use `SecureRandom` in favor of `Random`. Whilst the use-case (random flush shift) doesn't really require a strong random, I guess it's maintenance-friendlier to use `SecureRandom`.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-react-native/issues/3897

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
