### PR TITLE
[SR] Mask web and video views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
         - If you're using code obfuscation, adjust your proguard-rules accordingly, so your custom view class name is not minified
 - Session Replay: Support Jetpack Compose masking ([#3739](https://github.com/getsentry/sentry-java/pull/3739))
   - To selectively mask/unmask @Composables, use `Modifier.sentryReplayMask()` and `Modifier.sentryReplayUnmask()` modifiers
+- Session Replay: Mask `WebView`, `VideoView` and `androidx.media3.ui.PlayerView` by default ([#3775](https://github.com/getsentry/sentry-java/pull/3775))
 
 ### Fixes
 

--- a/sentry-android-replay/proguard-rules.pro
+++ b/sentry-android-replay/proguard-rules.pro
@@ -18,3 +18,6 @@
 # Rules to detect a compose view to parse its hierarchy
 -dontwarn androidx.compose.ui.platform.AndroidComposeView
 -keepnames class androidx.compose.ui.platform.AndroidComposeView
+# Rules to detect a media player view to later mask it
+-dontwarn androidx.media3.ui.PlayerView
+-keepnames class androidx.media3.ui.PlayerView

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -136,7 +136,7 @@ internal class SimpleVideoEncoder(
         )
         format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
         format.setFloat(MediaFormat.KEY_FRAME_RATE, muxerConfig.frameRate.toFloat())
-        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 10) // use 10 to force non-key frames, meaning only partial updates to save the video size. Every 10th second is a key frame, which is useful for buffer mode
+        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 6) // use 6 to force non-key frames, meaning only partial updates to save the video size. Every 6th second is a key frame, which is useful for buffer mode
 
         format
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -136,7 +136,7 @@ internal class SimpleVideoEncoder(
         )
         format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
         format.setFloat(MediaFormat.KEY_FRAME_RATE, muxerConfig.frameRate.toFloat())
-        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, -1) // use -1 to force always non-key frames, meaning only partial updates to save the video size
+        format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 10) // use 10 to force non-key frames, meaning only partial updates to save the video size. Every 10th second is a key frame, which is useful for buffer mode
 
         format
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2709,8 +2709,11 @@ public final class io/sentry/SentryReplayEvent$ReplayType$Deserializer : io/sent
 }
 
 public final class io/sentry/SentryReplayOptions {
+	public static final field ANDROIDX_MEDIA_VIEW_CLASS_NAME Ljava/lang/String;
 	public static final field IMAGE_VIEW_CLASS_NAME Ljava/lang/String;
 	public static final field TEXT_VIEW_CLASS_NAME Ljava/lang/String;
+	public static final field VIDEO_VIEW_CLASS_NAME Ljava/lang/String;
+	public static final field WEB_VIEW_CLASS_NAME Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;)V
 	public fun addMaskViewClass (Ljava/lang/String;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2710,6 +2710,8 @@ public final class io/sentry/SentryReplayEvent$ReplayType$Deserializer : io/sent
 
 public final class io/sentry/SentryReplayOptions {
 	public static final field ANDROIDX_MEDIA_VIEW_CLASS_NAME Ljava/lang/String;
+	public static final field EXOPLAYER_CLASS_NAME Ljava/lang/String;
+	public static final field EXOPLAYER_STYLED_CLASS_NAME Ljava/lang/String;
 	public static final field IMAGE_VIEW_CLASS_NAME Ljava/lang/String;
 	public static final field TEXT_VIEW_CLASS_NAME Ljava/lang/String;
 	public static final field VIDEO_VIEW_CLASS_NAME Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -11,6 +11,9 @@ public final class SentryReplayOptions {
 
   public static final String TEXT_VIEW_CLASS_NAME = "android.widget.TextView";
   public static final String IMAGE_VIEW_CLASS_NAME = "android.widget.ImageView";
+  public static final String WEB_VIEW_CLASS_NAME = "android.webkit.WebView";
+  public static final String VIDEO_VIEW_CLASS_NAME = "android.widget.VideoView";
+  public static final String EXOPLAYER_VIEW_CLASS_NAME = "androidx.media3.ui.PlayerView";
 
   public enum SentryReplayQuality {
     /** Video Scale: 80% Bit Rate: 50.000 */
@@ -99,6 +102,9 @@ public final class SentryReplayOptions {
   public SentryReplayOptions() {
     setMaskAllText(true);
     setMaskAllImages(true);
+    maskViewClasses.add(WEB_VIEW_CLASS_NAME);
+    maskViewClasses.add(VIDEO_VIEW_CLASS_NAME);
+    maskViewClasses.add(EXOPLAYER_VIEW_CLASS_NAME);
   }
 
   public SentryReplayOptions(

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -15,7 +15,8 @@ public final class SentryReplayOptions {
   public static final String VIDEO_VIEW_CLASS_NAME = "android.widget.VideoView";
   public static final String ANDROIDX_MEDIA_VIEW_CLASS_NAME = "androidx.media3.ui.PlayerView";
   public static final String EXOPLAYER_CLASS_NAME = "com.google.android.exoplayer2.ui.PlayerView";
-  public static final String EXOPLAYER_STYLED_CLASS_NAME = "com.google.android.exoplayer2.ui.StyledPlayerView";
+  public static final String EXOPLAYER_STYLED_CLASS_NAME =
+      "com.google.android.exoplayer2.ui.StyledPlayerView";
 
   public enum SentryReplayQuality {
     /** Video Scale: 80% Bit Rate: 50.000 */

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -13,7 +13,7 @@ public final class SentryReplayOptions {
   public static final String IMAGE_VIEW_CLASS_NAME = "android.widget.ImageView";
   public static final String WEB_VIEW_CLASS_NAME = "android.webkit.WebView";
   public static final String VIDEO_VIEW_CLASS_NAME = "android.widget.VideoView";
-  public static final String EXOPLAYER_VIEW_CLASS_NAME = "androidx.media3.ui.PlayerView";
+  public static final String ANDROIDX_MEDIA_VIEW_CLASS_NAME = "androidx.media3.ui.PlayerView";
 
   public enum SentryReplayQuality {
     /** Video Scale: 80% Bit Rate: 50.000 */
@@ -104,7 +104,7 @@ public final class SentryReplayOptions {
     setMaskAllImages(true);
     maskViewClasses.add(WEB_VIEW_CLASS_NAME);
     maskViewClasses.add(VIDEO_VIEW_CLASS_NAME);
-    maskViewClasses.add(EXOPLAYER_VIEW_CLASS_NAME);
+    maskViewClasses.add(ANDROIDX_MEDIA_VIEW_CLASS_NAME);
   }
 
   public SentryReplayOptions(

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -14,6 +14,8 @@ public final class SentryReplayOptions {
   public static final String WEB_VIEW_CLASS_NAME = "android.webkit.WebView";
   public static final String VIDEO_VIEW_CLASS_NAME = "android.widget.VideoView";
   public static final String ANDROIDX_MEDIA_VIEW_CLASS_NAME = "androidx.media3.ui.PlayerView";
+  public static final String EXOPLAYER_CLASS_NAME = "com.google.android.exoplayer2.ui.PlayerView";
+  public static final String EXOPLAYER_STYLED_CLASS_NAME = "com.google.android.exoplayer2.ui.StyledPlayerView";
 
   public enum SentryReplayQuality {
     /** Video Scale: 80% Bit Rate: 50.000 */
@@ -105,6 +107,8 @@ public final class SentryReplayOptions {
     maskViewClasses.add(WEB_VIEW_CLASS_NAME);
     maskViewClasses.add(VIDEO_VIEW_CLASS_NAME);
     maskViewClasses.add(ANDROIDX_MEDIA_VIEW_CLASS_NAME);
+    maskViewClasses.add(EXOPLAYER_CLASS_NAME);
+    maskViewClasses.add(EXOPLAYER_STYLED_CLASS_NAME);
   }
 
   public SentryReplayOptions(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Mask more things by default: WebViews, VideoViews, and androidx PlayerViews
* Reverted key_frame interval to 10s, because I realized for buffered replays (which are 30sec), the quality becomes garbage without having key_frames at all. 10s seems like a good middle-ground for low size but decent quality videos.


## :green_heart: How did you test it?
Manually on the pocketcasts app

