### PR TITLE
POTEL 37b - No longer selectively copy OTel span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Use OpenTelemetry span name as fallback for transaction name ([#3557](https://github.com/getsentry/sentry-java/pull/3557))
   - In certain cases we were sending transactions as "<unlabeled transaction>" when using OpenTelemetry 
 - Add OpenTelemetry span data to Sentry span ([#3593](https://github.com/getsentry/sentry-java/pull/3593))
-- No longer selectively copy OpenTelemetry attributes to Sentry spans `data` ([#3663](https://github.com/getsentry/sentry-java/pull/3663))
+- No longer selectively copy OpenTelemetry attributes to Sentry spans / transactions `data` ([#3663](https://github.com/getsentry/sentry-java/pull/3663))
 
 ## 8.0.0-alpha.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Use OpenTelemetry span name as fallback for transaction name ([#3557](https://github.com/getsentry/sentry-java/pull/3557))
   - In certain cases we were sending transactions as "<unlabeled transaction>" when using OpenTelemetry 
 - Add OpenTelemetry span data to Sentry span ([#3593](https://github.com/getsentry/sentry-java/pull/3593))
+- No longer selectively copy OpenTelemetry attributes to Sentry spans `data` ([#3663](https://github.com/getsentry/sentry-java/pull/3663))
 
 ## 8.0.0-alpha.4
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
@@ -32,9 +32,6 @@ public final class io/sentry/opentelemetry/OtelSentrySpanProcessor : io/opentele
 
 public final class io/sentry/opentelemetry/OtelSpanInfo {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;Ljava/util/Map;)V
-	public fun addDataField (Ljava/lang/String;Ljava/lang/Object;)V
-	public fun getDataFields ()Ljava/util/Map;
 	public fun getDescription ()Ljava/lang/String;
 	public fun getOp ()Ljava/lang/String;
 	public fun getTransactionNameSource ()Lio/sentry/protocol/TransactionNameSource;

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanInfo.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanInfo.java
@@ -1,8 +1,6 @@
 package io.sentry.opentelemetry;
 
 import io.sentry.protocol.TransactionNameSource;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,19 +12,6 @@ public final class OtelSpanInfo {
   private final @Nullable String description;
   private final @NotNull TransactionNameSource transactionNameSource;
 
-  private final @NotNull Map<String, Object> dataFields;
-
-  public OtelSpanInfo(
-      final @NotNull String op,
-      final @Nullable String description,
-      final @NotNull TransactionNameSource transactionNameSource,
-      final @NotNull Map<String, Object> dataFields) {
-    this.op = op;
-    this.description = description;
-    this.transactionNameSource = transactionNameSource;
-    this.dataFields = dataFields;
-  }
-
   public OtelSpanInfo(
       final @NotNull String op,
       final @Nullable String description,
@@ -34,7 +19,6 @@ public final class OtelSpanInfo {
     this.op = op;
     this.description = description;
     this.transactionNameSource = transactionNameSource;
-    this.dataFields = new HashMap<>();
   }
 
   public @NotNull String getOp() {
@@ -47,13 +31,5 @@ public final class OtelSpanInfo {
 
   public @NotNull TransactionNameSource getTransactionNameSource() {
     return transactionNameSource;
-  }
-
-  public @NotNull Map<String, Object> getDataFields() {
-    return dataFields;
-  }
-
-  public void addDataField(final @NotNull String key, final @NotNull Object value) {
-    dataFields.put(key, value);
   }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -228,6 +228,10 @@ public final class SentrySpanExporter implements SpanExporter {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
     }
 
+    for (Map.Entry<String, Object> dataField : toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
+      sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
+    }
+
     transferSpanDetails(sentrySpanMaybe, sentryChildSpan);
 
     for (SpanNode childNode : spanNode.getChildren()) {

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -225,10 +225,6 @@ public final class SentrySpanExporter implements SpanExporter {
 
     final @NotNull ISpan sentryChildSpan = parentSentrySpan.startChild(spanContext, spanOptions);
 
-    for (Map.Entry<String, Object> dataField : spanInfo.getDataFields().entrySet()) {
-      sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
-    }
-
     for (Map.Entry<String, Object> dataField :
         toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
@@ -344,10 +340,6 @@ public final class SentrySpanExporter implements SpanExporter {
 
     final @NotNull Map<String, Object> otelContext = toOtelContext(span);
     sentryTransaction.setContext("otel", otelContext);
-
-    for (Map.Entry<String, Object> dataField : spanInfo.getDataFields().entrySet()) {
-      sentryTransaction.setData(dataField.getKey(), dataField.getValue());
-    }
 
     setOtelInstrumentationInfo(span, sentryTransaction);
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -10,7 +10,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.semconv.ResourceAttributes;
 import io.opentelemetry.semconv.SemanticAttributes;
 import io.sentry.Baggage;
 import io.sentry.DateUtils;
@@ -53,7 +52,8 @@ public final class SentrySpanExporter implements SpanExporter {
       new SpanDescriptionExtractor();
   private final @NotNull IScopes scopes;
 
-  //TODO [POTEL] should we also ignore "process.command_args" (`ResourceAttributes.PROCESS_COMMAND_ARGS`)?
+  // TODO [POTEL] should we also ignore "process.command_args"
+  // (`ResourceAttributes.PROCESS_COMMAND_ARGS`)?
   // As these are apparently so long that information that is added after it is lost
   private final @NotNull List<String> attributeKeysToRemove =
       Arrays.asList(
@@ -229,7 +229,8 @@ public final class SentrySpanExporter implements SpanExporter {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
     }
 
-    for (Map.Entry<String, Object> dataField : toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
+    for (Map.Entry<String, Object> dataField :
+        toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
     }
 
@@ -506,12 +507,13 @@ public final class SentrySpanExporter implements SpanExporter {
 
   private void setOtelInstrumentationInfo(SpanData span, ISpan sentryTransaction) {
     final @Nullable String otelInstrumentationName = span.getInstrumentationScopeInfo().getName();
-    if(otelInstrumentationName != null) {
+    if (otelInstrumentationName != null) {
       sentryTransaction.setData("otel.instrumentation.name", otelInstrumentationName);
     }
 
-    final @Nullable String otelInstrumentationVersion = span.getInstrumentationScopeInfo().getVersion();
-    if(otelInstrumentationVersion != null) {
+    final @Nullable String otelInstrumentationVersion =
+        span.getInstrumentationScopeInfo().getVersion();
+    if (otelInstrumentationVersion != null) {
       sentryTransaction.setData("otel.instrumentation.version", otelInstrumentationVersion);
     }
   }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -10,6 +10,7 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.semconv.ResourceAttributes;
 import io.opentelemetry.semconv.SemanticAttributes;
 import io.sentry.Baggage;
 import io.sentry.DateUtils;
@@ -52,6 +53,8 @@ public final class SentrySpanExporter implements SpanExporter {
       new SpanDescriptionExtractor();
   private final @NotNull IScopes scopes;
 
+  //TODO [POTEL] should we also ignore "process.command_args" (`ResourceAttributes.PROCESS_COMMAND_ARGS`)?
+  // As these are apparently so long that information that is added after it is lost
   private final @NotNull List<String> attributeKeysToRemove =
       Arrays.asList(
           InternalSemanticAttributes.IS_REMOTE_PARENT.getKey(),
@@ -187,8 +190,6 @@ public final class SentrySpanExporter implements SpanExporter {
         spanStorage.getSentrySpan(spanData.getSpanContext());
     final @NotNull OtelSpanInfo spanInfo =
         spanDescriptionExtractor.extractSpanInfo(spanData, sentrySpanMaybe);
-    // TODO attributes
-    // TODO cleanup sentry attributes
 
     scopes
         .getOptions()
@@ -231,6 +232,8 @@ public final class SentrySpanExporter implements SpanExporter {
     for (Map.Entry<String, Object> dataField : toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
     }
+
+    setOtelInstrumentationInfo(spanData, sentryChildSpan);
 
     transferSpanDetails(sentrySpanMaybe, sentryChildSpan);
 
@@ -278,7 +281,6 @@ public final class SentrySpanExporter implements SpanExporter {
     final @NotNull String traceId = span.getTraceId();
     final @Nullable OtelSpanWrapper sentrySpanMaybe =
         spanStorage.getSentrySpan(span.getSpanContext());
-
     final @Nullable IScopes scopesMaybe =
         sentrySpanMaybe != null ? sentrySpanMaybe.getScopes() : null;
     final @NotNull IScopes scopesToUse =
@@ -345,6 +347,8 @@ public final class SentrySpanExporter implements SpanExporter {
     for (Map.Entry<String, Object> dataField : spanInfo.getDataFields().entrySet()) {
       sentryTransaction.setData(dataField.getKey(), dataField.getValue());
     }
+
+    setOtelInstrumentationInfo(span, sentryTransaction);
 
     transferSpanDetails(sentrySpanMaybe, sentryTransaction);
 
@@ -498,6 +502,18 @@ public final class SentrySpanExporter implements SpanExporter {
 
   private boolean isSentryInternalKey(final @NotNull String key) {
     return attributeKeysToRemove.contains(key);
+  }
+
+  private void setOtelInstrumentationInfo(SpanData span, ISpan sentryTransaction) {
+    final @Nullable String otelInstrumentationName = span.getInstrumentationScopeInfo().getName();
+    if(otelInstrumentationName != null) {
+      sentryTransaction.setData("otel.instrumentation.name", otelInstrumentationName);
+    }
+
+    final @Nullable String otelInstrumentationVersion = span.getInstrumentationScopeInfo().getVersion();
+    if(otelInstrumentationVersion != null) {
+      sentryTransaction.setData("otel.instrumentation.version", otelInstrumentationVersion);
+    }
   }
 
   @Override

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -230,11 +230,6 @@ public final class SentrySpanExporter implements SpanExporter {
       sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
     }
 
-    for (Map.Entry<String, Object> dataField :
-        toMapWithStringKeys(spanData.getAttributes()).entrySet()) {
-      sentryChildSpan.setData(dataField.getKey(), dataField.getValue());
-    }
-
     setOtelInstrumentationInfo(spanData, sentryChildSpan);
 
     transferSpanDetails(sentrySpanMaybe, sentryChildSpan);
@@ -345,8 +340,6 @@ public final class SentrySpanExporter implements SpanExporter {
 
     final @NotNull Map<String, Object> otelContext = toOtelContext(span);
     sentryTransaction.setContext("otel", otelContext);
-
-    setOtelInstrumentationInfo(span, sentryTransaction);
 
     setOtelInstrumentationInfo(span, sentryTransaction);
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -14,7 +14,9 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SpanDescriptionExtractor {
 
-  // TODO [POTEL] remove these method overloads and pass in SpanData instead (span.toSpanData())
+  //TODO POTEL: should we rely on the OTEL attributes, that are extracted in the exporter for the datafields?
+  // We are currently extracting some attributes and add it to the span info here
+  // In the `SentrySpanExporter` we extract all attributes and add it to the dataFields
   @SuppressWarnings("deprecation")
   public @NotNull OtelSpanInfo extractSpanInfo(
       final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {
@@ -47,7 +49,6 @@ public final class SpanDescriptionExtractor {
   @SuppressWarnings("deprecation")
   private OtelSpanInfo extractSpanDescription(
       final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {
-    //TODO POTEL add OTEL span attributes to SpanData!
     final @NotNull Attributes attributes = otelSpan.getAttributes();
 
     final @Nullable String httpMethod = attributes.get(SemanticAttributes.HTTP_METHOD);

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -12,10 +12,6 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SpanDescriptionExtractor {
 
-  // TODO POTEL: should we rely on the OTEL attributes, that are extracted in the exporter for the
-  // datafields?
-  // We are currently extracting some attributes and add it to the span info here
-  // In the `SentrySpanExporter` we extract all attributes and add it to the dataFields
   @SuppressWarnings("deprecation")
   public @NotNull OtelSpanInfo extractSpanInfo(
       final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -5,8 +5,6 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.semconv.SemanticAttributes;
 import io.sentry.protocol.TransactionNameSource;
-import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,41 +12,8 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SpanDescriptionExtractor {
 
-  // TODO POTEL: should we rely on the OTEL attributes, that are extracted in the exporter for the
-  // datafields?
-  // We are currently extracting some attributes and add it to the span info here
-  // In the `SentrySpanExporter` we extract all attributes and add it to the dataFields
   @SuppressWarnings("deprecation")
   public @NotNull OtelSpanInfo extractSpanInfo(
-      final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {
-    OtelSpanInfo spanInfo = extractSpanDescription(otelSpan, sentrySpan);
-
-    final @Nullable Long threadId = otelSpan.getAttributes().get(SemanticAttributes.THREAD_ID);
-    if (threadId != null) {
-      spanInfo.addDataField("thread.id", threadId);
-    }
-
-    final @Nullable String threadName =
-        otelSpan.getAttributes().get(SemanticAttributes.THREAD_NAME);
-    if (threadName != null) {
-      spanInfo.addDataField("thread.name", threadName);
-    }
-
-    final @Nullable String dbSystem = otelSpan.getAttributes().get(SemanticAttributes.DB_SYSTEM);
-    if (dbSystem != null) {
-      spanInfo.addDataField("db.system", dbSystem);
-    }
-
-    final @Nullable String dbName = otelSpan.getAttributes().get(SemanticAttributes.DB_NAME);
-    if (dbName != null) {
-      spanInfo.addDataField("db.name", dbName);
-    }
-
-    return spanInfo;
-  }
-
-  @SuppressWarnings("deprecation")
-  private OtelSpanInfo extractSpanDescription(
       final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {
     final @NotNull Attributes attributes = otelSpan.getAttributes();
 
@@ -82,9 +47,6 @@ public final class SpanDescriptionExtractor {
     final @NotNull SpanKind kind = otelSpan.getKind();
     final @NotNull StringBuilder opBuilder = new StringBuilder("http");
     final @NotNull Attributes attributes = otelSpan.getAttributes();
-    final @NotNull Map<String, Object> dataFields = new HashMap<>();
-
-    dataFields.put("http.request.method", httpMethod);
 
     if (SpanKind.CLIENT.equals(kind)) {
       opBuilder.append(".client");
@@ -99,20 +61,8 @@ public final class SpanDescriptionExtractor {
     }
     final @NotNull String op = opBuilder.toString();
 
-    final @Nullable Long httpStatusCode =
-        attributes.get(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE);
-    if (httpStatusCode != null) {
-      dataFields.put("http.response.status_code", httpStatusCode);
-    }
-
-    final @Nullable String serverAddress = attributes.get(SemanticAttributes.SERVER_ADDRESS);
-    if (serverAddress != null) {
-      dataFields.put("server.address", serverAddress);
-    }
-
     final @Nullable String urlFull = attributes.get(SemanticAttributes.URL_FULL);
     if (urlFull != null) {
-      dataFields.put("url.full", urlFull);
       if (httpPath == null) {
         httpPath = urlFull;
       }
@@ -126,7 +76,7 @@ public final class SpanDescriptionExtractor {
     final @NotNull TransactionNameSource transactionNameSource =
         httpRoute != null ? TransactionNameSource.ROUTE : TransactionNameSource.URL;
 
-    return new OtelSpanInfo(op, description, transactionNameSource, dataFields);
+    return new OtelSpanInfo(op, description, transactionNameSource);
   }
 
   @SuppressWarnings("deprecation")

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -14,7 +14,8 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SpanDescriptionExtractor {
 
-  //TODO POTEL: should we rely on the OTEL attributes, that are extracted in the exporter for the datafields?
+  // TODO POTEL: should we rely on the OTEL attributes, that are extracted in the exporter for the
+  // datafields?
   // We are currently extracting some attributes and add it to the span info here
   // In the `SentrySpanExporter` we extract all attributes and add it to the dataFields
   @SuppressWarnings("deprecation")

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -49,42 +49,39 @@ public final class SpanDescriptionExtractor {
       final @NotNull SpanData otelSpan, final @Nullable OtelSpanWrapper sentrySpan) {
     //TODO POTEL add OTEL span attributes to SpanData!
     final @NotNull Attributes attributes = otelSpan.getAttributes();
-    final @NotNull Map<String, Object> dataFields = new HashMap<>();
-
-    otelSpan.getAttributes().forEach((key, value) -> {
-      dataFields.put(key.getKey(), value);
-    });
 
     final @Nullable String httpMethod = attributes.get(SemanticAttributes.HTTP_METHOD);
     if (httpMethod != null) {
-      return descriptionForHttpMethod(otelSpan, httpMethod, dataFields);
+      return descriptionForHttpMethod(otelSpan, httpMethod);
     }
 
     final @Nullable String httpRequestMethod =
         attributes.get(SemanticAttributes.HTTP_REQUEST_METHOD);
     if (httpRequestMethod != null) {
-      return descriptionForHttpMethod(otelSpan, httpRequestMethod, dataFields);
+      return descriptionForHttpMethod(otelSpan, httpRequestMethod);
     }
 
     final @Nullable String dbSystem = attributes.get(SemanticAttributes.DB_SYSTEM);
     if (dbSystem != null) {
-      return descriptionForDbSystem(otelSpan, dataFields);
+      return descriptionForDbSystem(otelSpan);
     }
 
     final @NotNull String name = otelSpan.getName();
     final @Nullable String maybeDescription =
         sentrySpan != null ? sentrySpan.getDescription() : name;
     final @NotNull String description = maybeDescription != null ? maybeDescription : name;
-    return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM, dataFields);
+    return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
   }
 
   @SuppressWarnings("deprecation")
   private OtelSpanInfo descriptionForHttpMethod(
-      final @NotNull SpanData otelSpan, final @NotNull String httpMethod, @NotNull Map<String, Object> dataFields) {
+      final @NotNull SpanData otelSpan, final @NotNull String httpMethod) {
     final @NotNull String name = otelSpan.getName();
     final @NotNull SpanKind kind = otelSpan.getKind();
     final @NotNull StringBuilder opBuilder = new StringBuilder("http");
     final @NotNull Attributes attributes = otelSpan.getAttributes();
+    final @NotNull Map<String, Object> dataFields = new HashMap<>();
+
     dataFields.put("http.request.method", httpMethod);
 
     if (SpanKind.CLIENT.equals(kind)) {
@@ -120,7 +117,7 @@ public final class SpanDescriptionExtractor {
     }
 
     if (httpPath == null) {
-      return new OtelSpanInfo(op, name, TransactionNameSource.CUSTOM, dataFields);
+      return new OtelSpanInfo(op, name, TransactionNameSource.CUSTOM);
     }
 
     final @NotNull String description = httpMethod + " " + httpPath;
@@ -131,10 +128,10 @@ public final class SpanDescriptionExtractor {
   }
 
   @SuppressWarnings("deprecation")
-  private OtelSpanInfo descriptionForDbSystem(final @NotNull SpanData otelSpan, @NotNull Map<String, Object> dataFields) {
+  private OtelSpanInfo descriptionForDbSystem(final @NotNull SpanData otelSpan) {
     final @NotNull Attributes attributes = otelSpan.getAttributes();
     @Nullable String dbStatement = attributes.get(SemanticAttributes.DB_STATEMENT);
     @NotNull String description = dbStatement != null ? dbStatement : otelSpan.getName();
-    return new OtelSpanInfo("db", description, TransactionNameSource.TASK, dataFields);
+    return new OtelSpanInfo("db", description, TransactionNameSource.TASK);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We're copying all of attribues as of (https://github.com/getsentry/sentry-java/pull/3593). This means we no longer need to selectively copy some of them.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove unnecessary code.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
