### PR TITLE
Fix: Allow MaxBreadcrumb 0  / Expose MaxBreadcrumb metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features
 
-- Add meta option to set the maximum amount of breadcrumbs to be logged. ([#?](https://github.com/getsentry/sentry-java/pull/?))
+- Add meta option to set the maximum amount of breadcrumbs to be logged. ([#3836](https://github.com/getsentry/sentry-java/pull/3836))
 
 ### Fixes
 
-- using MaxBreadcrumb with value 0 no longer crashes. ([#?](https://github.com/getsentry/sentry-java/pull/?))
+- Using MaxBreadcrumb with value 0 no longer crashes. ([#3836](https://github.com/getsentry/sentry-java/pull/3836))
 - Accept manifest integer values when requiring floating values ([#3823](https://github.com/getsentry/sentry-java/pull/3823))
 
 ## 7.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add meta option to set the maximum amount of breadcrumbs to be logged. ([#?](https://github.com/getsentry/sentry-java/pull/?))
+
+
+### Fixes
+
+- using MaxBreadcrumb with value 0 no longer crashes. ([#?](https://github.com/getsentry/sentry-java/pull/?))
+
 ## 7.16.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -216,11 +216,7 @@ final class ManifestMetadataReader {
                 options.getSessionTrackingIntervalMillis()));
 
         options.setMaxBreadcrumbs(
-          (int)readLong(
-            metadata,
-            logger,
-            MAX_BREADCRUMBS,
-            options.getMaxBreadcrumbs()));
+            (int) readLong(metadata, logger, MAX_BREADCRUMBS, options.getMaxBreadcrumbs()));
 
         options.setEnableActivityLifecycleBreadcrumbs(
             readBool(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -104,6 +104,8 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_METRICS = "io.sentry.enable-metrics";
 
+  static final String MAX_BREADCRUMBS = "io.sentry.max-breadcrumbs";
+
   static final String REPLAYS_SESSION_SAMPLE_RATE = "io.sentry.session-replay.session-sample-rate";
 
   static final String REPLAYS_ERROR_SAMPLE_RATE = "io.sentry.session-replay.on-error-sample-rate";
@@ -212,6 +214,13 @@ final class ManifestMetadataReader {
                 logger,
                 SESSION_TRACKING_TIMEOUT_INTERVAL_MILLIS,
                 options.getSessionTrackingIntervalMillis()));
+
+        options.setMaxBreadcrumbs(
+          (int)readLong(
+            metadata,
+            logger,
+            MAX_BREADCRUMBS,
+            options.getMaxBreadcrumbs()));
 
         options.setEnableActivityLifecycleBreadcrumbs(
             readBool(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1517,7 +1517,7 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata reads maxbreadcrumb mask flags to options and sets the value if found`() {
+    fun `applyMetadata reads maxBreadcrumbs to options and sets the value if found`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.MAX_BREADCRUMBS to 1)
         val context = fixture.getContext(metaData = bundle)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1530,7 +1530,7 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
-    fun `applyMetadata reads max breadcrumb mask flags to options and keeps default if not found`() {
+    fun `applyMetadata reads maxBreadcrumbs to options and keeps default if not found`() {
         // Arrange
         val context = fixture.getContext()
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1515,4 +1515,30 @@ class ManifestMetadataReaderTest {
         assertTrue(fixture.options.experimental.sessionReplay.maskViewClasses.contains(SentryReplayOptions.IMAGE_VIEW_CLASS_NAME))
         assertTrue(fixture.options.experimental.sessionReplay.maskViewClasses.contains(SentryReplayOptions.TEXT_VIEW_CLASS_NAME))
     }
+
+    @Test
+    fun `applyMetadata reads maxbreadcrumb mask flags to options and sets the value if found`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.MAX_BREADCRUMBS to 1)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(1, fixture.options.maxBreadcrumbs)
+    }
+
+    @Test
+    fun `applyMetadata reads max breadcrumb mask flags to options and keeps default if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(100, fixture.options.maxBreadcrumbs)
+    }
+
 }

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -152,6 +152,9 @@
         <!--    how to enable the attach screenshot feature-->
         <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
 
+        <!--    how many breadcrumbs will be stored-->
+        <meta-data android:name="io.sentry.max-breadcrumbs" android:value="100"/>
+
         <!--    how to enable the attach view hierarchy feature-->
         <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
 

--- a/sentry/src/main/java/io/sentry/DisabledQueue.java
+++ b/sentry/src/main/java/io/sentry/DisabledQueue.java
@@ -1,19 +1,20 @@
 package io.sentry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.AbstractCollection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Queue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>, Serializable {
+final class DisabledQueue<E> extends AbstractCollection<E> implements Queue<E>, Serializable {
 
   /** Serialization version. */
   private static final long serialVersionUID = -8423413834657610417L;
 
   /** Constructor that creates a queue that does not accept any element. */
-  public DisabledQueue() { }
+  public DisabledQueue() {}
 
   // -----------------------------------------------------------------------
   /**
@@ -22,7 +23,9 @@ final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>,
    * @return this queue's size
    */
   @Override
-  public int size() { return 0; }
+  public int size() {
+    return 0;
+  }
 
   /**
    * Returns true if this queue is empty; false otherwise.
@@ -30,11 +33,13 @@ final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>,
    * @return false
    */
   @Override
-  public boolean isEmpty() { return false; }
+  public boolean isEmpty() {
+    return false;
+  }
 
   /** Does nothing. */
   @Override
-  public void clear() { }
+  public void clear() {}
 
   /**
    * Since the queue is disabled, the element will not be added.
@@ -43,7 +48,9 @@ final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>,
    * @return false, always
    */
   @Override
-  public boolean add(final @NotNull E element) { return false; }
+  public boolean add(final @NotNull E element) {
+    return false;
+  }
 
   // -----------------------------------------------------------------------
 
@@ -59,16 +66,24 @@ final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>,
   }
 
   @Override
-  public @Nullable E poll() { return null; }
+  public @Nullable E poll() {
+    return null;
+  }
 
   @Override
-  public @Nullable E element() { return null; }
+  public @Nullable E element() {
+    return null;
+  }
 
   @Override
-  public @Nullable E peek() { return null; }
+  public @Nullable E peek() {
+    return null;
+  }
 
   @Override
-  public @NotNull E remove() { throw new NoSuchElementException("queue is disabled"); }
+  public @NotNull E remove() {
+    throw new NoSuchElementException("queue is disabled");
+  }
 
   // -----------------------------------------------------------------------
 
@@ -93,8 +108,8 @@ final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>,
 
       @Override
       public void remove() {
-          throw new IllegalStateException();
-        }
+        throw new IllegalStateException();
+      }
     };
   }
 }

--- a/sentry/src/main/java/io/sentry/DisabledQueue.java
+++ b/sentry/src/main/java/io/sentry/DisabledQueue.java
@@ -1,0 +1,100 @@
+package io.sentry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+final class DisabledQueue <E> extends AbstractCollection<E> implements Queue<E>, Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = -8423413834657610417L;
+
+  /** Constructor that creates a queue that does not accept any element. */
+  public DisabledQueue() { }
+
+  // -----------------------------------------------------------------------
+  /**
+   * Returns the number of elements stored in the queue.
+   *
+   * @return this queue's size
+   */
+  @Override
+  public int size() { return 0; }
+
+  /**
+   * Returns true if this queue is empty; false otherwise.
+   *
+   * @return false
+   */
+  @Override
+  public boolean isEmpty() { return false; }
+
+  /** Does nothing. */
+  @Override
+  public void clear() { }
+
+  /**
+   * Since the queue is disabled, the element will not be added.
+   *
+   * @param element the element to add
+   * @return false, always
+   */
+  @Override
+  public boolean add(final @NotNull E element) { return false; }
+
+  // -----------------------------------------------------------------------
+
+  /**
+   * Receives an element but do nothing with it.
+   *
+   * @param element the element to add
+   * @return false, always
+   */
+  @Override
+  public boolean offer(@NotNull E element) {
+    return false;
+  }
+
+  @Override
+  public @Nullable E poll() { return null; }
+
+  @Override
+  public @Nullable E element() { return null; }
+
+  @Override
+  public @Nullable E peek() { return null; }
+
+  @Override
+  public @NotNull E remove() { throw new NoSuchElementException("queue is disabled"); }
+
+  // -----------------------------------------------------------------------
+
+  /**
+   * Returns an iterator over this queue's elements.
+   *
+   * @return an iterator over this queue's elements
+   */
+  @Override
+  public @NotNull Iterator<E> iterator() {
+    return new Iterator<E>() {
+
+      @Override
+      public boolean hasNext() {
+        return false;
+      }
+
+      @Override
+      public E next() {
+        throw new NoSuchElementException();
+      }
+
+      @Override
+      public void remove() {
+          throw new IllegalStateException();
+        }
+    };
+  }
+}

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -754,9 +754,9 @@ public final class Scope implements IScope {
    * @return the breadcrumbs queue
    */
   private @NotNull Queue<Breadcrumb> createBreadcrumbsList(final int maxBreadcrumb) {
-    return maxBreadcrumb > 0 ?
-      SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxBreadcrumb)) :
-      SynchronizedQueue.synchronizedQueue(new DisabledQueue<>());
+    return maxBreadcrumb > 0
+        ? SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxBreadcrumb))
+        : SynchronizedQueue.synchronizedQueue(new DisabledQueue<>());
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -754,7 +754,9 @@ public final class Scope implements IScope {
    * @return the breadcrumbs queue
    */
   private @NotNull Queue<Breadcrumb> createBreadcrumbsList(final int maxBreadcrumb) {
-    return SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxBreadcrumb));
+    return maxBreadcrumb > 0 ?
+      SynchronizedQueue.synchronizedQueue(new CircularFifoQueue<>(maxBreadcrumb)) :
+      SynchronizedQueue.synchronizedQueue(new DisabledQueue<>());
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
+++ b/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
@@ -1,0 +1,93 @@
+package io.sentry
+import org.junit.Assert.assertThrows
+import java.util.NoSuchElementException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class DisabledQueueTest {
+
+    @Test
+    fun `size starts empty`() {
+        val queue = DisabledQueue<Int>()
+        assertEquals(0, queue.size, "Size should always be zero.")
+    }
+
+    @Test
+    fun `add does not add elements`() {
+        val queue = DisabledQueue<Int>()
+        assertFalse(queue.add(1), "add should always return false.")
+        assertEquals(0, queue.size, "Size should still be zero after attempting to add an element.")
+    }
+
+    @Test
+    fun `isEmpty returns false when created`() {
+        val queue = DisabledQueue<Int>()
+        assertFalse(queue.isEmpty(), "isEmpty should always return false.")
+    }
+
+    @Test
+    fun `isEmpty always returns false if add function was called`() {
+        val queue = DisabledQueue<Int>()
+        queue.add(1);
+
+        assertFalse(queue.isEmpty(), "isEmpty should always return false.")
+    }
+
+    @Test
+    fun `offer does not add elements`() {
+        val queue = DisabledQueue<Int>()
+        assertFalse(queue.offer(1), "offer should always return false.")
+        assertEquals(0, queue.size, "Size should still be zero after attempting to offer an element.")
+    }
+
+    @Test
+    fun `poll returns null`() {
+        val queue = DisabledQueue<Int>()
+        queue.add(1);
+        assertNull(queue.poll(), "poll should always return null.")
+    }
+
+    @Test
+    fun `peek returns null`() {
+        val queue = DisabledQueue<Int>()
+        queue.add(1);
+
+        assertNull(queue.peek(), "peek should always return null.")
+    }
+
+    @Test
+    fun `element returns null`() {
+        val queue = DisabledQueue<Int>()
+        assertNull(queue.element(), "element should always return null.")
+    }
+
+    @Test
+    fun `remove throws NoSuchElementException`() {
+        val queue = DisabledQueue<Int>()
+        assertThrows(NoSuchElementException::class.java) { queue.remove() }
+    }
+
+    @Test
+    fun `clear does nothing`() {
+        val queue = DisabledQueue<Int>()
+        queue.clear() // Should not throw an exception
+        assertEquals(0, queue.size, "Size should remain zero after clear.")
+    }
+
+    @Test
+    fun `iterator has no elements`() {
+        val queue = DisabledQueue<Int>()
+        val iterator = queue.iterator()
+        assertFalse(iterator.hasNext(), "Iterator should have no elements.")
+        assertThrows(NoSuchElementException::class.java) { iterator.next() }
+    }
+
+    @Test
+    fun `iterator remove throws IllegalStateException`() {
+        val queue = DisabledQueue<Int>()
+        val iterator = queue.iterator()
+        assertThrows(IllegalStateException::class.java) { iterator.remove() }
+    }
+}

--- a/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
+++ b/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
@@ -30,7 +30,7 @@ class DisabledQueueTest {
     @Test
     fun `isEmpty always returns false if add function was called`() {
         val queue = DisabledQueue<Int>()
-        queue.add(1);
+        queue.add(1)
 
         assertFalse(queue.isEmpty(), "isEmpty should always return false.")
     }
@@ -45,14 +45,14 @@ class DisabledQueueTest {
     @Test
     fun `poll returns null`() {
         val queue = DisabledQueue<Int>()
-        queue.add(1);
+        queue.add(1)
         assertNull(queue.poll(), "poll should always return null.")
     }
 
     @Test
     fun `peek returns null`() {
         val queue = DisabledQueue<Int>()
-        queue.add(1);
+        queue.add(1)
 
         assertNull(queue.peek(), "peek should always return null.")
     }

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -1029,6 +1029,17 @@ class ScopeTest {
         )
     }
 
+    @Test
+    fun `creating a new scope won't crash if max breadcrumbs is set to zero`() {
+        val options = SentryOptions().apply {
+            maxBreadcrumbs = 0
+        }
+        val scope = Scope(options)
+
+        // expect no exception to be thrown
+        // previously was crashing, see https://github.com/getsentry/sentry-java/issues/3313
+    }
+
     private fun eventProcessor(): EventProcessor {
         return object : EventProcessor {
             override fun process(event: SentryEvent, hint: Hint): SentryEvent? {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Previously, when MaxBreadcrumbs was set to 0, the app would crash since the CircularQueue implementation must have a size higher than 0.
With that, I made a `disabledqueue` that behaves similarly like `CircularQueue` do, with the difference that any items inserted into it will be ignored. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was also surprised to see that max breadcrumbs wasn't exposed on the metadata, so I also exposed it on this PR to make tests with the sample easier.

To fix
https://github.com/getsentry/sentry-react-native/issues/3634
and
https://github.com/getsentry/sentry-java/issues/3313

## :green_heart: How did you test it?

Unit tests and running the sample app with max breadcrumbs set to 0 and 100.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
