### PR TITLE
[QA] Make replay lazy and faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix potential ANRs due to NDK System.loadLibrary calls ([#3670](https://github.com/getsentry/sentry-java/pull/3670))
 - Fix slow `Log` calls on app startup ([#3793](https://github.com/getsentry/sentry-java/pull/3793))
 - Fix slow Integration name parsing ([#3794](https://github.com/getsentry/sentry-java/pull/3794))
+- Session Replay: Reduce startup and capture overhead ([#3799](https://github.com/getsentry/sentry-java/pull/3799))
 
 ## 7.15.0
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -12,14 +12,16 @@ import kotlin.LazyThreadSafetyMode.NONE
 public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
     internal companion object {
         private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
-        private val supportedNetworkData = setOf(
-            "status_code",
-            "method",
-            "response_content_length",
-            "request_content_length",
-            "http.response_content_length",
-            "http.request_content_length"
-        )
+        private val supportedNetworkData by lazy(NONE) {
+            setOf(
+                "status_code",
+                "method",
+                "response_content_length",
+                "request_content_length",
+                "http.response_content_length",
+                "http.request_content_length"
+            )
+        }
     }
 
     private var lastConnectivityState: String? = null

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.math.roundToInt
 
 @TargetApi(26)
@@ -51,15 +52,19 @@ internal class ScreenshotRecorder(
     }
     private var rootView: WeakReference<View>? = null
     private val pendingViewHierarchy = AtomicReference<ViewHierarchyNode>()
-    private val maskingPaint = Paint()
-    private val singlePixelBitmap: Bitmap = Bitmap.createBitmap(
-        1,
-        1,
-        Bitmap.Config.ARGB_8888
-    )
-    private val singlePixelBitmapCanvas: Canvas = Canvas(singlePixelBitmap)
-    private val prescaledMatrix = Matrix().apply {
-        preScale(config.scaleFactorX, config.scaleFactorY)
+    private val maskingPaint by lazy(NONE) { Paint() }
+    private val singlePixelBitmap: Bitmap by lazy(NONE) {
+        Bitmap.createBitmap(
+            1,
+            1,
+            Bitmap.Config.ARGB_8888
+        )
+    }
+    private val singlePixelBitmapCanvas: Canvas by lazy(NONE) { Canvas(singlePixelBitmap) }
+    private val prescaledMatrix by lazy(NONE) {
+        Matrix().apply {
+            preScale(config.scaleFactorX, config.scaleFactorY)
+        }
     }
     private val contentChanged = AtomicBoolean(false)
     private val isCapturing = AtomicBoolean(true)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -209,10 +209,6 @@ internal abstract class BaseCaptureStrategy(
                 }
             }
 
-            init {
-                runInBackground { onChange(propertyName, initialValue, initialValue) }
-            }
-
             override fun getValue(thisRef: Any?, property: KProperty<*>): T? = value.get()
 
             override fun setValue(thisRef: Any?, property: KProperty<*>, value: T?) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -239,8 +239,8 @@ sealed class ViewHierarchyNode(
         private fun Class<*>.isAssignableFrom(set: Set<String>): Boolean {
             var cls: Class<*>? = this
             while (cls != null) {
-                val canonicalName = cls.canonicalName
-                if (canonicalName != null && set.contains(canonicalName)) {
+                val canonicalName = cls.name
+                if (set.contains(canonicalName)) {
                     return true
                 }
                 cls = cls.superclass


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* There are some things we were eagerly initializing for replay that we actually don't need (and only use them on a bg thread, so this should be a good improvement)
* Use `Class.getName` instead of `Class.getCanonicalName` as seems like the latter is quite a bit slower due to checks for class locality/anonymity which goes into the native layer. Maybe an outlier, but they are essentially the same thing except a couple of cases, so I think it's fine to use it here
* Get rid of unnecessary `positionInWindow` call as we already get the coords via `boundsInWindow` anyway
* Get rid of `runInBackground` init call as it wouldn't do anything because ReplayCache is null at that point anyway


### Before (canonicalName change)
![Screenshot 2024-10-15 at 23 39 01](https://github.com/user-attachments/assets/24adc231-9ecb-4c01-91b3-7cd58d9eba5a)


### After (canonicalName change)
![Screenshot 2024-10-15 at 23 51 47](https://github.com/user-attachments/assets/d2415b97-f6a2-4767-ae7a-c1f83bd4442b)


## :green_heart: How did you test it?
Existing tests should cover it

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
