### PR TITLE
Fix security vulnerability by bumping lifecycleVersion to 2.8.4

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -56,7 +56,7 @@ object Config {
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.8.1"
         val constraintLayout = "androidx.constraintlayout:constraintlayout:2.1.3"
 
-        private val lifecycleVersion = "2.2.0"
+        private val lifecycleVersion = "2.8.4"
         val lifecycleProcess = "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
         val lifecycleCommonJava8 = "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
         val androidxCore = "androidx.core:core:1.3.2"


### PR DESCRIPTION
Fix security vulnerability by bumping lifecycleVersion to 2.8.4

# 📢 Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

# 📜 Description
Bump lifecycleVersion to 2.8.4

# 💡 Motivation and Context
1. This version has a [security vulnerability CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250) from [junit 4.12](https://mvnrepository.com/artifact/junit/junit/4.12)
2.  [2.2.0 was released 9/21/2019 almost 5 years ago](https://maven.google.com/web/index.html?q=lifecycle-common#androidx.lifecycle:lifecycle-common:2.0.0).
3. `lifecycle-common-2.2.0`, `lifecycle-common-java8-2.2.0`, `lifecycle-process-2.2.0` and `lifecycle-runtime-2.2.0` does not have the corresponding `.asc` so it is not possible to verify the integrity of the libraries. This cause that we adding sentry to our project, we get the following error:

```
> Dependency verification failed for configuration ':log-decryptor:implementation':
    - On artifact lifecycle-common-2.2.0.pom (androidx.lifecycle:lifecycle-common:2.2.0) in repository 'Artifactory Google': checksum is missing from verification metadata.
    - On artifact lifecycle-common-java8-2.2.0.pom (androidx.lifecycle:lifecycle-common-java8:2.2.0) in repository 'Artifactory Google': checksum is missing from verification metadata.
    - On artifact lifecycle-process-2.2.0.pom (androidx.lifecycle:lifecycle-process:2.2.0) in repository 'Artifactory Google': checksum is missing from verification metadata.
    - On artifact lifecycle-runtime-2.2.0.pom (androidx.lifecycle:lifecycle-runtime:2.2.0) in repository 'Artifactory Google': checksum is missing from verification metadata.
```


# 💚 How did you test it?
📝 Checklist
- [x]  I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

# 🔮 Next steps
