### PR TITLE
Replace Android thread id with kernel thread id in span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
     - For example, (this is already a default behavior) to redact all `TextView`s and their subclasses (`RadioButton`, `EditText`, etc.): `options.experimental.sessionReplay.addRedactViewClass("android.widget.TextView")`
     - If you're using code obfuscation, adjust your proguard-rules accordingly, so your custom view class name is not minified
 
+### Behavioural Changes
+
+- (Android) Replace thread id with kernel thread id in span data ([#3706](https://github.com/getsentry/sentry-java/pull/3706))
+
 ### Dependencies
 
 - Bump OpenTelemetry to 1.41.0, OpenTelemetry Java Agent to 2.7.0 and Semantic Conventions to 1.25.0 ([#3668](https://github.com/getsentry/sentry-java/pull/3668))

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -396,10 +396,10 @@ public final class io/sentry/android/core/ViewHierarchyEventProcessor : io/sentr
 	public fun process (Lio/sentry/SentryEvent;Lio/sentry/Hint;)Lio/sentry/SentryEvent;
 	public fun process (Lio/sentry/protocol/SentryTransaction;Lio/sentry/Hint;)Lio/sentry/protocol/SentryTransaction;
 	public static fun snapshotViewHierarchy (Landroid/app/Activity;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;
-	public static fun snapshotViewHierarchy (Landroid/app/Activity;Ljava/util/List;Lio/sentry/util/thread/IMainThreadChecker;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;
+	public static fun snapshotViewHierarchy (Landroid/app/Activity;Ljava/util/List;Lio/sentry/util/thread/IThreadChecker;Lio/sentry/ILogger;)Lio/sentry/protocol/ViewHierarchy;
 	public static fun snapshotViewHierarchy (Landroid/view/View;)Lio/sentry/protocol/ViewHierarchy;
 	public static fun snapshotViewHierarchy (Landroid/view/View;Ljava/util/List;)Lio/sentry/protocol/ViewHierarchy;
-	public static fun snapshotViewHierarchyAsData (Landroid/app/Activity;Lio/sentry/util/thread/IMainThreadChecker;Lio/sentry/ISerializer;Lio/sentry/ILogger;)[B
+	public static fun snapshotViewHierarchyAsData (Landroid/app/Activity;Lio/sentry/util/thread/IThreadChecker;Lio/sentry/ISerializer;Lio/sentry/ILogger;)[B
 }
 
 public final class io/sentry/android/core/cache/AndroidEnvelopeCache : io/sentry/cache/EnvelopeCache {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -5,6 +5,7 @@ import android.util.SparseIntArray;
 import androidx.core.app.FrameMetricsAggregator;
 import io.sentry.MeasurementUnit;
 import io.sentry.SentryLevel;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
 import java.util.HashMap;
@@ -214,7 +215,7 @@ public final class ActivityFramesTracker {
 
   private void runSafelyOnUiThread(final Runnable runnable, final String tag) {
     try {
-      if (options.getThreadChecker().isMainThread()) {
+      if (AndroidThreadChecker.getInstance().isMainThread()) {
         runnable.run();
       } else {
         handler.post(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -5,7 +5,6 @@ import android.util.SparseIntArray;
 import androidx.core.app.FrameMetricsAggregator;
 import io.sentry.MeasurementUnit;
 import io.sentry.SentryLevel;
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
 import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
 import java.util.HashMap;
@@ -215,7 +214,7 @@ public final class ActivityFramesTracker {
 
   private void runSafelyOnUiThread(final Runnable runnable, final String tag) {
     try {
-      if (AndroidMainThreadChecker.getInstance().isMainThread()) {
+      if (options.getThreadChecker().isMainThread()) {
         runnable.run();
       } else {
         handler.post(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -19,7 +19,7 @@ import io.sentry.android.core.internal.debugmeta.AssetsDebugMetaLoader;
 import io.sentry.android.core.internal.gestures.AndroidViewGestureTargetLocator;
 import io.sentry.android.core.internal.modules.AssetsModulesLoader;
 import io.sentry.android.core.internal.util.AndroidConnectionStatusProvider;
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
@@ -211,7 +211,7 @@ final class AndroidOptionsInitializer {
       options.setViewHierarchyExporters(viewHierarchyExporters);
     }
 
-    options.setMainThreadChecker(AndroidMainThreadChecker.getInstance());
+    options.setThreadChecker(AndroidThreadChecker.getInstance());
     if (options.getPerformanceCollectors().isEmpty()) {
       options.addPerformanceCollector(new AndroidMemoryCollector());
       options.addPerformanceCollector(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -7,7 +7,7 @@ import io.sentry.IScopes;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
@@ -58,7 +58,7 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
       try {
         Class.forName("androidx.lifecycle.DefaultLifecycleObserver");
         Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
-        if (AndroidMainThreadChecker.getInstance().isMainThread()) {
+        if (this.options.getThreadChecker().isMainThread()) {
           addObserver(scopes);
         } else {
           // some versions of the androidx lifecycle-process require this to be executed on the main
@@ -127,7 +127,7 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
     if (watcher == null) {
       return;
     }
-    if (AndroidMainThreadChecker.getInstance().isMainThread()) {
+    if (AndroidThreadChecker.getInstance().isMainThread()) {
       removeObserver();
     } else {
       // some versions of the androidx lifecycle-process require this to be executed on the main

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -58,7 +58,7 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
       try {
         Class.forName("androidx.lifecycle.DefaultLifecycleObserver");
         Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
-        if (this.options.getThreadChecker().isMainThread()) {
+        if (AndroidThreadChecker.getInstance().isMainThread()) {
           addObserver(scopes);
         } else {
           // some versions of the androidx lifecycle-process require this to be executed on the main

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -11,6 +11,7 @@ import io.sentry.SentryBaseEvent;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryReplayEvent;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.protocol.App;
@@ -213,7 +214,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       final boolean isHybridSDK = HintUtils.isFromHybridSdk(hint);
 
       for (final SentryThread thread : event.getThreads()) {
-        final boolean isMainThread = options.getThreadChecker().isMainThread(thread);
+        final boolean isMainThread = AndroidThreadChecker.getInstance().isMainThread(thread);
 
         // TODO: Fix https://github.com/getsentry/team-mobile/issues/47
         if (thread.isCurrent() == null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -11,7 +11,6 @@ import io.sentry.SentryBaseEvent;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryReplayEvent;
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.protocol.App;
@@ -214,7 +213,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       final boolean isHybridSDK = HintUtils.isFromHybridSdk(hint);
 
       for (final SentryThread thread : event.getThreads()) {
-        final boolean isMainThread = AndroidMainThreadChecker.getInstance().isMainThread(thread);
+        final boolean isMainThread = options.getThreadChecker().isMainThread(thread);
 
         // TODO: Fix https://github.com/getsentry/team-mobile/issues/47
         if (thread.isCurrent() == null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -196,7 +196,7 @@ public final class InternalSentrySdk {
         deleteCurrentSessionFile(
             options,
             // should be sync if going to crash or already not a main thread
-            !maybeStartNewSession || !scopes.getOptions().getMainThreadChecker().isMainThread());
+            !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
         if (maybeStartNewSession) {
           scopes.startSession();
         }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -13,6 +13,7 @@ import io.sentry.SpanContext;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanId;
 import io.sentry.SpanStatus;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
@@ -317,7 +318,7 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
       final @NotNull String operation) {
 
     final Map<String, Object> defaultSpanData = new HashMap<>(2);
-    defaultSpanData.put(SpanDataConvention.THREAD_ID, Looper.getMainLooper().getThread().getId());
+    defaultSpanData.put(SpanDataConvention.THREAD_ID, AndroidThreadChecker.mainThreadId);
     defaultSpanData.put(SpanDataConvention.THREAD_NAME, "main");
 
     defaultSpanData.put(SpanDataConvention.CONTRIBUTES_TTID, true);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -317,7 +317,7 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
       final @NotNull String operation) {
 
     final Map<String, Object> defaultSpanData = new HashMap<>(2);
-    defaultSpanData.put(SpanDataConvention.THREAD_ID, AndroidThreadChecker.mainThreadId);
+    defaultSpanData.put(SpanDataConvention.THREAD_ID, AndroidThreadChecker.mainThreadSystemId);
     defaultSpanData.put(SpanDataConvention.THREAD_NAME, "main");
 
     defaultSpanData.put(SpanDataConvention.CONTRIBUTES_TTID, true);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -4,7 +4,6 @@ import static io.sentry.android.core.ActivityLifecycleIntegration.APP_START_COLD
 import static io.sentry.android.core.ActivityLifecycleIntegration.APP_START_WARM;
 import static io.sentry.android.core.ActivityLifecycleIntegration.UI_LOAD_OP;
 
-import android.os.Looper;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
 import io.sentry.MeasurementUnit;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -89,7 +89,7 @@ public final class ScreenshotEventProcessor implements EventProcessor {
 
     final byte[] screenshot =
         takeScreenshot(
-            activity, options.getMainThreadChecker(), options.getLogger(), buildInfoProvider);
+            activity, options.getThreadChecker(), options.getLogger(), buildInfoProvider);
     if (screenshot == null) {
       return event;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -15,7 +15,7 @@ import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.gestures.ViewUtils;
 import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.ClassUtil;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.internal.viewhierarchy.ViewHierarchyExporter;
@@ -25,7 +25,7 @@ import io.sentry.protocol.ViewHierarchyNode;
 import io.sentry.util.HintUtils;
 import io.sentry.util.JsonSerializationUtils;
 import io.sentry.util.Objects;
-import io.sentry.util.thread.IMainThreadChecker;
+import io.sentry.util.thread.IThreadChecker;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -101,7 +101,7 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
         snapshotViewHierarchy(
             activity,
             options.getViewHierarchyExporters(),
-            options.getMainThreadChecker(),
+            options.getThreadChecker(),
             options.getLogger());
 
     if (viewHierarchy != null) {
@@ -113,13 +113,13 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
 
   public static byte[] snapshotViewHierarchyAsData(
       @Nullable Activity activity,
-      @NotNull IMainThreadChecker mainThreadChecker,
+      @NotNull IThreadChecker threadChecker,
       @NotNull ISerializer serializer,
       @NotNull ILogger logger) {
 
     @Nullable
     ViewHierarchy viewHierarchy =
-        snapshotViewHierarchy(activity, new ArrayList<>(0), mainThreadChecker, logger);
+        snapshotViewHierarchy(activity, new ArrayList<>(0), threadChecker, logger);
 
     if (viewHierarchy == null) {
       logger.log(SentryLevel.ERROR, "Could not get ViewHierarchy.");
@@ -144,14 +144,14 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
   public static ViewHierarchy snapshotViewHierarchy(
       final @Nullable Activity activity, final @NotNull ILogger logger) {
     return snapshotViewHierarchy(
-        activity, new ArrayList<>(0), AndroidMainThreadChecker.getInstance(), logger);
+        activity, new ArrayList<>(0), AndroidThreadChecker.getInstance(), logger);
   }
 
   @Nullable
   public static ViewHierarchy snapshotViewHierarchy(
       final @Nullable Activity activity,
       final @NotNull List<ViewHierarchyExporter> exporters,
-      final @NotNull IMainThreadChecker mainThreadChecker,
+      final @NotNull IThreadChecker threadChecker,
       final @NotNull ILogger logger) {
 
     if (activity == null) {
@@ -172,7 +172,7 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
     }
 
     try {
-      if (mainThreadChecker.isMainThread()) {
+      if (threadChecker.isMainThread()) {
         return snapshotViewHierarchy(decorView, exporters);
       } else {
         final CountDownLatch latch = new CountDownLatch(1);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
@@ -1,5 +1,6 @@
 package io.sentry.android.core.internal.util;
 
+import android.os.Handler;
 import android.os.Looper;
 import android.os.Process;
 import io.sentry.protocol.SentryThread;
@@ -12,13 +13,16 @@ import org.jetbrains.annotations.NotNull;
 public final class AndroidThreadChecker implements IThreadChecker {
 
   private static final AndroidThreadChecker instance = new AndroidThreadChecker();
-  public static final long mainThreadId = Process.myTid();
+  public static long mainThreadId = Process.myTid();
 
   public static AndroidThreadChecker getInstance() {
     return instance;
   }
 
-  private AndroidThreadChecker() {}
+  private AndroidThreadChecker() {
+    // The first time this class is loaded, we make sure to set the correct mainThreadId
+    new Handler(Looper.getMainLooper()).post(() -> mainThreadId = Process.myTid());
+  }
 
   @Override
   public boolean isMainThread(final long threadId) {
@@ -42,7 +46,7 @@ public final class AndroidThreadChecker implements IThreadChecker {
   }
 
   @Override
-  public long currentThreadId() {
+  public long currentThreadSystemId() {
     return Process.myTid();
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
@@ -1,22 +1,24 @@
 package io.sentry.android.core.internal.util;
 
 import android.os.Looper;
+import android.os.Process;
 import io.sentry.protocol.SentryThread;
-import io.sentry.util.thread.IMainThreadChecker;
+import io.sentry.util.thread.IThreadChecker;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Class that checks if a given thread is the Android Main/UI thread */
 @ApiStatus.Internal
-public final class AndroidMainThreadChecker implements IMainThreadChecker {
+public final class AndroidThreadChecker implements IThreadChecker {
 
-  private static final AndroidMainThreadChecker instance = new AndroidMainThreadChecker();
+  private static final AndroidThreadChecker instance = new AndroidThreadChecker();
+  public static final long mainThreadId = Process.myTid();
 
-  public static AndroidMainThreadChecker getInstance() {
+  public static AndroidThreadChecker getInstance() {
     return instance;
   }
 
-  private AndroidMainThreadChecker() {}
+  private AndroidThreadChecker() {}
 
   @Override
   public boolean isMainThread(final long threadId) {
@@ -37,5 +39,10 @@ public final class AndroidMainThreadChecker implements IMainThreadChecker {
   public boolean isMainThread(final @NotNull SentryThread sentryThread) {
     final Long threadId = sentryThread.getId();
     return threadId != null && isMainThread(threadId);
+  }
+
+  @Override
+  public long currentThreadId() {
+    return Process.myTid();
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidThreadChecker.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 public final class AndroidThreadChecker implements IThreadChecker {
 
   private static final AndroidThreadChecker instance = new AndroidThreadChecker();
-  public static long mainThreadId = Process.myTid();
+  public static volatile long mainThreadSystemId = Process.myTid();
 
   public static AndroidThreadChecker getInstance() {
     return instance;
@@ -21,7 +21,7 @@ public final class AndroidThreadChecker implements IThreadChecker {
 
   private AndroidThreadChecker() {
     // The first time this class is loaded, we make sure to set the correct mainThreadId
-    new Handler(Looper.getMainLooper()).post(() -> mainThreadId = Process.myTid());
+    new Handler(Looper.getMainLooper()).post(() -> mainThreadSystemId = Process.myTid());
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/ScreenshotUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/ScreenshotUtils.java
@@ -14,7 +14,7 @@ import androidx.annotation.Nullable;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.BuildInfoProvider;
-import io.sentry.util.thread.IMainThreadChecker;
+import io.sentry.util.thread.IThreadChecker;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -31,14 +31,13 @@ public class ScreenshotUtils {
       final @NotNull Activity activity,
       final @NotNull ILogger logger,
       final @NotNull BuildInfoProvider buildInfoProvider) {
-    return takeScreenshot(
-        activity, AndroidMainThreadChecker.getInstance(), logger, buildInfoProvider);
+    return takeScreenshot(activity, AndroidThreadChecker.getInstance(), logger, buildInfoProvider);
   }
 
   @SuppressLint("NewApi")
   public static @Nullable byte[] takeScreenshot(
       final @NotNull Activity activity,
-      final @NotNull IMainThreadChecker mainThreadChecker,
+      final @NotNull IThreadChecker threadChecker,
       final @NotNull ILogger logger,
       final @NotNull BuildInfoProvider buildInfoProvider) {
     // We are keeping BuildInfoProvider param for compatibility, as it's being used by
@@ -113,7 +112,7 @@ public class ScreenshotUtils {
         }
       } else {
         final Canvas canvas = new Canvas(bitmap);
-        if (mainThreadChecker.isMainThread()) {
+        if (threadChecker.isMainThread()) {
           view.draw(canvas);
           latch.countDown();
         } else {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -13,7 +13,7 @@ import io.sentry.SentryOptions
 import io.sentry.android.core.cache.AndroidEnvelopeCache
 import io.sentry.android.core.internal.gestures.AndroidViewGestureTargetLocator
 import io.sentry.android.core.internal.modules.AssetsModulesLoader
-import io.sentry.android.core.internal.util.AndroidMainThreadChecker
+import io.sentry.android.core.internal.util.AndroidThreadChecker
 import io.sentry.android.fragment.FragmentLifecycleIntegration
 import io.sentry.android.replay.ReplayIntegration
 import io.sentry.android.timber.SentryTimberIntegration
@@ -582,10 +582,10 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `AndroidMainThreadChecker is set to options`() {
+    fun `AndroidThreadChecker is set to options`() {
         fixture.initSut()
 
-        assertTrue { fixture.sentryOptions.mainThreadChecker is AndroidMainThreadChecker }
+        assertTrue { fixture.sentryOptions.threadChecker is AndroidThreadChecker }
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ScreenshotEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ScreenshotEventProcessorTest.kt
@@ -11,7 +11,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.TypeCheckHint.ANDROID_ACTIVITY
 import io.sentry.protocol.SentryException
-import io.sentry.util.thread.IMainThreadChecker
+import io.sentry.util.thread.IThreadChecker
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -35,7 +35,7 @@ class ScreenshotEventProcessorTest {
         val window = mock<Window>()
         val view = mock<View>()
         val rootView = mock<View>()
-        val mainThreadChecker = mock<IMainThreadChecker>()
+        val threadChecker = mock<IThreadChecker>()
         val options = SentryAndroidOptions().apply {
             dsn = "https://key@sentry.io/proj"
         }
@@ -52,12 +52,12 @@ class ScreenshotEventProcessorTest {
                 it.getArgument<Runnable>(0).run()
             }
 
-            whenever(mainThreadChecker.isMainThread).thenReturn(true)
+            whenever(threadChecker.isMainThread).thenReturn(true)
         }
 
         fun getSut(attachScreenshot: Boolean = false): ScreenshotEventProcessor {
             options.isAttachScreenshot = attachScreenshot
-            options.mainThreadChecker = mainThreadChecker
+            options.threadChecker = threadChecker
 
             return ScreenshotEventProcessor(options, buildInfo)
         }
@@ -172,7 +172,7 @@ class ScreenshotEventProcessorTest {
     @Test
     fun `when screenshot event processor is called from background thread it executes on main thread`() {
         val sut = fixture.getSut(true)
-        whenever(fixture.mainThreadChecker.isMainThread).thenReturn(false)
+        whenever(fixture.threadChecker.isMainThread).thenReturn(false)
 
         CurrentActivityHolder.getInstance().setActivity(fixture.activity)
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ViewHierarchyEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ViewHierarchyEventProcessorTest.kt
@@ -12,7 +12,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.TypeCheckHint
 import io.sentry.protocol.SentryException
-import io.sentry.util.thread.IMainThreadChecker
+import io.sentry.util.thread.IThreadChecker
 import org.junit.runner.RunWith
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.any
@@ -46,7 +46,7 @@ class ViewHierarchyEventProcessorTest {
             }
         }
         val activity = mock<Activity>()
-        val mainThreadChecker = mock<IMainThreadChecker>()
+        val threadChecker = mock<IThreadChecker>()
         val window = mock<Window>()
         val view = mock<View>()
         val options = SentryAndroidOptions().apply {
@@ -62,14 +62,14 @@ class ViewHierarchyEventProcessorTest {
             whenever(activity.runOnUiThread(any())).then {
                 it.getArgument<Runnable>(0).run()
             }
-            whenever(mainThreadChecker.isMainThread).thenReturn(true)
+            whenever(threadChecker.isMainThread).thenReturn(true)
 
             CurrentActivityHolder.getInstance().setActivity(activity)
         }
 
         fun getSut(attachViewHierarchy: Boolean = false): ViewHierarchyEventProcessor {
             options.isAttachViewHierarchy = attachViewHierarchy
-            options.mainThreadChecker = mainThreadChecker
+            options.threadChecker = threadChecker
             return ViewHierarchyEventProcessor(options)
         }
 
@@ -96,7 +96,7 @@ class ViewHierarchyEventProcessorTest {
     fun `should return a view hierarchy as byte array`() {
         val viewHierarchy = ViewHierarchyEventProcessor.snapshotViewHierarchyAsData(
             fixture.activity,
-            fixture.mainThreadChecker,
+            fixture.threadChecker,
             fixture.serializer,
             fixture.logger
         )
@@ -109,7 +109,7 @@ class ViewHierarchyEventProcessorTest {
     fun `should return null as bytes are empty array`() {
         val viewHierarchy = ViewHierarchyEventProcessor.snapshotViewHierarchyAsData(
             fixture.activity,
-            fixture.mainThreadChecker,
+            fixture.threadChecker,
             fixture.emptySerializer,
             fixture.logger
         )
@@ -161,7 +161,7 @@ class ViewHierarchyEventProcessorTest {
 
     @Test
     fun `when an event errored in the background, the view hierarchy should captured on the main thread`() {
-        whenever(fixture.mainThreadChecker.isMainThread).thenReturn(false)
+        whenever(fixture.threadChecker.isMainThread).thenReturn(false)
 
         val (event, hint) = fixture.process(
             true,

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidThreadCheckerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidThreadCheckerTest.kt
@@ -8,23 +8,23 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
-class AndroidMainThreadCheckerTest {
+class AndroidThreadCheckerTest {
 
     @Test
     fun `When calling isMainThread from the same thread, it should return true`() {
-        assertTrue(AndroidMainThreadChecker.getInstance().isMainThread)
+        assertTrue(AndroidThreadChecker.getInstance().isMainThread)
     }
 
     @Test
     fun `When calling isMainThread with the current thread, it should return true`() {
         val thread = Thread.currentThread()
-        assertTrue(AndroidMainThreadChecker.getInstance().isMainThread(thread))
+        assertTrue(AndroidThreadChecker.getInstance().isMainThread(thread))
     }
 
     @Test
     fun `When calling isMainThread from a different thread, it should return false`() {
         val thread = Thread()
-        assertFalse(AndroidMainThreadChecker.getInstance().isMainThread(thread))
+        assertFalse(AndroidThreadChecker.getInstance().isMainThread(thread))
     }
 
     @Test
@@ -33,7 +33,7 @@ class AndroidMainThreadCheckerTest {
         val sentryThread = SentryThread().apply {
             id = thread.id
         }
-        assertTrue(AndroidMainThreadChecker.getInstance().isMainThread(sentryThread))
+        assertTrue(AndroidThreadChecker.getInstance().isMainThread(sentryThread))
     }
 
     @Test
@@ -42,6 +42,6 @@ class AndroidMainThreadCheckerTest {
         val sentryThread = SentryThread().apply {
             id = thread.id
         }
-        assertFalse(AndroidMainThreadChecker.getInstance().isMainThread(sentryThread))
+        assertFalse(AndroidThreadChecker.getInstance().isMainThread(sentryThread))
     }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -200,7 +200,7 @@ internal abstract class BaseCaptureStrategy(
             private val value = AtomicReference(initialValue)
 
             private fun runInBackground(task: () -> Unit) {
-                if (options.mainThreadChecker.isMainThread) {
+                if (options.threadChecker.isMainThread) {
                     persistingExecutor.submitSafely(options, "$TAG.runInBackground") {
                         task()
                     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
@@ -38,7 +38,7 @@ internal class PersistableLinkedList(
     private fun persistRecording() {
         val cache = cacheProvider() ?: return
         val recording = ReplayRecording().apply { payload = ArrayList(this@PersistableLinkedList) }
-        if (options.mainThreadChecker.isMainThread) {
+        if (options.threadChecker.isMainThread) {
             persistingExecutor.submit {
                 val stringWriter = StringWriter()
                 options.serializer.serialize(recording, BufferedWriter(stringWriter))

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -20,7 +20,7 @@ import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
-import io.sentry.util.thread.NoOpMainThreadChecker
+import io.sentry.util.thread.NoOpThreadChecker
 import org.awaitility.kotlin.await
 import org.junit.Rule
 import org.junit.Test
@@ -50,7 +50,7 @@ class ReplayIntegrationWithRecorderTest {
 
     internal class Fixture {
         val options = SentryOptions().apply {
-            mainThreadChecker = NoOpMainThreadChecker.getInstance()
+            threadChecker = NoOpThreadChecker.getInstance()
         }
         val scopes = mock<IScopes>()
 

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SQLiteSpanManager.kt
@@ -57,7 +57,7 @@ internal class SQLiteSpanManager(
             throw e
         } finally {
             span?.apply {
-                val isMainThread: Boolean = scopes.options.mainThreadChecker.isMainThread
+                val isMainThread: Boolean = scopes.options.threadChecker.isMainThread
                 setData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread)
                 if (isMainThread) {
                     setData(SpanDataConvention.CALL_STACK_KEY, stackTraceFactory.inAppCallStack)

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SQLiteSpanManagerTest.kt
@@ -9,7 +9,7 @@ import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
-import io.sentry.util.thread.IMainThreadChecker
+import io.sentry.util.thread.IThreadChecker
 import org.junit.Before
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -98,8 +98,8 @@ class SQLiteSpanManagerTest {
     fun `when performSql runs in background blocked_main_thread is false and no stack trace is attached`() {
         val sut = fixture.getSut()
 
-        fixture.options.mainThreadChecker = mock<IMainThreadChecker>()
-        whenever(fixture.options.mainThreadChecker.isMainThread).thenReturn(false)
+        fixture.options.threadChecker = mock<IThreadChecker>()
+        whenever(fixture.options.threadChecker.isMainThread).thenReturn(false)
 
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()
@@ -112,8 +112,8 @@ class SQLiteSpanManagerTest {
     fun `when performSql runs in foreground blocked_main_thread is true and a stack trace is attached`() {
         val sut = fixture.getSut()
 
-        fixture.options.mainThreadChecker = mock<IMainThreadChecker>()
-        whenever(fixture.options.mainThreadChecker.isMainThread).thenReturn(true)
+        fixture.options.threadChecker = mock<IThreadChecker>()
+        whenever(fixture.options.threadChecker.isMainThread).thenReturn(true)
 
         sut.performSql("sql") {}
         val span = fixture.sentryTracer.children.first()

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2878,7 +2878,7 @@ public class io/sentry/SentryOptions {
 	public fun getIntegrations ()Ljava/util/List;
 	public fun getInternalTracesSampler ()Lio/sentry/TracesSampler;
 	public fun getLogger ()Lio/sentry/ILogger;
-	public fun getMainThreadChecker ()Lio/sentry/util/thread/IMainThreadChecker;
+	public fun getMainThreadChecker ()Lio/sentry/util/thread/IThreadChecker;
 	public fun getMaxAttachmentSize ()J
 	public fun getMaxBreadcrumbs ()I
 	public fun getMaxCacheItems ()I
@@ -2914,6 +2914,7 @@ public class io/sentry/SentryOptions {
 	public fun getSpotlightConnectionUrl ()Ljava/lang/String;
 	public fun getSslSocketFactory ()Ljavax/net/ssl/SSLSocketFactory;
 	public fun getTags ()Ljava/util/Map;
+	public fun getThreadChecker ()Lio/sentry/util/thread/IThreadChecker;
 	public fun getTracePropagationTargets ()Ljava/util/List;
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracesSampler ()Lio/sentry/SentryOptions$TracesSamplerCallback;
@@ -3008,7 +3009,7 @@ public class io/sentry/SentryOptions {
 	public fun setInitPriority (Lio/sentry/InitPriority;)V
 	public fun setInstrumenter (Lio/sentry/Instrumenter;)V
 	public fun setLogger (Lio/sentry/ILogger;)V
-	public fun setMainThreadChecker (Lio/sentry/util/thread/IMainThreadChecker;)V
+	public fun setMainThreadChecker (Lio/sentry/util/thread/IThreadChecker;)V
 	public fun setMaxAttachmentSize (J)V
 	public fun setMaxBreadcrumbs (I)V
 	public fun setMaxCacheItems (I)V
@@ -3044,6 +3045,7 @@ public class io/sentry/SentryOptions {
 	public fun setSpotlightConnectionUrl (Ljava/lang/String;)V
 	public fun setSslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setThreadChecker (Lio/sentry/util/thread/IThreadChecker;)V
 	public fun setTraceOptionsRequests (Z)V
 	public fun setTracePropagationTargets (Ljava/util/List;)V
 	public fun setTraceSampling (Z)V
@@ -6423,24 +6425,27 @@ public final class io/sentry/util/UrlUtils$UrlDetails {
 	public fun getUrlOrFallback ()Ljava/lang/String;
 }
 
-public abstract interface class io/sentry/util/thread/IMainThreadChecker {
+public abstract interface class io/sentry/util/thread/IThreadChecker {
+	public abstract fun currentThreadId ()J
 	public abstract fun isMainThread ()Z
 	public abstract fun isMainThread (J)Z
 	public abstract fun isMainThread (Lio/sentry/protocol/SentryThread;)Z
 	public abstract fun isMainThread (Ljava/lang/Thread;)Z
 }
 
-public final class io/sentry/util/thread/MainThreadChecker : io/sentry/util/thread/IMainThreadChecker {
-	public static fun getInstance ()Lio/sentry/util/thread/MainThreadChecker;
+public final class io/sentry/util/thread/NoOpThreadChecker : io/sentry/util/thread/IThreadChecker {
+	public fun <init> ()V
+	public fun currentThreadId ()J
+	public static fun getInstance ()Lio/sentry/util/thread/NoOpThreadChecker;
 	public fun isMainThread ()Z
 	public fun isMainThread (J)Z
 	public fun isMainThread (Lio/sentry/protocol/SentryThread;)Z
 	public fun isMainThread (Ljava/lang/Thread;)Z
 }
 
-public final class io/sentry/util/thread/NoOpMainThreadChecker : io/sentry/util/thread/IMainThreadChecker {
-	public fun <init> ()V
-	public static fun getInstance ()Lio/sentry/util/thread/NoOpMainThreadChecker;
+public final class io/sentry/util/thread/ThreadChecker : io/sentry/util/thread/IThreadChecker {
+	public fun currentThreadId ()J
+	public static fun getInstance ()Lio/sentry/util/thread/ThreadChecker;
 	public fun isMainThread ()Z
 	public fun isMainThread (J)Z
 	public fun isMainThread (Lio/sentry/protocol/SentryThread;)Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -6426,7 +6426,7 @@ public final class io/sentry/util/UrlUtils$UrlDetails {
 }
 
 public abstract interface class io/sentry/util/thread/IThreadChecker {
-	public abstract fun currentThreadId ()J
+	public abstract fun currentThreadSystemId ()J
 	public abstract fun isMainThread ()Z
 	public abstract fun isMainThread (J)Z
 	public abstract fun isMainThread (Lio/sentry/protocol/SentryThread;)Z
@@ -6435,7 +6435,7 @@ public abstract interface class io/sentry/util/thread/IThreadChecker {
 
 public final class io/sentry/util/thread/NoOpThreadChecker : io/sentry/util/thread/IThreadChecker {
 	public fun <init> ()V
-	public fun currentThreadId ()J
+	public fun currentThreadSystemId ()J
 	public static fun getInstance ()Lio/sentry/util/thread/NoOpThreadChecker;
 	public fun isMainThread ()Z
 	public fun isMainThread (J)Z
@@ -6444,7 +6444,7 @@ public final class io/sentry/util/thread/NoOpThreadChecker : io/sentry/util/thre
 }
 
 public final class io/sentry/util/thread/ThreadChecker : io/sentry/util/thread/IThreadChecker {
-	public fun currentThreadId ()J
+	public fun currentThreadSystemId ()J
 	public static fun getInstance ()Lio/sentry/util/thread/ThreadChecker;
 	public fun isMainThread ()Z
 	public fun isMainThread (J)Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2878,7 +2878,6 @@ public class io/sentry/SentryOptions {
 	public fun getIntegrations ()Ljava/util/List;
 	public fun getInternalTracesSampler ()Lio/sentry/TracesSampler;
 	public fun getLogger ()Lio/sentry/ILogger;
-	public fun getMainThreadChecker ()Lio/sentry/util/thread/IThreadChecker;
 	public fun getMaxAttachmentSize ()J
 	public fun getMaxBreadcrumbs ()I
 	public fun getMaxCacheItems ()I
@@ -3009,7 +3008,6 @@ public class io/sentry/SentryOptions {
 	public fun setInitPriority (Lio/sentry/InitPriority;)V
 	public fun setInstrumenter (Lio/sentry/Instrumenter;)V
 	public fun setLogger (Lio/sentry/ILogger;)V
-	public fun setMainThreadChecker (Lio/sentry/util/thread/IThreadChecker;)V
 	public fun setMaxAttachmentSize (J)V
 	public fun setMaxBreadcrumbs (I)V
 	public fun setMaxCacheItems (I)V

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -20,9 +20,9 @@ import io.sentry.util.FileUtils;
 import io.sentry.util.InitUtil;
 import io.sentry.util.LoadClass;
 import io.sentry.util.Platform;
-import io.sentry.util.thread.IMainThreadChecker;
-import io.sentry.util.thread.MainThreadChecker;
-import io.sentry.util.thread.NoOpMainThreadChecker;
+import io.sentry.util.thread.IThreadChecker;
+import io.sentry.util.thread.NoOpThreadChecker;
+import io.sentry.util.thread.ThreadChecker;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -539,10 +539,10 @@ public final class Sentry {
     final @Nullable List<Properties> propertiesList = options.getDebugMetaLoader().loadDebugMeta();
     DebugMetaPropertiesApplier.applyToOptions(options, propertiesList);
 
-    final IMainThreadChecker mainThreadChecker = options.getMainThreadChecker();
-    // only override the MainThreadChecker if it's not already set by Android
-    if (mainThreadChecker instanceof NoOpMainThreadChecker) {
-      options.setMainThreadChecker(MainThreadChecker.getInstance());
+    final IThreadChecker threadChecker = options.getThreadChecker();
+    // only override the ThreadChecker if it's not already set by Android
+    if (threadChecker instanceof NoOpThreadChecker) {
+      options.setThreadChecker(ThreadChecker.getInstance());
     }
 
     if (options.getPerformanceCollectors().isEmpty()) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -22,10 +22,9 @@ import io.sentry.transport.NoOpTransportGate;
 import io.sentry.util.Platform;
 import io.sentry.util.SampleRateUtils;
 import io.sentry.util.StringUtils;
-import io.sentry.util.thread.IMainThreadChecker;
-import io.sentry.util.thread.NoOpMainThreadChecker;
+import io.sentry.util.thread.IThreadChecker;
+import io.sentry.util.thread.NoOpThreadChecker;
 import java.io.File;
-import java.net.Proxy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -410,7 +409,7 @@ public class SentryOptions {
    */
   private final @NotNull List<ViewHierarchyExporter> viewHierarchyExporters = new ArrayList<>();
 
-  private @NotNull IMainThreadChecker mainThreadChecker = NoOpMainThreadChecker.getInstance();
+  private @NotNull IThreadChecker threadChecker = NoOpThreadChecker.getInstance();
 
   // TODO [MAJOR] this should default to false on the next major
   /** Whether OPTIONS requests should be traced. */
@@ -2070,12 +2069,30 @@ public class SentryOptions {
     viewHierarchyExporters.addAll(exporters);
   }
 
-  public @NotNull IMainThreadChecker getMainThreadChecker() {
-    return mainThreadChecker;
+  /**
+   * @deprecated Use {@link SentryOptions#getThreadChecker} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public @NotNull IThreadChecker getMainThreadChecker() {
+    return getThreadChecker();
   }
 
-  public void setMainThreadChecker(final @NotNull IMainThreadChecker mainThreadChecker) {
-    this.mainThreadChecker = mainThreadChecker;
+  public @NotNull IThreadChecker getThreadChecker() {
+    return threadChecker;
+  }
+
+  /**
+   * @deprecated Use {@link SentryOptions#setThreadChecker} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public void setMainThreadChecker(final @NotNull IThreadChecker threadChecker) {
+    setThreadChecker(threadChecker);
+  }
+
+  public void setThreadChecker(final @NotNull IThreadChecker threadChecker) {
+    this.threadChecker = threadChecker;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2069,26 +2069,8 @@ public class SentryOptions {
     viewHierarchyExporters.addAll(exporters);
   }
 
-  /**
-   * @deprecated Use {@link SentryOptions#getThreadChecker} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public @NotNull IThreadChecker getMainThreadChecker() {
-    return getThreadChecker();
-  }
-
   public @NotNull IThreadChecker getThreadChecker() {
     return threadChecker;
-  }
-
-  /**
-   * @deprecated Use {@link SentryOptions#setThreadChecker} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public void setMainThreadChecker(final @NotNull IThreadChecker threadChecker) {
-    setThreadChecker(threadChecker);
   }
 
   public void setThreadChecker(final @NotNull IThreadChecker threadChecker) {

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -514,7 +514,7 @@ public final class SentryTracer implements ITransaction {
       //                }
       //              });
       //      span.setDescription(description);
-      final long threadId = scopes.getOptions().getThreadChecker().currentThreadId();
+      final long threadId = scopes.getOptions().getThreadChecker().currentThreadSystemId();
       span.setData(SpanDataConvention.THREAD_ID, String.valueOf(threadId));
       span.setData(
           SpanDataConvention.THREAD_NAME,

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -514,10 +514,11 @@ public final class SentryTracer implements ITransaction {
       //                }
       //              });
       //      span.setDescription(description);
-      span.setData(SpanDataConvention.THREAD_ID, String.valueOf(Thread.currentThread().getId()));
+      final long threadId = scopes.getOptions().getThreadChecker().currentThreadId();
+      span.setData(SpanDataConvention.THREAD_ID, String.valueOf(threadId));
       span.setData(
           SpanDataConvention.THREAD_NAME,
-          scopes.getOptions().getMainThreadChecker().isMainThread()
+          scopes.getOptions().getThreadChecker().isMainThread()
               ? "main"
               : Thread.currentThread().getName());
       this.children.add(span);

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -102,7 +102,7 @@ final class FileIOSpanManager {
         currentSpan.setDescription(byteCountToString);
       }
       currentSpan.setData("file.size", byteCount);
-      final boolean isMainThread = options.getMainThreadChecker().isMainThread();
+      final boolean isMainThread = options.getThreadChecker().isMainThread();
       currentSpan.setData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY, isMainThread);
       if (isMainThread) {
         currentSpan.setData(

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -36,8 +36,8 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
   private @Nullable String state;
   private @Nullable Boolean crashed;
   private @Nullable Boolean current;
-  private @Nullable Boolean daemon;
   private @Nullable Boolean main;
+  private @Nullable Boolean daemon;
   private @Nullable SentryStackTrace stacktrace;
 
   private @Nullable Map<String, SentryLockReason> heldLocks;

--- a/sentry/src/main/java/io/sentry/protocol/SentryThread.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryThread.java
@@ -36,8 +36,8 @@ public final class SentryThread implements JsonUnknown, JsonSerializable {
   private @Nullable String state;
   private @Nullable Boolean crashed;
   private @Nullable Boolean current;
-  private @Nullable Boolean main;
   private @Nullable Boolean daemon;
+  private @Nullable Boolean main;
   private @Nullable SentryStackTrace stacktrace;
 
   private @Nullable Map<String, SentryLockReason> heldLocks;

--- a/sentry/src/main/java/io/sentry/util/thread/IThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/IThreadChecker.java
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
-public interface IMainThreadChecker {
+public interface IThreadChecker {
 
   boolean isMainThread(final long threadId);
 
@@ -31,4 +31,11 @@ public interface IMainThreadChecker {
    * @return true if it is the main thread or false otherwise
    */
   boolean isMainThread(final @NotNull SentryThread sentryThread);
+
+  /**
+   * Returns the current thread id.
+   *
+   * @return the current thread id.
+   */
+  long currentThreadId();
 }

--- a/sentry/src/main/java/io/sentry/util/thread/IThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/IThreadChecker.java
@@ -33,9 +33,9 @@ public interface IThreadChecker {
   boolean isMainThread(final @NotNull SentryThread sentryThread);
 
   /**
-   * Returns the current thread id.
+   * Returns the system id of the current thread. Currently only used for Android.
    *
-   * @return the current thread id.
+   * @return the current thread system id.
    */
-  long currentThreadId();
+  long currentThreadSystemId();
 }

--- a/sentry/src/main/java/io/sentry/util/thread/NoOpThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/NoOpThreadChecker.java
@@ -5,11 +5,11 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
-public final class NoOpMainThreadChecker implements IMainThreadChecker {
+public final class NoOpThreadChecker implements IThreadChecker {
 
-  private static final NoOpMainThreadChecker instance = new NoOpMainThreadChecker();
+  private static final NoOpThreadChecker instance = new NoOpThreadChecker();
 
-  public static NoOpMainThreadChecker getInstance() {
+  public static NoOpThreadChecker getInstance() {
     return instance;
   }
 
@@ -31,5 +31,10 @@ public final class NoOpMainThreadChecker implements IMainThreadChecker {
   @Override
   public boolean isMainThread(@NotNull SentryThread sentryThread) {
     return false;
+  }
+
+  @Override
+  public long currentThreadId() {
+    return 0;
   }
 }

--- a/sentry/src/main/java/io/sentry/util/thread/NoOpThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/NoOpThreadChecker.java
@@ -34,7 +34,7 @@ public final class NoOpThreadChecker implements IThreadChecker {
   }
 
   @Override
-  public long currentThreadId() {
+  public long currentThreadSystemId() {
     return 0;
   }
 }

--- a/sentry/src/main/java/io/sentry/util/thread/ThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/ThreadChecker.java
@@ -45,7 +45,7 @@ public final class ThreadChecker implements IThreadChecker {
   }
 
   @Override
-  public long currentThreadId() {
+  public long currentThreadSystemId() {
     return Thread.currentThread().getId();
   }
 }

--- a/sentry/src/main/java/io/sentry/util/thread/ThreadChecker.java
+++ b/sentry/src/main/java/io/sentry/util/thread/ThreadChecker.java
@@ -12,16 +12,16 @@ import org.jetbrains.annotations.NotNull;
  * <p>We're gonna educate people through the docs.
  */
 @ApiStatus.Internal
-public final class MainThreadChecker implements IMainThreadChecker {
+public final class ThreadChecker implements IThreadChecker {
 
   private static final long mainThreadId = Thread.currentThread().getId();
-  private static final MainThreadChecker instance = new MainThreadChecker();
+  private static final ThreadChecker instance = new ThreadChecker();
 
-  public static MainThreadChecker getInstance() {
+  public static ThreadChecker getInstance() {
     return instance;
   }
 
-  private MainThreadChecker() {}
+  private ThreadChecker() {}
 
   @Override
   public boolean isMainThread(long threadId) {
@@ -42,5 +42,10 @@ public final class MainThreadChecker implements IMainThreadChecker {
   public boolean isMainThread(final @NotNull SentryThread sentryThread) {
     final Long threadId = sentryThread.getId();
     return threadId != null && isMainThread(threadId);
+  }
+
+  @Override
+  public long currentThreadId() {
+    return Thread.currentThread().getId();
   }
 }

--- a/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/DefaultTransactionPerformanceCollectorTest.kt
@@ -4,7 +4,7 @@ import io.sentry.test.DeferredExecutorService
 import io.sentry.test.getCtor
 import io.sentry.test.getProperty
 import io.sentry.test.injectForField
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.eq
@@ -28,7 +28,7 @@ class DefaultTransactionPerformanceCollectorTest {
     private val className = "io.sentry.DefaultTransactionPerformanceCollector"
     private val ctorTypes: Array<Class<*>> = arrayOf(SentryOptions::class.java)
     private val fixture = Fixture()
-    private val mainThreadChecker = MainThreadChecker.getInstance()
+    private val threadChecker = ThreadChecker.getInstance()
 
     private class Fixture {
         lateinit var transaction1: ITransaction
@@ -324,13 +324,13 @@ class DefaultTransactionPerformanceCollectorTest {
     inner class ThreadCheckerCollector :
         IPerformanceSnapshotCollector {
         override fun setup() {
-            if (mainThreadChecker.isMainThread) {
+            if (threadChecker.isMainThread) {
                 throw AssertionError("setup() was called in the main thread")
             }
         }
 
         override fun collect(performanceCollectionData: PerformanceCollectionData) {
-            if (mainThreadChecker.isMainThread) {
+            if (threadChecker.isMainThread) {
                 throw AssertionError("collect() was called in the main thread")
             }
         }

--- a/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
+++ b/sentry/src/test/java/io/sentry/OutboxSenderTest.kt
@@ -5,7 +5,7 @@ import io.sentry.hints.Retryable
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.util.HintUtils
-import io.sentry.util.thread.NoOpMainThreadChecker
+import io.sentry.util.thread.NoOpThreadChecker
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.check
@@ -38,7 +38,7 @@ class OutboxSenderTest {
         init {
             whenever(options.dsn).thenReturn("https://key@sentry.io/proj")
             whenever(options.dateProvider).thenReturn(SentryNanotimeDateProvider())
-            whenever(options.mainThreadChecker).thenReturn(NoOpMainThreadChecker.getInstance())
+            whenever(options.threadChecker).thenReturn(NoOpThreadChecker.getInstance())
             whenever(scopes.options).thenReturn(this.options)
         }
 

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -18,8 +18,8 @@ import io.sentry.test.ImmediateExecutorService
 import io.sentry.test.createSentryClientMock
 import io.sentry.test.injectForField
 import io.sentry.util.PlatformTestManipulator
-import io.sentry.util.thread.IMainThreadChecker
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.IThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.awaitility.kotlin.await
 import org.junit.Assert.assertThrows
 import org.junit.Rule
@@ -647,7 +647,7 @@ class SentryTest {
             sentryOptions = it
         }
 
-        assertTrue { sentryOptions!!.mainThreadChecker is MainThreadChecker }
+        assertTrue { sentryOptions!!.threadChecker is ThreadChecker }
     }
 
     @Test
@@ -656,11 +656,11 @@ class SentryTest {
 
         Sentry.init {
             it.dsn = dsn
-            it.mainThreadChecker = CustomMainThreadChecker()
+            it.threadChecker = CustomThreadChecker()
             sentryOptions = it
         }
 
-        assertTrue { sentryOptions!!.mainThreadChecker is CustomMainThreadChecker }
+        assertTrue { sentryOptions!!.threadChecker is CustomThreadChecker }
     }
 
     @Test
@@ -1269,11 +1269,12 @@ class SentryTest {
         }
     }
 
-    private class CustomMainThreadChecker : IMainThreadChecker {
+    private class CustomThreadChecker : IThreadChecker {
         override fun isMainThread(threadId: Long): Boolean = false
         override fun isMainThread(thread: Thread): Boolean = false
         override fun isMainThread(): Boolean = false
         override fun isMainThread(sentryThread: SentryThread): Boolean = false
+        override fun currentThreadId(): Long = 0
     }
 
     private class CustomMemoryCollector :

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1274,7 +1274,7 @@ class SentryTest {
         override fun isMainThread(thread: Thread): Boolean = false
         override fun isMainThread(): Boolean = false
         override fun isMainThread(sentryThread: SentryThread): Boolean = false
-        override fun currentThreadId(): Long = 0
+        override fun currentThreadSystemId(): Long = 0
     }
 
     private class CustomMemoryCollector :

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -4,7 +4,7 @@ import io.sentry.protocol.SentryId
 import io.sentry.protocol.TransactionNameSource
 import io.sentry.protocol.User
 import io.sentry.test.createTestScopes
-import io.sentry.util.thread.IMainThreadChecker
+import io.sentry.util.thread.IThreadChecker
 import org.awaitility.kotlin.await
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -1351,11 +1351,11 @@ class SentryTracerTest {
 
     @Test
     fun `when a span is launched on the main thread, the thread info should be set correctly`() {
-        val mainThreadChecker = mock<IMainThreadChecker>()
-        whenever(mainThreadChecker.isMainThread).thenReturn(true)
+        val threadChecker = mock<IThreadChecker>()
+        whenever(threadChecker.isMainThread).thenReturn(true)
 
         val tracer = fixture.getSut(optionsConfiguration = { options ->
-            options.mainThreadChecker = mainThreadChecker
+            options.threadChecker = threadChecker
         })
         val span = tracer.startChild("span.op")
         assertNotNull(span.getData(SpanDataConvention.THREAD_ID))
@@ -1364,11 +1364,11 @@ class SentryTracerTest {
 
     @Test
     fun `when a span is launched on the background thread, the thread info should be set correctly`() {
-        val mainThreadChecker = mock<IMainThreadChecker>()
-        whenever(mainThreadChecker.isMainThread).thenReturn(false)
+        val threadChecker = mock<IThreadChecker>()
+        whenever(threadChecker.isMainThread).thenReturn(false)
 
         val tracer = fixture.getSut(optionsConfiguration = { options ->
-            options.mainThreadChecker = mainThreadChecker
+            options.threadChecker = threadChecker
         })
         val span = tracer.startChild("span.op")
         assertNotNull(span.getData(SpanDataConvention.THREAD_ID))

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -8,7 +8,7 @@ import io.sentry.SpanStatus
 import io.sentry.SpanStatus.INTERNAL_ERROR
 import io.sentry.TransactionContext
 import io.sentry.protocol.SentryStackFrame
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.awaitility.kotlin.await
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -43,7 +43,7 @@ class SentryFileInputStreamTest {
             whenever(scopes.options).thenReturn(
                 options.apply {
                     isSendDefaultPii = sendDefaultPii
-                    mainThreadChecker = MainThreadChecker.getInstance()
+                    threadChecker = ThreadChecker.getInstance()
                     addInAppInclude("org.junit")
                 }
             )

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileOutputStreamTest.kt
@@ -7,7 +7,7 @@ import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.protocol.SentryStackFrame
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.awaitility.kotlin.await
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -34,7 +34,7 @@ class SentryFileOutputStreamTest {
         ): SentryFileOutputStream {
             whenever(scopes.options).thenReturn(
                 SentryOptions().apply {
-                    mainThreadChecker = MainThreadChecker.getInstance()
+                    threadChecker = ThreadChecker.getInstance()
                     addInAppInclude("org.junit")
                 }
             )

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileReaderTest.kt
@@ -6,7 +6,7 @@ import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus.OK
 import io.sentry.TransactionContext
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.mock
@@ -27,7 +27,7 @@ class SentryFileReaderTest {
             tmpFile.writeText("TEXT")
             whenever(scopes.options).thenReturn(
                 SentryOptions().apply {
-                    mainThreadChecker = MainThreadChecker.getInstance()
+                    threadChecker = ThreadChecker.getInstance()
                 }
             )
             sentryTracer = SentryTracer(TransactionContext("name", "op"), scopes)

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
@@ -6,7 +6,7 @@ import io.sentry.SentryTracer
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus.OK
 import io.sentry.TransactionContext
-import io.sentry.util.thread.MainThreadChecker
+import io.sentry.util.thread.ThreadChecker
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.mock
@@ -27,7 +27,7 @@ class SentryFileWriterTest {
         ): SentryFileWriter {
             whenever(scopes.options).thenReturn(
                 SentryOptions().apply {
-                    mainThreadChecker = MainThreadChecker.getInstance()
+                    threadChecker = ThreadChecker.getInstance()
                 }
             )
             sentryTracer = SentryTracer(TransactionContext("name", "op"), scopes)

--- a/sentry/src/test/java/io/sentry/util/thread/ThreadCheckerTest.kt
+++ b/sentry/src/test/java/io/sentry/util/thread/ThreadCheckerTest.kt
@@ -5,25 +5,25 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class MainThreadCheckerTest {
+class ThreadCheckerTest {
 
-    private val mainThreadChecker = MainThreadChecker.getInstance()
+    private val threadChecker = ThreadChecker.getInstance()
 
     @Test
     fun `When calling isMainThread from the same thread, it should return true`() {
-        assertTrue(mainThreadChecker.isMainThread)
+        assertTrue(threadChecker.isMainThread)
     }
 
     @Test
     fun `When calling isMainThread with the current thread, it should return true`() {
         val thread = Thread.currentThread()
-        assertTrue(mainThreadChecker.isMainThread(thread))
+        assertTrue(threadChecker.isMainThread(thread))
     }
 
     @Test
     fun `When calling isMainThread from a different thread, it should return false`() {
         val thread = Thread()
-        assertFalse(mainThreadChecker.isMainThread(thread))
+        assertFalse(threadChecker.isMainThread(thread))
     }
 
     @Test
@@ -32,7 +32,7 @@ class MainThreadCheckerTest {
         val sentryThread = SentryThread().apply {
             id = thread.id
         }
-        assertTrue(mainThreadChecker.isMainThread(sentryThread))
+        assertTrue(threadChecker.isMainThread(sentryThread))
     }
 
     @Test
@@ -41,6 +41,6 @@ class MainThreadCheckerTest {
         val sentryThread = SentryThread().apply {
             id = thread.id
         }
-        assertFalse(mainThreadChecker.isMainThread(sentryThread))
+        assertFalse(threadChecker.isMainThread(sentryThread))
     }
 }


### PR DESCRIPTION
## :scroll: Description
renamed IMainThreadChecker to IThreadChecker
added getCurrentThreadSystemId() to IThreadChecker
replaced thread id of SentryTracer and PerformanceAndroidEventProcessor

Adding to v8, since it's a behavioural change and users could already use it in some dashboard, as it's indexed. This is very unlikely, though.

## :bulb: Motivation and Context
Continuous profiler needs to bind the trace and span to the corresponding thread in the profile.
The Android profiler retrieves the kernel thread id, that we can get via `Process.myTid()`, so we have to set that instead of `Thread.getThreadId()`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
