### PR TITLE
docs(okhttp): update documented default value to match actual

### DIFF
--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -33,7 +33,7 @@ import java.io.IOException
  * @param hub The [IHub], internal and only used for testing.
  * @param beforeSpan The [ISpan] can be customized or dropped with the [BeforeSpanCallback].
  * @param captureFailedRequests The SDK will only capture HTTP Client errors if it is enabled,
- * Defaults to false.
+ * Defaults to true.
  * @param failedRequestStatusCodes The SDK will only capture HTTP Client errors if the HTTP Response
  * status code is within the defined ranges.
  * @param failedRequestTargets The SDK will only capture HTTP Client errors if the HTTP Request URL


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Update the documented default value for `captureFailedRequests` to match the actual default value in code.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looks like you forgot to update the docs when you flipped the default in 7.1.0 😅 

## :green_heart: How did you test it?
🫣

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
