### PR TITLE
Re-apply NDK init performance improvements for 8.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,9 @@
 
 ### Dependencies
 
-- Bump Native SDK from v0.7.5 to v0.7.8 ([#3851](https://github.com/getsentry/sentry-java/pull/3851))
-    - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#078)
-    - [diff](https://github.com/getsentry/sentry-native/compare/0.7.5...0.7.8)
+- Bump Native SDK from v0.7.5 to v0.7.14 ([#3851](https://github.com/getsentry/sentry-java/pull/3851))
+    - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0714)
+    - [diff](https://github.com/getsentry/sentry-native/compare/0.7.5...0.7.14)
 
 ### Behavioural Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ### Dependencies
 
-- Bump Native SDK from v0.7.5 to v0.7.14 ([#3851](https://github.com/getsentry/sentry-java/pull/3851))
+- Bump Native SDK from v0.7.5 to v0.7.14 ([#3851](https://github.com/getsentry/sentry-java/pull/3851)) ([#3914](https://github.com/getsentry/sentry-java/pull/3914))
     - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0714)
     - [diff](https://github.com/getsentry/sentry-native/compare/0.7.5...0.7.14)
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -153,7 +153,7 @@ object Config {
 
         val apolloKotlin = "com.apollographql.apollo3:apollo-runtime:3.8.2"
 
-        val sentryNativeNdk = "io.sentry:sentry-native-ndk:0.7.8"
+        val sentryNativeNdk = "io.sentry:sentry-native-ndk:0.7.14"
 
         object OpenTelemetry {
             val otelVersion = "1.41.0"

--- a/scripts/update-sentry-native-ndk.sh
+++ b/scripts/update-sentry-native-ndk.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 cd $(dirname "$0")/../
-GRADLE_NDK_FILEPATH=sentry-android-ndk/build.gradle.kts
-GRADLE_SAMPLE_FILEPATH=sentry-samples/sentry-samples-android/build.gradle.kts
+GRADLE_NDK_FILEPATH=buildSrc/src/main/java/Config.kt
 
 case $1 in
 get-version)
@@ -26,7 +25,6 @@ set-version)
 
     PATTERN="io\.sentry:sentry-native-ndk:([0-9.]+)+"
     perl -pi -e "s/$PATTERN/io.sentry:sentry-native-ndk:$version/g" $GRADLE_NDK_FILEPATH
-    perl -pi -e "s/$PATTERN/io.sentry:sentry-native-ndk:$version/g" $GRADLE_SAMPLE_FILEPATH
     ;;
 *)
     echo "Unknown argument $1"

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -3,13 +3,32 @@ package io.sentry.android.ndk;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.ndk.NativeModuleListLoader;
 import io.sentry.ndk.NdkOptions;
+import io.sentry.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
 public final class SentryNdk {
 
+  private static final @NotNull CountDownLatch loadLibraryLatch = new CountDownLatch(1);
+
   private SentryNdk() {}
+
+  static {
+    new Thread(
+            () -> {
+              try {
+                //noinspection UnstableApiUsage
+                io.sentry.ndk.SentryNdk.loadNativeLibraries();
+              } finally {
+                loadLibraryLatch.countDown();
+              }
+            },
+            "SentryNdkLoadLibs")
+        .start();
+  }
 
   /**
    * Init the NDK integration
@@ -18,29 +37,50 @@ public final class SentryNdk {
    */
   public static void init(@NotNull final SentryAndroidOptions options) {
     SentryNdkUtil.addPackage(options.getSdkVersion());
+    try {
+      if (loadLibraryLatch.await(2000, TimeUnit.MILLISECONDS)) {
+        final @NotNull NdkOptions ndkOptions =
+            new NdkOptions(
+                Objects.requireNonNull(options.getDsn(), "DSN is required for sentry-ndk"),
+                options.isDebug(),
+                Objects.requireNonNull(
+                    options.getOutboxPath(), "outbox path is required for sentry-ndk"),
+                options.getRelease(),
+                options.getEnvironment(),
+                options.getDist(),
+                options.getMaxBreadcrumbs(),
+                options.getNativeSdkName());
 
-    final @NotNull NdkOptions ndkOptions =
-        new NdkOptions(
-            options.getDsn(),
-            options.isDebug(),
-            options.getOutboxPath(),
-            options.getRelease(),
-            options.getEnvironment(),
-            options.getDist(),
-            options.getMaxBreadcrumbs(),
-            options.getNativeSdkName());
-    io.sentry.ndk.SentryNdk.init(ndkOptions);
+        //noinspection UnstableApiUsage
+        io.sentry.ndk.SentryNdk.init(ndkOptions);
 
-    // only add scope sync observer if the scope sync is enabled.
-    if (options.isEnableScopeSync()) {
-      options.addScopeObserver(new NdkScopeObserver(options));
+        // only add scope sync observer if the scope sync is enabled.
+        if (options.isEnableScopeSync()) {
+          options.addScopeObserver(new NdkScopeObserver(options));
+        }
+
+        options.setDebugImagesLoader(new DebugImagesLoader(options, new NativeModuleListLoader()));
+      } else {
+        throw new IllegalStateException("Timeout waiting for Sentry NDK library to load");
+      }
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(
+          "Thread interrupted while waiting for NDK libs to be loaded", e);
     }
-
-    options.setDebugImagesLoader(new DebugImagesLoader(options, new NativeModuleListLoader()));
   }
 
   /** Closes the NDK integration */
   public static void close() {
-    io.sentry.ndk.SentryNdk.close();
+    try {
+      if (loadLibraryLatch.await(2000, TimeUnit.MILLISECONDS)) {
+        //noinspection UnstableApiUsage
+        io.sentry.ndk.SentryNdk.close();
+      } else {
+        throw new IllegalStateException("Timeout waiting for Sentry NDK library to load");
+      }
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(
+          "Thread interrupted while waiting for NDK libs to be loaded", e);
+    }
   }
 }

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -16,7 +16,10 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments.add(0, "-DANDROID_STL=c++_shared")
+                // Android 15: As we're using an older version of AGP / NDK, the STL is not 16kb page aligned yet
+                // Our example code doesn't use the STL, so we simply disable it
+                // See https://developer.android.com/guide/practices/page-sizes
+                arguments.add(0, "-DANDROID_STL=none")
             }
         }
 


### PR DESCRIPTION
## :scroll: Description

Re-applies the NDK optimizations done on the 7.x.x branch: https://github.com/getsentry/sentry-java/blob/3d24791bd1b80d3dbf8a849d9f23bf14445902c9/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java

As some of the optimization code lies with `sentry-native` now, a version bump of `sentry-native-ndk` is required as well.

## :bulb: Motivation and Context

No degration in NDK init performance for 8.x.x

## :green_heart: How did you test it?

Manually double checked 16kb alignment using the official [check_elf_alignment.sh script
](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh)
````shell

./check_elf_alignment.sh sentry-samples-android-debug.apk

Recursively analyzing sentry-samples-android-debug.apk

NOTICE: Zip alignment check requires build-tools version 35.0.0-rc3 or higher.
  You can install the latest build-tools by running the below command
  and updating your $PATH:

    sdkmanager "build-tools;35.0.0-rc3"

=== ELF alignment ===
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/armeabi-v7a/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/armeabi-v7a/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/armeabi-v7a/libnative-sample.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86/libnative-sample.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/arm64-v8a/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/arm64-v8a/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/arm64-v8a/libnative-sample.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86_64/libsentry.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86_64/libsentry-android.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/9d/kv_9v4115l79s8hxbvlrqwsc0000gn/T/sentry-samples-android-debug_out_XXXXX.qfDwmu2goN/lib/x86_64/libnative-sample.so: \e[32mALIGNED\e[0m (2**14)
ELF Verification Successful
````

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps


#skip-changelog