### PR TITLE
added SentryOptions.continuousProfilesSampleRate

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -64,6 +64,9 @@ final class ManifestMetadataReader {
 
   static final String PROFILES_SAMPLE_RATE = "io.sentry.traces.profiling.sample-rate";
 
+  static final String CONTINUOUS_PROFILES_SAMPLE_RATE =
+      "io.sentry.traces.profiling.continuous-sample-rate";
+
   @ApiStatus.Experimental static final String TRACE_SAMPLING = "io.sentry.traces.trace-sampling";
   static final String TRACE_PROPAGATION_TARGETS = "io.sentry.traces.trace-propagation-targets";
 
@@ -312,6 +315,14 @@ final class ManifestMetadataReader {
           final Double profilesSampleRate = readDouble(metadata, logger, PROFILES_SAMPLE_RATE);
           if (profilesSampleRate != -1) {
             options.setProfilesSampleRate(profilesSampleRate);
+          }
+        }
+
+        if (options.getContinuousProfilesSampleRate() == 1.0) {
+          final double continuousProfilesSampleRate =
+              readDouble(metadata, logger, CONTINUOUS_PROFILES_SAMPLE_RATE);
+          if (continuousProfilesSampleRate != -1) {
+            options.setContinuousProfilesSampleRate(continuousProfilesSampleRate);
           }
         }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -162,6 +162,12 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
       final @NotNull Context context,
       final @NotNull SentryAppStartProfilingOptions profilingOptions,
       final @NotNull AppStartMetrics appStartMetrics) {
+
+    if (!profilingOptions.isContinuousProfileSampled()) {
+      logger.log(SentryLevel.DEBUG, "App start profiling was not sampled. It will not start.");
+      return;
+    }
+
     final @NotNull IContinuousProfiler appStartContinuousProfiler =
         new AndroidContinuousProfiler(
             buildInfoProvider,

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -801,6 +801,47 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
+    fun `applyMetadata reads continuousProfilesSampleRate from metadata`() {
+        // Arrange
+        val expectedSampleRate = 0.99f
+        val bundle = bundleOf(ManifestMetadataReader.CONTINUOUS_PROFILES_SAMPLE_RATE to expectedSampleRate)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.continuousProfilesSampleRate)
+    }
+
+    @Test
+    fun `applyMetadata does not override continuousProfilesSampleRate from options`() {
+        // Arrange
+        val expectedSampleRate = 0.99f
+        fixture.options.continuousProfilesSampleRate = expectedSampleRate.toDouble()
+        val bundle = bundleOf(ManifestMetadataReader.CONTINUOUS_PROFILES_SAMPLE_RATE to 0.1f)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(expectedSampleRate.toDouble(), fixture.options.continuousProfilesSampleRate)
+    }
+
+    @Test
+    fun `applyMetadata without specifying continuousProfilesSampleRate, stays 1`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(1.0, fixture.options.continuousProfilesSampleRate)
+    }
+
+    @Test
     fun `applyMetadata reads tracePropagationTargets to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.TRACE_PROPAGATION_TARGETS to """localhost,^(http|https)://api\..*$""")

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -259,6 +259,19 @@ class SentryPerformanceProviderTest {
         )
     }
 
+    @Test
+    fun `when continuous profile is not sampled, continuous profiler is not started`() {
+        fixture.getSut { config ->
+            writeConfig(config, continuousProfileSampled = false)
+        }
+        assertNull(AppStartMetrics.getInstance().appStartProfiler)
+        assertNull(AppStartMetrics.getInstance().appStartContinuousProfiler)
+        verify(fixture.logger).log(
+            eq(SentryLevel.DEBUG),
+            eq("App start profiling was not sampled. It will not start.")
+        )
+    }
+
     // This case should never happen in reality, but it's technically possible to have such configuration
     @Test
     fun `when both transaction and continuous profilers are enabled, only continuous profiler is created`() {
@@ -331,6 +344,7 @@ class SentryPerformanceProviderTest {
         traceSampleRate: Double = 1.0,
         profileSampled: Boolean = true,
         profileSampleRate: Double = 1.0,
+        continuousProfileSampled: Boolean = true,
         profilingTracesDirPath: String = traceDir.absolutePath
     ) {
         val appStartProfilingOptions = SentryAppStartProfilingOptions()
@@ -340,6 +354,7 @@ class SentryPerformanceProviderTest {
         appStartProfilingOptions.traceSampleRate = traceSampleRate
         appStartProfilingOptions.isProfileSampled = profileSampled
         appStartProfilingOptions.profileSampleRate = profileSampleRate
+        appStartProfilingOptions.isContinuousProfileSampled = continuousProfileSampled
         appStartProfilingOptions.profilingTracesDirPath = profilingTracesDirPath
         appStartProfilingOptions.profilingTracesHz = 101
         JsonSerializer(SentryOptions.empty()).serialize(appStartProfilingOptions, FileWriter(configFile))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -458,6 +458,7 @@ public final class io/sentry/ExternalOptions {
 	public static fun from (Lio/sentry/config/PropertiesProvider;Lio/sentry/ILogger;)Lio/sentry/ExternalOptions;
 	public fun getBundleIds ()Ljava/util/Set;
 	public fun getContextTags ()Ljava/util/List;
+	public fun getContinuousProfilesSampleRate ()Ljava/lang/Double;
 	public fun getCron ()Lio/sentry/SentryOptions$Cron;
 	public fun getDebug ()Ljava/lang/Boolean;
 	public fun getDist ()Ljava/lang/String;
@@ -491,6 +492,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isGlobalHubMode ()Ljava/lang/Boolean;
 	public fun isSendDefaultPii ()Ljava/lang/Boolean;
 	public fun isSendModules ()Ljava/lang/Boolean;
+	public fun setContinuousProfilesSampleRate (Ljava/lang/Double;)V
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDebug (Ljava/lang/Boolean;)V
 	public fun setDist (Ljava/lang/String;)V
@@ -2488,11 +2490,13 @@ public final class io/sentry/SentryAppStartProfilingOptions : io/sentry/JsonSeri
 	public fun getProfilingTracesHz ()I
 	public fun getTraceSampleRate ()Ljava/lang/Double;
 	public fun getUnknown ()Ljava/util/Map;
+	public fun isContinuousProfileSampled ()Z
 	public fun isContinuousProfilingEnabled ()Z
 	public fun isProfileSampled ()Z
 	public fun isProfilingEnabled ()Z
 	public fun isTraceSampled ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public fun setContinuousProfileSampled (Z)V
 	public fun setContinuousProfilingEnabled (Z)V
 	public fun setProfileSampleRate (Ljava/lang/Double;)V
 	public fun setProfileSampled (Z)V
@@ -2511,6 +2515,7 @@ public final class io/sentry/SentryAppStartProfilingOptions$Deserializer : io/se
 }
 
 public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
+	public static final field CONTINUOUS_PROFILE_SAMPLED Ljava/lang/String;
 	public static final field IS_CONTINUOUS_PROFILING_ENABLED Ljava/lang/String;
 	public static final field IS_PROFILING_ENABLED Ljava/lang/String;
 	public static final field PROFILE_SAMPLED Ljava/lang/String;
@@ -2944,6 +2949,7 @@ public class io/sentry/SentryOptions {
 	public fun getConnectionTimeoutMillis ()I
 	public fun getContextTags ()Ljava/util/List;
 	public fun getContinuousProfiler ()Lio/sentry/IContinuousProfiler;
+	public fun getContinuousProfilesSampleRate ()D
 	public fun getCron ()Lio/sentry/SentryOptions$Cron;
 	public fun getDateProvider ()Lio/sentry/SentryDateProvider;
 	public fun getDebugMetaLoader ()Lio/sentry/internal/debugmeta/IDebugMetaLoader;
@@ -3060,6 +3066,7 @@ public class io/sentry/SentryOptions {
 	public fun setConnectionStatusProvider (Lio/sentry/IConnectionStatusProvider;)V
 	public fun setConnectionTimeoutMillis (I)V
 	public fun setContinuousProfiler (Lio/sentry/IContinuousProfiler;)V
+	public fun setContinuousProfilesSampleRate (D)V
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDateProvider (Lio/sentry/SentryDateProvider;)V
 	public fun setDebug (Z)V
@@ -3759,6 +3766,7 @@ public final class io/sentry/TraceContext$JsonKeys {
 public final class io/sentry/TracesSampler {
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun sample (Lio/sentry/SamplingContext;)Lio/sentry/TracesSamplingDecision;
+	public fun sampleContinuousProfile ()Z
 }
 
 public final class io/sentry/TracesSamplingDecision {
@@ -6316,6 +6324,7 @@ public final class io/sentry/util/Random : java/io/Serializable {
 
 public final class io/sentry/util/SampleRateUtils {
 	public fun <init> ()V
+	public static fun isValidContinuousProfilesSampleRate (D)Z
 	public static fun isValidProfilesSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;)Z

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -28,6 +28,7 @@ public final class ExternalOptions {
   private @Nullable Boolean enableDeduplication;
   private @Nullable Double tracesSampleRate;
   private @Nullable Double profilesSampleRate;
+  private @Nullable Double continuousProfilesSampleRate;
   private @Nullable SentryOptions.RequestSize maxRequestBodySize;
   private final @NotNull Map<String, @NotNull String> tags = new ConcurrentHashMap<>();
   private @Nullable SentryOptions.Proxy proxy;
@@ -73,6 +74,8 @@ public final class ExternalOptions {
         propertiesProvider.getBooleanProperty("uncaught.handler.print-stacktrace"));
     options.setTracesSampleRate(propertiesProvider.getDoubleProperty("traces-sample-rate"));
     options.setProfilesSampleRate(propertiesProvider.getDoubleProperty("profiles-sample-rate"));
+    options.setContinuousProfilesSampleRate(
+        propertiesProvider.getDoubleProperty("continuous-profiles-sample-rate"));
     options.setDebug(propertiesProvider.getBooleanProperty("debug"));
     options.setEnableDeduplication(propertiesProvider.getBooleanProperty("enable-deduplication"));
     options.setSendClientReports(propertiesProvider.getBooleanProperty("send-client-reports"));
@@ -282,6 +285,14 @@ public final class ExternalOptions {
 
   public void setProfilesSampleRate(final @Nullable Double profilesSampleRate) {
     this.profilesSampleRate = profilesSampleRate;
+  }
+
+  public @Nullable Double getContinuousProfilesSampleRate() {
+    return continuousProfilesSampleRate;
+  }
+
+  public void setContinuousProfilesSampleRate(final @Nullable Double continuousProfilesSampleRate) {
+    this.continuousProfilesSampleRate = continuousProfilesSampleRate;
   }
 
   public @Nullable SentryOptions.RequestSize getMaxRequestBodySize() {

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -926,9 +926,15 @@ public final class Scopes implements IScopes {
   @Override
   public void startProfiler() {
     if (getOptions().isContinuousProfilingEnabled()) {
-      getOptions().getLogger().log(SentryLevel.DEBUG, "Started continuous Profiling.");
-      getOptions().getContinuousProfiler().start();
-    } else {
+      if (getOptions().getInternalTracesSampler().sampleContinuousProfile()) {
+        getOptions().getLogger().log(SentryLevel.DEBUG, "Started continuous Profiling.");
+        getOptions().getContinuousProfiler().start();
+      } else {
+        getOptions()
+            .getLogger()
+            .log(SentryLevel.DEBUG, "Profiler was not started due to sampling decision.");
+      }
+    } else if (getOptions().isProfilingEnabled()) {
       getOptions()
           .getLogger()
           .log(

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -514,7 +514,8 @@ public final class Sentry {
     }
 
     final String profilingTracesDirPath = options.getProfilingTracesDirPath();
-    if (options.isProfilingEnabled() && profilingTracesDirPath != null) {
+    if ((options.isProfilingEnabled() || options.isContinuousProfilingEnabled())
+        && profilingTracesDirPath != null) {
 
       final File profilingTracesDir = new File(profilingTracesDirPath);
       profilingTracesDir.mkdirs();

--- a/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
@@ -20,6 +20,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
   boolean isProfilingEnabled;
   boolean isContinuousProfilingEnabled;
   int profilingTracesHz;
+  boolean continuousProfileSampled;
 
   private @Nullable Map<String, Object> unknown;
 
@@ -29,6 +30,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     traceSampleRate = null;
     profileSampled = false;
     profileSampleRate = null;
+    continuousProfileSampled = false;
     profilingTracesDirPath = null;
     isProfilingEnabled = false;
     isContinuousProfilingEnabled = false;
@@ -42,6 +44,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     traceSampleRate = samplingDecision.getSampleRate();
     profileSampled = samplingDecision.getProfileSampled();
     profileSampleRate = samplingDecision.getProfileSampleRate();
+    continuousProfileSampled = options.getInternalTracesSampler().sampleContinuousProfile();
     profilingTracesDirPath = options.getProfilingTracesDirPath();
     isProfilingEnabled = options.isProfilingEnabled();
     isContinuousProfilingEnabled = options.isContinuousProfilingEnabled();
@@ -54,6 +57,14 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
 
   public boolean isProfileSampled() {
     return profileSampled;
+  }
+
+  public void setContinuousProfileSampled(boolean continuousProfileSampled) {
+    this.continuousProfileSampled = continuousProfileSampled;
+  }
+
+  public boolean isContinuousProfileSampled() {
+    return continuousProfileSampled;
   }
 
   public void setProfileSampleRate(final @Nullable Double profileSampleRate) {
@@ -117,6 +128,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
   public static final class JsonKeys {
     public static final String PROFILE_SAMPLED = "profile_sampled";
     public static final String PROFILE_SAMPLE_RATE = "profile_sample_rate";
+    public static final String CONTINUOUS_PROFILE_SAMPLED = "continuous_profile_sampled";
     public static final String TRACE_SAMPLED = "trace_sampled";
     public static final String TRACE_SAMPLE_RATE = "trace_sample_rate";
     public static final String PROFILING_TRACES_DIR_PATH = "profiling_traces_dir_path";
@@ -131,6 +143,7 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     writer.beginObject();
     writer.name(JsonKeys.PROFILE_SAMPLED).value(logger, profileSampled);
     writer.name(JsonKeys.PROFILE_SAMPLE_RATE).value(logger, profileSampleRate);
+    writer.name(JsonKeys.CONTINUOUS_PROFILE_SAMPLED).value(logger, continuousProfileSampled);
     writer.name(JsonKeys.TRACE_SAMPLED).value(logger, traceSampled);
     writer.name(JsonKeys.TRACE_SAMPLE_RATE).value(logger, traceSampleRate);
     writer.name(JsonKeys.PROFILING_TRACES_DIR_PATH).value(logger, profilingTracesDirPath);
@@ -184,6 +197,12 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
             Double profileSampleRate = reader.nextDoubleOrNull();
             if (profileSampleRate != null) {
               options.profileSampleRate = profileSampleRate;
+            }
+            break;
+          case JsonKeys.CONTINUOUS_PROFILE_SAMPLED:
+            Boolean continuousProfileSampled = reader.nextBooleanOrNull();
+            if (continuousProfileSampled != null) {
+              options.continuousProfileSampled = continuousProfileSampled;
             }
             break;
           case JsonKeys.TRACE_SAMPLED:

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1807,7 +1807,7 @@ public class SentryOptions {
     return continuousProfilesSampleRate;
   }
 
-  public void setContinuousProfilesSampleRate(double continuousProfilesSampleRate) {
+  public void setContinuousProfilesSampleRate(final double continuousProfilesSampleRate) {
     if (!SampleRateUtils.isValidContinuousProfilesSampleRate(continuousProfilesSampleRate)) {
       throw new IllegalArgumentException(
           "The value "

--- a/sentry/src/main/java/io/sentry/TracesSampler.java
+++ b/sentry/src/main/java/io/sentry/TracesSampler.java
@@ -85,6 +85,11 @@ public final class TracesSampler {
     return new TracesSamplingDecision(false, null, false, null);
   }
 
+  public boolean sampleContinuousProfile() {
+    final double sampling = options.getContinuousProfilesSampleRate();
+    return sample(sampling);
+  }
+
   private boolean sample(final @NotNull Double aDouble) {
     return !(aDouble < getRandom().nextDouble());
   }

--- a/sentry/src/main/java/io/sentry/util/SampleRateUtils.java
+++ b/sentry/src/main/java/io/sentry/util/SampleRateUtils.java
@@ -23,6 +23,10 @@ public final class SampleRateUtils {
     return isValidRate(profilesSampleRate, true);
   }
 
+  public static boolean isValidContinuousProfilesSampleRate(double profilesSampleRate) {
+    return isValidRate(profilesSampleRate, false);
+  }
+
   private static boolean isValidRate(final @Nullable Double rate, final boolean allowNull) {
     if (rate == null) {
       return allowNull;

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -121,6 +121,13 @@ class ExternalOptionsTest {
     }
 
     @Test
+    fun `creates options with continuousProfilesSampleRate using external properties`() {
+        withPropertiesFile("continuous-profiles-sample-rate=0.2") {
+            assertEquals(0.2, it.continuousProfilesSampleRate)
+        }
+    }
+
+    @Test
     fun `creates options with enableDeduplication using external properties`() {
         withPropertiesFile("enable-deduplication=true") {
             assertNotNull(it.enableDeduplication) {

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -1229,9 +1229,9 @@ class JsonSerializerTest {
     fun `serializing SentryAppStartProfilingOptions`() {
         val actual = serializeToString(appStartProfilingOptions)
 
-        val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\":false," +
-            "\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false," +
-            "\"is_continuous_profiling_enabled\":false,\"profiling_traces_hz\":65}"
+        val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"continuous_profile_sampled\":true," +
+            "\"trace_sampled\":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null," +
+            "\"is_profiling_enabled\":false,\"is_continuous_profiling_enabled\":false,\"profiling_traces_hz\":65}"
 
         assertEquals(expected, actual)
     }
@@ -1239,7 +1239,8 @@ class JsonSerializerTest {
     @Test
     fun `deserializing SentryAppStartProfilingOptions`() {
         val jsonAppStartProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
-            ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false,\"profiling_traces_hz\":65}"
+            ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false," +
+            "\"profiling_traces_hz\":65,\"continuous_profile_sampled\":true}"
 
         val actual = fixture.serializer.deserialize(StringReader(jsonAppStartProfilingOptions), SentryAppStartProfilingOptions::class.java)
         assertNotNull(actual)
@@ -1247,6 +1248,7 @@ class JsonSerializerTest {
         assertEquals(appStartProfilingOptions.traceSampleRate, actual.traceSampleRate)
         assertEquals(appStartProfilingOptions.profileSampled, actual.profileSampled)
         assertEquals(appStartProfilingOptions.profileSampleRate, actual.profileSampleRate)
+        assertEquals(appStartProfilingOptions.continuousProfileSampled, actual.isContinuousProfileSampled)
         assertEquals(appStartProfilingOptions.isProfilingEnabled, actual.isProfilingEnabled)
         assertEquals(appStartProfilingOptions.isContinuousProfilingEnabled, actual.isContinuousProfilingEnabled)
         assertEquals(appStartProfilingOptions.profilingTracesHz, actual.profilingTracesHz)
@@ -1549,6 +1551,7 @@ class JsonSerializerTest {
     private val appStartProfilingOptions = SentryAppStartProfilingOptions().apply {
         traceSampled = false
         traceSampleRate = 0.1
+        continuousProfileSampled = true
         profileSampled = true
         profileSampleRate = 0.8
         isProfilingEnabled = false

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -237,6 +237,15 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `when continuousProfilesSampleRate is set to a 0, isProfilingEnabled is false and isContinuousProfilingEnabled is false`() {
+        val options = SentryOptions().apply {
+            this.continuousProfilesSampleRate = 0.0
+        }
+        assertFalse(options.isProfilingEnabled)
+        assertFalse(options.isContinuousProfilingEnabled)
+    }
+
+    @Test
     fun `when setProfilesSampleRate is set to exactly 0, value is set`() {
         val options = SentryOptions().apply {
             this.profilesSampleRate = 0.0
@@ -252,6 +261,24 @@ class SentryOptionsTest {
     @Test
     fun `when setProfilesSampleRate is set to lower than 0, setter throws`() {
         assertFailsWith<IllegalArgumentException> { SentryOptions().profilesSampleRate = -0.0000000000001 }
+    }
+
+    @Test
+    fun `when setContinuousProfilesSampleRate is set to exactly 0, value is set`() {
+        val options = SentryOptions().apply {
+            this.continuousProfilesSampleRate = 0.0
+        }
+        assertEquals(0.0, options.continuousProfilesSampleRate)
+    }
+
+    @Test
+    fun `when setContinuousProfilesSampleRate is set to higher than 1_0, setter throws`() {
+        assertFailsWith<IllegalArgumentException> { SentryOptions().continuousProfilesSampleRate = 1.0000000000001 }
+    }
+
+    @Test
+    fun `when setContinuousProfilesSampleRate is set to lower than 0, setter throws`() {
+        assertFailsWith<IllegalArgumentException> { SentryOptions().continuousProfilesSampleRate = -0.0000000000001 }
     }
 
     @Test
@@ -322,6 +349,7 @@ class SentryOptionsTest {
         externalOptions.enableUncaughtExceptionHandler = false
         externalOptions.tracesSampleRate = 0.5
         externalOptions.profilesSampleRate = 0.5
+        externalOptions.continuousProfilesSampleRate = 0.3
         externalOptions.addInAppInclude("com.app")
         externalOptions.addInAppExclude("io.off")
         externalOptions.addTracePropagationTarget("localhost")
@@ -368,6 +396,7 @@ class SentryOptionsTest {
         assertFalse(options.isEnableUncaughtExceptionHandler)
         assertEquals(0.5, options.tracesSampleRate)
         assertEquals(0.5, options.profilesSampleRate)
+        assertEquals(0.3, options.continuousProfilesSampleRate)
         assertEquals(listOf("com.app"), options.inAppIncludes)
         assertEquals(listOf("io.off"), options.inAppExcludes)
         assertEquals(listOf("localhost", "api.foo.com"), options.tracePropagationTargets)
@@ -578,8 +607,16 @@ class SentryOptionsTest {
     fun `when profiling is disabled, isEnableAppStartProfiling is always false`() {
         val options = SentryOptions()
         options.isEnableAppStartProfiling = true
-        options.profilesSampleRate = 0.0
+        options.continuousProfilesSampleRate = 0.0
         assertFalse(options.isEnableAppStartProfiling)
+    }
+
+    @Test
+    fun `when setEnableAppStartProfiling is called and continuous profiling is enabled, isEnableAppStartProfiling is true`() {
+        val options = SentryOptions()
+        options.isEnableAppStartProfiling = true
+        options.continuousProfilesSampleRate = 1.0
+        assertTrue(options.isEnableAppStartProfiling)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -18,6 +18,7 @@ class TracesSamplerTest {
             randomResult: Double? = null,
             tracesSampleRate: Double? = null,
             profilesSampleRate: Double? = null,
+            continuousProfilesSampleRate: Double? = null,
             tracesSamplerCallback: SentryOptions.TracesSamplerCallback? = null,
             profilesSamplerCallback: SentryOptions.ProfilesSamplerCallback? = null,
             logger: ILogger? = null
@@ -32,6 +33,9 @@ class TracesSamplerTest {
             }
             if (profilesSampleRate != null) {
                 options.profilesSampleRate = profilesSampleRate
+            }
+            if (continuousProfilesSampleRate != null) {
+                options.continuousProfilesSampleRate = continuousProfilesSampleRate
             }
             if (tracesSamplerCallback != null) {
                 options.tracesSampler = tracesSamplerCallback
@@ -148,6 +152,27 @@ class TracesSamplerTest {
         assertTrue(samplingDecision.sampled)
         assertFalse(samplingDecision.profileSampled)
         assertEquals(0.2, samplingDecision.profileSampleRate)
+    }
+
+    @Test
+    fun `when continuousProfilesSampleRate is not set returns true`() {
+        val sampler = fixture.getSut(randomResult = 1.0)
+        val sampled = sampler.sampleContinuousProfile()
+        assertTrue(sampled)
+    }
+
+    @Test
+    fun `when continuousProfilesSampleRate is set and random returns lower number returns true`() {
+        val sampler = fixture.getSut(randomResult = 0.1, continuousProfilesSampleRate = 0.2)
+        val sampled = sampler.sampleContinuousProfile()
+        assertTrue(sampled)
+    }
+
+    @Test
+    fun `when continuousProfilesSampleRate is set and random returns greater number returns false`() {
+        val sampler = fixture.getSut(randomResult = 0.9, continuousProfilesSampleRate = 0.2)
+        val sampled = sampler.sampleContinuousProfile()
+        assertFalse(sampled)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
+++ b/sentry/src/test/java/io/sentry/util/SampleRateUtilTest.kt
@@ -130,4 +130,39 @@ class SampleRateUtilTest {
     fun `accepts null profiles sample rate`() {
         assertTrue(SampleRateUtils.isValidProfilesSampleRate(null))
     }
+
+    @Test
+    fun `accepts 0 for continuous profiles sample rate`() {
+        assertTrue(SampleRateUtils.isValidContinuousProfilesSampleRate(0.0))
+    }
+
+    @Test
+    fun `accepts 1 for continuous profiles sample rate`() {
+        assertTrue(SampleRateUtils.isValidContinuousProfilesSampleRate(1.0))
+    }
+
+    @Test
+    fun `rejects negative continuous profiles sample rate`() {
+        assertFalse(SampleRateUtils.isValidContinuousProfilesSampleRate(-0.5))
+    }
+
+    @Test
+    fun `rejects 1 dot 01 for continuous profiles sample rate`() {
+        assertFalse(SampleRateUtils.isValidContinuousProfilesSampleRate(1.01))
+    }
+
+    @Test
+    fun `rejects NaN continuous profiles sample rate`() {
+        assertFalse(SampleRateUtils.isValidContinuousProfilesSampleRate(Double.NaN))
+    }
+
+    @Test
+    fun `rejects positive infinite continuous profiles sample rate`() {
+        assertFalse(SampleRateUtils.isValidContinuousProfilesSampleRate(Double.POSITIVE_INFINITY))
+    }
+
+    @Test
+    fun `rejects negative infinite continuous profiles sample rate`() {
+        assertFalse(SampleRateUtils.isValidContinuousProfilesSampleRate(Double.NEGATIVE_INFINITY))
+    }
 }


### PR DESCRIPTION
## :scroll: Description
added SentryOptions.continuousProfilesSampleRate
now continuous profiling is disabled if continuousProfilesSampleRate is 0
profiles directory is created when continuous profiling is enabled, too
continuous profiling decision is passed to SentryAppStartProfilingOptions
app start continuous profiling is sampled, too

#skip-changelog


## :bulb: Motivation and Context
Add sample rate to continuous profiling
Part 7 of https://github.com/getsentry/sentry-java/pull/3710


## :green_heart: How did you test it?
Unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
