### PR TITLE
Add support for 16KB page sizes (Android 15)

### DIFF
--- a/sentry-android-ndk/CMakeLists.txt
+++ b/sentry-android-ndk/CMakeLists.txt
@@ -15,3 +15,7 @@ add_subdirectory(${SENTRY_NATIVE_SRC} sentry_build)
 target_link_libraries(sentry-android PRIVATE
     $<BUILD_INTERFACE:sentry::sentry>
 )
+
+# Android 15: Support 16KB page sizes
+# see https://developer.android.com/guide/practices/page-sizes
+target_link_options(sentry-android PRIVATE "-Wl,-z,max-page-size=16384")

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -95,6 +95,13 @@ android {
             ignore = true
         }
     }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+    ndkVersion = "27.0.12077973"
 }
 
 dependencies {

--- a/sentry-samples/sentry-samples-android/CMakeLists.txt
+++ b/sentry-samples/sentry-samples-android/CMakeLists.txt
@@ -15,3 +15,8 @@ target_link_libraries(native-sample PRIVATE
     ${LOG_LIB}
     $<BUILD_INTERFACE:sentry::sentry>
 )
+
+# Android 15: Support 16KB page sizes
+# see https://developer.android.com/guide/practices/page-sizes
+target_link_options(native-sample PRIVATE "-Wl,-z,max-page-size=16384")
+

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -99,6 +99,13 @@ android {
             ignore = true
         }
     }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
+    ndkVersion = "27.0.12077973"
 }
 
 dependencies {


### PR DESCRIPTION
## :scroll: Description
Configures all relevant builds to use 16KB page size, inspired by https://github.com/getsentry/sentry-native/pull/1028.

## :bulb: Motivation and Context
This fixes the `7.x` `sentry-android` SDK side of https://github.com/getsentry/sentry-native/issues/989.

## :green_heart: How did you test it?
Manual testing using the Android 15 - 16KB page size enabled emulator.

## :pencil: Open Tasks
- [ ] Switch to release branch of `sentry-native` (right now it's the feat/support_16kb_page_size branch)


## :crystal_ball: Next steps
