### PR TITLE
Mark hint flushed when rate limited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Send `otel.kind` to Sentry ([#3907](https://github.com/getsentry/sentry-java/pull/3907))
 - Allow passing `environment` to `CheckinUtils.withCheckIn` ([3889](https://github.com/getsentry/sentry-java/pull/3889))
 
+### Fixes
+
+- Mark `DiskFlushNotification` hint flushed when rate limited ([#3892](https://github.com/getsentry/sentry-java/pull/3892))
+  - Our `UncaughtExceptionHandlerIntegration` waited for the full flush timeout duration (default 15s) when rate limited. 
+
 ## 8.0.0-beta.2
 
 ### Breaking Changes

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -25,7 +25,6 @@ import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
 import io.sentry.util.HintUtils
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
@@ -300,8 +299,6 @@ class RateLimiterTest {
         rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
 
         val hint = mock<DiskFlushNotification>()
-        whenever(hint.isFlushable(any())).thenReturn(true)
-
         rateLimiter.filter(envelope, HintUtils.createWithTypeCheckHint(hint))
 
         verify(hint).markFlushed()

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -28,7 +28,6 @@ import io.sentry.util.HintUtils
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.same
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -305,26 +304,6 @@ class RateLimiterTest {
 
         rateLimiter.filter(envelope, HintUtils.createWithTypeCheckHint(hint))
 
-        verify(hint).isFlushable(sentryEvent.eventId)
         verify(hint).markFlushed()
-    }
-
-    @Test
-    fun `on rate limit DiskFlushNotification is not marked as flushed if not flushable`() {
-        val rateLimiter = fixture.getSUT()
-        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
-        val sentryEvent = SentryEvent()
-        val eventItem = SentryEnvelopeItem.fromEvent(fixture.serializer, sentryEvent)
-        val envelope = SentryEnvelope(SentryEnvelopeHeader(sentryEvent.eventId), arrayListOf(eventItem))
-
-        rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
-
-        val hint = mock<DiskFlushNotification>()
-        whenever(hint.isFlushable(any())).thenReturn(false)
-
-        rateLimiter.filter(envelope, HintUtils.createWithTypeCheckHint(hint))
-
-        verify(hint).isFlushable(sentryEvent.eventId)
-        verify(hint, never()).markFlushed()
     }
 }

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -20,11 +20,15 @@ import io.sentry.TransactionContext
 import io.sentry.UserFeedback
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.IClientReportRecorder
+import io.sentry.hints.DiskFlushNotification
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.util.HintUtils
+import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.same
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -284,5 +288,43 @@ class RateLimiterTest {
         rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
 
         assertTrue(rateLimiter.isAnyRateLimitActive)
+    }
+
+    @Test
+    fun `on rate limit DiskFlushNotification is marked as flushed`() {
+        val rateLimiter = fixture.getSUT()
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
+        val sentryEvent = SentryEvent()
+        val eventItem = SentryEnvelopeItem.fromEvent(fixture.serializer, sentryEvent)
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(sentryEvent.eventId), arrayListOf(eventItem))
+
+        rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
+
+        val hint = mock<DiskFlushNotification>()
+        whenever(hint.isFlushable(any())).thenReturn(true)
+
+        rateLimiter.filter(envelope, HintUtils.createWithTypeCheckHint(hint))
+
+        verify(hint).isFlushable(sentryEvent.eventId)
+        verify(hint).markFlushed()
+    }
+
+    @Test
+    fun `on rate limit DiskFlushNotification is not marked as flushed if not flushable`() {
+        val rateLimiter = fixture.getSUT()
+        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0)
+        val sentryEvent = SentryEvent()
+        val eventItem = SentryEnvelopeItem.fromEvent(fixture.serializer, sentryEvent)
+        val envelope = SentryEnvelope(SentryEnvelopeHeader(sentryEvent.eventId), arrayListOf(eventItem))
+
+        rateLimiter.updateRetryAfterLimits("50:transaction:key, 1:default;error;security:organization", null, 1)
+
+        val hint = mock<DiskFlushNotification>()
+        whenever(hint.isFlushable(any())).thenReturn(false)
+
+        rateLimiter.filter(envelope, HintUtils.createWithTypeCheckHint(hint))
+
+        verify(hint).isFlushable(sentryEvent.eventId)
+        verify(hint, never()).markFlushed()
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- `UncaughtExceptionHandlerIntegration.uncaughtException` waits the full 15s after capturing an event and calling `hint.waitFlush()` when rate limited since we never called `markFlushed` in `RateLimiter`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/3857

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
