### PR TITLE
Add data from transaction root span to trace.context.data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Emit transaction.data inside contexts.trace.data ([#3642](https://github.com/getsentry/sentry-java/pull/3642))
+
 ## 7.14.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2941,6 +2941,7 @@ public final class io/sentry/Span : io/sentry/ISpan {
 
 public class io/sentry/SpanContext : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public static final field TYPE Ljava/lang/String;
+	protected field data Ljava/util/Map;
 	protected field description Ljava/lang/String;
 	protected field op Ljava/lang/String;
 	protected field origin Ljava/lang/String;
@@ -2952,6 +2953,7 @@ public class io/sentry/SpanContext : io/sentry/JsonSerializable, io/sentry/JsonU
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lio/sentry/TracesSamplingDecision;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getData ()Ljava/util/Map;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getOperation ()Ljava/lang/String;
 	public fun getOrigin ()Ljava/lang/String;
@@ -2966,6 +2968,7 @@ public class io/sentry/SpanContext : io/sentry/JsonSerializable, io/sentry/JsonU
 	public fun getUnknown ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setData (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setOperation (Ljava/lang/String;)V
 	public fun setOrigin (Ljava/lang/String;)V
@@ -2984,6 +2987,7 @@ public final class io/sentry/SpanContext$Deserializer : io/sentry/JsonDeserializ
 }
 
 public final class io/sentry/SpanContext$JsonKeys {
+	public static final field DATA Ljava/lang/String;
 	public static final field DESCRIPTION Ljava/lang/String;
 	public static final field OP Ljava/lang/String;
 	public static final field ORIGIN Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SpanContext.java
+++ b/sentry/src/main/java/io/sentry/SpanContext.java
@@ -46,6 +46,8 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
   /** Describes the status of the Transaction. */
   protected @Nullable String origin = "manual";
 
+  protected @NotNull Map<String, Object> data = new ConcurrentHashMap<>();
+
   private @Nullable Map<String, Object> unknown;
 
   public SpanContext(
@@ -213,6 +215,14 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
     this.origin = origin;
   }
 
+  public @NotNull Map<String, Object> getData() {
+    return data;
+  }
+
+  public void setData(final @NotNull String key, final @NotNull Object value) {
+    data.put(key, value);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -242,6 +252,7 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
     public static final String STATUS = "status";
     public static final String TAGS = "tags";
     public static final String ORIGIN = "origin";
+    public static final String DATA = "data";
   }
 
   @Override
@@ -268,6 +279,9 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
     }
     if (!tags.isEmpty()) {
       writer.name(JsonKeys.TAGS).value(logger, tags);
+    }
+    if (!data.isEmpty()) {
+      writer.name(JsonKeys.DATA).value(logger, data);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -303,6 +317,7 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
       SpanStatus status = null;
       String origin = null;
       Map<String, String> tags = null;
+      Map<String, Object> data = null;
 
       Map<String, Object> unknown = null;
       while (reader.peek() == JsonToken.NAME) {
@@ -333,6 +348,9 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
             tags =
                 CollectionUtils.newConcurrentHashMap(
                     (Map<String, String>) reader.nextObjectOrNull());
+            break;
+          case JsonKeys.DATA:
+            data = (Map<String, Object>) reader.nextObjectOrNull();
             break;
           default:
             if (unknown == null) {
@@ -374,6 +392,11 @@ public class SpanContext implements JsonUnknown, JsonSerializable {
       if (tags != null) {
         spanContext.tags = tags;
       }
+
+      if (data != null) {
+        spanContext.data = data;
+      }
+
       spanContext.setUnknown(unknown);
       reader.endObject();
       return spanContext;

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -889,7 +889,10 @@ class JsonSerializerTest {
                               "trace_id": "b156a475de54423d9c1571df97ec7eb6",
                               "span_id": "0a53026963414893",
                               "op": "http",
-                              "status": "ok"
+                              "status": "ok",
+                              "data": {
+                                "transactionDataKey": "transactionDataValue"
+                              }
                             },
                             "custom": {
                               "some-key": "some-value"
@@ -930,6 +933,7 @@ class JsonSerializerTest {
         assertEquals("0a53026963414893", transaction.contexts.trace!!.spanId.toString())
         assertEquals("http", transaction.contexts.trace!!.operation)
         assertNotNull(transaction.contexts["custom"])
+        assertEquals("transactionDataValue", transaction.contexts.trace!!.data!!["transactionDataKey"])
         assertEquals("some-value", (transaction.contexts["custom"] as Map<*, *>)["some-key"])
 
         assertEquals("extraValue", transaction.getExtra("extraKey"))

--- a/sentry/src/test/java/io/sentry/protocol/SpanContextSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SpanContextSerializationTest.kt
@@ -35,6 +35,7 @@ class SpanContextSerializationTest {
             setTag("2a5fa3f5-7b87-487f-aaa5-84567aa73642", "4781d51a-c5af-47f2-a4ed-f030c9b3e194")
             setTag("29106d7d-7fa4-444f-9d34-b9d7510c69ab", "218c23ea-694a-497e-bf6d-e5f26f1ad7bd")
             setTag("ba9ce913-269f-4c03-882d-8ca5e6991b14", "35a74e90-8db8-4610-a411-872cbc1030ac")
+            setData("spanContextDataKey", "spanContextDataValue")
         }
     }
     private val fixture = Fixture()

--- a/sentry/src/test/resources/json/contexts.json
+++ b/sentry/src/test/resources/json/contexts.json
@@ -121,6 +121,10 @@
       "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
       "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
       "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+    },
+    "data":
+    {
+      "spanContextDataKey": "spanContextDataValue"
     }
   }
 }

--- a/sentry/src/test/resources/json/sentry_base_event.json
+++ b/sentry/src/test/resources/json/sentry_base_event.json
@@ -124,6 +124,10 @@
         "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
         "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
         "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+      },
+      "data":
+      {
+        "spanContextDataKey": "spanContextDataValue"
       }
     }
   },

--- a/sentry/src/test/resources/json/sentry_base_event_with_null_extra.json
+++ b/sentry/src/test/resources/json/sentry_base_event_with_null_extra.json
@@ -124,6 +124,10 @@
         "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
         "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
         "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+      },
+      "data":
+      {
+        "spanContextDataKey": "spanContextDataValue"
       }
     }
   },

--- a/sentry/src/test/resources/json/sentry_event.json
+++ b/sentry/src/test/resources/json/sentry_event.json
@@ -259,6 +259,10 @@
                 "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
                 "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
                 "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+            },
+            "data":
+            {
+                "spanContextDataKey": "spanContextDataValue"
             }
         }
     },

