### PR TITLE
[SR] Add `redactClasses` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `redactClasses` to Session Replay options ([#3546](https://github.com/getsentry/sentry-java/pull/3546))
+
 ## 7.11.0-alpha.2
 
 - Session Replay for Android ([#3339](https://github.com/getsentry/sentry-java/pull/3339))

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -232,6 +232,10 @@ sealed class ViewHierarchyNode(
             }
         }
 
+        private fun shouldRedact(view: View, options: SentryOptions): Boolean {
+            return options.experimental.sessionReplay.redactClasses.contains(view.javaClass.canonicalName)
+        }
+
         fun fromView(view: View, parent: ViewHierarchyNode?, distance: Int, options: SentryOptions): ViewHierarchyNode {
             val (isVisible, visibleRect) = view.isVisibleToUser()
             when {
@@ -282,7 +286,7 @@ sealed class ViewHierarchyNode(
                 (parent?.elevation ?: 0f) + view.elevation,
                 distance = distance,
                 parent = parent,
-                shouldRedact = options.experimental.sessionReplay.redactClasses.contains(view.javaClass.canonicalName),
+                shouldRedact = isVisible && shouldRedact(view, options),
                 isImportantForContentCapture = false, /* will be set by children */
                 isVisible = isVisible,
                 visibleRect = visibleRect

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -282,7 +282,7 @@ sealed class ViewHierarchyNode(
                 (parent?.elevation ?: 0f) + view.elevation,
                 distance = distance,
                 parent = parent,
-                shouldRedact = false,
+                shouldRedact = options.experimental.sessionReplay.redactClasses.contains(view.javaClass.canonicalName),
                 isImportantForContentCapture = false, /* will be set by children */
                 isVisible = isVisible,
                 visibleRect = visibleRect

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2701,6 +2701,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getQuality ()Lio/sentry/SentryReplayOptions$SentryReplayQuality;
 	public fun getRedactAllImages ()Z
 	public fun getRedactAllText ()Z
+	public fun getRedactClasses ()Ljava/util/Set;
 	public fun getSessionDuration ()J
 	public fun getSessionSampleRate ()Ljava/lang/Double;
 	public fun getSessionSegmentDuration ()J
@@ -2710,6 +2711,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun setQuality (Lio/sentry/SentryReplayOptions$SentryReplayQuality;)V
 	public fun setRedactAllImages (Z)V
 	public fun setRedactAllText (Z)V
+	public fun setRedactClasses (Ljava/util/Set;)V
 	public fun setSessionSampleRate (Ljava/lang/Double;)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2695,6 +2695,7 @@ public final class io/sentry/SentryReplayEvent$ReplayType$Deserializer : io/sent
 public final class io/sentry/SentryReplayOptions {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;)V
+	public fun addClassToRedact (Ljava/lang/String;)V
 	public fun getErrorReplayDuration ()J
 	public fun getErrorSampleRate ()Ljava/lang/Double;
 	public fun getFrameRate ()I
@@ -2711,7 +2712,6 @@ public final class io/sentry/SentryReplayOptions {
 	public fun setQuality (Lio/sentry/SentryReplayOptions$SentryReplayQuality;)V
 	public fun setRedactAllImages (Z)V
 	public fun setRedactAllText (Z)V
-	public fun setRedactClasses (Ljava/util/Set;)V
 	public fun setSessionSampleRate (Ljava/lang/Double;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -1,8 +1,8 @@
 package io.sentry;
 
 import io.sentry.util.SampleRateUtils;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -72,7 +72,7 @@ public final class SentryReplayOptions {
    *
    * <p>Default is empty.
    */
-  private Set<String> redactClasses = new HashSet<>();
+  private Set<String> redactClasses = new CopyOnWriteArraySet<>();
 
   /**
    * Defines the quality of the session replay. The higher the quality, the more accurate the replay
@@ -161,8 +161,8 @@ public final class SentryReplayOptions {
     return this.redactClasses;
   }
 
-  public void setRedactClasses(final Set<String> redactClasses) {
-    this.redactClasses = redactClasses;
+  public void addClassToRedact(final String className) {
+    this.redactClasses.add(className);
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -1,6 +1,8 @@
 package io.sentry;
 
 import io.sentry.util.SampleRateUtils;
+import java.util.HashSet;
+import java.util.Set;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -63,6 +65,14 @@ public final class SentryReplayOptions {
    * <p>Default is enabled.
    */
   private boolean redactAllImages = true;
+
+  /**
+   * Redact all views with the specified class names. The class name is the fully qualified class
+   * name of the view, e.g. android.widget.TextView.
+   *
+   * <p>Default is empty.
+   */
+  private Set<String> redactClasses = new HashSet<>();
 
   /**
    * Defines the quality of the session replay. The higher the quality, the more accurate the replay
@@ -145,6 +155,14 @@ public final class SentryReplayOptions {
 
   public void setRedactAllImages(final boolean redactAllImages) {
     this.redactAllImages = redactAllImages;
+  }
+
+  public Set<String> getRedactClasses() {
+    return this.redactClasses;
+  }
+
+  public void setRedactClasses(final Set<String> redactClasses) {
+    this.redactClasses = redactClasses;
   }
 
   @ApiStatus.Internal


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This adds option to redact any java class selected by users. 

This can be also used by React Native to redact SVGs.
 
- https://github.com/getsentry/sentry-react-native/pull/3930

## :green_heart: How did you test it?
rn sample app

![Screenshot 2024-07-03 at 14 12 06](https://github.com/getsentry/sentry-java/assets/31292499/6e76b641-c676-4031-b8c3-b584c7fa384e)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog 