### PR TITLE
POTEL 49 - Add `enable-spotlight` and `spotlight-connection-url` to external options and check if enabled in OTel

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelInternalSpanDetectionUtil.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelInternalSpanDetectionUtil.java
@@ -38,20 +38,18 @@ public final class OtelInternalSpanDetectionUtil {
       return true;
     }
 
-    // TODO [POTEL] should check if enabled but multi init with different options makes testing hard
-    // atm
-    //    if (scopes.getOptions().isEnableSpotlight()) {
-    final @Nullable String optionsSpotlightUrl = scopes.getOptions().getSpotlightConnectionUrl();
-    final @NotNull String spotlightUrl =
-        optionsSpotlightUrl != null ? optionsSpotlightUrl : "http://localhost:8969/stream";
+    if (scopes.getOptions().isEnableSpotlight()) {
+      final @Nullable String optionsSpotlightUrl = scopes.getOptions().getSpotlightConnectionUrl();
+      final @NotNull String spotlightUrl =
+          optionsSpotlightUrl != null ? optionsSpotlightUrl : "http://localhost:8969/stream";
 
-    if (containsSpotlightUrl(fullUrl, spotlightUrl)) {
-      return true;
+      if (containsSpotlightUrl(fullUrl, spotlightUrl)) {
+        return true;
+      }
+      if (containsSpotlightUrl(httpUrl, spotlightUrl)) {
+        return true;
+      }
     }
-    if (containsSpotlightUrl(httpUrl, spotlightUrl)) {
-      return true;
-    }
-    //    }
 
     return false;
   }

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -172,6 +172,8 @@ class SentryAutoConfigurationTest {
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
             "sentry.enable-backpressure-handling=false",
+            "sentry.enable-spotlight=true",
+            "sentry.spotlight-connection-url=http://local.sentry.io:1234",
             "sentry.force-init=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
@@ -211,6 +213,8 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)
+            assertThat(options.isEnableSpotlight).isEqualTo(true)
+            assertThat(options.spotlightConnectionUrl).isEqualTo("http://local.sentry.io:1234")
             assertThat(options.cron).isNotNull
             assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
             assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -171,6 +171,8 @@ class SentryAutoConfigurationTest {
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
             "sentry.enable-backpressure-handling=false",
+            "sentry.enable-spotlight=true",
+            "sentry.spotlight-connection-url=http://local.sentry.io:1234",
             "sentry.force-init=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
@@ -210,6 +212,8 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)
+            assertThat(options.isEnableSpotlight).isEqualTo(true)
+            assertThat(options.spotlightConnectionUrl).isEqualTo("http://local.sentry.io:1234")
             assertThat(options.cron).isNotNull
             assertThat(options.cron!!.defaultCheckinMargin).isEqualTo(10L)
             assertThat(options.cron!!.defaultMaxRuntime).isEqualTo(30L)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -463,12 +463,14 @@ public final class io/sentry/ExternalOptions {
 	public fun getRelease ()Ljava/lang/String;
 	public fun getSendClientReports ()Ljava/lang/Boolean;
 	public fun getServerName ()Ljava/lang/String;
+	public fun getSpotlightConnectionUrl ()Ljava/lang/String;
 	public fun getTags ()Ljava/util/Map;
 	public fun getTracePropagationTargets ()Ljava/util/List;
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun getTracingOrigins ()Ljava/util/List;
 	public fun isEnableBackpressureHandling ()Ljava/lang/Boolean;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
+	public fun isEnableSpotlight ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
 	public fun isForceInit ()Ljava/lang/Boolean;
 	public fun isSendDefaultPii ()Ljava/lang/Boolean;
@@ -480,6 +482,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setEnableBackpressureHandling (Ljava/lang/Boolean;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnablePrettySerializationOutput (Ljava/lang/Boolean;)V
+	public fun setEnableSpotlight (Ljava/lang/Boolean;)V
 	public fun setEnableTracing (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnabled (Ljava/lang/Boolean;)V
@@ -497,6 +500,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setSendDefaultPii (Ljava/lang/Boolean;)V
 	public fun setSendModules (Ljava/lang/Boolean;)V
 	public fun setServerName (Ljava/lang/String;)V
+	public fun setSpotlightConnectionUrl (Ljava/lang/String;)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTracesSampleRate (Ljava/lang/Double;)V
 }

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -45,6 +45,8 @@ public final class ExternalOptions {
   private @NotNull Set<String> bundleIds = new CopyOnWriteArraySet<>();
   private @Nullable Boolean enabled;
   private @Nullable Boolean enablePrettySerializationOutput;
+  private @Nullable Boolean enableSpotlight;
+  private @Nullable String spotlightConnectionUrl;
 
   private @Nullable List<String> ignoredCheckIns;
 
@@ -187,6 +189,9 @@ public final class ExternalOptions {
 
       options.setCron(cron);
     }
+
+    options.setEnableSpotlight(propertiesProvider.getBooleanProperty("enable-spotlight"));
+    options.setSpotlightConnectionUrl(propertiesProvider.getProperty("spotlight-connection-url"));
 
     return options;
   }
@@ -469,5 +474,25 @@ public final class ExternalOptions {
   @ApiStatus.Experimental
   public void setCron(final @Nullable SentryOptions.Cron cron) {
     this.cron = cron;
+  }
+
+  @ApiStatus.Experimental
+  public void setEnableSpotlight(final @Nullable Boolean enableSpotlight) {
+    this.enableSpotlight = enableSpotlight;
+  }
+
+  @ApiStatus.Experimental
+  public @Nullable Boolean isEnableSpotlight() {
+    return enableSpotlight;
+  }
+
+  @ApiStatus.Experimental
+  public @Nullable String getSpotlightConnectionUrl() {
+    return spotlightConnectionUrl;
+  }
+
+  @ApiStatus.Experimental
+  public void setSpotlightConnectionUrl(final @Nullable String spotlightConnectionUrl) {
+    this.spotlightConnectionUrl = spotlightConnectionUrl;
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2763,6 +2763,14 @@ public class SentryOptions {
       setSendDefaultPii(options.isSendDefaultPii());
     }
 
+    if (options.isEnableSpotlight() != null) {
+      setEnableSpotlight(options.isEnableSpotlight());
+    }
+
+    if (options.getSpotlightConnectionUrl() != null) {
+      setSpotlightConnectionUrl(options.getSpotlightConnectionUrl());
+    }
+
     if (options.getCron() != null) {
       if (getCron() == null) {
         setCron(options.getCron());

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -300,6 +300,20 @@ class ExternalOptionsTest {
         }
     }
 
+    @Test
+    fun `creates options with enableSpotlight set to true`() {
+        withPropertiesFile("enable-spotlight=true") { options ->
+            assertTrue(options.isEnableSpotlight == true)
+        }
+    }
+
+    @Test
+    fun `creates options with spotlightConnectionUrl set`() {
+        withPropertiesFile("spotlight-connection-url=http://local.sentry.io:1234") { options ->
+            assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
+        }
+    }
+
     private fun withPropertiesFile(textLines: List<String> = emptyList(), logger: ILogger = mock(), fn: (ExternalOptions) -> Unit) {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -382,6 +382,8 @@ class SentryOptionsTest {
             defaultFailureIssueThreshold = 40L
             defaultRecoveryThreshold = 50L
         }
+        externalOptions.isEnableSpotlight = true
+        externalOptions.spotlightConnectionUrl = "http://local.sentry.io:1234"
 
         val options = SentryOptions()
 
@@ -422,6 +424,8 @@ class SentryOptionsTest {
         assertEquals("America/New_York", options.cron?.defaultTimezone)
         assertTrue(options.isSendDefaultPii)
         assertEquals(RequestSize.MEDIUM, options.maxRequestBodySize)
+        assertTrue(options.isEnableSpotlight)
+        assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
     }
 
     @Test
@@ -573,6 +577,16 @@ class SentryOptionsTest {
     @Test
     fun `when options are initialized, enableBackpressureHandling is set to true by default`() {
         assertTrue(SentryOptions().isEnableBackpressureHandling)
+    }
+
+    @Test
+    fun `when options are initialized, enableSpotlight is set to false by default`() {
+        assertFalse(SentryOptions().isEnableSpotlight)
+    }
+
+    @Test
+    fun `when options are initialized, spotlightConnectionUrl is not set by default`() {
+        assertNull(SentryOptions().spotlightConnectionUrl)
     }
 
     @Test


### PR DESCRIPTION


## :scroll: Description
<!--- Describe your changes in detail -->
- Add `enable-spotlight` and `spotlight-connection-url` to external options
- Check if spotlight is enabled when deciding whether to inspect an OpenTelemetry span for connecting to splotlight

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
