### PR TITLE
POTEL 39 - Use RECORD_ONLY sampling decision if performance is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   - Errors weren't linked to traces correctly due to parts of the SDK not knowing the current span
 - Record dropped spans in client report when sampling out OpenTelemetry spans ([#3552](https://github.com/getsentry/sentry-java/pull/3552))
 - Retrieve the correct current span from `Scope`/`Scopes` when using OpenTelemetry ([#3554](https://github.com/getsentry/sentry-java/pull/3554))
+- Use RECORD_ONLY sampling decision if performance is disabled ([#3659](https://github.com/getsentry/sentry-java/pull/3659))
+  - Also fix check whether Performance is enabled when making a sampling decision in the OpenTelemetry sampler
 
 ## 8.0.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Add OpenTelemetry span data to Sentry span ([#3593](https://github.com/getsentry/sentry-java/pull/3593))
 - No longer selectively copy OpenTelemetry attributes to Sentry spans / transactions `data` ([#3663](https://github.com/getsentry/sentry-java/pull/3663))
 - Remove `PROCESS_COMMAND_ARGS` (`process.command_args`) OpenTelemetry span attribute as it can be very large ([#3664](https://github.com/getsentry/sentry-java/pull/3664))
+- Use RECORD_ONLY sampling decision if performance is disabled ([#3659](https://github.com/getsentry/sentry-java/pull/3659))
+    - Also fix check whether Performance is enabled when making a sampling decision in the OpenTelemetry sampler
 
 ### Dependencies
 
@@ -31,8 +33,6 @@
   - Errors weren't linked to traces correctly due to parts of the SDK not knowing the current span
 - Record dropped spans in client report when sampling out OpenTelemetry spans ([#3552](https://github.com/getsentry/sentry-java/pull/3552))
 - Retrieve the correct current span from `Scope`/`Scopes` when using OpenTelemetry ([#3554](https://github.com/getsentry/sentry-java/pull/3554))
-- Use RECORD_ONLY sampling decision if performance is disabled ([#3659](https://github.com/getsentry/sentry-java/pull/3659))
-  - Also fix check whether Performance is enabled when making a sampling decision in the OpenTelemetry sampler
 
 ## 8.0.0-alpha.3
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
@@ -71,7 +71,6 @@ public final class SentrySampler implements Sampler {
   private @NotNull SamplingResult handleRootOtelSpan(
       final @NotNull String traceId, final @NotNull Context parentContext) {
     if (!scopes.getOptions().isTracingEnabled()) {
-      System.out.println("not trace sampling -> RECORD_ONLY " + traceId);
       return SamplingResult.create(SamplingDecision.RECORD_ONLY);
     }
     @Nullable Baggage baggage = null;

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
@@ -70,9 +70,9 @@ public final class SentrySampler implements Sampler {
 
   private @NotNull SamplingResult handleRootOtelSpan(
       final @NotNull String traceId, final @NotNull Context parentContext) {
-    if (!scopes.getOptions().isTraceSampling()) {
-      // TODO [POTEL] should this return RECORD_ONLY to allow tracing without performance
-      return SamplingResult.create(SamplingDecision.DROP);
+    if (!scopes.getOptions().isTracingEnabled()) {
+      System.out.println("not trace sampling -> RECORD_ONLY " + traceId);
+      return SamplingResult.create(SamplingDecision.RECORD_ONLY);
     }
     @Nullable Baggage baggage = null;
     @Nullable


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Also fixes a bug where `isTraceSampling` was used instead of `isTracingEnabled`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
