### PR TITLE
Send file name and path only if isSendDefaultPii is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Do not replace `op` with auto generated content for OpenTelemetry spans with span kind `INTERNAL` ([#3906](https://github.com/getsentry/sentry-java/pull/3906))
 
+### Behavioural Changes
+
+- Send file name and path only if isSendDefaultPii is true ([#3919](https://github.com/getsentry/sentry-java/pull/3919))
+
 ## 8.0.0-beta.2
 
 ### Breaking Changes

--- a/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/FileIOSpanManager.java
@@ -93,9 +93,9 @@ final class FileIOSpanManager {
     if (currentSpan != null) {
       final String byteCountToString = StringUtils.byteCountToString(byteCount);
       if (file != null) {
-        final String description = file.getName() + " " + "(" + byteCountToString + ")";
+        final String description = getDescription(file);
         currentSpan.setDescription(description);
-        if (Platform.isAndroid() || options.isSendDefaultPii()) {
+        if (options.isSendDefaultPii()) {
           currentSpan.setData("file.path", file.getAbsolutePath());
         }
       } else {
@@ -109,6 +109,22 @@ final class FileIOSpanManager {
             SpanDataConvention.CALL_STACK_KEY, stackTraceFactory.getInAppCallStack());
       }
       currentSpan.finish(spanStatus);
+    }
+  }
+
+  private @NotNull String getDescription(final @NotNull File file) {
+    final String byteCountToString = StringUtils.byteCountToString(byteCount);
+    // if we send PII, we can send the file name directly
+    if (options.isSendDefaultPii()) {
+      return file.getName() + " (" + byteCountToString + ")";
+    }
+    final int lastDotIndex = file.getName().lastIndexOf('.');
+    // if the file has an extension, show it in the description, even without sending PII
+    if (lastDotIndex > 0 && lastDotIndex < file.getName().length() - 1) {
+      final String fileExtension = file.getName().substring(lastDotIndex);
+      return "***" + fileExtension + " (" + byteCountToString + ")";
+    } else {
+      return "***" + " (" + byteCountToString + ")";
     }
   }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileInputStreamTest.kt
@@ -23,6 +23,7 @@ import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -80,6 +81,8 @@ class SentryFileInputStreamTest {
 
     private val tmpFile: File get() = tmpDir.newFile("test.txt")
 
+    private val tmpFileWithoutExtension: File get() = tmpDir.newFile("test")
+
     @Test
     fun `when no active transaction does not capture a span`() {
         fixture.getSut(tmpFile, activeTransaction = false)
@@ -104,11 +107,40 @@ class SentryFileInputStreamTest {
 
         assertEquals(fixture.sentryTracer.children.size, 1)
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (0 B)")
         assertEquals(fileIOSpan.data["file.size"], 0L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
         assertEquals(fileIOSpan.status, SpanStatus.OK)
+    }
+
+    @Test
+    fun `captures file name in description and file path when isSendDefaultPii is true`() {
+        val fis = fixture.getSut(tmpFile, sendDefaultPii = true)
+        fis.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (0 B)")
+        assertNotNull(fileIOSpan.data["file.path"])
+    }
+
+    @Test
+    fun `captures only file extension in description when isSendDefaultPii is false`() {
+        val fis = fixture.getSut(tmpFile, sendDefaultPii = false)
+        fis.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (0 B)")
+        assertNull(fileIOSpan.data["file.path"])
+    }
+
+    @Test
+    fun `captures only file size if no extension is available when isSendDefaultPii is false`() {
+        val fis = fixture.getSut(tmpFileWithoutExtension, sendDefaultPii = false)
+        fis.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "*** (0 B)")
+        assertNull(fileIOSpan.data["file.path"])
     }
 
     @Test
@@ -123,7 +155,7 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.read() }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (1 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (1 B)")
         assertEquals(fileIOSpan.data["file.size"], 1L)
     }
 
@@ -132,7 +164,7 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.read(ByteArray(10)) }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (4 B)")
         assertEquals(fileIOSpan.data["file.size"], 4L)
     }
 
@@ -141,7 +173,7 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.read(ByteArray(10), 1, 3) }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (3 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (3 B)")
         assertEquals(fileIOSpan.data["file.size"], 3L)
     }
 
@@ -150,7 +182,7 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.skip(10) }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (10 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (10 B)")
         assertEquals(fileIOSpan.data["file.size"], 10L)
     }
 
@@ -159,7 +191,7 @@ class SentryFileInputStreamTest {
         fixture.getSut(tmpFile).use { it.reader().readText() }
 
         val fileIOSpan = fixture.sentryTracer.children.first()
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (4 B)")
         assertEquals(fileIOSpan.data["file.size"], 4L)
     }
 

--- a/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
+++ b/sentry/src/test/java/io/sentry/instrumentation/file/SentryFileWriterTest.kt
@@ -14,6 +14,8 @@ import org.mockito.kotlin.whenever
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class SentryFileWriterTest {
     class Fixture {
@@ -23,13 +25,14 @@ class SentryFileWriterTest {
         internal fun getSut(
             tmpFile: File,
             activeTransaction: Boolean = true,
-            append: Boolean = false
+            append: Boolean = false,
+            optionsConfiguration: (SentryOptions) -> Unit = {}
         ): SentryFileWriter {
-            whenever(scopes.options).thenReturn(
-                SentryOptions().apply {
-                    threadChecker = ThreadChecker.getInstance()
-                }
-            )
+            val options = SentryOptions().apply {
+                threadChecker = ThreadChecker.getInstance()
+                optionsConfiguration(this)
+            }
+            whenever(scopes.options).thenReturn(options)
             sentryTracer = SentryTracer(TransactionContext("name", "op"), scopes)
             if (activeTransaction) {
                 whenever(scopes.span).thenReturn(sentryTracer)
@@ -45,6 +48,8 @@ class SentryFileWriterTest {
 
     private val tmpFile: File by lazy { tmpDir.newFile("test.txt") }
 
+    private val tmpFileWithoutExtension: File by lazy { tmpDir.newFile("test") }
+
     @Test
     fun `captures a span`() {
         val writer = fixture.getSut(tmpFile)
@@ -54,7 +59,7 @@ class SentryFileWriterTest {
         assertEquals(fixture.sentryTracer.children.size, 1)
         val fileIOSpan = fixture.sentryTracer.children.first()
         assertEquals(fileIOSpan.spanContext.operation, "file.write")
-        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (4 B)")
         assertEquals(fileIOSpan.data["file.size"], 4L)
         assertEquals(fileIOSpan.throwable, null)
         assertEquals(fileIOSpan.isFinished, true)
@@ -76,5 +81,44 @@ class SentryFileWriterTest {
         }
 
         assertEquals("testtest2", tmpFile.readText())
+    }
+
+    @Test
+    fun `captures file name in description and file path when isSendDefaultPii is true`() {
+        val writer = fixture.getSut(tmpFile) {
+            it.isSendDefaultPii = true
+        }
+        writer.write("TEXT")
+        writer.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "test.txt (4 B)")
+        assertNotNull(fileIOSpan.data["file.path"])
+    }
+
+    @Test
+    fun `captures only file extension in description when isSendDefaultPii is false`() {
+        val writer = fixture.getSut(tmpFile) {
+            it.isSendDefaultPii = false
+        }
+        writer.write("TEXT")
+        writer.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "***.txt (4 B)")
+        assertNull(fileIOSpan.data["file.path"])
+    }
+
+    @Test
+    fun `captures only file size if no extension is available when isSendDefaultPii is false`() {
+        val writer = fixture.getSut(tmpFileWithoutExtension) {
+            it.isSendDefaultPii = false
+        }
+        writer.write("TEXT")
+        writer.close()
+
+        val fileIOSpan = fixture.sentryTracer.children.first()
+        assertEquals(fileIOSpan.spanContext.description, "*** (4 B)")
+        assertNull(fileIOSpan.data["file.path"])
     }
 }


### PR DESCRIPTION
## :scroll: Description
file span description is now masked if isSendDefaultPii is false
file path on Android is sent only if isSendDefaultPii is true


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/3324

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
