### PR TITLE
POTEL 65 - Replace bool with enum for `OpenTelemetryUtil` mode

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
@@ -8,6 +8,7 @@ import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.sentry.InitPriority;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryPackage;
@@ -38,7 +39,7 @@ public final class SentryAutoConfigurationCustomizerProvider
           options -> {
             options.setEnableExternalConfiguration(true);
             options.setInitPriority(InitPriority.HIGH);
-            OpenTelemetryUtil.applyOpenTelemetryOptions(options, true);
+            OpenTelemetryUtil.applyOpenTelemetryOptions(options, SentryOpenTelemetryMode.AGENT);
             final @Nullable SdkVersion sdkVersion = createSdkVersion(options, versionInfoHolder);
             if (sdkVersion != null) {
               options.setSdkVersion(sdkVersion);

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
@@ -26,7 +26,7 @@ public final class io/sentry/opentelemetry/InternalSemanticAttributes {
 
 public final class io/sentry/opentelemetry/OpenTelemetryUtil {
 	public fun <init> ()V
-	public static fun applyOpenTelemetryOptions (Lio/sentry/SentryOptions;Z)V
+	public static fun applyOpenTelemetryOptions (Lio/sentry/SentryOptions;Lio/sentry/SentryOpenTelemetryMode;)V
 }
 
 public final class io/sentry/opentelemetry/OtelContextScopesStorage : io/sentry/IScopesStorage {

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
@@ -1,17 +1,19 @@
 package io.sentry.opentelemetry;
 
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.util.SpanUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Experimental
 public final class OpenTelemetryUtil {
 
   public static void applyOpenTelemetryOptions(
-      final @Nullable SentryOptions options, final boolean isAgent) {
+      final @Nullable SentryOptions options, final @NotNull SentryOpenTelemetryMode mode) {
     if (options != null) {
-      options.setIgnoredSpanOrigins(SpanUtils.ignoredSpanOriginsForOpenTelemetry(isAgent));
+      options.setIgnoredSpanOrigins(SpanUtils.ignoredSpanOriginsForOpenTelemetry(mode));
     }
   }
 }

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/src/main/java/io/sentry/samples/console/Main.java
@@ -13,6 +13,7 @@ import io.sentry.ITransaction;
 import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SpanStatus;
 import io.sentry.opentelemetry.OpenTelemetryUtil;
 import io.sentry.protocol.Message;
@@ -29,7 +30,7 @@ public class Main {
           options.setDsn(
               "https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563");
 
-          OpenTelemetryUtil.applyOpenTelemetryOptions(options, false);
+          OpenTelemetryUtil.applyOpenTelemetryOptions(options, SentryOpenTelemetryMode.AGENTLESS);
 
           // All events get assigned to the release. See more at
           // https://docs.sentry.io/workflow/releases/

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/opentelemetry/SentryOpenTelemetryAgentWithoutAutoInitConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/opentelemetry/SentryOpenTelemetryAgentWithoutAutoInitConfiguration.java
@@ -3,6 +3,7 @@ package io.sentry.spring.jakarta.opentelemetry;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.opentelemetry.OpenTelemetryUtil;
 import org.jetbrains.annotations.NotNull;
@@ -21,7 +22,7 @@ public class SentryOpenTelemetryAgentWithoutAutoInitConfiguration {
     return options -> {
       SentryIntegrationPackageStorage.getInstance()
           .addIntegration("SpringBoot3OpenTelemetryAgentWithoutAutoInit");
-      OpenTelemetryUtil.applyOpenTelemetryOptions(options, true);
+      OpenTelemetryUtil.applyOpenTelemetryOptions(options, SentryOpenTelemetryMode.AGENT);
     };
   }
 }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/opentelemetry/SentryOpenTelemetryNoAgentConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/opentelemetry/SentryOpenTelemetryNoAgentConfiguration.java
@@ -5,6 +5,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.sentry.ISpanFactory;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.opentelemetry.OpenTelemetryUtil;
 import io.sentry.opentelemetry.OtelSpanFactory;
@@ -32,7 +33,8 @@ public class SentryOpenTelemetryNoAgentConfiguration {
       SentryIntegrationPackageStorage.getInstance()
           .addIntegration("SpringBoot3OpenTelemetryNoAgent");
       SentryAutoConfigurationCustomizerProvider.skipInit = true;
-      OpenTelemetryUtil.applyOpenTelemetryOptions(options, false);
+      OpenTelemetryUtil.applyOpenTelemetryOptions(
+          options, SentryOpenTelemetryMode.AGENTLESS_SPRING);
     };
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/opentelemetry/SentryOpenTelemetryAgentWithoutAutoInitConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/opentelemetry/SentryOpenTelemetryAgentWithoutAutoInitConfiguration.java
@@ -3,6 +3,7 @@ package io.sentry.spring.opentelemetry;
 import com.jakewharton.nopen.annotation.Open;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.opentelemetry.OpenTelemetryUtil;
 import org.jetbrains.annotations.NotNull;
@@ -21,7 +22,7 @@ public class SentryOpenTelemetryAgentWithoutAutoInitConfiguration {
     return options -> {
       SentryIntegrationPackageStorage.getInstance()
           .addIntegration("SpringBootOpenTelemetryAgentWithoutAutoInit");
-      OpenTelemetryUtil.applyOpenTelemetryOptions(options, true);
+      OpenTelemetryUtil.applyOpenTelemetryOptions(options, SentryOpenTelemetryMode.AGENT);
     };
   }
 }

--- a/sentry-spring/src/main/java/io/sentry/spring/opentelemetry/SentryOpenTelemetryNoAgentConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/opentelemetry/SentryOpenTelemetryNoAgentConfiguration.java
@@ -5,6 +5,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.sentry.ISpanFactory;
 import io.sentry.Sentry;
 import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.opentelemetry.OpenTelemetryUtil;
 import io.sentry.opentelemetry.OtelSpanFactory;
@@ -32,7 +33,8 @@ public class SentryOpenTelemetryNoAgentConfiguration {
       SentryIntegrationPackageStorage.getInstance()
           .addIntegration("SpringBootOpenTelemetryNoAgent");
       SentryAutoConfigurationCustomizerProvider.skipInit = true;
-      OpenTelemetryUtil.applyOpenTelemetryOptions(options, false);
+      OpenTelemetryUtil.applyOpenTelemetryOptions(
+          options, SentryOpenTelemetryMode.AGENTLESS_SPRING);
     };
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2781,6 +2781,14 @@ public final class io/sentry/SentryNanotimeDateProvider : io/sentry/SentryDatePr
 	public fun now ()Lio/sentry/SentryDate;
 }
 
+public final class io/sentry/SentryOpenTelemetryMode : java/lang/Enum {
+	public static final field AGENT Lio/sentry/SentryOpenTelemetryMode;
+	public static final field AGENTLESS Lio/sentry/SentryOpenTelemetryMode;
+	public static final field AGENTLESS_SPRING Lio/sentry/SentryOpenTelemetryMode;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryOpenTelemetryMode;
+	public static fun values ()[Lio/sentry/SentryOpenTelemetryMode;
+}
+
 public class io/sentry/SentryOptions {
 	public static final field DEFAULT_PROPAGATION_TARGETS Ljava/lang/String;
 	protected final field lock Lio/sentry/util/AutoClosableReentrantLock;
@@ -6194,7 +6202,7 @@ public final class io/sentry/util/SentryRandom {
 
 public final class io/sentry/util/SpanUtils {
 	public fun <init> ()V
-	public static fun ignoredSpanOriginsForOpenTelemetry (Z)Ljava/util/List;
+	public static fun ignoredSpanOriginsForOpenTelemetry (Lio/sentry/SentryOpenTelemetryMode;)Ljava/util/List;
 	public static fun isIgnored (Ljava/util/List;Ljava/lang/String;)Z
 }
 

--- a/sentry/src/main/java/io/sentry/SentryOpenTelemetryMode.java
+++ b/sentry/src/main/java/io/sentry/SentryOpenTelemetryMode.java
@@ -1,0 +1,7 @@
+package io.sentry;
+
+public enum SentryOpenTelemetryMode {
+  AGENT,
+  AGENTLESS,
+  AGENTLESS_SPRING
+}

--- a/sentry/src/main/java/io/sentry/util/SpanUtils.java
+++ b/sentry/src/main/java/io/sentry/util/SpanUtils.java
@@ -1,5 +1,6 @@
 package io.sentry.util;
 
+import io.sentry.SentryOpenTelemetryMode;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
@@ -13,23 +14,26 @@ public final class SpanUtils {
    *
    * @return a list of span origins to be ignored
    */
-  public static @NotNull List<String> ignoredSpanOriginsForOpenTelemetry(final boolean isAgent) {
+  public static @NotNull List<String> ignoredSpanOriginsForOpenTelemetry(
+      final @NotNull SentryOpenTelemetryMode mode) {
     final @NotNull List<String> origins = new ArrayList<>();
 
-    origins.add("auto.http.spring_jakarta.webmvc");
-    origins.add("auto.http.spring.webmvc");
-    origins.add("auto.spring_jakarta.webflux");
-    origins.add("auto.spring.webflux");
-    origins.add("auto.db.jdbc");
-    origins.add("auto.http.spring_jakarta.webclient");
-    origins.add("auto.http.spring.webclient");
-    origins.add("auto.http.spring_jakarta.restclient");
-    origins.add("auto.http.spring.restclient");
-    origins.add("auto.http.spring_jakarta.resttemplate");
-    origins.add("auto.http.spring.resttemplate");
-    origins.add("auto.http.openfeign");
+    if (SentryOpenTelemetryMode.AGENT == mode || SentryOpenTelemetryMode.AGENTLESS_SPRING == mode) {
+      origins.add("auto.http.spring_jakarta.webmvc");
+      origins.add("auto.http.spring.webmvc");
+      origins.add("auto.spring_jakarta.webflux");
+      origins.add("auto.spring.webflux");
+      origins.add("auto.db.jdbc");
+      origins.add("auto.http.spring_jakarta.webclient");
+      origins.add("auto.http.spring.webclient");
+      origins.add("auto.http.spring_jakarta.restclient");
+      origins.add("auto.http.spring.restclient");
+      origins.add("auto.http.spring_jakarta.resttemplate");
+      origins.add("auto.http.spring.resttemplate");
+      origins.add("auto.http.openfeign");
+    }
 
-    if (isAgent) {
+    if (SentryOpenTelemetryMode.AGENT == mode) {
       origins.add("auto.graphql.graphql");
       origins.add("auto.graphql.graphql22");
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Replace bool with enum for `OpenTelemetryUtil` mode

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bool did not allow us to distinguish between agentless with or without spring. The distinction is needed as the `opentelemetry-spring-boot-starter` has some of the auto instrumentation available.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
