### PR TITLE
Parse and use `send-default-pii` and `max-request-body-size` from `sentry.properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `sentry-android-okhttp` has been removed in favor of `sentry-okhttp`, removing android dependency from the module ([#3510](https://github.com/getsentry/sentry-java/pull/3510))
 
+### Fixes
+
+- Parse and use `send-default-pii` and `max-request-body-size` from `sentry.properties` ([#3534](https://github.com/getsentry/sentry-java/pull/3534))
+
 ## 8.0.0-alpha.2
 
 ### Behavioural Changes

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -459,6 +459,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isEnableBackpressureHandling ()Ljava/lang/Boolean;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
+	public fun isSendDefaultPii ()Ljava/lang/Boolean;
 	public fun isSendModules ()Ljava/lang/Boolean;
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDebug (Ljava/lang/Boolean;)V
@@ -480,6 +481,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setProxy (Lio/sentry/SentryOptions$Proxy;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setSendClientReports (Ljava/lang/Boolean;)V
+	public fun setSendDefaultPii (Ljava/lang/Boolean;)V
 	public fun setSendModules (Ljava/lang/Boolean;)V
 	public fun setServerName (Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -49,6 +49,7 @@ public final class ExternalOptions {
   private @Nullable List<String> ignoredCheckIns;
 
   private @Nullable Boolean sendModules;
+  private @Nullable Boolean sendDefaultPii;
   private @Nullable Boolean enableBackpressureHandling;
 
   private @Nullable SentryOptions.Cron cron;
@@ -131,6 +132,7 @@ public final class ExternalOptions {
         propertiesProvider.getBooleanProperty("enable-pretty-serialization-output"));
 
     options.setSendModules(propertiesProvider.getBooleanProperty("send-modules"));
+    options.setSendDefaultPii(propertiesProvider.getBooleanProperty("send-default-pii"));
 
     options.setIgnoredCheckIns(propertiesProvider.getList("ignored-checkins"));
 
@@ -419,6 +421,14 @@ public final class ExternalOptions {
 
   public void setSendModules(final @Nullable Boolean sendModules) {
     this.sendModules = sendModules;
+  }
+
+  public @Nullable Boolean isSendDefaultPii() {
+    return sendDefaultPii;
+  }
+
+  public void setSendDefaultPii(final @Nullable Boolean sendDefaultPii) {
+    this.sendDefaultPii = sendDefaultPii;
   }
 
   @ApiStatus.Experimental

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2688,6 +2688,12 @@ public class SentryOptions {
     if (options.isEnableBackpressureHandling() != null) {
       setEnableBackpressureHandling(options.isEnableBackpressureHandling());
     }
+    if (options.getMaxRequestBodySize() != null) {
+      setMaxRequestBodySize(options.getMaxRequestBodySize());
+    }
+    if (options.isSendDefaultPii() != null) {
+      setSendDefaultPii(options.isSendDefaultPii());
+    }
 
     if (options.getCron() != null) {
       if (getCron() == null) {

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -286,6 +286,13 @@ class ExternalOptionsTest {
         }
     }
 
+    @Test
+    fun `creates options with sendDefaultPii set to true`() {
+        withPropertiesFile("send-default-pii=true") { options ->
+            assertTrue(options.isSendDefaultPii == true)
+        }
+    }
+
     private fun withPropertiesFile(textLines: List<String> = emptyList(), logger: ILogger = mock(), fn: (ExternalOptions) -> Unit) {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import io.sentry.SentryOptions.RequestSize
 import io.sentry.util.StringUtils
 import org.mockito.kotlin.mock
 import java.io.File
@@ -371,6 +372,8 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.isEnableBackpressureHandling = false
+        externalOptions.maxRequestBodySize = SentryOptions.RequestSize.MEDIUM
+        externalOptions.isSendDefaultPii = true
         externalOptions.cron = SentryOptions.Cron().apply {
             defaultCheckinMargin = 10L
             defaultMaxRuntime = 30L
@@ -415,6 +418,8 @@ class SentryOptionsTest {
         assertEquals(40L, options.cron?.defaultFailureIssueThreshold)
         assertEquals(50L, options.cron?.defaultRecoveryThreshold)
         assertEquals("America/New_York", options.cron?.defaultTimezone)
+        assertTrue(options.isSendDefaultPii)
+        assertEquals(RequestSize.MEDIUM, options.maxRequestBodySize)
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We now parse and use `send-default-pii` and `max-request-body-size` from `sentry.properties`.

- `max-request-body-size` was already being parsed but never applied to `SentryOptions`
- `send-default-pii` was neither parsed nor applied

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As of `8.0.0-alpha.2` our Sentry OpenTelemetry Java Agent has been released and is supposed to be a vital part in our future Performance instrumentation. Some features (e.g. error reporting) are currently still based on the integrations that existed before.

Some data is only sent when certain options are enabled (see PR title). We never parsed those until now, meaning our OpenTelemetry Agent Init wasn't able to utilize all of the functionality Sentry offers.

NOTE: There might be more options, that aren't parsed yet. We should investigate and fix. Here's an issue for that: https://github.com/getsentry/sentry-java/issues/3535

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
