### PR TITLE
POTEL 28 - Use `auto.opentelemetry` for POTel span origin

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -64,7 +64,7 @@ public final class SentrySpanExporter implements SpanExporter {
           InternalSemanticAttributes.PARENT_SAMPLED.getKey());
   private static final @NotNull Long SPAN_TIMEOUT = DateUtils.secondsToNanos(5 * 60);
 
-  public static final String TRACE_ORIGIN = "auto.otel";
+  public static final String TRACE_ORIGIN = "auto.opentelemetry";
 
   public SentrySpanExporter() {
     this(ScopesAdapter.getInstance());


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Use `auto.opentelemetry` for POTel span origin

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So we can better distinguish it from our legacy OpenTelemetry integration.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
