### PR TITLE
POTEL 58 - Extract OpenTelemetry `URL_PATH` span attribute into description

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -68,10 +68,18 @@ public final class SpanDescriptionExtractor {
       httpPath = httpTarget;
     }
     final @NotNull String op = opBuilder.toString();
+
     final @Nullable String urlFull = attributes.get(UrlAttributes.URL_FULL);
     if (urlFull != null) {
       if (httpPath == null) {
         httpPath = urlFull;
+      }
+    }
+
+    final @Nullable String urlPath = attributes.get(UrlAttributes.URL_PATH);
+    if (urlPath != null) {
+      if (httpPath == null) {
+        httpPath = urlPath;
       }
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Extract OpenTelemetry `URL_PATH` span attribute into description if other attributes aren't available.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3932 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
