### PR TITLE
Do not set the exception group marker when there is a suppressed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Do not set the exception group marker when there is a suppressed exception ([#4056](https://github.com/getsentry/sentry-java/pull/4056))
+  - Due to how grouping works in Sentry currently sometimes the suppressed exception is treated as the main exception. This change ensures we keep using the main exception and not change how grouping works.
+  - As a consequence the list of exceptions in the group on top of an issue is no longer shown in Sentry UI.
+  - We are planning to improve this in the future but opted for this fix first.
+
 ### Internal
 
 - Make `SentryClient` constructor public ([#4045](https://github.com/getsentry/sentry-java/pull/4045))

--- a/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
+++ b/sentry/src/main/java/io/sentry/SentryExceptionFactory.java
@@ -189,7 +189,9 @@ public final class SentryExceptionFactory {
 
       Throwable[] suppressed = currentThrowable.getSuppressed();
       if (suppressed != null && suppressed.length > 0) {
-        exceptionMechanism.setExceptionGroup(true);
+        // Disabled for now as it causes grouping in Sentry to sometimes use
+        // the suppressed exception as main exception.
+        // exceptionMechanism.setExceptionGroup(true);
         for (Throwable suppressedThrowable : suppressed) {
           extractExceptionQueueInternal(
               suppressedThrowable, exceptionId, circularityDetector, exceptions);

--- a/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExceptionFactoryTest.kt
@@ -231,7 +231,7 @@ class SentryExceptionFactoryTest {
 
         assertEquals("message", mainInQueue.value)
         assertEquals(0, mainInQueue.mechanism?.exceptionId)
-        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
     }
 
     @Test
@@ -255,12 +255,12 @@ class SentryExceptionFactoryTest {
         assertEquals("inner", mainInQueue.value)
         assertEquals(1, mainInQueue.mechanism?.exceptionId)
         assertEquals(0, mainInQueue.mechanism?.parentId)
-        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("outer", outerInQueue.value)
         assertEquals(0, outerInQueue.mechanism?.exceptionId)
         assertNull(outerInQueue.mechanism?.parentId)
-        assertNull(outerInQueue.mechanism?.isExceptionGroup)
+//        assertNull(outerInQueue.mechanism?.isExceptionGroup)
     }
 
     @Test
@@ -288,12 +288,12 @@ class SentryExceptionFactoryTest {
         assertEquals("inner", mainInQueue.value)
         assertEquals(1, mainInQueue.mechanism?.exceptionId)
         assertEquals(0, mainInQueue.mechanism?.parentId)
-        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, mainInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("outer", outerInQueue.value)
         assertEquals(0, outerInQueue.mechanism?.exceptionId)
         assertNull(outerInQueue.mechanism?.parentId)
-        assertNull(outerInQueue.mechanism?.isExceptionGroup)
+//        assertNull(outerInQueue.mechanism?.isExceptionGroup)
     }
 
     @Test
@@ -324,7 +324,7 @@ class SentryExceptionFactoryTest {
         assertEquals("innermost", innerMostExceptionInQueue.value)
         assertEquals(3, innerMostExceptionInQueue.mechanism?.exceptionId)
         assertEquals(1, innerMostExceptionInQueue.mechanism?.parentId)
-        assertEquals(true, innerMostExceptionInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, innerMostExceptionInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("suppressed", innerSuppressedInQueue.value)
         assertEquals(2, innerSuppressedInQueue.mechanism?.exceptionId)
@@ -334,7 +334,7 @@ class SentryExceptionFactoryTest {
         assertEquals("inner", innerExceptionInQueue.value)
         assertEquals(1, innerExceptionInQueue.mechanism?.exceptionId)
         assertEquals(0, innerExceptionInQueue.mechanism?.parentId)
-        assertEquals(true, innerExceptionInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, innerExceptionInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("outer", outerInQueue.value)
         assertEquals(0, outerInQueue.mechanism?.exceptionId)
@@ -378,7 +378,7 @@ class SentryExceptionFactoryTest {
         assertEquals("innermost", innerMostExceptionInQueue.value)
         assertEquals(3, innerMostExceptionInQueue.mechanism?.exceptionId)
         assertEquals(1, innerMostExceptionInQueue.mechanism?.parentId)
-        assertEquals(true, innerMostExceptionInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, innerMostExceptionInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("suppressed", innerSuppressedInQueue.value)
         assertEquals(2, innerSuppressedInQueue.mechanism?.exceptionId)
@@ -388,7 +388,7 @@ class SentryExceptionFactoryTest {
         assertEquals("inner", innerExceptionInQueue.value)
         assertEquals(1, innerExceptionInQueue.mechanism?.exceptionId)
         assertEquals(0, innerExceptionInQueue.mechanism?.parentId)
-        assertEquals(true, innerExceptionInQueue.mechanism?.isExceptionGroup)
+//        assertEquals(true, innerExceptionInQueue.mechanism?.isExceptionGroup)
 
         assertEquals("outer", outerInQueue.value)
         assertEquals(0, outerInQueue.mechanism?.exceptionId)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not set the exception group marker (`"is_exception_group": true,`) when there is a suppressed exception.

<img width="763" alt="Screenshot 2025-01-15 at 17 17 43" src="https://github.com/user-attachments/assets/c476ae83-5064-45df-a81e-aa7e882f34f3" />


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/4054 but also removes the list of exceptions from the top of the issue detail page. We can fix that at a later point.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
