### PR TITLE
[QA] Lazily load SentryOptions members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     - If you're using code obfuscation, adjust your proguard-rules accordingly, so your custom view class name is not minified
 - Fix ensure Application Context is used even when SDK is initialized via Activity Context ([#3669](https://github.com/getsentry/sentry-java/pull/3669))
 - Fix potential ANRs due to `Calendar.getInstance` usage in Breadcrumbs constructor ([#3736](https://github.com/getsentry/sentry-java/pull/3736))
+- Lazily initialize heavy `SentryOptions` members to avoid ANRs on app start ([#3749](https://github.com/getsentry/sentry-java/pull/3749))
 
 *Breaking changes*:
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -13,6 +13,7 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import android.util.Log
 import android.view.PixelCopy
 import android.view.View
 import android.view.ViewGroup
@@ -101,6 +102,7 @@ internal class ScreenshotRecorder(
             Bitmap.Config.ARGB_8888
         )
 
+        val timeStart = System.nanoTime()
         // postAtFrontOfQueue to ensure the view hierarchy and bitmap are ase close in-sync as possible
         mainLooperHandler.post {
             try {
@@ -123,6 +125,8 @@ internal class ScreenshotRecorder(
 
                         val viewHierarchy = ViewHierarchyNode.fromView(root, null, 0, options)
                         root.traverse(viewHierarchy)
+                        val timeEnd = System.nanoTime()
+                        Log.e("TIME", String.format("%.2f", ((timeEnd - timeStart) / 1_000_000.0)))
 
                         recorder.submitSafely(options, "screenshot_recorder.redact") {
                             val canvas = Canvas(bitmap)

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -133,5 +133,5 @@ dependencies {
     implementation(Config.Libs.composeNavigation)
     implementation(Config.Libs.composeMaterial)
 
-    debugImplementation(Config.Libs.leakCanary)
+//    debugImplementation(Config.Libs.leakCanary)
 }

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -133,5 +133,5 @@ dependencies {
     implementation(Config.Libs.composeNavigation)
     implementation(Config.Libs.composeMaterial)
 
-//    debugImplementation(Config.Libs.leakCanary)
+    debugImplementation(Config.Libs.leakCanary)
 }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
         <meta-data android:name="io.sentry.dsn" android:value="https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559" />
 
         <!--    how to enable Sentry's debug mode-->
-        <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />
+        <meta-data android:name="io.sentry.debug" android:value="false" />
 
         <!--    how to set a custom debug level-->
         <!--    <meta-data android:name="io.sentry.debug.level" android:value="info" />-->
@@ -168,5 +168,6 @@
       <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
       <meta-data android:name="io.sentry.session-replay.redact-all-text" android:value="false" />
 
+      <profileable android:shell="true" />
     </application>
 </manifest>

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -73,7 +73,7 @@
         <meta-data android:name="io.sentry.dsn" android:value="https://1053864c67cc410aa1ffc9701bd6f93d@o447951.ingest.sentry.io/5428559" />
 
         <!--    how to enable Sentry's debug mode-->
-        <meta-data android:name="io.sentry.debug" android:value="false" />
+        <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />
 
         <!--    how to set a custom debug level-->
         <!--    <meta-data android:name="io.sentry.debug.level" android:value="info" />-->
@@ -167,7 +167,5 @@
 
       <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="1.0" />
       <meta-data android:name="io.sentry.session-replay.redact-all-text" android:value="false" />
-
-      <profileable android:shell="true" />
     </application>
 </manifest>

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -315,7 +315,7 @@ public abstract interface class io/sentry/EventProcessor {
 }
 
 public final class io/sentry/ExperimentalOptions {
-	public fun <init> ()V
+	public fun <init> (Z)V
 	public fun getSessionReplay ()Lio/sentry/SentryReplayOptions;
 	public fun setSessionReplay (Lio/sentry/SentryReplayOptions;)V
 }
@@ -2712,8 +2712,8 @@ public final class io/sentry/SentryReplayEvent$ReplayType$Deserializer : io/sent
 public final class io/sentry/SentryReplayOptions {
 	public static final field IMAGE_VIEW_CLASS_NAME Ljava/lang/String;
 	public static final field TEXT_VIEW_CLASS_NAME Ljava/lang/String;
-	public fun <init> ()V
 	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;)V
+	public fun <init> (Z)V
 	public fun addIgnoreViewClass (Ljava/lang/String;)V
 	public fun addRedactViewClass (Ljava/lang/String;)V
 	public fun getErrorReplayDuration ()J

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5698,6 +5698,7 @@ public final class io/sentry/util/JsonSerializationUtils {
 public final class io/sentry/util/LazyEvaluator {
 	public fun <init> (Lio/sentry/util/LazyEvaluator$Evaluator;)V
 	public fun getValue ()Ljava/lang/Object;
+	public fun setValue (Ljava/lang/Object;)V
 }
 
 public abstract interface class io/sentry/util/LazyEvaluator$Evaluator {

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -9,7 +9,11 @@ import org.jetbrains.annotations.NotNull;
  * <p>Beware that experimental options can change at any time.
  */
 public final class ExperimentalOptions {
-  private @NotNull SentryReplayOptions sessionReplay = new SentryReplayOptions();
+  private @NotNull SentryReplayOptions sessionReplay;
+
+  public ExperimentalOptions(final boolean empty) {
+    this.sessionReplay = new SentryReplayOptions(empty);
+  }
 
   @NotNull
   public SentryReplayOptions getSessionReplay() {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -419,8 +419,7 @@ public class SentryOptions {
   private boolean traceOptionsRequests = true;
 
   /** Date provider to retrieve the current date from. */
-  @ApiStatus.Internal
-  private volatile @Nullable SentryDateProvider dateProvider;
+  @ApiStatus.Internal private volatile @Nullable SentryDateProvider dateProvider;
 
   private final @NotNull Object dateProviderLock = new Object();
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -485,7 +485,7 @@ public class SentryOptions {
 
   @ApiStatus.Experimental private @Nullable Cron cron = null;
 
-  private final @NotNull ExperimentalOptions experimental = new ExperimentalOptions();
+  private final @NotNull ExperimentalOptions experimental;
 
   private @NotNull ReplayController replayController = NoOpReplayController.getInstance();
 
@@ -2567,6 +2567,7 @@ public class SentryOptions {
    * @param empty if options should be empty.
    */
   private SentryOptions(final boolean empty) {
+    experimental = new ExperimentalOptions(empty);
     if (!empty) {
       // SentryExecutorService should be initialized before any
       // SendCachedEventFireAndForgetIntegration

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -96,14 +96,16 @@ public final class SentryReplayOptions {
   /** The maximum duration of a full session replay, defaults to 1h. */
   private long sessionDuration = 60 * 60 * 1000L;
 
-  public SentryReplayOptions() {
-    setRedactAllText(true);
-    setRedactAllImages(true);
+  public SentryReplayOptions(final boolean empty) {
+    if (!empty) {
+      setRedactAllText(true);
+      setRedactAllImages(true);
+    }
   }
 
   public SentryReplayOptions(
       final @Nullable Double sessionSampleRate, final @Nullable Double onErrorSampleRate) {
-    this();
+    this(false);
     this.sessionSampleRate = sessionSampleRate;
     this.onErrorSampleRate = onErrorSampleRate;
   }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -116,7 +116,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         try (final Reader reader =
             new BufferedReader(
                 new InputStreamReader(new FileInputStream(currentSessionFile), UTF_8))) {
-          final Session session = serializer.deserialize(reader, Session.class);
+          final Session session = serializer.getValue().deserialize(reader, Session.class);
           if (session != null) {
             writeSessionToDisk(previousSessionFile, session);
           }
@@ -204,7 +204,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         try (final Reader reader =
             new BufferedReader(
                 new InputStreamReader(new FileInputStream(previousSessionFile), UTF_8))) {
-          final Session session = serializer.deserialize(reader, Session.class);
+          final Session session = serializer.getValue().deserialize(reader, Session.class);
           if (session != null) {
             final AbnormalExit abnormalHint = (AbnormalExit) sdkHint;
             final @Nullable Long abnormalExitTimestamp = abnormalHint.timestamp();
@@ -263,7 +263,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         try (final Reader reader =
             new BufferedReader(
                 new InputStreamReader(new ByteArrayInputStream(item.getData()), UTF_8))) {
-          final Session session = serializer.deserialize(reader, Session.class);
+          final Session session = serializer.getValue().deserialize(reader, Session.class);
           if (session == null) {
             options
                 .getLogger()
@@ -304,7 +304,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
 
     try (final OutputStream outputStream = new FileOutputStream(file)) {
-      serializer.serialize(envelope, outputStream);
+      serializer.getValue().serialize(envelope, outputStream);
     } catch (Throwable e) {
       options
           .getLogger()
@@ -324,7 +324,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
 
     try (final OutputStream outputStream = new FileOutputStream(file);
         final Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8))) {
-      serializer.serialize(session, writer);
+      serializer.getValue().serialize(session, writer);
     } catch (Throwable e) {
       options
           .getLogger()
@@ -388,7 +388,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     for (final File file : allCachedEnvelopes) {
       try (final InputStream is = new BufferedInputStream(new FileInputStream(file))) {
 
-        ret.add(serializer.deserializeEnvelope(is));
+        ret.add(serializer.getValue().deserializeEnvelope(is));
       } catch (FileNotFoundException e) {
         options
             .getLogger()

--- a/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
+++ b/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
@@ -16,19 +16,22 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 final class AtomicClientReportStorage implements IClientReportStorage {
 
-  private final @NotNull LazyEvaluator<Map<ClientReportKey, AtomicLong>> lostEventCounts = new LazyEvaluator<>(() -> {
-    final Map<ClientReportKey, AtomicLong> modifyableEventCountsForInit = new ConcurrentHashMap<>();
+  private final @NotNull LazyEvaluator<Map<ClientReportKey, AtomicLong>> lostEventCounts =
+      new LazyEvaluator<>(
+          () -> {
+            final Map<ClientReportKey, AtomicLong> modifyableEventCountsForInit =
+                new ConcurrentHashMap<>();
 
-    for (final DiscardReason discardReason : DiscardReason.values()) {
-      for (final DataCategory category : DataCategory.values()) {
-        modifyableEventCountsForInit.put(
-          new ClientReportKey(discardReason.getReason(), category.getCategory()),
-          new AtomicLong(0));
-      }
-    }
+            for (final DiscardReason discardReason : DiscardReason.values()) {
+              for (final DataCategory category : DataCategory.values()) {
+                modifyableEventCountsForInit.put(
+                    new ClientReportKey(discardReason.getReason(), category.getCategory()),
+                    new AtomicLong(0));
+              }
+            }
 
-    return Collections.unmodifiableMap(modifyableEventCountsForInit);
-  });
+            return Collections.unmodifiableMap(modifyableEventCountsForInit);
+          });
 
   public AtomicClientReportStorage() {}
 

--- a/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
+++ b/sentry/src/main/java/io/sentry/clientreport/AtomicClientReportStorage.java
@@ -1,10 +1,12 @@
 package io.sentry.clientreport;
 
 import io.sentry.DataCategory;
+import io.sentry.util.LazyEvaluator;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.ApiStatus;
@@ -14,25 +16,25 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 final class AtomicClientReportStorage implements IClientReportStorage {
 
-  private final @NotNull Map<ClientReportKey, AtomicLong> lostEventCounts;
-
-  public AtomicClientReportStorage() {
+  private final @NotNull LazyEvaluator<Map<ClientReportKey, AtomicLong>> lostEventCounts = new LazyEvaluator<>(() -> {
     final Map<ClientReportKey, AtomicLong> modifyableEventCountsForInit = new ConcurrentHashMap<>();
 
     for (final DiscardReason discardReason : DiscardReason.values()) {
       for (final DataCategory category : DataCategory.values()) {
         modifyableEventCountsForInit.put(
-            new ClientReportKey(discardReason.getReason(), category.getCategory()),
-            new AtomicLong(0));
+          new ClientReportKey(discardReason.getReason(), category.getCategory()),
+          new AtomicLong(0));
       }
     }
 
-    lostEventCounts = Collections.unmodifiableMap(modifyableEventCountsForInit);
-  }
+    return Collections.unmodifiableMap(modifyableEventCountsForInit);
+  });
+
+  public AtomicClientReportStorage() {}
 
   @Override
   public void addCount(ClientReportKey key, Long count) {
-    final @Nullable AtomicLong quantity = lostEventCounts.get(key);
+    final @Nullable AtomicLong quantity = lostEventCounts.getValue().get(key);
 
     if (quantity != null) {
       quantity.addAndGet(count);
@@ -43,7 +45,8 @@ final class AtomicClientReportStorage implements IClientReportStorage {
   public List<DiscardedEvent> resetCountsAndGet() {
     final List<DiscardedEvent> discardedEvents = new ArrayList<>();
 
-    for (final Map.Entry<ClientReportKey, AtomicLong> entry : lostEventCounts.entrySet()) {
+    Set<Map.Entry<ClientReportKey, AtomicLong>> entrySet = lostEventCounts.getValue().entrySet();
+    for (final Map.Entry<ClientReportKey, AtomicLong> entry : entrySet) {
       final Long quantity = entry.getValue().getAndSet(0);
       if (quantity > 0) {
         discardedEvents.add(

--- a/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
+++ b/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
@@ -10,7 +10,8 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.Internal
 public final class LazyEvaluator<T> {
-  private @Nullable T value = null;
+
+  private volatile @Nullable T value = null;
   private final @NotNull Evaluator<T> evaluator;
 
   /**
@@ -28,10 +29,16 @@ public final class LazyEvaluator<T> {
    *
    * @return The result of the evaluator function.
    */
-  public synchronized @NotNull T getValue() {
+  public @NotNull T getValue() {
     if (value == null) {
-      value = evaluator.evaluate();
+      synchronized (this) {
+        if (value == null) {
+          value = evaluator.evaluate();
+        }
+      }
     }
+
+    //noinspection DataFlowIssue
     return value;
   }
 

--- a/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
+++ b/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
@@ -42,6 +42,12 @@ public final class LazyEvaluator<T> {
     return value;
   }
 
+  public void setValue(final @Nullable T value) {
+    synchronized (this) {
+      this.value = value;
+    }
+  }
+
   public interface Evaluator<T> {
     @NotNull
     T evaluate();

--- a/sentry/src/test/java/io/sentry/SentryReplayOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryReplayOptionsTest.kt
@@ -7,7 +7,7 @@ class SentryReplayOptionsTest {
 
     @Test
     fun `uses medium quality as default`() {
-        val replayOptions = SentryReplayOptions()
+        val replayOptions = SentryReplayOptions(true)
 
         assertEquals(SentryReplayOptions.SentryReplayQuality.MEDIUM, replayOptions.quality)
         assertEquals(75_000, replayOptions.quality.bitRate)
@@ -16,7 +16,7 @@ class SentryReplayOptionsTest {
 
     @Test
     fun `low quality`() {
-        val replayOptions = SentryReplayOptions().apply { quality = SentryReplayOptions.SentryReplayQuality.LOW }
+        val replayOptions = SentryReplayOptions(true).apply { quality = SentryReplayOptions.SentryReplayQuality.LOW }
 
         assertEquals(50_000, replayOptions.quality.bitRate)
         assertEquals(0.8f, replayOptions.quality.sizeScale)
@@ -24,7 +24,7 @@ class SentryReplayOptionsTest {
 
     @Test
     fun `high quality`() {
-        val replayOptions = SentryReplayOptions().apply { quality = SentryReplayOptions.SentryReplayQuality.HIGH }
+        val replayOptions = SentryReplayOptions(true).apply { quality = SentryReplayOptions.SentryReplayQuality.HIGH }
 
         assertEquals(100_000, replayOptions.quality.bitRate)
         assertEquals(1.0f, replayOptions.quality.sizeScale)

--- a/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
@@ -108,13 +108,13 @@ class CacheStrategyTest {
         val files = createTempFilesSortByOldestToNewest()
 
         val okSession = createSessionMockData(Session.State.Ok, true)
-        val okEnvelope = SentryEnvelope.from(sut.serializer, okSession, null)
-        sut.serializer.serialize(okEnvelope, files[0].outputStream())
+        val okEnvelope = SentryEnvelope.from(sut.serializer.value, okSession, null)
+        sut.serializer.value.serialize(okEnvelope, files[0].outputStream())
 
         val updatedOkSession = okSession.clone()
         updatedOkSession.update(null, null, true)
-        val updatedOkEnvelope = SentryEnvelope.from(sut.serializer, updatedOkSession, null)
-        sut.serializer.serialize(updatedOkEnvelope, files[1].outputStream())
+        val updatedOkEnvelope = SentryEnvelope.from(sut.serializer.value, updatedOkSession, null)
+        sut.serializer.value.serialize(updatedOkEnvelope, files[1].outputStream())
 
         saveSessionToFile(files[2], sut, Session.State.Exited, null)
 
@@ -178,17 +178,17 @@ class CacheStrategyTest {
         )
 
     private fun getSessionFromFile(file: File, sut: CacheStrategy): Session {
-        val envelope = sut.serializer.deserializeEnvelope(file.inputStream())
+        val envelope = sut.serializer.value.deserializeEnvelope(file.inputStream())
         val item = envelope!!.items.first()
 
         val reader = InputStreamReader(ByteArrayInputStream(item.data), Charsets.UTF_8)
-        return sut.serializer.deserialize(reader, Session::class.java)!!
+        return sut.serializer.value.deserialize(reader, Session::class.java)!!
     }
 
     private fun saveSessionToFile(file: File, sut: CacheStrategy, state: Session.State = Session.State.Ok, init: Boolean? = true) {
         val okSession = createSessionMockData(state, init)
-        val okEnvelope = SentryEnvelope.from(sut.serializer, okSession, null)
-        sut.serializer.serialize(okEnvelope, file.outputStream())
+        val okEnvelope = SentryEnvelope.from(sut.serializer.value, okSession, null)
+        sut.serializer.value.serialize(okEnvelope, file.outputStream())
     }
 
     private fun getOptionsWithRealSerializer(): SentryOptions {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
There are members that we eagerly initialize, but we actually don't need them, so we can only init them when accessing for the first time:
* JsonSerializer
* EnvelopeReader
* DateProvider

Additionally, `AtomicClientReportStorage` was showing big numbers, so I made the lostEventCounts map a lazy one.

### AtomicClientReportStorage change

#### Before
![Screenshot 2024-10-02 at 23 52 46](https://github.com/user-attachments/assets/f568f447-662c-4569-8a60-f75c3a7e0652)

#### After

![Screenshot 2024-10-03 at 00 42 10](https://github.com/user-attachments/assets/5453abcc-e62c-4cc9-955b-1f23d86730d7)

### Lazy SentryOptions members (as an example took SentryOptions.empty())

#### Before
![Screenshot 2024-10-03 at 13 44 22](https://github.com/user-attachments/assets/1d3f7416-d9b8-42a0-9355-9765b07ab308)

#### After
![Screenshot 2024-10-03 at 15 49 58](https://github.com/user-attachments/assets/1a77f080-15ff-4780-a590-0ae04c75964b)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2541 

## :green_heart: How did you test it?
Manually, existing tests should cover this

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
