### PR TITLE
Replace `synchronized` with`ReentrantLock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - This will reduce the number of spans created by the SDK
 - `options.experimental.sessionReplay.errorSampleRate` was renamed to `options.experimental.sessionReplay.onErrorSampleRate` ([#3637](https://github.com/getsentry/sentry-java/pull/3637))
 - Manifest option `io.sentry.session-replay.error-sample-rate` was renamed to `io.sentry.session-replay.on-error-sample-rate` ([#3637](https://github.com/getsentry/sentry-java/pull/3637))
+- Replace `synchronized` methods and blocks with `ReentrantLock` (`AutoClosableReentrantLock`) ([#3715](https://github.com/getsentry/sentry-java/pull/3715))
+  - If you are subclassing any Sentry classes, please check if the parent class used `synchronized` before. Please make sure to use the same lock object as the parent class in that case. 
 
 ### Features
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -63,6 +63,7 @@ public class io/sentry/android/core/AndroidMemoryCollector : io/sentry/IPerforma
 }
 
 public class io/sentry/android/core/AndroidProfiler {
+	protected final field lock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Ljava/lang/String;ILio/sentry/android/core/internal/util/SentryFrameMetricsCollector;Lio/sentry/ISentryExecutorService;Lio/sentry/ILogger;Lio/sentry/android/core/BuildInfoProvider;)V
 	public fun close ()V
 	public fun endAndCollect (ZLjava/util/List;)Lio/sentry/android/core/AndroidProfiler$ProfileEndData;
@@ -194,6 +195,7 @@ public final class io/sentry/android/core/DeviceInfoUtil {
 }
 
 public abstract class io/sentry/android/core/EnvelopeFileObserverIntegration : io/sentry/Integration, java/io/Closeable {
+	protected final field startLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun close ()V
 	public static fun getOutboxFileObserver ()Lio/sentry/android/core/EnvelopeFileObserverIntegration;
@@ -355,6 +357,7 @@ public final class io/sentry/android/core/SentryPerformanceProvider {
 }
 
 public class io/sentry/android/core/SpanFrameMetricsCollector : io/sentry/IPerformanceContinuousCollector, io/sentry/android/core/internal/util/SentryFrameMetricsCollector$FrameMetricsCollectorListener {
+	protected final field lock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/android/core/internal/util/SentryFrameMetricsCollector;)V
 	public fun clear ()V
 	public fun onFrameMetricCollected (JJJJZZF)V
@@ -431,6 +434,7 @@ public class io/sentry/android/core/performance/ActivityLifecycleTimeSpan : java
 }
 
 public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/android/core/performance/ActivityLifecycleCallbacksAdapter {
+	public static final field staticLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun addActivityLifecycleTimeSpans (Lio/sentry/android/core/performance/ActivityLifecycleTimeSpan;)V
 	public fun clear ()V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
@@ -9,9 +9,11 @@ import android.os.Bundle;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
@@ -25,6 +27,7 @@ public final class ActivityBreadcrumbsIntegration
   private final @NotNull Application application;
   private @Nullable IScopes scopes;
   private boolean enabled;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public ActivityBreadcrumbsIntegration(final @NotNull Application application) {
     this.application = Objects.requireNonNull(application, "Application is required");
@@ -64,40 +67,54 @@ public final class ActivityBreadcrumbsIntegration
   }
 
   @Override
-  public synchronized void onActivityCreated(
+  public void onActivityCreated(
       final @NotNull Activity activity, final @Nullable Bundle savedInstanceState) {
-    addBreadcrumb(activity, "created");
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "created");
+    }
   }
 
   @Override
-  public synchronized void onActivityStarted(final @NotNull Activity activity) {
-    addBreadcrumb(activity, "started");
+  public void onActivityStarted(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "started");
+    }
   }
 
   @Override
-  public synchronized void onActivityResumed(final @NotNull Activity activity) {
-    addBreadcrumb(activity, "resumed");
+  public void onActivityResumed(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "resumed");
+    }
   }
 
   @Override
-  public synchronized void onActivityPaused(final @NotNull Activity activity) {
-    addBreadcrumb(activity, "paused");
+  public void onActivityPaused(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "paused");
+    }
   }
 
   @Override
-  public synchronized void onActivityStopped(final @NotNull Activity activity) {
-    addBreadcrumb(activity, "stopped");
+  public void onActivityStopped(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "stopped");
+    }
   }
 
   @Override
-  public synchronized void onActivitySaveInstanceState(
+  public void onActivitySaveInstanceState(
       final @NotNull Activity activity, final @NotNull Bundle outState) {
-    addBreadcrumb(activity, "saveInstanceState");
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "saveInstanceState");
+    }
   }
 
   @Override
-  public synchronized void onActivityDestroyed(final @NotNull Activity activity) {
-    addBreadcrumb(activity, "destroyed");
+  public void onActivityDestroyed(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      addBreadcrumb(activity, "destroyed");
+    }
   }
 
   private void addBreadcrumb(final @NotNull Activity activity, final @NotNull String state) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
@@ -29,6 +29,7 @@ public final class ActivityBreadcrumbsIntegration
   private boolean enabled;
   private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
+  // TODO check if locking is even required at all for lifecycle methods
   public ActivityBreadcrumbsIntegration(final @NotNull Application application) {
     this.application = Objects.requireNonNull(application, "Application is required");
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityFramesTracker.java
@@ -3,11 +3,13 @@ package io.sentry.android.core;
 import android.app.Activity;
 import android.util.SparseIntArray;
 import androidx.core.app.FrameMetricsAggregator;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.MeasurementUnit;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.util.AndroidMainThreadChecker;
 import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -37,6 +39,7 @@ public final class ActivityFramesTracker {
       new WeakHashMap<>();
 
   private final @NotNull MainLooperHandler handler;
+  protected @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public ActivityFramesTracker(
       final @NotNull io.sentry.util.LoadClass loadClass,
@@ -78,13 +81,15 @@ public final class ActivityFramesTracker {
   }
 
   @SuppressWarnings("NullAway")
-  public synchronized void addActivity(final @NotNull Activity activity) {
-    if (!isFrameMetricsAggregatorAvailable()) {
-      return;
-    }
+  public void addActivity(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (!isFrameMetricsAggregatorAvailable()) {
+        return;
+      }
 
-    runSafelyOnUiThread(() -> frameMetricsAggregator.add(activity), "FrameMetricsAggregator.add");
-    snapshotFrameCountsAtStart(activity);
+      runSafelyOnUiThread(() -> frameMetricsAggregator.add(activity), "FrameMetricsAggregator.add");
+      snapshotFrameCountsAtStart(activity);
+    }
   }
 
   private void snapshotFrameCountsAtStart(final @NotNull Activity activity) {
@@ -132,45 +137,46 @@ public final class ActivityFramesTracker {
   }
 
   @SuppressWarnings("NullAway")
-  public synchronized void setMetrics(
-      final @NotNull Activity activity, final @NotNull SentryId transactionId) {
-    if (!isFrameMetricsAggregatorAvailable()) {
-      return;
+  public void setMetrics(final @NotNull Activity activity, final @NotNull SentryId transactionId) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (!isFrameMetricsAggregatorAvailable()) {
+        return;
+      }
+
+      // NOTE: removing an activity does not reset the frame counts, only reset() does
+      // throws IllegalArgumentException when attempting to remove
+      // OnFrameMetricsAvailableListener
+      // that was never added.
+      // there's no contains method.
+      // throws NullPointerException when attempting to remove
+      // OnFrameMetricsAvailableListener and
+      // there was no
+      // Observers, See
+      // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+      runSafelyOnUiThread(() -> frameMetricsAggregator.remove(activity), null);
+
+      final @Nullable FrameCounts frameCounts = diffFrameCountsAtEnd(activity);
+
+      if (frameCounts == null
+          || (frameCounts.totalFrames == 0
+              && frameCounts.slowFrames == 0
+              && frameCounts.frozenFrames == 0)) {
+        return;
+      }
+
+      final MeasurementValue tfValues =
+          new MeasurementValue(frameCounts.totalFrames, MeasurementUnit.NONE);
+      final MeasurementValue sfValues =
+          new MeasurementValue(frameCounts.slowFrames, MeasurementUnit.NONE);
+      final MeasurementValue ffValues =
+          new MeasurementValue(frameCounts.frozenFrames, MeasurementUnit.NONE);
+      final Map<String, @NotNull MeasurementValue> measurements = new HashMap<>();
+      measurements.put(MeasurementValue.KEY_FRAMES_TOTAL, tfValues);
+      measurements.put(MeasurementValue.KEY_FRAMES_SLOW, sfValues);
+      measurements.put(MeasurementValue.KEY_FRAMES_FROZEN, ffValues);
+
+      activityMeasurements.put(transactionId, measurements);
     }
-
-    // NOTE: removing an activity does not reset the frame counts, only reset() does
-    // throws IllegalArgumentException when attempting to remove
-    // OnFrameMetricsAvailableListener
-    // that was never added.
-    // there's no contains method.
-    // throws NullPointerException when attempting to remove
-    // OnFrameMetricsAvailableListener and
-    // there was no
-    // Observers, See
-    // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
-    runSafelyOnUiThread(() -> frameMetricsAggregator.remove(activity), null);
-
-    final @Nullable FrameCounts frameCounts = diffFrameCountsAtEnd(activity);
-
-    if (frameCounts == null
-        || (frameCounts.totalFrames == 0
-            && frameCounts.slowFrames == 0
-            && frameCounts.frozenFrames == 0)) {
-      return;
-    }
-
-    final MeasurementValue tfValues =
-        new MeasurementValue(frameCounts.totalFrames, MeasurementUnit.NONE);
-    final MeasurementValue sfValues =
-        new MeasurementValue(frameCounts.slowFrames, MeasurementUnit.NONE);
-    final MeasurementValue ffValues =
-        new MeasurementValue(frameCounts.frozenFrames, MeasurementUnit.NONE);
-    final Map<String, @NotNull MeasurementValue> measurements = new HashMap<>();
-    measurements.put(MeasurementValue.KEY_FRAMES_TOTAL, tfValues);
-    measurements.put(MeasurementValue.KEY_FRAMES_SLOW, sfValues);
-    measurements.put(MeasurementValue.KEY_FRAMES_FROZEN, ffValues);
-
-    activityMeasurements.put(transactionId, measurements);
   }
 
   private @Nullable FrameCounts diffFrameCountsAtEnd(final @NotNull Activity activity) {
@@ -192,25 +198,28 @@ public final class ActivityFramesTracker {
   }
 
   @Nullable
-  public synchronized Map<String, @NotNull MeasurementValue> takeMetrics(
-      final @NotNull SentryId transactionId) {
-    if (!isFrameMetricsAggregatorAvailable()) {
-      return null;
-    }
+  public Map<String, @NotNull MeasurementValue> takeMetrics(final @NotNull SentryId transactionId) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (!isFrameMetricsAggregatorAvailable()) {
+        return null;
+      }
 
-    final Map<String, @NotNull MeasurementValue> stringMeasurementValueMap =
-        activityMeasurements.get(transactionId);
-    activityMeasurements.remove(transactionId);
-    return stringMeasurementValueMap;
+      final Map<String, @NotNull MeasurementValue> stringMeasurementValueMap =
+          activityMeasurements.get(transactionId);
+      activityMeasurements.remove(transactionId);
+      return stringMeasurementValueMap;
+    }
   }
 
   @SuppressWarnings("NullAway")
-  public synchronized void stop() {
-    if (isFrameMetricsAggregatorAvailable()) {
-      runSafelyOnUiThread(() -> frameMetricsAggregator.stop(), "FrameMetricsAggregator.stop");
-      frameMetricsAggregator.reset();
+  public void stop() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (isFrameMetricsAggregatorAvailable()) {
+        runSafelyOnUiThread(() -> frameMetricsAggregator.stop(), "FrameMetricsAggregator.stop");
+        frameMetricsAggregator.reset();
+      }
+      activityMeasurements.clear();
     }
-    activityMeasurements.clear();
   }
 
   private void runSafelyOnUiThread(final Runnable runnable, final String tag) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import io.sentry.FullyDisplayedReporter;
 import io.sentry.IScope;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ISpan;
 import io.sentry.ITransaction;
 import io.sentry.Instrumenter;
@@ -34,6 +35,7 @@ import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.TransactionNameSource;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import io.sentry.util.TracingUtils;
 import java.io.Closeable;
@@ -88,6 +90,7 @@ public final class ActivityLifecycleIntegration
       new WeakHashMap<>();
 
   private final @NotNull ActivityFramesTracker activityFramesTracker;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public ActivityLifecycleIntegration(
       final @NotNull Application application,
@@ -378,50 +381,56 @@ public final class ActivityLifecycleIntegration
   }
 
   @Override
-  public synchronized void onActivityCreated(
+  public void onActivityCreated(
       final @NotNull Activity activity, final @Nullable Bundle savedInstanceState) {
-    setColdStart(savedInstanceState);
-    if (scopes != null && options != null && options.isEnableScreenTracking()) {
-      final @Nullable String activityClassName = ClassUtil.getClassName(activity);
-      scopes.configureScope(scope -> scope.setScreen(activityClassName));
-    }
-    startTracing(activity);
-    final @Nullable ISpan ttfdSpan = ttfdSpanMap.get(activity);
-
-    firstActivityCreated = true;
-
-    if (fullyDisplayedReporter != null) {
-      fullyDisplayedReporter.registerFullyDrawnListener(() -> onFullFrameDrawn(ttfdSpan));
-    }
-  }
-
-  @Override
-  public synchronized void onActivityStarted(final @NotNull Activity activity) {
-    if (performanceEnabled) {
-      // The docs on the screen rendering performance tracing
-      // (https://firebase.google.com/docs/perf-mon/screen-traces?platform=android#definition),
-      // state that the tracing starts for every Activity class when the app calls
-      // .onActivityStarted.
-      // Adding an Activity in onActivityCreated leads to Window.FEATURE_NO_TITLE not
-      // working. Moving this to onActivityStarted fixes the problem.
-      activityFramesTracker.addActivity(activity);
-    }
-  }
-
-  @Override
-  public synchronized void onActivityResumed(final @NotNull Activity activity) {
-    if (performanceEnabled) {
-
-      final @Nullable ISpan ttidSpan = ttidSpanMap.get(activity);
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      setColdStart(savedInstanceState);
+      if (scopes != null && options != null && options.isEnableScreenTracking()) {
+        final @Nullable String activityClassName = ClassUtil.getClassName(activity);
+        scopes.configureScope(scope -> scope.setScreen(activityClassName));
+      }
+      startTracing(activity);
       final @Nullable ISpan ttfdSpan = ttfdSpanMap.get(activity);
-      final View rootView = activity.findViewById(android.R.id.content);
-      if (rootView != null) {
-        FirstDrawDoneListener.registerForNextDraw(
-            rootView, () -> onFirstFrameDrawn(ttfdSpan, ttidSpan), buildInfoProvider);
-      } else {
-        // Posting a task to the main thread's handler will make it executed after it finished
-        // its current job. That is, right after the activity draws the layout.
-        mainHandler.post(() -> onFirstFrameDrawn(ttfdSpan, ttidSpan));
+
+      firstActivityCreated = true;
+
+      if (fullyDisplayedReporter != null) {
+        fullyDisplayedReporter.registerFullyDrawnListener(() -> onFullFrameDrawn(ttfdSpan));
+      }
+    }
+  }
+
+  @Override
+  public void onActivityStarted(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (performanceEnabled) {
+        // The docs on the screen rendering performance tracing
+        // (https://firebase.google.com/docs/perf-mon/screen-traces?platform=android#definition),
+        // state that the tracing starts for every Activity class when the app calls
+        // .onActivityStarted.
+        // Adding an Activity in onActivityCreated leads to Window.FEATURE_NO_TITLE not
+        // working. Moving this to onActivityStarted fixes the problem.
+        activityFramesTracker.addActivity(activity);
+      }
+    }
+  }
+
+  @Override
+  public void onActivityResumed(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (performanceEnabled) {
+
+        final @Nullable ISpan ttidSpan = ttidSpanMap.get(activity);
+        final @Nullable ISpan ttfdSpan = ttfdSpanMap.get(activity);
+        final View rootView = activity.findViewById(android.R.id.content);
+        if (rootView != null) {
+          FirstDrawDoneListener.registerForNextDraw(
+              rootView, () -> onFirstFrameDrawn(ttfdSpan, ttidSpan), buildInfoProvider);
+        } else {
+          // Posting a task to the main thread's handler will make it executed after it finished
+          // its current job. That is, right after the activity draws the layout.
+          mainHandler.post(() -> onFirstFrameDrawn(ttfdSpan, ttidSpan));
+        }
       }
     }
   }
@@ -448,64 +457,74 @@ public final class ActivityLifecycleIntegration
   }
 
   @Override
-  public synchronized void onActivityPaused(final @NotNull Activity activity) {
-    // only executed if API < 29 otherwise it happens on onActivityPrePaused
-    if (!isAllActivityCallbacksAvailable) {
-      // as the SDK may gets (re-)initialized mid activity lifecycle, ensure we set the flag here as
-      // well
-      // this ensures any newly launched activity will not use the app start timestamp as txn start
-      firstActivityCreated = true;
-      if (scopes == null) {
-        lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
-      } else {
-        lastPausedTime = scopes.getOptions().getDateProvider().now();
+  public void onActivityPaused(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // only executed if API < 29 otherwise it happens on onActivityPrePaused
+      if (!isAllActivityCallbacksAvailable) {
+        // as the SDK may gets (re-)initialized mid activity lifecycle, ensure we set the flag here
+        // as
+        // well
+        // this ensures any newly launched activity will not use the app start timestamp as txn
+        // start
+        firstActivityCreated = true;
+        if (scopes == null) {
+          lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
+        } else {
+          lastPausedTime = scopes.getOptions().getDateProvider().now();
+        }
       }
     }
   }
 
   @Override
-  public synchronized void onActivityStopped(final @NotNull Activity activity) {
-    // no-op
-  }
-
-  @Override
-  public synchronized void onActivitySaveInstanceState(
-      final @NotNull Activity activity, final @NotNull Bundle outState) {
-    // no-op
-  }
-
-  @Override
-  public synchronized void onActivityDestroyed(final @NotNull Activity activity) {
-    if (performanceEnabled) {
-
-      // in case the appStartSpan isn't completed yet, we finish it as cancelled to avoid
-      // memory leak
-      finishSpan(appStartSpan, SpanStatus.CANCELLED);
-
-      // we finish the ttidSpan as cancelled in case it isn't completed yet
-      final ISpan ttidSpan = ttidSpanMap.get(activity);
-      final ISpan ttfdSpan = ttfdSpanMap.get(activity);
-      finishSpan(ttidSpan, SpanStatus.DEADLINE_EXCEEDED);
-
-      // we finish the ttfdSpan as deadline_exceeded in case it isn't completed yet
-      finishExceededTtfdSpan(ttfdSpan, ttidSpan);
-      cancelTtfdAutoClose();
-
-      // in case people opt-out enableActivityLifecycleTracingAutoFinish and forgot to finish it,
-      // we make sure to finish it when the activity gets destroyed.
-      stopTracing(activity, true);
-
-      // set it to null in case its been just finished as cancelled
-      appStartSpan = null;
-      ttidSpanMap.remove(activity);
-      ttfdSpanMap.remove(activity);
+  public void onActivityStopped(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // no-op
     }
+  }
 
-    // clear it up, so we don't start again for the same activity if the activity is in the
-    // activity
-    // stack still.
-    // if the activity is opened again and not in memory, transactions will be created normally.
-    activitiesWithOngoingTransactions.remove(activity);
+  @Override
+  public void onActivitySaveInstanceState(
+      final @NotNull Activity activity, final @NotNull Bundle outState) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // no-op
+    }
+  }
+
+  @Override
+  public void onActivityDestroyed(final @NotNull Activity activity) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (performanceEnabled) {
+
+        // in case the appStartSpan isn't completed yet, we finish it as cancelled to avoid
+        // memory leak
+        finishSpan(appStartSpan, SpanStatus.CANCELLED);
+
+        // we finish the ttidSpan as cancelled in case it isn't completed yet
+        final ISpan ttidSpan = ttidSpanMap.get(activity);
+        final ISpan ttfdSpan = ttfdSpanMap.get(activity);
+        finishSpan(ttidSpan, SpanStatus.DEADLINE_EXCEEDED);
+
+        // we finish the ttfdSpan as deadline_exceeded in case it isn't completed yet
+        finishExceededTtfdSpan(ttfdSpan, ttidSpan);
+        cancelTtfdAutoClose();
+
+        // in case people opt-out enableActivityLifecycleTracingAutoFinish and forgot to finish it,
+        // we make sure to finish it when the activity gets destroyed.
+        stopTracing(activity, true);
+
+        // set it to null in case its been just finished as cancelled
+        appStartSpan = null;
+        ttidSpanMap.remove(activity);
+        ttfdSpanMap.remove(activity);
+      }
+
+      // clear it up, so we don't start again for the same activity if the activity is in the
+      // activity
+      // stack still.
+      // if the activity is opened again and not in memory, transactions will be created normally.
+      activitiesWithOngoingTransactions.remove(activity);
+    }
   }
 
   private void finishSpan(final @Nullable ISpan span) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -478,17 +478,13 @@ public final class ActivityLifecycleIntegration
 
   @Override
   public void onActivityStopped(final @NotNull Activity activity) {
-    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      // no-op
-    }
+    // no-op (acquire lock if this no longer is no-op)
   }
 
   @Override
   public void onActivitySaveInstanceState(
       final @NotNull Activity activity, final @NotNull Bundle outState) {
-    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-      // no-op
-    }
+    // no-op (acquire lock if this no longer is no-op)
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageInfo;
 import io.sentry.DeduplicateMultithreadedEventProcessor;
 import io.sentry.DefaultTransactionPerformanceCollector;
 import io.sentry.ILogger;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransactionProfiler;
 import io.sentry.NoOpConnectionStatusProvider;
 import io.sentry.ScopeType;
@@ -161,7 +162,7 @@ final class AndroidOptionsInitializer {
     // Check if the profiler was already instantiated in the app start.
     // We use the Android profiler, that uses a global start/stop api, so we need to preserve the
     // state of the profiler, and it's only possible retaining the instance.
-    synchronized (AppStartMetrics.getInstance()) {
+    try (final @NotNull ISentryLifecycleToken ignored = AppStartMetrics.staticLock.acquire()) {
       final @Nullable ITransactionProfiler appStartProfiler =
           AppStartMetrics.getInstance().getAppStartProfiler();
       if (appStartProfiler != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidProfiler.java
@@ -9,12 +9,14 @@ import io.sentry.CpuCollectionData;
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.ISentryExecutorService;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.MemoryCollectionData;
 import io.sentry.PerformanceCollectionData;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.profilemeasurements.ProfileMeasurement;
 import io.sentry.profilemeasurements.ProfileMeasurementValue;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.io.File;
 import java.util.ArrayDeque;
@@ -96,6 +98,7 @@ public class AndroidProfiler {
   private final @NotNull ISentryExecutorService executorService;
   private final @NotNull ILogger logger;
   private boolean isRunning = false;
+  protected final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public AndroidProfiler(
       final @NotNull String tracesFilesDirPath,
@@ -116,176 +119,184 @@ public class AndroidProfiler {
   }
 
   @SuppressLint("NewApi")
-  public synchronized @Nullable ProfileStartData start() {
-    // intervalUs is 0 only if there was a problem in the init
-    if (intervalUs == 0) {
-      logger.log(
-          SentryLevel.WARNING, "Disabling profiling because intervaUs is set to %d", intervalUs);
-      return null;
-    }
+  public @Nullable ProfileStartData start() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // intervalUs is 0 only if there was a problem in the init
+      if (intervalUs == 0) {
+        logger.log(
+            SentryLevel.WARNING, "Disabling profiling because intervaUs is set to %d", intervalUs);
+        return null;
+      }
 
-    if (isRunning) {
-      logger.log(SentryLevel.WARNING, "Profiling has already started...");
-      return null;
-    }
+      if (isRunning) {
+        logger.log(SentryLevel.WARNING, "Profiling has already started...");
+        return null;
+      }
 
-    // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return null;
+      // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return null;
 
-    // We create a file with a uuid name, so no need to check if it already exists
-    traceFile = new File(traceFilesDir, UUID.randomUUID() + ".trace");
+      // We create a file with a uuid name, so no need to check if it already exists
+      traceFile = new File(traceFilesDir, UUID.randomUUID() + ".trace");
 
-    measurementsMap.clear();
-    screenFrameRateMeasurements.clear();
-    slowFrameRenderMeasurements.clear();
-    frozenFrameRenderMeasurements.clear();
+      measurementsMap.clear();
+      screenFrameRateMeasurements.clear();
+      slowFrameRenderMeasurements.clear();
+      frozenFrameRenderMeasurements.clear();
 
-    frameMetricsCollectorId =
-        frameMetricsCollector.startCollection(
-            new SentryFrameMetricsCollector.FrameMetricsCollectorListener() {
-              float lastRefreshRate = 0;
+      frameMetricsCollectorId =
+          frameMetricsCollector.startCollection(
+              new SentryFrameMetricsCollector.FrameMetricsCollectorListener() {
+                float lastRefreshRate = 0;
 
-              @Override
-              public void onFrameMetricCollected(
-                  final long frameStartNanos,
-                  final long frameEndNanos,
-                  final long durationNanos,
-                  final long delayNanos,
-                  final boolean isSlow,
-                  final boolean isFrozen,
-                  final float refreshRate) {
-                // profileStartNanos is calculated through SystemClock.elapsedRealtimeNanos(),
-                // but frameEndNanos uses System.nanotime(), so we convert it to get the timestamp
-                // relative to profileStartNanos
-                final long frameTimestampRelativeNanos =
-                    frameEndNanos
-                        - System.nanoTime()
-                        + SystemClock.elapsedRealtimeNanos()
-                        - profileStartNanos;
+                @Override
+                public void onFrameMetricCollected(
+                    final long frameStartNanos,
+                    final long frameEndNanos,
+                    final long durationNanos,
+                    final long delayNanos,
+                    final boolean isSlow,
+                    final boolean isFrozen,
+                    final float refreshRate) {
+                  // profileStartNanos is calculated through SystemClock.elapsedRealtimeNanos(),
+                  // but frameEndNanos uses System.nanotime(), so we convert it to get the timestamp
+                  // relative to profileStartNanos
+                  final long frameTimestampRelativeNanos =
+                      frameEndNanos
+                          - System.nanoTime()
+                          + SystemClock.elapsedRealtimeNanos()
+                          - profileStartNanos;
 
-                // We don't allow negative relative timestamps.
-                // So we add a check, even if this should never happen.
-                if (frameTimestampRelativeNanos < 0) {
-                  return;
+                  // We don't allow negative relative timestamps.
+                  // So we add a check, even if this should never happen.
+                  if (frameTimestampRelativeNanos < 0) {
+                    return;
+                  }
+                  if (isFrozen) {
+                    frozenFrameRenderMeasurements.addLast(
+                        new ProfileMeasurementValue(frameTimestampRelativeNanos, durationNanos));
+                  } else if (isSlow) {
+                    slowFrameRenderMeasurements.addLast(
+                        new ProfileMeasurementValue(frameTimestampRelativeNanos, durationNanos));
+                  }
+                  if (refreshRate != lastRefreshRate) {
+                    lastRefreshRate = refreshRate;
+                    screenFrameRateMeasurements.addLast(
+                        new ProfileMeasurementValue(frameTimestampRelativeNanos, refreshRate));
+                  }
                 }
-                if (isFrozen) {
-                  frozenFrameRenderMeasurements.addLast(
-                      new ProfileMeasurementValue(frameTimestampRelativeNanos, durationNanos));
-                } else if (isSlow) {
-                  slowFrameRenderMeasurements.addLast(
-                      new ProfileMeasurementValue(frameTimestampRelativeNanos, durationNanos));
-                }
-                if (refreshRate != lastRefreshRate) {
-                  lastRefreshRate = refreshRate;
-                  screenFrameRateMeasurements.addLast(
-                      new ProfileMeasurementValue(frameTimestampRelativeNanos, refreshRate));
-                }
-              }
-            });
+              });
 
-    // We stop profiling after a timeout to avoid huge profiles to be sent
-    try {
-      scheduledFinish =
-          executorService.schedule(() -> endAndCollect(true, null), PROFILING_TIMEOUT_MILLIS);
-    } catch (RejectedExecutionException e) {
-      logger.log(
-          SentryLevel.ERROR,
-          "Failed to call the executor. Profiling will not be automatically finished. Did you call Sentry.close()?",
-          e);
-    }
+      // We stop profiling after a timeout to avoid huge profiles to be sent
+      try {
+        scheduledFinish =
+            executorService.schedule(() -> endAndCollect(true, null), PROFILING_TIMEOUT_MILLIS);
+      } catch (RejectedExecutionException e) {
+        logger.log(
+            SentryLevel.ERROR,
+            "Failed to call the executor. Profiling will not be automatically finished. Did you call Sentry.close()?",
+            e);
+      }
 
-    profileStartNanos = SystemClock.elapsedRealtimeNanos();
-    final @NotNull Date profileStartTimestamp = DateUtils.getCurrentDateTime();
-    long profileStartCpuMillis = Process.getElapsedCpuTime();
+      profileStartNanos = SystemClock.elapsedRealtimeNanos();
+      final @NotNull Date profileStartTimestamp = DateUtils.getCurrentDateTime();
+      long profileStartCpuMillis = Process.getElapsedCpuTime();
 
-    // We don't make any check on the file existence or writeable state, because we don't want to
-    // make file IO in the main thread.
-    // We cannot offload the work to the executorService, as if that's very busy, profiles could
-    // start/stop with a lot of delay and even cause ANRs.
-    try {
-      // If there is any problem with the file this method will throw (but it will not throw in
-      // tests)
-      Debug.startMethodTracingSampling(traceFile.getPath(), BUFFER_SIZE_BYTES, intervalUs);
-      isRunning = true;
-      return new ProfileStartData(profileStartNanos, profileStartCpuMillis, profileStartTimestamp);
-    } catch (Throwable e) {
-      endAndCollect(false, null);
-      logger.log(SentryLevel.ERROR, "Unable to start a profile: ", e);
-      isRunning = false;
-      return null;
+      // We don't make any check on the file existence or writeable state, because we don't want to
+      // make file IO in the main thread.
+      // We cannot offload the work to the executorService, as if that's very busy, profiles could
+      // start/stop with a lot of delay and even cause ANRs.
+      try {
+        // If there is any problem with the file this method will throw (but it will not throw in
+        // tests)
+        Debug.startMethodTracingSampling(traceFile.getPath(), BUFFER_SIZE_BYTES, intervalUs);
+        isRunning = true;
+        return new ProfileStartData(
+            profileStartNanos, profileStartCpuMillis, profileStartTimestamp);
+      } catch (Throwable e) {
+        endAndCollect(false, null);
+        logger.log(SentryLevel.ERROR, "Unable to start a profile: ", e);
+        isRunning = false;
+        return null;
+      }
     }
   }
 
   @SuppressLint("NewApi")
-  public synchronized @Nullable ProfileEndData endAndCollect(
+  public @Nullable ProfileEndData endAndCollect(
       final boolean isTimeout,
       final @Nullable List<PerformanceCollectionData> performanceCollectionData) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (!isRunning) {
+        logger.log(SentryLevel.WARNING, "Profiler not running");
+        return null;
+      }
 
-    if (!isRunning) {
-      logger.log(SentryLevel.WARNING, "Profiler not running");
-      return null;
+      // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return null;
+
+      try {
+        // If there is any problem with the file this method could throw, but the start is also
+        // wrapped, so this should never happen (except for tests, where this is the only method
+        // that
+        // throws)
+        Debug.stopMethodTracing();
+      } catch (Throwable e) {
+        logger.log(SentryLevel.ERROR, "Error while stopping profiling: ", e);
+      } finally {
+        isRunning = false;
+      }
+      frameMetricsCollector.stopCollection(frameMetricsCollectorId);
+
+      long transactionEndNanos = SystemClock.elapsedRealtimeNanos();
+      long transactionEndCpuMillis = Process.getElapsedCpuTime();
+
+      if (traceFile == null) {
+        logger.log(SentryLevel.ERROR, "Trace file does not exists");
+        return null;
+      }
+
+      if (!slowFrameRenderMeasurements.isEmpty()) {
+        measurementsMap.put(
+            ProfileMeasurement.ID_SLOW_FRAME_RENDERS,
+            new ProfileMeasurement(
+                ProfileMeasurement.UNIT_NANOSECONDS, slowFrameRenderMeasurements));
+      }
+      if (!frozenFrameRenderMeasurements.isEmpty()) {
+        measurementsMap.put(
+            ProfileMeasurement.ID_FROZEN_FRAME_RENDERS,
+            new ProfileMeasurement(
+                ProfileMeasurement.UNIT_NANOSECONDS, frozenFrameRenderMeasurements));
+      }
+      if (!screenFrameRateMeasurements.isEmpty()) {
+        measurementsMap.put(
+            ProfileMeasurement.ID_SCREEN_FRAME_RATES,
+            new ProfileMeasurement(ProfileMeasurement.UNIT_HZ, screenFrameRateMeasurements));
+      }
+      putPerformanceCollectionDataInMeasurements(performanceCollectionData);
+
+      if (scheduledFinish != null) {
+        scheduledFinish.cancel(true);
+        scheduledFinish = null;
+      }
+
+      return new ProfileEndData(
+          transactionEndNanos, transactionEndCpuMillis, isTimeout, traceFile, measurementsMap);
     }
-
-    // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP) return null;
-
-    try {
-      // If there is any problem with the file this method could throw, but the start is also
-      // wrapped, so this should never happen (except for tests, where this is the only method that
-      // throws)
-      Debug.stopMethodTracing();
-    } catch (Throwable e) {
-      logger.log(SentryLevel.ERROR, "Error while stopping profiling: ", e);
-    } finally {
-      isRunning = false;
-    }
-    frameMetricsCollector.stopCollection(frameMetricsCollectorId);
-
-    long transactionEndNanos = SystemClock.elapsedRealtimeNanos();
-    long transactionEndCpuMillis = Process.getElapsedCpuTime();
-
-    if (traceFile == null) {
-      logger.log(SentryLevel.ERROR, "Trace file does not exists");
-      return null;
-    }
-
-    if (!slowFrameRenderMeasurements.isEmpty()) {
-      measurementsMap.put(
-          ProfileMeasurement.ID_SLOW_FRAME_RENDERS,
-          new ProfileMeasurement(ProfileMeasurement.UNIT_NANOSECONDS, slowFrameRenderMeasurements));
-    }
-    if (!frozenFrameRenderMeasurements.isEmpty()) {
-      measurementsMap.put(
-          ProfileMeasurement.ID_FROZEN_FRAME_RENDERS,
-          new ProfileMeasurement(
-              ProfileMeasurement.UNIT_NANOSECONDS, frozenFrameRenderMeasurements));
-    }
-    if (!screenFrameRateMeasurements.isEmpty()) {
-      measurementsMap.put(
-          ProfileMeasurement.ID_SCREEN_FRAME_RATES,
-          new ProfileMeasurement(ProfileMeasurement.UNIT_HZ, screenFrameRateMeasurements));
-    }
-    putPerformanceCollectionDataInMeasurements(performanceCollectionData);
-
-    if (scheduledFinish != null) {
-      scheduledFinish.cancel(true);
-      scheduledFinish = null;
-    }
-
-    return new ProfileEndData(
-        transactionEndNanos, transactionEndCpuMillis, isTimeout, traceFile, measurementsMap);
   }
 
-  public synchronized void close() {
-    // we cancel any scheduled work
-    if (scheduledFinish != null) {
-      scheduledFinish.cancel(true);
-      scheduledFinish = null;
-    }
+  public void close() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // we cancel any scheduled work
+      if (scheduledFinish != null) {
+        scheduledFinish.cancel(true);
+        scheduledFinish = null;
+      }
 
-    // stop profiling if running
-    if (isRunning) {
-      endAndCollect(true, null);
+      // stop profiling if running
+      if (isRunning) {
+        endAndCollect(true, null);
+      }
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidTransactionProfiler.java
@@ -13,6 +13,7 @@ import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.IScopes;
 import io.sentry.ISentryExecutorService;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransaction;
 import io.sentry.ITransactionProfiler;
 import io.sentry.PerformanceCollectionData;
@@ -23,6 +24,7 @@ import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.android.core.internal.util.CpuInfoUtils;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.ArrayList;
 import java.util.Date;
@@ -47,6 +49,7 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   private long profileStartNanos;
   private long profileStartCpuMillis;
   private @NotNull Date profileStartTimestamp;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   /**
    * @deprecated please use a constructor that doesn't takes a {@link IScopes} instead, as it would
@@ -136,22 +139,24 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @Override
-  public synchronized void start() {
-    // Debug.startMethodTracingSampling() is only available since Lollipop, but Android Profiler
-    // causes crashes on api 21 -> https://github.com/getsentry/sentry-java/issues/3392
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return;
+  public void start() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // Debug.startMethodTracingSampling() is only available since Lollipop, but Android Profiler
+      // causes crashes on api 21 -> https://github.com/getsentry/sentry-java/issues/3392
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return;
 
-    // Let's initialize trace folder and profiling interval
-    init();
+      // Let's initialize trace folder and profiling interval
+      init();
 
-    transactionsCounter++;
-    // When the first transaction is starting, we can start profiling
-    if (transactionsCounter == 1 && onFirstStart()) {
-      logger.log(SentryLevel.DEBUG, "Profiler started.");
-    } else {
-      transactionsCounter--;
-      logger.log(
-          SentryLevel.WARNING, "A profile is already running. This profile will be ignored.");
+      transactionsCounter++;
+      // When the first transaction is starting, we can start profiling
+      if (transactionsCounter == 1 && onFirstStart()) {
+        logger.log(SentryLevel.DEBUG, "Profiler started.");
+      } else {
+        transactionsCounter--;
+        logger.log(
+            SentryLevel.WARNING, "A profile is already running. This profile will be ignored.");
+      }
     }
   }
 
@@ -174,133 +179,138 @@ final class AndroidTransactionProfiler implements ITransactionProfiler {
   }
 
   @Override
-  public synchronized void bindTransaction(final @NotNull ITransaction transaction) {
-    // If the profiler is running, but no profilingTransactionData is set, we bind it here
-    if (transactionsCounter > 0 && currentProfilingTransactionData == null) {
-      currentProfilingTransactionData =
-          new ProfilingTransactionData(transaction, profileStartNanos, profileStartCpuMillis);
+  public void bindTransaction(final @NotNull ITransaction transaction) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // If the profiler is running, but no profilingTransactionData is set, we bind it here
+      if (transactionsCounter > 0 && currentProfilingTransactionData == null) {
+        currentProfilingTransactionData =
+            new ProfilingTransactionData(transaction, profileStartNanos, profileStartCpuMillis);
+      }
     }
   }
 
   @Override
-  public @Nullable synchronized ProfilingTraceData onTransactionFinish(
+  public @Nullable ProfilingTraceData onTransactionFinish(
       final @NotNull ITransaction transaction,
       final @Nullable List<PerformanceCollectionData> performanceCollectionData,
       final @NotNull SentryOptions options) {
-
-    return onTransactionFinish(
-        transaction.getName(),
-        transaction.getEventId().toString(),
-        transaction.getSpanContext().getTraceId().toString(),
-        false,
-        performanceCollectionData,
-        options);
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      return onTransactionFinish(
+          transaction.getName(),
+          transaction.getEventId().toString(),
+          transaction.getSpanContext().getTraceId().toString(),
+          false,
+          performanceCollectionData,
+          options);
+    }
   }
 
   @SuppressLint("NewApi")
-  private @Nullable synchronized ProfilingTraceData onTransactionFinish(
+  private @Nullable ProfilingTraceData onTransactionFinish(
       final @NotNull String transactionName,
       final @NotNull String transactionId,
       final @NotNull String traceId,
       final boolean isTimeout,
       final @Nullable List<PerformanceCollectionData> performanceCollectionData,
       final @NotNull SentryOptions options) {
-    // check if profiler was created
-    if (profiler == null) {
-      return null;
-    }
-
-    // onTransactionStart() is only available since Lollipop_MR1
-    // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
-    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return null;
-
-    // Transaction finished, but it's not in the current profile
-    if (currentProfilingTransactionData == null
-        || !currentProfilingTransactionData.getId().equals(transactionId)) {
-      // A transaction is finishing, but it's not profiled. We can skip it
-      logger.log(
-          SentryLevel.INFO,
-          "Transaction %s (%s) finished, but was not currently being profiled. Skipping",
-          transactionName,
-          traceId);
-      return null;
-    }
-
-    if (transactionsCounter > 0) {
-      transactionsCounter--;
-    }
-
-    logger.log(SentryLevel.DEBUG, "Transaction %s (%s) finished.", transactionName, traceId);
-
-    if (transactionsCounter != 0) {
-      // We notify the data referring to this transaction that it finished
-      if (currentProfilingTransactionData != null) {
-        currentProfilingTransactionData.notifyFinish(
-            SystemClock.elapsedRealtimeNanos(),
-            profileStartNanos,
-            Process.getElapsedCpuTime(),
-            profileStartCpuMillis);
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      // check if profiler was created
+      if (profiler == null) {
+        return null;
       }
-      return null;
+
+      // onTransactionStart() is only available since Lollipop_MR1
+      // and SystemClock.elapsedRealtimeNanos() since Jelly Bean
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.LOLLIPOP_MR1) return null;
+
+      // Transaction finished, but it's not in the current profile
+      if (currentProfilingTransactionData == null
+          || !currentProfilingTransactionData.getId().equals(transactionId)) {
+        // A transaction is finishing, but it's not profiled. We can skip it
+        logger.log(
+            SentryLevel.INFO,
+            "Transaction %s (%s) finished, but was not currently being profiled. Skipping",
+            transactionName,
+            traceId);
+        return null;
+      }
+
+      if (transactionsCounter > 0) {
+        transactionsCounter--;
+      }
+
+      logger.log(SentryLevel.DEBUG, "Transaction %s (%s) finished.", transactionName, traceId);
+
+      if (transactionsCounter != 0) {
+        // We notify the data referring to this transaction that it finished
+        if (currentProfilingTransactionData != null) {
+          currentProfilingTransactionData.notifyFinish(
+              SystemClock.elapsedRealtimeNanos(),
+              profileStartNanos,
+              Process.getElapsedCpuTime(),
+              profileStartCpuMillis);
+        }
+        return null;
+      }
+
+      final AndroidProfiler.ProfileEndData endData =
+          profiler.endAndCollect(false, performanceCollectionData);
+      // check if profiler end successfully
+      if (endData == null) {
+        return null;
+      }
+
+      long transactionDurationNanos = endData.endNanos - profileStartNanos;
+
+      List<ProfilingTransactionData> transactionList = new ArrayList<>(1);
+      final ProfilingTransactionData txData = currentProfilingTransactionData;
+      if (txData != null) {
+        transactionList.add(txData);
+      }
+      currentProfilingTransactionData = null;
+      // We clear the counter in case of a timeout
+      transactionsCounter = 0;
+
+      String totalMem = "0";
+      ActivityManager.MemoryInfo memInfo = getMemInfo();
+      if (memInfo != null) {
+        totalMem = Long.toString(memInfo.totalMem);
+      }
+      String[] abis = Build.SUPPORTED_ABIS;
+
+      // We notify all transactions data that all transactions finished.
+      // Some may not have been really finished, in case of a timeout
+      for (ProfilingTransactionData t : transactionList) {
+        t.notifyFinish(
+            endData.endNanos, profileStartNanos, endData.endCpuMillis, profileStartCpuMillis);
+      }
+
+      // cpu max frequencies are read with a lambda because reading files is involved, so it will be
+      // done in the background when the trace file is read
+      return new ProfilingTraceData(
+          endData.traceFile,
+          profileStartTimestamp,
+          transactionList,
+          transactionName,
+          transactionId,
+          traceId,
+          Long.toString(transactionDurationNanos),
+          buildInfoProvider.getSdkInfoVersion(),
+          abis != null && abis.length > 0 ? abis[0] : "",
+          () -> CpuInfoUtils.getInstance().readMaxFrequencies(),
+          buildInfoProvider.getManufacturer(),
+          buildInfoProvider.getModel(),
+          buildInfoProvider.getVersionRelease(),
+          buildInfoProvider.isEmulator(),
+          totalMem,
+          options.getProguardUuid(),
+          options.getRelease(),
+          options.getEnvironment(),
+          (endData.didTimeout || isTimeout)
+              ? ProfilingTraceData.TRUNCATION_REASON_TIMEOUT
+              : ProfilingTraceData.TRUNCATION_REASON_NORMAL,
+          endData.measurementsMap);
     }
-
-    final AndroidProfiler.ProfileEndData endData =
-        profiler.endAndCollect(false, performanceCollectionData);
-    // check if profiler end successfully
-    if (endData == null) {
-      return null;
-    }
-
-    long transactionDurationNanos = endData.endNanos - profileStartNanos;
-
-    List<ProfilingTransactionData> transactionList = new ArrayList<>(1);
-    final ProfilingTransactionData txData = currentProfilingTransactionData;
-    if (txData != null) {
-      transactionList.add(txData);
-    }
-    currentProfilingTransactionData = null;
-    // We clear the counter in case of a timeout
-    transactionsCounter = 0;
-
-    String totalMem = "0";
-    ActivityManager.MemoryInfo memInfo = getMemInfo();
-    if (memInfo != null) {
-      totalMem = Long.toString(memInfo.totalMem);
-    }
-    String[] abis = Build.SUPPORTED_ABIS;
-
-    // We notify all transactions data that all transactions finished.
-    // Some may not have been really finished, in case of a timeout
-    for (ProfilingTransactionData t : transactionList) {
-      t.notifyFinish(
-          endData.endNanos, profileStartNanos, endData.endCpuMillis, profileStartCpuMillis);
-    }
-
-    // cpu max frequencies are read with a lambda because reading files is involved, so it will be
-    // done in the background when the trace file is read
-    return new ProfilingTraceData(
-        endData.traceFile,
-        profileStartTimestamp,
-        transactionList,
-        transactionName,
-        transactionId,
-        traceId,
-        Long.toString(transactionDurationNanos),
-        buildInfoProvider.getSdkInfoVersion(),
-        abis != null && abis.length > 0 ? abis[0] : "",
-        () -> CpuInfoUtils.getInstance().readMaxFrequencies(),
-        buildInfoProvider.getManufacturer(),
-        buildInfoProvider.getModel(),
-        buildInfoProvider.getVersionRelease(),
-        buildInfoProvider.isEmulator(),
-        totalMem,
-        options.getProguardUuid(),
-        options.getRelease(),
-        options.getEnvironment(),
-        (endData.didTimeout || isTimeout)
-            ? ProfilingTraceData.TRUNCATION_REASON_TIMEOUT
-            : ProfilingTraceData.TRUNCATION_REASON_NORMAL,
-        endData.measurementsMap);
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import io.sentry.Hint;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
@@ -14,6 +15,7 @@ import io.sentry.exception.ExceptionMechanismException;
 import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.TransactionEnd;
 import io.sentry.protocol.Mechanism;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.Closeable;
@@ -30,7 +32,7 @@ public final class AnrIntegration implements Integration, Closeable {
 
   private final @NotNull Context context;
   private boolean isClosed = false;
-  private final @NotNull Object startLock = new Object();
+  private final @NotNull AutoClosableReentrantLock startLock = new AutoClosableReentrantLock();
 
   public AnrIntegration(final @NotNull Context context) {
     this.context = context;
@@ -45,7 +47,8 @@ public final class AnrIntegration implements Integration, Closeable {
 
   private @Nullable SentryOptions options;
 
-  private static final @NotNull Object watchDogLock = new Object();
+  protected static final @NotNull AutoClosableReentrantLock watchDogLock =
+      new AutoClosableReentrantLock();
 
   @Override
   public final void register(final @NotNull IScopes scopes, final @NotNull SentryOptions options) {
@@ -66,7 +69,7 @@ public final class AnrIntegration implements Integration, Closeable {
             .getExecutorService()
             .submit(
                 () -> {
-                  synchronized (startLock) {
+                  try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
                     if (!isClosed) {
                       startAnrWatchdog(scopes, options);
                     }
@@ -82,7 +85,7 @@ public final class AnrIntegration implements Integration, Closeable {
 
   private void startAnrWatchdog(
       final @NotNull IScopes scopes, final @NotNull SentryAndroidOptions options) {
-    synchronized (watchDogLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = watchDogLock.acquire()) {
       if (anrWatchDog == null) {
         options
             .getLogger()
@@ -151,10 +154,10 @@ public final class AnrIntegration implements Integration, Closeable {
 
   @Override
   public void close() throws IOException {
-    synchronized (startLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
       isClosed = true;
     }
-    synchronized (watchDogLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = watchDogLock.acquire()) {
       if (anrWatchDog != null) {
         anrWatchDog.interrupt();
         anrWatchDog = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppState.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppState.java
@@ -1,5 +1,7 @@
 package io.sentry.android.core;
 
+import io.sentry.ISentryLifecycleToken;
+import io.sentry.util.AutoClosableReentrantLock;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -9,6 +11,7 @@ import org.jetbrains.annotations.TestOnly;
 @ApiStatus.Internal
 public final class AppState {
   private static @NotNull AppState instance = new AppState();
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   private AppState() {}
 
@@ -27,7 +30,9 @@ public final class AppState {
     return inBackground;
   }
 
-  synchronized void setInBackground(final boolean inBackground) {
-    this.inBackground = inBackground;
+  void setInBackground(final boolean inBackground) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      this.inBackground = inBackground;
+    }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/Installation.java
@@ -1,6 +1,8 @@
 package io.sentry.android.core;
 
 import android.content.Context;
+import io.sentry.ISentryLifecycleToken;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -19,6 +21,9 @@ final class Installation {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
+  protected static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
+
   private Installation() {}
 
   /**
@@ -29,20 +34,22 @@ final class Installation {
    * @return the generated installationId
    * @throws RuntimeException if not possible to read nor to write to the file.
    */
-  public static synchronized String id(final @NotNull Context context) throws RuntimeException {
-    if (deviceId == null) {
-      final File installation = new File(context.getFilesDir(), INSTALLATION);
-      try {
-        if (!installation.exists()) {
-          deviceId = writeInstallationFile(installation);
-          return deviceId;
+  public static String id(final @NotNull Context context) throws RuntimeException {
+    try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
+      if (deviceId == null) {
+        final File installation = new File(context.getFilesDir(), INSTALLATION);
+        try {
+          if (!installation.exists()) {
+            deviceId = writeInstallationFile(installation);
+            return deviceId;
+          }
+          deviceId = readInstallationFile(installation);
+        } catch (Throwable e) {
+          throw new RuntimeException(e);
         }
-        deviceId = readInstallationFile(installation);
-      } catch (Throwable e) {
-        throw new RuntimeException(e);
       }
+      return deviceId;
     }
-    return deviceId;
   }
 
   @TestOnly

--- a/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/LifecycleWatcher.java
@@ -4,11 +4,13 @@ import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import io.sentry.Breadcrumb;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryLevel;
 import io.sentry.Session;
 import io.sentry.android.core.internal.util.BreadcrumbFactory;
 import io.sentry.transport.CurrentDateProvider;
 import io.sentry.transport.ICurrentDateProvider;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,7 +28,7 @@ final class LifecycleWatcher implements DefaultLifecycleObserver {
 
   private @Nullable TimerTask timerTask;
   private final @NotNull Timer timer = new Timer(true);
-  private final @NotNull Object timerLock = new Object();
+  private final @NotNull AutoClosableReentrantLock timerLock = new AutoClosableReentrantLock();
   private final @NotNull IScopes scopes;
   private final boolean enableSessionTracking;
   private final boolean enableAppLifecycleBreadcrumbs;
@@ -117,7 +119,7 @@ final class LifecycleWatcher implements DefaultLifecycleObserver {
   }
 
   private void scheduleEndSession() {
-    synchronized (timerLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
       cancelTask();
       if (timer != null) {
         timerTask =
@@ -138,7 +140,7 @@ final class LifecycleWatcher implements DefaultLifecycleObserver {
   }
 
   private void cancelTask() {
-    synchronized (timerLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
       if (timerTask != null) {
         timerTask.cancel();
         timerTask = null;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PerformanceAndroidEventProcessor.java
@@ -7,6 +7,7 @@ import static io.sentry.android.core.ActivityLifecycleIntegration.UI_LOAD_OP;
 import android.os.Looper;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.MeasurementUnit;
 import io.sentry.SentryEvent;
 import io.sentry.SpanContext;
@@ -21,6 +22,7 @@ import io.sentry.protocol.MeasurementValue;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentrySpan;
 import io.sentry.protocol.SentryTransaction;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +46,7 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
 
   private final @NotNull ActivityFramesTracker activityFramesTracker;
   private final @NotNull SentryAndroidOptions options;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   PerformanceAndroidEventProcessor(
       final @NotNull SentryAndroidOptions options,
@@ -71,70 +74,71 @@ final class PerformanceAndroidEventProcessor implements EventProcessor {
 
   @SuppressWarnings("NullAway")
   @Override
-  public synchronized @NotNull SentryTransaction process(
+  public @NotNull SentryTransaction process(
       @NotNull SentryTransaction transaction, @NotNull Hint hint) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      if (!options.isTracingEnabled()) {
+        return transaction;
+      }
 
-    if (!options.isTracingEnabled()) {
-      return transaction;
-    }
+      // the app start measurement is only sent once and only if the transaction has
+      // the app.start span, which is automatically created by the SDK.
+      if (hasAppStartSpan(transaction)) {
+        if (!sentStartMeasurement) {
+          final @NotNull TimeSpan appStartTimeSpan =
+              AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options);
+          final long appStartUpDurationMs = appStartTimeSpan.getDurationMs();
 
-    // the app start measurement is only sent once and only if the transaction has
-    // the app.start span, which is automatically created by the SDK.
-    if (hasAppStartSpan(transaction)) {
-      if (!sentStartMeasurement) {
-        final @NotNull TimeSpan appStartTimeSpan =
-            AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options);
-        final long appStartUpDurationMs = appStartTimeSpan.getDurationMs();
+          // if appStartUpDurationMs is 0, metrics are not ready to be sent
+          if (appStartUpDurationMs != 0) {
+            final MeasurementValue value =
+                new MeasurementValue(
+                    (float) appStartUpDurationMs, MeasurementUnit.Duration.MILLISECOND.apiName());
 
-        // if appStartUpDurationMs is 0, metrics are not ready to be sent
-        if (appStartUpDurationMs != 0) {
-          final MeasurementValue value =
-              new MeasurementValue(
-                  (float) appStartUpDurationMs, MeasurementUnit.Duration.MILLISECOND.apiName());
+            final String appStartKey =
+                AppStartMetrics.getInstance().getAppStartType() == AppStartMetrics.AppStartType.COLD
+                    ? MeasurementValue.KEY_APP_START_COLD
+                    : MeasurementValue.KEY_APP_START_WARM;
 
-          final String appStartKey =
-              AppStartMetrics.getInstance().getAppStartType() == AppStartMetrics.AppStartType.COLD
-                  ? MeasurementValue.KEY_APP_START_COLD
-                  : MeasurementValue.KEY_APP_START_WARM;
+            transaction.getMeasurements().put(appStartKey, value);
 
-          transaction.getMeasurements().put(appStartKey, value);
+            attachColdAppStartSpans(AppStartMetrics.getInstance(), transaction);
+            sentStartMeasurement = true;
+          }
+        }
 
-          attachColdAppStartSpans(AppStartMetrics.getInstance(), transaction);
-          sentStartMeasurement = true;
+        @Nullable App appContext = transaction.getContexts().getApp();
+        if (appContext == null) {
+          appContext = new App();
+          transaction.getContexts().setApp(appContext);
+        }
+        final String appStartType =
+            AppStartMetrics.getInstance().getAppStartType() == AppStartMetrics.AppStartType.COLD
+                ? "cold"
+                : "warm";
+        appContext.setStartType(appStartType);
+      }
+
+      setContributingFlags(transaction);
+
+      final SentryId eventId = transaction.getEventId();
+      final SpanContext spanContext = transaction.getContexts().getTrace();
+
+      // only add slow/frozen frames to transactions created by ActivityLifecycleIntegration
+      // which have the operation UI_LOAD_OP. If a user-defined (or hybrid SDK) transaction
+      // users it, we'll also add the metrics if available
+      if (eventId != null
+          && spanContext != null
+          && spanContext.getOperation().contentEquals(UI_LOAD_OP)) {
+        final Map<String, @NotNull MeasurementValue> framesMetrics =
+            activityFramesTracker.takeMetrics(eventId);
+        if (framesMetrics != null) {
+          transaction.getMeasurements().putAll(framesMetrics);
         }
       }
 
-      @Nullable App appContext = transaction.getContexts().getApp();
-      if (appContext == null) {
-        appContext = new App();
-        transaction.getContexts().setApp(appContext);
-      }
-      final String appStartType =
-          AppStartMetrics.getInstance().getAppStartType() == AppStartMetrics.AppStartType.COLD
-              ? "cold"
-              : "warm";
-      appContext.setStartType(appStartType);
+      return transaction;
     }
-
-    setContributingFlags(transaction);
-
-    final SentryId eventId = transaction.getEventId();
-    final SpanContext spanContext = transaction.getContexts().getTrace();
-
-    // only add slow/frozen frames to transactions created by ActivityLifecycleIntegration
-    // which have the operation UI_LOAD_OP. If a user-defined (or hybrid SDK) transaction
-    // users it, we'll also add the metrics if available
-    if (eventId != null
-        && spanContext != null
-        && spanContext.getOperation().contentEquals(UI_LOAD_OP)) {
-      final Map<String, @NotNull MeasurementValue> framesMetrics =
-          activityFramesTracker.takeMetrics(eventId);
-      if (framesMetrics != null) {
-        transaction.getMeasurements().putAll(framesMetrics);
-      }
-    }
-
-    return transaction;
   }
 
   private void setContributingFlags(SentryTransaction transaction) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -3,11 +3,13 @@ package io.sentry.android.core;
 import io.sentry.DataCategory;
 import io.sentry.IConnectionStatusProvider;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SendCachedEnvelopeFireAndForgetIntegration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.transport.RateLimiter;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.LazyEvaluator;
 import io.sentry.util.Objects;
 import java.io.Closeable;
@@ -33,6 +35,7 @@ final class SendCachedEnvelopeIntegration
   private @Nullable SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForget sender;
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public SendCachedEnvelopeIntegration(
       final @NotNull SendCachedEnvelopeFireAndForgetIntegration.SendFireAndForgetFactory factory,
@@ -75,9 +78,9 @@ final class SendCachedEnvelopeIntegration
   }
 
   @SuppressWarnings({"NullAway"})
-  private synchronized void sendCachedEnvelopes(
+  private void sendCachedEnvelopes(
       final @NotNull IScopes scopes, final @NotNull SentryAndroidOptions options) {
-    try {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       final Future<?> future =
           options
               .getExecutorService()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -7,6 +7,7 @@ import android.os.Process;
 import android.os.SystemClock;
 import io.sentry.ILogger;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.OptionsContainer;
 import io.sentry.Sentry;
@@ -18,6 +19,7 @@ import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
 import io.sentry.android.timber.SentryTimberIntegration;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +45,9 @@ public final class SentryAndroid {
   private static final String TIMBER_CLASS_NAME = "timber.log.Timber";
   private static final String FRAGMENT_CLASS_NAME =
       "androidx.fragment.app.FragmentManager$FragmentLifecycleCallbacks";
+
+  protected static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
 
   private SentryAndroid() {}
 
@@ -85,12 +90,11 @@ public final class SentryAndroid {
    * @param configuration Sentry.OptionsConfiguration configuration handler
    */
   @SuppressLint("NewApi")
-  public static synchronized void init(
+  public static void init(
       @NotNull final Context context,
       @NotNull ILogger logger,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
-
-    try {
+    try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
       Sentry.init(
           OptionsContainer.create(SentryAndroidOptions.class),
           options -> {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -14,6 +14,7 @@ import android.os.Process;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import io.sentry.ILogger;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransactionProfiler;
 import io.sentry.JsonSerializer;
 import io.sentry.NoOpLogger;
@@ -28,6 +29,7 @@ import io.sentry.android.core.performance.ActivityLifecycleCallbacksAdapter;
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,6 +55,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
 
   private final @NotNull ILogger logger;
   private final @NotNull BuildInfoProvider buildInfoProvider;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   @TestOnly
   SentryPerformanceProvider(
@@ -92,7 +95,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
 
   @Override
   public void shutdown() {
-    synchronized (AppStartMetrics.getInstance()) {
+    try (final @NotNull ISentryLifecycleToken ignored = AppStartMetrics.staticLock.acquire()) {
       final @Nullable ITransactionProfiler appStartProfiler =
           AppStartMetrics.getInstance().getAppStartProfiler();
       if (appStartProfiler != null) {
@@ -302,14 +305,16 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
   }
 
   @TestOnly
-  synchronized void onAppStartDone() {
-    final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
-    appStartMetrics.getSdkInitTimeSpan().stop();
-    appStartMetrics.getAppStartTimeSpan().stop();
+  void onAppStartDone() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
+      appStartMetrics.getSdkInitTimeSpan().stop();
+      appStartMetrics.getAppStartTimeSpan().stop();
 
-    if (app != null) {
-      if (activityCallback != null) {
-        app.unregisterActivityLifecycleCallbacks(activityCallback);
+      if (app != null) {
+        if (activityCallback != null) {
+          app.unregisterActivityLifecycleCallbacks(activityCallback);
+        }
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -12,9 +12,11 @@ import android.hardware.SensorManager;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.IOException;
@@ -31,7 +33,7 @@ public final class TempSensorBreadcrumbsIntegration
 
   @TestOnly @Nullable SensorManager sensorManager;
   private boolean isClosed = false;
-  private final @NotNull Object startLock = new Object();
+  private final @NotNull AutoClosableReentrantLock startLock = new AutoClosableReentrantLock();
 
   public TempSensorBreadcrumbsIntegration(final @NotNull Context context) {
     this.context = Objects.requireNonNull(context, "Context is required");
@@ -59,7 +61,7 @@ public final class TempSensorBreadcrumbsIntegration
             .getExecutorService()
             .submit(
                 () -> {
-                  synchronized (startLock) {
+                  try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
                     if (!isClosed) {
                       startSensorListener(options);
                     }
@@ -100,7 +102,7 @@ public final class TempSensorBreadcrumbsIntegration
 
   @Override
   public void close() throws IOException {
-    synchronized (startLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
       isClosed = true;
     }
     if (sensorManager != null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -10,12 +10,14 @@ import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransactionProfiler;
 import io.sentry.SentryDate;
 import io.sentry.SentryNanotimeDate;
 import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.ContextUtils;
 import io.sentry.android.core.SentryAndroidOptions;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +45,8 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   private static long CLASS_LOADED_UPTIME_MS = SystemClock.uptimeMillis();
 
   private static volatile @Nullable AppStartMetrics instance;
+  public static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
 
   private @NotNull AppStartType appStartType = AppStartType.UNKNOWN;
   private boolean appLaunchedInForeground = false;
@@ -59,9 +63,8 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   private boolean isCallbackRegistered = false;
 
   public static @NotNull AppStartMetrics getInstance() {
-
     if (instance == null) {
-      synchronized (AppStartMetrics.class) {
+      try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
         if (instance == null) {
           instance = new AppStartMetrics();
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -15,6 +15,7 @@ import io.sentry.android.replay.video.MuxerConfig
 import io.sentry.android.replay.video.SimpleVideoEncoder
 import io.sentry.protocol.SentryId
 import io.sentry.rrweb.RRWebEvent
+import io.sentry.util.AutoClosableReentrantLock
 import io.sentry.util.FileUtils
 import java.io.Closeable
 import java.io.File
@@ -43,7 +44,8 @@ public class ReplayCache(
 ) : Closeable {
 
     private val isClosed = AtomicBoolean(false)
-    private val encoderLock = Any()
+    private val encoderLock = AutoClosableReentrantLock()
+    private val lock = AutoClosableReentrantLock()
     private var encoder: SimpleVideoEncoder? = null
 
     internal val replayCacheDir: File? by lazy {
@@ -147,7 +149,7 @@ public class ReplayCache(
         }
 
         // TODO: reuse instance of encoder and just change file path to create a different muxer
-        encoder = synchronized(encoderLock) {
+        encoder = encoderLock.acquire().use {
             SimpleVideoEncoder(
                 options,
                 MuxerConfig(
@@ -195,7 +197,7 @@ public class ReplayCache(
         }
 
         var videoDuration: Long
-        synchronized(encoderLock) {
+        encoderLock.acquire().use {
             encoder?.release()
             videoDuration = encoder?.duration ?: 0
             encoder = null
@@ -209,7 +211,7 @@ public class ReplayCache(
     private fun encode(frame: ReplayFrame): Boolean {
         return try {
             val bitmap = BitmapFactory.decodeFile(frame.screenshot.absolutePath)
-            synchronized(encoderLock) {
+            encoderLock.acquire().use {
                 encoder?.encode(bitmap)
             }
             bitmap.recycle()
@@ -251,7 +253,7 @@ public class ReplayCache(
     }
 
     override fun close() {
-        synchronized(encoderLock) {
+        encoderLock.acquire().use {
             encoder?.release()
             encoder = null
         }
@@ -259,25 +261,26 @@ public class ReplayCache(
     }
 
     // TODO: it's awful, choose a better serialization format
-    @Synchronized
     fun persistSegmentValues(key: String, value: String?) {
-        if (isClosed.get()) {
-            return
-        }
-        if (ongoingSegment.isEmpty()) {
-            ongoingSegmentFile?.useLines { lines ->
-                lines.associateTo(ongoingSegment) {
-                    val (k, v) = it.split("=", limit = 2)
-                    k to v
+        lock.acquire().use {
+            if (isClosed.get()) {
+                return
+            }
+            if (ongoingSegment.isEmpty()) {
+                ongoingSegmentFile?.useLines { lines ->
+                    lines.associateTo(ongoingSegment) {
+                        val (k, v) = it.split("=", limit = 2)
+                        k to v
+                    }
                 }
             }
+            if (value == null) {
+                ongoingSegment.remove(key)
+            } else {
+                ongoingSegment[key] = value
+            }
+            ongoingSegmentFile?.writeText(ongoingSegment.entries.joinToString("\n") { (k, v) -> "$k=$v" })
         }
-        if (value == null) {
-            ongoingSegment.remove(key)
-        } else {
-            ongoingSegment[key] = value
-        }
-        ongoingSegmentFile?.writeText(ongoingSegment.entries.joinToString("\n") { (k, v) -> "$k=$v" })
     }
 
     companion object {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -161,7 +161,7 @@ internal abstract class BaseCaptureStrategy(
     override fun onTouchEvent(event: MotionEvent) {
         val rrwebEvents = gestureConverter.convert(event, recorderConfig)
         if (rrwebEvents != null) {
-            synchronized(currentEventsLock) {
+            currentEventsLock.acquire().use {
                 currentEvents += rrwebEvents
             }
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -17,6 +17,7 @@ import io.sentry.rrweb.RRWebBreadcrumbEvent
 import io.sentry.rrweb.RRWebEvent
 import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
+import io.sentry.util.AutoClosableReentrantLock
 import java.io.File
 import java.util.Date
 import java.util.LinkedList
@@ -56,7 +57,7 @@ internal interface CaptureStrategy {
     fun close()
 
     companion object {
-        internal val currentEventsLock = Any()
+        internal val currentEventsLock = AutoClosableReentrantLock()
 
         fun createSegment(
             scopes: IScopes?,
@@ -207,7 +208,7 @@ internal interface CaptureStrategy {
             until: Long,
             callback: ((RRWebEvent) -> Unit)? = null
         ) {
-            synchronized(currentEventsLock) {
+            currentEventsLock.acquire().use {
                 var event = events.peek()
                 while (event != null && event.timestamp < until) {
                     callback?.invoke(event)

--- a/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
+++ b/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
@@ -8,11 +8,13 @@ import androidx.compose.ui.semantics.SemanticsConfiguration;
 import androidx.compose.ui.semantics.SemanticsModifier;
 import androidx.compose.ui.semantics.SemanticsPropertyKey;
 import io.sentry.ILogger;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.compose.SentryComposeHelper;
 import io.sentry.compose.helper.BuildConfig;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.gestures.UiElement;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +29,7 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
 
   private final @NotNull ILogger logger;
   private volatile @Nullable SentryComposeHelper composeHelper;
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public ComposeGestureTargetLocator(final @NotNull ILogger logger) {
     this.logger = logger;
@@ -41,7 +44,7 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
 
     // lazy init composeHelper as it's using some reflection under the hood
     if (composeHelper == null) {
-      synchronized (this) {
+      try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
         if (composeHelper == null) {
           composeHelper = new SentryComposeHelper(logger);
         }

--- a/sentry-jdbc/api/sentry-jdbc.api
+++ b/sentry-jdbc/api/sentry-jdbc.api
@@ -15,6 +15,7 @@ public final class io/sentry/jdbc/DatabaseUtils$DatabaseDetails {
 }
 
 public class io/sentry/jdbc/SentryJdbcEventListener : com/p6spy/engine/event/SimpleJdbcEventListener {
+	protected final field databaseDetailsLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun onAfterAnyExecute (Lcom/p6spy/engine/common/StatementInformation;JLjava/sql/SQLException;)V

--- a/sentry-opentelemetry/sentry-opentelemetry-extra/src/main/java/io/sentry/opentelemetry/SentryWeakSpanStorage.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-extra/src/main/java/io/sentry/opentelemetry/SentryWeakSpanStorage.java
@@ -2,6 +2,8 @@ package io.sentry.opentelemetry;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.internal.shaded.WeakConcurrentMap;
+import io.sentry.ISentryLifecycleToken;
+import io.sentry.util.AutoClosableReentrantLock;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,10 +15,12 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SentryWeakSpanStorage {
   private static volatile @Nullable SentryWeakSpanStorage INSTANCE;
+  private static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
 
   public static @NotNull SentryWeakSpanStorage getInstance() {
     if (INSTANCE == null) {
-      synchronized (SentryWeakSpanStorage.class) {
+      try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
         if (INSTANCE == null) {
           INSTANCE = new SentryWeakSpanStorage();
         }

--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -49,6 +49,7 @@ public class io/sentry/spring/jakarta/SentryRequestHttpServletRequestProcessor :
 }
 
 public class io/sentry/spring/jakarta/SentryRequestResolver {
+	protected static final field staticLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Ljakarta/servlet/http/HttpServletRequest;)Lio/sentry/protocol/Request;
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentryRequestResolver.java
@@ -2,8 +2,10 @@ package io.sentry.spring.jakarta;
 
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.IScopes;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryLevel;
 import io.sentry.protocol.Request;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HttpUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.UrlUtils;
@@ -20,6 +22,8 @@ import org.jetbrains.annotations.Nullable;
 
 @Open
 public class SentryRequestResolver {
+  protected static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
   private final @NotNull IScopes scopes;
   private volatile @Nullable List<String> extraSecurityCookies;
 
@@ -71,7 +75,7 @@ public class SentryRequestResolver {
   private List<String> extractSecurityCookieNamesOrUseCached(
       final @NotNull HttpServletRequest httpRequest) {
     if (extraSecurityCookies == null) {
-      synchronized (SentryRequestResolver.class) {
+      try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
         if (extraSecurityCookies == null) {
           extraSecurityCookies = extractSecurityCookieNames(httpRequest);
         }

--- a/sentry-spring/api/sentry-spring.api
+++ b/sentry-spring/api/sentry-spring.api
@@ -49,6 +49,7 @@ public class io/sentry/spring/SentryRequestHttpServletRequestProcessor : io/sent
 }
 
 public class io/sentry/spring/SentryRequestResolver {
+	protected static final field staticLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun resolveSentryRequest (Ljavax/servlet/http/HttpServletRequest;)Lio/sentry/protocol/Request;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2822,6 +2822,7 @@ public final class io/sentry/SentryNanotimeDateProvider : io/sentry/SentryDatePr
 
 public class io/sentry/SentryOptions {
 	public static final field DEFAULT_PROPAGATION_TARGETS Ljava/lang/String;
+	protected final field lock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun addBundleId (Ljava/lang/String;)V
 	public fun addContextTag (Ljava/lang/String;)V
@@ -3831,6 +3832,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	public static final field STARTUP_CRASH_MARKER_FILE Ljava/lang/String;
 	public static final field SUFFIX_ENVELOPE_FILE Ljava/lang/String;
 	protected static final field UTF_8 Ljava/nio/charset/Charset;
+	protected final field cacheLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/SentryOptions;Ljava/lang/String;I)V
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/cache/IEnvelopeCache;
 	public fun discard (Lio/sentry/SentryEnvelope;)V
@@ -4513,6 +4515,7 @@ public final class io/sentry/protocol/Browser$JsonKeys {
 
 public class io/sentry/protocol/Contexts : io/sentry/JsonSerializable {
 	public static final field REPLAY_ID Ljava/lang/String;
+	protected final field responseLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/protocol/Contexts;)V
 	public fun containsKey (Ljava/lang/Object;)Z
@@ -6130,6 +6133,11 @@ public abstract class io/sentry/transport/TransportResult {
 	public abstract fun getResponseCode ()I
 	public abstract fun isSuccess ()Z
 	public static fun success ()Lio/sentry/transport/TransportResult;
+}
+
+public final class io/sentry/util/AutoClosableReentrantLock : java/util/concurrent/locks/ReentrantLock {
+	public fun <init> ()V
+	public fun acquire ()Lio/sentry/ISentryLifecycleToken;
 }
 
 public final class io/sentry/util/CheckInUtils {

--- a/sentry/src/main/java/io/sentry/Hint.java
+++ b/sentry/src/main/java/io/sentry/Hint.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -27,6 +28,7 @@ public final class Hint {
 
   private final @NotNull Map<String, Object> internalStorage = new HashMap<String, Object>();
   private final @NotNull List<Attachment> attachments = new ArrayList<>();
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
   private @Nullable Attachment screenshot = null;
   private @Nullable Attachment viewHierarchy = null;
   private @Nullable Attachment threadDump = null;
@@ -44,30 +46,37 @@ public final class Hint {
     return hint;
   }
 
-  public synchronized void set(@NotNull String name, @Nullable Object hint) {
-    internalStorage.put(name, hint);
-  }
-
-  public synchronized @Nullable Object get(@NotNull String name) {
-    return internalStorage.get(name);
-  }
-
-  @SuppressWarnings("unchecked")
-  public synchronized <T extends Object> @Nullable T getAs(
-      @NotNull String name, @NotNull Class<T> clazz) {
-    Object hintValue = internalStorage.get(name);
-
-    if (clazz.isInstance(hintValue)) {
-      return (T) hintValue;
-    } else if (isCastablePrimitive(hintValue, clazz)) {
-      return (T) hintValue;
-    } else {
-      return null;
+  public void set(@NotNull String name, @Nullable Object hint) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      internalStorage.put(name, hint);
     }
   }
 
-  public synchronized void remove(@NotNull String name) {
-    internalStorage.remove(name);
+  public @Nullable Object get(@NotNull String name) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      return internalStorage.get(name);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends Object> @Nullable T getAs(@NotNull String name, @NotNull Class<T> clazz) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      Object hintValue = internalStorage.get(name);
+
+      if (clazz.isInstance(hintValue)) {
+        return (T) hintValue;
+      } else if (isCastablePrimitive(hintValue, clazz)) {
+        return (T) hintValue;
+      } else {
+        return null;
+      }
+    }
+  }
+
+  public void remove(@NotNull String name) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      internalStorage.remove(name);
+    }
   }
 
   public void addAttachment(@Nullable Attachment attachment) {
@@ -101,13 +110,15 @@ public final class Hint {
    * referenced.
    */
   @ApiStatus.Internal
-  public synchronized void clear() {
-    final Iterator<Map.Entry<String, Object>> iterator = internalStorage.entrySet().iterator();
+  public void clear() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      final Iterator<Map.Entry<String, Object>> iterator = internalStorage.entrySet().iterator();
 
-    while (iterator.hasNext()) {
-      final Map.Entry<String, Object> entry = iterator.next();
-      if (entry.getKey() == null || !entry.getKey().startsWith("sentry:")) {
-        iterator.remove();
+      while (iterator.hasNext()) {
+        final Map.Entry<String, Object> entry = iterator.next();
+        if (entry.getKey() == null || !entry.getKey().startsWith("sentry:")) {
+          iterator.remove();
+        }
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -7,6 +7,7 @@ import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.SentryException;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.Closeable;
@@ -27,6 +28,8 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
   private final @NotNull SentryThreadFactory sentryThreadFactory;
   private final @NotNull SentryExceptionFactory sentryExceptionFactory;
   private volatile @Nullable HostnameCache hostnameCache = null;
+  private final @NotNull AutoClosableReentrantLock hostnameCacheLock =
+      new AutoClosableReentrantLock();
 
   public MainEventProcessor(final @NotNull SentryOptions options) {
     this.options = Objects.requireNonNull(options, "The SentryOptions is required.");
@@ -201,7 +204,7 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
 
   private void ensureHostnameCache() {
     if (hostnameCache == null) {
-      synchronized (this) {
+      try (final @NotNull ISentryLifecycleToken ignored = hostnameCacheLock.acquire()) {
         if (hostnameCache == null) {
           hostnameCache = HostnameCache.getInstance();
         }

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -3,6 +3,7 @@ package io.sentry;
 import static io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion;
 
 import io.sentry.transport.RateLimiter;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.io.Closeable;
 import java.io.File;
@@ -23,6 +24,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
   private @Nullable SendFireAndForget sender;
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   public interface SendFireAndForget {
     void send();
@@ -101,9 +103,9 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
   }
 
   @SuppressWarnings({"FutureReturnValueIgnored", "NullAway"})
-  private synchronized void sendCachedEnvelopes(
+  private void sendCachedEnvelopes(
       final @NotNull IScopes scopes, final @NotNull SentryOptions options) {
-    try {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       options
           .getExecutorService()
           .submit(

--- a/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
+++ b/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import io.sentry.protocol.SentryPackage;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -12,10 +13,12 @@ import org.jetbrains.annotations.TestOnly;
 @ApiStatus.Internal
 public final class SentryIntegrationPackageStorage {
   private static volatile @Nullable SentryIntegrationPackageStorage INSTANCE;
+  private static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
 
   public static @NotNull SentryIntegrationPackageStorage getInstance() {
     if (INSTANCE == null) {
-      synchronized (SentryIntegrationPackageStorage.class) {
+      try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
         if (INSTANCE == null) {
           INSTANCE = new SentryIntegrationPackageStorage();
         }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -19,6 +19,7 @@ import io.sentry.transport.ITransport;
 import io.sentry.transport.ITransportGate;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.transport.NoOpTransportGate;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Platform;
 import io.sentry.util.SampleRateUtils;
 import io.sentry.util.StringUtils;
@@ -503,6 +504,8 @@ public class SentryOptions {
 
   private boolean forceInit = false;
 
+  protected final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
+
   /**
    * Adds an event processor
    *
@@ -981,7 +984,7 @@ public class SentryOptions {
   @ApiStatus.Internal
   public @NotNull TracesSampler getInternalTracesSampler() {
     if (internalTracesSampler == null) {
-      synchronized (this) {
+      try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
         if (internalTracesSampler == null) {
           internalTracesSampler = new TracesSampler(this);
         }

--- a/sentry/src/main/java/io/sentry/SentrySpanStorage.java
+++ b/sentry/src/main/java/io/sentry/SentrySpanStorage.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus;
@@ -16,10 +17,12 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SentrySpanStorage {
   private static volatile @Nullable SentrySpanStorage INSTANCE;
+  private static final @NotNull AutoClosableReentrantLock staticLock =
+      new AutoClosableReentrantLock();
 
   public static @NotNull SentrySpanStorage getInstance() {
     if (INSTANCE == null) {
-      synchronized (SentrySpanStorage.class) {
+      try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
         if (INSTANCE == null) {
           INSTANCE = new SentrySpanStorage();
         }

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -5,6 +5,7 @@ import io.sentry.protocol.Contexts;
 import io.sentry.protocol.SentryId;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.TransactionNameSource;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import io.sentry.util.SpanUtils;
 import java.util.ArrayList;
@@ -40,7 +41,8 @@ public final class SentryTracer implements ITransaction {
   private volatile @Nullable TimerTask deadlineTimeoutTask;
 
   private volatile @Nullable Timer timer = null;
-  private final @NotNull Object timerLock = new Object();
+  private final @NotNull AutoClosableReentrantLock timerLock = new AutoClosableReentrantLock();
+  private final @NotNull AutoClosableReentrantLock tracerLock = new AutoClosableReentrantLock();
 
   private final @NotNull AtomicBoolean isIdleFinishTimerRunning = new AtomicBoolean(false);
   private final @NotNull AtomicBoolean isDeadlineTimerRunning = new AtomicBoolean(false);
@@ -103,7 +105,7 @@ public final class SentryTracer implements ITransaction {
 
   @Override
   public void scheduleFinish() {
-    synchronized (timerLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
       if (timer != null) {
         final @Nullable Long idleTimeout = transactionOptions.getIdleTimeout();
 
@@ -254,7 +256,7 @@ public final class SentryTracer implements ITransaction {
       final SentryTransaction transaction = new SentryTransaction(this);
 
       if (timer != null) {
-        synchronized (timerLock) {
+        try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
           if (timer != null) {
             cancelIdleTimer();
             cancelDeadlineTimer();
@@ -282,7 +284,7 @@ public final class SentryTracer implements ITransaction {
   }
 
   private void cancelIdleTimer() {
-    synchronized (timerLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
       if (idleTimeoutTask != null) {
         idleTimeoutTask.cancel();
         isIdleFinishTimerRunning.set(false);
@@ -294,7 +296,7 @@ public final class SentryTracer implements ITransaction {
   private void scheduleDeadlineTimeout() {
     final @Nullable Long deadlineTimeOut = transactionOptions.getDeadlineTimeout();
     if (deadlineTimeOut != null) {
-      synchronized (timerLock) {
+      try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
         if (timer != null) {
           cancelDeadlineTimer();
           isDeadlineTimerRunning.set(true);
@@ -322,7 +324,7 @@ public final class SentryTracer implements ITransaction {
   }
 
   private void cancelDeadlineTimer() {
-    synchronized (timerLock) {
+    try (final @NotNull ISentryLifecycleToken ignored = timerLock.acquire()) {
       if (deadlineTimeoutTask != null) {
         deadlineTimeoutTask.cancel();
         isDeadlineTimerRunning.set(false);
@@ -648,7 +650,7 @@ public final class SentryTracer implements ITransaction {
   }
 
   private void updateBaggageValues() {
-    synchronized (this) {
+    try (final @NotNull ISentryLifecycleToken ignored = tracerLock.acquire()) {
       if (baggage.isMutable()) {
         final AtomicReference<SentryId> replayId = new AtomicReference<>();
         scopes.configureScope(

--- a/sentry/src/main/java/io/sentry/Stack.java
+++ b/sentry/src/main/java/io/sentry/Stack.java
@@ -1,11 +1,13 @@
 package io.sentry;
 
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.concurrent.LinkedBlockingDeque;
 import org.jetbrains.annotations.NotNull;
 
+/** TODO [POTEL] can this class be removed? */
 final class Stack {
 
   static final class StackItem {
@@ -47,6 +49,7 @@ final class Stack {
 
   private final @NotNull Deque<StackItem> items = new LinkedBlockingDeque<>();
   private final @NotNull ILogger logger;
+  private final @NotNull AutoClosableReentrantLock itemsLock = new AutoClosableReentrantLock();
 
   public Stack(final @NotNull ILogger logger, final @NotNull StackItem rootStackItem) {
     this.logger = Objects.requireNonNull(logger, "logger is required");
@@ -73,7 +76,7 @@ final class Stack {
   }
 
   void pop() {
-    synchronized (items) {
+    try (final @NotNull ISentryLifecycleToken ignored = itemsLock.acquire()) {
       if (items.size() != 1) {
         items.pop();
       } else {

--- a/sentry/src/main/java/io/sentry/SynchronizedCollection.java
+++ b/sentry/src/main/java/io/sentry/SynchronizedCollection.java
@@ -19,9 +19,11 @@
 package io.sentry;
 
 import com.jakewharton.nopen.annotation.Open;
+import io.sentry.util.AutoClosableReentrantLock;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Decorates another {@link Collection} to synchronize its behaviour for a multi-threaded
@@ -50,7 +52,7 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
   /** The collection to decorate */
   private final Collection<E> collection;
   /** The object to lock on, needed for List/SortedSet views */
-  final Object lock;
+  final AutoClosableReentrantLock lock;
 
   /**
    * Factory method to create a synchronized collection.
@@ -77,7 +79,7 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
       throw new NullPointerException("Collection must not be null.");
     }
     this.collection = collection;
-    this.lock = this;
+    this.lock = new AutoClosableReentrantLock();
   }
 
   /**
@@ -87,7 +89,7 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
    * @param lock the lock object to use, must not be null
    * @throws NullPointerException if the collection or lock is null
    */
-  SynchronizedCollection(final Collection<E> collection, final Object lock) {
+  SynchronizedCollection(final Collection<E> collection, final AutoClosableReentrantLock lock) {
     if (collection == null) {
       throw new NullPointerException("Collection must not be null.");
     }
@@ -111,42 +113,42 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
 
   @Override
   public boolean add(final E object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().add(object);
     }
   }
 
   @Override
   public boolean addAll(final Collection<? extends E> coll) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().addAll(coll);
     }
   }
 
   @Override
   public void clear() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       decorated().clear();
     }
   }
 
   @Override
   public boolean contains(final Object object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().contains(object);
     }
   }
 
   @Override
   public boolean containsAll(final Collection<?> coll) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().containsAll(coll);
     }
   }
 
   @Override
   public boolean isEmpty() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().isEmpty();
     }
   }
@@ -170,42 +172,42 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
 
   @Override
   public Object[] toArray() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().toArray();
     }
   }
 
   @Override
   public <T> T[] toArray(final T[] object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().toArray(object);
     }
   }
 
   @Override
   public boolean remove(final Object object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().remove(object);
     }
   }
 
   @Override
   public boolean removeAll(final Collection<?> coll) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().removeAll(coll);
     }
   }
 
   @Override
   public boolean retainAll(final Collection<?> coll) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().retainAll(coll);
     }
   }
 
   @Override
   public int size() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().size();
     }
   }
@@ -213,7 +215,7 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
   @SuppressWarnings("UndefinedEquals")
   @Override
   public boolean equals(final Object object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       if (object == this) {
         return true;
       }
@@ -223,14 +225,14 @@ class SynchronizedCollection<E> implements Collection<E>, Serializable {
 
   @Override
   public int hashCode() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().hashCode();
     }
   }
 
   @Override
   public String toString() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().toString();
     }
   }

--- a/sentry/src/main/java/io/sentry/SynchronizedQueue.java
+++ b/sentry/src/main/java/io/sentry/SynchronizedQueue.java
@@ -18,7 +18,9 @@
  */
 package io.sentry;
 
+import io.sentry.util.AutoClosableReentrantLock;
 import java.util.Queue;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Decorates another {@link Queue} to synchronize its behaviour for a multi-threaded environment.
@@ -65,7 +67,7 @@ final class SynchronizedQueue<E> extends SynchronizedCollection<E> implements Qu
    * @throws NullPointerException if queue or lock is null
    */
   @SuppressWarnings("ProtectedMembersInFinalClass")
-  protected SynchronizedQueue(final Queue<E> queue, final Object lock) {
+  protected SynchronizedQueue(final Queue<E> queue, final AutoClosableReentrantLock lock) {
     super(queue, lock);
   }
 
@@ -81,7 +83,7 @@ final class SynchronizedQueue<E> extends SynchronizedCollection<E> implements Qu
 
   @Override
   public E element() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().element();
     }
   }
@@ -92,7 +94,7 @@ final class SynchronizedQueue<E> extends SynchronizedCollection<E> implements Qu
     if (object == this) {
       return true;
     }
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().equals(object);
     }
   }
@@ -101,49 +103,49 @@ final class SynchronizedQueue<E> extends SynchronizedCollection<E> implements Qu
 
   @Override
   public int hashCode() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().hashCode();
     }
   }
 
   @Override
   public boolean offer(final E e) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().offer(e);
     }
   }
 
   @Override
   public E peek() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().peek();
     }
   }
 
   @Override
   public E poll() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().poll();
     }
   }
 
   @Override
   public E remove() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().remove();
     }
   }
 
   @Override
   public Object[] toArray() {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().toArray();
     }
   }
 
   @Override
   public <T> T[] toArray(T[] object) {
-    synchronized (lock) {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return decorated().toArray(object);
     }
   }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -9,6 +9,7 @@ import static java.lang.String.format;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.DateUtils;
 import io.sentry.Hint;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryCrashLastRunState;
 import io.sentry.SentryEnvelope;
 import io.sentry.SentryEnvelopeItem;
@@ -21,6 +22,7 @@ import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.SessionEnd;
 import io.sentry.hints.SessionStart;
 import io.sentry.transport.NoOpEnvelopeCache;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
@@ -70,6 +72,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
   private final CountDownLatch previousSessionLatch;
 
   private final @NotNull Map<SentryEnvelope, String> fileNameMap = new WeakHashMap<>();
+  protected final @NotNull AutoClosableReentrantLock cacheLock = new AutoClosableReentrantLock();
 
   public static @NotNull IEnvelopeCache create(final @NotNull SentryOptions options) {
     final String cacheDirPath = options.getCacheDirPath();
@@ -359,16 +362,18 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
    * @param envelope the SentryEnvelope object
    * @return the file
    */
-  private synchronized @NotNull File getEnvelopeFile(final @NotNull SentryEnvelope envelope) {
-    final @NotNull String fileName;
-    if (fileNameMap.containsKey(envelope)) {
-      fileName = fileNameMap.get(envelope);
-    } else {
-      fileName = UUID.randomUUID() + SUFFIX_ENVELOPE_FILE;
-      fileNameMap.put(envelope, fileName);
-    }
+  private @NotNull File getEnvelopeFile(final @NotNull SentryEnvelope envelope) {
+    try (final @NotNull ISentryLifecycleToken ignored = cacheLock.acquire()) {
+      final @NotNull String fileName;
+      if (fileNameMap.containsKey(envelope)) {
+        fileName = fileNameMap.get(envelope);
+      } else {
+        fileName = UUID.randomUUID() + SUFFIX_ENVELOPE_FILE;
+        fileNameMap.put(envelope, fileName);
+      }
 
-    return new File(directory.getAbsolutePath(), fileName);
+      return new File(directory.getAbsolutePath(), fileName);
+    }
   }
 
   public static @NotNull File getCurrentSessionFile(final @NotNull String cacheDirPath) {

--- a/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
+++ b/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
@@ -1,0 +1,29 @@
+package io.sentry.util;
+
+import io.sentry.ISentryLifecycleToken;
+import java.util.concurrent.locks.ReentrantLock;
+import org.jetbrains.annotations.NotNull;
+
+public final class AutoClosableReentrantLock extends ReentrantLock {
+
+  private static final long serialVersionUID = -3283069816958445549L;
+
+  public ISentryLifecycleToken acquire() {
+    lock();
+    return new AutoClosableReentrantLockLifecycleToken(this);
+  }
+
+  static final class AutoClosableReentrantLockLifecycleToken implements ISentryLifecycleToken {
+
+    private final @NotNull ReentrantLock lock;
+
+    AutoClosableReentrantLockLifecycleToken(final @NotNull ReentrantLock lock) {
+      this.lock = lock;
+    }
+
+    @Override
+    public void close() {
+      lock.unlock();
+    }
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
+++ b/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
@@ -1,0 +1,17 @@
+package io.sentry.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AutoClosableReentrantLockTest {
+
+    @Test
+    fun `calls lock in acquire and unlock on close`() {
+        val lock = AutoClosableReentrantLock()
+        lock.acquire().use {
+            assertTrue(lock.isLocked)
+        }
+        assertFalse(lock.isLocked)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Most usages of `synchronized` keyword in method signatures and `synchronized (...) {` blocks have been replaced by using `ReentrantLock`
- Adds `AutoClosableReentrantLock` which offers an `acquire` method that locks and returns an `AutoClosable` that unlocks on `close`. This can be used in `try` blocks
- `SynchronizedCollection` and `SynchronizedQueue` now expect a `AutoClosableReentrantLock` instead of `Object` when passing a lock object
- Instance locks (previously `synchronized` methods and `synchronized (this)`) now use `lock`
- Static locks (previously `static synchronized`, `synchronized (...class)` and `synchronized (...getInstance)`) now use `staticLock` 
- If there was a lock object before, the type has been changed from `Object` to `AutoClosableReentrantLock`
- Changing Android only classes wasn't totally necessary but IMO it's easier to maintain if there's only one way of synchronizing that's being used

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3312

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
