### PR TITLE
[SR] Add stopgap for offline session recording

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -196,7 +196,7 @@ public class ReplayIntegration(
     }
 
     override fun onScreenshotRecorded(bitmap: Bitmap) {
-        captureStrategy?.onScreenshotRecorded { frameTimeStamp ->
+        captureStrategy?.onScreenshotRecorded(bitmap) { frameTimeStamp ->
             addFrame(bitmap, frameTimeStamp)
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -212,7 +212,7 @@ internal abstract class BaseCaptureStrategy(
             }
         }
 
-        if (screenAtStart.get() != null && urls.first != screenAtStart.get()) {
+        if (screenAtStart.get() != null && urls.firstOrNull() != screenAtStart.get()) {
             urls.addFirst(screenAtStart.get())
         }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.replay.capture
 
+import android.graphics.Bitmap
 import android.view.MotionEvent
 import io.sentry.DateUtils
 import io.sentry.Hint
@@ -122,7 +123,7 @@ internal class BufferCaptureStrategy(
         }
     }
 
-    override fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit) {
+    override fun onScreenshotRecorded(bitmap: Bitmap?, store: ReplayCache.(frameTimestamp: Long) -> Unit) {
         // have to do it before submitting, otherwise if the queue is busy, the timestamp won't be
         // reflecting the exact time of when it was captured
         val frameTimestamp = dateProvider.currentTimeMillis

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.replay.capture
 
+import android.graphics.Bitmap
 import android.view.MotionEvent
 import io.sentry.Hint
 import io.sentry.android.replay.ReplayCache
@@ -24,7 +25,7 @@ internal interface CaptureStrategy {
 
     fun sendReplayForEvent(isCrashed: Boolean, eventId: String?, hint: Hint?, onSegmentSent: () -> Unit)
 
-    fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit)
+    fun onScreenshotRecorded(bitmap: Bitmap? = null, store: ReplayCache.(frameTimestamp: Long) -> Unit)
 
     fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -2,6 +2,7 @@ package io.sentry.android.replay.capture
 
 import io.sentry.DateUtils
 import io.sentry.Hint
+import io.sentry.IConnectionStatusProvider.ConnectionStatus.DISCONNECTED
 import io.sentry.IHub
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
@@ -74,6 +75,10 @@ internal class SessionCaptureStrategy(
     }
 
     override fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit) {
+        if (options.connectionStatusProvider.connectionStatus == DISCONNECTED) {
+            options.logger.log(DEBUG, "Skipping screenshot recording, no internet connection")
+            return
+        }
         // have to do it before submitting, otherwise if the queue is busy, the timestamp won't be
         // reflecting the exact time of when it was captured
         val frameTimestamp = dateProvider.currentTimeMillis

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.replay.capture
 
+import android.graphics.Bitmap
 import io.sentry.DateUtils
 import io.sentry.Hint
 import io.sentry.IConnectionStatusProvider.ConnectionStatus.DISCONNECTED
@@ -74,9 +75,10 @@ internal class SessionCaptureStrategy(
         }
     }
 
-    override fun onScreenshotRecorded(store: ReplayCache.(frameTimestamp: Long) -> Unit) {
+    override fun onScreenshotRecorded(bitmap: Bitmap?, store: ReplayCache.(frameTimestamp: Long) -> Unit) {
         if (options.connectionStatusProvider.connectionStatus == DISCONNECTED) {
             options.logger.log(DEBUG, "Skipping screenshot recording, no internet connection")
+            bitmap?.recycle()
             return
         }
         // have to do it before submitting, otherwise if the queue is busy, the timestamp won't be


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Fixes small bug when there were no nav breadcrumb, we were trying to access an empty list
* Add an if-check and avoid capturing frames when offline in session mode

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/70065
