### PR TITLE
chore: Increase date range for MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2024 Sentry
+Copyright (c) 2019-2025 Sentry
 Copyright (c) 2015 Salomon BRYS for Android ANRWatchDog
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
It's 2025 now.

#skip-changelog