### PR TITLE
Change OkHttp sub-spans to span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- Change OkHttp sub-spans to span attributes ([#3556](https://github.com/getsentry/sentry-java/pull/3556))
+  - This will reduce the number of spans created by the SDK
+
 ## 8.0.0-alpha.4
 
 ### Fixes

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
@@ -7,13 +7,6 @@ import io.sentry.ISpan
 import io.sentry.SentryDate
 import io.sentry.SpanDataConvention
 import io.sentry.TypeCheckHint
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.CONNECTION_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.CONNECT_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.REQUEST_BODY_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.REQUEST_HEADERS_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_BODY_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.RESPONSE_HEADERS_EVENT
-import io.sentry.okhttp.SentryOkHttpEventListener.Companion.SECURE_CONNECT_EVENT
 import io.sentry.util.Platform
 import io.sentry.util.UrlUtils
 import okhttp3.Request
@@ -30,9 +23,8 @@ internal const val TRACE_ORIGIN = "auto.http.okhttp"
 @Suppress("TooManyFunctions")
 internal class SentryOkHttpEvent(private val scopes: IScopes, private val request: Request) {
     private val eventDates: MutableMap<String, SentryDate> = ConcurrentHashMap()
-    private val eventSubSpansNanos: MutableMap<String, Long> = ConcurrentHashMap()
     private val breadcrumb: Breadcrumb
-    internal val callRootSpan: ISpan?
+    internal val callSpan: ISpan?
     private var response: Response? = null
     private var clientErrorResponse: Response? = null
     private val isEventFinished = AtomicBoolean(false)
@@ -48,52 +40,52 @@ internal class SentryOkHttpEvent(private val scopes: IScopes, private val reques
 
         // We start the call span that will contain all the others
         val parentSpan = if (Platform.isAndroid()) scopes.transaction else scopes.span
-        callRootSpan = parentSpan?.startChild("http.client", "$method $url")
-        callRootSpan?.spanContext?.origin = TRACE_ORIGIN
-        urlDetails.applyToSpan(callRootSpan)
+        callSpan = parentSpan?.startChild("http.client", "$method $url")
+        callSpan?.spanContext?.origin = TRACE_ORIGIN
+        urlDetails.applyToSpan(callSpan)
 
         // We setup a breadcrumb with all meaningful data
         breadcrumb = Breadcrumb.http(url, method)
         breadcrumb.setData("host", host)
         breadcrumb.setData("path", encodedPath)
 
-        // We add the same data to the root call span
-        callRootSpan?.setData("url", url)
-        callRootSpan?.setData("host", host)
-        callRootSpan?.setData("path", encodedPath)
-        callRootSpan?.setData(SpanDataConvention.HTTP_METHOD_KEY, method.uppercase(Locale.ROOT))
+        // We add the same data to the call span
+        callSpan?.setData("url", url)
+        callSpan?.setData("host", host)
+        callSpan?.setData("path", encodedPath)
+        callSpan?.setData(SpanDataConvention.HTTP_METHOD_KEY, method.uppercase(Locale.ROOT))
     }
 
     /**
      * Sets the [Response] that will be sent in the breadcrumb [Hint].
-     * Also, it sets the protocol and status code in the breadcrumb and the call root span.
+     * Also, it sets the protocol and status code in the breadcrumb and the call span.
      */
     fun setResponse(response: Response) {
         this.response = response
         breadcrumb.setData(PROTOCOL_KEY, response.protocol.name)
         breadcrumb.setData("status_code", response.code)
-        callRootSpan?.setData(PROTOCOL_KEY, response.protocol.name)
-        callRootSpan?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
+        callSpan?.setData(PROTOCOL_KEY, response.protocol.name)
+        callSpan?.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
     }
 
     fun setProtocol(protocolName: String?) {
         if (protocolName != null) {
             breadcrumb.setData(PROTOCOL_KEY, protocolName)
-            callRootSpan?.setData(PROTOCOL_KEY, protocolName)
+            callSpan?.setData(PROTOCOL_KEY, protocolName)
         }
     }
 
     fun setRequestBodySize(byteCount: Long) {
         if (byteCount > -1) {
             breadcrumb.setData("request_content_length", byteCount)
-            callRootSpan?.setData("http.request_content_length", byteCount)
+            callSpan?.setData("http.request_content_length", byteCount)
         }
     }
 
     fun setResponseBodySize(byteCount: Long) {
         if (byteCount > -1) {
             breadcrumb.setData("response_content_length", byteCount)
-            callRootSpan?.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
+            callSpan?.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
         }
     }
 
@@ -105,40 +97,33 @@ internal class SentryOkHttpEvent(private val scopes: IScopes, private val reques
     fun setError(errorMessage: String?) {
         if (errorMessage != null) {
             breadcrumb.setData(ERROR_MESSAGE_KEY, errorMessage)
-            callRootSpan?.setData(ERROR_MESSAGE_KEY, errorMessage)
+            callSpan?.setData(ERROR_MESSAGE_KEY, errorMessage)
         }
     }
 
-    /** Starts a span, if the callRootSpan is not null. */
-    fun startSpan(event: String) {
-        callRootSpan ?: return
+    /** Record event start if the callRootSpan is not null. */
+    fun onEventStart(event: String) {
+        callSpan ?: return
         eventDates[event] = scopes.options.dateProvider.now()
     }
 
-    /** Finishes a previously started span, and runs [beforeFinish] on it, on its parent and on the call root span. */
-    fun finishSpan(event: String, beforeFinish: ((span: ISpan) -> Unit)? = null) {
-        callRootSpan ?: return
-        beforeFinish?.invoke(callRootSpan)
-        eventDates.remove(event)?.let { date ->
-            val subSpansNanos = eventSubSpansNanos[event] ?: 0
-            val eventDurationNanos = scopes.options.dateProvider.now().diff(date) - subSpansNanos
-            val parentEvent = findParentEvent(event)
-            parentEvent?.let { eventSubSpansNanos[it] = (eventSubSpansNanos[it] ?: 0) + eventDurationNanos }
-            callRootSpan.setData(event, TimeUnit.NANOSECONDS.toMillis(eventDurationNanos))
-        }
+    /** Record event finish and runs [beforeFinish] on the call span. */
+    fun onEventFinish(event: String, beforeFinish: ((span: ISpan) -> Unit)? = null) {
+        val eventDate = eventDates.remove(event) ?: return
+        callSpan ?: return
+        beforeFinish?.invoke(callSpan)
+        val eventDurationNanos = scopes.options.dateProvider.now().diff(eventDate)
+        callSpan.setData(event, TimeUnit.NANOSECONDS.toMillis(eventDurationNanos))
     }
 
-    /** Finishes the call root span, and runs [beforeFinish] on it. Then a breadcrumb is sent. */
-    fun finishEvent(beforeFinish: ((span: ISpan) -> Unit)? = null) {
-        eventDates.keys.forEach {
-            finishSpan(it)
-        }
-        eventSubSpansNanos.clear()
-        eventDates.clear()
+    /** Finishes the call span, and runs [beforeFinish] on it. Then a breadcrumb is sent. */
+    fun finish(beforeFinish: ((span: ISpan) -> Unit)? = null) {
         // If the event already finished, we don't do anything
         if (isEventFinished.getAndSet(true)) {
             return
         }
+        // We clear any date left, in case an event started, but never finished. Shouldn't happen.
+        eventDates.clear()
         // We put data in the hint and send a breadcrumb
         val hint = Hint()
         hint.set(TypeCheckHint.OKHTTP_REQUEST, request)
@@ -147,22 +132,12 @@ internal class SentryOkHttpEvent(private val scopes: IScopes, private val reques
         // We send the breadcrumb even without spans.
         scopes.addBreadcrumb(breadcrumb, hint)
 
-        callRootSpan?.let { beforeFinish?.invoke(it) }
-        // We report the client error here so that it will be bound to the root call span. We send it even if there is no running span.
+        callSpan?.let { beforeFinish?.invoke(it) }
+        // We report the client error here so that it will be bound to the call span. We send it even if there is no running span.
         clientErrorResponse?.let {
             SentryOkHttpUtils.captureClientError(scopes, it.request, it)
         }
-        callRootSpan?.finish()
+        callSpan?.finish()
         return
-    }
-
-    private fun findParentEvent(event: String): String? = when (event) {
-        // PROXY_SELECT, DNS, CONNECT and CONNECTION are not children of one another
-        SECURE_CONNECT_EVENT -> CONNECT_EVENT
-        REQUEST_HEADERS_EVENT -> CONNECTION_EVENT
-        REQUEST_BODY_EVENT -> CONNECTION_EVENT
-        RESPONSE_HEADERS_EVENT -> CONNECTION_EVENT
-        RESPONSE_BODY_EVENT -> CONNECTION_EVENT
-        else -> null
     }
 }

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -48,15 +48,15 @@ public open class SentryOkHttpEventListener(
     private var originalEventListener: EventListener? = null
 
     public companion object {
-        internal const val PROXY_SELECT_EVENT = "proxy_select"
-        internal const val DNS_EVENT = "dns"
-        internal const val SECURE_CONNECT_EVENT = "secure_connect"
-        internal const val CONNECT_EVENT = "connect"
-        internal const val CONNECTION_EVENT = "connection"
-        internal const val REQUEST_HEADERS_EVENT = "request_headers"
-        internal const val REQUEST_BODY_EVENT = "request_body"
-        internal const val RESPONSE_HEADERS_EVENT = "response_headers"
-        internal const val RESPONSE_BODY_EVENT = "response_body"
+        internal const val PROXY_SELECT_EVENT = "http.proxy_select_ms"
+        internal const val DNS_EVENT = "http.dns_ms"
+        internal const val SECURE_CONNECT_EVENT = "http.secure_connect_ms"
+        internal const val CONNECT_EVENT = "http.connect_ms"
+        internal const val CONNECTION_EVENT = "http.connection_ms"
+        internal const val REQUEST_HEADERS_EVENT = "http.request_headers_ms"
+        internal const val REQUEST_BODY_EVENT = "http.request_body_ms"
+        internal const val RESPONSE_HEADERS_EVENT = "http.response_headers_ms"
+        internal const val RESPONSE_BODY_EVENT = "http.response_body_ms"
 
         internal val eventMap: MutableMap<Call, SentryOkHttpEvent> = ConcurrentHashMap()
     }
@@ -311,14 +311,13 @@ public open class SentryOkHttpEventListener(
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setResponse(response)
-        val responseHeadersSpan = okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
+        okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
             it.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
             // Let's not override the status of a span that was set
             if (it.status == null) {
                 it.status = SpanStatus.fromHttpStatusCode(response.code)
             }
         }
-        okHttpEvent.scheduleFinish(responseHeadersSpan?.finishDate ?: scopes.options.dateProvider.now())
     }
 
     override fun responseBodyStart(call: Call) {

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEventListener.kt
@@ -48,15 +48,15 @@ public open class SentryOkHttpEventListener(
     private var originalEventListener: EventListener? = null
 
     public companion object {
-        internal const val PROXY_SELECT_EVENT = "http.proxy_select_ms"
-        internal const val DNS_EVENT = "http.dns_ms"
-        internal const val SECURE_CONNECT_EVENT = "http.secure_connect_ms"
+        internal const val PROXY_SELECT_EVENT = "http.client.proxy_select_ms"
+        internal const val DNS_EVENT = "http.client.resolve_dns_ms"
         internal const val CONNECT_EVENT = "http.connect_ms"
+        internal const val SECURE_CONNECT_EVENT = "http.connect.secure_connect_ms"
         internal const val CONNECTION_EVENT = "http.connection_ms"
-        internal const val REQUEST_HEADERS_EVENT = "http.request_headers_ms"
-        internal const val REQUEST_BODY_EVENT = "http.request_body_ms"
-        internal const val RESPONSE_HEADERS_EVENT = "http.response_headers_ms"
-        internal const val RESPONSE_BODY_EVENT = "http.response_body_ms"
+        internal const val REQUEST_HEADERS_EVENT = "http.connection.request_headers_ms"
+        internal const val REQUEST_BODY_EVENT = "http.connection.request_body_ms"
+        internal const val RESPONSE_HEADERS_EVENT = "http.connection.response_headers_ms"
+        internal const val RESPONSE_BODY_EVENT = "http.connection.response_body_ms"
 
         internal val eventMap: MutableMap<Call, SentryOkHttpEvent> = ConcurrentHashMap()
     }
@@ -102,7 +102,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(PROXY_SELECT_EVENT)
+        okHttpEvent.onEventStart(PROXY_SELECT_EVENT)
     }
 
     override fun proxySelectEnd(
@@ -115,7 +115,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(PROXY_SELECT_EVENT) {
+        okHttpEvent.onEventFinish(PROXY_SELECT_EVENT) {
             if (proxies.isNotEmpty()) {
                 it.setData("proxies", proxies.joinToString { proxy -> proxy.toString() })
             }
@@ -128,7 +128,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(DNS_EVENT)
+        okHttpEvent.onEventStart(DNS_EVENT)
     }
 
     override fun dnsEnd(
@@ -141,7 +141,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(DNS_EVENT) {
+        okHttpEvent.onEventFinish(DNS_EVENT) {
             it.setData("domain_name", domainName)
             if (inetAddressList.isNotEmpty()) {
                 it.setData("dns_addresses", inetAddressList.joinToString { address -> address.toString() })
@@ -159,7 +159,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(CONNECT_EVENT)
+        okHttpEvent.onEventStart(CONNECT_EVENT)
     }
 
     override fun secureConnectStart(call: Call) {
@@ -168,7 +168,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(SECURE_CONNECT_EVENT)
+        okHttpEvent.onEventStart(SECURE_CONNECT_EVENT)
     }
 
     override fun secureConnectEnd(call: Call, handshake: Handshake?) {
@@ -177,7 +177,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(SECURE_CONNECT_EVENT)
+        okHttpEvent.onEventFinish(SECURE_CONNECT_EVENT)
     }
 
     override fun connectEnd(
@@ -192,7 +192,7 @@ public open class SentryOkHttpEventListener(
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setProtocol(protocol?.name)
-        okHttpEvent.finishSpan(CONNECT_EVENT)
+        okHttpEvent.onEventFinish(CONNECT_EVENT)
     }
 
     override fun connectFailed(
@@ -209,7 +209,7 @@ public open class SentryOkHttpEventListener(
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setProtocol(protocol?.name)
         okHttpEvent.setError(ioe.message)
-        okHttpEvent.finishSpan(CONNECT_EVENT) {
+        okHttpEvent.onEventFinish(CONNECT_EVENT) {
             it.throwable = ioe
             it.status = SpanStatus.INTERNAL_ERROR
         }
@@ -221,7 +221,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(CONNECTION_EVENT)
+        okHttpEvent.onEventStart(CONNECTION_EVENT)
     }
 
     override fun connectionReleased(call: Call, connection: Connection) {
@@ -230,7 +230,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(CONNECTION_EVENT)
+        okHttpEvent.onEventFinish(CONNECTION_EVENT)
     }
 
     override fun requestHeadersStart(call: Call) {
@@ -239,7 +239,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(REQUEST_HEADERS_EVENT)
+        okHttpEvent.onEventStart(REQUEST_HEADERS_EVENT)
     }
 
     override fun requestHeadersEnd(call: Call, request: Request) {
@@ -248,7 +248,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(REQUEST_HEADERS_EVENT)
+        okHttpEvent.onEventFinish(REQUEST_HEADERS_EVENT)
     }
 
     override fun requestBodyStart(call: Call) {
@@ -257,7 +257,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(REQUEST_BODY_EVENT)
+        okHttpEvent.onEventStart(REQUEST_BODY_EVENT)
     }
 
     override fun requestBodyEnd(call: Call, byteCount: Long) {
@@ -266,7 +266,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.finishSpan(REQUEST_BODY_EVENT) {
+        okHttpEvent.onEventFinish(REQUEST_BODY_EVENT) {
             if (byteCount > 0) {
                 it.setData("http.request_content_length", byteCount)
             }
@@ -283,13 +283,13 @@ public open class SentryOkHttpEventListener(
         okHttpEvent.setError(ioe.message)
         // requestFailed can happen after requestHeaders or requestBody.
         // If requestHeaders already finished, we don't change its status.
-        okHttpEvent.finishSpan(REQUEST_HEADERS_EVENT) {
+        okHttpEvent.onEventFinish(REQUEST_HEADERS_EVENT) {
             if (!it.isFinished) {
                 it.status = SpanStatus.INTERNAL_ERROR
                 it.throwable = ioe
             }
         }
-        okHttpEvent.finishSpan(REQUEST_BODY_EVENT) {
+        okHttpEvent.onEventFinish(REQUEST_BODY_EVENT) {
             it.status = SpanStatus.INTERNAL_ERROR
             it.throwable = ioe
         }
@@ -301,7 +301,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(RESPONSE_HEADERS_EVENT)
+        okHttpEvent.onEventStart(RESPONSE_HEADERS_EVENT)
     }
 
     override fun responseHeadersEnd(call: Call, response: Response) {
@@ -311,7 +311,7 @@ public open class SentryOkHttpEventListener(
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setResponse(response)
-        okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
+        okHttpEvent.onEventFinish(RESPONSE_HEADERS_EVENT) {
             it.setData(SpanDataConvention.HTTP_STATUS_CODE_KEY, response.code)
             // Let's not override the status of a span that was set
             if (it.status == null) {
@@ -326,7 +326,7 @@ public open class SentryOkHttpEventListener(
             return
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
-        okHttpEvent.startSpan(RESPONSE_BODY_EVENT)
+        okHttpEvent.onEventStart(RESPONSE_BODY_EVENT)
     }
 
     override fun responseBodyEnd(call: Call, byteCount: Long) {
@@ -336,7 +336,7 @@ public open class SentryOkHttpEventListener(
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap[call] ?: return
         okHttpEvent.setResponseBodySize(byteCount)
-        okHttpEvent.finishSpan(RESPONSE_BODY_EVENT) {
+        okHttpEvent.onEventFinish(RESPONSE_BODY_EVENT) {
             if (byteCount > 0) {
                 it.setData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY, byteCount)
             }
@@ -352,13 +352,13 @@ public open class SentryOkHttpEventListener(
         okHttpEvent.setError(ioe.message)
         // responseFailed can happen after responseHeaders or responseBody.
         // If responseHeaders already finished, we don't change its status.
-        okHttpEvent.finishSpan(RESPONSE_HEADERS_EVENT) {
+        okHttpEvent.onEventFinish(RESPONSE_HEADERS_EVENT) {
             if (!it.isFinished) {
                 it.status = SpanStatus.INTERNAL_ERROR
                 it.throwable = ioe
             }
         }
-        okHttpEvent.finishSpan(RESPONSE_BODY_EVENT) {
+        okHttpEvent.onEventFinish(RESPONSE_BODY_EVENT) {
             it.status = SpanStatus.INTERNAL_ERROR
             it.throwable = ioe
         }
@@ -367,7 +367,7 @@ public open class SentryOkHttpEventListener(
     override fun callEnd(call: Call) {
         originalEventListener?.callEnd(call)
         val okHttpEvent: SentryOkHttpEvent = eventMap.remove(call) ?: return
-        okHttpEvent.finishEvent()
+        okHttpEvent.finish()
     }
 
     override fun callFailed(call: Call, ioe: IOException) {
@@ -377,7 +377,7 @@ public open class SentryOkHttpEventListener(
         }
         val okHttpEvent: SentryOkHttpEvent = eventMap.remove(call) ?: return
         okHttpEvent.setError(ioe.message)
-        okHttpEvent.finishEvent {
+        okHttpEvent.finish {
             it.status = SpanStatus.INTERNAL_ERROR
             it.throwable = ioe
         }

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -133,7 +133,7 @@ public open class SentryOkHttpInterceptor(
             }
             throw e
         } finally {
-            finishSpan(span, request, response, isFromEventListener)
+            finishSpan(span, request, response, isFromEventListener, okHttpEvent)
 
             // The SentryOkHttpEventListener will send the breadcrumb itself if used for this call
             if (!isFromEventListener) {
@@ -160,7 +160,7 @@ public open class SentryOkHttpInterceptor(
         scopes.addBreadcrumb(breadcrumb, hint)
     }
 
-    private fun finishSpan(span: ISpan?, request: Request, response: Response?, isFromEventListener: Boolean) {
+    private fun finishSpan(span: ISpan?, request: Request, response: Response?, isFromEventListener: Boolean, okHttpEvent: SentryOkHttpEvent?) {
         if (span == null) {
             return
         }
@@ -170,16 +170,12 @@ public open class SentryOkHttpInterceptor(
                 // span is dropped
                 span.spanContext.sampled = false
             }
-            // The SentryOkHttpEventListener will finish the span itself if used for this call
-            if (!isFromEventListener) {
-                span.finish()
-            }
-        } else {
-            // The SentryOkHttpEventListener will finish the span itself if used for this call
-            if (!isFromEventListener) {
-                span.finish()
-            }
         }
+        // The SentryOkHttpEventListener will finish the span itself if used for this call
+        if (!isFromEventListener) {
+            span.finish()
+        }
+        okHttpEvent?.finishEvent()
     }
 
     private fun Long?.ifHasValidLength(fn: (Long) -> Unit) {

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -72,7 +72,7 @@ public open class SentryOkHttpInterceptor(
         if (SentryOkHttpEventListener.eventMap.containsKey(chain.call())) {
             // read the span from the event listener
             okHttpEvent = SentryOkHttpEventListener.eventMap[chain.call()]
-            span = okHttpEvent?.callRootSpan
+            span = okHttpEvent?.callSpan
         } else {
             // read the span from the bound scope
             okHttpEvent = null
@@ -171,11 +171,11 @@ public open class SentryOkHttpInterceptor(
                 span.spanContext.sampled = false
             }
         }
-        // The SentryOkHttpEventListener will finish the span itself if used for this call
         if (!isFromEventListener) {
             span.finish()
         }
-        okHttpEvent?.finishEvent()
+        // The SentryOkHttpEventListener waits until the response is closed (which may never happen), so we close it here
+        okHttpEvent?.finish()
     }
 
     private fun Long?.ifHasValidLength(fn: (Long) -> Unit) {

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpEventListenerTest.kt
@@ -8,7 +8,6 @@ import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
-import io.sentry.test.ImmediateExecutorService
 import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
@@ -23,7 +22,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -135,7 +133,7 @@ class SentryOkHttpEventListenerTest {
         val call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
         response.close()
         assertNotNull(callSpan)
         assertEquals(callSpan, fixture.sentryTracer.children.first())
@@ -146,76 +144,40 @@ class SentryOkHttpEventListenerTest {
     }
 
     @Test
-    fun `creates a span for each event`() {
+    fun `adds a data for each event`() {
         val sut = fixture.getSut()
         val request = getRequest()
         val call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
         response.close()
-        assertEquals(8, fixture.sentryTracer.children.size)
-        fixture.sentryTracer.children.forEachIndexed { index, span ->
-            assertTrue(span.isFinished)
-            when (index) {
-                0 -> {
-                    assertEquals(callSpan, span)
-                    assertEquals("GET ${request.url}", span.description)
-                    assertNotNull(span.data["proxies"])
-                    assertNotNull(span.data["domain_name"])
-                    assertNotNull(span.data["dns_addresses"])
-                    assertEquals(201, span.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
-                }
-                1 -> {
-                    assertEquals("http.client.proxy_select", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                    assertNotNull(span.data["proxies"])
-                }
-                2 -> {
-                    assertEquals("http.client.dns", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                    assertNotNull(span.data["domain_name"])
-                    assertNotNull(span.data["dns_addresses"])
-                }
-                3 -> {
-                    assertEquals("http.client.connect", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                }
-                4 -> {
-                    assertEquals("http.client.connection", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                }
-                5 -> {
-                    assertEquals("http.client.request_headers", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                }
-                6 -> {
-                    assertEquals("http.client.response_headers", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                    assertEquals(201, span.data[SpanDataConvention.HTTP_STATUS_CODE_KEY])
-                }
-                7 -> {
-                    assertEquals("http.client.response_body", span.operation)
-                    assertEquals("GET ${request.url}", span.description)
-                }
-            }
-        }
+        assertEquals(1, fixture.sentryTracer.children.size)
+        assertNotNull(callSpan)
+        assertNotNull(callSpan.getData("proxies"))
+        assertNotNull(callSpan.getData("domain_name"))
+        assertNotNull(callSpan.getData("dns_addresses"))
+        assertEquals(201, callSpan.getData(SpanDataConvention.HTTP_STATUS_CODE_KEY))
+        assertNotNull(callSpan.getData("http.client.proxy_select_ms"))
+        assertNotNull(callSpan.getData("http.client.resolve_dns_ms"))
+        assertNotNull(callSpan.getData("http.connect_ms"))
+        assertNotNull(callSpan.getData("http.connection_ms"))
+        assertNotNull(callSpan.getData("http.connection.request_headers_ms"))
+        assertNotNull(callSpan.getData("http.connection.response_headers_ms"))
+        assertNotNull(callSpan.getData("http.connection.response_body_ms"))
     }
 
     @Test
-    fun `has requestBody span for requests with body`() {
+    fun `has requestBody data for requests with body`() {
         val sut = fixture.getSut()
         val requestBody = "request body sent in the request"
         val request = postRequest(body = requestBody)
         val call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
         response.close()
-        assertEquals(9, fixture.sentryTracer.children.size)
-        val requestBodySpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.request_body" }
-        assertNotNull(requestBodySpan)
-        assertEquals(requestBody.toByteArray().size.toLong(), requestBodySpan.data["http.request_content_length"])
+        assertNotNull(callSpan?.getData("http.connection.request_body_ms"))
         assertEquals(requestBody.toByteArray().size.toLong(), callSpan?.getData("http.request_content_length"))
     }
 
@@ -227,19 +189,15 @@ class SentryOkHttpEventListenerTest {
         val call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
+        assertNull(callSpan?.getData("http.connection.response_body_ms"))
 
         // Consume the response
         val responseBytes = response.body?.byteStream()?.readBytes()
         assertNotNull(responseBytes)
+        assertNotNull(callSpan?.getData("http.connection.response_body_ms"))
 
         response.close()
-        val requestBodySpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_body" }
-        assertNotNull(requestBodySpan)
-        assertEquals(
-            responseBytes.size.toLong(),
-            requestBodySpan.data[SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY]
-        )
         assertEquals(
             responseBytes.size.toLong(),
             callSpan?.getData(SpanDataConvention.HTTP_RESPONSE_CONTENT_LENGTH_KEY)
@@ -247,13 +205,13 @@ class SentryOkHttpEventListenerTest {
     }
 
     @Test
-    fun `root call span status depends on http status code`() {
+    fun `call span status depends on http status code`() {
         val sut = fixture.getSut(httpStatusCode = 404)
         val request = getRequest()
         val call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
         response.close()
         assertNotNull(callSpan)
         assertEquals(SpanStatus.fromHttpStatusCode(404), callSpan.status)
@@ -314,79 +272,16 @@ class SentryOkHttpEventListenerTest {
         val response = call.execute()
         response.close()
         // Spans are created by the originalListener, so the listener doesn't create duplicates
-        assertEquals(9, fixture.sentryTracer.children.size)
+        assertEquals(1, fixture.sentryTracer.children.size)
     }
 
     @Test
-    fun `status propagates to parent span and call root span`() {
-        val sut = fixture.getSut(httpStatusCode = 500)
-        val request = getRequest()
-        val call = sut.newCall(request)
-        val response = call.execute()
-        val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
-        val responseHeaderSpan =
-            fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_headers" }
-        val connectionSpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.connection" }
-        response.close()
-        assertNotNull(callSpan)
-        assertNotNull(responseHeaderSpan)
-        assertNotNull(connectionSpan)
-        assertEquals(SpanStatus.fromHttpStatusCode(500), callSpan.status)
-        assertEquals(SpanStatus.fromHttpStatusCode(500), responseHeaderSpan.status)
-        assertEquals(SpanStatus.fromHttpStatusCode(500), connectionSpan.status)
-    }
-
-    @Test
-    fun `when response is not closed, root call is trimmed to responseHeadersEnd`() {
-        val sut = fixture.getSut(
-            httpStatusCode = 500,
-            configureOptions = { it.executorService = ImmediateExecutorService() }
-        )
-        val request = getRequest()
-        val call = sut.newCall(request)
-        val response = spy(call.execute())
-        val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
-        val responseHeaderSpan =
-            fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_headers" }
-        val responseBodySpan = fixture.sentryTracer.children.firstOrNull { it.operation == "http.client.response_body" }
-
-        // Response is not finished
-        verify(response, never()).close()
-
-        // response body span is never started
-        assertNull(responseBodySpan)
-
-        assertNotNull(callSpan)
-        assertNotNull(responseHeaderSpan)
-
-        // Call span is trimmed to responseHeader finishTimestamp
-        assertEquals(callSpan.finishDate?.nanoTimestamp(), responseHeaderSpan.finishDate?.nanoTimestamp())
-
-        // All children spans of the root call are finished
-        assertTrue(fixture.sentryTracer.children.all { it.isFinished })
-    }
-
-    @Test
-    fun `responseHeadersEnd schedules event finish`() {
-        val listener = SentryOkHttpEventListener(fixture.scopes, fixture.mockEventListener)
-        whenever(fixture.scopes.options).thenReturn(SentryOptions())
-        val call = mock<Call>()
-        whenever(call.request()).thenReturn(getRequest())
-        val okHttpEvent = mock<SentryOkHttpEvent>()
-        SentryOkHttpEventListener.eventMap[call] = okHttpEvent
-        listener.responseHeadersEnd(call, mock())
-        verify(okHttpEvent).scheduleFinish(any())
-    }
-
-    @Test
-    fun `call root span status is not overridden if not null`() {
+    fun `call span status is not overridden if not null`() {
         val mockListener = mock<EventListener>()
         lateinit var call: Call
         whenever(mockListener.connectStart(any(), anyOrNull(), anyOrNull())).then {
             val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-            val callSpan = okHttpEvent?.callRootSpan
+            val callSpan = okHttpEvent?.callSpan
             assertNotNull(callSpan)
             assertNull(callSpan.status)
             callSpan.status = SpanStatus.UNKNOWN
@@ -397,7 +292,7 @@ class SentryOkHttpEventListenerTest {
         call = sut.newCall(request)
         val response = call.execute()
         val okHttpEvent = SentryOkHttpEventListener.eventMap[call]
-        val callSpan = okHttpEvent?.callRootSpan
+        val callSpan = okHttpEvent?.callSpan
         assertNotNull(callSpan)
         response.close()
         assertEquals(SpanStatus.UNKNOWN, callSpan.status)

--- a/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpInterceptorTest.kt
+++ b/sentry-okhttp/src/test/java/io/sentry/okhttp/SentryOkHttpInterceptorTest.kt
@@ -13,6 +13,7 @@ import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.Span
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
@@ -583,5 +584,17 @@ class SentryOkHttpInterceptorTest {
         SentryOkHttpEventListener.eventMap[call] = mock()
         call.execute()
         verify(fixture.scopes, never()).captureEvent(any(), any<Hint>())
+    }
+
+    @Test
+    fun `when a call is captured by SentryOkHttpEventListener, interceptor finishes event`() {
+        val sut = fixture.getSut()
+        val call = sut.newCall(getRequest())
+        val event = mock<SentryOkHttpEvent>()
+        val span = Span(mock(), fixture.sentryTracer, fixture.scopes, mock())
+        whenever(event.callSpan).thenReturn(span)
+        SentryOkHttpEventListener.eventMap[call] = event
+        call.execute()
+        verify(event).finish()
     }
 }


### PR DESCRIPTION
## :scroll: Description
SentryOkHttpEvent now set data instead of creating child spans
renamed constants to make them nicer in the UI
SentryOkHttpInterceptor now closes the listener call

[Before](https://sentry-sdks.sentry.io/performance/trace/9e4523f514dd49cf8e6902a3de94af25/?node=span-080479a614234019&node=txn-4f56a4eb30da4150ac7d0818e99a10fb&project=5428559&query=&referrer=performance-transaction-summary&showTransactions=recent&source=performance_transaction_summary&statsPeriod=14d&timestamp=1719498761&transaction=SecondActivity&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)

![Screenshot 2024-07-08 at 12 06 37](https://github.com/getsentry/sentry-java/assets/16819053/c931f88f-41d3-4181-ae2e-636f67a76e28)


[After](https://sentry-sdks.sentry.io/performance/trace/d8e2db038c254758b419da8a57c3ecb7/?node=span-6eb58507b1fa4033&node=txn-6ec8c14919854bcb822eb364d7201a76&project=5428559&query=&referrer=performance-transaction-summary&showTransactions=recent&source=performance_transaction_summary&statsPeriod=1h&timestamp=1720446593&transaction=SecondActivity&transactionCursor=0%3A0%3A1&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)

<img width="1464" alt="Screenshot 2024-07-08 at 15 52 02" src="https://github.com/getsentry/sentry-java/assets/16819053/e2b60ad8-9148-474f-8d71-f2b4c6b13976">


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/3520


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
