### PR TITLE
Support spans that are split into multiple batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - `sentry-android-okhttp` has been removed in favor of `sentry-okhttp`, removing android dependency from the module ([#3510](https://github.com/getsentry/sentry-java/pull/3510))
 
+### Fixes
+
+- Support spans that are split into multiple batches ([#3539](https://github.com/getsentry/sentry-java/pull/3539))
+  - When spans belonging to a single transaction were split into multiple batches for SpanExporter, we did not add all spans because the isSpanTooOld check wasn't inverted.
+
 ## 8.0.0-alpha.2
 
 ### Behavioural Changes

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -105,7 +105,8 @@ public final class SentrySpanExporter implements SpanExporter {
     final @NotNull SentryInstantDate now = new SentryInstantDate();
 
     final @NotNull List<SpanData> nonExpired =
-        remaining.stream().filter((span) -> isSpanTooOld(span, now)).collect(Collectors.toList());
+        remaining.stream().filter((span) -> !isSpanTooOld(span, now)).collect(Collectors.toList());
+
     this.finishedSpans.addAll(nonExpired);
 
     // TODO


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Invert `isSpanTooOld` check so spans that haven't been sent to Sentry yet survive until the next invocation of `SpanExporter.export`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When spans belonging to a single transaction were split into multiple batches for `SpanExporter`, we did not add all spans because the `isSpanTooOld` check wasn't inverted.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
