### PR TITLE
Fix app start spans missing from Pixel devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fix app start spans missing from Pixel devices ([#3634](https://github.com/getsentry/sentry-java/pull/3634))
 - Avoid ArrayIndexOutOfBoundsException on Android cpu data collection ([#3598](https://github.com/getsentry/sentry-java/pull/3598))
 - Fix lazy select queries instrumentation ([#3604](https://github.com/getsentry/sentry-java/pull/3604))
 - Session Replay: buffer mode improvements ([#3622](https://github.com/getsentry/sentry-java/pull/3622))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -243,7 +243,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     isCallbackRegistered = true;
     appLaunchedInForeground = appLaunchedInForeground || ContextUtils.isForegroundImportance();
     application.registerActivityLifecycleCallbacks(instance);
-    checkCreateTimeOnMain(application);
+//    checkCreateTimeOnMain(application);
     new Handler(Looper.getMainLooper()).post(() -> checkCreateTimeOnMain(application));
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -243,8 +243,8 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     isCallbackRegistered = true;
     appLaunchedInForeground = appLaunchedInForeground || ContextUtils.isForegroundImportance();
     application.registerActivityLifecycleCallbacks(instance);
-//    checkCreateTimeOnMain(application);
-    new Handler(Looper.getMainLooper()).post(() -> checkCreateTimeOnMain(application));
+    checkCreateTimeOnMain(application);
+//    new Handler(Looper.getMainLooper()).post(() -> checkCreateTimeOnMain(application));
   }
 
   private void checkCreateTimeOnMain(final @NotNull Application application) {


### PR DESCRIPTION
## :scroll: Description
Pixel devices were missing app start spans.


## :bulb: Motivation and Context
We post a task on the main thread on Application creation and register a callback on activity creation to check if an activity has been created right after the application is created.
This works fine, unless running on Pixel devices, where the task posted on the main thread in application creation is called before the Activity.onCreate().
So we are now posting a task to post another task to check the activity creation, meaning we post it twice. This seems to work fine on Pixel devices from our tests
Closes https://github.com/getsentry/sentry-java/issues/3608


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
