### PR TITLE
No longer set Instrumenter to `OTEL` for the new Java Agent

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -214,7 +214,7 @@ public final class SentrySpanExporter implements SpanExporter {
                 parentSentrySpan.getSpanContext().getSpanId(),
                 new SpanId(spanId));
     spanContext.setDescription(spanInfo.getDescription());
-    spanContext.setInstrumenter(Instrumenter.OTEL);
+    spanContext.setInstrumenter(Instrumenter.SENTRY);
     if (sentrySpanMaybe != null) {
       spanContext.setSamplingDecision(sentrySpanMaybe.getSamplingDecision());
       spanOptions.setOrigin(sentrySpanMaybe.getSpanContext().getOrigin());
@@ -329,7 +329,7 @@ public final class SentrySpanExporter implements SpanExporter {
         transactionName == null ? DEFAULT_TRANSACTION_NAME : transactionName);
     transactionContext.setTransactionNameSource(transactionNameSource);
     transactionContext.setOperation(spanInfo.getOp());
-    transactionContext.setInstrumenter(Instrumenter.OTEL);
+    transactionContext.setInstrumenter(Instrumenter.SENTRY);
     if (sentrySpanMaybe != null) {
       transactionContext.setSamplingDecision(sentrySpanMaybe.getSamplingDecision());
       transactionOptions.setOrigin(sentrySpanMaybe.getSpanContext().getOrigin());

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -850,17 +850,15 @@ public final class Scopes implements IScopes, MetricsApi.IMetricsInterface {
               transactionContext.getOrigin());
       transaction = NoOpTransaction.getInstance();
 
-      //    } else if (!getOptions().getInstrumenter().equals(transactionContext.getInstrumenter()))
-      // {
-      //      getOptions()
-      //          .getLogger()
-      //          .log(
-      //              SentryLevel.DEBUG,
-      //              "Returning no-op for instrumenter %s as the SDK has been configured to use
-      // instrumenter %s",
-      //              transactionContext.getInstrumenter(),
-      //              getOptions().getInstrumenter());
-      //      transaction = NoOpTransaction.getInstance();
+    } else if (!getOptions().getInstrumenter().equals(transactionContext.getInstrumenter())) {
+      getOptions()
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Returning no-op for instrumenter %s as the SDK has been configured to use instrumenter %s",
+              transactionContext.getInstrumenter(),
+              getOptions().getInstrumenter());
+      transaction = NoOpTransaction.getInstance();
     } else if (!getOptions().isTracingEnabled()) {
       getOptions()
           .getLogger()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Also re-enable instrumenter logic in `Scopes`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
