### PR TITLE
Fix duplicated http spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Properly reset metric flush flag on metric emission ([#3493](https://github.com/getsentry/sentry-java/pull/3493))
 - Use SecureRandom in favor of Random for Metrics ([#3495](https://github.com/getsentry/sentry-java/pull/3495))
 - Fix UncaughtExceptionHandlerIntegration Memory Leak ([#3398](https://github.com/getsentry/sentry-java/pull/3398))
+- Fix duplicated http spans ([#3526](https://github.com/getsentry/sentry-java/pull/3526))
 
 ### Dependencies
 

--- a/sentry-android-okhttp/build.gradle.kts
+++ b/sentry-android-okhttp/build.gradle.kts
@@ -24,7 +24,9 @@ android {
 
     buildTypes {
         getByName("debug")
-        getByName("release")
+        getByName("release") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
     }
 
     kotlinOptions {

--- a/sentry-android-okhttp/proguard-rules.pro
+++ b/sentry-android-okhttp/proguard-rules.pro
@@ -11,3 +11,5 @@
 # https://raw.githubusercontent.com/square/okhttp/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro
 
 ##---------------End: proguard configuration for OkHttp  ----------
+# We keep this name to avoid the sentry-okttp module to call the old listener multiple times
+-keepnames class io.sentry.android.okhttp.SentryOkHttpEventListener

--- a/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-android-okhttp/src/test/java/io/sentry/android/okhttp/SentryOkHttpEventListenerTest.kt
@@ -1,0 +1,70 @@
+package io.sentry.android.okhttp
+
+import io.sentry.IHub
+import io.sentry.SentryOptions
+import io.sentry.SentryTracer
+import io.sentry.TransactionContext
+import okhttp3.EventListener
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@SuppressWarnings("Deprecated")
+class SentryOkHttpEventListenerTest {
+
+    class Fixture {
+        val hub = mock<IHub>()
+        val server = MockWebServer()
+        lateinit var sentryTracer: SentryTracer
+
+        @SuppressWarnings("LongParameterList")
+        fun getSut(
+            eventListener: EventListener? = null
+        ): OkHttpClient {
+            val options = SentryOptions().apply {
+                dsn = "https://key@sentry.io/proj"
+            }
+            whenever(hub.options).thenReturn(options)
+
+            sentryTracer = SentryTracer(TransactionContext("name", "op"), hub)
+            whenever(hub.span).thenReturn(sentryTracer)
+            server.enqueue(
+                MockResponse()
+                    .setBody("responseBody")
+                    .setSocketPolicy(SocketPolicy.KEEP_OPEN)
+                    .setResponseCode(200)
+            )
+
+            val builder = OkHttpClient.Builder().addInterceptor(SentryOkHttpInterceptor(hub))
+            val sentryOkHttpEventListener = when {
+                eventListener != null -> SentryOkHttpEventListener(hub, eventListener)
+                else -> SentryOkHttpEventListener(hub)
+            }
+            return builder.eventListener(sentryOkHttpEventListener).build()
+        }
+    }
+
+    private val fixture = Fixture()
+
+    private fun getRequest(url: String = "/hello"): Request {
+        return Request.Builder()
+            .addHeader("myHeader", "myValue")
+            .get()
+            .url(fixture.server.url(url))
+            .build()
+    }
+
+    @Test
+    fun `when there are multiple SentryOkHttpEventListeners, they don't duplicate spans`() {
+        val sut = fixture.getSut(eventListener = SentryOkHttpEventListener(fixture.hub))
+        val call = sut.newCall(getRequest())
+        call.execute().close()
+        assertEquals(8, fixture.sentryTracer.children.size)
+    }
+}

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -406,6 +406,7 @@ public open class SentryOkHttpEventListener(
 
     private fun canCreateEventSpan(): Boolean {
         // If the wrapped EventListener is ours, we shouldn't create spans, as the originalEventListener already did it
-        return originalEventListener !is SentryOkHttpEventListener
+        return originalEventListener !is SentryOkHttpEventListener &&
+            "io.sentry.android.okhttp.SentryOkHttpEventListener" != originalEventListener?.javaClass?.name
     }
 }

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -406,6 +406,8 @@ public open class SentryOkHttpEventListener(
 
     private fun canCreateEventSpan(): Boolean {
         // If the wrapped EventListener is ours, we shouldn't create spans, as the originalEventListener already did it
+        // In case SentryOkHttpEventListener from sentry-android-okhttp is used, the is check won't work so we check
+        // for the class name as well.
         return originalEventListener !is SentryOkHttpEventListener &&
             "io.sentry.android.okhttp.SentryOkHttpEventListener" != originalEventListener?.javaClass?.name
     }


### PR DESCRIPTION
## :scroll: Description
SentryOkHttpEventListener now checks if an existing `io.sentry.android.SentryOkHttpEventListener` is attached and skips it


## :bulb: Motivation and Context
Customers reported duplicated http spans, that was happening due to our Gradle plugin auto instrument using the old version of the `SentryOkHttpEventListener` from the `sentry-android-okhttp` artifact. 
That was delegating to the listener from `sentry-okhttp`, and when being instrumented multiple times, it was creating multiple http spans, overwriting the parent `http.client` span in the listener, causing the duplicated spans to never finish, due to their reference being lost.


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
