### PR TITLE
Fix flaky RateLimiter test

### DIFF
--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -42,8 +42,6 @@ import org.mockito.kotlin.whenever
 import java.io.File
 import java.util.Timer
 import java.util.UUID
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -366,8 +366,14 @@ class RateLimiterTest {
         val rateLimiter = fixture.getSUT()
         val timer = mock<Timer>()
         rateLimiter.injectForField("timer", timer)
+
+        // When the rate limiter is closed
         rateLimiter.close()
+
+        // Then the timer is cancelled
         verify(timer).cancel()
+
+        // And is removed by the rateLimiter
         assertNull(rateLimiter.getProperty("timer"))
     }
 }


### PR DESCRIPTION
## :scroll: Description
#skip-changelog


## :bulb: Motivation and Context
RateLimiterTest `close cancels the timer`  was flaky
Now it uses reflection to assert the timer was cancelled


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
