### PR TITLE
Use LazyEvaluator for SpanId creation

### DIFF
--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -12,6 +12,7 @@ public final class SpanId implements JsonSerializable {
   private final @NotNull LazyEvaluator<String> lazyValue;
 
   public SpanId(final @NotNull String value) {
+		Objects.requireNonNull(value, "value is required")
     this.lazyValue = new LazyEvaluator<>(() -> value);
   }
 

--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -1,26 +1,24 @@
 package io.sentry;
 
-import io.sentry.util.Objects;
+import io.sentry.util.LazyEvaluator;
 import io.sentry.util.StringUtils;
 import java.io.IOException;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 
 public final class SpanId implements JsonSerializable {
-  public static final SpanId EMPTY_ID = new SpanId(new UUID(0, 0));
+  public static final SpanId EMPTY_ID = new SpanId("00000000-0000-0000-0000-000000000000");
 
-  private final @NotNull String value;
+  private final @NotNull LazyEvaluator<String> lazyValue;
 
   public SpanId(final @NotNull String value) {
-    this.value = Objects.requireNonNull(value, "value is required");
+    this.lazyValue = new LazyEvaluator<>(() -> value);
   }
 
   public SpanId() {
-    this(UUID.randomUUID());
-  }
-
-  private SpanId(final @NotNull UUID uuid) {
-    this(StringUtils.normalizeUUID(uuid.toString()).replace("-", "").substring(0, 16));
+    this.lazyValue = new LazyEvaluator<>(() ->
+      StringUtils.normalizeUUID(UUID.randomUUID().toString()).replace("-", "").substring(0, 16)
+    );
   }
 
   @Override
@@ -28,17 +26,17 @@ public final class SpanId implements JsonSerializable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SpanId spanId = (SpanId) o;
-    return value.equals(spanId.value);
+    return lazyValue.getValue().equals(spanId.lazyValue.getValue());
   }
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    return lazyValue.getValue().hashCode();
   }
 
   @Override
   public String toString() {
-    return this.value;
+    return lazyValue.getValue();
   }
 
   // JsonElementSerializer
@@ -46,7 +44,7 @@ public final class SpanId implements JsonSerializable {
   @Override
   public void serialize(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
       throws IOException {
-    writer.value(value);
+    writer.value(lazyValue.getValue());
   }
 
   // JsonElementDeserializer

--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -16,9 +16,12 @@ public final class SpanId implements JsonSerializable {
   }
 
   public SpanId() {
-    this.lazyValue = new LazyEvaluator<>(() ->
-      StringUtils.normalizeUUID(UUID.randomUUID().toString()).replace("-", "").substring(0, 16)
-    );
+    this.lazyValue =
+        new LazyEvaluator<>(
+            () ->
+                StringUtils.normalizeUUID(UUID.randomUUID().toString())
+                    .replace("-", "")
+                    .substring(0, 16));
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/protocol/SentryId.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryId.java
@@ -33,9 +33,9 @@ public final class SentryId implements JsonSerializable {
   public SentryId(final @NotNull String sentryIdString) {
     if (sentryIdString.length() != 32 && sentryIdString.length() != 36) {
       throw new IllegalArgumentException(
-        "String representation of SentryId has either 32 (UUID no dashes) "
-          + "or 36 characters long (completed UUID). Received: "
-          + sentryIdString);
+          "String representation of SentryId has either 32 (UUID no dashes) "
+              + "or 36 characters long (completed UUID). Received: "
+              + sentryIdString);
     }
     this.lazyValue =
         new LazyEvaluator<>(() -> fromStringSentryId(StringUtils.normalizeUUID(sentryIdString)));


### PR DESCRIPTION
## :scroll: Description
Use LazyEvaluator to generate UUID on demand


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
