### PR TITLE
Report dropped spans v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Report dropped spans ([#3528](https://github.com/getsentry/sentry-java/pull/3528))
+- Report dropped spans ([#3536](https://github.com/getsentry/sentry-java/pull/3536))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Report dropped spans ([#3528](https://github.com/getsentry/sentry-java/pull/3528))
+
 ### Breaking Changes
 
 - `sentry-android-okhttp` has been removed in favor of `sentry-okhttp`, removing android dependency from the module ([#3510](https://github.com/getsentry/sentry-java/pull/3510))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -326,6 +326,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static final field Profile Lio/sentry/DataCategory;
 	public static final field Security Lio/sentry/DataCategory;
 	public static final field Session Lio/sentry/DataCategory;
+	public static final field Span Lio/sentry/DataCategory;
 	public static final field Transaction Lio/sentry/DataCategory;
 	public static final field Unknown Lio/sentry/DataCategory;
 	public static final field UserReport Lio/sentry/DataCategory;
@@ -3632,6 +3633,7 @@ public final class io/sentry/clientreport/ClientReportRecorder : io/sentry/clien
 	public fun recordLostEnvelope (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelope;)V
 	public fun recordLostEnvelopeItem (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelopeItem;)V
 	public fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;)V
+	public fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;J)V
 }
 
 public final class io/sentry/clientreport/DiscardReason : java/lang/Enum {
@@ -3677,6 +3679,7 @@ public abstract interface class io/sentry/clientreport/IClientReportRecorder {
 	public abstract fun recordLostEnvelope (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelope;)V
 	public abstract fun recordLostEnvelopeItem (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelopeItem;)V
 	public abstract fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;)V
+	public abstract fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;J)V
 }
 
 public abstract interface class io/sentry/clientreport/IClientReportStorage {
@@ -3690,6 +3693,7 @@ public final class io/sentry/clientreport/NoOpClientReportRecorder : io/sentry/c
 	public fun recordLostEnvelope (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelope;)V
 	public fun recordLostEnvelopeItem (Lio/sentry/clientreport/DiscardReason;Lio/sentry/SentryEnvelopeItem;)V
 	public fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;)V
+	public fun recordLostEvent (Lio/sentry/clientreport/DiscardReason;Lio/sentry/DataCategory;J)V
 }
 
 public abstract interface class io/sentry/config/PropertiesProvider {

--- a/sentry/src/main/java/io/sentry/DataCategory.java
+++ b/sentry/src/main/java/io/sentry/DataCategory.java
@@ -14,6 +14,7 @@ public enum DataCategory {
   Profile("profile"),
   MetricBucket("metric_bucket"),
   Transaction("transaction"),
+  Span("span"),
   Security("security"),
   UserReport("user_report"),
   Unknown("unknown");

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -775,10 +775,22 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
             getOptions()
                 .getClientReportRecorder()
                 .recordLostEvent(DiscardReason.BACKPRESSURE, DataCategory.Transaction);
+            getOptions()
+                .getClientReportRecorder()
+                .recordLostEvent(
+                    DiscardReason.BACKPRESSURE,
+                    DataCategory.Span,
+                    transaction.getSpans().size() + 1);
           } else {
             getOptions()
                 .getClientReportRecorder()
                 .recordLostEvent(DiscardReason.SAMPLE_RATE, DataCategory.Transaction);
+            getOptions()
+                .getClientReportRecorder()
+                .recordLostEvent(
+                    DiscardReason.SAMPLE_RATE,
+                    DataCategory.Span,
+                    transaction.getSpans().size() + 1);
           }
         } else {
           try {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -413,6 +413,7 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
       final @NotNull Hint hint,
       final @NotNull List<EventProcessor> eventProcessors) {
     for (final EventProcessor processor : eventProcessors) {
+      final int spanCountBeforeProcessor = transaction.getSpans().size();
       try {
         transaction = processor.process(transaction, hint);
       } catch (Throwable e) {
@@ -424,6 +425,7 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
                 "An exception occurred while processing transaction by processor: %s",
                 processor.getClass().getName());
       }
+      final int spanCountAfterProcessor = transaction == null ? 0 : transaction.getSpans().size();
 
       if (transaction == null) {
         options
@@ -435,7 +437,25 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Transaction);
+        // If we drop a transaction, we are also dropping all its spans (+1 for the root span)
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(
+                DiscardReason.EVENT_PROCESSOR, DataCategory.Span, spanCountBeforeProcessor + 1);
         break;
+      } else if (spanCountAfterProcessor < spanCountBeforeProcessor) {
+        // If the callback removed some spans, we report it
+        final int droppedSpanCount = spanCountBeforeProcessor - spanCountAfterProcessor;
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "%d spans were dropped by a processor: %s",
+                droppedSpanCount,
+                processor.getClass().getName());
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Span, droppedSpanCount);
       }
     }
     return transaction;
