### PR TITLE
throw when calling Sentry.init on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Throw when calling Sentry.init on Android ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
+- Throw IllegalArgumentException when calling Sentry.init on Android ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
 - Change OkHttp sub-spans to span attributes ([#3556](https://github.com/getsentry/sentry-java/pull/3556))
   - This will reduce the number of spans created by the SDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- Throw when calling Sentry.init on Android ([#3596](https://github.com/getsentry/sentry-java/pull/3596))
 - Change OkHttp sub-spans to span attributes ([#3556](https://github.com/getsentry/sentry-java/pull/3556))
   - This will reduce the number of spans created by the SDK
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -264,6 +264,13 @@ public final class Sentry {
   @SuppressWarnings("deprecation")
   private static synchronized void init(
       final @NotNull SentryOptions options, final boolean globalHubMode) {
+
+    if (!options.getClass().getName().equals("io.sentry.android.core.SentryAndroidOptions")
+        && Platform.isAndroid()) {
+      throw new IllegalArgumentException(
+          "You are running Android. Please, use SentryAndroid.init. "
+              + options.getClass().getName());
+    }
     if (isEnabled()) {
       options
           .getLogger()


### PR DESCRIPTION
## :scroll: Description
added a check in Sentry.init to check the options against the SentryAndroidOptions when using Android


## :bulb: Motivation and Context
We want to avoid people on Android calling Sentry.init directly, instead of SentryAndroid.init.
Closes https://github.com/getsentry/sentry-java/issues/3440


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
