### PR TITLE
Avoid ArrayIndexOutOfBoundsException on Android cpu data collection

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidCpuCollector.java
@@ -115,7 +115,7 @@ public final class AndroidCpuCollector implements IPerformanceSnapshotCollector 
         // Amount of clock ticks this process' waited-for children has been scheduled in kernel mode
         long csTime = Long.parseLong(stats[16]);
         return (long) ((uTime + sTime + cuTime + csTime) * nanosecondsPerClockTick);
-      } catch (NumberFormatException e) {
+      } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
         logger.log(SentryLevel.ERROR, "Error parsing /proc/self/stat file.", e);
         return 0;
       }


### PR DESCRIPTION
## :scroll: Description
added ArrayIndexOutOfBoundsException to try catch block in AndroidCpuCollector


## :bulb: Motivation and Context
We got a report of this crash from SDK console.
Closes https://github.com/getsentry/sentry-java/issues/3575


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
