### PR TITLE
Use `Random` through `ThreadLocal<Random>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Use a separate `Random` instance per thread to improve SDK performance ([#3835](https://github.com/getsentry/sentry-java/pull/3835))
+
 ### Fixes
 
 - Accept manifest integer values when requiring floating values ([#3823](https://github.com/getsentry/sentry-java/pull/3823))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -55,6 +55,7 @@ import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Random;
+import io.sentry.util.SentryRandom;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -180,7 +181,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
 
     try {
       // we have to sample here with the old sample rate, because it may change between app launches
-      final @NotNull Random random = this.random != null ? this.random : new Random();
+      final @NotNull Random random = this.random != null ? this.random : SentryRandom.current();
       final double replayErrorSampleRateDouble = Double.parseDouble(replayErrorSampleRate);
       if (replayErrorSampleRateDouble < random.nextDouble()) {
         options

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -54,7 +54,6 @@ import io.sentry.protocol.SentryThread;
 import io.sentry.protocol.SentryTransaction;
 import io.sentry.protocol.User;
 import io.sentry.util.HintUtils;
-import io.sentry.util.Random;
 import io.sentry.util.SentryRandom;
 import java.io.File;
 import java.util.ArrayList;
@@ -84,24 +83,13 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
 
   private final @NotNull SentryExceptionFactory sentryExceptionFactory;
 
-  private final @Nullable Random random;
-
   public AnrV2EventProcessor(
       final @NotNull Context context,
       final @NotNull SentryAndroidOptions options,
       final @NotNull BuildInfoProvider buildInfoProvider) {
-    this(context, options, buildInfoProvider, null);
-  }
-
-  AnrV2EventProcessor(
-      final @NotNull Context context,
-      final @NotNull SentryAndroidOptions options,
-      final @NotNull BuildInfoProvider buildInfoProvider,
-      final @Nullable Random random) {
     this.context = ContextUtils.getApplicationContext(context);
     this.options = options;
     this.buildInfoProvider = buildInfoProvider;
-    this.random = random;
 
     final SentryStackTraceFactory sentryStackTraceFactory =
         new SentryStackTraceFactory(this.options);
@@ -181,9 +169,8 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
 
     try {
       // we have to sample here with the old sample rate, because it may change between app launches
-      final @NotNull Random random = this.random != null ? this.random : SentryRandom.current();
       final double replayErrorSampleRateDouble = Double.parseDouble(replayErrorSampleRate);
-      if (replayErrorSampleRateDouble < random.nextDouble()) {
+      if (replayErrorSampleRateDouble < SentryRandom.current().nextDouble()) {
         options
             .getLogger()
             .log(

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5829,6 +5829,11 @@ public final class io/sentry/util/SampleRateUtils {
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;Z)Z
 }
 
+public final class io/sentry/util/SentryRandom {
+	public fun <init> ()V
+	public static fun current ()Lio/sentry/util/Random;
+}
+
 public final class io/sentry/util/StringUtils {
 	public static fun byteCountToString (J)Ljava/lang/String;
 	public static fun calculateStringHash (Ljava/lang/String;Lio/sentry/ILogger;)Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -18,6 +18,7 @@ import io.sentry.util.CheckInUtils;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.Random;
+import io.sentry.util.SentryRandom;
 import io.sentry.util.TracingUtils;
 import java.io.Closeable;
 import java.io.IOException;
@@ -40,7 +41,6 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
 
   private final @NotNull SentryOptions options;
   private final @NotNull ITransport transport;
-  private final @Nullable Random random;
   private final @NotNull SortBreadcrumbsByDate sortBreadcrumbsByDate = new SortBreadcrumbsByDate();
   private final @NotNull IMetricsAggregator metricsAggregator;
 
@@ -66,8 +66,6 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
         options.isEnableMetrics()
             ? new MetricsAggregator(options, this)
             : NoopMetricsAggregator.getInstance();
-
-    this.random = options.getSampleRate() == null ? null : new Random();
   }
 
   private boolean shouldApplyScopeData(
@@ -1183,6 +1181,7 @@ public final class SentryClient implements ISentryClient, IMetricsClient {
   }
 
   private boolean sample() {
+    final @Nullable Random random = options.getSampleRate() == null ? null : SentryRandom.current();
     // https://docs.sentry.io/development/sdk-dev/features/#event-sampling
     if (options.getSampleRate() != null && random != null) {
       final double sampling = options.getSampleRate();

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import io.sentry.util.Objects;
 import io.sentry.util.Random;
+import io.sentry.util.SentryRandom;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -10,14 +11,14 @@ final class TracesSampler {
   private static final @NotNull Double DEFAULT_TRACES_SAMPLE_RATE = 1.0;
 
   private final @NotNull SentryOptions options;
-  private final @NotNull Random random;
+  private final @Nullable Random random;
 
   public TracesSampler(final @NotNull SentryOptions options) {
-    this(Objects.requireNonNull(options, "options are required"), new Random());
+    this(Objects.requireNonNull(options, "options are required"), null);
   }
 
   @TestOnly
-  TracesSampler(final @NotNull SentryOptions options, final @NotNull Random random) {
+  TracesSampler(final @NotNull SentryOptions options, final @Nullable Random random) {
     this.options = options;
     this.random = random;
   }
@@ -90,6 +91,13 @@ final class TracesSampler {
   }
 
   private boolean sample(final @NotNull Double aDouble) {
-    return !(aDouble < random.nextDouble());
+    return !(aDouble < getRandom().nextDouble());
+  }
+
+  private Random getRandom() {
+    if (random == null) {
+      return SentryRandom.current();
+    }
+    return random;
   }
 }

--- a/sentry/src/main/java/io/sentry/util/SentryRandom.java
+++ b/sentry/src/main/java/io/sentry/util/SentryRandom.java
@@ -1,0 +1,20 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class SentryRandom {
+
+  private static final SentryRandomThreadLocal instance = new SentryRandomThreadLocal();
+
+  public static @NotNull Random current() {
+    return instance.get();
+  }
+
+  private static class SentryRandomThreadLocal extends ThreadLocal<Random> {
+
+    @Override
+    protected Random initialValue() {
+      return new Random();
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/util/SentryRandom.java
+++ b/sentry/src/main/java/io/sentry/util/SentryRandom.java
@@ -2,10 +2,27 @@ package io.sentry.util;
 
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * This SentryRandom is a compromise used for improving performance of the SDK.
+ *
+ * <p>We did some testing where using Random from multiple threads degrades performance
+ * significantly. We opted for this approach as it wasn't easily possible to vendor
+ * ThreadLocalRandom since it's using advanced features that can cause java.lang.IllegalAccessError.
+ */
 public final class SentryRandom {
 
-  private static final SentryRandomThreadLocal instance = new SentryRandomThreadLocal();
+  private static final @NotNull SentryRandomThreadLocal instance = new SentryRandomThreadLocal();
 
+  /**
+   * Returns the current threads instance of {@link Random}. An instance of {@link Random} will be
+   * created the first time this is invoked on each thread.
+   *
+   * <p>NOTE: Avoid holding a reference to the returned {@link Random} instance as sharing a
+   * reference across threads (while being thread-safe) will likely degrade performance
+   * significantly.
+   *
+   * @return random
+   */
   public static @NotNull Random current() {
     return instance.get();
   }

--- a/sentry/src/test/java/io/sentry/util/SentryRandomTest.kt
+++ b/sentry/src/test/java/io/sentry/util/SentryRandomTest.kt
@@ -1,0 +1,45 @@
+package io.sentry.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SentryRandomTest {
+
+    @Test
+    fun `thread local creates a new instance per thread but keeps re-using it for the same thread`() {
+        val mainThreadRandom1 = SentryRandom.current()
+        val mainThreadRandom2 = SentryRandom.current()
+        assertEquals(mainThreadRandom1.toString(), mainThreadRandom2.toString())
+
+        var thread1Random1: Random? = null
+        var thread1Random2: Random? = null
+
+        val thread1 = Thread() {
+            thread1Random1 = SentryRandom.current()
+            thread1Random2 = SentryRandom.current()
+        }
+
+        var thread2Random1: Random? = null
+        var thread2Random2: Random? = null
+
+        val thread2 = Thread() {
+            thread2Random1 = SentryRandom.current()
+            thread2Random2 = SentryRandom.current()
+        }
+
+        thread1.start()
+        thread2.start()
+        thread1.join()
+        thread2.join()
+
+        assertEquals(thread1Random1.toString(), thread1Random2.toString())
+        assertNotEquals(mainThreadRandom1.toString(), thread1Random1.toString())
+
+        assertEquals(thread2Random1.toString(), thread2Random2.toString())
+        assertNotEquals(mainThreadRandom1.toString(), thread2Random1.toString())
+
+        val mainThreadRandom3 = SentryRandom.current()
+        assertEquals(mainThreadRandom1.toString(), mainThreadRandom3.toString())
+    }
+}

--- a/sentry/src/test/java/io/sentry/util/SentryRandomTest.kt
+++ b/sentry/src/test/java/io/sentry/util/SentryRandomTest.kt
@@ -1,8 +1,8 @@
 package io.sentry.util
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 
 class SentryRandomTest {
 
@@ -10,7 +10,7 @@ class SentryRandomTest {
     fun `thread local creates a new instance per thread but keeps re-using it for the same thread`() {
         val mainThreadRandom1 = SentryRandom.current()
         val mainThreadRandom2 = SentryRandom.current()
-        assertEquals(mainThreadRandom1.toString(), mainThreadRandom2.toString())
+        assertSame(mainThreadRandom1, mainThreadRandom2)
 
         var thread1Random1: Random? = null
         var thread1Random2: Random? = null
@@ -33,13 +33,13 @@ class SentryRandomTest {
         thread1.join()
         thread2.join()
 
-        assertEquals(thread1Random1.toString(), thread1Random2.toString())
-        assertNotEquals(mainThreadRandom1.toString(), thread1Random1.toString())
+        assertSame(thread1Random1, thread1Random2)
+        assertNotSame(mainThreadRandom1, thread1Random1)
 
-        assertEquals(thread2Random1.toString(), thread2Random2.toString())
-        assertNotEquals(mainThreadRandom1.toString(), thread2Random1.toString())
+        assertSame(thread2Random1, thread2Random2)
+        assertNotSame(mainThreadRandom1, thread2Random1)
 
         val mainThreadRandom3 = SentryRandom.current()
-        assertEquals(mainThreadRandom1.toString(), mainThreadRandom3.toString())
+        assertSame(mainThreadRandom1, mainThreadRandom3)
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Instead of using `Random` directly, we now go through `SentryRandom.current()` which keeps one instance per thread. While there's still some synchronization overhead when compared to `ThreadLocalRandom` it still performs much better than using `Random` from multiple threads directly.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've found reduced performance when using `Random` from multiple threads. While it's thead-safe, it slows down significantly. It'd be even better to use `ThreadLocalRandom` instead, since it has even better performance but we'd risk being flagged in security audits again (`Random` vs. `SecureRandom`).

See https://github.com/getsentry/sentry-java/pull/3818#issuecomment-2445034392 for more details on performance test results.

Vendoring `ThreadLocalRandom` (like we did with `Random`) doesn't seem possible as it's doing some advanced things like using `Unsafe` and `AccessController.doPrivileged` which caused`java.lang.IllegalAccessError: class io.sentry.util.ThreadLocalRandom (in unnamed module @0x58651fd0) cannot access class sun.security.action.GetPropertyAction (in module java.base) because module java.base does not export sun.security.action to unnamed module @0x58651fd0` as well as `java.lang.NoClassDefFoundError: Could not initialize class io.sentry.util.ThreadLocalRandom` when trying to vendor it.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
