### PR TITLE
[SR] Detect dominant color for TextViews with Spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Avoid stopping appStartProfiler after application creation ([#3630](https://github.com/getsentry/sentry-java/pull/3630))
+- Session Replay: Correctly detect dominant color for `TextView`s with Spans ([#3682](https://github.com/getsentry/sentry-java/pull/3682))
 
 *Breaking changes*:
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -24,6 +24,7 @@ import io.sentry.SentryLevel.WARNING
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayOptions
 import io.sentry.android.replay.util.MainLooperHandler
+import io.sentry.android.replay.util.dominantTextColor
 import io.sentry.android.replay.util.getVisibleRects
 import io.sentry.android.replay.util.gracefullyShutdown
 import io.sentry.android.replay.util.submitSafely
@@ -142,13 +143,14 @@ internal class ScreenshotRecorder(
                                         }
 
                                         is TextViewHierarchyNode -> {
-                                            // TODO: find a way to get the correct text color for RN
-                                            // TODO: now it always returns black
+                                            val textColor = node.layout.dominantTextColor
+                                                ?: node.dominantColor
+                                                ?: Color.BLACK
                                             node.layout.getVisibleRects(
                                                 node.visibleRect,
                                                 node.paddingLeft,
                                                 node.paddingTop
-                                            ) to (node.dominantColor ?: Color.BLACK)
+                                            ) to textColor
                                         }
 
                                         else -> {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -104,8 +104,15 @@ internal val TextView.totalPaddingTopSafe: Int
         extendedPaddingTop
     }
 
-internal val TextView.dominantTextColor: Int get() {
-    if (text !is Spanned) return currentTextColor
+/**
+ * Returns the dominant text color of the layout by looking at the [ForegroundColorSpan] spans if
+ * this text is a [Spanned] text. If the text is not a [Spanned] text or there are no spans, it
+ * returns null.
+ */
+internal val Layout?.dominantTextColor: Int? get() {
+    this ?: return null
+
+    if (text !is Spanned) return null
 
     val spans = (text as Spanned).getSpans(0, text.length, ForegroundColorSpan::class.java)
 
@@ -125,5 +132,5 @@ internal val TextView.dominantTextColor: Int get() {
             dominantColor = span.foregroundColor
         }
     }
-    return dominantColor ?: currentTextColor
+    return dominantColor
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -13,6 +13,8 @@ import android.graphics.drawable.VectorDrawable
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.text.Layout
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import android.view.View
 import android.widget.TextView
 import java.lang.NullPointerException
@@ -101,3 +103,27 @@ internal val TextView.totalPaddingTopSafe: Int
     } catch (e: NullPointerException) {
         extendedPaddingTop
     }
+
+internal val TextView.dominantTextColor: Int get() {
+    if (text !is Spanned) return currentTextColor
+
+    val spans = (text as Spanned).getSpans(0, text.length, ForegroundColorSpan::class.java)
+
+    // determine the dominant color by the span with the longest range
+    var longestSpan = Int.MIN_VALUE
+    var dominantColor: Int? = null
+    for (span in spans) {
+        val spanStart = (text as Spanned).getSpanStart(span)
+        val spanEnd = (text as Spanned).getSpanEnd(span)
+        if (spanStart == -1 || spanEnd == -1) {
+            // the span is not attached
+            continue
+        }
+        val spanLength = spanEnd - spanStart
+        if (spanLength > longestSpan) {
+            longestSpan = spanLength
+            dominantColor = span.foregroundColor
+        }
+    }
+    return dominantColor ?: currentTextColor
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import io.sentry.SentryOptions
+import io.sentry.android.replay.util.dominantTextColor
 import io.sentry.android.replay.util.isRedactable
 import io.sentry.android.replay.util.isVisibleToUser
 import io.sentry.android.replay.util.totalPaddingTopSafe
@@ -220,30 +221,6 @@ sealed class ViewHierarchyNode(
     companion object {
 
         private fun Int.toOpaque() = this or 0xFF000000.toInt()
-
-        private val TextView.dominantTextColor: Int get() {
-            if (text !is Spanned) return currentTextColor
-
-            val spans = (text as Spanned).getSpans(0, text.length, ForegroundColorSpan::class.java)
-
-            // determine the dominant color by the span with the longest range
-            var longestSpan = Int.MIN_VALUE
-            var dominantColor: Int? = null
-            for (span in spans) {
-                val spanStart = (text as Spanned).getSpanStart(span)
-                val spanEnd = (text as Spanned).getSpanEnd(span)
-                if (spanStart == -1 || spanEnd == -1) {
-                    // the span is not attached
-                    continue
-                }
-                val spanLength = spanEnd - spanStart
-                if (spanLength > longestSpan) {
-                    longestSpan = spanLength
-                    dominantColor = span.foregroundColor
-                }
-            }
-            return dominantColor ?: currentTextColor
-        }
 
         /**
          * Basically replicating this: https://developer.android.com/reference/android/view/View#isImportantForContentCapture()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -222,7 +222,7 @@ sealed class ViewHierarchyNode(
         private fun Int.toOpaque() = this or 0xFF000000.toInt()
 
         private val TextView.dominantTextColor: Int get() {
-            if (text !is Spqanned) return currentTextColor
+            if (text !is Spanned) return currentTextColor
 
             val spans = (text as Spanned).getSpans(0, text.length, ForegroundColorSpan::class.java)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -3,8 +3,6 @@ package io.sentry.android.replay.viewhierarchy
 import android.annotation.TargetApi
 import android.graphics.Rect
 import android.text.Layout
-import android.text.Spanned
-import android.text.style.ForegroundColorSpan
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -245,7 +245,7 @@ sealed class ViewHierarchyNode(
                     parent.setImportantForCaptureToAncestors(true)
                     return TextViewHierarchyNode(
                         layout = view.layout,
-                        dominantColor = view.dominantTextColor.toOpaque(),
+                        dominantColor = view.currentTextColor.toOpaque(),
                         paddingLeft = view.totalPaddingLeft,
                         paddingTop = view.totalPaddingTopSafe,
                         x = view.x,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import io.sentry.SentryOptions
-import io.sentry.android.replay.util.dominantTextColor
 import io.sentry.android.replay.util.isRedactable
 import io.sentry.android.replay.util.isVisibleToUser
 import io.sentry.android.replay.util.totalPaddingTopSafe

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/TextViewDominantColorTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/TextViewDominantColorTest.kt
@@ -1,0 +1,52 @@
+package io.sentry.android.replay.util
+
+import android.graphics.Color
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30])
+class TextViewDominantColorTest {
+
+    @Test
+    fun `when no spans, returns currentTextColor`() {
+        val textView = TextView(ApplicationProvider.getApplicationContext())
+        textView.text = "Hello, World!"
+        textView.setTextColor(Color.WHITE)
+
+        assertEquals(Color.WHITE, textView.dominantTextColor)
+    }
+
+    @Test
+    fun `when has a foreground color span, returns its color`() {
+        val textView = TextView(ApplicationProvider.getApplicationContext())
+        val text = "Hello, World!"
+        textView.text = SpannableString(text).apply {
+            setSpan(ForegroundColorSpan(Color.RED), 0, text.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+        }
+        textView.setTextColor(Color.WHITE)
+
+        assertEquals(Color.RED, textView.dominantTextColor)
+    }
+
+    @Test
+    fun `when has multiple foreground color spans, returns color of the longest span`() {
+        val textView = TextView(ApplicationProvider.getApplicationContext())
+        val text = "Hello, World!"
+        textView.text = SpannableString(text).apply {
+            setSpan(ForegroundColorSpan(Color.RED), 0, 5, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+            setSpan(ForegroundColorSpan(Color.BLACK), 6, text.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
+        }
+        textView.setTextColor(Color.WHITE)
+
+        assertEquals(Color.BLACK, textView.dominantTextColor)
+    }
+}

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/TextViewDominantColorTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/TextViewDominantColorTest.kt
@@ -1,16 +1,27 @@
 package io.sentry.android.replay.util
 
+import android.app.Activity
 import android.graphics.Color
+import android.os.Bundle
+import android.os.Looper
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
+import android.widget.LinearLayout
+import android.widget.LinearLayout.LayoutParams
 import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.sentry.SentryOptions
+import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode
+import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.TextViewHierarchyNode
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [30])
@@ -18,35 +29,76 @@ class TextViewDominantColorTest {
 
     @Test
     fun `when no spans, returns currentTextColor`() {
-        val textView = TextView(ApplicationProvider.getApplicationContext())
-        textView.text = "Hello, World!"
-        textView.setTextColor(Color.WHITE)
+        val controller = buildActivity(TextViewActivity::class.java, null).setup()
+        controller.create().start().resume()
 
-        assertEquals(Color.WHITE, textView.dominantTextColor)
+        TextViewActivity.textView?.setTextColor(Color.WHITE)
+
+        val node = ViewHierarchyNode.fromView(TextViewActivity.textView!!, null, 0, SentryOptions())
+        assertTrue(node is TextViewHierarchyNode)
+        assertNull(node.layout.dominantTextColor)
     }
 
     @Test
     fun `when has a foreground color span, returns its color`() {
-        val textView = TextView(ApplicationProvider.getApplicationContext())
+        val controller = buildActivity(TextViewActivity::class.java, null).setup()
+        controller.create().start().resume()
+
         val text = "Hello, World!"
-        textView.text = SpannableString(text).apply {
+        TextViewActivity.textView?.text = SpannableString(text).apply {
             setSpan(ForegroundColorSpan(Color.RED), 0, text.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
         }
-        textView.setTextColor(Color.WHITE)
+        TextViewActivity.textView?.setTextColor(Color.WHITE)
+        TextViewActivity.textView?.requestLayout()
 
-        assertEquals(Color.RED, textView.dominantTextColor)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val node = ViewHierarchyNode.fromView(TextViewActivity.textView!!, null, 0, SentryOptions())
+        assertTrue(node is TextViewHierarchyNode)
+        assertEquals(Color.RED, node.layout.dominantTextColor)
     }
 
     @Test
     fun `when has multiple foreground color spans, returns color of the longest span`() {
-        val textView = TextView(ApplicationProvider.getApplicationContext())
+        val controller = buildActivity(TextViewActivity::class.java, null).setup()
+        controller.create().start().resume()
+
         val text = "Hello, World!"
-        textView.text = SpannableString(text).apply {
+        TextViewActivity.textView?.text = SpannableString(text).apply {
             setSpan(ForegroundColorSpan(Color.RED), 0, 5, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
             setSpan(ForegroundColorSpan(Color.BLACK), 6, text.length, Spanned.SPAN_INCLUSIVE_INCLUSIVE)
         }
-        textView.setTextColor(Color.WHITE)
+        TextViewActivity.textView?.setTextColor(Color.WHITE)
+        TextViewActivity.textView?.requestLayout()
 
-        assertEquals(Color.BLACK, textView.dominantTextColor)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val node = ViewHierarchyNode.fromView(TextViewActivity.textView!!, null, 0, SentryOptions())
+        assertTrue(node is TextViewHierarchyNode)
+        assertEquals(Color.BLACK, node.layout.dominantTextColor)
+    }
+}
+
+private class TextViewActivity : Activity() {
+
+    companion object {
+        var textView: TextView? = null
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val linearLayout = LinearLayout(this).apply {
+            setBackgroundColor(android.R.color.white)
+            orientation = LinearLayout.VERTICAL
+            layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+        }
+
+        textView = TextView(this).apply {
+            text = "Hello, World!"
+            layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        }
+        linearLayout.addView(textView)
+
+        setContentView(linearLayout)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* RN always uses Spannables to apply/change the text color, so we just iterate over the spans and pick the longest one to determine the dominant color, if the text is `Spanned`, otherwise fall back to `currentTextColor`

Results on RN:

<img src="https://github.com/user-attachments/assets/4047da64-7b1f-49c0-9433-79c5f193a8df" width="250"/>

<img src="https://github.com/user-attachments/assets/dd694f2d-b79e-48e9-9af1-69bff12806b8" width="250"/>


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/74441

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
