### PR TITLE
[SR] Support replays for crashes in buffer and session modes

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -180,7 +180,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
 
     try {
       // we have to sample here with the old sample rate, because it may change between app launches
-      final SecureRandom random = this.random != null ? this.random : new SecureRandom();
+      final @NotNull SecureRandom random = this.random != null ? this.random : new SecureRandom();
       final double replayErrorSampleRateDouble = Double.parseDouble(replayErrorSampleRate);
       if (replayErrorSampleRateDouble < random.nextDouble()) {
         options
@@ -202,7 +202,8 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
   private void setReplayId(final @NotNull SentryEvent event) {
     @Nullable
     String persistedReplayId = PersistingScopeObserver.read(options, REPLAY_FILENAME, String.class);
-    final File replayFolder = new File(options.getCacheDirPath(), "replay_" + persistedReplayId);
+    final @NotNull File replayFolder =
+        new File(options.getCacheDirPath(), "replay_" + persistedReplayId);
     if (!replayFolder.exists()) {
       if (!sampleReplay(event)) {
         return;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -200,7 +200,8 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
   }
 
   private void setReplayId(final @NotNull SentryEvent event) {
-    @Nullable String persistedReplayId = PersistingScopeObserver.read(options, REPLAY_FILENAME, String.class);
+    @Nullable
+    String persistedReplayId = PersistingScopeObserver.read(options, REPLAY_FILENAME, String.class);
     final File replayFolder = new File(options.getCacheDirPath(), "replay_" + persistedReplayId);
     if (!replayFolder.exists()) {
       if (!sampleReplay(event)) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -15,13 +15,14 @@ import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SpanContext
-import io.sentry.cache.PersistingOptionsObserver
 import io.sentry.cache.PersistingOptionsObserver.DIST_FILENAME
 import io.sentry.cache.PersistingOptionsObserver.ENVIRONMENT_FILENAME
 import io.sentry.cache.PersistingOptionsObserver.OPTIONS_CACHE
 import io.sentry.cache.PersistingOptionsObserver.PROGUARD_UUID_FILENAME
 import io.sentry.cache.PersistingOptionsObserver.RELEASE_FILENAME
+import io.sentry.cache.PersistingOptionsObserver.REPLAY_ERROR_SAMPLE_RATE_FILENAME
 import io.sentry.cache.PersistingOptionsObserver.SDK_VERSION_FILENAME
+import io.sentry.cache.PersistingScopeObserver
 import io.sentry.cache.PersistingScopeObserver.BREADCRUMBS_FILENAME
 import io.sentry.cache.PersistingScopeObserver.CONTEXTS_FILENAME
 import io.sentry.cache.PersistingScopeObserver.EXTRAS_FILENAME
@@ -77,7 +78,9 @@ class AnrV2EventProcessorTest {
     val tmpDir = TemporaryFolder()
 
     class Fixture {
-
+        companion object {
+            const val REPLAY_ID = "64cf554cc8d74c6eafa3e08b7c984f6d"
+        }
         val buildInfo = mock<BuildInfoProvider>()
         lateinit var context: Context
         val options = SentryAndroidOptions().apply {
@@ -89,7 +92,8 @@ class AnrV2EventProcessorTest {
             dir: TemporaryFolder,
             currentSdk: Int = Build.VERSION_CODES.LOLLIPOP,
             populateScopeCache: Boolean = false,
-            populateOptionsCache: Boolean = false
+            populateOptionsCache: Boolean = false,
+            replayErrorSampleRate: Double? = null
         ): AnrV2EventProcessor {
             options.cacheDirPath = dir.newFolder().absolutePath
             options.environment = "release"
@@ -120,7 +124,7 @@ class AnrV2EventProcessorTest {
                     REQUEST_FILENAME,
                     Request().apply { url = "google.com"; method = "GET" }
                 )
-                persistScope(REPLAY_FILENAME, SentryId("64cf554cc8d74c6eafa3e08b7c984f6d"))
+                persistScope(REPLAY_FILENAME, SentryId(REPLAY_ID))
             }
 
             if (populateOptionsCache) {
@@ -129,7 +133,10 @@ class AnrV2EventProcessorTest {
                 persistOptions(SDK_VERSION_FILENAME, SdkVersion("sentry.java.android", "6.15.0"))
                 persistOptions(DIST_FILENAME, "232")
                 persistOptions(ENVIRONMENT_FILENAME, "debug")
-                persistOptions(PersistingOptionsObserver.TAGS_FILENAME, mapOf("option" to "tag"))
+                persistOptions(TAGS_FILENAME, mapOf("option" to "tag"))
+                replayErrorSampleRate?.let {
+                    persistOptions(REPLAY_ERROR_SAMPLE_RATE_FILENAME, it.toString())
+                }
             }
 
             return AnrV2EventProcessor(context, options, buildInfo)
@@ -295,8 +302,6 @@ class AnrV2EventProcessorTest {
         // contexts
         assertEquals(1024, processed.contexts.response!!.bodySize)
         assertEquals("Google Chrome", processed.contexts.browser!!.name)
-        // replay_id
-        assertEquals("64cf554cc8d74c6eafa3e08b7c984f6d", processed.contexts[Contexts.REPLAY_ID].toString())
     }
 
     @Test
@@ -547,6 +552,65 @@ class AnrV2EventProcessorTest {
         val foregroundHint = HintUtils.createWithTypeCheckHint(AbnormalExitHint(mechanism = "anr_foreground"))
         val processedForeground = processEvent(foregroundHint, populateScopeCache = false)
         assertEquals(listOf("{{ default }}", "foreground-anr"), processedForeground.fingerprints)
+    }
+
+    @Test
+    fun `sets replayId when replay folder exists`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
+        val processor = fixture.getSut(tmpDir, populateScopeCache = true)
+        val replayFolder = File(fixture.options.cacheDirPath, "replay_${Fixture.REPLAY_ID}").also { it.mkdirs() }
+
+        val processed = processor.process(SentryEvent(), hint)!!
+
+        assertEquals(Fixture.REPLAY_ID, processed.contexts[Contexts.REPLAY_ID].toString())
+    }
+
+    @Test
+    fun `does not set replayId when replay folder does not exist and no sample rate persisted`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
+        val processor = fixture.getSut(tmpDir, populateScopeCache = true)
+        val replayId1 = SentryId()
+        val replayId2 = SentryId()
+
+        val replayFolder1 = File(fixture.options.cacheDirPath, "replay_$replayId1").also { it.mkdirs() }
+        val replayFolder2 = File(fixture.options.cacheDirPath, "replay_$replayId2").also { it.mkdirs() }
+
+        val processed = processor.process(SentryEvent(), hint)!!
+
+        assertNull(processed.contexts[Contexts.REPLAY_ID])
+    }
+
+    @Test
+    fun `does not set replayId when replay folder does not exist and not sampled`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
+        val processor = fixture.getSut(tmpDir, populateScopeCache = true, populateOptionsCache = true, replayErrorSampleRate = 0.0)
+        val replayId1 = SentryId()
+        val replayId2 = SentryId()
+
+        val replayFolder1 = File(fixture.options.cacheDirPath, "replay_$replayId1").also { it.mkdirs() }
+        val replayFolder2 = File(fixture.options.cacheDirPath, "replay_$replayId2").also { it.mkdirs() }
+
+        val processed = processor.process(SentryEvent(), hint)!!
+
+        assertNull(processed.contexts[Contexts.REPLAY_ID])
+    }
+
+    @Test
+    fun `set replayId of the last modified folder`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
+        val processor = fixture.getSut(tmpDir, populateScopeCache = true, populateOptionsCache = true, replayErrorSampleRate = 1.0)
+        val replayId1 = SentryId()
+        val replayId2 = SentryId()
+
+        val replayFolder1 = File(fixture.options.cacheDirPath, "replay_$replayId1").also { it.mkdirs() }
+        val replayFolder2 = File(fixture.options.cacheDirPath, "replay_$replayId2").also { it.mkdirs() }
+        replayFolder1.setLastModified(1000)
+        replayFolder2.setLastModified(500)
+
+        val processed = processor.process(SentryEvent(), hint)!!
+
+        assertEquals(replayId1.toString(), processed.contexts[Contexts.REPLAY_ID].toString())
+        assertEquals(replayId1.toString(), PersistingScopeObserver.read(fixture.options, REPLAY_FILENAME, String::class.java))
     }
 
     private fun processEvent(

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -52,6 +52,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun captureReplay (Ljava/lang/Boolean;)V
 	public fun close ()V
 	public fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public final fun getReplayCacheDir ()Ljava/io/File;
@@ -65,8 +66,6 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun pause ()V
 	public fun register (Lio/sentry/IHub;Lio/sentry/SentryOptions;)V
 	public fun resume ()V
-	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
-	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V
 	public fun stop ()V

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -131,14 +131,23 @@ public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
 
     private fun Breadcrumb.toRRWebSpanEvent(): RRWebSpanEvent {
         val breadcrumb = this
+        val httpStartTimestamp = breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP]
+        val httpEndTimestamp = breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP]
         return RRWebSpanEvent().apply {
             timestamp = breadcrumb.timestamp.time
             op = "resource.http"
             description = breadcrumb.data["url"] as String
-            startTimestamp =
-                (breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP] as Long) / 1000.0
-            endTimestamp =
-                (breadcrumb.data[SpanDataConvention.HTTP_END_TIMESTAMP] as Long) / 1000.0
+            // can be double if it was serialized to disk
+            startTimestamp = if (httpStartTimestamp is Double) {
+                httpStartTimestamp / 1000.0
+            } else {
+                (httpStartTimestamp as Long) / 1000.0
+            }
+            endTimestamp = if (httpEndTimestamp is Double) {
+                httpEndTimestamp / 1000.0
+            } else {
+                (httpEndTimestamp as Long) / 1000.0
+            }
 
             val breadcrumbData = mutableMapOf<String, Any?>()
             for ((key, value) in breadcrumb.data) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -132,7 +132,7 @@ public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
     private fun Breadcrumb.toRRWebSpanEvent(): RRWebSpanEvent {
         val breadcrumb = this
         val httpStartTimestamp = breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP]
-        val httpEndTimestamp = breadcrumb.data[SpanDataConvention.HTTP_START_TIMESTAMP]
+        val httpEndTimestamp = breadcrumb.data[SpanDataConvention.HTTP_END_TIMESTAMP]
         return RRWebSpanEvent().apply {
             timestamp = breadcrumb.timestamp.time
             op = "resource.http"

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -10,6 +10,7 @@ import io.sentry.SentryLevel.ERROR
 import io.sentry.SentryLevel.WARNING
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType
+import io.sentry.SentryReplayEvent.ReplayType.SESSION
 import io.sentry.android.replay.video.MuxerConfig
 import io.sentry.android.replay.video.SimpleVideoEncoder
 import io.sentry.protocol.SentryId
@@ -21,7 +22,6 @@ import java.io.StringReader
 import java.util.Date
 import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.ceil
 
 /**
  * A basic in-memory and disk cache for Session Replay frames. Frames are stored in order under the
@@ -82,7 +82,7 @@ public class ReplayCache internal constructor(
      * @param frameTimestamp the timestamp when the frame screenshot was taken
      */
     internal fun addFrame(bitmap: Bitmap, frameTimestamp: Long) {
-        if (replayCacheDir == null) {
+        if (replayCacheDir == null || bitmap.isRecycled) {
             return
         }
 
@@ -139,6 +139,9 @@ public class ReplayCache internal constructor(
         width: Int,
         videoFile: File = File(replayCacheDir, "$segmentId.mp4")
     ): GeneratedVideo? {
+        if (videoFile.exists() && videoFile.length() > 0) {
+            videoFile.delete()
+        }
         if (frames.isEmpty()) {
             options.logger.log(
                 DEBUG,
@@ -371,17 +374,17 @@ public class ReplayCache internal constructor(
             }
 
             cache.frames.sortBy { it.timestamp }
-
-            fun roundToNearestFrame(duration: Long, frameDuration: Int): Long {
-                val frames = duration.toDouble() / frameDuration.toDouble()
-                return ceil(frames).toLong() * frameDuration
+            // TODO: this should be removed when we start sending buffered segments on next launch
+            val normalizedSegmentId = if (replayType == SESSION) segmentId else 0
+            val normalizedTimestamp = if (replayType == SESSION) {
+                segmentTimestamp
+            } else {
+                // in buffer mode we have to set the timestamp of the first frame as the actual start
+                DateUtils.getDateTime(cache.frames.first().timestamp)
             }
 
-            // we need to round to the nearest frame to include breadcrumbs/events happened after the frame was captured
-            val duration = roundToNearestFrame(
-                duration = (cache.frames.last().timestamp - segmentTimestamp.time),
-                frameDuration = 1000 / frameRate
-            ) - 1 // we need to subtract 1ms to avoid capturing the next frame which doesn't exist
+            // add one frame to include breadcrumbs/events happened after the frame was captured
+            val duration = cache.frames.last().timestamp - normalizedTimestamp.time + (1000 / frameRate)
 
             val events = lastSegment[SEGMENT_KEY_REPLAY_RECORDING]?.let {
                 val reader = StringReader(it)
@@ -396,8 +399,8 @@ public class ReplayCache internal constructor(
             return LastSegmentData(
                 recorderConfig = recorderConfig,
                 cache = cache,
-                timestamp = segmentTimestamp,
-                id = segmentId,
+                timestamp = normalizedTimestamp,
+                id = normalizedSegmentId,
                 duration = duration,
                 replayType = replayType,
                 screenAtStart = lastSegment[SEGMENT_KEY_REPLAY_SCREEN_AT_START],

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -6,30 +6,38 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.os.Build
 import android.view.MotionEvent
-import io.sentry.Hint
+import io.sentry.Breadcrumb
 import io.sentry.IHub
 import io.sentry.Integration
 import io.sentry.NoOpReplayBreadcrumbConverter
 import io.sentry.ReplayBreadcrumbConverter
 import io.sentry.ReplayController
 import io.sentry.ScopeObserverAdapter
-import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
 import io.sentry.SentryOptions
 import io.sentry.android.replay.capture.BufferCaptureStrategy
 import io.sentry.android.replay.capture.CaptureStrategy
+import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.capture.SessionCaptureStrategy
 import io.sentry.android.replay.util.MainLooperHandler
 import io.sentry.android.replay.util.sample
+import io.sentry.android.replay.util.submitSafely
+import io.sentry.cache.PersistingScopeObserver
+import io.sentry.cache.PersistingScopeObserver.BREADCRUMBS_FILENAME
+import io.sentry.cache.PersistingScopeObserver.REPLAY_FILENAME
+import io.sentry.hints.Backfillable
 import io.sentry.protocol.Contexts
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
+import io.sentry.util.FileUtils
+import io.sentry.util.HintUtils
 import io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion
 import java.io.Closeable
 import java.io.File
 import java.security.SecureRandom
+import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 
 public class ReplayIntegration(
@@ -112,6 +120,8 @@ public class ReplayIntegration(
         addIntegrationToSdkVersion(javaClass)
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-android-replay", BuildConfig.VERSION_NAME)
+
+        finalizePreviousReplay()
     }
 
     override fun isRecording() = isRecording.get()
@@ -156,30 +166,17 @@ public class ReplayIntegration(
         recorder?.resume()
     }
 
-    override fun sendReplayForEvent(event: SentryEvent, hint: Hint) {
-        if (!isEnabled.get() || !isRecording.get()) {
-            return
-        }
-
-        if (!(event.isErrored || event.isCrashed)) {
-            options.logger.log(DEBUG, "Event is not error or crash, not capturing for event %s", event.eventId)
-            return
-        }
-
-        sendReplay(event.isCrashed, event.eventId.toString(), hint)
-    }
-
-    override fun sendReplay(isCrashed: Boolean?, eventId: String?, hint: Hint?) {
+    override fun captureReplay(isTerminating: Boolean?) {
         if (!isEnabled.get() || !isRecording.get()) {
             return
         }
 
         if (SentryId.EMPTY_ID.equals(captureStrategy?.currentReplayId)) {
-            options.logger.log(DEBUG, "Replay id is not set, not capturing for event %s", eventId)
+            options.logger.log(DEBUG, "Replay id is not set, not capturing for event")
             return
         }
 
-        captureStrategy?.sendReplayForEvent(isCrashed == true, eventId, hint, onSegmentSent = {
+        captureStrategy?.captureReplay(isTerminating == true, onSegmentSent = {
             captureStrategy?.currentSegment = captureStrategy?.currentSegment!! + 1
         })
         captureStrategy = captureStrategy?.convert()
@@ -258,5 +255,68 @@ public class ReplayIntegration(
 
     override fun onTouchEvent(event: MotionEvent) {
         captureStrategy?.onTouchEvent(event)
+    }
+
+    private fun cleanupReplays(unfinishedReplayId: String = "") {
+        // clean up old replays
+        options.cacheDirPath?.let { cacheDir ->
+            File(cacheDir).listFiles { dir, name ->
+                if (name.startsWith("replay_") &&
+                    !name.contains(replayId.toString()) &&
+                    !(unfinishedReplayId.isNotBlank() && name.contains(unfinishedReplayId))
+                ) {
+                    FileUtils.deleteRecursively(File(dir, name))
+                }
+                false
+            }
+        }
+    }
+
+    private fun finalizePreviousReplay() {
+        // TODO: read persisted options/scope values form the
+        // TODO: previous run and set them directly to the ReplayEvent so they don't get overwritten in MainEventProcessor
+
+        options.executorService.submitSafely(options, "ReplayIntegration.finalize_previous_replay") {
+            val previousReplayIdString = PersistingScopeObserver.read(options, REPLAY_FILENAME, String::class.java) ?: run {
+                cleanupReplays()
+                return@submitSafely
+            }
+            val previousReplayId = SentryId(previousReplayIdString)
+            if (previousReplayId == SentryId.EMPTY_ID) {
+                cleanupReplays()
+                return@submitSafely
+            }
+            val lastSegment = ReplayCache.fromDisk(options, previousReplayId, replayCacheProvider) ?: run {
+                cleanupReplays()
+                return@submitSafely
+            }
+            val breadcrumbs = PersistingScopeObserver.read(options, BREADCRUMBS_FILENAME, List::class.java, Breadcrumb.Deserializer()) as? List<Breadcrumb>
+            val segment = CaptureStrategy.createSegment(
+                hub = hub,
+                options = options,
+                duration = lastSegment.duration,
+                currentSegmentTimestamp = lastSegment.timestamp,
+                replayId = previousReplayId,
+                segmentId = lastSegment.id,
+                height = lastSegment.recorderConfig.recordingHeight,
+                width = lastSegment.recorderConfig.recordingWidth,
+                frameRate = lastSegment.recorderConfig.frameRate,
+                cache = lastSegment.cache,
+                replayType = lastSegment.replayType,
+                screenAtStart = lastSegment.screenAtStart,
+                breadcrumbs = breadcrumbs,
+                events = LinkedList(lastSegment.events)
+            )
+
+            if (segment is ReplaySegment.Created) {
+                val hint = HintUtils.createWithTypeCheckHint(PreviousReplayHint())
+                segment.capture(hub, hint)
+            }
+            cleanupReplays(unfinishedReplayId = previousReplayIdString) // will be cleaned up after the envelope is assembled
+        }
+    }
+
+    private class PreviousReplayHint : Backfillable {
+        override fun shouldEnrich(): Boolean = false
     }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -260,14 +260,14 @@ public class ReplayIntegration(
     private fun cleanupReplays(unfinishedReplayId: String = "") {
         // clean up old replays
         options.cacheDirPath?.let { cacheDir ->
-            File(cacheDir).listFiles { dir, name ->
+            File(cacheDir).listFiles()?.forEach { file ->
+                val name = file.name
                 if (name.startsWith("replay_") &&
                     !name.contains(replayId.toString()) &&
                     !(unfinishedReplayId.isNotBlank() && name.contains(unfinishedReplayId))
                 ) {
-                    FileUtils.deleteRecursively(File(dir, name))
+                    FileUtils.deleteRecursively(file)
                 }
-                false
             }
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -150,7 +150,7 @@ public class ReplayIntegration(
         captureStrategy = replayCaptureStrategyProvider?.invoke(isFullSession) ?: if (isFullSession) {
             SessionCaptureStrategy(options, hub, dateProvider, replayCacheProvider = replayCacheProvider)
         } else {
-            BufferCaptureStrategy(options, hub, dateProvider, random, replayCacheProvider)
+            BufferCaptureStrategy(options, hub, dateProvider, random, replayCacheProvider = replayCacheProvider)
         }
 
         captureStrategy?.start(recorderConfig)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -3,14 +3,16 @@ package io.sentry.android.replay.capture
 import android.graphics.Bitmap
 import android.view.MotionEvent
 import io.sentry.DateUtils
-import io.sentry.Hint
 import io.sentry.IHub
+import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.ERROR
 import io.sentry.SentryLevel.INFO
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType.BUFFER
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
+import io.sentry.android.replay.capture.CaptureStrategy.Companion.rotateEvents
+import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.util.sample
 import io.sentry.android.replay.util.submitSafely
 import io.sentry.protocol.SentryId
@@ -27,7 +29,10 @@ internal class BufferCaptureStrategy(
     replayCacheProvider: ((replayId: SentryId, recorderConfig: ScreenshotRecorderConfig) -> ReplayCache)? = null
 ) : BaseCaptureStrategy(options, hub, dateProvider, replayCacheProvider = replayCacheProvider) {
 
+    // TODO: capture envelopes for buffered segments instead, but don't send them until buffer is triggered
     private val bufferedSegments = mutableListOf<ReplaySegment.Created>()
+
+    // TODO: rework this bs, it doesn't work with sending replay on restart
     private val bufferedScreensLock = Any()
     private val bufferedScreens = mutableListOf<Pair<String, Long>>()
 
@@ -38,13 +43,12 @@ internal class BufferCaptureStrategy(
     override fun start(
         recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int,
-        replayId: SentryId,
-        cleanupOldReplays: Boolean
+        replayId: SentryId
     ) {
-        super.start(recorderConfig, segmentId, replayId, cleanupOldReplays)
+        super.start(recorderConfig, segmentId, replayId)
 
         hub?.configureScope {
-            val screen = it.screen
+            val screen = it.screen?.substringAfterLast('.')
             if (screen != null) {
                 synchronized(bufferedScreensLock) {
                     bufferedScreens.add(screen to dateProvider.currentTimeMillis)
@@ -62,6 +66,17 @@ internal class BufferCaptureStrategy(
         }
     }
 
+    override fun pause() {
+        createCurrentSegment("pause") { segment ->
+            if (segment is ReplaySegment.Created) {
+                bufferedSegments += segment
+
+                currentSegment++
+            }
+        }
+        super.pause()
+    }
+
     override fun stop() {
         val replayCacheDir = cache?.replayCacheDir
         replayExecutor.submitSafely(options, "$TAG.stop") {
@@ -70,16 +85,14 @@ internal class BufferCaptureStrategy(
         super.stop()
     }
 
-    override fun sendReplayForEvent(
-        isCrashed: Boolean,
-        eventId: String?,
-        hint: Hint?,
+    override fun captureReplay(
+        isTerminating: Boolean,
         onSegmentSent: () -> Unit
     ) {
         val sampled = random.sample(options.experimental.sessionReplay.errorSampleRate)
 
         if (!sampled) {
-            options.logger.log(INFO, "Replay wasn't sampled by errorSampleRate, not capturing for event %s", eventId)
+            options.logger.log(INFO, "Replay wasn't sampled by errorSampleRate, not capturing for event")
             return
         }
 
@@ -89,45 +102,23 @@ internal class BufferCaptureStrategy(
             it.replayId = currentReplayId
         }
 
-        val errorReplayDuration = options.experimental.sessionReplay.errorReplayDuration
-        val now = dateProvider.currentTimeMillis
-        val currentSegmentTimestamp = if (cache?.frames?.isNotEmpty() == true) {
-            // in buffer mode we have to set the timestamp of the first frame as the actual start
-            DateUtils.getDateTime(cache!!.frames.first().timestamp)
-        } else {
-            DateUtils.getDateTime(now - errorReplayDuration)
+        if (isTerminating) {
+            this.isTerminating.set(true)
+            // avoid capturing replay, because the video will be malformed
+            options.logger.log(DEBUG, "Not capturing replay for crashed event, will be captured on next launch")
+            return
         }
-        val segmentId = currentSegment
-        val replayId = currentReplayId
-        val height = recorderConfig.recordingHeight
-        val width = recorderConfig.recordingWidth
 
-        findAndSetStartScreen(currentSegmentTimestamp.time)
+        createCurrentSegment("capture_replay") { segment ->
+            bufferedSegments.capture()
 
-        replayExecutor.submitSafely(options, "$TAG.send_replay_for_event") {
-            var bufferedSegment = bufferedSegments.removeFirstOrNull()
-            while (bufferedSegment != null) {
-                // capture without hint, so the buffered segments don't trigger flush notification
-                bufferedSegment.capture(hub)
-                bufferedSegment = bufferedSegments.removeFirstOrNull()
-                Thread.sleep(100L)
-            }
-            val segment =
-                createSegment(
-                    now - currentSegmentTimestamp.time,
-                    currentSegmentTimestamp,
-                    replayId,
-                    segmentId,
-                    height,
-                    width,
-                    BUFFER
-                )
             if (segment is ReplaySegment.Created) {
-                segment.capture(hub, hint ?: Hint())
+                segment.capture(hub)
 
                 // we only want to increment segment_id in the case of success, but currentSegment
                 // might be irrelevant since we changed strategies, so in the callback we increment
                 // it on the new strategy already
+                // TODO: also pass new segmentTimestamp to the new strategy
                 onSegmentSent()
             }
         }
@@ -143,25 +134,7 @@ internal class BufferCaptureStrategy(
             val now = dateProvider.currentTimeMillis
             val bufferLimit = now - options.experimental.sessionReplay.errorReplayDuration
             cache?.rotate(bufferLimit)
-
-            var removed = false
-            bufferedSegments.removeAll {
-                // it can be that the buffered segment is half-way older than the buffer limit, but
-                // we only drop it if its end timestamp is older
-                if (it.replay.timestamp.time < bufferLimit) {
-                    currentSegment--
-                    deleteFile(it.replay.videoFile)
-                    removed = true
-                    return@removeAll true
-                }
-                return@removeAll false
-            }
-            if (removed) {
-                // shift segmentIds after rotating buffered segments
-                bufferedSegments.forEachIndexed { index, segment ->
-                    segment.setSegmentId(index)
-                }
-            }
+            bufferedSegments.rotate(bufferLimit)
         }
     }
 
@@ -179,22 +152,7 @@ internal class BufferCaptureStrategy(
     }
 
     override fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig) {
-        val errorReplayDuration = options.experimental.sessionReplay.errorReplayDuration
-        val now = dateProvider.currentTimeMillis
-        val currentSegmentTimestamp = if (cache?.frames?.isNotEmpty() == true) {
-            // in buffer mode we have to set the timestamp of the first frame as the actual start
-            DateUtils.getDateTime(cache!!.frames.first().timestamp)
-        } else {
-            DateUtils.getDateTime(now - errorReplayDuration)
-        }
-        val segmentId = currentSegment
-        val duration = now - currentSegmentTimestamp.time
-        val replayId = currentReplayId
-        val height = this.recorderConfig.recordingHeight
-        val width = this.recorderConfig.recordingWidth
-        replayExecutor.submitSafely(options, "$TAG.onConfigurationChanged") {
-            val segment =
-                createSegment(duration, currentSegmentTimestamp, replayId, segmentId, height, width, BUFFER)
+        createCurrentSegment("configuration_changed") { segment ->
             if (segment is ReplaySegment.Created) {
                 bufferedSegments += segment
 
@@ -205,9 +163,13 @@ internal class BufferCaptureStrategy(
     }
 
     override fun convert(): CaptureStrategy {
+        if (isTerminating.get()) {
+            options.logger.log(DEBUG, "Not converting to session mode, because the process is about to terminate")
+            return this
+        }
         // we hand over replayExecutor to the new strategy to preserve order of execution
         val captureStrategy = SessionCaptureStrategy(options, hub, dateProvider, replayExecutor)
-        captureStrategy.start(recorderConfig, segmentId = currentSegment, replayId = currentReplayId, cleanupOldReplays = false)
+        captureStrategy.start(recorderConfig, segmentId = currentSegment, replayId = currentReplayId)
         return captureStrategy
     }
 
@@ -228,7 +190,61 @@ internal class BufferCaptureStrategy(
                 screenAtStart = startScreen
             }
             // can clear as we switch to session mode and don't care anymore about buffering
-            bufferedSegments.clear()
+            bufferedScreens.clear()
+        }
+    }
+
+    private fun MutableList<ReplaySegment.Created>.capture() {
+        var bufferedSegment = removeFirstOrNull()
+        while (bufferedSegment != null) {
+            bufferedSegment.capture(hub)
+            bufferedSegment = removeFirstOrNull()
+            Thread.sleep(100L)
+        }
+    }
+
+    private fun MutableList<ReplaySegment.Created>.rotate(bufferLimit: Long) {
+        var removed = false
+        removeAll {
+            // it can be that the buffered segment is half-way older than the buffer limit, but
+            // we only drop it if its end timestamp is older
+            if (it.replay.timestamp.time < bufferLimit) {
+                currentSegment--
+                deleteFile(it.replay.videoFile)
+                removed = true
+                return@removeAll true
+            }
+            return@removeAll false
+        }
+        if (removed) {
+            // shift segmentIds after rotating buffered segments
+            forEachIndexed { index, segment ->
+                segment.setSegmentId(index)
+            }
+        }
+    }
+
+    private fun createCurrentSegment(taskName: String, onSegmentCreated: (ReplaySegment) -> Unit) {
+        val errorReplayDuration = options.experimental.sessionReplay.errorReplayDuration
+        val now = dateProvider.currentTimeMillis
+        val currentSegmentTimestamp = if (cache?.frames?.isNotEmpty() == true) {
+            // in buffer mode we have to set the timestamp of the first frame as the actual start
+            DateUtils.getDateTime(cache!!.frames.first().timestamp)
+        } else {
+            DateUtils.getDateTime(now - errorReplayDuration)
+        }
+        val segmentId = currentSegment
+        val duration = now - currentSegmentTimestamp.time
+        val replayId = currentReplayId
+        val height = this.recorderConfig.recordingHeight
+        val width = this.recorderConfig.recordingWidth
+
+        findAndSetStartScreen(currentSegmentTimestamp.time)
+
+        replayExecutor.submitSafely(options, "$TAG.$taskName") {
+            val segment =
+                createSegmentInternal(duration, currentSegmentTimestamp, replayId, segmentId, height, width, BUFFER)
+            onSegmentCreated(segment)
         }
     }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -40,6 +40,7 @@ internal class BufferCaptureStrategy(
 
     internal companion object {
         private const val TAG = "BufferCaptureStrategy"
+        private const val ENVELOPE_PROCESSING_DELAY: Long = 100L
     }
 
     override fun start(
@@ -201,7 +202,10 @@ internal class BufferCaptureStrategy(
         while (bufferedSegment != null) {
             bufferedSegment.capture(hub)
             bufferedSegment = removeFirstOrNull()
-            Thread.sleep(100L)
+            // a short delay between processing envelopes to avoid bursting our server and hitting
+            // another rate limit https://develop.sentry.dev/sdk/features/#additional-capabilities
+            // InterruptedException will be handled by the outer try-catch
+            Thread.sleep(ENVELOPE_PROCESSING_DELAY)
         }
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -2,18 +2,35 @@ package io.sentry.android.replay.capture
 
 import android.graphics.Bitmap
 import android.view.MotionEvent
+import io.sentry.Breadcrumb
+import io.sentry.DateUtils
 import io.sentry.Hint
+import io.sentry.IHub
+import io.sentry.ReplayRecording
+import io.sentry.SentryOptions
+import io.sentry.SentryReplayEvent
+import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.protocol.SentryId
+import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebEvent
+import io.sentry.rrweb.RRWebMetaEvent
+import io.sentry.rrweb.RRWebVideoEvent
 import java.io.File
+import java.util.Date
+import java.util.LinkedList
 
 internal interface CaptureStrategy {
     var currentSegment: Int
     var currentReplayId: SentryId
     val replayCacheDir: File?
 
-    fun start(recorderConfig: ScreenshotRecorderConfig, segmentId: Int = 0, replayId: SentryId = SentryId(), cleanupOldReplays: Boolean = true)
+    fun start(
+        recorderConfig: ScreenshotRecorderConfig,
+        segmentId: Int = 0,
+        replayId: SentryId = SentryId()
+    )
 
     fun stop()
 
@@ -21,7 +38,7 @@ internal interface CaptureStrategy {
 
     fun resume()
 
-    fun sendReplayForEvent(isCrashed: Boolean, eventId: String?, hint: Hint?, onSegmentSent: () -> Unit)
+    fun captureReplay(isTerminating: Boolean, onSegmentSent: () -> Unit)
 
     fun onScreenshotRecorded(bitmap: Bitmap? = null, store: ReplayCache.(frameTimestamp: Long) -> Unit)
 
@@ -34,4 +51,190 @@ internal interface CaptureStrategy {
     fun convert(): CaptureStrategy
 
     fun close()
+
+    companion object {
+        internal val currentEventsLock = Any()
+
+        fun createSegment(
+            hub: IHub?,
+            options: SentryOptions,
+            duration: Long,
+            currentSegmentTimestamp: Date,
+            replayId: SentryId,
+            segmentId: Int,
+            height: Int,
+            width: Int,
+            replayType: ReplayType,
+            cache: ReplayCache?,
+            frameRate: Int,
+            screenAtStart: String?,
+            breadcrumbs: List<Breadcrumb>?,
+            events: LinkedList<RRWebEvent>
+        ): ReplaySegment {
+            val generatedVideo = cache?.createVideoOf(
+                duration,
+                currentSegmentTimestamp.time,
+                segmentId,
+                height,
+                width
+            ) ?: return ReplaySegment.Failed
+
+            val (video, frameCount, videoDuration) = generatedVideo
+
+            val replayBreadcrumbs: List<Breadcrumb> = if (breadcrumbs == null) {
+                var crumbs = emptyList<Breadcrumb>()
+                hub?.configureScope { scope ->
+                    crumbs = ArrayList(scope.breadcrumbs)
+                }
+                crumbs
+            } else {
+                breadcrumbs
+            }
+
+            return buildReplay(
+                options,
+                video,
+                replayId,
+                currentSegmentTimestamp,
+                segmentId,
+                height,
+                width,
+                frameCount,
+                frameRate,
+                videoDuration,
+                replayType,
+                screenAtStart,
+                replayBreadcrumbs,
+                events
+            )
+        }
+
+        private fun buildReplay(
+            options: SentryOptions,
+            video: File,
+            currentReplayId: SentryId,
+            segmentTimestamp: Date,
+            segmentId: Int,
+            height: Int,
+            width: Int,
+            frameCount: Int,
+            frameRate: Int,
+            videoDuration: Long,
+            replayType: ReplayType,
+            screenAtStart: String?,
+            breadcrumbs: List<Breadcrumb>,
+            events: LinkedList<RRWebEvent>
+        ): ReplaySegment {
+            val endTimestamp = DateUtils.getDateTime(segmentTimestamp.time + videoDuration)
+            val replay = SentryReplayEvent().apply {
+                eventId = currentReplayId
+                replayId = currentReplayId
+                this.segmentId = segmentId
+                this.timestamp = endTimestamp
+                replayStartTimestamp = segmentTimestamp
+                this.replayType = replayType
+                videoFile = video
+            }
+
+            val recordingPayload = mutableListOf<RRWebEvent>()
+            recordingPayload += RRWebMetaEvent().apply {
+                this.timestamp = segmentTimestamp.time
+                this.height = height
+                this.width = width
+            }
+            recordingPayload += RRWebVideoEvent().apply {
+                this.timestamp = segmentTimestamp.time
+                this.segmentId = segmentId
+                this.durationMs = videoDuration
+                this.frameCount = frameCount
+                size = video.length()
+                this.frameRate = frameRate
+                this.height = height
+                this.width = width
+                // TODO: support non-fullscreen windows later
+                left = 0
+                top = 0
+            }
+
+            val urls = LinkedList<String>()
+            breadcrumbs.forEach { breadcrumb ->
+                if (breadcrumb.timestamp.time >= segmentTimestamp.time &&
+                    breadcrumb.timestamp.time < endTimestamp.time
+                ) {
+                    val rrwebEvent = options
+                        .replayController
+                        .breadcrumbConverter
+                        .convert(breadcrumb)
+
+                    if (rrwebEvent != null) {
+                        recordingPayload += rrwebEvent
+
+                        // fill in the urls array from navigation breadcrumbs
+                        if ((rrwebEvent as? RRWebBreadcrumbEvent)?.category == "navigation") {
+                            urls.add(rrwebEvent.data!!["to"] as String)
+                        }
+                    }
+                }
+            }
+
+            if (screenAtStart != null && urls.firstOrNull() != screenAtStart) {
+                urls.addFirst(screenAtStart)
+            }
+
+            rotateEvents(events, endTimestamp.time) { event ->
+                if (event.timestamp >= segmentTimestamp.time) {
+                    recordingPayload += event
+                }
+            }
+
+            val recording = ReplayRecording().apply {
+                this.segmentId = segmentId
+                payload = recordingPayload.sortedBy { it.timestamp }
+            }
+
+            replay.urls = urls
+            return ReplaySegment.Created(
+                videoDuration = videoDuration,
+                replay = replay,
+                recording = recording
+            )
+        }
+
+        internal fun rotateEvents(
+            events: LinkedList<RRWebEvent>,
+            until: Long,
+            callback: ((RRWebEvent) -> Unit)? = null
+        ) {
+            synchronized(currentEventsLock) {
+                var event = events.peek()
+                while (event != null && event.timestamp < until) {
+                    callback?.invoke(event)
+                    events.remove()
+                    event = events.peek()
+                }
+            }
+        }
+    }
+
+    sealed class ReplaySegment {
+        object Failed : ReplaySegment()
+        data class Created(
+            val videoDuration: Long,
+            val replay: SentryReplayEvent,
+            val recording: ReplayRecording
+        ) : ReplaySegment() {
+            fun capture(hub: IHub?, hint: Hint = Hint()) {
+                hub?.captureReplay(replay, hint.apply { replayRecording = recording })
+            }
+
+            fun setSegmentId(segmentId: Int) {
+                replay.segmentId = segmentId
+                recording.payload?.forEach {
+                    when (it) {
+                        is RRWebVideoEvent -> it.segmentId = segmentId
+                    }
+                }
+            }
+        }
+    }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -127,13 +127,13 @@ internal interface CaptureStrategy {
         ): ReplaySegment {
             val endTimestamp = DateUtils.getDateTime(segmentTimestamp.time + videoDuration)
             val replay = SentryReplayEvent().apply {
-                eventId = currentReplayId
-                replayId = currentReplayId
+                this.eventId = currentReplayId
+                this.replayId = currentReplayId
                 this.segmentId = segmentId
                 this.timestamp = endTimestamp
-                replayStartTimestamp = segmentTimestamp
+                this.replayStartTimestamp = segmentTimestamp
                 this.replayType = replayType
-                videoFile = video
+                this.videoFile = video
             }
 
             val recordingPayload = mutableListOf<RRWebEvent>()
@@ -147,13 +147,13 @@ internal interface CaptureStrategy {
                 this.segmentId = segmentId
                 this.durationMs = videoDuration
                 this.frameCount = frameCount
-                size = video.length()
+                this.size = video.length()
                 this.frameRate = frameRate
                 this.height = height
                 this.width = width
                 // TODO: support non-fullscreen windows later
-                left = 0
-                top = 0
+                this.left = 0
+                this.top = 0
             }
 
             val urls = LinkedList<String>()
@@ -189,7 +189,7 @@ internal interface CaptureStrategy {
 
             val recording = ReplayRecording().apply {
                 this.segmentId = segmentId
-                payload = recordingPayload.sortedBy { it.timestamp }
+                this.payload = recordingPayload.sortedBy { it.timestamp }
             }
 
             replay.urls = urls

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -120,7 +120,7 @@ internal class SimpleVideoEncoder(
         )
         format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
         format.setFloat(MediaFormat.KEY_FRAME_RATE, muxerConfig.frameRate.toFloat())
-        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 10)
+        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, -1) // use -1 to force always non-key frames, meaning only partial updates to save the video size
 
         format
     }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverterTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverterTest.kt
@@ -62,6 +62,28 @@ class DefaultReplayBreadcrumbConverterTest {
     }
 
     @Test
+    fun `convert RRWebSpanEvent works with floating timestamps`() {
+        val converter = fixture.getSut()
+
+        val breadcrumb = Breadcrumb(Date(123L)).apply {
+            category = "http"
+            data["url"] = "http://example.com"
+            data["status_code"] = 404
+            data["method"] = "GET"
+            data[SpanDataConvention.HTTP_START_TIMESTAMP] = 1234.0
+            data[SpanDataConvention.HTTP_END_TIMESTAMP] = 2234.0
+            data["http.response_content_length"] = 300
+            data["http.request_content_length"] = 400
+        }
+
+        val rrwebEvent = converter.convert(breadcrumb)
+
+        check(rrwebEvent is RRWebSpanEvent)
+        assertEquals(1.234, rrwebEvent.startTimestamp)
+        assertEquals(2.234, rrwebEvent.endTimestamp)
+    }
+
+    @Test
     fun `returns null if not eligible for RRWebSpanEvent`() {
         val converter = fixture.getSut()
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -1,25 +1,49 @@
 package io.sentry.android.replay
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Bitmap.CompressFormat.JPEG
+import android.graphics.Bitmap.Config.ARGB_8888
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.Breadcrumb
+import io.sentry.DateUtils
 import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryOptions
-import io.sentry.android.replay.ReplayCacheTest.Fixture
+import io.sentry.SentryReplayEvent.ReplayType
+import io.sentry.android.replay.ReplayCache.Companion.ONGOING_SEGMENT
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_BIT_RATE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FRAME_RATE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_HEIGHT
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_ID
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_RECORDING
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_TYPE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_WIDTH
 import io.sentry.android.replay.capture.CaptureStrategy
+import io.sentry.android.replay.capture.SessionCaptureStrategyTest.Fixture.Companion.VIDEO_DURATION
+import io.sentry.cache.PersistingScopeObserver
 import io.sentry.protocol.SentryException
 import io.sentry.protocol.SentryId
+import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebInteractionEvent
+import io.sentry.rrweb.RRWebInteractionEvent.InteractionType
+import io.sentry.rrweb.RRWebMetaEvent
+import io.sentry.rrweb.RRWebVideoEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -27,6 +51,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
+import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -40,8 +65,25 @@ class ReplayIntegrationTest {
     val tmpDir = TemporaryFolder()
 
     internal class Fixture {
-        val options = SentryOptions()
+        val options = SentryOptions().apply {
+            setReplayController(
+                mock {
+                    on { breadcrumbConverter }.thenReturn(DefaultReplayBreadcrumbConverter())
+                }
+            )
+            executorService = mock {
+                doAnswer {
+                    (it.arguments[0] as Runnable).run()
+                }.whenever(mock).submit(any<Runnable>())
+            }
+        }
         val hub = mock<IHub>()
+
+        val replayCache = mock<ReplayCache> {
+            on { frames }.thenReturn(mutableListOf(ReplayFrame(File("1720693523997.jpg"), 1720693523997)))
+            on { createVideoOf(anyLong(), anyLong(), anyInt(), anyInt(), anyInt(), any()) }
+                .thenReturn(GeneratedVideo(File("0.mp4"), 5, VIDEO_DURATION))
+        }
 
         fun getSut(
             context: Context,
@@ -61,7 +103,7 @@ class ReplayIntegrationTest {
                 dateProvider,
                 recorderProvider,
                 recorderConfigProvider = recorderConfigProvider,
-                replayCacheProvider = null,
+                replayCacheProvider = { _, _ -> replayCache },
                 replayCaptureStrategyProvider = replayCaptureStrategyProvider
             )
         }
@@ -118,7 +160,7 @@ class ReplayIntegrationTest {
 
         replay.start()
 
-        verify(captureStrategy, never()).start(any(), any(), any(), any())
+        verify(captureStrategy, never()).start(any(), any(), any())
     }
 
     @Test
@@ -141,7 +183,11 @@ class ReplayIntegrationTest {
         replay.start()
         replay.start()
 
-        verify(captureStrategy, times(1)).start(any(), eq(0), argThat { this != SentryId.EMPTY_ID }, eq(true))
+        verify(captureStrategy, times(1)).start(
+            any(),
+            eq(0),
+            argThat { this != SentryId.EMPTY_ID }
+        )
     }
 
     @Test
@@ -152,7 +198,11 @@ class ReplayIntegrationTest {
         replay.register(fixture.hub, fixture.options)
         replay.start()
 
-        verify(captureStrategy, never()).start(any(), eq(0), argThat { this != SentryId.EMPTY_ID }, eq(true))
+        verify(captureStrategy, never()).start(
+            any(),
+            eq(0),
+            argThat { this != SentryId.EMPTY_ID }
+        )
     }
 
     @Test
@@ -163,7 +213,11 @@ class ReplayIntegrationTest {
         replay.register(fixture.hub, fixture.options)
         replay.start()
 
-        verify(captureStrategy, times(1)).start(any(), eq(0), argThat { this != SentryId.EMPTY_ID }, eq(true))
+        verify(captureStrategy, times(1)).start(
+            any(),
+            eq(0),
+            argThat { this != SentryId.EMPTY_ID }
+        )
     }
 
     @Test
@@ -203,7 +257,7 @@ class ReplayIntegrationTest {
     }
 
     @Test
-    fun `sendReplayForEvent does nothing when not recording`() {
+    fun `captureReplay does nothing when not recording`() {
         val captureStrategy = mock<CaptureStrategy>()
         val replay = fixture.getSut(context, replayCaptureStrategyProvider = { captureStrategy })
 
@@ -212,27 +266,13 @@ class ReplayIntegrationTest {
         val event = SentryEvent().apply {
             exceptions = listOf(SentryException())
         }
-        replay.sendReplayForEvent(event, Hint())
+        replay.captureReplay(event.isCrashed)
 
-        verify(captureStrategy, never()).sendReplayForEvent(any(), anyOrNull(), anyOrNull(), any())
+        verify(captureStrategy, never()).captureReplay(any(), any())
     }
 
     @Test
-    fun `sendReplayForEvent does nothing for non errored events`() {
-        val captureStrategy = mock<CaptureStrategy>()
-        val replay = fixture.getSut(context, replayCaptureStrategyProvider = { captureStrategy })
-
-        replay.register(fixture.hub, fixture.options)
-        replay.start()
-
-        val event = SentryEvent()
-        replay.sendReplayForEvent(event, Hint())
-
-        verify(captureStrategy, never()).sendReplayForEvent(any(), anyOrNull(), anyOrNull(), any())
-    }
-
-    @Test
-    fun `sendReplayForEvent does nothing when currentReplayId is not set`() {
+    fun `captureReplay does nothing when currentReplayId is not set`() {
         val captureStrategy = mock<CaptureStrategy> {
             whenever(mock.currentReplayId).thenReturn(SentryId.EMPTY_ID)
         }
@@ -244,13 +284,13 @@ class ReplayIntegrationTest {
         val event = SentryEvent().apply {
             exceptions = listOf(SentryException())
         }
-        replay.sendReplayForEvent(event, Hint())
+        replay.captureReplay(event.isCrashed)
 
-        verify(captureStrategy, never()).sendReplayForEvent(any(), anyOrNull(), anyOrNull(), any())
+        verify(captureStrategy, never()).captureReplay(any(), any())
     }
 
     @Test
-    fun `sendReplayForEvent calls and converts strategy`() {
+    fun `captureReplay calls and converts strategy`() {
         val captureStrategy = mock<CaptureStrategy> {
             whenever(mock.currentReplayId).thenReturn(SentryId())
         }
@@ -265,9 +305,9 @@ class ReplayIntegrationTest {
         }
         event.eventId = id
         val hint = Hint()
-        replay.sendReplayForEvent(event, hint)
+        replay.captureReplay(event.isCrashed)
 
-        verify(captureStrategy).sendReplayForEvent(eq(false), eq(id.toString()), eq(hint), any())
+        verify(captureStrategy).captureReplay(eq(false), any())
         verify(captureStrategy).convert()
     }
 
@@ -375,5 +415,118 @@ class ReplayIntegrationTest {
         verify(captureStrategy).onConfigurationChanged(eq(recorderConfig))
         verify(recorder, times(2)).start(eq(recorderConfig))
         assertTrue(configChanged)
+    }
+
+    @Test
+    fun `register finalizes previous replay`() {
+        val oldReplayId = SentryId()
+
+        fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
+        val oldReplay =
+            File(fixture.options.cacheDirPath, "replay_$oldReplayId").also { it.mkdirs() }
+        val screenshot = File(oldReplay, "1720693523997.jpg").also { it.createNewFile() }
+        screenshot.outputStream().use {
+            Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)
+            it.flush()
+        }
+        val scopeCache = File(
+            fixture.options.cacheDirPath,
+            PersistingScopeObserver.SCOPE_CACHE
+        ).also { it.mkdirs() }
+        File(scopeCache, PersistingScopeObserver.REPLAY_FILENAME).also {
+            it.createNewFile()
+            it.writeText("\"$oldReplayId\"")
+        }
+        val breadcrumbsFile = File(scopeCache, PersistingScopeObserver.BREADCRUMBS_FILENAME)
+        fixture.options.serializer.serialize(
+            listOf(
+                Breadcrumb(DateUtils.getDateTime("2024-07-11T10:25:23.454Z")).apply {
+                    category = "navigation"
+                    type = "navigation"
+                    setData("from", "from")
+                    setData("to", "to")
+                }
+            ),
+            breadcrumbsFile.writer()
+        )
+        File(oldReplay, ONGOING_SEGMENT).also {
+            it.writeText(
+                """
+                $SEGMENT_KEY_HEIGHT=912
+                $SEGMENT_KEY_WIDTH=416
+                $SEGMENT_KEY_FRAME_RATE=1
+                $SEGMENT_KEY_BIT_RATE=75000
+                $SEGMENT_KEY_ID=1
+                $SEGMENT_KEY_TIMESTAMP=2024-07-11T10:25:21.454Z
+                $SEGMENT_KEY_REPLAY_TYPE=SESSION
+                $SEGMENT_KEY_REPLAY_RECORDING={}[{"type":3,"timestamp":1720693523997,"data":{"source":2,"type":7,"id":0,"x":314.2979431152344,"y":625.44140625,"pointerType":2,"pointerId":0}},{"type":3,"timestamp":1720693524774,"data":{"source":2,"type":9,"id":0,"x":322.00390625,"y":424.4384765625,"pointerType":2,"pointerId":0}}]
+                """.trimIndent()
+            )
+        }
+
+        val replay = fixture.getSut(context)
+        replay.register(fixture.hub, fixture.options)
+
+        assertTrue(oldReplay.exists()) // should not be deleted until the video is packed into envelope
+        verify(fixture.hub).captureReplay(
+            check {
+                assertEquals(oldReplayId, it.replayId)
+                assertEquals(ReplayType.SESSION, it.replayType)
+                assertEquals("0.mp4", it.videoFile?.name)
+            },
+            check {
+                val metaEvents = it.replayRecording?.payload?.filterIsInstance<RRWebMetaEvent>()
+                assertEquals(912, metaEvents?.first()?.height)
+                assertEquals(416, metaEvents?.first()?.width) // clamped to power of 16
+
+                val videoEvents = it.replayRecording?.payload?.filterIsInstance<RRWebVideoEvent>()
+                assertEquals(912, videoEvents?.first()?.height)
+                assertEquals(416, videoEvents?.first()?.width) // clamped to power of 16
+                assertEquals(5000, videoEvents?.first()?.durationMs)
+                assertEquals(5, videoEvents?.first()?.frameCount)
+                assertEquals(1, videoEvents?.first()?.frameRate)
+                assertEquals(1, videoEvents?.first()?.segmentId)
+
+                val breadcrumbEvents =
+                    it.replayRecording?.payload?.filterIsInstance<RRWebBreadcrumbEvent>()
+                assertEquals("navigation", breadcrumbEvents?.first()?.category)
+                assertEquals("to", breadcrumbEvents?.first()?.data?.get("to"))
+
+                val interactionEvents =
+                    it.replayRecording?.payload?.filterIsInstance<RRWebInteractionEvent>()
+                assertEquals(
+                    InteractionType.TouchStart,
+                    interactionEvents?.first()?.interactionType
+                )
+                assertEquals(314.29794f, interactionEvents?.first()?.x)
+                assertEquals(625.4414f, interactionEvents?.first()?.y)
+
+                assertEquals(InteractionType.TouchEnd, interactionEvents?.last()?.interactionType)
+                assertEquals(322.0039f, interactionEvents?.last()?.x)
+                assertEquals(424.43848f, interactionEvents?.last()?.y)
+            }
+        )
+    }
+
+    @Test
+    fun `register cleans up old replays`() {
+        val replayId = SentryId()
+
+        fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
+        val evenOlderReplay =
+            File(fixture.options.cacheDirPath, "replay_${SentryId()}").also { it.mkdirs() }
+        val scopeCache = File(
+            fixture.options.cacheDirPath,
+            PersistingScopeObserver.SCOPE_CACHE
+        ).also { it.mkdirs() }
+
+        val captureStrategy = mock<CaptureStrategy> {
+            on { currentReplayId }.thenReturn(replayId)
+        }
+        val replay = fixture.getSut(context, replayCaptureStrategyProvider = { captureStrategy })
+        replay.register(fixture.hub, fixture.options)
+
+        assertTrue(scopeCache.exists())
+        assertFalse(evenOlderReplay.exists())
     }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -22,6 +22,7 @@ import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
+import io.sentry.util.thread.NoOpMainThreadChecker
 import org.awaitility.kotlin.await
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +50,9 @@ class ReplayIntegrationWithRecorderTest {
     val tmpDir = TemporaryFolder()
 
     internal class Fixture {
-        val options = SentryOptions()
+        val options = SentryOptions().apply {
+            mainThreadChecker = NoOpMainThreadChecker.getInstance()
+        }
         val hub = mock<IHub>()
         var encoder: SimpleVideoEncoder? = null
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
@@ -13,17 +13,13 @@ import android.widget.LinearLayout.LayoutParams
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.Scope
 import io.sentry.ScopeCallback
-import io.sentry.SentryEvent
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.video.MuxerConfig
 import io.sentry.android.replay.video.SimpleVideoEncoder
-import io.sentry.protocol.Mechanism
-import io.sentry.protocol.SentryException
 import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
 import io.sentry.transport.CurrentDateProvider
@@ -221,14 +217,7 @@ class ReplaySmokeTest {
         } catch (e: ConditionTimeoutException) {
         }
 
-        val crash = SentryEvent().apply {
-            exceptions = listOf(
-                SentryException().apply {
-                    mechanism = Mechanism().apply { isHandled = false }
-                }
-            )
-        }
-        replay.sendReplayForEvent(crash, Hint())
+        replay.captureReplay(isTerminating = false)
 
         await.timeout(Duration.ofSeconds(5)).untilTrue(captured)
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -1,0 +1,270 @@
+package io.sentry.android.replay.capture
+
+import android.graphics.Bitmap
+import android.view.MotionEvent
+import io.sentry.IHub
+import io.sentry.Scope
+import io.sentry.ScopeCallback
+import io.sentry.SentryOptions
+import io.sentry.SentryReplayEvent.ReplayType
+import io.sentry.android.replay.DefaultReplayBreadcrumbConverter
+import io.sentry.android.replay.GeneratedVideo
+import io.sentry.android.replay.ReplayCache
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_ID
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_ID
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_TYPE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
+import io.sentry.android.replay.ReplayFrame
+import io.sentry.android.replay.ScreenshotRecorderConfig
+import io.sentry.protocol.SentryId
+import io.sentry.transport.CurrentDateProvider
+import io.sentry.transport.ICurrentDateProvider
+import org.awaitility.kotlin.await
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.security.SecureRandom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BufferCaptureStrategyTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    internal class Fixture {
+        companion object {
+            const val VIDEO_DURATION = 5000L
+        }
+
+        val options = SentryOptions().apply {
+            setReplayController(
+                mock {
+                    on { breadcrumbConverter }.thenReturn(DefaultReplayBreadcrumbConverter())
+                }
+            )
+        }
+        val scope = Scope(options)
+        val hub = mock<IHub> {
+            doAnswer {
+                (it.arguments[0] as ScopeCallback).run(scope)
+            }.whenever(it).configureScope(any())
+        }
+        var persistedSegment = mutableMapOf<String, String?>()
+        val replayCache = mock<ReplayCache> {
+            on { frames }.thenReturn(mutableListOf(ReplayFrame(File("1720693523997.jpg"), 1720693523997)))
+            on { persistSegmentValues(any(), anyOrNull()) }.then {
+                persistedSegment.put(it.arguments[0].toString(), it.arguments[1]?.toString())
+            }
+            on { createVideoOf(anyLong(), anyLong(), anyInt(), anyInt(), anyInt(), any()) }
+                .thenReturn(GeneratedVideo(File("0.mp4"), 5, VIDEO_DURATION))
+        }
+        val recorderConfig = ScreenshotRecorderConfig(
+            recordingWidth = 1080,
+            recordingHeight = 1920,
+            scaleFactorX = 1f,
+            scaleFactorY = 1f,
+            frameRate = 1,
+            bitRate = 20_000
+        )
+
+        fun getSut(
+            errorSampleRate: Double = 1.0,
+            dateProvider: ICurrentDateProvider = CurrentDateProvider.getInstance(),
+            replayCacheDir: File? = null
+        ): BufferCaptureStrategy {
+            replayCacheDir?.let {
+                whenever(replayCache.replayCacheDir).thenReturn(it)
+            }
+            options.run {
+                experimental.sessionReplay.errorSampleRate = errorSampleRate
+            }
+            return BufferCaptureStrategy(
+                options,
+                hub,
+                dateProvider,
+                SecureRandom(),
+                mock {
+                    doAnswer { invocation ->
+                        (invocation.arguments[0] as Runnable).run()
+                        null
+                    }.whenever(it).submit(any<Runnable>())
+                }
+            ) { _, _ -> replayCache }
+        }
+
+        fun mockedMotionEvent(action: Int): MotionEvent = mock {
+            on { actionMasked }.thenReturn(action)
+            on { getPointerId(anyInt()) }.thenReturn(0)
+            on { findPointerIndex(anyInt()) }.thenReturn(0)
+            on { getX(anyInt()) }.thenReturn(1f)
+            on { getY(anyInt()) }.thenReturn(1f)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `start does not set replayId on scope for buffered session`() {
+        val strategy = fixture.getSut()
+        val replayId = SentryId()
+
+        strategy.start(fixture.recorderConfig, 0, replayId)
+
+        assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
+        assertEquals(replayId, strategy.currentReplayId)
+        assertEquals(0, strategy.currentSegment)
+    }
+
+    @Test
+    fun `start persists segment values`() {
+        val strategy = fixture.getSut()
+        val replayId = SentryId()
+
+        strategy.start(fixture.recorderConfig, 0, replayId)
+
+        assertEquals("0", fixture.persistedSegment[SEGMENT_KEY_ID])
+        assertEquals(replayId.toString(), fixture.persistedSegment[SEGMENT_KEY_REPLAY_ID])
+        assertEquals(
+            ReplayType.BUFFER.toString(),
+            fixture.persistedSegment[SEGMENT_KEY_REPLAY_TYPE]
+        )
+        assertTrue(fixture.persistedSegment[SEGMENT_KEY_TIMESTAMP]?.isNotEmpty() == true)
+    }
+
+    @Test
+    fun `pause creates but does not capture current segment`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig, 0, SentryId())
+
+        strategy.pause()
+
+        await.until { strategy.currentSegment == 1 }
+
+        verify(fixture.hub, never()).captureReplay(any(), any())
+        assertEquals(1, strategy.currentSegment)
+    }
+
+    @Test
+    fun `stop clears replay cache dir`() {
+        val replayId = SentryId()
+        val currentReplay =
+            File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
+
+        val strategy = fixture.getSut(replayCacheDir = currentReplay)
+        strategy.start(fixture.recorderConfig, 0, replayId)
+
+        strategy.stop()
+
+        verify(fixture.hub, never()).captureReplay(any(), any())
+
+        assertEquals(SentryId.EMPTY_ID, strategy.currentReplayId)
+        assertEquals(-1, strategy.currentSegment)
+        assertFalse(currentReplay.exists())
+        verify(fixture.replayCache).close()
+    }
+
+    @Test
+    fun `onScreenshotRecorded adds screenshot to cache`() {
+        val now =
+            System.currentTimeMillis() + (fixture.options.experimental.sessionReplay.errorReplayDuration * 5)
+        val strategy = fixture.getSut(
+            dateProvider = { now }
+        )
+        strategy.start(fixture.recorderConfig)
+
+        strategy.onScreenshotRecorded(mock<Bitmap>()) { frameTimestamp ->
+            assertEquals(now, frameTimestamp)
+        }
+    }
+
+    @Test
+    fun `onScreenshotRecorded rotates screenshots when out of buffer bounds`() {
+        val now =
+            System.currentTimeMillis() + (fixture.options.experimental.sessionReplay.errorReplayDuration * 5)
+        val strategy = fixture.getSut(
+            dateProvider = { now }
+        )
+        strategy.start(fixture.recorderConfig)
+
+        strategy.onScreenshotRecorded(mock<Bitmap>()) { frameTimestamp ->
+            assertEquals(now, frameTimestamp)
+        }
+        verify(fixture.replayCache).rotate(eq(now - fixture.options.experimental.sessionReplay.errorReplayDuration))
+    }
+
+    @Test
+    fun `onConfigurationChanged creates new segment and updates config`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+
+        val newConfig = fixture.recorderConfig.copy(recordingHeight = 1080, recordingWidth = 1920)
+        strategy.onConfigurationChanged(newConfig)
+
+        await.until { strategy.currentSegment == 1 }
+
+        verify(fixture.hub, never()).captureReplay(any(), any())
+        assertEquals(1, strategy.currentSegment)
+    }
+
+    @Test
+    fun `convert does nothing when process is terminating`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+
+        strategy.captureReplay(true) {}
+
+        val converted = strategy.convert()
+        assertTrue(converted is BufferCaptureStrategy)
+    }
+
+    @Test
+    fun `convert converts to session strategy and sets replayId to scope`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+
+        val converted = strategy.convert()
+        assertTrue(converted is SessionCaptureStrategy)
+        assertEquals(strategy.currentReplayId, fixture.scope.replayId)
+    }
+
+    @Test
+    fun `captureReplay does not replayId to scope when not sampled`() {
+        val strategy = fixture.getSut(errorSampleRate = 0.0)
+        strategy.start(fixture.recorderConfig)
+
+        strategy.captureReplay(false) {}
+
+        assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
+    }
+
+    @Test
+    fun `captureReplay sets replayId to scope and captures buffered segments`() {
+        var called = false
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+        strategy.pause()
+
+        strategy.captureReplay(false) {
+            called = true
+        }
+
+        // buffered + current = 2
+        verify(fixture.hub, times(2)).captureReplay(any(), any())
+        assertEquals(strategy.currentReplayId, fixture.scope.replayId)
+        assertTrue(called)
+    }
+}

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.replay.capture
 import android.graphics.Bitmap
 import io.sentry.Breadcrumb
 import io.sentry.DateUtils
-import io.sentry.Hint
 import io.sentry.IHub
 import io.sentry.Scope
 import io.sentry.ScopeCallback
@@ -13,25 +12,19 @@ import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.DefaultReplayBreadcrumbConverter
 import io.sentry.android.replay.GeneratedVideo
 import io.sentry.android.replay.ReplayCache
-import io.sentry.android.replay.ReplayCache.Companion.ONGOING_SEGMENT
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_BIT_RATE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FRAME_RATE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_HEIGHT
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_ID
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_ID
-import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_RECORDING
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_TYPE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_WIDTH
 import io.sentry.android.replay.ReplayFrame
 import io.sentry.android.replay.ScreenshotRecorderConfig
-import io.sentry.cache.PersistingScopeObserver
 import io.sentry.protocol.SentryId
 import io.sentry.rrweb.RRWebBreadcrumbEvent
-import io.sentry.rrweb.RRWebInteractionEvent
-import io.sentry.rrweb.RRWebInteractionEvent.InteractionType
 import io.sentry.rrweb.RRWebMetaEvent
-import io.sentry.rrweb.RRWebVideoEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
 import org.junit.Rule
@@ -123,7 +116,7 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId, false)
+        strategy.start(fixture.recorderConfig, 0, replayId)
 
         assertEquals(replayId, fixture.scope.replayId)
         assertEquals(replayId, strategy.currentReplayId)
@@ -135,7 +128,7 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId, false)
+        strategy.start(fixture.recorderConfig, 0, replayId)
 
         assertEquals("0", fixture.persistedSegment[SEGMENT_KEY_ID])
         assertEquals(replayId.toString(), fixture.persistedSegment[SEGMENT_KEY_REPLAY_ID])
@@ -163,123 +156,9 @@ class SessionCaptureStrategyTest {
     }
 
     @Test
-    fun `start cleans up old replays`() {
-        val replayId = SentryId()
-
-        fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
-        val currentReplay =
-            File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
-        val evenOlderReplay =
-            File(fixture.options.cacheDirPath, "replay_${SentryId()}").also { it.mkdirs() }
-        val scopeCache = File(
-            fixture.options.cacheDirPath,
-            PersistingScopeObserver.SCOPE_CACHE
-        ).also { it.mkdirs() }
-
-        val strategy = fixture.getSut()
-
-        strategy.start(fixture.recorderConfig, 0, replayId, true)
-
-        // deletes older replay folders, but keeps current and previous replay + everything else
-        assertTrue(currentReplay.exists())
-        assertTrue(scopeCache.exists())
-        assertFalse(evenOlderReplay.exists())
-    }
-
-    @Test
-    fun `start finalizes previous replay`() {
-        val replayId = SentryId()
-        val oldReplayId = SentryId()
-
-        fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
-        val currentReplay =
-            File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
-        val oldReplay =
-            File(fixture.options.cacheDirPath, "replay_$oldReplayId").also { it.mkdirs() }
-        val scopeCache = File(
-            fixture.options.cacheDirPath,
-            PersistingScopeObserver.SCOPE_CACHE
-        ).also { it.mkdirs() }
-        File(scopeCache, PersistingScopeObserver.REPLAY_FILENAME).also {
-            it.createNewFile()
-            it.writeText("\"$oldReplayId\"")
-        }
-        val breadcrumbsFile = File(scopeCache, PersistingScopeObserver.BREADCRUMBS_FILENAME)
-        fixture.options.serializer.serialize(
-            listOf(
-                Breadcrumb(DateUtils.getDateTime("2024-07-11T10:25:23.454Z")).apply {
-                    category = "navigation"
-                    type = "navigation"
-                    setData("from", "from")
-                    setData("to", "to")
-                }
-            ),
-            breadcrumbsFile.writer()
-        )
-        File(oldReplay, ONGOING_SEGMENT).also {
-            it.writeText(
-                """
-                $SEGMENT_KEY_HEIGHT=912
-                $SEGMENT_KEY_WIDTH=416
-                $SEGMENT_KEY_FRAME_RATE=1
-                $SEGMENT_KEY_BIT_RATE=75000
-                $SEGMENT_KEY_ID=1
-                $SEGMENT_KEY_TIMESTAMP=2024-07-11T10:25:21.454Z
-                $SEGMENT_KEY_REPLAY_TYPE=SESSION
-                $SEGMENT_KEY_REPLAY_RECORDING={}[{"type":3,"timestamp":1720693523997,"data":{"source":2,"type":7,"id":0,"x":314.2979431152344,"y":625.44140625,"pointerType":2,"pointerId":0}},{"type":3,"timestamp":1720693524774,"data":{"source":2,"type":9,"id":0,"x":322.00390625,"y":424.4384765625,"pointerType":2,"pointerId":0}}]
-                """.trimIndent()
-            )
-        }
-
-        val strategy = fixture.getSut(replayCacheDir = oldReplay)
-        strategy.start(fixture.recorderConfig, 0, replayId, true)
-
-        assertTrue(currentReplay.exists())
-        assertFalse(oldReplay.exists())
-        verify(fixture.hub).captureReplay(
-            check {
-                assertEquals(oldReplayId, it.replayId)
-                assertEquals(ReplayType.SESSION, it.replayType)
-                assertEquals("0.mp4", it.videoFile?.name)
-            },
-            check {
-                val metaEvents = it.replayRecording?.payload?.filterIsInstance<RRWebMetaEvent>()
-                assertEquals(912, metaEvents?.first()?.height)
-                assertEquals(416, metaEvents?.first()?.width) // clamped to power of 16
-
-                val videoEvents = it.replayRecording?.payload?.filterIsInstance<RRWebVideoEvent>()
-                assertEquals(912, videoEvents?.first()?.height)
-                assertEquals(416, videoEvents?.first()?.width) // clamped to power of 16
-                assertEquals(5000, videoEvents?.first()?.durationMs)
-                assertEquals(5, videoEvents?.first()?.frameCount)
-                assertEquals(1, videoEvents?.first()?.frameRate)
-                assertEquals(1, videoEvents?.first()?.segmentId)
-
-                val breadcrumbEvents =
-                    it.replayRecording?.payload?.filterIsInstance<RRWebBreadcrumbEvent>()
-                assertEquals("navigation", breadcrumbEvents?.first()?.category)
-                assertEquals("to", breadcrumbEvents?.first()?.data?.get("to"))
-
-                val interactionEvents =
-                    it.replayRecording?.payload?.filterIsInstance<RRWebInteractionEvent>()
-                assertEquals(
-                    InteractionType.TouchStart,
-                    interactionEvents?.first()?.interactionType
-                )
-                assertEquals(314.29794f, interactionEvents?.first()?.x)
-                assertEquals(625.4414f, interactionEvents?.first()?.y)
-
-                assertEquals(InteractionType.TouchEnd, interactionEvents?.last()?.interactionType)
-                assertEquals(322.0039f, interactionEvents?.last()?.x)
-                assertEquals(424.43848f, interactionEvents?.last()?.y)
-            }
-        )
-    }
-
-    @Test
     fun `pause creates and captures current segment`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig, 0, SentryId(), false)
+        strategy.start(fixture.recorderConfig, 0, SentryId())
 
         strategy.pause()
 
@@ -299,7 +178,7 @@ class SessionCaptureStrategyTest {
             File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
 
         val strategy = fixture.getSut(replayCacheDir = currentReplay)
-        strategy.start(fixture.recorderConfig, 0, replayId, false)
+        strategy.start(fixture.recorderConfig, 0, replayId)
 
         strategy.stop()
 
@@ -317,26 +196,26 @@ class SessionCaptureStrategyTest {
     }
 
     @Test
-    fun `sendReplayForEvent captures last segment for crashed event`() {
+    fun `captureReplay does nothing for non-crashed event`() {
         val strategy = fixture.getSut()
         strategy.start(fixture.recorderConfig)
 
-        strategy.sendReplayForEvent(true, "event-id", Hint()) {}
+        strategy.captureReplay(false) {}
 
-        verify(fixture.hub).captureReplay(
-            argThat { event ->
-                event is SentryReplayEvent && event.segmentId == 0
-            },
-            any()
-        )
+        verify(fixture.hub, never()).captureReplay(any(), any())
     }
 
     @Test
-    fun `sendReplayForEvent does nothing for non-crashed event`() {
-        val strategy = fixture.getSut()
+    fun `when process is crashing, onScreenshotRecorded does not create new segment`() {
+        val now =
+            System.currentTimeMillis() + (fixture.options.experimental.sessionReplay.sessionSegmentDuration * 5)
+        val strategy = fixture.getSut(
+            dateProvider = { now }
+        )
         strategy.start(fixture.recorderConfig)
 
-        strategy.sendReplayForEvent(false, "event-id", Hint()) {}
+        strategy.captureReplay(true) {}
+        strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 
         verify(fixture.hub, never()).captureReplay(any(), any())
     }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -165,7 +165,7 @@
 
       <meta-data android:name="io.sentry.enable-metrics" android:value="true" />
 
-      <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
+      <meta-data android:name="io.sentry.session-replay.error-sample-rate" android:value="1.0" />
       <meta-data android:name="io.sentry.session-replay.redact-all-text" android:value="false" />
 
     </application>

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -165,7 +165,7 @@
 
       <meta-data android:name="io.sentry.enable-metrics" android:value="true" />
 
-      <meta-data android:name="io.sentry.session-replay.error-sample-rate" android:value="1.0" />
+      <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
       <meta-data android:name="io.sentry.session-replay.redact-all-text" android:value="false" />
 
     </application>

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -658,6 +658,7 @@ public abstract interface class io/sentry/IOptionsObserver {
 	public abstract fun setEnvironment (Ljava/lang/String;)V
 	public abstract fun setProguardUuid (Ljava/lang/String;)V
 	public abstract fun setRelease (Ljava/lang/String;)V
+	public abstract fun setReplayErrorSampleRate (Ljava/lang/Double;)V
 	public abstract fun setSdkVersion (Lio/sentry/protocol/SdkVersion;)V
 	public abstract fun setTags (Ljava/util/Map;)V
 }
@@ -1260,14 +1261,13 @@ public final class io/sentry/NoOpReplayBreadcrumbConverter : io/sentry/ReplayBre
 }
 
 public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
+	public fun captureReplay (Ljava/lang/Boolean;)V
 	public fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public static fun getInstance ()Lio/sentry/NoOpReplayController;
 	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isRecording ()Z
 	public fun pause ()V
 	public fun resume ()V
-	public fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
-	public fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V
 	public fun stop ()V
@@ -1676,13 +1676,12 @@ public abstract interface class io/sentry/ReplayBreadcrumbConverter {
 }
 
 public abstract interface class io/sentry/ReplayController {
+	public abstract fun captureReplay (Ljava/lang/Boolean;)V
 	public abstract fun getBreadcrumbConverter ()Lio/sentry/ReplayBreadcrumbConverter;
 	public abstract fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
 	public abstract fun resume ()V
-	public abstract fun sendReplay (Ljava/lang/Boolean;Ljava/lang/String;Lio/sentry/Hint;)V
-	public abstract fun sendReplayForEvent (Lio/sentry/SentryEvent;Lio/sentry/Hint;)V
 	public abstract fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public abstract fun start ()V
 	public abstract fun stop ()V
@@ -2120,7 +2119,7 @@ public final class io/sentry/SentryEnvelopeItem {
 	public static fun fromEvent (Lio/sentry/ISerializer;Lio/sentry/SentryBaseEvent;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromMetrics (Lio/sentry/metrics/EncodedMetrics;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromProfilingTrace (Lio/sentry/ProfilingTraceData;JLio/sentry/ISerializer;)Lio/sentry/SentryEnvelopeItem;
-	public static fun fromReplay (Lio/sentry/ISerializer;Lio/sentry/ILogger;Lio/sentry/SentryReplayEvent;Lio/sentry/ReplayRecording;)Lio/sentry/SentryEnvelopeItem;
+	public static fun fromReplay (Lio/sentry/ISerializer;Lio/sentry/ILogger;Lio/sentry/SentryReplayEvent;Lio/sentry/ReplayRecording;Z)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromSession (Lio/sentry/ISerializer;Lio/sentry/Session;)Lio/sentry/SentryEnvelopeItem;
 	public static fun fromUserFeedback (Lio/sentry/ISerializer;Lio/sentry/UserFeedback;)Lio/sentry/SentryEnvelopeItem;
 	public fun getClientReport (Lio/sentry/ISerializer;)Lio/sentry/clientreport/ClientReport;
@@ -3332,6 +3331,7 @@ public final class io/sentry/cache/PersistingOptionsObserver : io/sentry/IOption
 	public static final field OPTIONS_CACHE Ljava/lang/String;
 	public static final field PROGUARD_UUID_FILENAME Ljava/lang/String;
 	public static final field RELEASE_FILENAME Ljava/lang/String;
+	public static final field REPLAY_ERROR_SAMPLE_RATE_FILENAME Ljava/lang/String;
 	public static final field SDK_VERSION_FILENAME Ljava/lang/String;
 	public static final field TAGS_FILENAME Ljava/lang/String;
 	public fun <init> (Lio/sentry/SentryOptions;)V
@@ -3341,6 +3341,7 @@ public final class io/sentry/cache/PersistingOptionsObserver : io/sentry/IOption
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setProguardUuid (Ljava/lang/String;)V
 	public fun setRelease (Ljava/lang/String;)V
+	public fun setReplayErrorSampleRate (Ljava/lang/Double;)V
 	public fun setSdkVersion (Lio/sentry/protocol/SdkVersion;)V
 	public fun setTags (Ljava/util/Map;)V
 }
@@ -3372,6 +3373,7 @@ public final class io/sentry/cache/PersistingScopeObserver : io/sentry/ScopeObse
 	public fun setTrace (Lio/sentry/SpanContext;Lio/sentry/IScope;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
+	public static fun store (Lio/sentry/SentryOptions;Ljava/lang/Object;Ljava/lang/String;)V
 }
 
 public final class io/sentry/clientreport/ClientReport : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/IOptionsObserver.java
+++ b/sentry/src/main/java/io/sentry/IOptionsObserver.java
@@ -22,4 +22,6 @@ public interface IOptionsObserver {
   void setDist(@Nullable String dist);
 
   void setTags(@NotNull Map<String, @NotNull String> tags);
+
+  void setReplayErrorSampleRate(@Nullable Double replayErrorSampleRate);
 }

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -32,11 +32,7 @@ public final class NoOpReplayController implements ReplayController {
   }
 
   @Override
-  public void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint) {}
-
-  @Override
-  public void sendReplay(
-      @Nullable Boolean isCrashed, @Nullable String eventId, @Nullable Hint hint) {}
+  public void captureReplay(@Nullable Boolean isTerminating) {}
 
   @Override
   public @NotNull SentryId getReplayId() {

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -17,9 +17,7 @@ public interface ReplayController {
 
   boolean isRecording();
 
-  void sendReplayForEvent(@NotNull SentryEvent event, @NotNull Hint hint);
-
-  void sendReplay(@Nullable Boolean isCrashed, @Nullable String eventId, @Nullable Hint hint);
+  void captureReplay(@Nullable Boolean isTerminating);
 
   @NotNull
   SentryId getReplayId();

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -356,6 +356,8 @@ public final class Sentry {
                   observer.setDist(options.getDist());
                   observer.setEnvironment(options.getEnvironment());
                   observer.setTags(options.getTags());
+                  observer.setReplayErrorSampleRate(
+                      options.getExperimental().getSessionReplay().getErrorSampleRate());
                 }
               });
     } catch (Throwable e) {

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -8,6 +8,7 @@ import io.sentry.clientreport.ClientReport;
 import io.sentry.exception.SentryEnvelopeException;
 import io.sentry.metrics.EncodedMetrics;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.util.FileUtils;
 import io.sentry.util.JsonSerializationUtils;
 import io.sentry.util.Objects;
 import io.sentry.vendor.Base64;
@@ -372,7 +373,8 @@ public final class SentryEnvelopeItem {
       final @NotNull ISerializer serializer,
       final @NotNull ILogger logger,
       final @NotNull SentryReplayEvent replayEvent,
-      final @Nullable ReplayRecording replayRecording) {
+      final @Nullable ReplayRecording replayRecording,
+      final boolean cleanupReplayFolder) {
 
     final File replayVideo = replayEvent.getVideoFile();
 
@@ -415,7 +417,11 @@ public final class SentryEnvelopeItem {
                 return null;
               } finally {
                 if (replayVideo != null) {
-                  replayVideo.delete();
+                  if (cleanupReplayFolder) {
+                    FileUtils.deleteRecursively(replayVideo.getParentFile());
+                  } else {
+                    replayVideo.delete();
+                  }
                 }
               }
             });

--- a/sentry/src/main/java/io/sentry/cache/PersistingOptionsObserver.java
+++ b/sentry/src/main/java/io/sentry/cache/PersistingOptionsObserver.java
@@ -16,6 +16,7 @@ public final class PersistingOptionsObserver implements IOptionsObserver {
   public static final String ENVIRONMENT_FILENAME = "environment.json";
   public static final String DIST_FILENAME = "dist.json";
   public static final String TAGS_FILENAME = "tags.json";
+  public static final String REPLAY_ERROR_SAMPLE_RATE_FILENAME = "replay-error-sample-rate.json";
 
   private final @NotNull SentryOptions options;
 
@@ -71,6 +72,15 @@ public final class PersistingOptionsObserver implements IOptionsObserver {
   @Override
   public void setTags(@NotNull Map<String, @NotNull String> tags) {
     store(tags, TAGS_FILENAME);
+  }
+
+  @Override
+  public void setReplayErrorSampleRate(@Nullable Double replayErrorSampleRate) {
+    if (replayErrorSampleRate == null) {
+      delete(REPLAY_ERROR_SAMPLE_RATE_FILENAME);
+    } else {
+      store(replayErrorSampleRate.toString(), REPLAY_ERROR_SAMPLE_RATE_FILENAME);
+    }
   }
 
   private <T> void store(final @NotNull T entity, final @NotNull String fileName) {

--- a/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
+++ b/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
@@ -150,11 +150,18 @@ public final class PersistingScopeObserver extends ScopeObserverAdapter {
   }
 
   private <T> void store(final @NotNull T entity, final @NotNull String fileName) {
-    CacheUtils.store(options, entity, SCOPE_CACHE, fileName);
+    store(options, entity, fileName);
   }
 
   private void delete(final @NotNull String fileName) {
     CacheUtils.delete(options, SCOPE_CACHE, fileName);
+  }
+
+  public static <T> void store(
+      final @NotNull SentryOptions options,
+      final @NotNull T entity,
+      final @NotNull String fileName) {
+    CacheUtils.store(options, entity, SCOPE_CACHE, fileName);
   }
 
   public static <T> @Nullable T read(

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -28,6 +28,8 @@ import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
 import io.sentry.util.HintUtils
 import org.junit.Assert.assertArrayEquals
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
@@ -66,6 +68,9 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SentryClientTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
 
     class Fixture {
         var transport = mock<ITransport>()
@@ -2362,41 +2367,6 @@ class SentryClientTest {
     @Test
     fun `when event has DiskFlushNotification, TransactionEnds set transaction id as flushable`() {
         val sut = fixture.getSut()
-        val replayId = SentryId()
-        val scope = mock<Scope> {
-            whenever(it.replayId).thenReturn(replayId)
-            whenever(it.breadcrumbs).thenReturn(LinkedList<Breadcrumb>())
-            whenever(it.extras).thenReturn(emptyMap())
-            whenever(it.contexts).thenReturn(Contexts())
-        }
-        val scopePropagationContext = PropagationContext()
-        whenever(scope.propagationContext).thenReturn(scopePropagationContext)
-        doAnswer { (it.arguments[0] as IWithPropagationContext).accept(scopePropagationContext); scopePropagationContext }.whenever(scope).withPropagationContext(any())
-
-        var capturedEventId: SentryId? = null
-        val transactionEnd = object : TransactionEnd, DiskFlushNotification {
-            override fun markFlushed() {}
-            override fun isFlushable(eventId: SentryId?): Boolean = true
-            override fun setFlushable(eventId: SentryId) {
-                capturedEventId = eventId
-            }
-        }
-        val transactionEndHint = HintUtils.createWithTypeCheckHint(transactionEnd)
-
-        sut.captureEvent(SentryEvent(), scope, transactionEndHint)
-
-        assertEquals(replayId, capturedEventId)
-        verify(fixture.transport).send(
-            check {
-                assertEquals(1, it.items.count())
-            },
-            any()
-        )
-    }
-
-    @Test
-    fun `when event has DiskFlushNotification, TransactionEnds set replay id as flushable`() {
-        val sut = fixture.getSut()
 
         // build up a running transaction
         val spanContext = SpanContext("op.load")
@@ -2761,8 +2731,73 @@ class SentryClientTest {
         })
         val sut = fixture.getSut()
 
-        sut.captureMessage("Test", WARNING)
+        sut.captureEvent(SentryEvent().apply { exceptions = listOf(SentryException()) })
         assertTrue(called)
+    }
+
+    @Test
+    fun `calls captureReplay on replay controller for crash events and sets isTerminating`() {
+        var terminated: Boolean? = false
+        fixture.sentryOptions.setReplayController(object : ReplayController by NoOpReplayController.getInstance() {
+            override fun captureReplay(isTerminating: Boolean?) {
+                terminated = isTerminating
+            }
+        })
+        val sut = fixture.getSut()
+
+        sut.captureEvent(
+            SentryEvent().apply {
+                exceptions = listOf(
+                    SentryException().apply {
+                        mechanism = Mechanism().apply { isHandled = false }
+                    }
+                )
+            }
+        )
+        assertTrue(terminated == true)
+    }
+
+    @Test
+    fun `cleans up replay folder for Backfillable replay events`() {
+        val dir = File(tmpDir.newFolder().absolutePath)
+        val sut = fixture.getSut()
+        val replayEvent = createReplayEvent().apply {
+            videoFile = File(dir, "hello.txt").apply { writeText("hello") }
+        }
+
+        sut.captureReplayEvent(replayEvent, createScope(), HintUtils.createWithTypeCheckHint(BackfillableHint()))
+
+        verify(fixture.transport).send(
+            check { actual ->
+                val item = actual.items.first()
+                item.data
+                assertFalse(dir.exists())
+            },
+            any<Hint>()
+        )
+    }
+
+    @Test
+    fun `does not captureReplay for backfillable events`() {
+        var called = false
+        fixture.sentryOptions.setReplayController(object : ReplayController by NoOpReplayController.getInstance() {
+            override fun captureReplay(isTerminating: Boolean?) {
+                called = true
+            }
+        })
+        val sut = fixture.getSut()
+
+        sut.captureEvent(
+            SentryEvent().apply {
+                exceptions = listOf(
+                    SentryException().apply {
+                        mechanism = Mechanism().apply { isHandled = false }
+                    }
+                )
+            },
+            HintUtils.createWithTypeCheckHint(BackfillableHint())
+        )
+        assertFalse(called)
     }
 
     private fun givenScopeWithStartedSession(errored: Boolean = false, crashed: Boolean = false): IScope {

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -2752,11 +2752,10 @@ class SentryClientTest {
     }
 
     @Test
-    fun `calls sendReplayForEvent on replay controller for error events`() {
+    fun `calls captureReplay on replay controller for error events`() {
         var called = false
         fixture.sentryOptions.setReplayController(object : ReplayController by NoOpReplayController.getInstance() {
-            override fun sendReplayForEvent(event: SentryEvent, hint: Hint) {
-                assertEquals("Test", event.message?.formatted)
+            override fun captureReplay(isTerminating: Boolean?) {
                 called = true
             }
         })

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -737,6 +737,7 @@ class SentryTest {
             it.sdkVersion = SdkVersion("sentry.java.android", "6.13.0")
             it.environment = "debug"
             it.setTag("one", "two")
+            it.experimental.sessionReplay.errorSampleRate = 0.5
         }
 
         assertEquals("io.sentry.sample@1.1.0+220", optionsObserver.release)
@@ -745,6 +746,7 @@ class SentryTest {
         assertEquals("uuid", optionsObserver.proguardUuid)
         assertEquals(mapOf("one" to "two"), optionsObserver.tags)
         assertEquals(SdkVersion("sentry.java.android", "6.13.0"), optionsObserver.sdkVersion)
+        assertEquals(0.5, optionsObserver.replayErrorSampleRate)
     }
 
     @Test
@@ -1164,6 +1166,8 @@ class SentryTest {
             private set
         var tags: Map<String, String> = mapOf()
             private set
+        var replayErrorSampleRate: Double? = null
+            private set
 
         override fun setRelease(release: String?) {
             this.release = release
@@ -1187,6 +1191,10 @@ class SentryTest {
 
         override fun setTags(tags: MutableMap<String, String>) {
             this.tags = tags
+        }
+
+        override fun setReplayErrorSampleRate(replayErrorSampleRate: Double?) {
+            this.replayErrorSampleRate = replayErrorSampleRate
         }
     }
 


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
* Make buffer mode work for ANRs
  * For that we have to store errorSampleRate to disk and then roll the dice on next launch, because it could change in the meantime
  * Also, since in buffer mode we don't actually write `replayId` to scope until an error happens (and in the case of an ANR we don't know until next restart), the persisted `replayId` to disk might be irrelevant. So we have to iterate through the leftover  replay folders and find the one that was last modified closest to the ANR and take it as the previous replay
  * Important part is: we set the relevant `replayId` back to the disk cache, so later `ReplayIntegration` can pick it up and finalize and send it. The order will be ensured by an integration test
* Make buffer mode work for Crashes
  * Renamed `sendReplayForEvent` to `captureReplay` which just accept one argument now to define whether the app process is terminating or not. If it is, then we don't capture the buffered replay in the current process, but will capture it on next launch, to avoid weird issues with half-captured videos
  * Refactored `createSegment` method and moved it to a static method under `CaptureStrategy` so we could call it from `ReplayIntegration` as well
* Small fix for network breadcrumbs where we could deserialize double values sometimes (didn't want to change the deserializer for that to not break something accidentally)
* Small fix for the video encoder, set IFRAME_INTERVAL to -1 so it always only encode partial updates without full frames to save the video size

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/74441

## :green_heart: How did you test it?
manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

