### PR TITLE
[SR] Buffer mode improvements

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -36,12 +36,13 @@ public abstract interface class io/sentry/android/replay/Recorder : java/io/Clos
 public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 	public static final field Companion Lio/sentry/android/replay/ReplayCache$Companion;
 	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/protocol/SentryId;Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
-	public final fun addFrame (Ljava/io/File;J)V
+	public final fun addFrame (Ljava/io/File;JLjava/lang/String;)V
+	public static synthetic fun addFrame$default (Lio/sentry/android/replay/ReplayCache;Ljava/io/File;JLjava/lang/String;ILjava/lang/Object;)V
 	public fun close ()V
 	public final fun createVideoOf (JJIIILjava/io/File;)Lio/sentry/android/replay/GeneratedVideo;
 	public static synthetic fun createVideoOf$default (Lio/sentry/android/replay/ReplayCache;JJIIILjava/io/File;ILjava/lang/Object;)Lio/sentry/android/replay/GeneratedVideo;
 	public final fun persistSegmentValues (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun rotate (J)V
+	public final fun rotate (J)Ljava/lang/String;
 }
 
 public final class io/sentry/android/replay/ReplayCache$Companion {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -12,7 +12,6 @@ import io.sentry.Integration
 import io.sentry.NoOpReplayBreadcrumbConverter
 import io.sentry.ReplayBreadcrumbConverter
 import io.sentry.ReplayController
-import io.sentry.ScopeObserverAdapter
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
@@ -28,7 +27,6 @@ import io.sentry.cache.PersistingScopeObserver
 import io.sentry.cache.PersistingScopeObserver.BREADCRUMBS_FILENAME
 import io.sentry.cache.PersistingScopeObserver.REPLAY_FILENAME
 import io.sentry.hints.Backfillable
-import io.sentry.protocol.Contexts
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.FileUtils
@@ -102,12 +100,6 @@ public class ReplayIntegration(
         }
 
         this.hub = hub
-        this.options.addScopeObserver(object : ScopeObserverAdapter() {
-            override fun setContexts(contexts: Contexts) {
-                // scope screen has fully-qualified name
-                captureStrategy?.onScreenChanged(contexts.app?.viewNames?.lastOrNull()?.substringAfterLast('.'))
-            }
-        })
         recorder = recorderProvider?.invoke() ?: WindowRecorder(options, this, this, mainLooperHandler)
         isEnabled.set(true)
 
@@ -213,8 +205,10 @@ public class ReplayIntegration(
     }
 
     override fun onScreenshotRecorded(bitmap: Bitmap) {
+        var screen: String? = null
+        hub?.configureScope { screen = it.screen?.substringAfterLast('.') }
         captureStrategy?.onScreenshotRecorded(bitmap) { frameTimeStamp ->
-            addFrame(bitmap, frameTimeStamp)
+            addFrame(bitmap, frameTimeStamp, screen)
         }
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -176,8 +176,9 @@ public class ReplayIntegration(
             return
         }
 
-        captureStrategy?.captureReplay(isTerminating == true, onSegmentSent = {
+        captureStrategy?.captureReplay(isTerminating == true, onSegmentSent = { newTimestamp ->
             captureStrategy?.currentSegment = captureStrategy?.currentSegment!! + 1
+            captureStrategy?.segmentTimestamp = newTimestamp
         })
         captureStrategy = captureStrategy?.convert()
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -78,7 +78,7 @@ internal abstract class BaseCaptureStrategy(
         cache?.persistSegmentValues(SEGMENT_KEY_FRAME_RATE, newValue.frameRate.toString())
         cache?.persistSegmentValues(SEGMENT_KEY_BIT_RATE, newValue.bitRate.toString())
     }
-    protected var segmentTimestamp by persistableAtomicNullable<Date>(propertyName = SEGMENT_KEY_TIMESTAMP) { _, _, newValue ->
+    override var segmentTimestamp by persistableAtomicNullable<Date>(propertyName = SEGMENT_KEY_TIMESTAMP) { _, _, newValue ->
         cache?.persistSegmentValues(SEGMENT_KEY_TIMESTAMP, if (newValue == null) null else DateUtils.getTimestamp(newValue))
     }
     protected val replayStartTimestamp = AtomicLong()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -8,6 +8,7 @@ import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.ERROR
 import io.sentry.SentryLevel.INFO
 import io.sentry.SentryOptions
+import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.SentryReplayEvent.ReplayType.BUFFER
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
@@ -46,9 +47,10 @@ internal class BufferCaptureStrategy(
     override fun start(
         recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int,
-        replayId: SentryId
+        replayId: SentryId,
+        replayType: ReplayType?
     ) {
-        super.start(recorderConfig, segmentId, replayId)
+        super.start(recorderConfig, segmentId, replayId, replayType)
 
         hub?.configureScope {
             val screen = it.screen?.substringAfterLast('.')
@@ -159,7 +161,7 @@ internal class BufferCaptureStrategy(
         }
         // we hand over replayExecutor to the new strategy to preserve order of execution
         val captureStrategy = SessionCaptureStrategy(options, hub, dateProvider, replayExecutor)
-        captureStrategy.start(recorderConfig, segmentId = currentSegment, replayId = currentReplayId)
+        captureStrategy.start(recorderConfig, segmentId = currentSegment, replayId = currentReplayId, replayType = BUFFER)
         return captureStrategy
     }
 
@@ -250,7 +252,7 @@ internal class BufferCaptureStrategy(
 
         replayExecutor.submitSafely(options, "$TAG.$taskName") {
             val segment =
-                createSegmentInternal(duration, currentSegmentTimestamp, replayId, segmentId, height, width, BUFFER)
+                createSegmentInternal(duration, currentSegmentTimestamp, replayId, segmentId, height, width)
             onSegmentCreated(segment)
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -21,6 +21,7 @@ import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.FileUtils
 import java.io.File
 import java.security.SecureRandom
+import java.util.Date
 import java.util.concurrent.ScheduledExecutorService
 
 internal class BufferCaptureStrategy(
@@ -92,7 +93,7 @@ internal class BufferCaptureStrategy(
 
     override fun captureReplay(
         isTerminating: Boolean,
-        onSegmentSent: () -> Unit
+        onSegmentSent: (Date) -> Unit
     ) {
         val sampled = random.sample(options.experimental.sessionReplay.errorSampleRate)
 
@@ -123,8 +124,7 @@ internal class BufferCaptureStrategy(
                 // we only want to increment segment_id in the case of success, but currentSegment
                 // might be irrelevant since we changed strategies, so in the callback we increment
                 // it on the new strategy already
-                // TODO: also pass new segmentTimestamp to the new strategy
-                onSegmentSent()
+                onSegmentSent(segment.replay.timestamp)
             }
         }
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -25,11 +25,13 @@ internal interface CaptureStrategy {
     var currentSegment: Int
     var currentReplayId: SentryId
     val replayCacheDir: File?
+    var replayType: ReplayType
 
     fun start(
         recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int = 0,
-        replayId: SentryId = SentryId()
+        replayId: SentryId = SentryId(),
+        replayType: ReplayType? = null
     )
 
     fun stop()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -26,6 +26,7 @@ internal interface CaptureStrategy {
     var currentReplayId: SentryId
     val replayCacheDir: File?
     var replayType: ReplayType
+    var segmentTimestamp: Date?
 
     fun start(
         recorderConfig: ScreenshotRecorderConfig,
@@ -40,7 +41,7 @@ internal interface CaptureStrategy {
 
     fun resume()
 
-    fun captureReplay(isTerminating: Boolean, onSegmentSent: () -> Unit)
+    fun captureReplay(isTerminating: Boolean, onSegmentSent: (Date) -> Unit)
 
     fun onScreenshotRecorded(bitmap: Bitmap? = null, store: ReplayCache.(frameTimestamp: Long) -> Unit)
 
@@ -196,7 +197,6 @@ internal interface CaptureStrategy {
 
             replay.urls = urls
             return ReplaySegment.Created(
-                videoDuration = videoDuration,
                 replay = replay,
                 recording = recording
             )
@@ -221,7 +221,6 @@ internal interface CaptureStrategy {
     sealed class ReplaySegment {
         object Failed : ReplaySegment()
         data class Created(
-            val videoDuration: Long,
             val replay: SentryReplayEvent,
             val recording: ReplayRecording
         ) : ReplaySegment() {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -40,7 +40,7 @@ internal class SessionCaptureStrategy(
         // tagged with the replay that might never be sent when we're recording in buffer mode
         hub?.configureScope {
             it.replayId = currentReplayId
-            screenAtStart = it.screen
+            screenAtStart = it.screen?.substringAfterLast('.')
         }
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -1,7 +1,6 @@
 package io.sentry.android.replay.capture
 
 import android.graphics.Bitmap
-import io.sentry.DateUtils
 import io.sentry.IConnectionStatusProvider.ConnectionStatus.DISCONNECTED
 import io.sentry.IHub
 import io.sentry.SentryLevel.DEBUG
@@ -15,6 +14,7 @@ import io.sentry.android.replay.util.submitSafely
 import io.sentry.protocol.SentryId
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.FileUtils
+import java.util.Date
 import java.util.concurrent.ScheduledExecutorService
 
 internal class SessionCaptureStrategy(
@@ -67,7 +67,7 @@ internal class SessionCaptureStrategy(
         super.stop()
     }
 
-    override fun captureReplay(isTerminating: Boolean, onSegmentSent: () -> Unit) {
+    override fun captureReplay(isTerminating: Boolean, onSegmentSent: (Date) -> Unit) {
         options.logger.log(DEBUG, "Replay is already running in 'session' mode, not capturing for event")
         this.isTerminating.set(isTerminating)
     }
@@ -112,7 +112,7 @@ internal class SessionCaptureStrategy(
                     segment.capture(hub)
                     currentSegment++
                     // set next segment timestamp as close to the previous one as possible to avoid gaps
-                    segmentTimestamp = DateUtils.getDateTime(currentSegmentTimestamp.time + segment.videoDuration)
+                    segmentTimestamp = segment.replay.timestamp
                 }
             }
 
@@ -131,7 +131,7 @@ internal class SessionCaptureStrategy(
 
                 currentSegment++
                 // set next segment timestamp as close to the previous one as possible to avoid gaps
-                segmentTimestamp = DateUtils.getDateTime(currentSegmentTimestamp.time + segment.videoDuration)
+                segmentTimestamp = segment.replay.timestamp
             }
         }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -7,6 +7,7 @@ import io.sentry.IHub
 import io.sentry.SentryLevel.DEBUG
 import io.sentry.SentryLevel.INFO
 import io.sentry.SentryOptions
+import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
@@ -31,9 +32,10 @@ internal class SessionCaptureStrategy(
     override fun start(
         recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int,
-        replayId: SentryId
+        replayId: SentryId,
+        replayType: ReplayType?
     ) {
-        super.start(recorderConfig, segmentId, replayId)
+        super.start(recorderConfig, segmentId, replayId, replayType)
         // only set replayId on the scope if it's a full session, otherwise all events will be
         // tagged with the replay that might never be sent when we're recording in buffer mode
         hub?.configureScope {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -267,6 +267,23 @@ class ReplayCacheTest {
     }
 
     @Test
+    fun `rotate returns first screen in buffer`() {
+        val replayCache = fixture.getSut(
+            tmpDir,
+            frameRate = 1
+        )
+
+        val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
+        replayCache.addFrame(bitmap, 1, "MainActivity")
+        replayCache.addFrame(bitmap, 1001, "SecondActivity")
+        replayCache.addFrame(bitmap, 2001, "ThirdActivity")
+        replayCache.addFrame(bitmap, 3001, "FourthActivity")
+
+        val screen = replayCache.rotate(2000)
+        assertEquals("ThirdActivity", screen)
+    }
+
+    @Test
     fun `does not persist segment if already closed`() {
         val replayId = SentryId()
         val replayCache = fixture.getSut(

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doAnswer
@@ -160,7 +161,7 @@ class ReplayIntegrationTest {
 
         replay.start()
 
-        verify(captureStrategy, never()).start(any(), any(), any())
+        verify(captureStrategy, never()).start(any(), any(), any(), anyOrNull())
     }
 
     @Test
@@ -186,7 +187,8 @@ class ReplayIntegrationTest {
         verify(captureStrategy, times(1)).start(
             any(),
             eq(0),
-            argThat { this != SentryId.EMPTY_ID }
+            argThat { this != SentryId.EMPTY_ID },
+            anyOrNull()
         )
     }
 
@@ -201,7 +203,8 @@ class ReplayIntegrationTest {
         verify(captureStrategy, never()).start(
             any(),
             eq(0),
-            argThat { this != SentryId.EMPTY_ID }
+            argThat { this != SentryId.EMPTY_ID },
+            anyOrNull()
         )
     }
 
@@ -216,7 +219,8 @@ class ReplayIntegrationTest {
         verify(captureStrategy, times(1)).start(
             any(),
             eq(0),
-            argThat { this != SentryId.EMPTY_ID }
+            argThat { this != SentryId.EMPTY_ID },
+            anyOrNull()
         )
     }
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -242,6 +242,18 @@ class BufferCaptureStrategyTest {
     }
 
     @Test
+    fun `convert persists buffer replayType when converting to session strategy`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+
+        val converted = strategy.convert()
+        assertEquals(
+            ReplayType.BUFFER,
+            converted.replayType
+        )
+    }
+
+    @Test
     fun `captureReplay does not replayId to scope when not sampled`() {
         val strategy = fixture.getSut(errorSampleRate = 0.0)
         strategy.start(fixture.recorderConfig)

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -16,6 +16,7 @@ import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_REPLAY_TYPE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
 import io.sentry.android.replay.ReplayFrame
 import io.sentry.android.replay.ScreenshotRecorderConfig
+import io.sentry.android.replay.capture.BufferCaptureStrategyTest.Fixture.Companion.VIDEO_DURATION
 import io.sentry.protocol.SentryId
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
@@ -278,5 +279,18 @@ class BufferCaptureStrategyTest {
         verify(fixture.hub, times(2)).captureReplay(any(), any())
         assertEquals(strategy.currentReplayId, fixture.scope.replayId)
         assertTrue(called)
+    }
+
+    @Test
+    fun `captureReplay sets new segment timestamp to new strategy after successful creation`() {
+        val strategy = fixture.getSut()
+        strategy.start(fixture.recorderConfig)
+        val oldTimestamp = strategy.segmentTimestamp
+
+        strategy.captureReplay(false) { newTimestamp ->
+            assertEquals(oldTimestamp!!.time + VIDEO_DURATION, newTimestamp.time)
+        }
+
+        verify(fixture.hub).captureReplay(any(), any())
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Resolved some TODOs:
* Align next segment timestamp with the end of the buffered segment, when converting from buffer mode to session mode
* Persist `buffer` replay type for the entire replay when converting from buffer mode to session mode
* Rework how `screenAtStart` is stored - now we retrieve current screen name for each frame and store it in the replay cache, and then when we have to rotate the cached frames, we always get the correct screen at start of the buffered replay

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
part of https://github.com/getsentry/sentry/issues/74441

## :green_heart: How did you test it?
manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

