### PR TITLE
Fix duplicate session start for React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Move fragment auto span finish to onFragmentStarted ([#3424](https://github.com/getsentry/sentry-java/pull/3424))
 - Remove profiling timeout logic and disable profiling on API 21 ([#3478](https://github.com/getsentry/sentry-java/pull/3478))
 - Properly reset metric flush flag on metric emission ([#3493](https://github.com/getsentry/sentry-java/pull/3493))
+- Fix duplicate session start for React Native ([#3504](https://github.com/getsentry/sentry-java/pull/3504))
 
 ## 7.10.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -11,6 +11,7 @@ import io.sentry.OptionsContainer;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.Session;
 import io.sentry.android.core.internal.util.BreadcrumbFactory;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
@@ -19,7 +20,9 @@ import io.sentry.android.timber.SentryTimberIntegration;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Sentry initialization class */
 public final class SentryAndroid {
@@ -146,8 +149,21 @@ public final class SentryAndroid {
 
       final @NotNull IHub hub = Sentry.getCurrentHub();
       if (hub.getOptions().isEnableAutoSessionTracking() && ContextUtils.isForegroundImportance()) {
-        hub.addBreadcrumb(BreadcrumbFactory.forSession("session.start"));
-        hub.startSession();
+        // The LifecycleWatcher of AppLifecycleIntegration may already started a session
+        // so only start a session if it's not already started
+        // This e.g. happens on React Native, or e.g. on deferred SDK init
+        final AtomicBoolean sessionStarted = new AtomicBoolean(false);
+        hub.configureScope(
+            scope -> {
+              final @Nullable Session currentSession = scope.getSession();
+              if (currentSession != null && currentSession.getStarted() != null) {
+                sessionStarted.set(true);
+              }
+            });
+        if (!sessionStarted.get()) {
+          hub.addBreadcrumb(BreadcrumbFactory.forSession("session.start"));
+          hub.startSession();
+        }
       }
     } catch (IllegalAccessException e) {
       logger.log(SentryLevel.FATAL, "Fatal error during SentryAndroid.init(...)", e);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.Breadcrumb
 import io.sentry.Hint
 import io.sentry.ILogger
+import io.sentry.ISentryClient
 import io.sentry.Sentry
 import io.sentry.SentryEnvelope
 import io.sentry.SentryLevel
@@ -50,6 +51,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
@@ -314,8 +316,24 @@ class SentryAndroidTest {
         }
     }
 
+    @Test
+    fun `init does not start a session if one is already running`() {
+        val client = mock<ISentryClient>()
+
+        initSentryWithForegroundImportance(true, { options ->
+            options.addIntegration { hub, _ ->
+                hub.bindClient(client)
+                // usually done by LifecycleWatcher
+                hub.startSession()
+            }
+        }) {}
+
+        verify(client, times(1)).captureSession(any(), any())
+    }
+
     private fun initSentryWithForegroundImportance(
         inForeground: Boolean,
+        optionsConfig: (SentryAndroidOptions) -> Unit = {},
         callback: (session: Session?) -> Unit
     ) {
         val context = ContextUtilsTestHelper.createMockContext()
@@ -327,6 +345,7 @@ class SentryAndroidTest {
                 options.release = "prod"
                 options.dsn = "https://key@sentry.io/123"
                 options.isEnableAutoSessionTracking = true
+                optionsConfig(options)
             }
 
             var session: Session? = null


### PR DESCRIPTION
## :scroll: Description

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3503

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
