### PR TITLE
Fix standalone tomcat jndi issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Using MaxBreadcrumb with value 0 no longer crashes. ([#3836](https://github.com/getsentry/sentry-java/pull/3836))
 - Accept manifest integer values when requiring floating values ([#3823](https://github.com/getsentry/sentry-java/pull/3823))
 - Fix standalone tomcat jndi issue ([#3873](https://github.com/getsentry/sentry-java/pull/3873))
+  - Using Sentry Spring Boot on a standalone tomcat caused the following error:
+    - Failed to bind properties under 'sentry.parsed-dsn' to io.sentry.Dsn
 
 ## 7.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Using MaxBreadcrumb with value 0 no longer crashes. ([#3836](https://github.com/getsentry/sentry-java/pull/3836))
 - Accept manifest integer values when requiring floating values ([#3823](https://github.com/getsentry/sentry-java/pull/3823))
+- Fix standalone tomcat jndi issue ([#3873](https://github.com/getsentry/sentry-java/pull/3873))
 
 ## 7.16.0
 

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -134,7 +134,7 @@ public final class Baggage {
     final Baggage baggage = new Baggage(options.getLogger());
     final SpanContext trace = event.getContexts().getTrace();
     baggage.setTraceId(trace != null ? trace.getTraceId().toString() : null);
-    baggage.setPublicKey(options.getParsedDsn().getPublicKey());
+    baggage.setPublicKey(options.retrieveParsedDsn().getPublicKey());
     baggage.setRelease(event.getRelease());
     baggage.setEnvironment(event.getEnvironment());
     final User user = event.getUser();
@@ -405,7 +405,7 @@ public final class Baggage {
       final @NotNull SentryOptions sentryOptions,
       final @Nullable TracesSamplingDecision samplingDecision) {
     setTraceId(transaction.getSpanContext().getTraceId().toString());
-    setPublicKey(sentryOptions.getParsedDsn().getPublicKey());
+    setPublicKey(sentryOptions.retrieveParsedDsn().getPublicKey());
     setRelease(sentryOptions.getRelease());
     setEnvironment(sentryOptions.getEnvironment());
     setUserSegment(user != null ? getSegment(user) : null);
@@ -427,7 +427,7 @@ public final class Baggage {
     final @Nullable User user = scope.getUser();
     final @NotNull SentryId replayId = scope.getReplayId();
     setTraceId(propagationContext.getTraceId().toString());
-    setPublicKey(options.getParsedDsn().getPublicKey());
+    setPublicKey(options.retrieveParsedDsn().getPublicKey());
     setRelease(options.getRelease());
     setEnvironment(options.getEnvironment());
     if (!SentryId.EMPTY_ID.equals(replayId)) {

--- a/sentry/src/main/java/io/sentry/DsnUtil.java
+++ b/sentry/src/main/java/io/sentry/DsnUtil.java
@@ -23,7 +23,7 @@ public final class DsnUtil {
       return false;
     }
 
-    final @NotNull Dsn dsn = options.getParsedDsn();
+    final @NotNull Dsn dsn = options.retrieveParsedDsn();
     final @NotNull URI sentryUri = dsn.getSentryUri();
     final @Nullable String dsnHost = sentryUri.getHost();
 

--- a/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
+++ b/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
@@ -21,7 +21,7 @@ final class RequestDetailsResolver {
 
   @NotNull
   RequestDetails resolve() {
-    final Dsn dsn = options.getParsedDsn();
+    final Dsn dsn = options.retrieveParsedDsn();
     final URI sentryUri = dsn.getSentryUri();
     final String envelopeUrl = sentryUri.resolve(sentryUri.getPath() + "/envelope/").toString();
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -398,7 +398,7 @@ public final class Sentry {
     }
 
     // This creates the DSN object and performs some checks
-    options.getParsedDsn();
+    options.retrieveParsedDsn();
 
     ILogger logger = options.getLogger();
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -541,9 +541,9 @@ public class SentryOptions {
   }
 
   /**
-   * Evaluates and parses the DSN. May throw an exception if the DSN is invalid.
-   * Renamed from `getParsedDsn` as this would cause an error when deploying as WAR to
-   * Tomcat due to `JNDI` property binding.
+   * Evaluates and parses the DSN. May throw an exception if the DSN is invalid. Renamed from
+   * `getParsedDsn` as this would cause an error when deploying as WAR to Tomcat due to `JNDI`
+   * property binding.
    *
    * @return the parsed DSN or throws if dsn is invalid
    */

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -542,12 +542,14 @@ public class SentryOptions {
 
   /**
    * Evaluates and parses the DSN. May throw an exception if the DSN is invalid.
+   * Renamed from `getParsedDsn` as this would cause an error when deploying as WAR to
+   * Tomcat due to `JNDI` property binding.
    *
    * @return the parsed DSN or throws if dsn is invalid
    */
   @ApiStatus.Internal
   @NotNull
-  Dsn getParsedDsn() throws IllegalArgumentException {
+  Dsn retrieveParsedDsn() throws IllegalArgumentException {
     return parsedDsn.getValue();
   }
 
@@ -2457,7 +2459,7 @@ public class SentryOptions {
    */
   void loadLazyFields() {
     getSerializer();
-    getParsedDsn();
+    retrieveParsedDsn();
     getEnvelopeReader();
     getDateProvider();
   }


### PR DESCRIPTION
## :scroll: Description
Rename `getParsedDsn()` to `retrieveParsedDsn()` to fix issue with `JNDI` property binding.
This caused `getParsedDsn()` to be called prematurely and lead to crashes with an emtpy `Dsn`.


## :bulb: Motivation and Context
Fixes #3825 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
