### PR TITLE
Avoid stopping appStartProfiler after application creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Avoid stopping appStartProfiler after application creation ([#3630](https://github.com/getsentry/sentry-java/pull/3630))
 - Avoid ArrayIndexOutOfBoundsException on Android cpu data collection ([#3598](https://github.com/getsentry/sentry-java/pull/3598))
 - Fix lazy select queries instrumentation ([#3604](https://github.com/getsentry/sentry-java/pull/3604))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -247,13 +247,14 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
               // if no activity has ever been created, app was launched in background
               if (onCreateTime == null) {
                 appLaunchedInForeground = false;
+
+                // we stop the app start profiler, as it's useless and likely to timeout
+                if (appStartProfiler != null && appStartProfiler.isRunning()) {
+                  appStartProfiler.close();
+                  appStartProfiler = null;
+                }
               }
               application.unregisterActivityLifecycleCallbacks(instance);
-              // we stop the app start profiler, as it's useless and likely to timeout
-              if (appStartProfiler != null && appStartProfiler.isRunning()) {
-                appStartProfiler.close();
-                appStartProfiler = null;
-              }
             });
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -197,6 +197,20 @@ class AppStartMetricsTest {
     }
 
     @Test
+    fun `if activity is started, does not stop app start profiler if running`() {
+        val profiler = mock<ITransactionProfiler>()
+        whenever(profiler.isRunning).thenReturn(true)
+        AppStartMetrics.getInstance().appStartProfiler = profiler
+        AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
+
+        AppStartMetrics.getInstance().registerApplicationForegroundCheck(mock())
+        // Job on main thread checks if activity was launched
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        verify(profiler, never()).close()
+    }
+
+    @Test
     fun `if app start span is longer than 1 minute, appStartTimeSpanWithFallback returns an empty span`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
         appStartTimeSpan.start()


### PR DESCRIPTION
## :scroll: Description
AppStartMetrics stops appStartProfiler only if no activity ever started


## :bulb: Motivation and Context
We were always stopping appStartProfiler after application creation.
Not a real issue, as the profiler should already be detatched from AppStartMetrics at that point.

## :green_heart: How did you test it?
Unit test


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