@@ -667,7 +687,9 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
       return SentryId.EMPTY_ID;
     }
 
+    final int spanCountBeforeCallback = transaction.getSpans().size();
     transaction = executeBeforeSendTransaction(transaction, hint);
+    final int spanCountAfterCallback = transaction == null ? 0 : transaction.getSpans().size();
 
     if (transaction == null) {
       options
@@ -676,7 +698,24 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
       options
           .getClientReportRecorder()
           .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Transaction);
+      // If we drop a transaction, we are also dropping all its spans (+1 for the root span)
+      options
+          .getClientReportRecorder()
+          .recordLostEvent(
+              DiscardReason.BEFORE_SEND, DataCategory.Span, spanCountBeforeCallback + 1);
       return SentryId.EMPTY_ID;
+    } else if (spanCountAfterCallback < spanCountBeforeCallback) {
+      // If the callback removed some spans, we report it
+      final int droppedSpanCount = spanCountBeforeCallback - spanCountAfterCallback;
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "%d spans were dropped by beforeSendTransaction.",
+              droppedSpanCount);
+      options
+          .getClientReportRecorder()
+          .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.Span, droppedSpanCount);
     }
 
     try {

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -7,6 +7,8 @@ import io.sentry.SentryEnvelopeItem;
 import io.sentry.SentryItemType;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.protocol.SentrySpan;
+import io.sentry.protocol.SentryTransaction;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -84,8 +86,19 @@ public final class ClientReportRecorder implements IClientReportRecorder {
               .log(SentryLevel.ERROR, "Unable to restore counts from previous client report.");
         }
       } else {
-        recordLostEventInternal(
-            reason.getReason(), categoryFromItemType(itemType).getCategory(), 1L);
+        final @NotNull DataCategory itemCategory = categoryFromItemType(itemType);
+        if (itemCategory.equals(DataCategory.Transaction)) {
+          final @Nullable SentryTransaction transaction =
+              envelopeItem.getTransaction(options.getSerializer());
+          if (transaction != null) {
+            final @NotNull List<SentrySpan> spans = transaction.getSpans();
+            // When a transaction is dropped, we also record its spans as dropped plus one,
+            // since Relay extracts an additional span from the transaction.
+            recordLostEventInternal(
+                reason.getReason(), DataCategory.Span.getCategory(), spans.size() + 1L);
+          }
+        }
+        recordLostEventInternal(reason.getReason(), itemCategory.getCategory(), 1L);
       }
     } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, e, "Unable to record lost envelope item.");
@@ -94,8 +107,14 @@ public final class ClientReportRecorder implements IClientReportRecorder {
 
   @Override
   public void recordLostEvent(@NotNull DiscardReason reason, @NotNull DataCategory category) {
+    recordLostEvent(reason, category, 1);
+  }
+
+  @Override
+  public void recordLostEvent(
+      @NotNull DiscardReason reason, @NotNull DataCategory category, long count) {
     try {
-      recordLostEventInternal(reason.getReason(), category.getCategory(), 1L);
+      recordLostEventInternal(reason.getReason(), category.getCategory(), count);
     } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, e, "Unable to record lost event.");
     }

--- a/sentry/src/main/java/io/sentry/clientreport/IClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/IClientReportRecorder.java
@@ -16,6 +16,8 @@ public interface IClientReportRecorder {
 
   void recordLostEvent(@NotNull DiscardReason reason, @NotNull DataCategory category);
 
+  void recordLostEvent(@NotNull DiscardReason reason, @NotNull DataCategory category, long count);
+
   @NotNull
   SentryEnvelope attachReportToEnvelope(@NotNull SentryEnvelope envelope);
 }

