### PR TITLE
Update CodeQL for sentry-java 8.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,8 +20,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: ['cpp', 'java']
 
     steps:
       - name: Checkout Repo
@@ -45,12 +43,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - if: matrix.language == 'cpp'
-        name: Build Cpp
-        run: |
-          ./gradlew sentry-android-ndk:buildCMakeRelWithDebInfo
-      - if: matrix.language == 'java'
-        name: Build Java
+      - name: Build Java
         run: |
           ./gradlew buildForCodeQL
 


### PR DESCRIPTION
## :scroll: Description

With 8.x we won't have sentry-native as a submodule anymore, thus there's no need to run cpp codeql.

#skip-changelog