### PR TITLE
[SR] Fix various crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: fix various crashes and issues ([#3970](https://github.com/getsentry/sentry-java/pull/3970))
+  - Fix `IndexOutOfBoundsException` when tracking window changes
+  - Fix `IllegalStateException` when adding/removing draw listener for a dead view
+  - Fix `ConcurrentModificationException` when registering window listeners and stopping `WindowRecorder`/`GestureRecorder`
+
 ## 7.18.0
 
 ### Features

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -93,7 +93,7 @@ public class ReplayIntegration(
     private var recorder: Recorder? = null
     private var gestureRecorder: GestureRecorder? = null
     private val random by lazy { Random() }
-    private val rootViewsSpy by lazy(NONE) { RootViewsSpy.install() }
+    internal val rootViewsSpy by lazy(NONE) { RootViewsSpy.install() }
 
     // TODO: probably not everything has to be thread-safe here
     internal val isEnabled = AtomicBoolean(false)
@@ -263,6 +263,7 @@ public class ReplayIntegration(
         stop()
         recorder?.close()
         recorder = null
+        rootViewsSpy.close()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -23,8 +23,10 @@ import io.sentry.SentryLevel.WARNING
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayOptions
 import io.sentry.android.replay.util.MainLooperHandler
+import io.sentry.android.replay.util.addOnDrawListenerSafe
 import io.sentry.android.replay.util.getVisibleRects
 import io.sentry.android.replay.util.gracefullyShutdown
+import io.sentry.android.replay.util.removeOnDrawListenerSafe
 import io.sentry.android.replay.util.submitSafely
 import io.sentry.android.replay.util.traverse
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode
@@ -204,13 +206,13 @@ internal class ScreenshotRecorder(
 
         // next bind the new root
         rootView = WeakReference(root)
-        root.viewTreeObserver?.addOnDrawListener(this)
+        root.addOnDrawListenerSafe(this)
         // invalidate the flag to capture the first frame after new window is attached
         contentChanged.set(true)
     }
 
     fun unbind(root: View?) {
-        root?.viewTreeObserver?.removeOnDrawListener(this)
+        root?.removeOnDrawListenerSafe(this)
     }
 
     fun pause() {
@@ -220,7 +222,7 @@ internal class ScreenshotRecorder(
 
     fun resume() {
         // can't use bind() as it will invalidate the weakref
-        rootView?.get()?.viewTreeObserver?.addOnDrawListener(this)
+        rootView?.get()?.addOnDrawListenerSafe(this)
         isCapturing.set(true)
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -17,7 +17,9 @@ import android.text.Spanned
 import android.text.style.ForegroundColorSpan
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.TextView
+import androidx.annotation.RequiresApi
 import io.sentry.SentryOptions
 import io.sentry.android.replay.viewhierarchy.ComposeViewHierarchyNode
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode
@@ -177,4 +179,20 @@ class AndroidTextLayout(private val layout: Layout) : TextLayout {
     override fun getLineTop(line: Int): Int = layout.getLineTop(line)
     override fun getLineBottom(line: Int): Int = layout.getLineBottom(line)
     override fun getLineStart(line: Int): Int = layout.getLineStart(line)
+}
+
+@RequiresApi(VERSION_CODES.JELLY_BEAN)
+internal fun View?.addOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawListener) {
+    if (this == null || viewTreeObserver == null || !viewTreeObserver.isAlive) {
+        return
+    }
+    viewTreeObserver.addOnDrawListener(listener)
+}
+
+@RequiresApi(VERSION_CODES.JELLY_BEAN)
+internal fun View?.removeOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawListener) {
+    if (this == null || viewTreeObserver == null || !viewTreeObserver.isAlive) {
+        return
+    }
+    viewTreeObserver.removeOnDrawListener(listener)
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -19,7 +19,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.TextView
-import androidx.annotation.RequiresApi
 import io.sentry.SentryOptions
 import io.sentry.android.replay.viewhierarchy.ComposeViewHierarchyNode
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode
@@ -181,7 +180,6 @@ class AndroidTextLayout(private val layout: Layout) : TextLayout {
     override fun getLineStart(line: Int): Int = layout.getLineStart(line)
 }
 
-@RequiresApi(VERSION_CODES.JELLY_BEAN)
 internal fun View?.addOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawListener) {
     if (this == null || viewTreeObserver == null || !viewTreeObserver.isAlive) {
         return
@@ -189,7 +187,6 @@ internal fun View?.addOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawListen
     viewTreeObserver.addOnDrawListener(listener)
 }
 
-@RequiresApi(VERSION_CODES.JELLY_BEAN)
 internal fun View?.removeOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawListener) {
     if (this == null || viewTreeObserver == null || !viewTreeObserver.isAlive) {
         return


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- Fix `IndexOutOfBoundsException` when tracking window changes. The problem here was that we had an `object RootViewSpy`, and it was shared between different instances of the ReplayIntegration, hence messing up things.
- Fix `IllegalStateException` when adding/removing draw listener for a dead view
- Fix `ConcurrentModificationException` when registering window listeners and stopping `WindowRecorder`/`GestureRecorder`
- Fix some TODOs in Windows.kt


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/3859
Closes https://github.com/getsentry/sentry-react-native/issues/4234

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
