### PR TITLE
DisabledQueue.isEmpty now returns true

### DIFF
--- a/sentry/src/main/java/io/sentry/DisabledQueue.java
+++ b/sentry/src/main/java/io/sentry/DisabledQueue.java
@@ -34,7 +34,7 @@ final class DisabledQueue<E> extends AbstractCollection<E> implements Queue<E>, 
    */
   @Override
   public boolean isEmpty() {
-    return false;
+    return true;
   }
 
   /** Does nothing. */

--- a/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
+++ b/sentry/src/test/java/io/sentry/DisabledQueueTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DisabledQueueTest {
 
@@ -22,17 +23,17 @@ class DisabledQueueTest {
     }
 
     @Test
-    fun `isEmpty returns false when created`() {
+    fun `isEmpty returns true when created`() {
         val queue = DisabledQueue<Int>()
-        assertFalse(queue.isEmpty(), "isEmpty should always return false.")
+        assertTrue(queue.isEmpty(), "isEmpty should always return true.")
     }
 
     @Test
-    fun `isEmpty always returns false if add function was called`() {
+    fun `isEmpty always returns true if add function was called`() {
         val queue = DisabledQueue<Int>()
         queue.add(1)
 
-        assertFalse(queue.isEmpty(), "isEmpty should always return false.")
+        assertTrue(queue.isEmpty(), "isEmpty should always return true.")
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
DisabledQueue.isEmpty now returns true

#skip-changelog

## :bulb: Motivation and Context
This isn't really used anywhere, but it's conceptually correct for the `DisabledQueue` to return true on `isEmpty()`
Left from [another PR](https://github.com/getsentry/sentry-java/pull/3836#discussion_r1839687988)

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
