### PR TITLE
Add modules that are new in v8 to `.craft.yml`

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -43,14 +43,15 @@ targets:
       maven:io.sentry:sentry-openfeign:
       maven:io.sentry:sentry-opentelemetry-agent:
       maven:io.sentry:sentry-opentelemetry-agentcustomization:
+      maven:io.sentry:sentry-opentelemetry-agentless:
+      maven:io.sentry:sentry-opentelemetry-agentless-spring:
+      maven:io.sentry:sentry-opentelemetry-bootstrap:
       maven:io.sentry:sentry-opentelemetry-core:
-#      maven:io.sentry:sentry-opentelemetry-agentless:
-#      maven:io.sentry:sentry-opentelemetry-agentless-spring:
       maven:io.sentry:sentry-apollo:
       maven:io.sentry:sentry-jdbc:
       maven:io.sentry:sentry-graphql:
-#      maven:io.sentry:sentry-graphql-core:
-#      maven:io.sentry:sentry-graphql-22:
+      maven:io.sentry:sentry-graphql-22:
+      maven:io.sentry:sentry-graphql-core:
       maven:io.sentry:sentry-quartz:
       maven:io.sentry:sentry-okhttp:
       maven:io.sentry:sentry-android-navigation:


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Add modules that are new in v8 to `.craft.yml`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So registry is updated automatically on every release after `8.0.0`.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
