### PR TITLE
[QA] Hardcode integration names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Vendor `java.util.Random` and replace `java.security.SecureRandom` usages ([#3783](https://github.com/getsentry/sentry-java/pull/3783))
 - Fix potential ANRs due to NDK scope sync ([#3754](https://github.com/getsentry/sentry-java/pull/3754))
 - Fix potential ANRs due to NDK System.loadLibrary calls ([#3670](https://github.com/getsentry/sentry-java/pull/3670))
+- Fix slow Integration name parsing ([#3794](https://github.com/getsentry/sentry-java/pull/3794))
 
 ## 7.15.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityBreadcrumbsIntegration.java
@@ -46,7 +46,7 @@ public final class ActivityBreadcrumbsIntegration
     if (enabled) {
       application.registerActivityLifecycleCallbacks(this);
       options.getLogger().log(SentryLevel.DEBUG, "ActivityBreadcrumbIntegration installed.");
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("ActivityBreadcrumbs");
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -118,7 +118,7 @@ public final class ActivityLifecycleIntegration
 
     application.registerActivityLifecycleCallbacks(this);
     this.options.getLogger().log(SentryLevel.DEBUG, "ActivityLifecycleIntegration installed.");
-    addIntegrationToSdkVersion(getClass());
+    addIntegrationToSdkVersion("ActivityLifecycle");
   }
 
   private boolean isPerformanceEnabled(final @NotNull SentryAndroidOptions options) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrIntegration.java
@@ -59,7 +59,7 @@ public final class AnrIntegration implements Integration, Closeable {
         .log(SentryLevel.DEBUG, "AnrIntegration enabled: %s", options.isAnrEnabled());
 
     if (options.isAnrEnabled()) {
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("Anr");
       try {
         options
             .getExecutorService()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -95,7 +95,7 @@ public class AnrV2Integration implements Integration, Closeable {
         options.getLogger().log(SentryLevel.DEBUG, "Failed to start AnrProcessor.", e);
       }
       options.getLogger().log(SentryLevel.DEBUG, "AnrV2Integration installed.");
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("AnrV2");
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegration.java
@@ -55,7 +55,7 @@ public final class AppComponentsBreadcrumbsIntegration
         options
             .getLogger()
             .log(SentryLevel.DEBUG, "AppComponentsBreadcrumbsIntegration installed.");
-        addIntegrationToSdkVersion(getClass());
+        addIntegrationToSdkVersion("AppComponentsBreadcrumbs");
       } catch (Throwable e) {
         this.options.setEnableAppComponentBreadcrumbs(false);
         options.getLogger().log(SentryLevel.INFO, e, "ComponentCallbacks2 is not available.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -96,7 +96,7 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
     try {
       ProcessLifecycleOwner.get().getLifecycle().addObserver(watcher);
       options.getLogger().log(SentryLevel.DEBUG, "AppLifecycleIntegration installed.");
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("AppLifecycle");
     } catch (Throwable e) {
       // This is to handle a potential 'AbstractMethodError' gracefully. The error is triggered in
       // connection with conflicting dependencies of the androidx.lifecycle.

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -55,7 +55,7 @@ public final class NdkIntegration implements Integration, Closeable {
         method.invoke(null, args);
 
         this.options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
-        addIntegrationToSdkVersion(getClass());
+        addIntegrationToSdkVersion("Ndk");
       } catch (NoSuchMethodException e) {
         disableNdkIntegration(this.options);
         this.options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NetworkBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NetworkBreadcrumbsIntegration.java
@@ -96,7 +96,7 @@ public final class NetworkBreadcrumbsIntegration implements Integration, Closeab
                               context, logger, buildInfoProvider, networkCallback);
                       if (registered) {
                         logger.log(SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration installed.");
-                        addIntegrationToSdkVersion(getClass());
+                        addIntegrationToSdkVersion("NetworkBreadcrumbs");
                       } else {
                         logger.log(
                             SentryLevel.DEBUG, "NetworkBreadcrumbsIntegration not installed.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/PhoneStateBreadcrumbsIntegration.java
@@ -81,7 +81,7 @@ public final class PhoneStateBreadcrumbsIntegration implements Integration, Clos
         telephonyManager.listen(listener, android.telephony.PhoneStateListener.LISTEN_CALL_STATE);
 
         options.getLogger().log(SentryLevel.DEBUG, "PhoneStateBreadcrumbsIntegration installed.");
-        addIntegrationToSdkVersion(getClass());
+        addIntegrationToSdkVersion("PhoneStateBreadcrumbs");
       } catch (Throwable e) {
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ScreenshotEventProcessor.java
@@ -46,7 +46,7 @@ public final class ScreenshotEventProcessor implements EventProcessor {
             DEBOUNCE_MAX_EXECUTIONS);
 
     if (options.isAttachScreenshot()) {
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("Screenshot");
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SendCachedEnvelopeIntegration.java
@@ -1,5 +1,7 @@
 package io.sentry.android.core;
 
+import static io.sentry.util.IntegrationUtils.addIntegrationToSdkVersion;
+
 import io.sentry.DataCategory;
 import io.sentry.IConnectionStatusProvider;
 import io.sentry.IHub;
@@ -54,6 +56,7 @@ final class SendCachedEnvelopeIntegration
       options.getLogger().log(SentryLevel.ERROR, "No cache dir path is defined in options.");
       return;
     }
+    addIntegrationToSdkVersion("SendCachedEnvelope");
 
     sendCachedEnvelopes(hub, this.options);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -132,7 +132,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       // registerReceiver can throw SecurityException but it's not documented in the official docs
       ContextUtils.registerReceiver(context, options, receiver, filter);
       options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("SystemEventsBreadcrumbs");
     } catch (Throwable e) {
       options.setEnableSystemEventBreadcrumbs(false);
       options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -87,7 +87,7 @@ public final class TempSensorBreadcrumbsIntegration
           sensorManager.registerListener(this, defaultSensor, SensorManager.SENSOR_DELAY_NORMAL);
 
           options.getLogger().log(SentryLevel.DEBUG, "TempSensorBreadcrumbsIntegration installed.");
-          addIntegrationToSdkVersion(getClass());
+          addIntegrationToSdkVersion("TempSensor");
         } else {
           options.getLogger().log(SentryLevel.INFO, "TYPE_AMBIENT_TEMPERATURE is not available.");
         }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TempSensorBreadcrumbsIntegration.java
@@ -87,7 +87,7 @@ public final class TempSensorBreadcrumbsIntegration
           sensorManager.registerListener(this, defaultSensor, SensorManager.SENSOR_DELAY_NORMAL);
 
           options.getLogger().log(SentryLevel.DEBUG, "TempSensorBreadcrumbsIntegration installed.");
-          addIntegrationToSdkVersion("TempSensor");
+          addIntegrationToSdkVersion("TempSensorBreadcrumbs");
         } else {
           options.getLogger().log(SentryLevel.INFO, "TYPE_AMBIENT_TEMPERATURE is not available.");
         }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/UserInteractionIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/UserInteractionIntegration.java
@@ -121,7 +121,7 @@ public final class UserInteractionIntegration
       if (isAndroidXAvailable) {
         application.registerActivityLifecycleCallbacks(this);
         this.options.getLogger().log(SentryLevel.DEBUG, "UserInteractionIntegration installed.");
-        addIntegrationToSdkVersion(getClass());
+        addIntegrationToSdkVersion("UserInteraction");
       } else {
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ViewHierarchyEventProcessor.java
@@ -55,7 +55,7 @@ public final class ViewHierarchyEventProcessor implements EventProcessor {
             DEBOUNCE_MAX_EXECUTIONS);
 
     if (options.isAttachViewHierarchy()) {
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("ViewHierarchy");
     }
   }
 

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleIntegration.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleIntegration.kt
@@ -49,7 +49,7 @@ class FragmentLifecycleIntegration(
 
         application.registerActivityLifecycleCallbacks(this)
         options.logger.log(DEBUG, "FragmentLifecycleIntegration installed.")
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("FragmentLifecycle")
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-android-fragment", BuildConfig.VERSION_NAME)
     }

--- a/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
+++ b/sentry-android-navigation/src/main/java/io/sentry/android/navigation/SentryNavigationListener.kt
@@ -49,7 +49,7 @@ class SentryNavigationListener @JvmOverloads constructor(
     private var activeTransaction: ITransaction? = null
 
     init {
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("NavigationListener")
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-android-navigation", BuildConfig.VERSION_NAME)
     }

--- a/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt
@@ -54,7 +54,7 @@ class SentryOkHttpInterceptor(
     constructor(beforeSpan: BeforeSpanCallback) : this(HubAdapter.getInstance(), beforeSpan)
 
     init {
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("OkHttp")
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-android-okhttp", BuildConfig.VERSION_NAME)
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -119,7 +119,7 @@ public class ReplayIntegration(
             options.logger.log(INFO, "ComponentCallbacks is not available, orientation changes won't be handled by Session replay", e)
         }
 
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("Replay")
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-android-replay", BuildConfig.VERSION_NAME)
 

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberIntegration.kt
@@ -29,7 +29,7 @@ class SentryTimberIntegration(
 
         logger.log(SentryLevel.DEBUG, "SentryTimberIntegration installed.")
         SentryIntegrationPackageStorage.getInstance().addPackage("maven:io.sentry:sentry-android-timber", VERSION_NAME)
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("Timber")
     }
 
     override fun close() {

--- a/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
+++ b/sentry-apollo/src/main/java/io/sentry/apollo/SentryApolloInterceptor.kt
@@ -40,7 +40,7 @@ class SentryApolloInterceptor(
     constructor(beforeSpan: BeforeSpanCallback) : this(HubAdapter.getInstance(), beforeSpan)
 
     init {
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("Apollo")
         SentryIntegrationPackageStorage.getInstance().addPackage("maven:io.sentry:sentry-apollo", BuildConfig.VERSION_NAME)
     }
 

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -54,7 +54,7 @@ public open class SentryOkHttpInterceptor(
     public constructor(beforeSpan: BeforeSpanCallback) : this(HubAdapter.getInstance(), beforeSpan)
 
     init {
-        addIntegrationToSdkVersion(javaClass)
+        addIntegrationToSdkVersion("OkHttp")
         SentryIntegrationPackageStorage.getInstance()
             .addPackage("maven:io.sentry:sentry-okhttp", BuildConfig.VERSION_NAME)
     }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5690,7 +5690,6 @@ public final class io/sentry/util/HttpUtils {
 
 public final class io/sentry/util/IntegrationUtils {
 	public fun <init> ()V
-	public static fun addIntegrationToSdkVersion (Ljava/lang/Class;)V
 	public static fun addIntegrationToSdkVersion (Ljava/lang/String;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -79,7 +79,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
     options
         .getLogger()
         .log(SentryLevel.DEBUG, "SendCachedEventFireAndForgetIntegration installed.");
-    addIntegrationToSdkVersion("SendCachedEventFireAndForget");
+    addIntegrationToSdkVersion("SendCachedEnvelopeFireAndForget");
 
     sendCachedEnvelopes(hub, options);
   }

--- a/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
+++ b/sentry/src/main/java/io/sentry/SendCachedEnvelopeFireAndForgetIntegration.java
@@ -79,7 +79,7 @@ public final class SendCachedEnvelopeFireAndForgetIntegration
     options
         .getLogger()
         .log(SentryLevel.DEBUG, "SendCachedEventFireAndForgetIntegration installed.");
-    addIntegrationToSdkVersion(getClass());
+    addIntegrationToSdkVersion("SendCachedEventFireAndForget");
 
     sendCachedEnvelopes(hub, options);
   }

--- a/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
+++ b/sentry/src/main/java/io/sentry/ShutdownHookIntegration.java
@@ -37,7 +37,7 @@ public final class ShutdownHookIntegration implements Integration, Closeable {
           () -> {
             runtime.addShutdownHook(thread);
             options.getLogger().log(SentryLevel.DEBUG, "ShutdownHookIntegration installed.");
-            addIntegrationToSdkVersion(getClass());
+            addIntegrationToSdkVersion("ShutdownHook");
           });
     } else {
       options.getLogger().log(SentryLevel.INFO, "enableShutdownHook is disabled.");

--- a/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
+++ b/sentry/src/main/java/io/sentry/UncaughtExceptionHandlerIntegration.java
@@ -90,7 +90,7 @@ public final class UncaughtExceptionHandlerIntegration
       this.options
           .getLogger()
           .log(SentryLevel.DEBUG, "UncaughtExceptionHandlerIntegration installed.");
-      addIntegrationToSdkVersion(getClass());
+      addIntegrationToSdkVersion("UncaughtExceptionHandler");
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/IntegrationUtils.java
+++ b/sentry/src/main/java/io/sentry/util/IntegrationUtils.java
@@ -6,16 +6,6 @@ import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
 public final class IntegrationUtils {
-  public static void addIntegrationToSdkVersion(final @NotNull Class<?> clazz) {
-    final String name =
-        clazz
-            .getSimpleName()
-            .replace("Sentry", "")
-            .replace("Integration", "")
-            .replace("Interceptor", "")
-            .replace("EventProcessor", "");
-    addIntegrationToSdkVersion(name);
-  }
 
   public static void addIntegrationToSdkVersion(final @NotNull String name) {
     SentryIntegrationPackageStorage.getInstance().addIntegration(name);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Profiling showed that there's quite some time spent on adding integrations to the sdk version, probably due to string manipulation and reflection for class name, so I've just dropped this entirely in favour of hardcoding integration names as-is.

### Before
![Android Studio 2024-10-15 22 10 46](https://github.com/user-attachments/assets/0dc4f1fe-7399-469e-9e57-96293914f4e9)

### After
It's gone completely, we just add directly to the sdk version

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

