### PR TITLE
[QA] Load lazy fields on init in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Load lazy fields on init in the background ([#3803](https://github.com/getsentry/sentry-java/pull/3803))
+- Replace setOf with HashSet.add ([#3801](https://github.com/getsentry/sentry-java/pull/3801))
+
 ## 7.16.0-alpha.1
 
 ### Features
@@ -8,7 +15,6 @@
 
 ### Fixes
 
-- Replace setOf with HashSet.add ([#3801](https://github.com/getsentry/sentry-java/pull/3801))
 - Cache parsed Dsn ([#3796](https://github.com/getsentry/sentry-java/pull/3796))
 - fix invalid profiles when the transaction name is empty ([#3747](https://github.com/getsentry/sentry-java/pull/3747))
 - Deprecate `enableTracing` option ([#3777](https://github.com/getsentry/sentry-java/pull/3777))

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -217,6 +217,7 @@ public final class Sentry {
    * @param options options the SentryOptions
    * @param globalHubMode the globalHubMode
    */
+  @SuppressWarnings("Convert2MethodRef") // older AGP versions do not support method references
   private static synchronized void init(
       final @NotNull SentryOptions options, final boolean globalHubMode) {
     if (isEnabled()) {
@@ -230,6 +231,9 @@ public final class Sentry {
     if (!initConfigurations(options)) {
       return;
     }
+
+    // load lazy fields of the options in a separate thread
+    new Thread(() -> options.loadLazyFields()).start();
 
     options.getLogger().log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubMode));
     Sentry.globalHubMode = globalHubMode;

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2451,6 +2451,17 @@ public class SentryOptions {
     this.enableScreenTracking = enableScreenTracking;
   }
 
+  /**
+   * Load the lazy fields. Useful to load in the background, so that results are already cached.
+   * DO NOT CALL THIS METHOD ON THE MAIN THREAD.
+   */
+  void loadLazyFields() {
+    getSerializer();
+    getParsedDsn();
+    getEnvelopeReader();
+    getDateProvider();
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2452,8 +2452,8 @@ public class SentryOptions {
   }
 
   /**
-   * Load the lazy fields. Useful to load in the background, so that results are already cached.
-   * DO NOT CALL THIS METHOD ON THE MAIN THREAD.
+   * Load the lazy fields. Useful to load in the background, so that results are already cached. DO
+   * NOT CALL THIS METHOD ON THE MAIN THREAD.
    */
   void loadLazyFields() {
     getSerializer();


### PR DESCRIPTION
## :scroll: Description
Lazy fields in SentryOptions are now loaded on init in the background


## :bulb: Motivation and Context
Instead of loading the options fields backed by LazyEvaluator when needed, we do it in the background as soon as we can. When the SDK will need these fields, they will be already cached and ready to use

This improved init() by ~5-15ms in profileable builds 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
