### PR TITLE
Add support for `feedback` envelope header item type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for `feedback` envelope header item type ([#3687](https://github.com/getsentry/sentry-java/pull/3687))
+
 ### Fixes
 
 - Avoid stopping appStartProfiler after application creation ([#3630](https://github.com/getsentry/sentry-java/pull/3630))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2247,6 +2247,7 @@ public final class io/sentry/SentryItemType : java/lang/Enum, io/sentry/JsonSeri
 	public static final field CheckIn Lio/sentry/SentryItemType;
 	public static final field ClientReport Lio/sentry/SentryItemType;
 	public static final field Event Lio/sentry/SentryItemType;
+	public static final field Feedback Lio/sentry/SentryItemType;
 	public static final field Profile Lio/sentry/SentryItemType;
 	public static final field ReplayEvent Lio/sentry/SentryItemType;
 	public static final field ReplayRecording Lio/sentry/SentryItemType;
@@ -2262,6 +2263,12 @@ public final class io/sentry/SentryItemType : java/lang/Enum, io/sentry/JsonSeri
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryItemType;
 	public static fun valueOfLabel (Ljava/lang/String;)Lio/sentry/SentryItemType;
 	public static fun values ()[Lio/sentry/SentryItemType;
+}
+
+public final class io/sentry/SentryItemType$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryItemType;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryLevel : java/lang/Enum, io/sentry/JsonSerializable {

--- a/sentry/src/main/java/io/sentry/SentryItemType.java
+++ b/sentry/src/main/java/io/sentry/SentryItemType.java
@@ -21,6 +21,7 @@ public enum SentryItemType implements JsonSerializable {
   ReplayVideo("replay_video"),
   CheckIn("check_in"),
   Statsd("statsd"),
+  Feedback("feedback"),
   Unknown("__unknown__"); // DataCategory.Unknown
 
   private final String itemType;
@@ -62,7 +63,7 @@ public enum SentryItemType implements JsonSerializable {
     writer.value(itemType);
   }
 
-  static final class Deserializer implements JsonDeserializer<SentryItemType> {
+  public static final class Deserializer implements JsonDeserializer<SentryItemType> {
 
     @Override
     public @NotNull SentryItemType deserialize(

--- a/sentry/src/test/java/io/sentry/protocol/SentryItemTypeSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryItemTypeSerializationTest.kt
@@ -1,0 +1,74 @@
+package io.sentry.protocol
+
+import io.sentry.ILogger
+import io.sentry.JsonObjectReader
+import io.sentry.JsonObjectWriter
+import io.sentry.SentryItemType
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.io.StringReader
+import java.io.StringWriter
+import kotlin.test.assertEquals
+
+class SentryItemTypeSerializationTest {
+
+    class Fixture {
+        val logger = mock<ILogger>()
+    }
+    private val fixture = Fixture()
+
+    @Test
+    fun serialize() {
+        assertEquals(serialize(SentryItemType.Session), json("session"))
+        assertEquals(serialize(SentryItemType.Event), json("event"))
+        assertEquals(serialize(SentryItemType.UserFeedback), json("user_report"))
+        assertEquals(serialize(SentryItemType.Attachment), json("attachment"))
+        assertEquals(serialize(SentryItemType.Transaction), json("transaction"))
+        assertEquals(serialize(SentryItemType.Profile), json("profile"))
+        assertEquals(serialize(SentryItemType.ClientReport), json("client_report"))
+        assertEquals(serialize(SentryItemType.ReplayEvent), json("replay_event"))
+        assertEquals(serialize(SentryItemType.ReplayRecording), json("replay_recording"))
+        assertEquals(serialize(SentryItemType.ReplayVideo), json("replay_video"))
+        assertEquals(serialize(SentryItemType.CheckIn), json("check_in"))
+        assertEquals(serialize(SentryItemType.Statsd), json("statsd"))
+        assertEquals(serialize(SentryItemType.Feedback), json("feedback"))
+    }
+
+    @Test
+    fun deserialize() {
+        assertEquals(deserialize(json("session")), SentryItemType.Session)
+        assertEquals(deserialize(json("event")), SentryItemType.Event)
+        assertEquals(deserialize(json("user_report")), SentryItemType.UserFeedback)
+        assertEquals(deserialize(json("attachment")), SentryItemType.Attachment)
+        assertEquals(deserialize(json("transaction")), SentryItemType.Transaction)
+        assertEquals(deserialize(json("profile")), SentryItemType.Profile)
+        assertEquals(deserialize(json("client_report")), SentryItemType.ClientReport)
+        assertEquals(deserialize(json("replay_event")), SentryItemType.ReplayEvent)
+        assertEquals(deserialize(json("replay_recording")), SentryItemType.ReplayRecording)
+        assertEquals(deserialize(json("replay_video")), SentryItemType.ReplayVideo)
+        assertEquals(deserialize(json("check_in")), SentryItemType.CheckIn)
+        assertEquals(deserialize(json("statsd")), SentryItemType.Statsd)
+        assertEquals(deserialize(json("feedback")), SentryItemType.Feedback)
+    }
+
+    private fun json(type: String): String {
+        return "{\"type\":\"${type}\"}"
+    }
+
+    private fun serialize(src: SentryItemType): String {
+        val wrt = StringWriter()
+        val jsonWrt = JsonObjectWriter(wrt, 100)
+        jsonWrt.beginObject()
+        jsonWrt.name("type")
+        src.serialize(jsonWrt, fixture.logger)
+        jsonWrt.endObject()
+        return wrt.toString()
+    }
+
+    private fun deserialize(json: String): SentryItemType {
+        val reader = JsonObjectReader(StringReader(json))
+        reader.beginObject()
+        reader.nextName()
+        return SentryItemType.Deserializer().deserialize(reader, fixture.logger)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Adds the `feedback` envelope header item type

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feedback envelope items are just regular envelope items, with additional context data and support for attachments.

Currently we are implementing this on flutter, and android is the only platform missing, as the type is lost from the envelope sent to the native sdk from the flutter side.

Relates to https://github.com/getsentry/sentry-dart/pull/2230#issuecomment-2341262726

## :green_heart: How did you test it?

Added unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.