### PR TITLE
Wrap up continuous profiling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,27 @@
   To enable Continuous Profiling use the `Sentry.startProfiler` and `Sentry.stopProfiler` experimental APIs. Sampling rate can be set through `options.continuousProfilesSampleRate` (defaults to 1.0).   
   Note: Both `options.profilesSampler` and `options.profilesSampleRate` must not be set to enable Continuous Profiling.
 
+  ```java
+  import io.sentry.android.core.SentryAndroid;
+
+  SentryAndroid.init(context) { options ->
+   
+    // Currently under experimental options:
+    options.getExperimental().setContinuousProfilesSampleRate(1.0);
+  }
+  // Start profiling
+  Sentry.startProfiler();
+  
+  // After all profiling is done, stop the profiler. Profiles can last indefinitely if not stopped.
+  Sentry.stopProfiler();
+  ```
   ```kotlin
   import io.sentry.android.core.SentryAndroid
 
   SentryAndroid.init(context) { options ->
    
     // Currently under experimental options:
-    options.continuousProfilesSampleRate = 1.0
+    options.experimental.continuousProfilesSampleRate = 1.0
   }
   // Start profiling
   Sentry.startProfiler()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add Continuous Profiling Support ([#3710](https://github.com/getsentry/sentry-java/pull/3710))
 
   To enable Continuous Profiling use the `Sentry.startProfiler` and `Sentry.stopProfiler` experimental APIs. Sampling rate can be set through `options.continuousProfilesSampleRate` (defaults to 1.0).   
-  Note: Both `options.profilesSampler` and `options.profilesSampleRate` must not be set to enable Continuous Profiling.
+  Note: Both `options.profilesSampler` and `options.profilesSampleRate` must **not** be set to enable Continuous Profiling.
 
   ```java
   import io.sentry.android.core.SentryAndroid;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add Continuous Profiling Support ([#3710](https://github.com/getsentry/sentry-java/pull/3710))
+
+  To enable Continuous Profiling use the `Sentry.startProfiler` and `Sentry.stopProfiler` experimental APIs. Sampling rate can be set through `options.continuousProfilesSampleRate` (defaults to 1.0).   
+  Note: Both `options.profilesSampler` and `options.profilesSampleRate` must not be set to enable Continuous Profiling.
+
+  ```kotlin
+  import io.sentry.android.core.SentryAndroid
+
+  SentryAndroid.init(context) { options ->
+   
+    // Currently under experimental options:
+    options.continuousProfilesSampleRate = 1.0
+  }
+  // Start profiling
+  Sentry.startProfiler()
+  
+  // After all profiling is done, stop the profiler. Profiles can last indefinitely if not stopped.
+  Sentry.stopProfiler()
+  ```
+
+  To learn more visit [Sentry's Continuous Profiling](https://docs.sentry.io/product/explore/profiling/transaction-vs-continuous-profiling/#continuous-profiling-mode) documentation page.
+
 ## 8.0.0-beta.3
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 @ApiStatus.Internal
 public class AndroidContinuousProfiler
     implements IContinuousProfiler, RateLimiter.IRateLimitObserver {
-  private static final long MAX_CHUNK_DURATION_MILLIS = 10000;
+  private static final long MAX_CHUNK_DURATION_MILLIS = 60000;
 
   private final @NotNull ILogger logger;
   private final @Nullable String profilingTracesDirPath;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -322,7 +322,7 @@ final class ManifestMetadataReader {
           final double continuousProfilesSampleRate =
               readDouble(metadata, logger, CONTINUOUS_PROFILES_SAMPLE_RATE);
           if (continuousProfilesSampleRate != -1) {
-            options.setContinuousProfilesSampleRate(continuousProfilesSampleRate);
+            options.getExperimental().setContinuousProfilesSampleRate(continuousProfilesSampleRate);
           }
         }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -818,7 +818,7 @@ class ManifestMetadataReaderTest {
     fun `applyMetadata does not override continuousProfilesSampleRate from options`() {
         // Arrange
         val expectedSampleRate = 0.99f
-        fixture.options.continuousProfilesSampleRate = expectedSampleRate.toDouble()
+        fixture.options.experimental.continuousProfilesSampleRate = expectedSampleRate.toDouble()
         val bundle = bundleOf(ManifestMetadataReader.CONTINUOUS_PROFILES_SAMPLE_RATE to 0.1f)
         val context = fixture.getContext(metaData = bundle)
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1846,7 +1846,7 @@ public final class io/sentry/PerformanceCollectionData {
 
 public final class io/sentry/ProfileChunk : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> ()V
-	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SentryId;Ljava/io/File;Ljava/util/Map;Lio/sentry/SentryOptions;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SentryId;Ljava/io/File;Ljava/util/Map;Ljava/lang/Double;Lio/sentry/SentryOptions;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChunkId ()Lio/sentry/protocol/SentryId;
 	public fun getClientSdk ()Lio/sentry/protocol/SdkVersion;
@@ -1857,6 +1857,7 @@ public final class io/sentry/ProfileChunk : io/sentry/JsonSerializable, io/sentr
 	public fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getSampledProfile ()Ljava/lang/String;
+	public fun getTimestamp ()D
 	public fun getTraceFile ()Ljava/io/File;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getVersion ()Ljava/lang/String;
@@ -1868,7 +1869,7 @@ public final class io/sentry/ProfileChunk : io/sentry/JsonSerializable, io/sentr
 }
 
 public final class io/sentry/ProfileChunk$Builder {
-	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SentryId;Ljava/util/Map;Ljava/io/File;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/protocol/SentryId;Ljava/util/Map;Ljava/io/File;Lio/sentry/SentryDate;)V
 	public fun build (Lio/sentry/SentryOptions;)Lio/sentry/ProfileChunk;
 }
 
@@ -1888,6 +1889,7 @@ public final class io/sentry/ProfileChunk$JsonKeys {
 	public static final field PROFILER_ID Ljava/lang/String;
 	public static final field RELEASE Ljava/lang/String;
 	public static final field SAMPLED_PROFILE Ljava/lang/String;
+	public static final field TIMESTAMP Ljava/lang/String;
 	public static final field VERSION Ljava/lang/String;
 	public fun <init> ()V
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -443,7 +443,9 @@ public abstract interface class io/sentry/EventProcessor {
 
 public final class io/sentry/ExperimentalOptions {
 	public fun <init> (Z)V
+	public fun getContinuousProfilesSampleRate ()D
 	public fun getSessionReplay ()Lio/sentry/SentryReplayOptions;
+	public fun setContinuousProfilesSampleRate (D)V
 	public fun setSessionReplay (Lio/sentry/SentryReplayOptions;)V
 }
 
@@ -3068,7 +3070,6 @@ public class io/sentry/SentryOptions {
 	public fun setConnectionStatusProvider (Lio/sentry/IConnectionStatusProvider;)V
 	public fun setConnectionTimeoutMillis (I)V
 	public fun setContinuousProfiler (Lio/sentry/IContinuousProfiler;)V
-	public fun setContinuousProfilesSampleRate (D)V
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
 	public fun setDateProvider (Lio/sentry/SentryDateProvider;)V
 	public fun setDebug (Z)V

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -1,5 +1,7 @@
 package io.sentry;
 
+import io.sentry.util.SampleRateUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -10,6 +12,15 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class ExperimentalOptions {
   private @NotNull SentryReplayOptions sessionReplay;
+
+  /**
+   * Configures the continuous profiling sample rate as a percentage of profiles to be sent in the
+   * range of 0.0 to 1.0. if 1.0 is set it means that 100% of profiles will be sent. If set to 0.1
+   * only 10% of profiles will be sent. Profiles are picked randomly. Default is 1 (100%).
+   * ProfilesSampleRate takes precedence over this. To enable continuous profiling, don't set
+   * profilesSampleRate or profilesSampler, or set them to null.
+   */
+  private double continuousProfilesSampleRate = 1.0;
 
   public ExperimentalOptions(final boolean empty) {
     this.sessionReplay = new SentryReplayOptions(empty);
@@ -22,5 +33,20 @@ public final class ExperimentalOptions {
 
   public void setSessionReplay(final @NotNull SentryReplayOptions sessionReplayOptions) {
     this.sessionReplay = sessionReplayOptions;
+  }
+
+  public double getContinuousProfilesSampleRate() {
+    return continuousProfilesSampleRate;
+  }
+
+  @ApiStatus.Experimental
+  public void setContinuousProfilesSampleRate(final double continuousProfilesSampleRate) {
+    if (!SampleRateUtils.isValidContinuousProfilesSampleRate(continuousProfilesSampleRate)) {
+      throw new IllegalArgumentException(
+          "The value "
+              + continuousProfilesSampleRate
+              + " is not valid. Use values between 0.0 and 1.0.");
+    }
+    this.continuousProfilesSampleRate = continuousProfilesSampleRate;
   }
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1051,11 +1051,13 @@ public final class Sentry {
   }
 
   /** Starts the continuous profiler, if enabled. */
+  @ApiStatus.Experimental
   public static void startProfiler() {
     getCurrentScopes().startProfiler();
   }
 
-  /** Starts the continuous profiler, if enabled. */
+  /** Stops the continuous profiler, if enabled. */
+  @ApiStatus.Experimental
   public static void stopProfiler() {
     getCurrentScopes().stopProfiler();
   }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1713,6 +1713,7 @@ public class SentryOptions {
    *
    * @return the continuous profiler.
    */
+  @ApiStatus.Experimental
   public @NotNull IContinuousProfiler getContinuousProfiler() {
     return continuousProfiler;
   }
@@ -1722,6 +1723,7 @@ public class SentryOptions {
    *
    * @param continuousProfiler - the continuous profiler
    */
+  @ApiStatus.Experimental
   public void setContinuousProfiler(final @Nullable IContinuousProfiler continuousProfiler) {
     // We allow to set the profiler only if it was not set before, and we don't allow to unset it.
     if (this.continuousProfiler == NoOpContinuousProfiler.getInstance()
@@ -1803,10 +1805,12 @@ public class SentryOptions {
    *
    * @return the sample rate
    */
+  @ApiStatus.Experimental
   public double getContinuousProfilesSampleRate() {
     return continuousProfilesSampleRate;
   }
 
+  @ApiStatus.Experimental
   public void setContinuousProfilesSampleRate(final double continuousProfilesSampleRate) {
     if (!SampleRateUtils.isValidContinuousProfilesSampleRate(continuousProfilesSampleRate)) {
       throw new IllegalArgumentException(

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -357,15 +357,6 @@ public class SentryOptions {
    */
   private @Nullable ProfilesSamplerCallback profilesSampler;
 
-  /**
-   * Configures the continuous profiling sample rate as a percentage of profiles to be sent in the
-   * range of 0.0 to 1.0. if 1.0 is set it means that 100% of profiles will be sent. If set to 0.1
-   * only 10% of profiles will be sent. Profiles are picked randomly. Default is 1 (100%).
-   * ProfilesSampleRate takes precedence over this. To enable continuous profiling, don't set
-   * profilesSampleRate or profilesSampler, or set them to null.
-   */
-  private double continuousProfilesSampleRate = 1.0;
-
   /** Max trace file size in bytes. */
   private long maxTraceFileSize = 5 * 1024 * 1024;
 
@@ -1751,7 +1742,7 @@ public class SentryOptions {
   public boolean isContinuousProfilingEnabled() {
     return profilesSampleRate == null
         && profilesSampler == null
-        && continuousProfilesSampleRate > 0;
+        && experimental.getContinuousProfilesSampleRate() > 0;
   }
 
   /**
@@ -1807,18 +1798,7 @@ public class SentryOptions {
    */
   @ApiStatus.Experimental
   public double getContinuousProfilesSampleRate() {
-    return continuousProfilesSampleRate;
-  }
-
-  @ApiStatus.Experimental
-  public void setContinuousProfilesSampleRate(final double continuousProfilesSampleRate) {
-    if (!SampleRateUtils.isValidContinuousProfilesSampleRate(continuousProfilesSampleRate)) {
-      throw new IllegalArgumentException(
-          "The value "
-              + continuousProfilesSampleRate
-              + " is not valid. Use values between 0.0 and 1.0.");
-    }
-    this.continuousProfilesSampleRate = continuousProfilesSampleRate;
+    return experimental.getContinuousProfilesSampleRate();
   }
 
   /**
@@ -2748,7 +2728,7 @@ public class SentryOptions {
       setProfilesSampleRate(options.getProfilesSampleRate());
     }
     if (options.getContinuousProfilesSampleRate() != null) {
-      setContinuousProfilesSampleRate(options.getContinuousProfilesSampleRate());
+      experimental.setContinuousProfilesSampleRate(options.getContinuousProfilesSampleRate());
     }
     if (options.getDebug() != null) {
       setDebug(options.getDebug());

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -885,7 +885,7 @@ class JsonSerializerTest {
         fixture.options.sdkVersion = SdkVersion("test", "1.2.3")
         fixture.options.release = "release"
         fixture.options.environment = "environment"
-        val profileChunk = ProfileChunk(profilerId, chunkId, fixture.traceFile, HashMap(), fixture.options)
+        val profileChunk = ProfileChunk(profilerId, chunkId, fixture.traceFile, HashMap(), 5.3, fixture.options)
         val measurementNow = SentryNanotimeDate()
         val measurementNowSeconds =
             BigDecimal.valueOf(DateUtils.nanosToSeconds(measurementNow.nanoTimestamp())).setScale(6, RoundingMode.DOWN)
@@ -928,6 +928,7 @@ class JsonSerializerTest {
         assertEquals("release", element["release"] as String)
         assertEquals(mapOf("name" to "test", "version" to "1.2.3"), element["client_sdk"] as Map<String, String>)
         assertEquals("2", element["version"] as String)
+        assertEquals(5.3, element["timestamp"] as Double)
         assertEquals("sampled profile in base 64", element["sampled_profile"] as String)
         assertEquals(
             mapOf(
@@ -992,6 +993,7 @@ class JsonSerializerTest {
                             "profiler_id":"$profilerId",
                             "release":"release",
                             "sampled_profile":"sampled profile in base 64",
+                            "timestamp":"5.3",
                             "version":"2",
                             "measurements":{
                                 "screen_frame_rates": {
@@ -1035,6 +1037,7 @@ class JsonSerializerTest {
         assertEquals(profilerId, profileChunk.profilerId)
         assertEquals("release", profileChunk.release)
         assertEquals("sampled profile in base 64", profileChunk.sampledProfile)
+        assertEquals(5.3, profileChunk.timestamp)
         assertEquals("2", profileChunk.version)
         val expectedMeasurements = mapOf(
             ProfileMeasurement.ID_SCREEN_FRAME_RATES to ProfileMeasurement(

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -2177,7 +2177,7 @@ class ScopesTest {
         val logger = mock<ILogger>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.continuousProfilesSampleRate = 0.1
+            it.experimental.continuousProfilesSampleRate = 0.1
             it.setLogger(logger)
             it.isDebug = true
         }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -98,7 +98,7 @@ class SentryClientTest {
             whenever(scopes.options).thenReturn(sentryOptions)
             sentryTracer = SentryTracer(TransactionContext("a-transaction", "op", TracesSamplingDecision(true)), scopes)
             sentryTracer.startChild("a-span", "span 1").finish()
-            profileChunk = ProfileChunk(SentryId(), SentryId(), profilingTraceFile, emptyMap(), sentryOptions)
+            profileChunk = ProfileChunk(SentryId(), SentryId(), profilingTraceFile, emptyMap(), 1.0, sentryOptions)
         }
 
         var attachment = Attachment("hello".toByteArray(), "hello.txt", "text/plain", true)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -239,7 +239,7 @@ class SentryOptionsTest {
     @Test
     fun `when continuousProfilesSampleRate is set to a 0, isProfilingEnabled is false and isContinuousProfilingEnabled is false`() {
         val options = SentryOptions().apply {
-            this.continuousProfilesSampleRate = 0.0
+            this.experimental.continuousProfilesSampleRate = 0.0
         }
         assertFalse(options.isProfilingEnabled)
         assertFalse(options.isContinuousProfilingEnabled)
@@ -266,19 +266,19 @@ class SentryOptionsTest {
     @Test
     fun `when setContinuousProfilesSampleRate is set to exactly 0, value is set`() {
         val options = SentryOptions().apply {
-            this.continuousProfilesSampleRate = 0.0
+            this.experimental.continuousProfilesSampleRate = 0.0
         }
         assertEquals(0.0, options.continuousProfilesSampleRate)
     }
 
     @Test
     fun `when setContinuousProfilesSampleRate is set to higher than 1_0, setter throws`() {
-        assertFailsWith<IllegalArgumentException> { SentryOptions().continuousProfilesSampleRate = 1.0000000000001 }
+        assertFailsWith<IllegalArgumentException> { SentryOptions().experimental.continuousProfilesSampleRate = 1.0000000000001 }
     }
 
     @Test
     fun `when setContinuousProfilesSampleRate is set to lower than 0, setter throws`() {
-        assertFailsWith<IllegalArgumentException> { SentryOptions().continuousProfilesSampleRate = -0.0000000000001 }
+        assertFailsWith<IllegalArgumentException> { SentryOptions().experimental.continuousProfilesSampleRate = -0.0000000000001 }
     }
 
     @Test
@@ -607,7 +607,7 @@ class SentryOptionsTest {
     fun `when profiling is disabled, isEnableAppStartProfiling is always false`() {
         val options = SentryOptions()
         options.isEnableAppStartProfiling = true
-        options.continuousProfilesSampleRate = 0.0
+        options.experimental.continuousProfilesSampleRate = 0.0
         assertFalse(options.isEnableAppStartProfiling)
     }
 
@@ -615,7 +615,7 @@ class SentryOptionsTest {
     fun `when setEnableAppStartProfiling is called and continuous profiling is enabled, isEnableAppStartProfiling is true`() {
         val options = SentryOptions()
         options.isEnableAppStartProfiling = true
-        options.continuousProfilesSampleRate = 1.0
+        options.experimental.continuousProfilesSampleRate = 1.0
         assertTrue(options.isEnableAppStartProfiling)
     }
 

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -407,7 +407,7 @@ class SentryTest {
         var sentryOptions: SentryOptions? = null
         Sentry.init {
             it.dsn = dsn
-            it.continuousProfilesSampleRate = 1.0
+            it.experimental.continuousProfilesSampleRate = 1.0
             it.cacheDirPath = tempPath
             sentryOptions = it
         }
@@ -422,7 +422,7 @@ class SentryTest {
         var sentryOptions: SentryOptions? = null
         Sentry.init {
             it.dsn = dsn
-            it.continuousProfilesSampleRate = 0.0
+            it.experimental.continuousProfilesSampleRate = 0.0
             it.cacheDirPath = tempPath
             sentryOptions = it
         }
@@ -1336,7 +1336,7 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
-            it.continuousProfilesSampleRate = 0.1
+            it.experimental.continuousProfilesSampleRate = 0.1
         }
         // We cannot set sample rate to 0, as it would not start the profiler. So we set the seed to have consistent results
         SentryRandom.current().setSeed(0)

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -35,7 +35,7 @@ class TracesSamplerTest {
                 options.profilesSampleRate = profilesSampleRate
             }
             if (continuousProfilesSampleRate != null) {
-                options.continuousProfilesSampleRate = continuousProfilesSampleRate
+                options.experimental.continuousProfilesSampleRate = continuousProfilesSampleRate
             }
             if (tracesSamplerCallback != null) {
                 options.tracesSampler = tracesSamplerCallback


### PR DESCRIPTION
## :scroll: Description
Last changes in order to have working continuous profiling on Android.
Notable change: chunk duration is now increased to 60 seconds

There is still a frontend fix that needs to be deployed before testing it out completely

#skip-changelog


## :bulb: Motivation and Context
Last part of https://github.com/getsentry/sentry-java/pull/3710


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
