### PR TITLE
Limit emulator size to 4096M

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -69,6 +69,7 @@ jobs:
           target: 'aosp_atd'
           arch: x86
           channel: canary # Necessary for ATDs
+          disk-size: 4096M
           script: ./gradlew sentry-android-integration-tests:sentry-uitest-android:connectedReleaseAndroidTest -DtestBuildType=release --daemon
 
       - name: Upload test results


### PR DESCRIPTION
## :scroll: Description

CI runs recently started to fail due to disk size issues when creating the emulator:
>  ERROR        | Not enough space to create userdata partition. Available: 7329.925781 MB at /home/runner/.android/avd/../avd/test.avd, need 7372.800000 MB.

This PR sets the disk size to 4096M which should be large enough for our tests.

#skip-changelog

