### PR TITLE
Enable `ThreadLocalAccessor` for Spring Boot 3 WebFlux by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Enable `ThreadLocalAccessor` for Spring Boot 3 WebFlux by default ([#4023](https://github.com/getsentry/sentry-java/pull/4023))
+
 ## 8.0.0-rc.3
 
 ### Features

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfiguration.java
@@ -91,8 +91,7 @@ public class SentryWebfluxAutoConfiguration {
 
     @ConditionalOnProperty(
         name = "sentry.reactive.thread-local-accessor-enabled",
-        havingValue = "false",
-        matchIfMissing = true)
+        havingValue = "false")
     @SuppressWarnings("UnusedNestedClass")
     private static class SentryDisableThreadLocalAccessorCondition {}
 
@@ -109,7 +108,8 @@ public class SentryWebfluxAutoConfiguration {
 
     @ConditionalOnProperty(
         name = "sentry.reactive.thread-local-accessor-enabled",
-        havingValue = "true")
+        havingValue = "true",
+        matchIfMissing = true)
     @SuppressWarnings("UnusedNestedClass")
     private static class SentryEnableThreadLocalAccessorCondition {}
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryWebfluxAutoConfigurationTest.kt
@@ -21,8 +21,8 @@ class SentryWebfluxAutoConfigurationTest {
     fun `configures sentryWebFilter`() {
         contextRunner.withPropertyValues("sentry.dsn=http://key@localhost/proj")
             .run {
-                assertThat(it).hasSingleBean(SentryWebFilter::class.java)
-                assertThat(it).doesNotHaveBean(SentryWebFilterWithThreadLocalAccessor::class.java)
+                assertThat(it).hasSingleBean(SentryWebFilterWithThreadLocalAccessor::class.java)
+                assertThat(it).doesNotHaveBean(SentryWebFilter::class.java)
             }
     }
 
@@ -63,6 +63,7 @@ class SentryWebfluxAutoConfigurationTest {
             )
             .run {
                 assertThat(it).hasSingleBean(SentryWebFilterWithThreadLocalAccessor::class.java)
+                assertThat(it).doesNotHaveBean(SentryWebFilter::class.java)
             }
     }
 
@@ -75,6 +76,7 @@ class SentryWebfluxAutoConfigurationTest {
             )
             .run {
                 assertThat(it).doesNotHaveBean(SentryWebFilterWithThreadLocalAccessor::class.java)
+                assertThat(it).hasSingleBean(SentryWebFilter::class.java)
             }
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Change default for `sentry.reactive.thread-local-accessor-enabled` when the property is missing to use `ThreadLocalAccessor` by default.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4020

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
