### PR TITLE
Replace awaitility with CountDownLatch to try and fix the test on CI

### DIFF
--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -375,7 +375,6 @@ class RateLimiterTest {
         rateLimiter.updateRetryAfterLimits("1:replay:key", null, 1)
         rateLimiter.close()
 
-        // If rate limit didn't already change, wait for 1.5s to ensure the timer has run after 1s
         applied.await(2, TimeUnit.SECONDS)
         assertTrue(activeForReplay)
     }

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -39,6 +39,8 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -363,18 +365,18 @@ class RateLimiterTest {
         val rateLimiter = fixture.getSUT()
         whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 1, 2001)
 
-        val applied = AtomicBoolean(true)
+        val applied = CountDownLatch(1)
+        var activeForReplay = false
         rateLimiter.addRateLimitObserver {
-            applied.set(rateLimiter.isActiveForCategory(Replay))
+            applied.countDown()
+            activeForReplay = rateLimiter.isActiveForCategory(Replay)
         }
 
         rateLimiter.updateRetryAfterLimits("1:replay:key", null, 1)
         rateLimiter.close()
 
         // If rate limit didn't already change, wait for 1.5s to ensure the timer has run after 1s
-        if (!applied.get()) {
-            await.untilTrue(applied)
-        }
-        assertTrue(applied.get())
+        applied.await(2, TimeUnit.SECONDS)
+        assertTrue(activeForReplay)
     }
 }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Replace awaitility with CountDownLatch to try and fix the test on CI

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
