### PR TITLE
Only send {{auto}} ip-adress if sendDefaultPii is enabled (7.x.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ SentryAndroid.init(context) { options ->
 
 If you would like to keep some of the default broadcast events as breadcrumbs, consider opening a [GitHub issue](https://github.com/getsentry/sentry-java/issues/new).
 
+- The user ip-address is now only set to `"{{auto}}"` if sendDefaultPii is enabled ([#4071](https://github.com/getsentry/sentry-java/pull/4071))
+    - This change gives you control over IP address collection directly on the client
+
 ## 7.20.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2EventProcessor.java
@@ -575,7 +575,7 @@ public final class AnrV2EventProcessor implements BackfillingEventProcessor {
     if (user.getId() == null) {
       user.setId(getDeviceId());
     }
-    if (user.getIpAddress() == null) {
+    if (user.getIpAddress() == null && options.isSendDefaultPii()) {
       user.setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -156,7 +156,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     if (user.getId() == null) {
       user.setId(Installation.id(context));
     }
-    if (user.getIpAddress() == null) {
+    if (user.getIpAddress() == null && options.isSendDefaultPii()) {
       user.setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
     }
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AnrV2EventProcessorTest.kt
@@ -85,7 +85,6 @@ class AnrV2EventProcessorTest {
         lateinit var context: Context
         val options = SentryAndroidOptions().apply {
             setLogger(NoOpLogger.getInstance())
-            isSendDefaultPii = true
         }
 
         fun getSut(
@@ -93,10 +92,13 @@ class AnrV2EventProcessorTest {
             currentSdk: Int = Build.VERSION_CODES.LOLLIPOP,
             populateScopeCache: Boolean = false,
             populateOptionsCache: Boolean = false,
-            replayErrorSampleRate: Double? = null
+            replayErrorSampleRate: Double? = null,
+            isSendDefaultPii: Boolean = true
         ): AnrV2EventProcessor {
             options.cacheDirPath = dir.newFolder().absolutePath
             options.environment = "release"
+            options.isSendDefaultPii = isSendDefaultPii
+
             whenever(buildInfo.sdkInfoVersion).thenReturn(currentSdk)
             whenever(buildInfo.isEmulator).thenReturn(true)
 
@@ -278,6 +280,7 @@ class AnrV2EventProcessorTest {
         // user
         assertEquals("bot", processed.user!!.username)
         assertEquals("bot@me.com", processed.user!!.id)
+        assertEquals("{{auto}}", processed.user!!.ipAddress)
         // trace
         assertEquals("ui.load", processed.contexts.trace!!.operation)
         // tags
@@ -302,6 +305,13 @@ class AnrV2EventProcessorTest {
         // contexts
         assertEquals(1024, processed.contexts.response!!.bodySize)
         assertEquals("Google Chrome", processed.contexts.browser!!.name)
+    }
+
+    @Test
+    fun `when backfillable event is enrichable, does not backfill user ip`() {
+        val hint = HintUtils.createWithTypeCheckHint(BackfillableHint())
+        val processed = processEvent(hint, isSendDefaultPii = false, populateScopeCache = true)
+        assertNull(processed.user!!.ipAddress)
     }
 
     @Test
@@ -617,6 +627,7 @@ class AnrV2EventProcessorTest {
         hint: Hint,
         populateScopeCache: Boolean = false,
         populateOptionsCache: Boolean = false,
+        isSendDefaultPii: Boolean = true,
         configureEvent: SentryEvent.() -> Unit = {}
     ): SentryEvent {
         val original = SentryEvent().apply(configureEvent)
@@ -624,7 +635,8 @@ class AnrV2EventProcessorTest {
         val processor = fixture.getSut(
             tmpDir,
             populateScopeCache = populateScopeCache,
-            populateOptionsCache = populateOptionsCache
+            populateOptionsCache = populateOptionsCache,
+            isSendDefaultPii = isSendDefaultPii
         )
         return processor.process(original, hint)!!
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/DefaultAndroidEventProcessorTest.kt
@@ -66,7 +66,8 @@ class DefaultAndroidEventProcessorTest {
 
         lateinit var sentryTracer: SentryTracer
 
-        fun getSut(context: Context): DefaultAndroidEventProcessor {
+        fun getSut(context: Context, isSendDefaultPii: Boolean = false): DefaultAndroidEventProcessor {
+            options.isSendDefaultPii = isSendDefaultPii
             whenever(hub.options).thenReturn(options)
             sentryTracer = SentryTracer(TransactionContext("", ""), hub)
             return DefaultAndroidEventProcessor(context, buildInfo, options)
@@ -284,8 +285,20 @@ class DefaultAndroidEventProcessorTest {
     }
 
     @Test
-    fun `when event user data does not have ip address set, sets {{auto}} as the ip address`() {
-        val sut = fixture.getSut(context)
+    fun `when event user data does not have ip address set, sets no ip address if sendDefaultPii is false`() {
+        val sut = fixture.getSut(context, isSendDefaultPii = false)
+        val event = SentryEvent().apply {
+            user = User()
+        }
+        sut.process(event, Hint())
+        assertNotNull(event.user) {
+            assertNull(it.ipAddress)
+        }
+    }
+
+    @Test
+    fun `when event user data does not have ip address set, sets {{auto}} if sendDefaultPii is true`() {
+        val sut = fixture.getSut(context, isSendDefaultPii = true)
         val event = SentryEvent().apply {
             user = User()
         }

--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -245,7 +245,7 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
       user = new User();
       event.setUser(user);
     }
-    if (user.getIpAddress() == null) {
+    if (user.getIpAddress() == null && options.isSendDefaultPii()) {
       user.setIpAddress(IpAddressUtils.DEFAULT_IP_ADDRESS);
     }
   }

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -307,6 +307,16 @@ class MainEventProcessorTest {
     }
 
     @Test
+    fun `when event does not have ip address set, do not enrich ip address if sendDefaultPii is false`() {
+        val sut = fixture.getSut(sendDefaultPii = false)
+        val event = SentryEvent()
+        sut.process(event, Hint())
+        assertNotNull(event.user) {
+            assertNull(it.ipAddress)
+        }
+    }
+
+    @Test
     fun `when event has ip address set, keeps original ip address`() {
         val sut = fixture.getSut(sendDefaultPii = true)
         val event = SentryEvent()


### PR DESCRIPTION
## :scroll: Description
Fixes https://github.com/getsentry/sentry-java/issues/4068


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
