### PR TITLE
[SR] Redaction fixes for RN

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -130,9 +130,10 @@ internal class ScreenshotRecorder(
                                 if (node.shouldRedact && (node.width > 0 && node.height > 0)) {
                                     node.visibleRect ?: return@traverse false
 
-                                    if (viewHierarchy.isObscured(node)) {
-                                        return@traverse true
-                                    }
+                                    // TODO: investigate why it returns true on RN when it shouldn't
+//                                    if (viewHierarchy.isObscured(node)) {
+//                                        return@traverse true
+//                                    }
 
                                     val (visibleRects, color) = when (node) {
                                         is ImageViewHierarchyNode -> {
@@ -141,6 +142,8 @@ internal class ScreenshotRecorder(
                                         }
 
                                         is TextViewHierarchyNode -> {
+                                            // TODO: find a way to get the correct text color for RN
+                                            // TODO: now it always returns black
                                             node.layout.getVisibleRects(
                                                 node.visibleRect,
                                                 node.paddingLeft,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -67,7 +67,11 @@ internal fun Layout?.getVisibleRects(globalRect: Rect, paddingLeft: Int, padding
     for (i in 0 until lineCount) {
         val lineStart = getPrimaryHorizontal(getLineStart(i)).toInt()
         val ellipsisCount = getEllipsisCount(i)
-        val lineEnd = getPrimaryHorizontal(getLineVisibleEnd(i) - ellipsisCount + if (ellipsisCount > 0) 1 else 0).toInt()
+        var lineEnd = getPrimaryHorizontal(getLineVisibleEnd(i) - ellipsisCount + if (ellipsisCount > 0) 1 else 0).toInt()
+        if (lineEnd == 0) {
+            // looks like the case for when emojis are present in text
+            lineEnd = getPrimaryHorizontal(getLineVisibleEnd(i) - 1).toInt() + 1
+        }
         val lineTop = getLineTop(i)
         val lineBottom = getLineBottom(i)
         val rect = Rect()


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Our `isObscured` was falsely returning `true` for many views in the test app (BlueSky), still not sure if it's purely RN issue or may also happen on Android. For now I've just commented out, as the gains are not that high, compared to losses, gonna figure it out later
* Fixed a small bug when we were not redacting text lines containing emojis - for some reason `lineEnd` was returning 0, so we fix it by getting the pixel offset of the second-to-last character and then adding 1 pixel to it (not exactly correct, as we should consider resolution/density, but I think it will cover most cases)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3558 
Closes #3559 

@krystofwoldrich you can check this replay and compare with your runs https://sentry-sdks.sentry.io/replays/a34a01679f7e4d43b80f7c46d36ea7a1/ it should have the mentioned things fixed