--- a/sentry/src/test/resources/json/sentry_replay_event.json
+++ b/sentry/src/test/resources/json/sentry_replay_event.json
@@ -142,6 +142,10 @@
                 "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
                 "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
                 "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+            },
+            "data":
+            {
+                "spanContextDataKey": "spanContextDataValue"
             }
         }
     },

--- a/sentry/src/test/resources/json/sentry_transaction.json
+++ b/sentry/src/test/resources/json/sentry_transaction.json
@@ -207,6 +207,10 @@
                 "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
                 "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
                 "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+            },
+            "data":
+            {
+                "spanContextDataKey": "spanContextDataValue"
             }
         }
     },

--- a/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
+++ b/sentry/src/test/resources/json/sentry_transaction_legacy_date_format.json
@@ -207,6 +207,10 @@
                 "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
                 "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
                 "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+            },
+            "data":
+            {
+                "spanContextDataKey": "spanContextDataValue"
             }
         }
     },

--- a/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
+++ b/sentry/src/test/resources/json/sentry_transaction_no_measurement_unit.json
@@ -177,6 +177,10 @@
                 "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
                 "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
                 "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+            },
+            "data":
+            {
+                "spanContextDataKey": "spanContextDataValue"
             }
         }
     },

--- a/sentry/src/test/resources/json/span_context.json
+++ b/sentry/src/test/resources/json/span_context.json
@@ -11,5 +11,8 @@
     "2a5fa3f5-7b87-487f-aaa5-84567aa73642": "4781d51a-c5af-47f2-a4ed-f030c9b3e194",
     "29106d7d-7fa4-444f-9d34-b9d7510c69ab": "218c23ea-694a-497e-bf6d-e5f26f1ad7bd",
     "ba9ce913-269f-4c03-882d-8ca5e6991b14": "35a74e90-8db8-4610-a411-872cbc1030ac"
+  },
+  "data": {
+    "spanContextDataKey": "spanContextDataValue"
   }
 }


### PR DESCRIPTION
## :scroll: Description
Add root span data to `traceContext` when `SentryTransaction` is created

## :bulb: Motivation and Context
Fixes #3626 

## :green_heart: How did you test it?
Modified existing serialization tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
