### PR TITLE
(Android) Enable Performance V2 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   - `globalHubMode` used to only be a param on `Sentry.init`. To make it easier to be used in e.g. Desktop environments, we now additionally added it as an option on SentryOptions that can also be set via `sentry.properties`.
   - If both the param on `Sentry.init` and the option are set, the option will win. By default the option is set to `null` meaning whatever is passed to `Sentry.init` takes effect.
 
+### Behavioural Changes
+
+- (Android) Performance V2 is enabled by default ([#](https://github.com/getsentry/sentry-java/pull/))
+  - With this change cold app start spans will include spans for ContentProviders, Application and Activity load.
+
 ## 8.0.0-beta.1
 
 ### Breaking Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -206,7 +206,7 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   private boolean attachAnrThreadDump = false;
 
-  private boolean enablePerformanceV2 = false;
+  private boolean enablePerformanceV2 = true;
 
   private @Nullable SentryFrameMetricsCollector frameMetricsCollector;
 
@@ -555,20 +555,18 @@ public final class SentryAndroidOptions extends SentryOptions {
    * @return true if performance-v2 is enabled. See {@link #setEnablePerformanceV2(boolean)} for
    *     more details.
    */
-  @ApiStatus.Experimental
   public boolean isEnablePerformanceV2() {
     return enablePerformanceV2;
   }
 
   /**
-   * Experimental: Enables or disables the Performance V2 SDK features.
+   * Enables or disables the Performance V2 SDK features.
    *
    * <p>With this change - Cold app start spans will provide more accurate timings - Cold app start
    * spans will be enriched with detailed ContentProvider, Application and Activity startup times
    *
    * @param enablePerformanceV2 true if enabled or false otherwise
    */
-  @ApiStatus.Experimental
   public void setEnablePerformanceV2(final boolean enablePerformanceV2) {
     this.enablePerformanceV2 = enablePerformanceV2;
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1185,14 +1185,14 @@ class ManifestMetadataReaderTest {
     @Test
     fun `applyMetadata reads performance-v2 flag to options`() {
         // Arrange
-        val bundle = bundleOf(ManifestMetadataReader.ENABLE_PERFORMANCE_V2 to true)
+        val bundle = bundleOf(ManifestMetadataReader.ENABLE_PERFORMANCE_V2 to false)
         val context = fixture.getContext(metaData = bundle)
 
         // Act
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertTrue(fixture.options.isEnablePerformanceV2)
+        assertFalse(fixture.options.isEnablePerformanceV2)
     }
 
     @Test
@@ -1204,7 +1204,7 @@ class ManifestMetadataReaderTest {
         ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
 
         // Assert
-        assertFalse(fixture.options.isEnablePerformanceV2)
+        assertTrue(fixture.options.isEnablePerformanceV2)
     }
 
     @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -151,16 +151,16 @@ class SentryAndroidOptionsTest {
     }
 
     @Test
-    fun `performance v2 is disabled by default`() {
+    fun `performance v2 is enabled by default`() {
         val sentryOptions = SentryAndroidOptions()
-        assertFalse(sentryOptions.isEnablePerformanceV2)
+        assertTrue(sentryOptions.isEnablePerformanceV2)
     }
 
     @Test
-    fun `performance v2 can be enabled`() {
+    fun `performance v2 can be disabled`() {
         val sentryOptions = SentryAndroidOptions()
-        sentryOptions.isEnablePerformanceV2 = true
-        assertTrue(sentryOptions.isEnablePerformanceV2)
+        sentryOptions.isEnablePerformanceV2 = false
+        assertFalse(sentryOptions.isEnablePerformanceV2)
     }
 
     fun `when options is initialized, enableScopeSync is enabled by default`() {


### PR DESCRIPTION
## :scroll: Description
Performance V2 is enabled by default


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/3563


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
