### PR TITLE
ActivityLifecycleIntegration now sets cold or warm start type if not …

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -661,16 +661,17 @@ public final class ActivityLifecycleIntegration
       lastPausedTime = AndroidDateUtils.getCurrentSentryDateTime();
     }
     if (!firstActivityCreated) {
+      final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
       // if Activity has savedInstanceState then its a warm start
       // https://developer.android.com/topic/performance/vitals/launch-time#warm
       // SentryPerformanceProvider sets this already
       // pre-performance-v2: back-fill with best guess
-      if (options != null && !options.isEnablePerformanceV2()) {
-        AppStartMetrics.getInstance()
-            .setAppStartType(
-                savedInstanceState == null
-                    ? AppStartMetrics.AppStartType.COLD
-                    : AppStartMetrics.AppStartType.WARM);
+      if ((options != null && !options.isEnablePerformanceV2())
+          || appStartMetrics.getAppStartType() == AppStartMetrics.AppStartType.UNKNOWN) {
+        appStartMetrics.setAppStartType(
+            savedInstanceState == null
+                ? AppStartMetrics.AppStartType.COLD
+                : AppStartMetrics.AppStartType.WARM);
       }
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityFramesTrackerTest.kt
@@ -30,6 +30,11 @@ class ActivityFramesTrackerTest {
         val handler = mock<MainLooperHandler>()
         val options = SentryAndroidOptions()
 
+        init {
+            // ActivityFramesTracker is used only if performanceV2 is disabled
+            options.isEnablePerformanceV2 = false
+        }
+
         fun getSut(mockAggregator: Boolean = true): ActivityFramesTracker {
             return if (mockAggregator) {
                 ActivityFramesTracker(loadClass, options, handler, aggregator)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -817,6 +817,7 @@ class ActivityLifecycleIntegrationTest {
         val appStartMetrics = AppStartMetrics.getInstance()
         appStartMetrics.appStartType = AppStartType.WARM
         appStartMetrics.sdkInitTimeSpan.setStoppedAt(2)
+        appStartMetrics.appStartTimeSpan.setStoppedAt(2)
 
         val endDate = appStartMetrics.sdkInitTimeSpan.projectedStopTimestamp
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -524,11 +524,30 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `When Activity Frames Tracking is enabled, the Activity Frames Tracker should be available`() {
+    fun `When Activity Frames Tracking is enabled, the Activity Frames Tracker should be unavailable`() {
         fixture.initSut(
             hasAppContext = true,
             useRealContext = true,
             configureOptions = {
+                isEnableFramesTracking = true
+            }
+        )
+
+        val activityLifeCycleIntegration = fixture.sentryOptions.integrations
+            .first { it is ActivityLifecycleIntegration }
+
+        assertFalse(
+            (activityLifeCycleIntegration as ActivityLifecycleIntegration).activityFramesTracker.isFrameMetricsAggregatorAvailable
+        )
+    }
+
+    @Test
+    fun `When Activity Frames Tracking is enabled, the Activity Frames Tracker should be available if perfv2 is false`() {
+        fixture.initSut(
+            hasAppContext = true,
+            useRealContext = true,
+            configureOptions = {
+                isEnablePerformanceV2 = false
                 isEnableFramesTracking = true
             }
         )
@@ -556,12 +575,32 @@ class AndroidOptionsInitializerTest {
     }
 
     @Test
-    fun `When Frames Tracking is initially disabled, but enabled via configureOptions it should be available`() {
+    fun `When Frames Tracking is initially disabled, but enabled via configureOptions it should be unavailable`() {
         fixture.sentryOptions.isEnableFramesTracking = false
         fixture.initSut(
             hasAppContext = true,
             useRealContext = true,
             configureOptions = {
+                isEnableFramesTracking = true
+            }
+        )
+
+        val activityLifeCycleIntegration = fixture.sentryOptions.integrations
+            .first { it is ActivityLifecycleIntegration }
+
+        assertFalse(
+            (activityLifeCycleIntegration as ActivityLifecycleIntegration).activityFramesTracker.isFrameMetricsAggregatorAvailable
+        )
+    }
+
+    @Test
+    fun `When Frames Tracking is initially disabled, but enabled via configureOptions it should be available if perfv2 is false`() {
+        fixture.sentryOptions.isEnableFramesTracking = false
+        fixture.initSut(
+            hasAppContext = true,
+            useRealContext = true,
+            configureOptions = {
+                isEnablePerformanceV2 = false
                 isEnableFramesTracking = true
             }
         )


### PR DESCRIPTION
## :scroll: Description
ActivityLifecycleIntegration now sets cold or warm start type if not set even in perfV2
updated test for perfV2 enabled by default

#skip-changelog

## :bulb: Motivation and Context
Fix tests

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
