### PR TITLE
[QA] Make logging faster on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Vendor `java.util.Random` and replace `java.security.SecureRandom` usages ([#3783](https://github.com/getsentry/sentry-java/pull/3783))
 - Fix potential ANRs due to NDK scope sync ([#3754](https://github.com/getsentry/sentry-java/pull/3754))
 - Fix potential ANRs due to NDK System.loadLibrary calls ([#3670](https://github.com/getsentry/sentry-java/pull/3670))
+- Fix slow `Log` calls on app startup ([#3793](https://github.com/getsentry/sentry-java/pull/3793))
 
 ## 7.15.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidLogger.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidLogger.java
@@ -26,7 +26,11 @@ public final class AndroidLogger implements ILogger {
       final @NotNull SentryLevel level,
       final @NotNull String message,
       final @Nullable Object... args) {
-    Log.println(toLogcatLevel(level), tag, String.format(message, args));
+    if (args == null || args.length == 0) {
+      Log.println(toLogcatLevel(level), tag, message);
+    } else {
+      Log.println(toLogcatLevel(level), tag, String.format(message, args));
+    }
   }
 
   @SuppressWarnings("AnnotateFormatMethod")
@@ -36,7 +40,11 @@ public final class AndroidLogger implements ILogger {
       final @Nullable Throwable throwable,
       final @NotNull String message,
       final @Nullable Object... args) {
-    log(level, String.format(message, args), throwable);
+    if (args == null || args.length == 0) {
+      log(level, message, throwable);
+    } else {
+      log(level, String.format(message, args), throwable);
+    }
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -437,7 +437,7 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final boolean defaultValue) {
     final boolean value = metadata.getBoolean(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }
 
@@ -450,10 +450,10 @@ final class ManifestMetadataReader {
     if (metadata.getSerializable(key) != null) {
       final boolean nonNullDefault = defaultValue == null ? false : true;
       final boolean bool = metadata.getBoolean(key, nonNullDefault);
-      logger.log(SentryLevel.DEBUG, "%s read: %s", key, bool);
+      logger.log(SentryLevel.DEBUG, key + " read: " + bool);
       return bool;
     } else {
-      logger.log(SentryLevel.DEBUG, "%s used default %s", key, defaultValue);
+      logger.log(SentryLevel.DEBUG, key + " used default " + defaultValue);
       return defaultValue;
     }
   }
@@ -464,7 +464,7 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final @Nullable String defaultValue) {
     final String value = metadata.getString(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }
 
@@ -474,14 +474,14 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final @NotNull String defaultValue) {
     final String value = metadata.getString(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }
 
   private static @Nullable List<String> readList(
       final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
     final String value = metadata.getString(key);
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     if (value != null) {
       return Arrays.asList(value.split(",", -1));
     } else {
@@ -493,7 +493,7 @@ final class ManifestMetadataReader {
       final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
     // manifest meta-data only reads float
     final Double value = ((Float) metadata.getFloat(key, -1)).doubleValue();
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }
 
@@ -504,7 +504,7 @@ final class ManifestMetadataReader {
       final long defaultValue) {
     // manifest meta-data only reads int if the value is not big enough
     final long value = metadata.getInt(key, (int) defaultValue);
-    logger.log(SentryLevel.DEBUG, "%s read: %s", key, value);
+    logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }
 
@@ -524,7 +524,6 @@ final class ManifestMetadataReader {
       if (metadata != null) {
         autoInit = readBool(metadata, logger, AUTO_INIT, true);
       }
-      logger.log(SentryLevel.INFO, "Retrieving auto-init from AndroidManifest.xml");
     } catch (Throwable e) {
       logger.log(SentryLevel.ERROR, "Failed to read auto-init from android manifest metadata.", e);
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* There are some benchmarks in [here](https://stackoverflow.com/questions/513600/should-i-use-javas-string-format-if-performance-is-important) comparing `String.format` vs plus-operator, and `String.format` is indeed slower.
  * Since we're doing some logging on startup (e.g. when parsing the manifest), even when `debug` is set to `false`, this was adding some overhead. I've removed the redundant log call + add changed `String.format` usages to the plus operator
* We were doing unnecessary `String.format` even when there are no args passed, so we check for their presence now and call the method without `String.format` explicitly now


### Before
![Android Studio 2024-10-15 18 37 08](https://github.com/user-attachments/assets/73327cea-1c7d-402c-beb8-1bf0b009e478)


### After
![Android Studio 2024-10-15 18 36 10](https://github.com/user-attachments/assets/f7da54c8-393b-4454-ab57-4c4bf0bc03c8)


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
