### PR TITLE
Warm start detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix warm start detection ([#3937](https://github.com/getsentry/sentry-java/pull/3937))
+
 ## 7.18.1
 
 ### Fixes
 
 - Fix testTag not working for Jetpack Compose user interaction tracking ([#3878](https://github.com/getsentry/sentry-java/pull/3878))
-- Fix warm start detection ([#3937](https://github.com/getsentry/sentry-java/pull/3937))
 
 ## 7.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix testTag not working for Jetpack Compose user interaction tracking ([#3878](https://github.com/getsentry/sentry-java/pull/3878))
+- Fix warm start detection ([#3937](https://github.com/getsentry/sentry-java/pull/3937))
 
 ## 7.18.0
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -27,8 +27,12 @@ public final class io/sentry/android/core/ActivityLifecycleIntegration : android
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityDestroyed (Landroid/app/Activity;)V
 	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityPostCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityPostResumed (Landroid/app/Activity;)V
+	public fun onActivityPostStarted (Landroid/app/Activity;)V
+	public fun onActivityPreCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityPrePaused (Landroid/app/Activity;)V
+	public fun onActivityPreStarted (Landroid/app/Activity;)V
 	public fun onActivityResumed (Landroid/app/Activity;)V
 	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityStarted (Landroid/app/Activity;)V
@@ -445,16 +449,19 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public fun getSdkInitTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
 	public fun isAppLaunchedInForeground ()Z
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onAppStartSpansSent ()V
 	public static fun onApplicationCreate (Landroid/app/Application;)V
 	public static fun onApplicationPostCreate (Landroid/app/Application;)V
 	public static fun onContentProviderCreate (Landroid/content/ContentProvider;)V
 	public static fun onContentProviderPostCreate (Landroid/content/ContentProvider;)V
 	public fun registerApplicationForegroundCheck (Landroid/app/Application;)V
+	public fun restartAppStart (J)V
 	public fun setAppLaunchedInForeground (Z)V
 	public fun setAppStartProfiler (Lio/sentry/ITransactionProfiler;)V
 	public fun setAppStartSamplingDecision (Lio/sentry/TracesSamplingDecision;)V
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
 	public fun setClassLoadedUptimeMs (J)V
+	public fun shouldSendStartMeasurements ()Z
 }
 
 public final class io/sentry/android/core/performance/AppStartMetrics$AppStartType : java/lang/Enum {

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -448,6 +448,7 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public static fun getInstance ()Lio/sentry/android/core/performance/AppStartMetrics;
 	public fun getSdkInitTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
 	public fun isAppLaunchedInForeground ()Z
+	public fun isColdStartValid ()Z
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onAppStartSpansSent ()V
 	public static fun onApplicationCreate (Landroid/app/Application;)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -429,13 +429,12 @@ public final class ActivityLifecycleIntegration
 
   @Override
   public void onActivityPreStarted(final @NotNull Activity activity) {
-    final long now = SystemClock.uptimeMillis();
     if (appStartSpan == null) {
       return;
     }
     final @Nullable ActivityLifecycleTimeSpan timeSpan = activityLifecycleMap.get(activity);
     if (timeSpan != null) {
-      timeSpan.getOnStart().setStartedAt(now);
+      timeSpan.getOnStart().setStartedAt(SystemClock.uptimeMillis());
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -708,9 +708,13 @@ public final class ActivityLifecycleIntegration
                     ? AppStartMetrics.AppStartType.COLD
                     : AppStartMetrics.AppStartType.WARM);
       } else {
-        TimeSpan appStartSpan = AppStartMetrics.getInstance().getAppStartTimeSpan();
-        // If the app start span already started and stopped, it means we are in a warm start
-        if (appStartSpan.hasStarted() && appStartSpan.hasStopped()) {
+        final @NotNull TimeSpan appStartSpan = AppStartMetrics.getInstance().getAppStartTimeSpan();
+        // If the app start span already started and stopped, it means the app restarted without
+        //  killing the process, so we are in a warm start
+        // If the app has an invalid cold start, it means it was started in the background, like
+        //  via BroadcastReceiver, so we consider it a warm start
+        if ((appStartSpan.hasStarted() && appStartSpan.hasStopped())
+            || (!AppStartMetrics.getInstance().isColdStartValid())) {
           AppStartMetrics.getInstance().restartAppStart(lastPausedUptimeMillis);
           AppStartMetrics.getInstance().setAppStartType(AppStartMetrics.AppStartType.WARM);
         } else {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -672,7 +672,8 @@ public final class ActivityLifecycleIntegration
   }
 
   @TestOnly
-  @NotNull WeakHashMap<Activity, ActivityLifecycleTimeSpan> getActivityLifecycleMap() {
+  @NotNull
+  WeakHashMap<Activity, ActivityLifecycleTimeSpan> getActivityLifecycleMap() {
     return activityLifecycleMap;
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -232,10 +232,4 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
       }
     }
   }
-
-  @TestOnly
-  @Nullable
-  Application.ActivityLifecycleCallbacks getActivityCallback() {
-    return activityCallback;
-  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -9,14 +9,14 @@ import android.content.Context;
 import android.content.pm.ProviderInfo;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Process;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import io.sentry.ILogger;
 import io.sentry.ITransactionProfiler;
 import io.sentry.JsonSerializer;
-import io.sentry.NoOpLogger;
 import io.sentry.SentryAppStartProfilingOptions;
 import io.sentry.SentryExecutorService;
 import io.sentry.SentryLevel;
@@ -25,7 +25,6 @@ import io.sentry.TracesSamplingDecision;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
 import io.sentry.android.core.performance.ActivityLifecycleCallbacksAdapter;
-import io.sentry.android.core.performance.ActivityLifecycleTimeSpan;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import java.io.BufferedReader;
@@ -34,7 +33,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -206,101 +204,23 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
 
     activityCallback =
         new ActivityLifecycleCallbacksAdapter() {
-          final WeakHashMap<Activity, ActivityLifecycleTimeSpan> activityLifecycleMap =
-              new WeakHashMap<>();
-
-          @Override
-          public void onActivityPreCreated(
-              @NonNull Activity activity, @Nullable Bundle savedInstanceState) {
-            final long now = SystemClock.uptimeMillis();
-            if (appStartMetrics.getAppStartTimeSpan().hasStopped()) {
-              return;
-            }
-
-            final ActivityLifecycleTimeSpan timeSpan = new ActivityLifecycleTimeSpan();
-            timeSpan.getOnCreate().setStartedAt(now);
-            activityLifecycleMap.put(activity, timeSpan);
-          }
-
-          @Override
-          public void onActivityCreated(
-              @NonNull Activity activity, @Nullable Bundle savedInstanceState) {
-            if (appStartMetrics.getAppStartType() == AppStartMetrics.AppStartType.UNKNOWN) {
-              appStartMetrics.setAppStartType(
-                  savedInstanceState == null
-                      ? AppStartMetrics.AppStartType.COLD
-                      : AppStartMetrics.AppStartType.WARM);
-            }
-          }
-
-          @Override
-          public void onActivityPostCreated(
-              @NonNull Activity activity, @Nullable Bundle savedInstanceState) {
-            if (appStartMetrics.getAppStartTimeSpan().hasStopped()) {
-              return;
-            }
-
-            final @Nullable ActivityLifecycleTimeSpan timeSpan = activityLifecycleMap.get(activity);
-            if (timeSpan != null) {
-              timeSpan.getOnCreate().stop();
-              timeSpan.getOnCreate().setDescription(activity.getClass().getName() + ".onCreate");
-            }
-          }
-
-          @Override
-          public void onActivityPreStarted(@NonNull Activity activity) {
-            final long now = SystemClock.uptimeMillis();
-            if (appStartMetrics.getAppStartTimeSpan().hasStopped()) {
-              return;
-            }
-            final @Nullable ActivityLifecycleTimeSpan timeSpan = activityLifecycleMap.get(activity);
-            if (timeSpan != null) {
-              timeSpan.getOnStart().setStartedAt(now);
-            }
-          }
-
           @Override
           public void onActivityStarted(@NonNull Activity activity) {
             if (firstDrawDone.get()) {
               return;
             }
-            FirstDrawDoneListener.registerForNextDraw(
-                activity,
-                () -> {
-                  if (firstDrawDone.compareAndSet(false, true)) {
-                    onAppStartDone();
-                  }
-                },
-                // as the SDK isn't initialized yet, we don't have access to SentryOptions
-                new BuildInfoProvider(NoOpLogger.getInstance()));
-          }
-
-          @Override
-          public void onActivityPostStarted(@NonNull Activity activity) {
-            final @Nullable ActivityLifecycleTimeSpan timeSpan =
-                activityLifecycleMap.remove(activity);
-            if (appStartMetrics.getAppStartTimeSpan().hasStopped()) {
-              return;
+            if (activity.getWindow() != null) {
+              FirstDrawDoneListener.registerForNextDraw(
+                  activity, () -> onAppStartDone(), buildInfoProvider);
+            } else {
+              new Handler(Looper.getMainLooper()).post(() -> onAppStartDone());
             }
-            if (timeSpan != null) {
-              timeSpan.getOnStart().stop();
-              timeSpan.getOnStart().setDescription(activity.getClass().getName() + ".onStart");
-
-              appStartMetrics.addActivityLifecycleTimeSpans(timeSpan);
-            }
-          }
-
-          @Override
-          public void onActivityDestroyed(@NonNull Activity activity) {
-            // safety net for activities which were created but never stopped
-            activityLifecycleMap.remove(activity);
           }
         };
 
     app.registerActivityLifecycleCallbacks(activityCallback);
   }
 
-  @TestOnly
   synchronized void onAppStartDone() {
     final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
     appStartMetrics.getSdkInitTimeSpan().stop();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -152,11 +152,11 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     return shouldSendStartMeasurements;
   }
 
-  public void restartAppStart(final long timestampMs) {
+  public void restartAppStart(final long uptimeMillis) {
     shouldSendStartMeasurements = true;
     appStartSpan.reset();
     appStartSpan.start();
-    appStartSpan.setStartUnixTimeMs(timestampMs);
+    appStartSpan.setStartedAt(uptimeMillis);
     CLASS_LOADED_UPTIME_MS = appStartSpan.getStartUptimeMs();
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.TestOnly;
 
 /**
  * A measurement for time critical components on a macro (ms) level. Based on {@link
@@ -148,9 +147,12 @@ public class TimeSpan implements Comparable<TimeSpan> {
     }
   }
 
-  @TestOnly
   public void setStartUnixTimeMs(long startUnixTimeMs) {
     this.startUnixTimeMs = startUnixTimeMs;
+
+    final long shiftMs = System.currentTimeMillis() - startUnixTimeMs;
+    this.startUptimeMs = SystemClock.uptimeMillis() - shiftMs;
+    startSystemNanos = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(shiftMs);
   }
 
   public @Nullable String getDescription() {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/TimeSpan.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * A measurement for time critical components on a macro (ms) level. Based on {@link
@@ -147,12 +148,9 @@ public class TimeSpan implements Comparable<TimeSpan> {
     }
   }
 
+  @TestOnly
   public void setStartUnixTimeMs(long startUnixTimeMs) {
     this.startUnixTimeMs = startUnixTimeMs;
-
-    final long shiftMs = System.currentTimeMillis() - startUnixTimeMs;
-    this.startUptimeMs = SystemClock.uptimeMillis() - shiftMs;
-    startSystemNanos = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(shiftMs);
   }
 
   public @Nullable String getDescription() {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -1437,7 +1437,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         // Activity onCreate date will be used
         sut.onActivityPreCreated(activity, fixture.bundle)
-        //sut.onActivityCreated(activity, fixture.bundle)
+        // sut.onActivityCreated(activity, fixture.bundle)
 
         assertFalse(sut.activityLifecycleMap.isEmpty())
         assertTrue(sut.activityLifecycleMap.values.first().onCreate.hasStarted())

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -338,13 +338,25 @@ class ActivityLifecycleIntegrationTest {
         sut.onActivityPostResumed(activity)
 
         verify(fixture.hub, never()).captureTransaction(
-            check {
-                assertEquals(SpanStatus.OK, it.status)
-            },
+            any(),
             anyOrNull<TraceContext>(),
             anyOrNull(),
             anyOrNull()
         )
+    }
+
+    @Test
+    fun `When tracing auto finish is disabled, do not finish transaction`() {
+        val sut = fixture.getSut(initializer = {
+            it.tracesSampleRate = 1.0
+            it.isEnableActivityLifecycleTracingAutoFinish = false
+        })
+        sut.register(fixture.hub, fixture.options)
+        val activity = mock<Activity>()
+        sut.onActivityCreated(activity, fixture.bundle)
+        // We don't schedule the transaction to finish
+        assertFalse(fixture.transaction.isFinishing())
+        assertFalse(fixture.transaction.isFinished)
     }
 
     @Test
@@ -369,20 +381,6 @@ class ActivityLifecycleIntegrationTest {
             anyOrNull(),
             anyOrNull()
         )
-    }
-
-    @Test
-    fun `When tracing auto finish is disabled, do not finish transaction`() {
-        val sut = fixture.getSut(initializer = {
-            it.tracesSampleRate = 1.0
-            it.isEnableActivityLifecycleTracingAutoFinish = false
-        })
-        sut.register(fixture.hub, fixture.options)
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, fixture.bundle)
-        sut.onActivityPostResumed(activity)
-
-        verify(fixture.hub, never()).captureTransaction(any(), anyOrNull(), anyOrNull(), anyOrNull())
     }
 
     @Test
@@ -467,24 +465,7 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When Activity is destroyed, sets ttidSpan status to deadline_exceeded and finish it`() {
-        val sut = fixture.getSut()
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        setAppStartTime()
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, fixture.bundle)
-        sut.onActivityDestroyed(activity)
-
-        val span = fixture.transaction.children.first { it.operation == ActivityLifecycleIntegration.TTID_OP }
-        assertEquals(SpanStatus.DEADLINE_EXCEEDED, span.status)
-        assertTrue(span.isFinished)
-    }
-
-    @Test
-    fun `When Activity is destroyed, sets ttidSpan to null`() {
+    fun `When Activity is destroyed, finish ttidSpan with deadline_exceeded and remove from map`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
@@ -494,31 +475,16 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, fixture.bundle)
         assertNotNull(sut.ttidSpanMap[activity])
-
         sut.onActivityDestroyed(activity)
+
+        val span = fixture.transaction.children.first { it.operation == ActivityLifecycleIntegration.TTID_OP }
+        assertEquals(SpanStatus.DEADLINE_EXCEEDED, span.status)
+        assertTrue(span.isFinished)
         assertNull(sut.ttidSpanMap[activity])
     }
 
     @Test
-    fun `When Activity is destroyed, sets ttfdSpan status to deadline_exceeded and finish it`() {
-        val sut = fixture.getSut()
-        fixture.options.tracesSampleRate = 1.0
-        fixture.options.isEnableTimeToFullDisplayTracing = true
-        sut.register(fixture.hub, fixture.options)
-
-        setAppStartTime()
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, fixture.bundle)
-        sut.onActivityDestroyed(activity)
-
-        val span = fixture.transaction.children.first { it.operation == ActivityLifecycleIntegration.TTFD_OP }
-        assertEquals(SpanStatus.DEADLINE_EXCEEDED, span.status)
-        assertTrue(span.isFinished)
-    }
-
-    @Test
-    fun `When Activity is destroyed, sets ttfdSpan to null`() {
+    fun `When Activity is destroyed, finish ttfdSpan with deadline_exceeded and remove from map`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         fixture.options.isEnableTimeToFullDisplayTracing = true
@@ -529,8 +495,11 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, fixture.bundle)
         assertNotNull(sut.ttfdSpanMap[activity])
-
         sut.onActivityDestroyed(activity)
+
+        val span = fixture.transaction.children.first { it.operation == ActivityLifecycleIntegration.TTFD_OP }
+        assertEquals(SpanStatus.DEADLINE_EXCEEDED, span.status)
+        assertTrue(span.isFinished)
         assertNull(sut.ttfdSpanMap[activity])
     }
 
@@ -547,7 +516,7 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `do not stop transaction on resumed if API 29`() {
+    fun `do not stop transaction on resumed`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
@@ -560,31 +529,11 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `do not stop transaction on resumed if API less than 29 and ttid and ttfd are finished`() {
-        val sut = fixture.getSut(Build.VERSION_CODES.P)
-        fixture.options.tracesSampleRate = 1.0
-        fixture.options.isEnableTimeToFullDisplayTracing = true
-        sut.register(fixture.hub, fixture.options)
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, mock())
-        sut.ttidSpanMap.values.first().finish()
-        sut.ttfdSpanMap.values.first().finish()
-        sut.onActivityResumed(activity)
-
-        verify(fixture.hub, never()).captureTransaction(any(), any(), anyOrNull(), anyOrNull())
-    }
-
-    @Test
-    fun `start transaction on created if API less than 29`() {
-        val sut = fixture.getSut(Build.VERSION_CODES.P)
+    fun `start transaction on created`() {
+        val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
-
-        setAppStartTime()
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, mock())
+        sut.onActivityCreated(mock(), mock())
 
         verify(fixture.hub).startTransaction(any(), any<TransactionOptions>())
     }
@@ -594,6 +543,7 @@ class ActivityLifecycleIntegrationTest {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         fixture.options.isEnableTimeToFullDisplayTracing = true
+        fixture.options.idleTimeout = 0
         sut.register(fixture.hub, fixture.options)
 
         val activity = mock<Activity>()
@@ -602,6 +552,7 @@ class ActivityLifecycleIntegrationTest {
         sut.ttidSpanMap.values.first().finish()
         sut.onActivityResumed(activity)
         sut.onActivityPostResumed(activity)
+        runFirstDraw(fixture.createView())
 
         assertNotNull(ttfd)
         assertFalse(ttfd.isFinished)
@@ -682,15 +633,18 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true, start transaction with given appStartTime`() {
+    fun `When firstActivityCreated is false, start transaction with given appStartTime`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime(date)
+        fixture.options.dateProvider = SentryDateProvider { date }
 
         val activity = mock<Activity>()
+        sut.onActivityPreCreated(activity, fixture.bundle)
         sut.onActivityCreated(activity, fixture.bundle)
 
         // call only once
@@ -703,15 +657,17 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true and app start sampling decision is set, start transaction with isAppStart true`() {
+    fun `When firstActivityCreated is false and app start sampling decision is set, start transaction with isAppStart true`() {
         AppStartMetrics.getInstance().appStartSamplingDecision = mock()
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime(date)
 
         val activity = mock<Activity>()
+        sut.onActivityPreCreated(activity, fixture.bundle)
         sut.onActivityCreated(activity, fixture.bundle)
 
         verify(fixture.hub).startTransaction(
@@ -724,9 +680,10 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true and app start sampling decision is not set, start transaction with isAppStart false`() {
+    fun `When firstActivityCreated is false and app start sampling decision is not set, start transaction with isAppStart false`() {
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         val date2 = SentryNanotimeDate(Date(2), 2)
@@ -735,6 +692,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         // The activity onCreate date will be ignored
         fixture.options.dateProvider = SentryDateProvider { date2 }
+        sut.onActivityPreCreated(activity, fixture.bundle)
         sut.onActivityCreated(activity, fixture.bundle)
 
         verify(fixture.hub).startTransaction(
@@ -748,43 +706,27 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is false and app start sampling decision is set, start transaction with isAppStart false`() {
+    fun `When firstActivityCreated is true and app start sampling decision is set, start transaction with isAppStart false`() {
         AppStartMetrics.getInstance().appStartSamplingDecision = mock()
         val sut = fixture.getSut { it.tracesSampleRate = 1.0 }
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(true)
+        val date = SentryNanotimeDate(Date(1), 0)
+        setAppStartTime(date)
 
         val activity = mock<Activity>()
+        sut.onActivityPreCreated(activity, fixture.bundle)
         sut.onActivityCreated(activity, fixture.bundle)
 
         verify(fixture.hub).startTransaction(any(), check<TransactionOptions> { assertFalse(it.isAppStartTransaction) })
     }
 
     @Test
-    fun `When firstActivityCreated is true, do not create app start span if not foregroundImportance`() {
-        val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_BACKGROUND)
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        // usually set by SentryPerformanceProvider
-        val date = SentryNanotimeDate(Date(1), 0)
-        setAppStartTime(date)
-        AppStartMetrics.getInstance().sdkInitTimeSpan.setStoppedAt(2)
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, fixture.bundle)
-
-        // call only once
-        verify(fixture.hub).startTransaction(
-            any(),
-            check<TransactionOptions> { assertNotEquals(date, it.startTimestamp) }
-        )
-    }
-
-    @Test
-    fun `When firstActivityCreated is true and no app start time is set, default to onActivityCreated time`() {
+    fun `When firstActivityCreated is false and no app start time is set, default to onActivityPreCreated time`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         // usually set by SentryPerformanceProvider
         val date = SentryNanotimeDate(Date(1), 0)
@@ -793,6 +735,7 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         // Activity onCreate date will be used
         fixture.options.dateProvider = SentryDateProvider { date2 }
+        sut.onActivityPreCreated(activity, fixture.bundle)
         sut.onActivityCreated(activity, fixture.bundle)
 
         verify(fixture.hub).startTransaction(
@@ -805,8 +748,29 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
+    fun `When not foregroundImportance, do not create app start span`() {
+        val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_BACKGROUND)
+        fixture.options.tracesSampleRate = 1.0
+        sut.register(fixture.hub, fixture.options)
+
+        // usually set by SentryPerformanceProvider
+        val date = SentryNanotimeDate(Date(1), 0)
+        setAppStartTime(date)
+
+        val activity = mock<Activity>()
+        sut.onActivityPreCreated(activity, fixture.bundle)
+        sut.onActivityCreated(activity, fixture.bundle)
+
+        // call only once
+        verify(fixture.hub).startTransaction(
+            any(),
+            check<TransactionOptions> { assertNotEquals(date.nanoTimestamp(), it.startTimestamp!!.nanoTimestamp()) }
+        )
+    }
+
+    @Test
     fun `Create and finish app start span immediately in case SDK init is deferred`() {
-        val sut = fixture.getSut(importance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
+        val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
 
@@ -822,12 +786,10 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, fixture.bundle)
 
-        val appStartSpanCount = fixture.transaction.children.count {
-            it.spanContext.operation.startsWith("app.start.warm") &&
-                it.startDate.nanoTimestamp() == startDate.nanoTimestamp() &&
-                it.finishDate!!.nanoTimestamp() == endDate!!.nanoTimestamp()
-        }
-        assertEquals(1, appStartSpanCount)
+        val appStartSpan = fixture.transaction.children.first { it.operation.startsWith("app.start.warm") }
+        assertEquals(startDate.nanoTimestamp(), appStartSpan.startDate.nanoTimestamp())
+        assertEquals(endDate!!.nanoTimestamp(), appStartSpan.finishDate!!.nanoTimestamp())
+        assertTrue(appStartSpan.isFinished)
     }
 
     @Test
@@ -921,10 +883,11 @@ class ActivityLifecycleIntegrationTest {
     }
 
     @Test
-    fun `When firstActivityCreated is true, start app start warm span with given appStartTime`() {
+    fun `When firstActivityCreated is false and bundle is not null, start app start warm span with given appStartTime`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime(date)
@@ -934,14 +897,16 @@ class ActivityLifecycleIntegrationTest {
 
         val span = fixture.transaction.children.first()
         assertEquals(span.operation, "app.start.warm")
+        assertEquals(span.description, "Warm Start")
         assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
     }
 
     @Test
-    fun `When firstActivityCreated is true, start app start cold span with given appStartTime`() {
+    fun `When firstActivityCreated is false and bundle is not null, start app start cold span with given appStartTime`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime(date)
@@ -951,48 +916,16 @@ class ActivityLifecycleIntegrationTest {
 
         val span = fixture.transaction.children.first()
         assertEquals(span.operation, "app.start.cold")
-        assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
-    }
-
-    @Test
-    fun `When firstActivityCreated is true, start app start span with Warm description`() {
-        val sut = fixture.getSut()
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        val date = SentryNanotimeDate(Date(1), 0)
-        setAppStartTime(date)
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, fixture.bundle)
-
-        val span = fixture.transaction.children.first()
-        assertEquals(span.description, "Warm Start")
-        assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
-    }
-
-    @Test
-    fun `When firstActivityCreated is true, start app start span with Cold description`() {
-        val sut = fixture.getSut()
-        fixture.options.tracesSampleRate = 1.0
-        sut.register(fixture.hub, fixture.options)
-
-        val date = SentryNanotimeDate(Date(1), 0)
-        setAppStartTime(date)
-
-        val activity = mock<Activity>()
-        sut.onActivityCreated(activity, null)
-
-        val span = fixture.transaction.children.first()
         assertEquals(span.description, "Cold Start")
         assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
     }
 
     @Test
-    fun `When firstActivityCreated is true and app started more than 1 minute ago, app start spans are dropped`() {
+    fun `When firstActivityCreated is false and app started more than 1 minute ago, start app with Warm start`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         val duration = TimeUnit.MINUTES.toMillis(1) + 2
@@ -1003,18 +936,19 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, null)
 
-        val appStartSpan = fixture.transaction.children.firstOrNull {
-            it.description == "Cold Start"
-        }
-        assertNull(appStartSpan)
+        val span = fixture.transaction.children.first()
+        assertEquals(span.operation, "app.start.warm")
+        assertEquals(span.description, "Warm Start")
+        assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
     }
 
     @Test
-    fun `When firstActivityCreated is true and app started in background, app start spans are dropped`() {
+    fun `When firstActivityCreated is false and app started in background, start app with Warm start`() {
         val sut = fixture.getSut()
         AppStartMetrics.getInstance().isAppLaunchedInForeground = false
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(false)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime(date)
@@ -1022,17 +956,18 @@ class ActivityLifecycleIntegrationTest {
         val activity = mock<Activity>()
         sut.onActivityCreated(activity, null)
 
-        val appStartSpan = fixture.transaction.children.firstOrNull {
-            it.description == "Cold Start"
-        }
-        assertNull(appStartSpan)
+        val span = fixture.transaction.children.first()
+        assertEquals(span.operation, "app.start.warm")
+        assertEquals(span.description, "Warm Start")
+        assertEquals(span.startDate.nanoTimestamp(), date.nanoTimestamp())
     }
 
     @Test
-    fun `When firstActivityCreated is false, start transaction but not with given appStartTime`() {
+    fun `When firstActivityCreated is true, start transaction but not with given appStartTime`() {
         val sut = fixture.getSut()
         fixture.options.tracesSampleRate = 1.0
         sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(true)
 
         val date = SentryNanotimeDate(Date(1), 0)
         setAppStartTime()
@@ -1041,11 +976,6 @@ class ActivityLifecycleIntegrationTest {
         // First invocation: we expect to start a transaction with the appStartTime
         sut.onActivityCreated(activity, fixture.bundle)
         sut.onActivityPostResumed(activity)
-        assertEquals(date.nanoTimestamp(), fixture.transaction.startDate.nanoTimestamp())
-
-        val newActivity = mock<Activity>()
-        // Second invocation: we expect to start a transaction with a different start timestamp
-        sut.onActivityCreated(newActivity, fixture.bundle)
         assertNotEquals(date.nanoTimestamp(), fixture.transaction.startDate.nanoTimestamp())
     }
 
@@ -1492,6 +1422,151 @@ class ActivityLifecycleIntegrationTest {
         // then the transaction should start with the paused time
         assertEquals(now.nanoTimestamp(), fixture.transaction.startDate.nanoTimestamp())
     }
+
+    @Test
+    fun `On activity preCreated onCreate span is created`() {
+        val sut = fixture.getSut()
+        fixture.options.tracesSampleRate = 1.0
+        sut.register(fixture.hub, fixture.options)
+
+        val date = SentryNanotimeDate(Date(1), 0)
+        setAppStartTime(date)
+
+        assertTrue(sut.activityLifecycleMap.isEmpty())
+
+        val activity = mock<Activity>()
+        // Activity onCreate date will be used
+        sut.onActivityPreCreated(activity, fixture.bundle)
+        //sut.onActivityCreated(activity, fixture.bundle)
+
+        assertFalse(sut.activityLifecycleMap.isEmpty())
+        assertTrue(sut.activityLifecycleMap.values.first().onCreate.hasStarted())
+        assertFalse(sut.activityLifecycleMap.values.first().onCreate.hasStopped())
+    }
+
+    @Test
+    fun `Creates activity lifecycle spans`() {
+        val sut = fixture.getSut()
+        fixture.options.tracesSampleRate = 1.0
+        val appStartDate = SentryNanotimeDate(Date(1), 0)
+        val startDate = SentryNanotimeDate(Date(2), 0)
+        val appStartMetrics = AppStartMetrics.getInstance()
+        val activity = mock<Activity>()
+        fixture.options.dateProvider = SentryDateProvider { startDate }
+        setAppStartTime(appStartDate)
+
+        sut.register(fixture.hub, fixture.options)
+        assertTrue(sut.activityLifecycleMap.isEmpty())
+
+        sut.onActivityPreCreated(activity, null)
+
+        assertFalse(sut.activityLifecycleMap.isEmpty())
+        val activityLifecycleSpan = sut.activityLifecycleMap.values.first()
+        assertTrue(activityLifecycleSpan.onCreate.hasStarted())
+        assertEquals(startDate.nanoTimestamp(), sut.getProperty<SentryDate>("lastPausedTime").nanoTimestamp())
+
+        sut.onActivityCreated(activity, null)
+        assertNotNull(sut.appStartSpan)
+
+        sut.onActivityPostCreated(activity, null)
+        assertTrue(activityLifecycleSpan.onCreate.hasStopped())
+
+        sut.onActivityPreStarted(activity)
+        assertTrue(activityLifecycleSpan.onStart.hasStarted())
+
+        sut.onActivityStarted(activity)
+        assertTrue(appStartMetrics.activityLifecycleTimeSpans.isEmpty())
+
+        sut.onActivityPostStarted(activity)
+        assertTrue(activityLifecycleSpan.onStart.hasStopped())
+        assertFalse(appStartMetrics.activityLifecycleTimeSpans.isEmpty())
+    }
+
+    @Test
+    fun `Creates activity lifecycle spans on API lower than 29`() {
+        val sut = fixture.getSut(apiVersion = Build.VERSION_CODES.P)
+        fixture.options.tracesSampleRate = 1.0
+        val appStartDate = SentryNanotimeDate(Date(1), 0)
+        val startDate = SentryNanotimeDate(Date(2), 0)
+        val appStartMetrics = AppStartMetrics.getInstance()
+        val activity = mock<Activity>()
+        fixture.options.dateProvider = SentryDateProvider { startDate }
+        setAppStartTime(appStartDate)
+
+        sut.register(fixture.hub, fixture.options)
+        assertTrue(sut.activityLifecycleMap.isEmpty())
+
+        sut.onActivityCreated(activity, null)
+
+        assertFalse(sut.activityLifecycleMap.isEmpty())
+        val activityLifecycleSpan = sut.activityLifecycleMap.values.first()
+        assertTrue(activityLifecycleSpan.onCreate.hasStarted())
+        assertEquals(startDate.nanoTimestamp(), sut.getProperty<SentryDate>("lastPausedTime").nanoTimestamp())
+        assertNotNull(sut.appStartSpan)
+
+        sut.onActivityStarted(activity)
+        assertTrue(activityLifecycleSpan.onCreate.hasStopped())
+        assertTrue(activityLifecycleSpan.onStart.hasStarted())
+        assertTrue(appStartMetrics.activityLifecycleTimeSpans.isEmpty())
+
+        sut.onActivityResumed(activity)
+        assertTrue(activityLifecycleSpan.onStart.hasStopped())
+        assertFalse(appStartMetrics.activityLifecycleTimeSpans.isEmpty())
+    }
+
+    @Test
+    fun `Does not add activity lifecycle spans when firstActivityCreated is true`() {
+        val sut = fixture.getSut()
+        fixture.options.tracesSampleRate = 1.0
+        val appStartDate = SentryNanotimeDate(Date(1), 0)
+        val startDate = SentryNanotimeDate(Date(2), 0)
+        val appStartMetrics = AppStartMetrics.getInstance()
+        val activity = mock<Activity>()
+        fixture.options.dateProvider = SentryDateProvider { startDate }
+        setAppStartTime(appStartDate)
+        sut.register(fixture.hub, fixture.options)
+        sut.setFirstActivityCreated(true)
+
+        sut.onActivityPreCreated(activity, null)
+        sut.onActivityCreated(activity, null)
+        sut.onActivityPostCreated(activity, null)
+        sut.onActivityPreStarted(activity)
+        sut.onActivityStarted(activity)
+        sut.onActivityPostStarted(activity)
+        assertTrue(appStartMetrics.activityLifecycleTimeSpans.isEmpty())
+    }
+
+    @Test
+    fun `When firstActivityCreated is false and app start span has stopped, restart app start to current date`() {
+        val sut = fixture.getSut()
+        fixture.options.tracesSampleRate = 1.0
+        val appStartDate = SentryNanotimeDate(Date(1), 0)
+        val appStartMetrics = AppStartMetrics.getInstance()
+        val activity = mock<Activity>()
+        setAppStartTime(appStartDate)
+        // Let's pretend app start started and finished
+        appStartMetrics.appStartTimeSpan.stop()
+        sut.register(fixture.hub, fixture.options)
+
+        assertEquals(0, sut.getProperty<Long>("lastPausedUptimeMillis"))
+
+        // An Activity (the first) is created after app start has finished
+        sut.onActivityPreCreated(activity, null)
+        // lastPausedUptimeMillis is set to current SystemClock.uptimeMillis()
+        val lastUptimeMillis = sut.getProperty<Long>("lastPausedUptimeMillis")
+        assertNotEquals(0, lastUptimeMillis)
+
+        sut.onActivityCreated(activity, null)
+        // AppStartMetrics app start time is set to Activity preCreated timestamp
+        assertEquals(lastUptimeMillis, appStartMetrics.appStartTimeSpan.startUptimeMs)
+        // AppStart type is considered warm
+        assertEquals(AppStartType.WARM, appStartMetrics.appStartType)
+
+        // Activity appStart span timestamp is the same of AppStartMetrics.appStart timestamp
+        assertEquals(sut.appStartSpan!!.startDate.nanoTimestamp(), appStartMetrics.getAppStartTimeSpanWithFallback(fixture.options).startTimestamp!!.nanoTimestamp())
+    }
+
+    private fun SentryTracer.isFinishing() = getProperty<Any>("finishStatus").getProperty<Boolean>("isFinishing")
 
     private fun runFirstDraw(view: View) {
         // Removes OnDrawListener in the next OnGlobalLayout after onDraw

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -13,6 +13,7 @@ import io.sentry.SpanStatus
 import io.sentry.TracesSamplingDecision
 import io.sentry.TransactionContext
 import io.sentry.android.core.ActivityLifecycleIntegration.APP_START_COLD
+import io.sentry.android.core.ActivityLifecycleIntegration.APP_START_WARM
 import io.sentry.android.core.ActivityLifecycleIntegration.UI_LOAD_OP
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan
 import io.sentry.android.core.performance.AppStartMetrics
@@ -59,13 +60,13 @@ class PerformanceAndroidEventProcessorTest {
 
     private val fixture = Fixture()
 
-    private fun createAppStartSpan(traceId: SentryId) = SentrySpan(
+    private fun createAppStartSpan(traceId: SentryId, coldStart: Boolean = true) = SentrySpan(
         0.0,
         1.0,
         traceId,
         SpanId(),
         null,
-        APP_START_COLD,
+        if (coldStart) APP_START_COLD else APP_START_WARM,
         "App Start",
         SpanStatus.OK,
         null,
@@ -293,6 +294,56 @@ class PerformanceAndroidEventProcessorTest {
     }
 
     @Test
+    fun `adds app start metrics to app warm start txn`() {
+        // given some app start metrics
+        val appStartMetrics = AppStartMetrics.getInstance()
+        appStartMetrics.appStartType = AppStartType.WARM
+        appStartMetrics.appStartTimeSpan.setStartedAt(123)
+        appStartMetrics.appStartTimeSpan.setStoppedAt(456)
+
+        val contentProvider = mock<ContentProvider>()
+        AppStartMetrics.onContentProviderCreate(contentProvider)
+        AppStartMetrics.onContentProviderPostCreate(contentProvider)
+
+        appStartMetrics.applicationOnCreateTimeSpan.apply {
+            setStartedAt(10)
+            setStoppedAt(42)
+        }
+
+        val activityTimeSpan = ActivityLifecycleTimeSpan()
+        activityTimeSpan.onCreate.description = "MainActivity.onCreate"
+        activityTimeSpan.onStart.description = "MainActivity.onStart"
+
+        activityTimeSpan.onCreate.setStartedAt(200)
+        activityTimeSpan.onStart.setStartedAt(220)
+        activityTimeSpan.onStart.setStoppedAt(240)
+        activityTimeSpan.onCreate.setStoppedAt(260)
+        appStartMetrics.addActivityLifecycleTimeSpans(activityTimeSpan)
+
+        // when an activity transaction is created
+        val sut = fixture.getSut(enablePerformanceV2 = true)
+        val context = TransactionContext("Activity", UI_LOAD_OP)
+        val tracer = SentryTracer(context, fixture.hub)
+        var tr = SentryTransaction(tracer)
+
+        // and it contains an app.start.warm span
+        val appStartSpan = createAppStartSpan(tr.contexts.trace!!.traceId, false)
+        tr.spans.add(appStartSpan)
+
+        // then the app start metrics should be attached
+        tr = sut.process(tr, Hint())
+
+        // process init, content provider and application span should not be attached
+        assertFalse(tr.spans.any { "process.load" == it.op })
+        assertFalse(tr.spans.any { "contentprovider.load" == it.op })
+        assertFalse(tr.spans.any { "application.load" == it.op })
+
+        // activity spans should be attached
+        assertTrue(tr.spans.any { "activity.load" == it.op && "MainActivity.onCreate" == it.description })
+        assertTrue(tr.spans.any { "activity.load" == it.op && "MainActivity.onStart" == it.description })
+    }
+
+    @Test
     fun `when app launched from background, app start spans are dropped`() {
         // given some app start metrics
         val appStartMetrics = AppStartMetrics.getInstance()
@@ -444,8 +495,10 @@ class PerformanceAndroidEventProcessorTest {
         val appStartSpan = createAppStartSpan(tr.contexts.trace!!.traceId)
         tr.spans.add(appStartSpan)
 
-        // then the app start metrics should not be attached
+        assertTrue(appStartMetrics.shouldSendStartMeasurements())
+        // then the app start metrics should be attached
         tr = sut.process(tr, Hint())
+        assertFalse(appStartMetrics.shouldSendStartMeasurements())
 
         assertTrue(
             tr.spans.any {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -3,7 +3,6 @@ package io.sentry.android.core
 import android.app.Application
 import android.content.pm.ProviderInfo
 import android.os.Build
-import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
 import io.sentry.JsonSerializer
@@ -12,7 +11,6 @@ import io.sentry.SentryAppStartProfilingOptions
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.android.core.performance.AppStartMetrics
-import io.sentry.android.core.performance.AppStartMetrics.AppStartType
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -28,7 +26,6 @@ import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -105,50 +105,6 @@ class SentryPerformanceProviderTest {
     }
 
     @Test
-    fun `provider sets cold start based on first activity`() {
-        val provider = fixture.getSut()
-
-        // up until this point app start is not known
-        assertEquals(AppStartType.UNKNOWN, AppStartMetrics.getInstance().appStartType)
-
-        // when there's no saved state
-        provider.activityCallback!!.onActivityCreated(mock(), null)
-        // then app start should be cold
-        assertEquals(AppStartType.COLD, AppStartMetrics.getInstance().appStartType)
-    }
-
-    @Test
-    fun `provider sets warm start based on first activity`() {
-        val provider = fixture.getSut()
-
-        // up until this point app start is not known
-        assertEquals(AppStartType.UNKNOWN, AppStartMetrics.getInstance().appStartType)
-
-        // when there's a saved state
-        provider.activityCallback!!.onActivityCreated(mock(), Bundle())
-
-        // then app start should be warm
-        assertEquals(AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
-    }
-
-    @Test
-    fun `provider keeps startup state even if multiple activities are launched`() {
-        val provider = fixture.getSut()
-
-        // when there's a saved state
-        provider.activityCallback!!.onActivityCreated(mock(), Bundle())
-
-        // then app start should be warm
-        assertEquals(AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
-
-        // when another activity is launched cold
-        provider.activityCallback!!.onActivityCreated(mock(), null)
-
-        // then app start should remain warm
-        assertEquals(AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
-    }
-
-    @Test
     fun `provider sets both appstart and sdk init start + end times`() {
         val provider = fixture.getSut()
         provider.onAppStartDone()


### PR DESCRIPTION
## :scroll: Description
* ActivityLifecycleIntegration:
  - creates `onCreate` and `onStart` TimeSpans
  - set app start type to warm in AppStartMetrics when needed
* AppStartMetrics has now a method to restart appStartSpan and reset its uptime_ms
* PerformanceAndroidEventProcessor now attaches activity start spans to warm starts, too
* SentryPerformanceProvider doesn't create spans anymore

Confirm warm starts are registered for background starts (BroadcastReceiver)

Cold start:
<img width="1505" alt="Cold start" src="https://github.com/user-attachments/assets/92e7c80d-ee62-45b4-9f2b-1cf494c570c0">
Open second Activity:
<img width="1505" alt="open second activity" src="https://github.com/user-attachments/assets/c4ea771d-7932-4f65-8ec0-413151d242bf">
Reopen first Activity without closing app:
<img width="1505" alt="reopen first activity" src="https://github.com/user-attachments/assets/2f6b0818-65cb-40f5-bd43-a01cbc4016da">
Open first Activity after close app with `Don't keep activity` developer option enabled:
<img width="1505" alt="open after close and no keep activity" src="https://github.com/user-attachments/assets/2f6f603e-ff0e-4106-b6c4-526c3f802492">


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3896
Relates and possibly fixes https://github.com/getsentry/sentry-java/issues/3899


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

In a [followup PR](https://github.com/getsentry/sentry-java/pull/3954):
- Remove the activityCallback completely from the `SentryPerformanceProvider`
- Create and attach spans directly in `ActivityLifecycleIntegration` instead of adding them to `AppStartMetrics` and let the `PerformanceAndroidEventProcessor` add them to the transaction
- Avoid creating process init span using `setStartUnixTimeMs` as it is a testOnly method. This means care, as the method is exposed to hybrid sdks