### PR TITLE
Add `globalHubMode` to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `globalHubMode` to options ([#3805](https://github.com/getsentry/sentry-java/pull/3805))
+  - `globalHubMode` used to only be a param on `Sentry.init`. To make it easier to be used in e.g. Desktop environments, we now additionally added it as an option on SentryOptions that can also be set via `sentry.properties`.
+  - If both the param on `Sentry.init` and the option are set, the option will win. By default the option is set to `null` meaning whatever is passed to `Sentry.init` takes effect.
+
 ## 8.0.0-beta.1
 
 ### Breaking Changes

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -174,6 +174,7 @@ class SentryAutoConfigurationTest {
             "sentry.enable-spotlight=true",
             "sentry.spotlight-connection-url=http://local.sentry.io:1234",
             "sentry.force-init=true",
+            "sentry.global-hub-mode=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
             "sentry.cron.default-timezone=America/New_York",
@@ -211,6 +212,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)
+            assertThat(options.isGlobalHubMode).isEqualTo(true)
             assertThat(options.isEnableSpotlight).isEqualTo(true)
             assertThat(options.spotlightConnectionUrl).isEqualTo("http://local.sentry.io:1234")
             assertThat(options.cron).isNotNull

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -173,6 +173,7 @@ class SentryAutoConfigurationTest {
             "sentry.enable-spotlight=true",
             "sentry.spotlight-connection-url=http://local.sentry.io:1234",
             "sentry.force-init=true",
+            "sentry.global-hub-mode=true",
             "sentry.cron.default-checkin-margin=10",
             "sentry.cron.default-max-runtime=30",
             "sentry.cron.default-timezone=America/New_York",
@@ -210,6 +211,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.ignoredCheckIns).containsOnly("slug1", "slugB")
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)
+            assertThat(options.isGlobalHubMode).isEqualTo(true)
             assertThat(options.isEnableSpotlight).isEqualTo(true)
             assertThat(options.spotlightConnectionUrl).isEqualTo("http://local.sentry.io:1234")
             assertThat(options.cron).isNotNull

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -473,6 +473,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isEnableSpotlight ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
 	public fun isForceInit ()Ljava/lang/Boolean;
+	public fun isGlobalHubMode ()Ljava/lang/Boolean;
 	public fun isSendDefaultPii ()Ljava/lang/Boolean;
 	public fun isSendModules ()Ljava/lang/Boolean;
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
@@ -487,6 +488,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setEnabled (Ljava/lang/Boolean;)V
 	public fun setEnvironment (Ljava/lang/String;)V
 	public fun setForceInit (Ljava/lang/Boolean;)V
+	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
@@ -2891,6 +2893,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableUserInteractionTracing ()Z
 	public fun isEnabled ()Z
 	public fun isForceInit ()Z
+	public fun isGlobalHubMode ()Ljava/lang/Boolean;
 	public fun isPrintUncaughtStackTrace ()Z
 	public fun isProfilingEnabled ()Z
 	public fun isSendClientReports ()Z
@@ -2943,6 +2946,7 @@ public class io/sentry/SentryOptions {
 	public fun setForceInit (Z)V
 	public fun setFullyDisplayedReporter (Lio/sentry/FullyDisplayedReporter;)V
 	public fun setGestureTargetLocators (Ljava/util/List;)V
+	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
 	public fun setIgnoredSpanOrigins (Ljava/util/List;)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -52,6 +52,7 @@ public final class ExternalOptions {
   private @Nullable Boolean sendModules;
   private @Nullable Boolean sendDefaultPii;
   private @Nullable Boolean enableBackpressureHandling;
+  private @Nullable Boolean globalHubMode;
   private @Nullable Boolean forceInit;
 
   private @Nullable SentryOptions.Cron cron;
@@ -140,6 +141,8 @@ public final class ExternalOptions {
 
     options.setEnableBackpressureHandling(
         propertiesProvider.getBooleanProperty("enable-backpressure-handling"));
+
+    options.setGlobalHubMode(propertiesProvider.getBooleanProperty("global-hub-mode"));
 
     for (final String ignoredExceptionType :
         propertiesProvider.getList("ignored-exceptions-for-type")) {
@@ -435,6 +438,15 @@ public final class ExternalOptions {
   @ApiStatus.Experimental
   public @Nullable Boolean isEnableBackpressureHandling() {
     return enableBackpressureHandling;
+  }
+
+  public void setGlobalHubMode(final @Nullable Boolean globalHubMode) {
+    this.globalHubMode = globalHubMode;
+  }
+
+  @ApiStatus.Experimental
+  public @Nullable Boolean isGlobalHubMode() {
+    return globalHubMode;
   }
 
   public void setForceInit(final @Nullable Boolean forceInit) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -267,7 +267,6 @@ public final class Sentry {
   @SuppressWarnings("deprecation")
   private static void init(final @NotNull SentryOptions options, final boolean globalHubMode) {
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
-
       if (!options.getClass().getName().equals("io.sentry.android.core.SentryAndroidOptions")
           && Platform.isAndroid()) {
         throw new IllegalArgumentException(
@@ -279,10 +278,12 @@ public final class Sentry {
         return;
       }
 
+      final boolean globalHubModeToUse =
+          options.isGlobalHubMode() != null ? options.isGlobalHubMode() : globalHubMode;
       options
           .getLogger()
-          .log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubMode));
-      Sentry.globalHubMode = globalHubMode;
+          .log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubModeToUse));
+      Sentry.globalHubMode = globalHubModeToUse;
       final boolean shouldInit =
           InitUtil.shouldInit(globalScope.getOptions(), options, isEnabled());
       if (shouldInit) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -278,8 +278,9 @@ public final class Sentry {
         return;
       }
 
+      final @Nullable Boolean globalHubModeFromOptions = options.isGlobalHubMode();
       final boolean globalHubModeToUse =
-          options.isGlobalHubMode() != null ? options.isGlobalHubMode() : globalHubMode;
+          globalHubModeFromOptions != null ? globalHubModeFromOptions : globalHubMode;
       options
           .getLogger()
           .log(SentryLevel.INFO, "GlobalHubMode: '%s'", String.valueOf(globalHubModeToUse));

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -2381,7 +2381,8 @@ public class SentryOptions {
    * <p>If this is set to something other than `null`, it will take precedence over what is passed
    * to Sentry.init.
    *
-   * <p>Enabling this is intended for mobile and desktop apps, not backends.
+   * <p>Enabling this is intended for mobile and desktop apps, not backends. For Android the default
+   * value passed to Sentry.init is true (globalHubMode enabled), for backends it defaults to false.
    *
    * @param globalHubMode true = automatic scope forking is disabled
    */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -496,6 +496,9 @@ public class SentryOptions {
 
   private boolean forceInit = false;
 
+  // TODO replace hub in name
+  private @Nullable Boolean globalHubMode = null;
+
   protected final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
 
   /**
@@ -2370,6 +2373,26 @@ public class SentryOptions {
     return forceInit;
   }
 
+  /**
+   * If set to true, automatic scope forking will be disabled. If set to false, scopes will be
+   * forked automatically, e.g. when scopes are accessed on a thread for the first time, pushScope
+   * is invoked, in some cases when we explicitly want to fork the root scopes, etc.
+   *
+   * <p>If this is set to something other than `null`, it will take precedence over what is passed
+   * to Sentry.init.
+   *
+   * <p>Enabling this is intended for mobile and desktop apps, not backends.
+   *
+   * @param globalHubMode true = automatic scope forking is disabled
+   */
+  public void setGlobalHubMode(final @Nullable Boolean globalHubMode) {
+    this.globalHubMode = globalHubMode;
+  }
+
+  public @Nullable Boolean isGlobalHubMode() {
+    return globalHubMode;
+  }
+
   /** The BeforeSend callback */
   public interface BeforeSendCallback {
 
@@ -2632,6 +2655,10 @@ public class SentryOptions {
 
     if (options.getSpotlightConnectionUrl() != null) {
       setSpotlightConnectionUrl(options.getSpotlightConnectionUrl());
+    }
+
+    if (options.isGlobalHubMode() != null) {
+      setGlobalHubMode(options.isGlobalHubMode());
     }
 
     if (options.getCron() != null) {

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -307,6 +307,20 @@ class ExternalOptionsTest {
         }
     }
 
+    @Test
+    fun `creates options with globalHubMode set to true`() {
+        withPropertiesFile("global-hub-mode=true") { options ->
+            assertTrue(options.isGlobalHubMode == true)
+        }
+    }
+
+    @Test
+    fun `creates options with globalHubMode set to false`() {
+        withPropertiesFile("global-hub-mode=false") { options ->
+            assertTrue(options.isGlobalHubMode == false)
+        }
+    }
+
     private fun withPropertiesFile(textLines: List<String> = emptyList(), logger: ILogger = mock(), fn: (ExternalOptions) -> Unit) {
         // create a sentry.properties file in temporary folder
         val temporaryFolder = TemporaryFolder()

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -338,6 +338,7 @@ class SentryOptionsTest {
         }
         externalOptions.isEnableSpotlight = true
         externalOptions.spotlightConnectionUrl = "http://local.sentry.io:1234"
+        externalOptions.isGlobalHubMode = true
 
         val options = SentryOptions()
 
@@ -379,6 +380,7 @@ class SentryOptionsTest {
         assertEquals(RequestSize.MEDIUM, options.maxRequestBodySize)
         assertTrue(options.isEnableSpotlight)
         assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
+        assertTrue(options.isGlobalHubMode!!)
     }
 
     @Test
@@ -545,6 +547,11 @@ class SentryOptionsTest {
     @Test
     fun `when options are initialized, enableAppStartProfiling is set to false by default`() {
         assertFalse(SentryOptions().isEnableAppStartProfiling)
+    }
+
+    @Test
+    fun `when options are initialized, isGlobalHubMode is set to null by default`() {
+        assertNull(SentryOptions().isGlobalHubMode)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -49,7 +49,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SentryTest {
@@ -1241,6 +1243,38 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
         }
+    }
+
+    @Test
+    fun `if globalHubMode on options is not set, uses false from init param`() {
+        Sentry.init({ o -> o.dsn = dsn }, false)
+        val s1 = Sentry.forkedRootScopes("s1")
+        val s2 = Sentry.forkedRootScopes("s2")
+        assertNotSame(s1, s2)
+    }
+
+    @Test
+    fun `if globalHubMode on options is not set, uses true from init param`() {
+        Sentry.init({ o -> o.dsn = dsn }, true)
+        val s1 = Sentry.forkedRootScopes("s1")
+        val s2 = Sentry.forkedRootScopes("s2")
+        assertSame(s1, s2)
+    }
+
+    @Test
+    fun `if globalHubMode on options is set, ignores false from init param`() {
+        Sentry.init({ o -> o.dsn = dsn; o.isGlobalHubMode = true }, false)
+        val s1 = Sentry.forkedRootScopes("s1")
+        val s2 = Sentry.forkedRootScopes("s2")
+        assertSame(s1, s2)
+    }
+
+    @Test
+    fun `if globalHubMode on options is set, ignores true from init param`() {
+        Sentry.init({ o -> o.dsn = dsn; o.isGlobalHubMode = false }, true)
+        val s1 = Sentry.forkedRootScopes("s1")
+        val s2 = Sentry.forkedRootScopes("s2")
+        assertNotSame(s1, s2)
     }
 
     private class InMemoryOptionsObserver : IOptionsObserver {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`globalHubMode` used to only be a param on `Sentry.init`. To make it easier to be used in e.g. Desktop environments, we now additionally added it as an option on `SentryOptions` that can also be set via `sentry.properties`.

We can consider deprecating and removing the `Sentry.init` overloads that have the `globalHubMode` parameter.

If both the param on `Sentry.init` and the option are set, the option will win. By default the option is set to `null` meaning whatever is passed to `Sentry.init` wins.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3779

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
