### PR TITLE
[SR] Fix ANRs and speed up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Change TTFD timeout to 25 seconds ([#3984](https://github.com/getsentry/sentry-java/pull/3984))
 - Session Replay: Fix memory leak when masking Compose screens ([#3985](https://github.com/getsentry/sentry-java/pull/3985))
+- Session Replay: Fix potential ANRs in `GestureRecorder` ([#4001](https://github.com/getsentry/sentry-java/pull/4001))
 
 ## 7.19.0
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -8,6 +8,7 @@ import io.sentry.android.replay.util.gracefullyShutdown
 import io.sentry.android.replay.util.scheduleAtFixedRateSafely
 import java.lang.ref.WeakReference
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -17,7 +18,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class WindowRecorder(
     private val options: SentryOptions,
     private val screenshotRecorderCallback: ScreenshotRecorderCallback? = null,
-    private val mainLooperHandler: MainLooperHandler
+    private val mainLooperHandler: MainLooperHandler,
+    private val replayExecutor: ScheduledExecutorService
 ) : Recorder, OnRootViewsChangedListener {
 
     internal companion object {
@@ -57,7 +59,7 @@ internal class WindowRecorder(
             return
         }
 
-        recorder = ScreenshotRecorder(recorderConfig, options, mainLooperHandler, screenshotRecorderCallback)
+        recorder = ScreenshotRecorder(recorderConfig, options, mainLooperHandler, replayExecutor, screenshotRecorderCallback)
         capturingTask = capturer.scheduleAtFixedRateSafely(
             options,
             "$TAG.capture",

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -60,6 +60,8 @@ internal class WindowRecorder(
         }
 
         recorder = ScreenshotRecorder(recorderConfig, options, mainLooperHandler, replayExecutor, screenshotRecorderCallback)
+        // TODO: change this to use MainThreadHandler and just post on the main thread with delay
+        // to avoid thread context switch every time
         capturingTask = capturer.scheduleAtFixedRateSafely(
             options,
             "$TAG.capture",

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.replay.capture
 
+import android.annotation.TargetApi
 import android.view.MotionEvent
 import io.sentry.Breadcrumb
 import io.sentry.DateUtils
@@ -21,7 +22,6 @@ import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_TIMESTAMP
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_WIDTH
 import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.capture.CaptureStrategy.Companion.createSegment
-import io.sentry.android.replay.capture.CaptureStrategy.Companion.currentEventsLock
 import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.gestures.ReplayGestureConverter
 import io.sentry.android.replay.util.PersistableLinkedList
@@ -32,7 +32,8 @@ import io.sentry.rrweb.RRWebEvent
 import io.sentry.transport.ICurrentDateProvider
 import java.io.File
 import java.util.Date
-import java.util.LinkedList
+import java.util.Deque
+import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ThreadFactory
@@ -42,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+@TargetApi(26)
 internal abstract class BaseCaptureStrategy(
     private val options: SentryOptions,
     private val hub: IHub?,
@@ -81,12 +83,8 @@ internal abstract class BaseCaptureStrategy(
     override val replayCacheDir: File? get() = cache?.replayCacheDir
 
     override var replayType by persistableAtomic<ReplayType>(propertyName = SEGMENT_KEY_REPLAY_TYPE)
-    protected val currentEvents: LinkedList<RRWebEvent> = PersistableLinkedList(
-        propertyName = SEGMENT_KEY_REPLAY_RECORDING,
-        options,
-        persistingExecutor,
-        cacheProvider = { cache }
-    )
+
+    protected val currentEvents: Deque<RRWebEvent> = ConcurrentLinkedDeque()
 
     protected val replayExecutor: ScheduledExecutorService by lazy {
         executor ?: Executors.newSingleThreadScheduledExecutor(ReplayExecutorServiceThreadFactory())
@@ -135,7 +133,7 @@ internal abstract class BaseCaptureStrategy(
         frameRate: Int = recorderConfig.frameRate,
         screenAtStart: String? = this.screenAtStart,
         breadcrumbs: List<Breadcrumb>? = null,
-        events: LinkedList<RRWebEvent> = this.currentEvents
+        events: Deque<RRWebEvent> = this.currentEvents
     ): ReplaySegment =
         createSegment(
             hub,
@@ -161,9 +159,7 @@ internal abstract class BaseCaptureStrategy(
     override fun onTouchEvent(event: MotionEvent) {
         val rrwebEvents = gestureConverter.convert(event, recorderConfig)
         if (rrwebEvents != null) {
-            synchronized(currentEventsLock) {
-                currentEvents += rrwebEvents
-            }
+            currentEvents += rrwebEvents
         }
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -1,5 +1,6 @@
 package io.sentry.android.replay.capture
 
+import android.annotation.TargetApi
 import android.graphics.Bitmap
 import android.view.MotionEvent
 import io.sentry.DateUtils
@@ -23,6 +24,7 @@ import java.io.File
 import java.util.Date
 import java.util.concurrent.ScheduledExecutorService
 
+@TargetApi(26)
 internal class BufferCaptureStrategy(
     private val options: SentryOptions,
     private val hub: IHub?,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -30,9 +30,9 @@ internal class BufferCaptureStrategy(
     private val hub: IHub?,
     private val dateProvider: ICurrentDateProvider,
     private val random: Random,
-    executor: ScheduledExecutorService? = null,
+    executor: ScheduledExecutorService,
     replayCacheProvider: ((replayId: SentryId, recorderConfig: ScreenshotRecorderConfig) -> ReplayCache)? = null
-) : BaseCaptureStrategy(options, hub, dateProvider, executor = executor, replayCacheProvider = replayCacheProvider) {
+) : BaseCaptureStrategy(options, hub, dateProvider, executor, replayCacheProvider = replayCacheProvider) {
 
     // TODO: capture envelopes for buffered segments instead, but don't send them until buffer is triggered
     private val bufferedSegments = mutableListOf<ReplaySegment.Created>()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -54,8 +54,6 @@ internal interface CaptureStrategy {
 
     fun convert(): CaptureStrategy
 
-    fun close()
-
     companion object {
         private const val BREADCRUMB_START_OFFSET = 100L
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -19,6 +19,7 @@ import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
 import java.io.File
 import java.util.Date
+import java.util.Deque
 import java.util.LinkedList
 
 internal interface CaptureStrategy {
@@ -57,7 +58,6 @@ internal interface CaptureStrategy {
 
     companion object {
         private const val BREADCRUMB_START_OFFSET = 100L
-        internal val currentEventsLock = Any()
 
         fun createSegment(
             hub: IHub?,
@@ -73,7 +73,7 @@ internal interface CaptureStrategy {
             frameRate: Int,
             screenAtStart: String?,
             breadcrumbs: List<Breadcrumb>?,
-            events: LinkedList<RRWebEvent>
+            events: Deque<RRWebEvent>
         ): ReplaySegment {
             val generatedVideo = cache?.createVideoOf(
                 duration,
@@ -127,7 +127,7 @@ internal interface CaptureStrategy {
             replayType: ReplayType,
             screenAtStart: String?,
             breadcrumbs: List<Breadcrumb>,
-            events: LinkedList<RRWebEvent>
+            events: Deque<RRWebEvent>
         ): ReplaySegment {
             val endTimestamp = DateUtils.getDateTime(segmentTimestamp.time + videoDuration)
             val replay = SentryReplayEvent().apply {
@@ -207,16 +207,16 @@ internal interface CaptureStrategy {
         }
 
         internal fun rotateEvents(
-            events: LinkedList<RRWebEvent>,
+            events: Deque<RRWebEvent>,
             until: Long,
             callback: ((RRWebEvent) -> Unit)? = null
         ) {
-            synchronized(currentEventsLock) {
-                var event = events.peek()
-                while (event != null && event.timestamp < until) {
+            val iter = events.iterator()
+            while (iter.hasNext()) {
+                val event = iter.next()
+                if (event.timestamp < until) {
                     callback?.invoke(event)
-                    events.remove()
-                    event = events.peek()
+                    iter.remove()
                 }
             }
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -20,7 +20,7 @@ internal class SessionCaptureStrategy(
     private val options: SentryOptions,
     private val hub: IHub?,
     private val dateProvider: ICurrentDateProvider,
-    executor: ScheduledExecutorService? = null,
+    executor: ScheduledExecutorService,
     replayCacheProvider: ((replayId: SentryId, recorderConfig: ScreenshotRecorderConfig) -> ReplayCache)? = null
 ) : BaseCaptureStrategy(options, hub, dateProvider, executor, replayCacheProvider) {
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/gestures/ReplayGestureConverter.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/gestures/ReplayGestureConverter.kt
@@ -56,7 +56,7 @@ class ReplayGestureConverter(
 
                 val totalOffset = now - touchMoveBaseline
                 return if (totalOffset > CAPTURE_MOVE_EVENT_THRESHOLD) {
-                    val moveEvents = mutableListOf<RRWebInteractionMoveEvent>()
+                    val moveEvents = ArrayList<RRWebInteractionMoveEvent>(currentPositions.size)
                     for ((pointerId, positions) in currentPositions) {
                         if (positions.isNotEmpty()) {
                             moveEvents += RRWebInteractionMoveEvent().apply {
@@ -88,7 +88,7 @@ class ReplayGestureConverter(
                 }
 
                 // new finger down - add a new pointer for tracking movement
-                currentPositions[pId] = ArrayList()
+                currentPositions[pId] = ArrayList(10)
                 listOf(
                     RRWebInteractionEvent().apply {
                         timestamp = dateProvider.currentTimeMillis

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
@@ -78,7 +78,7 @@ internal fun ScheduledExecutorService.scheduleAtFixedRateSafely(
     task: Runnable
 ): ScheduledFuture<*>? {
     return try {
-        scheduleWithFixedDelay({
+        scheduleAtFixedRate({
             try {
                 task.run()
             } catch (e: Throwable) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Executors.kt
@@ -50,6 +50,11 @@ internal fun ExecutorService.submitSafely(
     taskName: String,
     task: Runnable
 ): Future<*>? {
+    if (Thread.currentThread().name.startsWith("SentryReplayIntegration")) {
+        // we're already on the worker thread, no need to submit
+        task.run()
+        return null
+    }
     return try {
         submit {
             try {
@@ -73,7 +78,7 @@ internal fun ScheduledExecutorService.scheduleAtFixedRateSafely(
     task: Runnable
 ): ScheduledFuture<*>? {
     return try {
-        scheduleAtFixedRate({
+        scheduleWithFixedDelay({
             try {
                 task.run()
             } catch (e: Throwable) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
@@ -1,6 +1,9 @@
 // ktlint-disable filename
 package io.sentry.android.replay.util
 
+import android.annotation.TargetApi
+import android.os.Build.VERSION_CODES
+import androidx.annotation.RequiresApi
 import io.sentry.ReplayRecording
 import io.sentry.SentryOptions
 import io.sentry.android.replay.ReplayCache
@@ -8,14 +11,18 @@ import io.sentry.rrweb.RRWebEvent
 import java.io.BufferedWriter
 import java.io.StringWriter
 import java.util.LinkedList
+import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ScheduledExecutorService
 
+// TODO: enable this back after we are able to serialize individual touches to disk to not overload cpu
+@Suppress("unused")
+@TargetApi(26)
 internal class PersistableLinkedList(
     private val propertyName: String,
     private val options: SentryOptions,
     private val persistingExecutor: ScheduledExecutorService,
     private val cacheProvider: () -> ReplayCache?
-) : LinkedList<RRWebEvent>() {
+) : ConcurrentLinkedDeque<RRWebEvent>() {
     // only overriding methods that we use, to observe the collection
     override fun addAll(elements: Collection<RRWebEvent>): Boolean {
         val result = super.addAll(elements)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Persistable.kt
@@ -2,15 +2,12 @@
 package io.sentry.android.replay.util
 
 import android.annotation.TargetApi
-import android.os.Build.VERSION_CODES
-import androidx.annotation.RequiresApi
 import io.sentry.ReplayRecording
 import io.sentry.SentryOptions
 import io.sentry.android.replay.ReplayCache
 import io.sentry.rrweb.RRWebEvent
 import java.io.BufferedWriter
 import java.io.StringWriter
-import java.util.LinkedList
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ScheduledExecutorService
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -411,7 +411,6 @@ class ReplayIntegrationTest {
         verify(recorder).stop()
         verify(recorder).close()
         verify(captureStrategy).stop()
-        verify(captureStrategy).close()
         assertFalse(replay.isRecording())
     }
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -136,9 +136,6 @@ class ReplayIntegrationWithRecorderTest {
         replay.stop()
         assertEquals(STOPPED, recorder.state)
 
-        replay.close()
-        assertEquals(CLOSED, recorder.state)
-
         // start again and capture some frames
         replay.start()
 
@@ -176,6 +173,9 @@ class ReplayIntegrationWithRecorderTest {
                 assertEquals(0, videoEvents?.first()?.segmentId)
             }
         )
+
+        replay.close()
+        assertEquals(CLOSED, recorder.state)
     }
 
     enum class LifecycleState {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
* Switch touch events from `LinkedList` with a lock to `ConcurrentLinkedDeque` which suits this case better. Iterators of this deque are [weakly consistent](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ConcurrentLinkedQueue.html), which means it's possible another thread will add new touch events while we're iterating but this is fine for us, because we filter them out based on timestamp upon sending, so the newly-added touch events won't make it to the current segment, but to the next one.
* Get rid of storing touch events to disk (for now), because it was overloading cpu a lot, and we only need them for the last segment in case of an ANR or Crash. iOS is currently not storing them either, so I think it's fine. But we should do it eventually, after we have proper disk serialization support (like serialize a single touch event, instead of the entire collection everytime)
* Pre-allocate some arraylists for GestureRecorder to avoid growing them on the main thread
* Get rid of one (out of 4) background threads in replay to avoid thread context switching. We reuse the same executor for masking screenshots that we use for creating segments/etc. My plan is to eventually have only 1 (or maybe 2) threads for the alll the replay stuff, but that's for followup PRs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry/issues/74441
Fixes #3693 (partially, but not sure how to fix the first ANR there, so let's close it for now until we get actual reports about that)

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
