### PR TITLE
graphql 22 update instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- Replace deprecated `SimpleInstrumentation` with `SimplePerformantInstrumentation` for graphql 22 ([#3974](https://github.com/getsentry/sentry-java/pull/3974))
+
 ## 8.0.0-rc.2
 
 ### Fixes

--- a/sentry-graphql-22/api/sentry-graphql-22.api
+++ b/sentry-graphql-22/api/sentry-graphql-22.api
@@ -3,7 +3,7 @@ public final class io/sentry/graphql22/BuildConfig {
 	public static final field VERSION_NAME Ljava/lang/String;
 }
 
-public final class io/sentry/graphql22/SentryInstrumentation : graphql/execution/instrumentation/SimpleInstrumentation {
+public final class io/sentry/graphql22/SentryInstrumentation : graphql/execution/instrumentation/SimplePerformantInstrumentation {
 	public static final field SENTRY_EXCEPTIONS_CONTEXT_KEY Ljava/lang/String;
 	public static final field SENTRY_SCOPES_CONTEXT_KEY Ljava/lang/String;
 	public fun <init> (Lio/sentry/graphql/SentryGraphqlInstrumentation$BeforeSpanCallback;Lio/sentry/graphql/SentrySubscriptionHandler;Lio/sentry/graphql/ExceptionReporter;Ljava/util/List;)V

--- a/sentry-graphql-22/src/main/java/io/sentry/graphql22/SentryInstrumentation.java
+++ b/sentry-graphql-22/src/main/java/io/sentry/graphql22/SentryInstrumentation.java
@@ -19,9 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
-@SuppressWarnings("deprecation")
 public final class SentryInstrumentation
-    extends graphql.execution.instrumentation.SimpleInstrumentation {
+    extends graphql.execution.instrumentation.SimplePerformantInstrumentation {
 
   /**
    * @deprecated please use {@link SentryGraphqlInstrumentation#SENTRY_SCOPES_CONTEXT_KEY}
@@ -144,7 +143,7 @@ public final class SentryInstrumentation
   }
 
   @Override
-  @SuppressWarnings({"FutureReturnValueIgnored", "deprecation"})
+  @SuppressWarnings({"FutureReturnValueIgnored"})
   public @NotNull DataFetcher<?> instrumentDataFetcher(
       final @NotNull DataFetcher<?> dataFetcher,
       final @NotNull InstrumentationFieldFetchParameters parameters,


### PR DESCRIPTION
## :scroll: Description
Replace deprecated `SimpleInstrumentation` with `SimplePerformantInstrumentation` in `sentry-graphql-22`.

## :bulb: Motivation and Context
Fixes #3968


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
