### PR TITLE
Do not replace `op` with auto generated content for OpenTelemetry spans with span kind`INTERNAL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Do not replace `op` with auto generated content for OpenTelemetry spans with span kind`INTERNAL` ([#3906](https://github.com/getsentry/sentry-java/pull/3906))
+- Do not replace `op` with auto generated content for OpenTelemetry spans with span kind `INTERNAL` ([#3906](https://github.com/getsentry/sentry-java/pull/3906))
 
 ## 8.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Send `otel.kind` to Sentry ([#3907](https://github.com/getsentry/sentry-java/pull/3907))
 - Allow passing `environment` to `CheckinUtils.withCheckIn` ([3889](https://github.com/getsentry/sentry-java/pull/3889))
 
+### Fixes
+
+- Do not replace `op` with auto generated content for OpenTelemetry spans with span kind`INTERNAL` ([#3906](https://github.com/getsentry/sentry-java/pull/3906))
+
 ## 8.0.0-beta.2
 
 ### Breaking Changes

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -18,21 +18,23 @@ public final class SpanDescriptionExtractor {
   @SuppressWarnings("deprecation")
   public @NotNull OtelSpanInfo extractSpanInfo(
       final @NotNull SpanData otelSpan, final @Nullable IOtelSpanWrapper sentrySpan) {
-    final @NotNull Attributes attributes = otelSpan.getAttributes();
+    if (!isInternalSpanKind(otelSpan)) {
+      final @NotNull Attributes attributes = otelSpan.getAttributes();
 
-    final @Nullable String httpMethod = attributes.get(HttpAttributes.HTTP_REQUEST_METHOD);
-    if (httpMethod != null) {
-      return descriptionForHttpMethod(otelSpan, httpMethod);
-    }
+      final @Nullable String httpMethod = attributes.get(HttpAttributes.HTTP_REQUEST_METHOD);
+      if (httpMethod != null) {
+        return descriptionForHttpMethod(otelSpan, httpMethod);
+      }
 
-    final @Nullable String httpRequestMethod = attributes.get(HttpAttributes.HTTP_REQUEST_METHOD);
-    if (httpRequestMethod != null) {
-      return descriptionForHttpMethod(otelSpan, httpRequestMethod);
-    }
+      final @Nullable String httpRequestMethod = attributes.get(HttpAttributes.HTTP_REQUEST_METHOD);
+      if (httpRequestMethod != null) {
+        return descriptionForHttpMethod(otelSpan, httpRequestMethod);
+      }
 
-    final @Nullable String dbSystem = attributes.get(DbIncubatingAttributes.DB_SYSTEM);
-    if (dbSystem != null) {
-      return descriptionForDbSystem(otelSpan);
+      final @Nullable String dbSystem = attributes.get(DbIncubatingAttributes.DB_SYSTEM);
+      if (dbSystem != null) {
+        return descriptionForDbSystem(otelSpan);
+      }
     }
 
     final @NotNull String name = otelSpan.getName();
@@ -40,6 +42,10 @@ public final class SpanDescriptionExtractor {
         sentrySpan != null ? sentrySpan.getDescription() : name;
     final @NotNull String description = maybeDescription != null ? maybeDescription : name;
     return new OtelSpanInfo(name, description, TransactionNameSource.CUSTOM);
+  }
+
+  private boolean isInternalSpanKind(final @NotNull SpanData otelSpan) {
+    return SpanKind.INTERNAL.equals(otelSpan.getKind());
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Disabled auto `op` generation based on span kind. We only do it if it's something other than `INTERNAL`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solution 5b from https://github.com/getsentry/sentry-java/issues/3904

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
