### PR TITLE
[WIP] fix console samples

### DIFF
--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
@@ -4,6 +4,9 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.sentry.Breadcrumb;
 import io.sentry.EventProcessor;
 import io.sentry.Hint;
@@ -17,10 +20,23 @@ import io.sentry.SpanStatus;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.User;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Main {
 
   public static void main(String[] args) throws InterruptedException {
+    final OpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.builder()
+      .addPropertiesSupplier(() -> {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("otel.logs.exporter", "none");
+        properties.put("otel.metrics.exporter", "none");
+        properties.put("otel.traces.exporter", "none");
+        return properties;
+      })
+      .build().getOpenTelemetrySdk();
+    GlobalOpenTelemetry.set(sdk);
+
     Sentry.init(
         options -> {
           // NOTE: Replace the test DSN below with YOUR OWN DSN to see the events from this app in

--- a/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console/src/main/java/io/sentry/samples/console/Main.java
@@ -86,10 +86,10 @@ public class Main {
           options.setTracesSampler(
               context -> {
                 // only 10% of transactions with "/product" prefix will be collected
-                if (!context.getTransactionContext().getName().startsWith("/products")) {
+                if (context.getTransactionContext().getName().startsWith("/products")) {
                   return 0.1;
                 } else {
-                  return 0.5;
+                  return 1.0;
                 }
               });
         });
@@ -155,7 +155,9 @@ public class Main {
     //
     // Transactions collect execution time of the piece of code that's executed between the start
     // and finish of transaction.
-    ITransaction transaction = Sentry.startTransaction("transaction name", "op");
+    final TransactionOptions options = new TransactionOptions();
+    options.setBindToScope(true);
+    ITransaction transaction = Sentry.startTransaction("transaction name", "op", options);
     // Transactions can contain one or more Spans
     ISpan outerSpan = transaction.startChild("child");
     Thread.sleep(100);


### PR DESCRIPTION
## :scroll: Description
Fixes the sentry console samples


## :bulb: Motivation and Context
The `sentry-samples-console-opentelemetry-noagent` sample did not produce any spans.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
