### PR TITLE
Add gradle task to start spring boot samples with agent

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/README.md
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/README.md
@@ -4,7 +4,7 @@ Sample application showing how to use Sentry with [Spring boot](http://spring.io
 
 ## How to run? 
 
-Make sure the `sentry-opentelemetry` module is built.
+Make sure the `sentry-opentelemetry` module is built (`../../gradlew :sentry-opentelemetry:sentry-opentelemetry-agent:assemble`).
 
 Then, execute a command from the module directory:
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/README.md
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/README.md
@@ -1,16 +1,20 @@
 # Sentry Sample Spring Boot 3.0+
 
-Sample application showing how to use Sentry with [Spring boot](http://spring.io/projects/spring-boot) from version `3.0` onwards.
+Sample application showing how to use Sentry with [Spring boot](http://spring.io/projects/spring-boot) from version `3.0` onwards and the Sentry OpenTelemetry agent.
 
 ## How to run? 
 
-To see events triggered in this sample application in your Sentry dashboard, go to `src/main/resources/application.properties` and replace the test DSN with your own DSN.
+Make sure the `sentry-opentelemetry` module is built.
 
 Then, execute a command from the module directory:
 
 ```
-../../gradlew bootRun
+SENTRY_DSN="https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563" SENTRY_DEBUG=true ../../gradlew bootRunWithAgent
 ```
+
+To see events triggered in this sample application in your Sentry dashboard, replace the `SENTRY_DSN` above with your own.
+
+## Http
 
 Make an HTTP request that will trigger events:
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -35,49 +35,6 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-//tasks.getByName<BootRun>("bootRun") {
-//    val versionName = project.properties["versionName"] as String
-//    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
-//    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
-//    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
-//
-//    systemProperty("SENTRY_DSN", "http://502f25099c204a2fbf4cb16edc5975d1@localhost:8000/0")
-//    systemProperty("SENTRY_AUTO_INIT", "true")
-//    systemProperty("SENTRY_TRACES_SAMPLE_RATE", "1.0")
-//    systemProperty("OTEL_TRACES_EXPORTER", "none")
-//    systemProperty("OTEL_METRICS_EXPORTER", "none")
-//    systemProperty("OTEL_LOGS_EXPORTER", "none")
-//
-//    jvmArgs =
-//        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
-//}
-
-tasks.register<BootRun>("bootRunWithAgent").configure {
-    group = "application"
-
-    val mainBootRunTask = tasks.getByName<BootRun>("bootRun")
-    mainClass = mainBootRunTask.mainClass
-    classpath = mainBootRunTask.classpath
-
-    val versionName = project.properties["versionName"] as String
-    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
-    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
-    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
-
-    println("#######")
-    println(agentJarPath)
-
-    systemProperty("SENTRY_DSN", "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563")
-    systemProperty("SENTRY_AUTO_INIT", "true")
-    systemProperty("SENTRY_TRACES_SAMPLE_RATE", "1.0")
-    systemProperty("OTEL_TRACES_EXPORTER", "none")
-    systemProperty("OTEL_METRICS_EXPORTER", "none")
-    systemProperty("OTEL_LOGS_EXPORTER", "none")
-
-    jvmArgs =
-        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
-}
-
 dependencies {
     implementation(Config.Libs.springBoot3StarterSecurity)
     implementation(Config.Libs.springBoot3StarterActuator)
@@ -121,6 +78,30 @@ configure<SourceSetContainer> {
     test {
         java.srcDir("src/test/java")
     }
+}
+
+tasks.register<BootRun>("bootRunWithAgent").configure {
+    group = "application"
+
+    val mainBootRunTask = tasks.getByName<BootRun>("bootRun")
+    mainClass = mainBootRunTask.mainClass
+    classpath = mainBootRunTask.classpath
+
+    val versionName = project.properties["versionName"] as String
+    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
+    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
+    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
+
+    val dsn = System.getenv("SENTRY_DSN") ?: "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563"
+    environment("SENTRY_DSN", dsn)
+    environment("SENTRY_AUTO_INIT", "true")
+    environment("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+    environment("OTEL_TRACES_EXPORTER", "none")
+    environment("OTEL_METRICS_EXPORTER", "none")
+    environment("OTEL_LOGS_EXPORTER", "none")
+
+    jvmArgs =
+        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
 tasks.register<Test>("systemTest").configure {

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -93,9 +93,10 @@ tasks.register<BootRun>("bootRunWithAgent").configure {
     val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
 
     val dsn = System.getenv("SENTRY_DSN") ?: "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563"
+    val tracesSampleRate = System.getenv("SENTRY_TRACES_SAMPLE_RATE") ?: "1"
+
     environment("SENTRY_DSN", dsn)
-    environment("SENTRY_AUTO_INIT", "true")
-    environment("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+    environment("SENTRY_TRACES_SAMPLE_RATE", tracesSampleRate)
     environment("OTEL_TRACES_EXPORTER", "none")
     environment("OTEL_METRICS_EXPORTER", "none")
     environment("OTEL_LOGS_EXPORTER", "none")

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version
@@ -32,6 +33,49 @@ tasks.withType<KotlinCompile> {
         freeCompilerArgs = listOf("-Xjsr305=strict")
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
+}
+
+//tasks.getByName<BootRun>("bootRun") {
+//    val versionName = project.properties["versionName"] as String
+//    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
+//    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
+//    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
+//
+//    systemProperty("SENTRY_DSN", "http://502f25099c204a2fbf4cb16edc5975d1@localhost:8000/0")
+//    systemProperty("SENTRY_AUTO_INIT", "true")
+//    systemProperty("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+//    systemProperty("OTEL_TRACES_EXPORTER", "none")
+//    systemProperty("OTEL_METRICS_EXPORTER", "none")
+//    systemProperty("OTEL_LOGS_EXPORTER", "none")
+//
+//    jvmArgs =
+//        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
+//}
+
+tasks.register<BootRun>("bootRunWithAgent").configure {
+    group = "application"
+
+    val mainBootRunTask = tasks.getByName<BootRun>("bootRun")
+    mainClass = mainBootRunTask.mainClass
+    classpath = mainBootRunTask.classpath
+
+    val versionName = project.properties["versionName"] as String
+    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
+    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
+    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
+
+    println("#######")
+    println(agentJarPath)
+
+    systemProperty("SENTRY_DSN", "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563")
+    systemProperty("SENTRY_AUTO_INIT", "true")
+    systemProperty("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+    systemProperty("OTEL_TRACES_EXPORTER", "none")
+    systemProperty("OTEL_METRICS_EXPORTER", "none")
+    systemProperty("OTEL_LOGS_EXPORTER", "none")
+
+    jvmArgs =
+        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
 dependencies {

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/README.md
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/README.md
@@ -1,16 +1,20 @@
 # Sentry Sample Spring Boot
 
-Sample application showing how to use Sentry with [Spring boot](http://spring.io/projects/spring-boot).
+Sample application showing how to use Sentry with [Spring boot](http://spring.io/projects/spring-boot) and the Sentry OpenTelemetry agent.
 
-## How to run? 
+## How to run?
 
-To see events triggered in this sample application in your Sentry dashboard, go to `src/main/resources/application.properties` and replace the test DSN with your own DSN. 
+Make sure the `sentry-opentelemetry` module is built.
 
 Then, execute a command from the module directory:
 
 ```
-../../gradlew bootRun
+SENTRY_DSN="https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563" SENTRY_DEBUG=true ../../gradlew bootRunWithAgent
 ```
+
+To see events triggered in this sample application in your Sentry dashboard, replace the `SENTRY_DSN` above with your own.
+
+## Http
 
 Make an HTTP request that will trigger events:
 

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/README.md
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/README.md
@@ -4,7 +4,7 @@ Sample application showing how to use Sentry with [Spring boot](http://spring.io
 
 ## How to run?
 
-Make sure the `sentry-opentelemetry` module is built.
+Make sure the `sentry-opentelemetry` module is built (`../../gradlew :sentry-opentelemetry:sentry-opentelemetry-agent:assemble`).
 
 Then, execute a command from the module directory:
 

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -88,9 +88,10 @@ tasks.register<BootRun>("bootRunWithAgent").configure {
     val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
 
     val dsn = System.getenv("SENTRY_DSN") ?: "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563"
+    val tracesSampleRate = System.getenv("SENTRY_TRACES_SAMPLE_RATE") ?: "1"
+
     environment("SENTRY_DSN", dsn)
-    environment("SENTRY_AUTO_INIT", "true")
-    environment("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+    environment("SENTRY_TRACES_SAMPLE_RATE", tracesSampleRate)
     environment("OTEL_TRACES_EXPORTER", "none")
     environment("OTEL_METRICS_EXPORTER", "none")
     environment("OTEL_LOGS_EXPORTER", "none")

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
@@ -72,6 +73,30 @@ configure<SourceSetContainer> {
     test {
         java.srcDir("src/test/java")
     }
+}
+
+tasks.register<BootRun>("bootRunWithAgent").configure {
+    group = "application"
+
+    val mainBootRunTask = tasks.getByName<BootRun>("bootRun")
+    mainClass = mainBootRunTask.mainClass
+    classpath = mainBootRunTask.classpath
+
+    val versionName = project.properties["versionName"] as String
+    val agentProjectId = projects.sentryOpentelemetry.sentryOpentelemetryAgent.identityPath.toString()
+    val agentProjectPath = project(agentProjectId).projectDir.absolutePath
+    val agentJarPath = "$agentProjectPath/build/libs/sentry-opentelemetry-agent-$versionName.jar"
+
+    val dsn = System.getenv("SENTRY_DSN") ?: "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563"
+    environment("SENTRY_DSN", dsn)
+    environment("SENTRY_AUTO_INIT", "true")
+    environment("SENTRY_TRACES_SAMPLE_RATE", "1.0")
+    environment("OTEL_TRACES_EXPORTER", "none")
+    environment("OTEL_METRICS_EXPORTER", "none")
+    environment("OTEL_LOGS_EXPORTER", "none")
+
+    jvmArgs =
+        listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
 tasks.register<Test>("systemTest").configure {


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
Adds new gradle task `bootRunWithAgent` to our spring boot opentelemetry samples.

## :bulb: Motivation and Context
Implements #3880 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
