### PR TITLE
POTEL 59 - Bump OpenTelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Extract OpenTelemetry `URL_PATH` span attribute into description ([#3933](https://github.com/getsentry/sentry-java/pull/3933))
 
+### Dependencies
+
+- Bump OpenTelemetry to 1.44.1, OpenTelemetry Java Agent to 2.10.0 and Semantic Conventions to 1.28.0 ([#3935](https://github.com/getsentry/sentry-java/pull/3935))
+
 ## 8.0.0-beta.3
 
 ### Features

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -156,11 +156,11 @@ object Config {
         val sentryNativeNdk = "io.sentry:sentry-native-ndk:0.7.14"
 
         object OpenTelemetry {
-            val otelVersion = "1.41.0"
+            val otelVersion = "1.44.1"
             val otelAlphaVersion = "$otelVersion-alpha"
-            val otelInstrumentationVersion = "2.7.0"
+            val otelInstrumentationVersion = "2.10.0"
             val otelInstrumentationAlphaVersion = "$otelInstrumentationVersion-alpha"
-            val otelSemanticConvetionsVersion = "1.25.0-alpha" // check https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/dependencyManagement/build.gradle.kts#L49 for release version above to find a compatible version
+            val otelSemanticConvetionsVersion = "1.28.0-alpha" // check https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/dependencyManagement/build.gradle.kts#L49 for release version above to find a compatible version
 
             val otelSdk = "io.opentelemetry:opentelemetry-sdk:$otelVersion"
             val otelSemconv = "io.opentelemetry.semconv:opentelemetry-semconv:$otelSemanticConvetionsVersion"

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -170,6 +170,7 @@ object Config {
             val otelJavaAgentTooling = "io.opentelemetry.javaagent:opentelemetry-javaagent-tooling:$otelInstrumentationAlphaVersion"
             val otelExtensionAutoconfigureSpi = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:$otelVersion"
             val otelExtensionAutoconfigure = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:$otelVersion"
+            val otelInstrumentationBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:$otelInstrumentationVersion"
         }
     }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -96,7 +96,14 @@ public final class SpanDescriptionExtractor {
   private OtelSpanInfo descriptionForDbSystem(final @NotNull SpanData otelSpan) {
     final @NotNull Attributes attributes = otelSpan.getAttributes();
     @Nullable String dbStatement = attributes.get(DbIncubatingAttributes.DB_STATEMENT);
-    @NotNull String description = dbStatement != null ? dbStatement : otelSpan.getName();
-    return new OtelSpanInfo("db", description, TransactionNameSource.TASK);
+    if (dbStatement != null) {
+      return new OtelSpanInfo("db", dbStatement, TransactionNameSource.TASK);
+    }
+    @Nullable String dbQueryText = attributes.get(DbIncubatingAttributes.DB_QUERY_TEXT);
+    if (dbQueryText != null) {
+      return new OtelSpanInfo("db", dbQueryText, TransactionNameSource.TASK);
+    }
+
+    return new OtelSpanInfo("db", otelSpan.getName(), TransactionNameSource.TASK);
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.7.0")
+        mavenBom(Config.Libs.OpenTelemetry.otelInstrumentationBom)
     }
 }
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -68,12 +68,6 @@ dependencies {
     testImplementation(Config.Libs.apolloKotlin)
 }
 
-dependencyManagement {
-    imports {
-        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.7.0")
-    }
-}
-
 configure<SourceSetContainer> {
     test {
         java.srcDir("src/test/java")

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -70,6 +70,12 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom(Config.Libs.OpenTelemetry.otelInstrumentationBom)
+    }
+}
+
 configure<SourceSetContainer> {
     test {
         java.srcDir("src/test/java")


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Bump OpenTelemetry SDK to `1.44.1`, OpenTelemetry instrumentation to `2.10.0` and OpenTelemetry semantic conventions to `1.28.0`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
