### PR TITLE
Add `options.ignoredErrors` accepting String and Regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Features
+
+- Add `options.ignoreExceptions` to filter out exceptions that match a certain String or Regex ([#4083](https://github.com/getsentry/sentry-java/pull/4083))
+  - Can be set in `sentry.properties`, e.g. `ignored-exceptions=java.lang.RuntimeException,io.sentry..*`
+  - Can be set in environment variables, e.g. `SENTRY_IGNORED_EXCEPTIONS=java.lang.RuntimeException,io.sentry..*`
+  - For Spring Boot, it can be set in `application.properties`, e.g. `sentry.ignored-exceptions=java.lang.RuntimeException,io.sentry..*`
+
+## 8.0.0
+
+### Summary
+
 Version 8 of the Sentry Android/Java SDK brings a variety of features and fixes. The most notable changes are:
 
 - `Hub` has been replaced by `Scopes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add `options.ignoredErrors` to filter out errors that match a certain String or Regex ([#4083](https://github.com/getsentry/sentry-java/pull/4083))
+  - The matching is attempted on `event.message`, `event.formatted`, and `{event.throwable.class.name}: {event.throwable.message}`
   - Can be set in `sentry.properties`, e.g. `ignored-errors=Some error,Another .*`
   - Can be set in environment variables, e.g. `SENTRY_IGNORED_ERRORS=Some error,Another .*`
   - For Spring Boot, it can be set in `application.properties`, e.g. `sentry.ignored-errors=Some error,Another .*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Features
 
-- Add `options.ignoreExceptions` to filter out exceptions that match a certain String or Regex ([#4083](https://github.com/getsentry/sentry-java/pull/4083))
-  - Can be set in `sentry.properties`, e.g. `ignored-exceptions=java.lang.RuntimeException,io.sentry..*`
-  - Can be set in environment variables, e.g. `SENTRY_IGNORED_EXCEPTIONS=java.lang.RuntimeException,io.sentry..*`
-  - For Spring Boot, it can be set in `application.properties`, e.g. `sentry.ignored-exceptions=java.lang.RuntimeException,io.sentry..*`
+- Add `options.ignoredErrors` to filter out errors that match a certain String or Regex ([#4083](https://github.com/getsentry/sentry-java/pull/4083))
+  - Can be set in `sentry.properties`, e.g. `ignored-errors=Some error,Another .*`
+  - Can be set in environment variables, e.g. `SENTRY_IGNORED_ERRORS=Some error,Another .*`
+  - For Spring Boot, it can be set in `application.properties`, e.g. `sentry.ignored-errors=Some error,Another .*`
 
 ## 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-## 8.0.0
-
-### Summary
+## Unreleased
 
 ### Features
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -174,7 +174,7 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
-            "sentry.ignored-exceptions=com.some.Exception,io.sentry..*",
+            "sentry.ignored-errors=Some error,Another .*",
             "sentry.ignored-transactions=transactionName1,transactionNameB",
             "sentry.enable-backpressure-handling=false",
             "sentry.enable-spotlight=true",
@@ -216,7 +216,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.isEnabled).isEqualTo(false)
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly(FilterString("slug1"), FilterString("slugB"))
-            assertThat(options.ignoredExceptions).containsOnly(FilterString("com.some.Exception"), FilterString("io.sentry..*"))
+            assertThat(options.ignoredErrors).containsOnly(FilterString("Some error"), FilterString("Another .*"))
             assertThat(options.ignoredTransactions).containsOnly(FilterString("transactionName1"), FilterString("transactionNameB"))
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryAutoConfigurationTest.kt
@@ -174,6 +174,7 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
+            "sentry.ignored-exceptions=com.some.Exception,io.sentry..*",
             "sentry.ignored-transactions=transactionName1,transactionNameB",
             "sentry.enable-backpressure-handling=false",
             "sentry.enable-spotlight=true",
@@ -215,6 +216,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.isEnabled).isEqualTo(false)
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly(FilterString("slug1"), FilterString("slugB"))
+            assertThat(options.ignoredExceptions).containsOnly(FilterString("com.some.Exception"), FilterString("io.sentry..*"))
             assertThat(options.ignoredTransactions).containsOnly(FilterString("transactionName1"), FilterString("transactionNameB"))
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -173,7 +173,7 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
-            "sentry.ignored-exceptions=com.some.Exception,io.sentry..*",
+            "sentry.ignored-errors=Some error,Another .*",
             "sentry.ignored-transactions=transactionName1,transactionNameB",
             "sentry.enable-backpressure-handling=false",
             "sentry.enable-spotlight=true",
@@ -215,7 +215,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.isEnabled).isEqualTo(false)
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly(FilterString("slug1"), FilterString("slugB"))
-            assertThat(options.ignoredExceptions).containsOnly(FilterString("com.some.Exception"), FilterString("io.sentry..*"))
+            assertThat(options.ignoredErrors).containsOnly(FilterString("Some error"), FilterString("Another .*"))
             assertThat(options.ignoredTransactions).containsOnly(FilterString("transactionName1"), FilterString("transactionNameB"))
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -173,6 +173,7 @@ class SentryAutoConfigurationTest {
             "sentry.enabled=false",
             "sentry.send-modules=false",
             "sentry.ignored-checkins=slug1,slugB",
+            "sentry.ignored-exceptions=com.some.Exception,io.sentry..*",
             "sentry.ignored-transactions=transactionName1,transactionNameB",
             "sentry.enable-backpressure-handling=false",
             "sentry.enable-spotlight=true",
@@ -214,6 +215,7 @@ class SentryAutoConfigurationTest {
             assertThat(options.isEnabled).isEqualTo(false)
             assertThat(options.isSendModules).isEqualTo(false)
             assertThat(options.ignoredCheckIns).containsOnly(FilterString("slug1"), FilterString("slugB"))
+            assertThat(options.ignoredExceptions).containsOnly(FilterString("com.some.Exception"), FilterString("io.sentry..*"))
             assertThat(options.ignoredTransactions).containsOnly(FilterString("transactionName1"), FilterString("transactionNameB"))
             assertThat(options.isEnableBackpressureHandling).isEqualTo(false)
             assertThat(options.isForceInit).isEqualTo(true)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -6061,6 +6061,7 @@ public final class io/sentry/util/EventProcessorUtils {
 public final class io/sentry/util/ExceptionUtils {
 	public fun <init> ()V
 	public static fun findRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+	public static fun isIgnored (Ljava/util/Set;Ljava/util/List;Ljava/lang/Throwable;)Z
 }
 
 public final class io/sentry/util/FileUtils {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -436,6 +436,7 @@ public final class io/sentry/ExternalOptions {
 	public fun <init> ()V
 	public fun addBundleId (Ljava/lang/String;)V
 	public fun addContextTag (Ljava/lang/String;)V
+	public fun addIgnoredException (Ljava/lang/String;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
@@ -452,6 +453,7 @@ public final class io/sentry/ExternalOptions {
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getIgnoredCheckIns ()Ljava/util/List;
+	public fun getIgnoredExceptions ()Ljava/util/List;
 	public fun getIgnoredExceptionsForType ()Ljava/util/Set;
 	public fun getIgnoredTransactions ()Ljava/util/List;
 	public fun getInAppExcludes ()Ljava/util/List;
@@ -491,6 +493,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
+	public fun setIgnoredExceptions (Ljava/util/List;)V
 	public fun setIgnoredTransactions (Ljava/util/List;)V
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setPrintUncaughtStackTrace (Ljava/lang/Boolean;)V
@@ -2814,6 +2817,7 @@ public class io/sentry/SentryOptions {
 	public fun addContextTag (Ljava/lang/String;)V
 	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
 	public fun addIgnoredCheckIn (Ljava/lang/String;)V
+	public fun addIgnoredException (Ljava/lang/String;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addIgnoredSpanOrigin (Ljava/lang/String;)V
 	public fun addIgnoredTransaction (Ljava/lang/String;)V
@@ -2855,6 +2859,7 @@ public class io/sentry/SentryOptions {
 	public fun getGestureTargetLocators ()Ljava/util/List;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getIgnoredCheckIns ()Ljava/util/List;
+	public fun getIgnoredExceptions ()Ljava/util/List;
 	public fun getIgnoredExceptionsForType ()Ljava/util/Set;
 	public fun getIgnoredSpanOrigins ()Ljava/util/List;
 	public fun getIgnoredTransactions ()Ljava/util/List;
@@ -2987,6 +2992,7 @@ public class io/sentry/SentryOptions {
 	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
+	public fun setIgnoredExceptions (Ljava/util/List;)V
 	public fun setIgnoredSpanOrigins (Ljava/util/List;)V
 	public fun setIgnoredTransactions (Ljava/util/List;)V
 	public fun setInitPriority (Lio/sentry/InitPriority;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -436,7 +436,6 @@ public final class io/sentry/ExternalOptions {
 	public fun <init> ()V
 	public fun addBundleId (Ljava/lang/String;)V
 	public fun addContextTag (Ljava/lang/String;)V
-	public fun addIgnoredException (Ljava/lang/String;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addInAppExclude (Ljava/lang/String;)V
 	public fun addInAppInclude (Ljava/lang/String;)V
@@ -453,7 +452,7 @@ public final class io/sentry/ExternalOptions {
 	public fun getEnvironment ()Ljava/lang/String;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getIgnoredCheckIns ()Ljava/util/List;
-	public fun getIgnoredExceptions ()Ljava/util/List;
+	public fun getIgnoredErrors ()Ljava/util/List;
 	public fun getIgnoredExceptionsForType ()Ljava/util/Set;
 	public fun getIgnoredTransactions ()Ljava/util/List;
 	public fun getInAppExcludes ()Ljava/util/List;
@@ -493,7 +492,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
-	public fun setIgnoredExceptions (Ljava/util/List;)V
+	public fun setIgnoredErrors (Ljava/util/List;)V
 	public fun setIgnoredTransactions (Ljava/util/List;)V
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setPrintUncaughtStackTrace (Ljava/lang/Boolean;)V
@@ -2817,7 +2816,7 @@ public class io/sentry/SentryOptions {
 	public fun addContextTag (Ljava/lang/String;)V
 	public fun addEventProcessor (Lio/sentry/EventProcessor;)V
 	public fun addIgnoredCheckIn (Ljava/lang/String;)V
-	public fun addIgnoredException (Ljava/lang/String;)V
+	public fun addIgnoredError (Ljava/lang/String;)V
 	public fun addIgnoredExceptionForType (Ljava/lang/Class;)V
 	public fun addIgnoredSpanOrigin (Ljava/lang/String;)V
 	public fun addIgnoredTransaction (Ljava/lang/String;)V
@@ -2859,7 +2858,7 @@ public class io/sentry/SentryOptions {
 	public fun getGestureTargetLocators ()Ljava/util/List;
 	public fun getIdleTimeout ()Ljava/lang/Long;
 	public fun getIgnoredCheckIns ()Ljava/util/List;
-	public fun getIgnoredExceptions ()Ljava/util/List;
+	public fun getIgnoredErrors ()Ljava/util/List;
 	public fun getIgnoredExceptionsForType ()Ljava/util/Set;
 	public fun getIgnoredSpanOrigins ()Ljava/util/List;
 	public fun getIgnoredTransactions ()Ljava/util/List;
@@ -2992,7 +2991,7 @@ public class io/sentry/SentryOptions {
 	public fun setGlobalHubMode (Ljava/lang/Boolean;)V
 	public fun setIdleTimeout (Ljava/lang/Long;)V
 	public fun setIgnoredCheckIns (Ljava/util/List;)V
-	public fun setIgnoredExceptions (Ljava/util/List;)V
+	public fun setIgnoredErrors (Ljava/util/List;)V
 	public fun setIgnoredSpanOrigins (Ljava/util/List;)V
 	public fun setIgnoredTransactions (Ljava/util/List;)V
 	public fun setInitPriority (Lio/sentry/InitPriority;)V
@@ -6053,6 +6052,11 @@ public final class io/sentry/util/DebugMetaPropertiesApplier {
 	public static fun getProguardUuid (Ljava/util/Properties;)Ljava/lang/String;
 }
 
+public final class io/sentry/util/ErrorUtils {
+	public fun <init> ()V
+	public static fun isIgnored (Ljava/util/List;Lio/sentry/SentryEvent;)Z
+}
+
 public final class io/sentry/util/EventProcessorUtils {
 	public fun <init> ()V
 	public static fun unwrap (Ljava/util/List;)Ljava/util/List;
@@ -6061,7 +6065,7 @@ public final class io/sentry/util/EventProcessorUtils {
 public final class io/sentry/util/ExceptionUtils {
 	public fun <init> ()V
 	public static fun findRootCause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
-	public static fun isIgnored (Ljava/util/Set;Ljava/util/List;Ljava/lang/Throwable;)Z
+	public static fun isIgnored (Ljava/util/Set;Ljava/lang/Throwable;)Z
 }
 
 public final class io/sentry/util/FileUtils {

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -1,10 +1,7 @@
 package io.sentry;
 
 import io.sentry.config.PropertiesProvider;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -39,6 +36,7 @@ public final class ExternalOptions {
   private @Nullable Long idleTimeout;
   private final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType =
       new CopyOnWriteArraySet<>();
+  private @Nullable List<String> ignoredExceptions;
   private @Nullable Boolean printUncaughtStackTrace;
   private @Nullable Boolean sendClientReports;
   private @NotNull Set<String> bundleIds = new CopyOnWriteArraySet<>();
@@ -129,6 +127,10 @@ public final class ExternalOptions {
       options.addBundleId(bundleId);
     }
     options.setIdleTimeout(propertiesProvider.getLongProperty("idle-timeout"));
+
+    for (final String pattern : propertiesProvider.getList("ignored-exceptions")) {
+      options.addIgnoredException(pattern);
+    }
 
     options.setEnabled(propertiesProvider.getBooleanProperty("enabled"));
 
@@ -371,6 +373,21 @@ public final class ExternalOptions {
 
   public void setIdleTimeout(final @Nullable Long idleTimeout) {
     this.idleTimeout = idleTimeout;
+  }
+
+  public @Nullable List<String> getIgnoredExceptions() {
+    return ignoredExceptions;
+  }
+
+  public void setIgnoredExceptions(final @Nullable List<String> ignoredExceptions) {
+    this.ignoredExceptions = ignoredExceptions;
+  }
+
+  public void addIgnoredException(final @NotNull String pattern) {
+    if (ignoredExceptions == null) {
+      ignoredExceptions = new ArrayList<>();
+    }
+    ignoredExceptions.add(pattern);
   }
 
   public @Nullable Boolean getSendClientReports() {

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -128,9 +128,7 @@ public final class ExternalOptions {
     }
     options.setIdleTimeout(propertiesProvider.getLongProperty("idle-timeout"));
 
-    for (final String pattern : propertiesProvider.getList("ignored-exceptions")) {
-      options.addIgnoredException(pattern);
-    }
+    options.setIgnoredExceptions(propertiesProvider.getList("ignored-exceptions"));
 
     options.setEnabled(propertiesProvider.getBooleanProperty("enabled"));
 

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -36,7 +36,7 @@ public final class ExternalOptions {
   private @Nullable Long idleTimeout;
   private final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType =
       new CopyOnWriteArraySet<>();
-  private @Nullable List<String> ignoredExceptions;
+  private @Nullable List<String> ignoredErrors;
   private @Nullable Boolean printUncaughtStackTrace;
   private @Nullable Boolean sendClientReports;
   private @NotNull Set<String> bundleIds = new CopyOnWriteArraySet<>();
@@ -128,7 +128,7 @@ public final class ExternalOptions {
     }
     options.setIdleTimeout(propertiesProvider.getLongProperty("idle-timeout"));
 
-    options.setIgnoredExceptions(propertiesProvider.getList("ignored-exceptions"));
+    options.setIgnoredErrors(propertiesProvider.getList("ignored-errors"));
 
     options.setEnabled(propertiesProvider.getBooleanProperty("enabled"));
 
@@ -373,19 +373,12 @@ public final class ExternalOptions {
     this.idleTimeout = idleTimeout;
   }
 
-  public @Nullable List<String> getIgnoredExceptions() {
-    return ignoredExceptions;
+  public @Nullable List<String> getIgnoredErrors() {
+    return ignoredErrors;
   }
 
-  public void setIgnoredExceptions(final @Nullable List<String> ignoredExceptions) {
-    this.ignoredExceptions = ignoredExceptions;
-  }
-
-  public void addIgnoredException(final @NotNull String pattern) {
-    if (ignoredExceptions == null) {
-      ignoredExceptions = new ArrayList<>();
-    }
-    ignoredExceptions.add(pattern);
+  public void setIgnoredErrors(final @Nullable List<String> ignoredErrors) {
+    this.ignoredErrors = ignoredErrors;
   }
 
   public @Nullable Boolean getSendClientReports() {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -99,16 +99,26 @@ public final class SentryClient implements ISentryClient {
     if (event != null) {
       final Throwable eventThrowable = event.getThrowable();
       if (eventThrowable != null
-          && ExceptionUtils.isIgnored(
-              options.getIgnoredExceptionsForType(),
-              options.getIgnoredExceptions(),
-              eventThrowable)) {
+          && ExceptionUtils.isIgnored(options.getIgnoredExceptionsForType(), eventThrowable)) {
         options
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
                 "Event was dropped as the exception %s is ignored",
                 eventThrowable.getClass());
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);
+        return SentryId.EMPTY_ID;
+      }
+
+      if (ErrorUtils.isIgnored(options.getIgnoredErrors(), event)) {
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "Event was dropped as the error %s is ignored",
+                event.getMessage());
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.Error);

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -117,7 +117,7 @@ public final class SentryClient implements ISentryClient {
             .getLogger()
             .log(
                 SentryLevel.DEBUG,
-                "Event was dropped as the error %s is ignored",
+                "Event was dropped as it matched a string/pattern in ignoredErrors",
                 event.getMessage());
         options
             .getClientReportRecorder()

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -70,10 +70,10 @@ public class SentryOptions {
       new CopyOnWriteArraySet<>();
 
   /**
-   * Exception names or regex patterns that the captured exception will be tested against. If there
-   * is a match, the captured exception will not be sent to Sentry as {@link SentryEvent}.
+   * Strings or regex patterns that possible error messages for an event will be tested against. If
+   * there is a match, the captured event will not be sent to Sentry.
    */
-  private @Nullable List<FilterString> ignoredExceptions = null;
+  private @Nullable List<FilterString> ignoredErrors = null;
 
   /**
    * Code that provides middlewares, bindings or hooks into certain frameworks or environments,
@@ -1578,30 +1578,30 @@ public class SentryOptions {
     return this.ignoredExceptionsForType.contains(throwable.getClass());
   }
 
-  public @Nullable List<FilterString> getIgnoredExceptions() {
-    return ignoredExceptions;
+  public @Nullable List<FilterString> getIgnoredErrors() {
+    return ignoredErrors;
   }
 
-  public void setIgnoredExceptions(final @Nullable List<String> ignoredExceptions) {
-    if (ignoredExceptions == null) {
-      this.ignoredExceptions = null;
+  public void setIgnoredErrors(final @Nullable List<String> ignoredErrors) {
+    if (ignoredErrors == null) {
+      this.ignoredErrors = null;
     } else {
       @NotNull final List<FilterString> patterns = new ArrayList<>();
-      for (String pattern : ignoredExceptions) {
+      for (String pattern : ignoredErrors) {
         if (pattern != null && !pattern.isEmpty()) {
           patterns.add(new FilterString(pattern));
         }
       }
 
-      this.ignoredExceptions = patterns;
+      this.ignoredErrors = patterns;
     }
   }
 
-  public void addIgnoredException(final @NotNull String pattern) {
-    if (ignoredExceptions == null) {
-      ignoredExceptions = new ArrayList<>();
+  public void addIgnoredError(final @NotNull String pattern) {
+    if (ignoredErrors == null) {
+      ignoredErrors = new ArrayList<>();
     }
-    ignoredExceptions.add(new FilterString(pattern));
+    ignoredErrors.add(new FilterString(pattern));
   }
 
   /**
@@ -2833,9 +2833,9 @@ public class SentryOptions {
       final List<String> ignoredTransactions = new ArrayList<>(options.getIgnoredTransactions());
       setIgnoredTransactions(ignoredTransactions);
     }
-    if (options.getIgnoredExceptions() != null) {
-      final List<String> ignoredExceptions = new ArrayList<>(options.getIgnoredExceptions());
-      setIgnoredExceptions(ignoredExceptions);
+    if (options.getIgnoredErrors() != null) {
+      final List<String> ignoredExceptions = new ArrayList<>(options.getIgnoredErrors());
+      setIgnoredErrors(ignoredExceptions);
     }
     if (options.isEnableBackpressureHandling() != null) {
       setEnableBackpressureHandling(options.isEnableBackpressureHandling());

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1578,10 +1578,26 @@ public class SentryOptions {
     return this.ignoredExceptionsForType.contains(throwable.getClass());
   }
 
+  /**
+   * Returns the list of strings/regex patterns that `event.message`, `event.formatted`, and
+   * `{event.throwable.class.name}: {event.throwable.message}` are checked against to determine if
+   * an event shall be sent to Sentry or ignored.
+   *
+   * @return the list of strings/regex patterns that `event.message`, `event.formatted`, and
+   *     `{event.throwable.class.name}: {event.throwable.message}` are checked against to determine
+   *     if an event shall be sent to Sentry or ignored
+   */
   public @Nullable List<FilterString> getIgnoredErrors() {
     return ignoredErrors;
   }
 
+  /**
+   * Sets the list of strings/regex patterns that `event.message`, `event.formatted`, and
+   * `{event.throwable.class.name}: {event.throwable.message}` are checked against to determine if
+   * an event shall be sent to Sentry or ignored.
+   *
+   * @param ignoredErrors the list of strings/regex patterns
+   */
   public void setIgnoredErrors(final @Nullable List<String> ignoredErrors) {
     if (ignoredErrors == null) {
       this.ignoredErrors = null;
@@ -1597,6 +1613,13 @@ public class SentryOptions {
     }
   }
 
+  /**
+   * Adds an item to the list of strings/regex patterns that `event.message`, `event.formatted`, and
+   * `{event.throwable.class.name}: {event.throwable.message}` are checked against to determine if
+   * an event shall be sent to Sentry or ignored.
+   *
+   * @param pattern the string/regex pattern
+   */
   public void addIgnoredError(final @NotNull String pattern) {
     if (ignoredErrors == null) {
       ignoredErrors = new ArrayList<>();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -70,6 +70,12 @@ public class SentryOptions {
       new CopyOnWriteArraySet<>();
 
   /**
+   * Exception names or regex patterns that the captured exception will be tested against. If there
+   * is a match, the captured exception will not be sent to Sentry as {@link SentryEvent}.
+   */
+  private @Nullable List<FilterString> ignoredExceptions = null;
+
+  /**
    * Code that provides middlewares, bindings or hooks into certain frameworks or environments,
    * along with code that inserts those bindings and activates them.
    */
@@ -1572,6 +1578,32 @@ public class SentryOptions {
     return this.ignoredExceptionsForType.contains(throwable.getClass());
   }
 
+  public @Nullable List<FilterString> getIgnoredExceptions() {
+    return ignoredExceptions;
+  }
+
+  public void setIgnoredExceptions(final @Nullable List<String> ignoredExceptions) {
+    if (ignoredExceptions == null) {
+      this.ignoredExceptions = null;
+    } else {
+      @NotNull final List<FilterString> patterns = new ArrayList<>();
+      for (String pattern : ignoredExceptions) {
+        if (pattern != null && !pattern.isEmpty()) {
+          patterns.add(new FilterString(pattern));
+        }
+      }
+
+      this.ignoredExceptions = patterns;
+    }
+  }
+
+  public void addIgnoredException(final @NotNull String pattern) {
+    if (ignoredExceptions == null) {
+      ignoredExceptions = new ArrayList<>();
+    }
+    ignoredExceptions.add(new FilterString(pattern));
+  }
+
   /**
    * Returns the maximum number of spans that can be attached to single transaction.
    *
@@ -2800,6 +2832,10 @@ public class SentryOptions {
     if (options.getIgnoredTransactions() != null) {
       final List<String> ignoredTransactions = new ArrayList<>(options.getIgnoredTransactions());
       setIgnoredTransactions(ignoredTransactions);
+    }
+    if (options.getIgnoredExceptions() != null) {
+      final List<String> ignoredExceptions = new ArrayList<>(options.getIgnoredExceptions());
+      setIgnoredExceptions(ignoredExceptions);
     }
     if (options.isEnableBackpressureHandling() != null) {
       setEnableBackpressureHandling(options.isEnableBackpressureHandling());

--- a/sentry/src/main/java/io/sentry/util/ErrorUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ErrorUtils.java
@@ -3,7 +3,6 @@ package io.sentry.util;
 import io.sentry.FilterString;
 import io.sentry.SentryEvent;
 import io.sentry.protocol.Message;
-import io.sentry.protocol.SentryException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,17 +31,6 @@ public final class ErrorUtils {
       final @Nullable String formattedMessage = eventMessage.getFormatted();
       if (formattedMessage != null) {
         possibleMessages.add(formattedMessage);
-      }
-    }
-    final @Nullable List<SentryException> exceptions = event.getExceptions();
-    if (exceptions != null && !exceptions.isEmpty()) {
-      for (final @Nullable SentryException exception : exceptions) {
-        if (exception != null) {
-          final @Nullable String value = exception.getValue();
-          if (value != null) {
-            possibleMessages.add(value);
-          }
-        }
       }
     }
     final @Nullable Throwable throwable = event.getThrowable();

--- a/sentry/src/main/java/io/sentry/util/ErrorUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ErrorUtils.java
@@ -1,0 +1,69 @@
+package io.sentry.util;
+
+import io.sentry.FilterString;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.Message;
+import io.sentry.protocol.SentryException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class ErrorUtils {
+
+  /** Checks if an error has been ignored. */
+  @ApiStatus.Internal
+  public static boolean isIgnored(
+      final @Nullable List<FilterString> ignoredErrors, final @NotNull SentryEvent event) {
+    if (event == null || ignoredErrors == null || ignoredErrors.isEmpty()) {
+      return false;
+    }
+
+    final @NotNull Set<String> possibleMessages = new HashSet<>();
+
+    final @Nullable Message eventMessage = event.getMessage();
+    if (eventMessage != null) {
+      final @Nullable String stringMessage = eventMessage.getMessage();
+      if (stringMessage != null) {
+        possibleMessages.add(stringMessage);
+      }
+      final @Nullable String formattedMessage = eventMessage.getFormatted();
+      if (formattedMessage != null) {
+        possibleMessages.add(formattedMessage);
+      }
+    }
+    final @Nullable List<SentryException> exceptions = event.getExceptions();
+    if (exceptions != null && !exceptions.isEmpty()) {
+      for (final @Nullable SentryException exception : exceptions) {
+        if (exception != null) {
+          final @Nullable String value = exception.getValue();
+          if (value != null) {
+            possibleMessages.add(value);
+          }
+        }
+      }
+    }
+    final @Nullable Throwable throwable = event.getThrowable();
+    if (throwable != null) {
+      possibleMessages.add(throwable.toString());
+    }
+
+    for (final @NotNull FilterString filter : ignoredErrors) {
+      if (possibleMessages.contains(filter.getFilterString())) {
+        return true;
+      }
+    }
+
+    for (final @NotNull FilterString filter : ignoredErrors) {
+      for (final @NotNull String message : possibleMessages) {
+        if (filter.matches(message)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -1,7 +1,11 @@
 package io.sentry.util;
 
+import io.sentry.FilterString;
+import java.util.List;
+import java.util.Set;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class ExceptionUtils {
@@ -19,5 +23,43 @@ public final class ExceptionUtils {
       rootCause = rootCause.getCause();
     }
     return rootCause;
+  }
+
+  /** Checks if an exception has been ignored. */
+  @ApiStatus.Internal
+  public static @NotNull boolean isIgnored(
+      final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType,
+      final @Nullable List<FilterString> ignoredExceptions,
+      final @NotNull Throwable throwable) {
+    if (throwable == null) {
+      return false;
+    }
+
+    final Class<? extends Throwable> throwableClass = throwable.getClass();
+    if (ignoredExceptionsForType.contains(throwableClass)) {
+      return true;
+    }
+
+    if (ignoredExceptions == null || ignoredExceptions.isEmpty()) {
+      return false;
+    }
+    final String throwableClassName = throwableClass.getCanonicalName();
+    if (throwableClassName == null) {
+      return false;
+    }
+
+    for (final FilterString filter : ignoredExceptions) {
+      if (filter.getFilterString().equals(throwableClassName)) {
+        return true;
+      }
+    }
+
+    for (final FilterString filter : ignoredExceptions) {
+      if (filter.matches(throwableClassName)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ExceptionUtils.java
@@ -1,11 +1,8 @@
 package io.sentry.util;
 
-import io.sentry.FilterString;
-import java.util.List;
 import java.util.Set;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class ExceptionUtils {
@@ -27,39 +24,9 @@ public final class ExceptionUtils {
 
   /** Checks if an exception has been ignored. */
   @ApiStatus.Internal
-  public static @NotNull boolean isIgnored(
+  public static boolean isIgnored(
       final @NotNull Set<Class<? extends Throwable>> ignoredExceptionsForType,
-      final @Nullable List<FilterString> ignoredExceptions,
       final @NotNull Throwable throwable) {
-    if (throwable == null) {
-      return false;
-    }
-
-    final Class<? extends Throwable> throwableClass = throwable.getClass();
-    if (ignoredExceptionsForType.contains(throwableClass)) {
-      return true;
-    }
-
-    if (ignoredExceptions == null || ignoredExceptions.isEmpty()) {
-      return false;
-    }
-    final String throwableClassName = throwableClass.getCanonicalName();
-    if (throwableClassName == null) {
-      return false;
-    }
-
-    for (final FilterString filter : ignoredExceptions) {
-      if (filter.getFilterString().equals(throwableClassName)) {
-        return true;
-      }
-    }
-
-    for (final FilterString filter : ignoredExceptions) {
-      if (filter.matches(throwableClassName)) {
-        return true;
-      }
-    }
-
-    return false;
+    return ignoredExceptionsForType.contains(throwable.getClass());
   }
 }

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -210,12 +210,11 @@ class ExternalOptionsTest {
     }
 
     @Test
-    fun `creates options with ignored exception patterns using external properties`() {
+    fun `creates options with ignored error patterns using external properties`() {
         val logger = mock<ILogger>()
-        withPropertiesFile("ignored-exceptions=java.lang.RuntimeException,io.sentry..*", logger) { options ->
-            System.out.println(options.ignoredExceptions)
-            assertTrue(options.ignoredExceptions!!.contains("java.lang.RuntimeException"))
-            assertTrue(options.ignoredExceptions!!.contains("io.sentry..*"))
+        withPropertiesFile("ignored-errors=Some error,Another .*", logger) { options ->
+            assertTrue(options.ignoredErrors!!.contains("Some error"))
+            assertTrue(options.ignoredErrors!!.contains("Another .*"))
         }
     }
 

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -210,6 +210,16 @@ class ExternalOptionsTest {
     }
 
     @Test
+    fun `creates options with ignored exception patterns using external properties`() {
+        val logger = mock<ILogger>()
+        withPropertiesFile("ignored-exceptions=java.lang.RuntimeException,io.sentry..*", logger) { options ->
+            System.out.println(options.ignoredExceptions)
+            assertTrue(options.ignoredExceptions!!.contains("java.lang.RuntimeException"))
+            assertTrue(options.ignoredExceptions!!.contains("io.sentry..*"))
+        }
+    }
+
+    @Test
     fun `creates options with single bundle ID using external properties`() {
         withPropertiesFile("bundle-ids=12ea7a02-46ac-44c0-a5bb-6d1fd9586411") { options ->
             assertTrue(options.bundleIds.containsAll(listOf("12ea7a02-46ac-44c0-a5bb-6d1fd9586411")))

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -1759,6 +1759,40 @@ class SentryClientTest {
     }
 
     @Test
+    fun `when exception matches pattern in ignoredExceptions, capturing event does not send it`() {
+        fixture.sentryOptions.addIgnoredException(IllegalStateException::class.java.canonicalName)
+        val sut = fixture.getSut()
+        sut.captureException(IllegalStateException())
+        verify(fixture.transport, never()).send(any(), anyOrNull())
+    }
+
+    @Test
+    fun `when exception does not match pattern in ignoredExceptions, capturing event sends it`() {
+        fixture.sentryOptions.addIgnoredException(IllegalStateException::class.java.canonicalName)
+        val sut = fixture.getSut()
+        class MyException(message: String) : Exception(message)
+        sut.captureException(MyException("hello"))
+        verify(fixture.transport).send(any(), anyOrNull())
+    }
+
+    @Test
+    fun `when exception matches regex pattern in ignoredExceptions, capturing event does not send it`() {
+        fixture.sentryOptions.addIgnoredException("java.lang..*")
+        val sut = fixture.getSut()
+        sut.captureException(IllegalStateException())
+        verify(fixture.transport, never()).send(any(), anyOrNull())
+    }
+
+    @Test
+    fun `when exception does not match regex pattern in ignoredExceptions, capturing event sends it`() {
+        fixture.sentryOptions.addIgnoredException("java.lang..*")
+        val sut = fixture.getSut()
+        class MyException(message: String) : Exception(message)
+        sut.captureException(MyException("hello"))
+        verify(fixture.transport).send(any(), anyOrNull())
+    }
+
+    @Test
     fun `screenshot is added to the envelope from the hint`() {
         val sut = fixture.getSut()
         val attachment = Attachment.fromScreenshot(byteArrayOf())

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
@@ -1790,6 +1791,15 @@ class SentryClientTest {
         class MyException(message: String) : Exception(message)
         sut.captureException(MyException("hello"))
         verify(fixture.transport).send(any(), anyOrNull())
+    }
+
+    @Test
+    fun `when ignoredExceptionsForType and ignoredExceptions are not explicitly specified, capturing event sends exceptions`() {
+        val sut = fixture.getSut()
+        sut.captureException(IllegalStateException())
+        class MyException(message: String) : Exception(message)
+        sut.captureException(MyException("hello"))
+        verify(fixture.transport, atLeast(2)).send(any(), anyOrNull())
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -326,6 +326,7 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.ignoredTransactions = listOf("transactionName1", "transaction-name-B")
+        externalOptions.ignoredExceptions = listOf("com.some.Exception1", "com.some.Exception2")
         externalOptions.isEnableBackpressureHandling = false
         externalOptions.maxRequestBodySize = SentryOptions.RequestSize.MEDIUM
         externalOptions.isSendDefaultPii = true
@@ -370,6 +371,7 @@ class SentryOptionsTest {
         assertFalse(options.isSendModules)
         assertEquals(listOf(FilterString("slug1"), FilterString("slug-B")), options.ignoredCheckIns)
         assertEquals(listOf(FilterString("transactionName1"), FilterString("transaction-name-B")), options.ignoredTransactions)
+        assertEquals(listOf(FilterString("com.some.Exception1"), FilterString("com.some.Exception2")), options.ignoredExceptions)
         assertFalse(options.isEnableBackpressureHandling)
         assertTrue(options.isForceInit)
         assertNotNull(options.cron)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -326,7 +326,7 @@ class SentryOptionsTest {
         externalOptions.isSendModules = false
         externalOptions.ignoredCheckIns = listOf("slug1", "slug-B")
         externalOptions.ignoredTransactions = listOf("transactionName1", "transaction-name-B")
-        externalOptions.ignoredExceptions = listOf("com.some.Exception1", "com.some.Exception2")
+        externalOptions.ignoredErrors = listOf("Some error", "Another .*")
         externalOptions.isEnableBackpressureHandling = false
         externalOptions.maxRequestBodySize = SentryOptions.RequestSize.MEDIUM
         externalOptions.isSendDefaultPii = true
@@ -371,7 +371,7 @@ class SentryOptionsTest {
         assertFalse(options.isSendModules)
         assertEquals(listOf(FilterString("slug1"), FilterString("slug-B")), options.ignoredCheckIns)
         assertEquals(listOf(FilterString("transactionName1"), FilterString("transaction-name-B")), options.ignoredTransactions)
-        assertEquals(listOf(FilterString("com.some.Exception1"), FilterString("com.some.Exception2")), options.ignoredExceptions)
+        assertEquals(listOf(FilterString("Some error"), FilterString("Another .*")), options.ignoredErrors)
         assertFalse(options.isEnableBackpressureHandling)
         assertTrue(options.isForceInit)
         assertNotNull(options.cron)


### PR DESCRIPTION
## :scroll: Description
Adds an option `ignoredErrors` (called `ignoreErrors` in other SDKs) to ignore Errors matching a certain String or Regex

## :bulb: Motivation and Context
Closes #3471 

## :green_heart: How did you test it?
Unit tests for Client, Options and ExternalOptions

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
