### PR TITLE
Remove debug logs when searching for OpenTelemetry marker classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 
 - Avoid logging an error when a float is passed in the manifest ([#4031](https://github.com/getsentry/sentry-java/pull/4031))
+- Remove `java.lang.ClassNotFoundException` debug logs when searching for OpenTelemetry marker classes ([#4091](https://github.com/getsentry/sentry-java/pull/4091))
+  - There was up to three of these, one for `io.sentry.opentelemetry.agent.AgentMarker`, `io.sentry.opentelemetry.agent.AgentlessMarker` and `io.sentry.opentelemetry.agent.AgentlessSpringMarker`.
+  - These were not indicators of something being wrong but rather the SDK looking at what is available at runtime to configure itself accordingly.
 
 ## 8.0.0
 

--- a/sentry/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
+++ b/sentry/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
@@ -1,5 +1,6 @@
 package io.sentry.opentelemetry;
 
+import io.sentry.NoOpLogger;
 import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.util.LoadClass;
@@ -29,15 +30,15 @@ public final class OpenTelemetryUtil {
     final @NotNull SentryOpenTelemetryMode openTelemetryMode = options.getOpenTelemetryMode();
     if (SentryOpenTelemetryMode.AUTO.equals(openTelemetryMode)) {
       if (loadClass.isClassAvailable(
-          "io.sentry.opentelemetry.agent.AgentMarker", options.getLogger())) {
+          "io.sentry.opentelemetry.agent.AgentMarker", NoOpLogger.getInstance())) {
         return SpanUtils.ignoredSpanOriginsForOpenTelemetry(SentryOpenTelemetryMode.AGENT);
       }
       if (loadClass.isClassAvailable(
-          "io.sentry.opentelemetry.agent.AgentlessMarker", options.getLogger())) {
+          "io.sentry.opentelemetry.agent.AgentlessMarker", NoOpLogger.getInstance())) {
         return SpanUtils.ignoredSpanOriginsForOpenTelemetry(SentryOpenTelemetryMode.AGENTLESS);
       }
       if (loadClass.isClassAvailable(
-          "io.sentry.opentelemetry.agent.AgentlessSpringMarker", options.getLogger())) {
+          "io.sentry.opentelemetry.agent.AgentlessSpringMarker", NoOpLogger.getInstance())) {
         return SpanUtils.ignoredSpanOriginsForOpenTelemetry(
             SentryOpenTelemetryMode.AGENTLESS_SPRING);
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use `NoOpLogger` for `LoadClass` when searching for OpenTelemetry marker classes to determine if Sentry OpenTelemetry dependencies / agent are present.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's not a nice experience to start the SDK without OpenTelemetry and be greeted with a wall of stacktraces when `debug` is enabled.

```
DEBUG: Class not available:io.sentry.opentelemetry.agent.AgentMarker
java.lang.ClassNotFoundException: io.sentry.opentelemetry.agent.AgentMarker
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at io.sentry.util.LoadClass.loadClass(LoadClass.java:23)
	at io.sentry.util.LoadClass.isClassAvailable(LoadClass.java:41)
	at io.sentry.opentelemetry.OpenTelemetryUtil.ignoredSpanOrigins(OpenTelemetryUtil.java:31)
	at io.sentry.opentelemetry.OpenTelemetryUtil.applyIgnoredSpanOrigins(OpenTelemetryUtil.java:20)
	at io.sentry.Sentry.initConfigurations(Sentry.java:516)
	at io.sentry.Sentry.init(Sentry.java:328)
	at io.sentry.Sentry.init(Sentry.java:259)
	...

DEBUG: Class not available:io.sentry.opentelemetry.agent.AgentlessMarker
java.lang.ClassNotFoundException: io.sentry.opentelemetry.agent.AgentlessMarker
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	...

DEBUG: Class not available:io.sentry.opentelemetry.agent.AgentlessSpringMarker
java.lang.ClassNotFoundException: io.sentry.opentelemetry.agent.AgentlessSpringMarker
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	...
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
