### PR TITLE
POTEL 64 - `sentry-opentelemetry-agentless` module

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -44,6 +44,7 @@ targets:
       maven:io.sentry:sentry-opentelemetry-agent:
       maven:io.sentry:sentry-opentelemetry-agentcustomization:
       maven:io.sentry:sentry-opentelemetry-core:
+#      maven:io.sentry:sentry-opentelemetry-agentless:
       maven:io.sentry:sentry-apollo:
       maven:io.sentry:sentry-jdbc:
       maven:io.sentry:sentry-graphql:

--- a/.github/ISSUE_TEMPLATE/bug_report_java.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_java.yml
@@ -15,6 +15,7 @@ body:
         - sentry-apollo-3
         - sentry-kotlin-extensions
         - sentry-opentelemetry-agent
+        - sentry-opentelemetry-agentless
         - sentry-opentelemetry-core
         - sentry-servlet
         - sentry-servlet-jakarta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `sentry-opentelemetry-agentless` module ([#3961](https://github.com/getsentry/sentry-java/pull/3961))
+  - This module can be added as a dependency when using Sentry with OpenTelemetry but don't want to use our Agent. It takes care of configuring OpenTelemetry for use with Sentry.
+  - To enable the auto configuration of it, please set `-Dotel.java.global-autoconfigure.enabled=true` on the `java` command, when starting your application.
+  - You may also want to set `OTEL_LOGS_EXPORTER=none;OTEL_METRICS_EXPORTER=none;OTEL_TRACES_EXPORTER=none` env vars to not have the log flooded with error messages regarding OpenTelemetry features we don't use.
+
 ## 8.0.0-rc.2
 
 ### Fixes

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/README.md
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/README.md
@@ -1,0 +1,54 @@
+# sentry-opentelemetry-agentless
+
+*NOTE: Our OpenTelemetry modules are still experimental. Any feedback is welcome.*
+
+## How to use it
+
+Add the latest `sentry-opentelemetry-agentless` module as a dependency and add a `sentry.properties` 
+configuration file to your project that could look like this:
+
+```properties
+# NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in your Sentry project/dashboard
+dsn=https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563
+traces-sample-rate=1.0
+```
+
+For more details on configuring Sentry via `sentry.properties` please see the
+[docs page](https://docs.sentry.io/platforms/java/configuration/).
+
+As an alternative to the `SENTRY_PROPERTIES_FILE` environment variable you can provide individual
+settings as environment variables (e.g. `SENTRY_DSN=...`) or you may initialize `Sentry` inside
+your target application. If you do so, please make sure to apply OpenTelemetry specific options, e.g.
+like this:
+
+```
+Sentry.init(
+        options -> {
+          options.setDsn("...");
+          ...
+          OpenTelemetryUtil.applyOpenTelemetryOptions(options, false);
+        }
+)
+```
+
+## Getting rid of exporter error messages
+
+In case you are using this module without needing to use any OpenTelemetry exporters you can add
+the following environment variables to turn off exporters and stop seeing error messages about 
+servers not being reachable in the logs.
+
+Example log message:
+```
+ERROR io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export spans. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
+ERROR io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter - Failed to export metrics. The request could not be executed. Full error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317
+```
+
+### Traces
+
+To turn off exporting of traces you can set `OTEL_TRACES_EXPORTER=none`
+see [OpenTelemetry GitHub](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#otlp-exporter-span-metric-and-log-exporters)
+
+### Metrics
+
+To turn off exporting of metrics you can set `OTEL_METRICS_EXPORTER=none`
+see [OpenTelemetry GitHub](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure#otlp-exporter-span-metric-and-log-exporters)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
     api(Config.Libs.OpenTelemetry.otelSdk)
     api(Config.Libs.OpenTelemetry.otelSemconv)
     api(Config.Libs.OpenTelemetry.otelSemconvIncubating)
-    implementation(Config.Libs.OpenTelemetry.otelExtensionAutoconfigure)
+    api(Config.Libs.OpenTelemetry.otelExtensionAutoconfigure)
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    `java-library`
+}
+
+configure<JavaPluginExtension> {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+dependencies {
+    api(projects.sentry)
+    api(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
+    api(Config.Libs.OpenTelemetry.otelSdk)
+    api(Config.Libs.OpenTelemetry.otelSemconv)
+    api(Config.Libs.OpenTelemetry.otelSemconvIncubating)
+    implementation(Config.Libs.OpenTelemetry.otelExtensionAutoconfigure)
+}

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/src/main/java/io/sentry/opentelemetry/agent/AgentlessMarker.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/src/main/java/io/sentry/opentelemetry/agent/AgentlessMarker.java
@@ -1,0 +1,3 @@
+package io.sentry.opentelemetry.agent;
+
+public final class AgentlessMarker {}

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
@@ -14,12 +14,5 @@ configure<JavaPluginExtension> {
 }
 
 dependencies {
-    implementation(projects.sentry)
-
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
-    implementation(Config.Libs.OpenTelemetry.otelSdk)
-    implementation(Config.Libs.OpenTelemetry.otelExtensionAutoconfigure)
-    implementation(Config.Libs.OpenTelemetry.otelSemconv)
-    implementation(Config.Libs.OpenTelemetry.otelSemconvIncubating)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentless)
 }

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
@@ -14,6 +14,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SpanStatus;
+import io.sentry.opentelemetry.OpenTelemetryUtil;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.User;
 import java.util.Collections;
@@ -27,6 +28,8 @@ public class Main {
           // your Sentry project/dashboard
           options.setDsn(
               "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563");
+
+          OpenTelemetryUtil.applyOpenTelemetryOptions(options, false);
 
           // All events get assigned to the release. See more at
           // https://docs.sentry.io/workflow/releases/

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -53,8 +53,7 @@ dependencies {
     implementation(projects.sentryGraphql22)
     implementation(projects.sentryQuartz)
     implementation(Config.Libs.springBoot3StarterOpenTelemetry)
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentless)
 
     // database query tracing
     implementation(projects.sentryJdbc)
@@ -71,7 +70,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.7.0")
+        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:${Config.Libs.OpenTelemetry.otelInstrumentationVersion}")
     }
 }
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.7.0")
+        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:${Config.Libs.OpenTelemetry.otelInstrumentationVersion}")
     }
 }
 

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -53,8 +53,7 @@ dependencies {
     implementation(projects.sentryGraphql)
     implementation(projects.sentryQuartz)
     implementation(Config.Libs.springBoot3StarterOpenTelemetry)
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
-    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentless)
 
     // database query tracing
     implementation(projects.sentryJdbc)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,7 @@ include(
     "sentry-opentelemetry:sentry-opentelemetry-core",
     "sentry-opentelemetry:sentry-opentelemetry-agentcustomization",
     "sentry-opentelemetry:sentry-opentelemetry-agent",
+    "sentry-opentelemetry:sentry-opentelemetry-agentless",
     "sentry-quartz",
     "sentry-okhttp",
     "sentry-samples:sentry-samples-android",


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `sentry-opentelemetry-agentless` module that customers can add as a single dependency to use our OpenTelemetry offering instead of having to add multiple dependencies and manage versions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/3913

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
- Consider `agentless-spring-boot` that pulls in `opentelemetry-spring-boot-starter` with the required version
- Consider creating a BOM, that also drags in the OTel BOM to manage Sentry + OTel versions
- Update README