--- a/sentry/src/main/java/io/sentry/clientreport/NoOpClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/NoOpClientReportRecorder.java
@@ -26,6 +26,12 @@ public final class NoOpClientReportRecorder implements IClientReportRecorder {
   }
 
   @Override
+  public void recordLostEvent(
+      @NotNull DiscardReason reason, @NotNull DataCategory category, long count) {
+    // do nothing
+  }
+
+  @Override
   public @NotNull SentryEnvelope attachReportToEnvelope(@NotNull SentryEnvelope envelope) {
     return envelope;
   }

--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
@@ -18,6 +18,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.SentryTracer
 import io.sentry.Session
+import io.sentry.TracesSamplingDecision
 import io.sentry.TransactionContext
 import io.sentry.UncaughtExceptionHandlerIntegration.UncaughtExceptionHint
 import io.sentry.UserFeedback
@@ -63,6 +64,7 @@ class ClientReportTest {
 
         val envelope = testHelper.newEnvelope(
             SentryEnvelopeItem.fromClientReport(opts.serializer, lostClientReport),
+            SentryEnvelopeItem.fromEvent(opts.serializer, SentryTransaction(transaction)),
             SentryEnvelopeItem.fromEvent(opts.serializer, SentryEvent()),
             SentryEnvelopeItem.fromSession(opts.serializer, Session("dis", User(), "env", "0.0.1")),
             SentryEnvelopeItem.fromUserFeedback(opts.serializer, UserFeedback(SentryId(UUID.randomUUID()))),
@@ -75,10 +77,12 @@ class ClientReportTest {
         clientReportRecorder.recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope)
 
         val clientReportAtEnd = clientReportRecorder.resetCountsAndGenerateClientReport()
-        testHelper.assertTotalCount(13, clientReportAtEnd)
+        testHelper.assertTotalCount(15, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.SAMPLE_RATE, DataCategory.Error, 3, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.BEFORE_SEND, DataCategory.Error, 2, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.QUEUE_OVERFLOW, DataCategory.Transaction, 1, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Span, 1, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Transaction, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Error, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.UserReport, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Session, 1, clientReportAtEnd)
@@ -86,6 +90,29 @@ class ClientReportTest {
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Profile, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Monitor, 1, clientReportAtEnd)
         testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.MetricBucket, 1, clientReportAtEnd)
+    }
+
+    @Test
+    fun `lost transaction records dropped spans`() {
+        givenClientReportRecorder()
+        val scopes = mock<IScopes>()
+        whenever(scopes.options).thenReturn(opts)
+        val transaction = SentryTracer(TransactionContext("name", "op", TracesSamplingDecision(true)), scopes)
+        transaction.startChild("lost span", "span1").finish()
+        transaction.startChild("lost span", "span2").finish()
+        transaction.startChild("lost span", "span3").finish()
+        transaction.startChild("lost span", "span4").finish()
+
+        val envelope = testHelper.newEnvelope(
+            SentryEnvelopeItem.fromEvent(opts.serializer, SentryTransaction(transaction))
+        )
+
+        clientReportRecorder.recordLostEnvelope(DiscardReason.NETWORK_ERROR, envelope)
+
+        val clientReportAtEnd = clientReportRecorder.resetCountsAndGenerateClientReport()
+        testHelper.assertTotalCount(6, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Span, 5, clientReportAtEnd)
+        testHelper.assertCountFor(DiscardReason.NETWORK_ERROR, DataCategory.Transaction, 1, clientReportAtEnd)
     }
 
     @Test
@@ -189,7 +216,7 @@ class DropEverythingEventProcessor : EventProcessor {
 class ClientReportTestHelper(val options: SentryOptions) {
 
     val reasons = DiscardReason.values()
-    val categories = listOf(DataCategory.Error, DataCategory.Attachment, DataCategory.Session, DataCategory.Transaction, DataCategory.UserReport)
+    val categories = DataCategory.values()
 
     fun assertTotalCount(expectedCount: Long, clientReport: ClientReport?) {
         assertEquals(expectedCount, clientReport?.discardedEvents?.sumOf { it.quantity } ?: 0L)


### PR DESCRIPTION
## :scroll: Description
added span data category for client reports
added dropped span report when recording lostEnvelopeItem added dropped span report on beforeSend and eventProcessor filtering (SentryClient) and backpressure and sampleRate (Hub)


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3527, already added to main, now it's been merged in v8 branch, too


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
