### PR TITLE
Ensure android initialization process continues even if options configuration block throws an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Ensure android initialization process continues even if options configuration block throws an exception ([#3887](https://github.com/getsentry/sentry-java/pull/3887))
+
 ## 7.17.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -129,7 +129,17 @@ public final class SentryAndroid {
                 isTimberAvailable,
                 isReplayAvailable);
 
-            configuration.configure(options);
+            try {
+              configuration.configure(options);
+            } catch (Throwable t) {
+              // let it slip, but log it
+              options
+                  .getLogger()
+                  .log(
+                      SentryLevel.ERROR,
+                      "Error in the 'OptionsConfiguration.configure' callback.",
+                      t);
+            }
 
             // if SentryPerformanceProvider was disabled or removed,
             // we set the app start / sdk init time here instead

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidTest.kt
@@ -517,6 +517,19 @@ class SentryAndroidTest {
         assertEquals(99, AppStartMetrics.getInstance().appStartTimeSpan.startUptimeMs)
     }
 
+    @Test
+    fun `if the config options block throws still intializes android event processors`() {
+        lateinit var optionsRef: SentryOptions
+        fixture.initSut(context = mock<Application>()) { options ->
+            optionsRef = options
+            options.dsn = "https://key@sentry.io/123"
+            throw RuntimeException("Boom!")
+        }
+
+        assertTrue(optionsRef.eventProcessors.any { it is DefaultAndroidEventProcessor })
+        assertTrue(optionsRef.eventProcessors.any { it is AnrV2EventProcessor })
+    }
+
     private fun prefillScopeCache(cacheDir: String) {
         val scopeDir = File(cacheDir, SCOPE_CACHE).also { it.mkdirs() }
         File(scopeDir, BREADCRUMBS_FILENAME).writeText(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We were not swallowing exceptions in case the user options config throws on Android, therefore everything that comes after that (event processors and a bunch of other stuff) were not added and executed at all.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal customer report

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
