### PR TITLE
Fix swallow NDK loadLibrary errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,7 @@ If you have been using `8.0.0-rc.4` of the Java SDK, here's the new changes that
     - Due to how grouping works in Sentry currently sometimes the suppressed exception is treated as the main exception. This change ensures we keep using the main exception and not change how grouping works.
     - As a consequence the list of exceptions in the group on top of an issue is no longer shown in Sentry UI.
     - We are planning to improve this in the future but opted for this fix first.
+- Fix swallow NDK loadLibrary errors ([#4082](https://github.com/getsentry/sentry-java/pull/4082))
 
 ## 7.20.0
 

--- a/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
+++ b/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java
@@ -22,6 +22,9 @@ public final class SentryNdk {
               try {
                 //noinspection UnstableApiUsage
                 io.sentry.ndk.SentryNdk.loadNativeLibraries();
+              } catch (Throwable t) {
+                // ignored
+                // if loadLibrary() fails, the later init() will throw an exception anyway
               } finally {
                 loadLibraryLatch.countDown();
               }


### PR DESCRIPTION
## :scroll: Description

Restores the same behaviour we had in 7.x.x: 
https://github.com/getsentry/sentry-java/blob/1e796d816d8218e33084e02800c7485dcdd5b722/sentry-android-ndk/src/main/java/io/sentry/android/ndk/SentryNdk.java#L29-L32

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
