### PR TITLE
[QA] Replace setOf with HashSet.add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Replace setOf with HashSet.add ([#3801](https://github.com/getsentry/sentry-java/pull/3801))
 - Cache parsed Dsn ([#3796](https://github.com/getsentry/sentry-java/pull/3796))
 - fix invalid profiles when the transaction name is empty ([#3747](https://github.com/getsentry/sentry-java/pull/3747))
 - Deprecate `enableTracing` option ([#3777](https://github.com/getsentry/sentry-java/pull/3777))

--- a/sentry-android-fragment/api/sentry-android-fragment.api
+++ b/sentry-android-fragment/api/sentry-android-fragment.api
@@ -24,6 +24,7 @@ public final class io/sentry/android/fragment/FragmentLifecycleIntegration : and
 public final class io/sentry/android/fragment/FragmentLifecycleState : java/lang/Enum {
 	public static final field ATTACHED Lio/sentry/android/fragment/FragmentLifecycleState;
 	public static final field CREATED Lio/sentry/android/fragment/FragmentLifecycleState;
+	public static final field Companion Lio/sentry/android/fragment/FragmentLifecycleState$Companion;
 	public static final field DESTROYED Lio/sentry/android/fragment/FragmentLifecycleState;
 	public static final field DETACHED Lio/sentry/android/fragment/FragmentLifecycleState;
 	public static final field PAUSED Lio/sentry/android/fragment/FragmentLifecycleState;
@@ -35,6 +36,10 @@ public final class io/sentry/android/fragment/FragmentLifecycleState : java/lang
 	public static final field VIEW_DESTROYED Lio/sentry/android/fragment/FragmentLifecycleState;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/android/fragment/FragmentLifecycleState;
 	public static fun values ()[Lio/sentry/android/fragment/FragmentLifecycleState;
+}
+
+public final class io/sentry/android/fragment/FragmentLifecycleState$Companion {
+	public final fun getStates ()Ljava/util/HashSet;
 }
 
 public final class io/sentry/android/fragment/SentryFragmentLifecycleCallbacks : androidx/fragment/app/FragmentManager$FragmentLifecycleCallbacks {

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleIntegration.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleIntegration.kt
@@ -24,7 +24,7 @@ class FragmentLifecycleIntegration(
 
     constructor(application: Application) : this(
         application = application,
-        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.values().toSet(),
+        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.states,
         enableAutoFragmentLifecycleTracing = false
     )
 
@@ -34,7 +34,7 @@ class FragmentLifecycleIntegration(
         enableAutoFragmentLifecycleTracing: Boolean
     ) : this(
         application = application,
-        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.values().toSet()
+        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.states
             .takeIf { enableFragmentLifecycleBreadcrumbs }
             .orEmpty(),
         enableAutoFragmentLifecycleTracing = enableAutoFragmentLifecycleTracing

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleState.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/FragmentLifecycleState.kt
@@ -11,5 +11,21 @@ enum class FragmentLifecycleState(internal val breadcrumbName: String) {
     STOPPED("stopped"),
     VIEW_DESTROYED("view destroyed"),
     DESTROYED("destroyed"),
-    DETACHED("detached")
+    DETACHED("detached");
+
+    companion object {
+        val states = HashSet<FragmentLifecycleState>().apply {
+            add(ATTACHED)
+            add(SAVE_INSTANCE_STATE)
+            add(CREATED)
+            add(VIEW_CREATED)
+            add(STARTED)
+            add(RESUMED)
+            add(PAUSED)
+            add(STOPPED)
+            add(VIEW_DESTROYED)
+            add(DESTROYED)
+            add(DETACHED)
+        }
+    }
 }

--- a/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
+++ b/sentry-android-fragment/src/main/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacks.kt
@@ -31,7 +31,7 @@ class SentryFragmentLifecycleCallbacks(
         enableAutoFragmentLifecycleTracing: Boolean
     ) : this(
         hub = hub,
-        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.values().toSet()
+        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.states
             .takeIf { enableFragmentLifecycleBreadcrumbs }
             .orEmpty(),
         enableAutoFragmentLifecycleTracing = enableAutoFragmentLifecycleTracing
@@ -42,7 +42,7 @@ class SentryFragmentLifecycleCallbacks(
         enableAutoFragmentLifecycleTracing: Boolean = false
     ) : this(
         hub = HubAdapter.getInstance(),
-        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.values().toSet()
+        filterFragmentLifecycleBreadcrumbs = FragmentLifecycleState.states
             .takeIf { enableFragmentLifecycleBreadcrumbs }
             .orEmpty(),
         enableAutoFragmentLifecycleTracing = enableAutoFragmentLifecycleTracing

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/FragmentLifecycleStateTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/FragmentLifecycleStateTest.kt
@@ -1,0 +1,11 @@
+package io.sentry.android.fragment
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FragmentLifecycleStateTest {
+    @Test
+    fun `states contains all states`() {
+        assertEquals(FragmentLifecycleState.states, FragmentLifecycleState.values().toSet())
+    }
+}

--- a/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
+++ b/sentry-android-fragment/src/test/java/io/sentry/android/fragment/SentryFragmentLifecycleCallbacksTest.kt
@@ -40,7 +40,7 @@ class SentryFragmentLifecycleCallbacksTest {
         val span = mock<ISpan>()
 
         fun getSut(
-            loggedFragmentLifecycleStates: Set<FragmentLifecycleState> = FragmentLifecycleState.values().toSet(),
+            loggedFragmentLifecycleStates: Set<FragmentLifecycleState> = FragmentLifecycleState.states,
             enableAutoFragmentLifecycleTracing: Boolean = false,
             tracesSampleRate: Double? = 1.0,
             isAdded: Boolean = true

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/DefaultReplayBreadcrumbConverter.kt
@@ -12,15 +12,13 @@ import kotlin.LazyThreadSafetyMode.NONE
 public open class DefaultReplayBreadcrumbConverter : ReplayBreadcrumbConverter {
     internal companion object {
         private val snakecasePattern by lazy(NONE) { "_[a-z]".toRegex() }
-        private val supportedNetworkData by lazy(NONE) {
-            setOf(
-                "status_code",
-                "method",
-                "response_content_length",
-                "request_content_length",
-                "http.response_content_length",
-                "http.request_content_length"
-            )
+        private val supportedNetworkData = HashSet<String>().apply {
+            add("status_code")
+            add("method")
+            add("response_content_length")
+            add("request_content_length")
+            add("http.response_content_length")
+            add("http.request_content_length")
         }
     }
 


### PR DESCRIPTION
## :scroll: Description
replaced kotlin setOf() with HashSet<>() + add() calls

setOf() was taking ~10ms to run, while instantiating an HashSet and then calling add multiple times is almost instantaneous - at least in debug builds


## :bulb: Motivation and Context


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
