### PR TITLE
[SR] Rename errorSampleRate to onErrorSampleRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 *Breaking changes*:
 
-- `options.experimental.sessionReplay.errorSampleRate` was renamed to `options.experimental.sessionReplay.onErrorSampleRate`
-- Manifest option `io.sentry.session-replay.error-sample-rate` was renamed to `io.sentry.session-replay.on-error-sample-rate`
+- `options.experimental.sessionReplay.errorSampleRate` was renamed to `options.experimental.sessionReplay.onErrorSampleRate` ([#3637](https://github.com/getsentry/sentry-java/pull/3637))
+- Manifest option `io.sentry.session-replay.error-sample-rate` was renamed to `io.sentry.session-replay.on-error-sample-rate` ([#3637](https://github.com/getsentry/sentry-java/pull/3637))
 
 ## 7.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+*Breaking changes*:
+
+- `options.experimental.sessionReplay.errorSampleRate` was renamed to `options.experimental.sessionReplay.onErrorSampleRate`
+- Manifest option `io.sentry.session-replay.error-sample-rate` was renamed to `io.sentry.session-replay.on-error-sample-rate`
+
 ## 7.14.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -106,7 +106,7 @@ final class ManifestMetadataReader {
 
   static final String REPLAYS_SESSION_SAMPLE_RATE = "io.sentry.session-replay.session-sample-rate";
 
-  static final String REPLAYS_ERROR_SAMPLE_RATE = "io.sentry.session-replay.error-sample-rate";
+  static final String REPLAYS_ERROR_SAMPLE_RATE = "io.sentry.session-replay.on-error-sample-rate";
 
   static final String REPLAYS_REDACT_ALL_TEXT = "io.sentry.session-replay.redact-all-text";
 
@@ -399,10 +399,10 @@ final class ManifestMetadataReader {
           }
         }
 
-        if (options.getExperimental().getSessionReplay().getErrorSampleRate() == null) {
-          final Double errorSampleRate = readDouble(metadata, logger, REPLAYS_ERROR_SAMPLE_RATE);
-          if (errorSampleRate != -1) {
-            options.getExperimental().getSessionReplay().setErrorSampleRate(errorSampleRate);
+        if (options.getExperimental().getSessionReplay().getOnErrorSampleRate() == null) {
+          final Double onErrorSampleRate = readDouble(metadata, logger, REPLAYS_ERROR_SAMPLE_RATE);
+          if (onErrorSampleRate != -1) {
+            options.getExperimental().getSessionReplay().setOnErrorSampleRate(onErrorSampleRate);
           }
         }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1422,7 +1422,7 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata reads replays errorSampleRate from metadata`() {
+    fun `applyMetadata reads replays onErrorSampleRate from metadata`() {
         // Arrange
         val expectedSampleRate = 0.99f
 
@@ -1433,14 +1433,14 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.errorSampleRate)
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.onErrorSampleRate)
     }
 
     @Test
-    fun `applyMetadata does not override replays errorSampleRate from options`() {
+    fun `applyMetadata does not override replays onErrorSampleRate from options`() {
         // Arrange
         val expectedSampleRate = 0.99f
-        fixture.options.experimental.sessionReplay.errorSampleRate = expectedSampleRate.toDouble()
+        fixture.options.experimental.sessionReplay.onErrorSampleRate = expectedSampleRate.toDouble()
         val bundle = bundleOf(ManifestMetadataReader.REPLAYS_ERROR_SAMPLE_RATE to 0.1f)
         val context = fixture.getContext(metaData = bundle)
 
@@ -1448,11 +1448,11 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.errorSampleRate)
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.experimental.sessionReplay.onErrorSampleRate)
     }
 
     @Test
-    fun `applyMetadata without specifying replays errorSampleRate, stays null`() {
+    fun `applyMetadata without specifying replays onErrorSampleRate, stays null`() {
         // Arrange
         val context = fixture.getContext()
 
@@ -1460,7 +1460,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertNull(fixture.options.experimental.sessionReplay.errorSampleRate)
+        assertNull(fixture.options.experimental.sessionReplay.onErrorSampleRate)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -369,7 +369,7 @@ class SentryAndroidTest {
                 options.release = "prod"
                 options.dsn = "https://key@sentry.io/123"
                 options.isEnableAutoSessionTracking = true
-                options.experimental.sessionReplay.errorSampleRate = 1.0
+                options.experimental.sessionReplay.onErrorSampleRate = 1.0
                 optionsConfig(options)
             }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -143,7 +143,7 @@ public class ReplayIntegration(
 
         val isFullSession = random.sample(options.experimental.sessionReplay.sessionSampleRate)
         if (!isFullSession && !options.experimental.sessionReplay.isSessionReplayForErrorsEnabled) {
-            options.logger.log(INFO, "Session replay is not started, full session was not sampled and errorSampleRate is not specified")
+            options.logger.log(INFO, "Session replay is not started, full session was not sampled and onErrorSampleRate is not specified")
             return
         }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -63,10 +63,10 @@ internal class BufferCaptureStrategy(
         isTerminating: Boolean,
         onSegmentSent: (Date) -> Unit
     ) {
-        val sampled = random.sample(options.experimental.sessionReplay.errorSampleRate)
+        val sampled = random.sample(options.experimental.sessionReplay.onErrorSampleRate)
 
         if (!sampled) {
-            options.logger.log(INFO, "Replay wasn't sampled by errorSampleRate, not capturing for event")
+            options.logger.log(INFO, "Replay wasn't sampled by onErrorSampleRate, not capturing for event")
             return
         }
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/AnrWithReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/AnrWithReplayIntegrationTest.kt
@@ -151,7 +151,7 @@ class AnrWithReplayIntegrationTest {
             it.cacheDirPath = cacheDir
             it.isDebug = true
             it.setLogger(SystemOutLogger())
-            it.experimental.sessionReplay.errorSampleRate = 1.0
+            it.experimental.sessionReplay.onErrorSampleRate = 1.0
             // beforeSend is called after event processors are applied, so we can assert here
             // against the enriched ANR event
             it.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -97,7 +97,7 @@ class ReplayIntegrationTest {
         fun getSut(
             context: Context,
             sessionSampleRate: Double = 1.0,
-            errorSampleRate: Double = 1.0,
+            onErrorSampleRate: Double = 1.0,
             recorderProvider: (() -> Recorder)? = null,
             replayCaptureStrategyProvider: ((isFullSession: Boolean) -> CaptureStrategy)? = null,
             recorderConfigProvider: ((configChanged: Boolean) -> ScreenshotRecorderConfig)? = null,
@@ -105,7 +105,7 @@ class ReplayIntegrationTest {
             dateProvider: ICurrentDateProvider = CurrentDateProvider.getInstance()
         ): ReplayIntegration {
             options.run {
-                experimental.sessionReplay.errorSampleRate = errorSampleRate
+                experimental.sessionReplay.onErrorSampleRate = onErrorSampleRate
                 experimental.sessionReplay.sessionSampleRate = sessionSampleRate
             }
             return ReplayIntegration(
@@ -204,7 +204,7 @@ class ReplayIntegrationTest {
     @Test
     fun `does not start replay when session is not sampled`() {
         val captureStrategy = mock<CaptureStrategy>()
-        val replay = fixture.getSut(context, errorSampleRate = 0.0, sessionSampleRate = 0.0, replayCaptureStrategyProvider = { captureStrategy })
+        val replay = fixture.getSut(context, onErrorSampleRate = 0.0, sessionSampleRate = 0.0, replayCaptureStrategyProvider = { captureStrategy })
 
         replay.register(fixture.hub, fixture.options)
         replay.start()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
@@ -154,7 +154,7 @@ class ReplaySmokeTest {
             captured.set(true)
         }
 
-        fixture.options.experimental.sessionReplay.errorSampleRate = 1.0
+        fixture.options.experimental.sessionReplay.onErrorSampleRate = 1.0
         fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
 
         val replay: ReplayIntegration = fixture.getSut(context)

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -83,7 +83,7 @@ class BufferCaptureStrategyTest {
         )
 
         fun getSut(
-            errorSampleRate: Double = 1.0,
+            onErrorSampleRate: Double = 1.0,
             dateProvider: ICurrentDateProvider = CurrentDateProvider.getInstance(),
             replayCacheDir: File? = null
         ): BufferCaptureStrategy {
@@ -91,7 +91,7 @@ class BufferCaptureStrategyTest {
                 whenever(replayCache.replayCacheDir).thenReturn(it)
             }
             options.run {
-                experimental.sessionReplay.errorSampleRate = errorSampleRate
+                experimental.sessionReplay.onErrorSampleRate = onErrorSampleRate
             }
             return BufferCaptureStrategy(
                 options,
@@ -256,7 +256,7 @@ class BufferCaptureStrategyTest {
 
     @Test
     fun `captureReplay does not replayId to scope when not sampled`() {
-        val strategy = fixture.getSut(errorSampleRate = 0.0)
+        val strategy = fixture.getSut(onErrorSampleRate = 0.0)
         strategy.start(fixture.recorderConfig)
 
         strategy.captureReplay(false) {}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2703,8 +2703,8 @@ public final class io/sentry/SentryReplayOptions {
 	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;)V
 	public fun addClassToRedact (Ljava/lang/String;)V
 	public fun getErrorReplayDuration ()J
-	public fun getErrorSampleRate ()Ljava/lang/Double;
 	public fun getFrameRate ()I
+	public fun getOnErrorSampleRate ()Ljava/lang/Double;
 	public fun getQuality ()Lio/sentry/SentryReplayOptions$SentryReplayQuality;
 	public fun getRedactAllImages ()Z
 	public fun getRedactAllText ()Z
@@ -2714,7 +2714,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getSessionSegmentDuration ()J
 	public fun isSessionReplayEnabled ()Z
 	public fun isSessionReplayForErrorsEnabled ()Z
-	public fun setErrorSampleRate (Ljava/lang/Double;)V
+	public fun setOnErrorSampleRate (Ljava/lang/Double;)V
 	public fun setQuality (Lio/sentry/SentryReplayOptions$SentryReplayQuality;)V
 	public fun setRedactAllImages (Z)V
 	public fun setRedactAllText (Z)V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -357,7 +357,7 @@ public final class Sentry {
                   observer.setEnvironment(options.getEnvironment());
                   observer.setTags(options.getTags());
                   observer.setReplayErrorSampleRate(
-                      options.getExperimental().getSessionReplay().getErrorSampleRate());
+                      options.getExperimental().getSessionReplay().getOnErrorSampleRate());
                 }
               });
     } catch (Throwable e) {

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -46,7 +46,7 @@ public final class SentryReplayOptions {
    * Specifying 0 means never, 1.0 means always. The value needs to be >= 0.0 and <= 1.0. The
    * default is null (disabled).
    */
-  private @Nullable Double errorSampleRate;
+  private @Nullable Double onErrorSampleRate;
 
   /**
    * Redact all text content. Draws a rectangle of text bounds with text color on top. By default
@@ -98,28 +98,28 @@ public final class SentryReplayOptions {
   public SentryReplayOptions() {}
 
   public SentryReplayOptions(
-      final @Nullable Double sessionSampleRate, final @Nullable Double errorSampleRate) {
+      final @Nullable Double sessionSampleRate, final @Nullable Double onErrorSampleRate) {
     this.sessionSampleRate = sessionSampleRate;
-    this.errorSampleRate = errorSampleRate;
+    this.onErrorSampleRate = onErrorSampleRate;
   }
 
   @Nullable
-  public Double getErrorSampleRate() {
-    return errorSampleRate;
+  public Double getOnErrorSampleRate() {
+    return onErrorSampleRate;
   }
 
   public boolean isSessionReplayEnabled() {
     return (getSessionSampleRate() != null && getSessionSampleRate() > 0);
   }
 
-  public void setErrorSampleRate(final @Nullable Double errorSampleRate) {
-    if (!SampleRateUtils.isValidSampleRate(errorSampleRate)) {
+  public void setOnErrorSampleRate(final @Nullable Double onErrorSampleRate) {
+    if (!SampleRateUtils.isValidSampleRate(onErrorSampleRate)) {
       throw new IllegalArgumentException(
           "The value "
-              + errorSampleRate
+              + onErrorSampleRate
               + " is not valid. Use null to disable or values >= 0.0 and <= 1.0.");
     }
-    this.errorSampleRate = errorSampleRate;
+    this.onErrorSampleRate = onErrorSampleRate;
   }
 
   @Nullable
@@ -128,7 +128,7 @@ public final class SentryReplayOptions {
   }
 
   public boolean isSessionReplayForErrorsEnabled() {
-    return (getErrorSampleRate() != null && getErrorSampleRate() > 0);
+    return (getOnErrorSampleRate() != null && getOnErrorSampleRate() > 0);
   }
 
   public void setSessionSampleRate(final @Nullable Double sessionSampleRate) {

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -737,7 +737,7 @@ class SentryTest {
             it.sdkVersion = SdkVersion("sentry.java.android", "6.13.0")
             it.environment = "debug"
             it.setTag("one", "two")
-            it.experimental.sessionReplay.errorSampleRate = 0.5
+            it.experimental.sessionReplay.onErrorSampleRate = 0.5
         }
 
         assertEquals("io.sentry.sample@1.1.0+220", optionsObserver.release)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
To better reflect and align with web replays, we've changed it to `onErrorSampleRate`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3616
