### PR TITLE
Avoid logging an error when a float is passed in the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Enable `ThreadLocalAccessor` for Spring Boot 3 WebFlux by default ([#4023](https://github.com/getsentry/sentry-java/pull/4023))
 
+### Fixes
+
+- Avoid logging an error when a float is passed in the manifest ([#4031](https://github.com/getsentry/sentry-java/pull/4031))
+
 ## 8.0.0-rc.3
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -477,7 +477,10 @@ final class ManifestMetadataReader {
   private static @NotNull Double readDouble(
       final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
     // manifest meta-data only reads float
-    final Double value = ((Number) metadata.getFloat(key, metadata.getInt(key, -1))).doubleValue();
+    double value = ((Float) metadata.getFloat(key, -1)).doubleValue();
+    if (value == -1) {
+      value = ((Integer) metadata.getInt(key, -1)).doubleValue();
+    }
     logger.log(SentryLevel.DEBUG, key + " read: " + value);
     return value;
   }


### PR DESCRIPTION
## :scroll: Description
Avoid logging an error when a float is passed in the manifest

https://github.com/getsentry/sentry-java/pull/3823 added support for integer values in the manifest.
But that's used as default value when parsing floats. This means that all float values are evaluated as integers and floats, causing one of the checks to fail.
Everything still works correctly, but when the type is wrong, the error is logged in the logcat.
This PR avoids the log if the value passed in the manifest is a float

## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/803


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
