### PR TITLE
[SR]  Capture screen names as urls 

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -371,7 +371,7 @@ public final class ActivityLifecycleIntegration
   public synchronized void onActivityCreated(
       final @NotNull Activity activity, final @Nullable Bundle savedInstanceState) {
     setColdStart(savedInstanceState);
-    if (hub != null) {
+    if (hub != null && options != null && options.isEnableScreenTracking()) {
       final @Nullable String activityClassName = ClassUtil.getClassName(activity);
       hub.configureScope(scope -> scope.setScreen(activityClassName));
     }

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -81,6 +81,9 @@ class SentryFragmentLifecycleCallbacks(
         // we only start the tracing for the fragment if the fragment has been added to its activity
         // and not only to the backstack
         if (fragment.isAdded) {
+            if (hub.options.isEnableScreenTracking) {
+                hub.configureScope { it.screen = getFragmentName(fragment) }
+            }
             startTracing(fragment)
         }
     }

--- a/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
+++ b/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
@@ -177,6 +177,7 @@ class SentryNavigationListener @JvmOverloads constructor(
             }.associateWith { args[it] }
         } ?: emptyMap()
 
+    @Suppress("SwallowedException") // we swallow it on purpose
     private fun NavDestination.extractName(context: Context): String? {
         val name = route ?: try {
             context.resources.getResourceEntryName(id)

--- a/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
+++ b/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.navigation
 
+import android.content.Context
 import android.content.res.Resources.NotFoundException
 import android.os.Bundle
 import androidx.navigation.NavController
@@ -59,9 +60,15 @@ class SentryNavigationListener @JvmOverloads constructor(
         arguments: Bundle?
     ) {
         val toArguments = arguments.refined()
-
         addBreadcrumb(destination, toArguments)
-        startTracing(controller, destination, toArguments)
+
+        val routeName = destination.extractName(controller.context)
+        if (routeName != null) {
+            if (hub.options.isEnableScreenTracking) {
+                hub.configureScope { it.screen = routeName }
+            }
+            startTracing(routeName, destination, toArguments)
+        }
         previousDestinationRef = WeakReference(destination)
         previousArgs = arguments
     }
@@ -95,7 +102,7 @@ class SentryNavigationListener @JvmOverloads constructor(
     }
 
     private fun startTracing(
-        controller: NavController,
+        routeName: String,
         destination: NavDestination,
         arguments: Map<String, Any?>
     ) {
@@ -118,20 +125,6 @@ class SentryNavigationListener @JvmOverloads constructor(
             return
         }
 
-        @Suppress("SwallowedException") // we swallow it on purpose
-        var name = destination.route ?: try {
-            controller.context.resources.getResourceEntryName(destination.id)
-        } catch (e: NotFoundException) {
-            hub.options.logger.log(
-                DEBUG,
-                "Destination id cannot be retrieved from Resources, no transaction captured."
-            )
-            return
-        }
-
-        // we add '/' to the name to match dart and web pattern
-        name = "/" + name.substringBefore('/') // strip out arguments from the tx name
-
         val transactionOptions = TransactionOptions().also {
             it.isWaitForChildren = true
             it.idleTimeout = hub.options.idleTimeout
@@ -140,7 +133,7 @@ class SentryNavigationListener @JvmOverloads constructor(
         }
 
         val transaction = hub.startTransaction(
-            TransactionContext(name, TransactionNameSource.ROUTE, NAVIGATION_OP),
+            TransactionContext(routeName, TransactionNameSource.ROUTE, NAVIGATION_OP),
             transactionOptions
         )
 
@@ -183,6 +176,21 @@ class SentryNavigationListener @JvmOverloads constructor(
                 it != NavController.KEY_DEEP_LINK_INTENT // there's a lot of unrelated stuff
             }.associateWith { args[it] }
         } ?: emptyMap()
+
+    private fun NavDestination.extractName(context: Context): String? {
+        val name = route ?: try {
+            context.resources.getResourceEntryName(id)
+        } catch (e: NotFoundException) {
+            hub.options.logger.log(
+                DEBUG,
+                "Destination id cannot be retrieved from Resources, no transaction captured."
+            )
+            null
+        } ?: return null
+
+        // we add '/' to the name to match dart and web pattern
+        return "/" + name.substringBefore('/') // strip out arguments from the tx name
+    }
 
     companion object {
         const val NAVIGATION_OP = "navigation"

--- a/sentry-android-navigation/src/test/java/io/sentry/android/navigation/SentryNavigationListenerTest.kt
+++ b/sentry-android-navigation/src/test/java/io/sentry/android/navigation/SentryNavigationListenerTest.kt
@@ -56,6 +56,7 @@ class SentryNavigationListenerTest {
             toId: String? = "destination-id-1",
             enableBreadcrumbs: Boolean = true,
             enableTracing: Boolean = true,
+            enableScreenTracking: Boolean = true,
             tracesSampleRate: Double? = 1.0,
             hasViewIdInRes: Boolean = true,
             transaction: SentryTracer? = null,
@@ -66,6 +67,7 @@ class SentryNavigationListenerTest {
                 setTracesSampleRate(
                     tracesSampleRate
                 )
+                isEnableScreenTracking = enableScreenTracking
             }
             whenever(hub.options).thenReturn(options)
 
@@ -371,7 +373,7 @@ class SentryNavigationListenerTest {
 
         sut.onDestinationChanged(fixture.navController, fixture.destination, null)
 
-        verify(fixture.hub).configureScope(any())
+        verify(fixture.hub, times(2)).configureScope(any())
         assertNotSame(propagationContextAtStart, scope.propagationContext)
     }
 
@@ -405,5 +407,23 @@ class SentryNavigationListenerTest {
                 assertEquals(TransactionOptions.DEFAULT_DEADLINE_TIMEOUT_AUTO_TRANSACTION, options.deadlineTimeout)
             }
         )
+    }
+
+    @Test
+    fun `onDestinationChanged sets scope screen`() {
+        val sut = fixture.getSut()
+
+        sut.onDestinationChanged(fixture.navController, fixture.destination, null)
+
+        verify(fixture.scope).screen = "/route"
+    }
+
+    @Test
+    fun `onDestinationChanged does not set scope screen when screen tracking is disabled`() {
+        val sut = fixture.getSut(enableScreenTracking = false)
+
+        sut.onDestinationChanged(fixture.navController, fixture.destination, null)
+
+        verify(fixture.scope, never()).screen = "/route"
     }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -12,6 +12,7 @@ import io.sentry.Integration
 import io.sentry.NoOpReplayBreadcrumbConverter
 import io.sentry.ReplayBreadcrumbConverter
 import io.sentry.ReplayController
+import io.sentry.ScopeObserverAdapter
 import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel.DEBUG
@@ -21,6 +22,7 @@ import io.sentry.android.replay.capture.BufferCaptureStrategy
 import io.sentry.android.replay.capture.CaptureStrategy
 import io.sentry.android.replay.capture.SessionCaptureStrategy
 import io.sentry.android.replay.util.sample
+import io.sentry.protocol.Contexts
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion
@@ -76,6 +78,11 @@ public class ReplayIntegration(
         }
 
         this.hub = hub
+        this.options.addScopeObserver(object : ScopeObserverAdapter() {
+            override fun setContexts(contexts: Contexts) {
+                captureStrategy?.onScreenChanged(contexts.app?.viewNames?.lastOrNull())
+            }
+        })
         recorder = recorderProvider?.invoke() ?: WindowRecorder(options, this, this)
         isEnabled.set(true)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -80,7 +80,8 @@ public class ReplayIntegration(
         this.hub = hub
         this.options.addScopeObserver(object : ScopeObserverAdapter() {
             override fun setContexts(contexts: Contexts) {
-                captureStrategy?.onScreenChanged(contexts.app?.viewNames?.lastOrNull())
+                // scope screen has fully-qualified name
+                captureStrategy?.onScreenChanged(contexts.app?.viewNames?.lastOrNull()?.substringAfterLast('.'))
             }
         })
         recorder = recorderProvider?.invoke() ?: WindowRecorder(options, this, this)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -55,6 +55,7 @@ internal abstract class BaseCaptureStrategy(
     protected var cache: ReplayCache? = null
     protected val segmentTimestamp = AtomicReference<Date>()
     protected val replayStartTimestamp = AtomicLong()
+    protected val screenAtStart = AtomicReference<String>()
     override val currentReplayId = AtomicReference(SentryId.EMPTY_ID)
     override val currentSegment = AtomicInteger(0)
     override val replayCacheDir: File? get() = cache?.replayCacheDir
@@ -188,7 +189,7 @@ internal abstract class BaseCaptureStrategy(
             top = 0
         }
 
-        val urls = ArrayList<String>(options.maxBreadcrumbs)
+        val urls = LinkedList<String>()
         hub?.configureScope { scope ->
             scope.breadcrumbs.forEach { breadcrumb ->
                 if (breadcrumb.timestamp.time >= segmentTimestamp.time &&
@@ -209,6 +210,10 @@ internal abstract class BaseCaptureStrategy(
                     }
                 }
             }
+        }
+
+        if (screenAtStart.get() != null && urls.first != screenAtStart.get()) {
+            urls.addFirst(screenAtStart.get())
         }
 
         rotateCurrentEvents(endTimestamp.time) { event ->

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -204,7 +204,7 @@ internal abstract class BaseCaptureStrategy(
                         recordingPayload += rrwebEvent
 
                         // fill in the urls array from navigation breadcrumbs
-                        if ((rrwebEvent as? RRWebBreadcrumbEvent)?.breadcrumbType == "navigation") {
+                        if ((rrwebEvent as? RRWebBreadcrumbEvent)?.category == "navigation") {
                             urls.add(rrwebEvent.data!!["to"] as String)
                         }
                     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -30,6 +30,8 @@ internal interface CaptureStrategy {
 
     fun onTouchEvent(event: MotionEvent)
 
+    fun onScreenChanged(screen: String?) = Unit
+
     fun convert(): CaptureStrategy
 
     fun close()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -31,7 +31,10 @@ internal class SessionCaptureStrategy(
         super.start(segmentId, replayId, cleanupOldReplays)
         // only set replayId on the scope if it's a full session, otherwise all events will be
         // tagged with the replay that might never be sent when we're recording in buffer mode
-        hub?.configureScope { it.replayId = currentReplayId.get() }
+        hub?.configureScope {
+            it.replayId = currentReplayId.get()
+            screenAtStart.set(it.screen)
+        }
     }
 
     override fun pause() {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2444,6 +2444,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableMetrics ()Z
 	public fun isEnablePrettySerializationOutput ()Z
 	public fun isEnableScopePersistence ()Z
+	public fun isEnableScreenTracking ()Z
 	public fun isEnableShutdownHook ()Z
 	public fun isEnableSpanLocalMetricAggregation ()Z
 	public fun isEnableSpotlight ()Z
@@ -2490,6 +2491,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableMetrics (Z)V
 	public fun setEnablePrettySerializationOutput (Z)V
 	public fun setEnableScopePersistence (Z)V
+	public fun setEnableScreenTracking (Z)V
 	public fun setEnableShutdownHook (Z)V
 	public fun setEnableSpanLocalMetricAggregation (Z)V
 	public fun setEnableSpotlight (Z)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -487,6 +487,7 @@ public class SentryOptions {
    * Controls whether to enable screen tracking. When enabled, the SDK will automatically capture
    * screen transitions as context for events.
    */
+  @ApiStatus.Experimental
   private boolean enableScreenTracking = true;
 
   /**
@@ -2409,10 +2410,12 @@ public class SentryOptions {
         replayController != null ? replayController : NoOpReplayController.getInstance();
   }
 
+  @ApiStatus.Experimental
   public boolean isEnableScreenTracking() {
     return enableScreenTracking;
   }
 
+  @ApiStatus.Experimental
   public void setEnableScreenTracking(final boolean enableScreenTracking) {
     this.enableScreenTracking = enableScreenTracking;
   }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -487,8 +487,7 @@ public class SentryOptions {
    * Controls whether to enable screen tracking. When enabled, the SDK will automatically capture
    * screen transitions as context for events.
    */
-  @ApiStatus.Experimental
-  private boolean enableScreenTracking = true;
+  @ApiStatus.Experimental private boolean enableScreenTracking = true;
 
   /**
    * Adds an event processor

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -484,6 +484,12 @@ public class SentryOptions {
   private @NotNull ReplayController replayController = NoOpReplayController.getInstance();
 
   /**
+   * Controls whether to enable screen tracking. When enabled, the SDK will automatically capture
+   * screen transitions as context for events.
+   */
+  private boolean enableScreenTracking = true;
+
+  /**
    * Adds an event processor
    *
    * @param eventProcessor the event processor
@@ -2401,6 +2407,14 @@ public class SentryOptions {
   public void setReplayController(final @Nullable ReplayController replayController) {
     this.replayController =
         replayController != null ? replayController : NoOpReplayController.getInstance();
+  }
+
+  public boolean isEnableScreenTracking() {
+    return enableScreenTracking;
+  }
+
+  public void setEnableScreenTracking(final boolean enableScreenTracking) {
+    this.enableScreenTracking = enableScreenTracking;
   }
 
   /** The BeforeSend callback */


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Adds an option to disable screen tracking - this is necessary for RN/Flutter, so they can set their own screens to the native scope and we won't override them
* Adds screen tracking to the missing places (fragment and navigation integrations) to match what we capture as navigation breadcrumbs for replay
* Fills in `replay.urls` array based on navigation breadcrumbs
* For the buffer mode: we have to know what was the last screen before the buffer replay started to display the correct screen name. For that we:
  * Install ScopeObserver to observe whenever `scope.screen` changes and persist it with timestamp
  * When capturing the buffered replay we then search for the last screen before the buffered replay started and add it to the `replay.urls` array

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/70065


example buffered replay: https://sentry-sdks.sentry.io/replays/0a7eb9067746443c90cfad13662349d3/?project=5428559&query=&referrer=%2Freplays%2F%3AreplaySlug%2F&statsPeriod=1h&yAxis=count%28%29&t=0

and its json payload:
https://us.sentry.io/api/0/projects/sentry-sdks/sentry-android/replays/0a7eb9067746443c90cfad13662349d3/