### PR TITLE
Various fixes to instrumentations running on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Do not instrument File I/O operations if tracing is disabled ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
+- Do not instrument User Interaction multiple times ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
+- Speed up view traversal to find touched target in `UserInteractionIntegration` ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
+
 ## 7.20.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixes
 
-- Do not instrument File I/O operations if tracing is disabled ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
-- Do not instrument User Interaction multiple times ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
-- Speed up view traversal to find touched target in `UserInteractionIntegration` ([#4039](https://github.com/getsentry/sentry-java/pull/4039))
+- Do not instrument File I/O operations if tracing is disabled ([#4051](https://github.com/getsentry/sentry-java/pull/4051))
+- Do not instrument User Interaction multiple times ([#4051](https://github.com/getsentry/sentry-java/pull/4051))
+- Speed up view traversal to find touched target in `UserInteractionIntegration` ([#4051](https://github.com/getsentry/sentry-java/pull/4051))
 
 ## 7.20.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/UserInteractionIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/UserInteractionIntegration.java
@@ -50,6 +50,11 @@ public final class UserInteractionIntegration
         delegate = new NoOpWindowCallback();
       }
 
+      if (delegate instanceof SentryWindowCallback) {
+        // already instrumented
+        return;
+      }
+
       final SentryGestureListener gestureListener =
           new SentryGestureListener(activity, hub, options);
       window.setCallback(new SentryWindowCallback(delegate, activity, gestureListener, options));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/AndroidViewGestureTargetLocator.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/AndroidViewGestureTargetLocator.java
@@ -18,7 +18,6 @@ public final class AndroidViewGestureTargetLocator implements GestureTargetLocat
   private static final String ORIGIN = "old_view_system";
 
   private final boolean isAndroidXAvailable;
-  private final int[] coordinates = new int[2];
 
   public AndroidViewGestureTargetLocator(final boolean isAndroidXAvailable) {
     this.isAndroidXAvailable = isAndroidXAvailable;
@@ -31,13 +30,11 @@ public final class AndroidViewGestureTargetLocator implements GestureTargetLocat
       return null;
     }
     final View view = (View) root;
-    if (touchWithinBounds(view, x, y)) {
-      if (targetType == UiElement.Type.CLICKABLE && isViewTappable(view)) {
-        return createUiElement(view);
-      } else if (targetType == UiElement.Type.SCROLLABLE
-          && isViewScrollable(view, isAndroidXAvailable)) {
-        return createUiElement(view);
-      }
+    if (targetType == UiElement.Type.CLICKABLE && isViewTappable(view)) {
+      return createUiElement(view);
+    } else if (targetType == UiElement.Type.SCROLLABLE
+        && isViewScrollable(view, isAndroidXAvailable)) {
+      return createUiElement(view);
     }
     return null;
   }
@@ -50,17 +47,6 @@ public final class AndroidViewGestureTargetLocator implements GestureTargetLocat
     } catch (Resources.NotFoundException ignored) {
       return null;
     }
-  }
-
-  private boolean touchWithinBounds(final @NotNull View view, final float x, final float y) {
-    view.getLocationOnScreen(coordinates);
-    int vx = coordinates[0];
-    int vy = coordinates[1];
-
-    int w = view.getWidth();
-    int h = view.getHeight();
-
-    return !(x < vx || x > vx + w || y < vy || y > vy + h);
   }
 
   private static boolean isViewTappable(final @NotNull View view) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/AndroidViewGestureTargetLocator.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/AndroidViewGestureTargetLocator.java
@@ -26,7 +26,7 @@ public final class AndroidViewGestureTargetLocator implements GestureTargetLocat
 
   @Override
   public @Nullable UiElement locate(
-      @NotNull Object root, float x, float y, UiElement.Type targetType) {
+      @Nullable Object root, float x, float y, UiElement.Type targetType) {
     if (!(root instanceof View)) {
       return null;
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
@@ -16,6 +16,32 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class ViewUtils {
 
+  private static final int[] coordinates = new int[2];
+
+  /**
+   * Verifies if the given touch coordinates are within the bounds of the given view.
+   *
+   * @param view the view to check if the touch coordinates are within its bounds
+   * @param x - the x coordinate of a {@link MotionEvent}
+   * @param y - the y coordinate of {@link MotionEvent}
+   * @return true if the touch coordinates are within the bounds of the view, false otherwise
+   */
+  private static boolean touchWithinBounds(
+      final @Nullable View view, final float x, final float y) {
+    if (view == null) {
+      return false;
+    }
+
+    view.getLocationOnScreen(coordinates);
+    int vx = coordinates[0];
+    int vy = coordinates[1];
+
+    int w = view.getWidth();
+    int h = view.getHeight();
+
+    return !(x < vx || x > vx + w || y < vy || y > vy + h);
+  }
+
   /**
    * Finds a target view, that has been selected/clicked by the given coordinates x and y and the
    * given {@code viewTargetSelector}.
@@ -41,6 +67,11 @@ public final class ViewUtils {
     while (queue.size() > 0) {
       final View view = queue.poll();
 
+      if (!touchWithinBounds(view, x, y)) {
+        // if the touch is not hitting the view, skip traversal of its children
+        continue;
+      }
+
       if (view instanceof ViewGroup) {
         final ViewGroup viewGroup = (ViewGroup) view;
         for (int i = 0; i < viewGroup.getChildCount(); i++) {
@@ -53,7 +84,7 @@ public final class ViewUtils {
         if (newTarget != null) {
           if (targetType == UiElement.Type.CLICKABLE) {
             target = newTarget;
-          } else {
+          } else if (targetType == UiElement.Type.SCROLLABLE) {
             return newTarget;
           }
         }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.gestures.UiElement;
-import io.sentry.util.Objects;
 import java.util.LinkedList;
 import java.util.Queue;
 import org.jetbrains.annotations.ApiStatus;
@@ -40,7 +39,7 @@ public final class ViewUtils {
 
     @Nullable UiElement target = null;
     while (queue.size() > 0) {
-      final View view = Objects.requireNonNull(queue.poll(), "view is required");
+      final View view = queue.poll();
 
       if (view instanceof ViewGroup) {
         final ViewGroup viewGroup = (ViewGroup) view;

--- a/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
@@ -140,6 +140,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = null
@@ -160,6 +161,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = delegate
@@ -170,8 +172,30 @@ class UserInteractionIntegrationTest {
         val callback = mock<SentryWindowCallback>()
         val sut = fixture.getSut(callback)
 
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(callback).stopTracking()
+    }
+
+    @Test
+    fun `does not instrument if the callback is already ours`() {
+        val delegate = mock<Window.Callback>()
+        val context = mock<Context>()
+        val resources = Fixture.mockResources()
+        whenever(context.resources).thenReturn(resources)
+        val existingCallback = SentryWindowCallback(
+            delegate,
+            context,
+            mock(),
+            mock()
+        )
+        val sut = fixture.getSut(existingCallback)
+
+        sut.register(fixture.hub, fixture.options)
+        sut.onActivityResumed(fixture.activity)
+
+        val argumentCaptor = argumentCaptor<Window.Callback>()
+        verify(fixture.window, never()).callback = argumentCaptor.capture()
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
@@ -140,7 +140,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
-        sut.register(fixture.scopes, fixture.options)
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = null
@@ -161,7 +161,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
-        sut.register(fixture.scopes, fixture.options)
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = delegate
@@ -172,7 +172,7 @@ class UserInteractionIntegrationTest {
         val callback = mock<SentryWindowCallback>()
         val sut = fixture.getSut(callback)
 
-        sut.register(fixture.scopes, fixture.options)
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(callback).stopTracking()
@@ -192,7 +192,7 @@ class UserInteractionIntegrationTest {
         )
         val sut = fixture.getSut(existingCallback)
 
-        sut.register(fixture.scopes, fixture.options)
+        sut.register(fixture.hub, fixture.options)
         sut.onActivityResumed(fixture.activity)
 
         val argumentCaptor = argumentCaptor<Window.Callback>()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/UserInteractionIntegrationTest.kt
@@ -140,7 +140,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
-        sut.register(fixture.hub, fixture.options)
+        sut.register(fixture.scopes, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = null
@@ -161,7 +161,7 @@ class UserInteractionIntegrationTest {
             )
         )
 
-        sut.register(fixture.hub, fixture.options)
+        sut.register(fixture.scopes, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(fixture.window).callback = delegate
@@ -172,7 +172,7 @@ class UserInteractionIntegrationTest {
         val callback = mock<SentryWindowCallback>()
         val sut = fixture.getSut(callback)
 
-        sut.register(fixture.hub, fixture.options)
+        sut.register(fixture.scopes, fixture.options)
         sut.onActivityPaused(fixture.activity)
 
         verify(callback).stopTracking()
@@ -192,7 +192,7 @@ class UserInteractionIntegrationTest {
         )
         val sut = fixture.getSut(existingCallback)
 
-        sut.register(fixture.hub, fixture.options)
+        sut.register(fixture.scopes, fixture.options)
         sut.onActivityResumed(fixture.activity)
 
         val argumentCaptor = argumentCaptor<Window.Callback>()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerClickTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerClickTest.kt
@@ -185,7 +185,7 @@ class SentryGestureListenerClickTest {
 
         sut.onSingleTapUp(event)
 
-        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), anyOrNull())
     }
 
     @Test
@@ -214,7 +214,7 @@ class SentryGestureListenerClickTest {
 
         sut.onSingleTapUp(event)
 
-        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), anyOrNull())
     }
 
     @Test
@@ -257,7 +257,7 @@ class SentryGestureListenerClickTest {
     @Test
     fun `if touch is not within view group bounds does not traverse its children`() {
         val event = mock<MotionEvent>()
-        val sut = fixture.getSut<View>(event, attachViewsToRoot = true)
+        val sut = fixture.getSut<View>(event, attachViewsToRoot = false)
         fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = false) {
             whenever(it.childCount).thenReturn(1)
             whenever(it.getChildAt(0)).thenReturn(fixture.target)
@@ -265,6 +265,6 @@ class SentryGestureListenerClickTest {
 
         sut.onSingleTapUp(event)
 
-        verify(fixture.scopes, never()).addBreadcrumb(any<Breadcrumb>())
+        verify(fixture.hub, never()).addBreadcrumb(any<Breadcrumb>(), anyOrNull())
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerClickTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerClickTest.kt
@@ -223,7 +223,7 @@ class SentryGestureListenerClickTest {
 
         val event = mock<MotionEvent>()
         val sut = fixture.getSut<LocalView>(event, attachViewsToRoot = false)
-        fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = false) {
+        fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = true) {
             whenever(it.childCount).thenReturn(1)
             whenever(it.getChildAt(0)).thenReturn(fixture.target)
         }
@@ -244,7 +244,7 @@ class SentryGestureListenerClickTest {
 
         val event = mock<MotionEvent>()
         val sut = fixture.getSut<LocalView>(event, attachViewsToRoot = false)
-        fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = false) {
+        fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = true) {
             whenever(it.childCount).thenReturn(1)
             whenever(it.getChildAt(0)).thenReturn(fixture.target)
         }
@@ -252,5 +252,19 @@ class SentryGestureListenerClickTest {
         sut.onSingleTapUp(event)
 
         verify(fixture.scope).propagationContext = any()
+    }
+
+    @Test
+    fun `if touch is not within view group bounds does not traverse its children`() {
+        val event = mock<MotionEvent>()
+        val sut = fixture.getSut<View>(event, attachViewsToRoot = true)
+        fixture.window.mockDecorView<ViewGroup>(event = event, touchWithinBounds = false) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(fixture.target)
+        }
+
+        sut.onSingleTapUp(event)
+
+        verify(fixture.scopes, never()).addBreadcrumb(any<Breadcrumb>())
     }
 }

--- a/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
+++ b/sentry-compose-helper/src/jvmMain/java/io/sentry/compose/gestures/ComposeGestureTargetLocator.java
@@ -39,7 +39,7 @@ public final class ComposeGestureTargetLocator implements GestureTargetLocator {
 
   @Override
   public @Nullable UiElement locate(
-      @NotNull Object root, float x, float y, UiElement.Type targetType) {
+      @Nullable Object root, float x, float y, UiElement.Type targetType) {
 
     // lazy init composeHelper as it's using some reflection under the hood
     if (composeHelper == null) {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3645,7 +3645,7 @@ public final class io/sentry/instrumentation/file/SentryFileOutputStream : java/
 public final class io/sentry/instrumentation/file/SentryFileOutputStream$Factory {
 	public fun <init> ()V
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;)Ljava/io/FileOutputStream;
-	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Lio/sentry/IScopes;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Lio/sentry/IHub;)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Z)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/FileDescriptor;)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;)Ljava/io/FileOutputStream;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3645,6 +3645,7 @@ public final class io/sentry/instrumentation/file/SentryFileOutputStream : java/
 public final class io/sentry/instrumentation/file/SentryFileOutputStream$Factory {
 	public fun <init> ()V
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;)Ljava/io/FileOutputStream;
+	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Lio/sentry/IScopes;)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/File;Z)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/io/FileDescriptor;)Ljava/io/FileOutputStream;
 	public static fun create (Ljava/io/FileOutputStream;Ljava/lang/String;)Ljava/io/FileOutputStream;

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileInputStream.java
@@ -3,6 +3,7 @@ package io.sentry.instrumentation.file;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
+import io.sentry.SentryOptions;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
@@ -127,26 +128,40 @@ public final class SentryFileInputStream extends FileInputStream {
     public static FileInputStream create(
         final @NotNull FileInputStream delegate, final @Nullable String name)
         throws FileNotFoundException {
-      return new SentryFileInputStream(
-          init(name != null ? new File(name) : null, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileInputStream(init(name != null ? new File(name) : null, delegate, hub))
+          : delegate;
     }
 
     public static FileInputStream create(
         final @NotNull FileInputStream delegate, final @Nullable File file)
         throws FileNotFoundException {
-      return new SentryFileInputStream(init(file, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileInputStream(init(file, delegate, hub))
+          : delegate;
     }
 
     public static FileInputStream create(
         final @NotNull FileInputStream delegate, final @NotNull FileDescriptor descriptor) {
-      return new SentryFileInputStream(
-          init(descriptor, delegate, HubAdapter.getInstance()), descriptor);
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileInputStream(init(descriptor, delegate, hub), descriptor)
+          : delegate;
     }
 
     static FileInputStream create(
         final @NotNull FileInputStream delegate, final @Nullable File file, final @NotNull IHub hub)
         throws FileNotFoundException {
-      return new SentryFileInputStream(init(file, delegate, hub));
+      return isTracingEnabled(hub)
+          ? new SentryFileInputStream(init(file, delegate, hub))
+          : delegate;
+    }
+
+    private static boolean isTracingEnabled(final @NotNull IHub hub) {
+      final @NotNull SentryOptions options = hub.getOptions();
+      return options.isTracingEnabled();
     }
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -3,6 +3,7 @@ package io.sentry.instrumentation.file;
 import io.sentry.HubAdapter;
 import io.sentry.IHub;
 import io.sentry.ISpan;
+import io.sentry.SentryOptions;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
@@ -131,32 +132,52 @@ public final class SentryFileOutputStream extends FileOutputStream {
     public static FileOutputStream create(
         final @NotNull FileOutputStream delegate, final @Nullable String name)
         throws FileNotFoundException {
-      return new SentryFileOutputStream(
-          init(name != null ? new File(name) : null, false, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(
+              init(name != null ? new File(name) : null, false, delegate, hub))
+          : delegate;
     }
 
     public static FileOutputStream create(
         final @NotNull FileOutputStream delegate, final @Nullable String name, final boolean append)
         throws FileNotFoundException {
-      return new SentryFileOutputStream(
-          init(name != null ? new File(name) : null, append, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(
+              init(name != null ? new File(name) : null, append, delegate, hub))
+          : delegate;
     }
 
     public static FileOutputStream create(
         final @NotNull FileOutputStream delegate, final @Nullable File file)
         throws FileNotFoundException {
-      return new SentryFileOutputStream(init(file, false, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(init(file, false, delegate, hub))
+          : delegate;
     }
 
     public static FileOutputStream create(
         final @NotNull FileOutputStream delegate, final @Nullable File file, final boolean append)
         throws FileNotFoundException {
-      return new SentryFileOutputStream(init(file, append, delegate, HubAdapter.getInstance()));
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(init(file, append, delegate, hub))
+          : delegate;
     }
 
     public static FileOutputStream create(
         final @NotNull FileOutputStream delegate, final @NotNull FileDescriptor fdObj) {
-      return new SentryFileOutputStream(init(fdObj, delegate, HubAdapter.getInstance()), fdObj);
+      final @NotNull IHub hub = HubAdapter.getInstance();
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(init(fdObj, delegate, hub), fdObj)
+          : delegate;
+    }
+
+    private static boolean isTracingEnabled(final @NotNull IHub hub) {
+      final @NotNull SentryOptions options = hub.getOptions();
+      return options.isTracingEnabled();
     }
   }
 }

--- a/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
+++ b/sentry/src/main/java/io/sentry/instrumentation/file/SentryFileOutputStream.java
@@ -175,6 +175,16 @@ public final class SentryFileOutputStream extends FileOutputStream {
           : delegate;
     }
 
+    public static FileOutputStream create(
+        final @NotNull FileOutputStream delegate,
+        final @Nullable File file,
+        final @NotNull IHub hub)
+        throws FileNotFoundException {
+      return isTracingEnabled(hub)
+          ? new SentryFileOutputStream(init(file, false, delegate, hub))
+          : delegate;
+    }
+
     private static boolean isTracingEnabled(final @NotNull IHub hub) {
       final @NotNull SentryOptions options = hub.getOptions();
       return options.isTracingEnabled();

--- a/sentry/src/main/java/io/sentry/internal/gestures/GestureTargetLocator.java
+++ b/sentry/src/main/java/io/sentry/internal/gestures/GestureTargetLocator.java
@@ -1,11 +1,10 @@
 package io.sentry.internal.gestures;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public interface GestureTargetLocator {
 
   @Nullable
   UiElement locate(
-      final @NotNull Object root, final float x, final float y, final UiElement.Type targetType);
+      final @Nullable Object root, final float x, final float y, final UiElement.Type targetType);
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Here are just some preventive measure that will make less code/instructions to run on the main thread:
- Safety check for the `Window.Callback` to not be a `SentryWindowCallback` already to prevent multiple callbacks running simultaneously
- Get rid of `requireNonNull` calls as they are redundant (we do `instanceof` checks later on anyway)
- Check if tracing is enabled before instrumenting File I/O streams, because otherwise they go into the void anyway
- Speed up ViewUtils.findTarget method by avoiding ViewGroup children traversal if the touch was not within the ViewGroup bounds

### Before

![Screenshot 2025-01-13 at 23 36 38](https://github.com/user-attachments/assets/112c9da0-8b3f-4fee-85a8-2a70ccc16d8e)

### After
 
![Screenshot 2025-01-14 at 00 09 42](https://github.com/user-attachments/assets/6d0db0c8-aa38-42ad-9211-90cb13c43097)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal customer discussions

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

