### PR TITLE
POTEL 35 - Use OtelSpan name as fallback for transaction name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use OpenTelemetry span name as fallback for transaction name ([#3557](https://github.com/getsentry/sentry-java/pull/3557))
+  - In certain cases we were sending transactions as "<unlabeled transaction>" when using OpenTelemetry 
+
 ## 8.0.0-alpha.4
 
 ### Fixes

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -66,11 +66,10 @@ public final class SpanDescriptionExtractor {
     }
 
     final @NotNull String name = otelSpan.getName();
-    final @Nullable String description = sentrySpan != null ? sentrySpan.getDescription() : name;
-    return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
     final @Nullable String maybeDescription =
         sentrySpan != null ? sentrySpan.getDescription() : name;
     final @NotNull String description = maybeDescription != null ? maybeDescription : name;
+    return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -68,7 +68,8 @@ public final class SpanDescriptionExtractor {
     final @NotNull String name = otelSpan.getName();
     final @Nullable String description = sentrySpan != null ? sentrySpan.getDescription() : name;
     return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
-    final @Nullable String maybeDescription = sentrySpan != null ? sentrySpan.getDescription() : name;
+    final @Nullable String maybeDescription =
+        sentrySpan != null ? sentrySpan.getDescription() : name;
     final @NotNull String description = maybeDescription != null ? maybeDescription : name;
   }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -68,6 +68,8 @@ public final class SpanDescriptionExtractor {
     final @NotNull String name = otelSpan.getName();
     final @Nullable String description = sentrySpan != null ? sentrySpan.getDescription() : name;
     return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
+    final @Nullable String maybeDescription = sentrySpan != null ? sentrySpan.getDescription() : name;
+    final @NotNull String description = maybeDescription != null ? maybeDescription : name;
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
## :scroll: Description
Fallback to otelspan name as transaction description if sentry span description is null


## :bulb: Motivation and Context
Avoid having `<unlabeled transaction>` as label in sentry.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
