### PR TITLE
POTEL 72 - Change api to implementation for dependency of agentless modules on bootstrap

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-agentless-spring/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless-spring/build.gradle.kts
@@ -9,7 +9,7 @@ configure<JavaPluginExtension> {
 
 dependencies {
     api(projects.sentry)
-    api(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
     implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
     api(Config.Libs.OpenTelemetry.otelSdk)
     api(Config.Libs.OpenTelemetry.otelSemconv)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
@@ -9,7 +9,7 @@ configure<JavaPluginExtension> {
 
 dependencies {
     api(projects.sentry)
-    api(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
+    implementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
     implementation(projects.sentryOpentelemetry.sentryOpentelemetryAgentcustomization)
     api(Config.Libs.OpenTelemetry.otelSdk)
     api(Config.Libs.OpenTelemetry.otelSemconv)


### PR DESCRIPTION
#skip-changelog

Change api to implementation for dependency of agentless modules on bootstrap

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
