### PR TITLE
[QA] Cache parsed Dsn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Cache parsed Dsn ([#3796](https://github.com/getsentry/sentry-java/pull/3796))
 - fix invalid profiles when the transaction name is empty ([#3747](https://github.com/getsentry/sentry-java/pull/3747))
 - Deprecate `enableTracing` option ([#3777](https://github.com/getsentry/sentry-java/pull/3777))
 - Vendor `java.util.Random` and replace `java.security.SecureRandom` usages ([#3783](https://github.com/getsentry/sentry-java/pull/3783))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5704,6 +5704,7 @@ public final class io/sentry/util/JsonSerializationUtils {
 public final class io/sentry/util/LazyEvaluator {
 	public fun <init> (Lio/sentry/util/LazyEvaluator$Evaluator;)V
 	public fun getValue ()Ljava/lang/Object;
+	public fun resetValue ()V
 	public fun setValue (Ljava/lang/Object;)V
 }
 

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -134,7 +134,7 @@ public final class Baggage {
     final Baggage baggage = new Baggage(options.getLogger());
     final SpanContext trace = event.getContexts().getTrace();
     baggage.setTraceId(trace != null ? trace.getTraceId().toString() : null);
-    baggage.setPublicKey(new Dsn(options.getDsn()).getPublicKey());
+    baggage.setPublicKey(options.getParsedDsn().getPublicKey());
     baggage.setRelease(event.getRelease());
     baggage.setEnvironment(event.getEnvironment());
     final User user = event.getUser();
@@ -405,7 +405,7 @@ public final class Baggage {
       final @NotNull SentryOptions sentryOptions,
       final @Nullable TracesSamplingDecision samplingDecision) {
     setTraceId(transaction.getSpanContext().getTraceId().toString());
-    setPublicKey(new Dsn(sentryOptions.getDsn()).getPublicKey());
+    setPublicKey(sentryOptions.getParsedDsn().getPublicKey());
     setRelease(sentryOptions.getRelease());
     setEnvironment(sentryOptions.getEnvironment());
     setUserSegment(user != null ? getSegment(user) : null);
@@ -427,7 +427,7 @@ public final class Baggage {
     final @Nullable User user = scope.getUser();
     final @NotNull SentryId replayId = scope.getReplayId();
     setTraceId(propagationContext.getTraceId().toString());
-    setPublicKey(new Dsn(options.getDsn()).getPublicKey());
+    setPublicKey(options.getParsedDsn().getPublicKey());
     setRelease(options.getRelease());
     setEnvironment(options.getEnvironment());
     if (!SentryId.EMPTY_ID.equals(replayId)) {

--- a/sentry/src/main/java/io/sentry/DsnUtil.java
+++ b/sentry/src/main/java/io/sentry/DsnUtil.java
@@ -23,7 +23,7 @@ public final class DsnUtil {
       return false;
     }
 
-    final @NotNull Dsn dsn = new Dsn(dsnString);
+    final @NotNull Dsn dsn = options.getParsedDsn();
     final @NotNull URI sentryUri = dsn.getSentryUri();
     final @Nullable String dsnHost = sentryUri.getHost();
 

--- a/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
+++ b/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
@@ -21,7 +21,7 @@ final class RequestDetailsResolver {
 
   @NotNull
   RequestDetails resolve() {
-    final Dsn dsn = new Dsn(options.getDsn());
+    final Dsn dsn = options.getParsedDsn();
     final URI sentryUri = dsn.getSentryUri();
     final String envelopeUrl = sentryUri.resolve(sentryUri.getPath() + "/envelope/").toString();
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -381,8 +381,8 @@ public final class Sentry {
           "DSN is required. Use empty string or set enabled to false in SentryOptions to disable SDK.");
     }
 
-    @SuppressWarnings("unused")
-    final Dsn parsedDsn = new Dsn(dsn);
+    // This creates the DSN object and performs some checks
+    options.getParsedDsn();
 
     ILogger logger = options.getLogger();
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -82,6 +82,9 @@ public class SentryOptions {
    */
   private @Nullable String dsn;
 
+  /** Parsed DSN to avoid parsing it every time. */
+  private final @NotNull LazyEvaluator<Dsn> parsedDsn = new LazyEvaluator<>(() -> new Dsn(dsn));
+
   /** dsnHash is used as a subfolder of cacheDirPath to isolate events when rotating DSNs */
   private @Nullable String dsnHash;
 
@@ -538,12 +541,26 @@ public class SentryOptions {
   }
 
   /**
+   * Returns the DSN
+   *
+   * @return the DSN or null if not set
+   */
+  @ApiStatus.Internal
+  @NotNull
+  Dsn getParsedDsn() {
+    return parsedDsn.getValue();
+  }
+
+  /**
    * Sets the DSN
    *
    * @param dsn the DSN
    */
   public void setDsn(final @Nullable String dsn) {
     this.dsn = dsn;
+    if (!isEnabled() || (dsn != null && dsn.isEmpty())) {
+      this.parsedDsn.resetValue();
+    }
 
     dsnHash = StringUtils.calculateStringHash(this.dsn, logger);
   }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -532,7 +532,7 @@ public class SentryOptions {
   }
 
   /**
-   * Returns the DSN
+   * Returns the DSN.
    *
    * @return the DSN or null if not set
    */
@@ -541,13 +541,13 @@ public class SentryOptions {
   }
 
   /**
-   * Returns the DSN
+   * Evaluates and parses the DSN. May throw an exception if the DSN is invalid.
    *
-   * @return the DSN or null if not set
+   * @return the parsed DSN or throws if dsn is invalid
    */
   @ApiStatus.Internal
   @NotNull
-  Dsn getParsedDsn() {
+  Dsn getParsedDsn() throws IllegalArgumentException {
     return parsedDsn.getValue();
   }
 
@@ -558,9 +558,7 @@ public class SentryOptions {
    */
   public void setDsn(final @Nullable String dsn) {
     this.dsn = dsn;
-    if (!isEnabled() || (dsn != null && dsn.isEmpty())) {
-      this.parsedDsn.resetValue();
-    }
+    this.parsedDsn.resetValue();
 
     dsnHash = StringUtils.calculateStringHash(this.dsn, logger);
   }

--- a/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
+++ b/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
@@ -25,7 +25,8 @@ public final class LazyEvaluator<T> {
   }
 
   /**
-   * Executes the evaluator function and caches its result, so that it's called only once.
+   * Executes the evaluator function and caches its result, so that it's called only once, unless
+   * resetValue is called.
    *
    * @return The result of the evaluator function.
    */
@@ -48,6 +49,10 @@ public final class LazyEvaluator<T> {
     }
   }
 
+  /**
+   * Resets the internal value and forces the evaluator function to be called the next time
+   * getValue() is called.
+   */
   public void resetValue() {
     synchronized (this) {
       this.value = null;

--- a/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
+++ b/sentry/src/main/java/io/sentry/util/LazyEvaluator.java
@@ -48,6 +48,12 @@ public final class LazyEvaluator<T> {
     }
   }
 
+  public void resetValue() {
+    synchronized (this) {
+      this.value = null;
+    }
+  }
+
   public interface Evaluator<T> {
     @NotNull
     T evaluate();

--- a/sentry/src/test/java/io/sentry/util/LazyEvaluatorTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LazyEvaluatorTest.kt
@@ -38,4 +38,18 @@ class LazyEvaluatorTest {
         assertEquals(1, evaluator.value)
         assertEquals(1, fixture.count)
     }
+
+    @Test
+    fun `evaluates again after resetValue`() {
+        val evaluator = fixture.getSut()
+        assertEquals(0, fixture.count)
+        assertEquals(1, evaluator.value)
+        assertEquals(1, evaluator.value)
+        assertEquals(1, fixture.count)
+        // Evaluate again, only once
+        evaluator.resetValue()
+        assertEquals(2, evaluator.value)
+        assertEquals(2, evaluator.value)
+        assertEquals(2, fixture.count)
+    }
 }


### PR DESCRIPTION
## :scroll: Description
We parse the dsn multiple times in the app lifecycle, and most of the times on the main thread. We can parse it once and cache its result


## :bulb: Motivation and Context



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
