### PR TITLE
Log debug messages giving info about OpenTelemetry related config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Can be set in `sentry.properties`, e.g. `ignored-errors=Some error,Another .*`
   - Can be set in environment variables, e.g. `SENTRY_IGNORED_ERRORS=Some error,Another .*`
   - For Spring Boot, it can be set in `application.properties`, e.g. `sentry.ignored-errors=Some error,Another .*`
+- Log OpenTelemetry related Sentry config ([#4122](https://github.com/getsentry/sentry-java/pull/4122))
 
 ### Fixes
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4253,7 +4253,8 @@ public abstract interface class io/sentry/internal/viewhierarchy/ViewHierarchyEx
 
 public final class io/sentry/opentelemetry/OpenTelemetryUtil {
 	public fun <init> ()V
-	public static fun applyIgnoredSpanOrigins (Lio/sentry/SentryOptions;Lio/sentry/util/LoadClass;)V
+	public static fun applyIgnoredSpanOrigins (Lio/sentry/SentryOptions;)V
+	public static fun updateOpenTelemetryModeIfAuto (Lio/sentry/SentryOptions;Lio/sentry/util/LoadClass;)V
 }
 
 public final class io/sentry/profilemeasurements/ProfileMeasurement : io/sentry/JsonSerializable, io/sentry/JsonUnknown {

--- a/sentry/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
+++ b/sentry/src/main/java/io/sentry/opentelemetry/OpenTelemetryUtil.java
@@ -1,6 +1,7 @@
 package io.sentry.opentelemetry;
 
 import io.sentry.NoOpLogger;
+import io.sentry.SentryLevel;
 import io.sentry.SentryOpenTelemetryMode;
 import io.sentry.SentryOptions;
 import io.sentry.util.LoadClass;
@@ -15,37 +16,60 @@ import org.jetbrains.annotations.NotNull;
 public final class OpenTelemetryUtil {
 
   @ApiStatus.Internal
-  public static void applyIgnoredSpanOrigins(
-      final @NotNull SentryOptions options, final @NotNull LoadClass loadClass) {
+  public static void applyIgnoredSpanOrigins(final @NotNull SentryOptions options) {
     if (Platform.isJvm()) {
-      final @NotNull List<String> ignored = ignoredSpanOrigins(options, loadClass);
+      final @NotNull List<String> ignored = ignoredSpanOrigins(options);
       for (String origin : ignored) {
         options.addIgnoredSpanOrigin(origin);
       }
     }
   }
 
-  private static @NotNull List<String> ignoredSpanOrigins(
+  @ApiStatus.Internal
+  public static void updateOpenTelemetryModeIfAuto(
       final @NotNull SentryOptions options, final @NotNull LoadClass loadClass) {
+    if (!Platform.isJvm()) {
+      return;
+    }
+
     final @NotNull SentryOpenTelemetryMode openTelemetryMode = options.getOpenTelemetryMode();
     if (SentryOpenTelemetryMode.AUTO.equals(openTelemetryMode)) {
       if (loadClass.isClassAvailable(
           "io.sentry.opentelemetry.agent.AgentMarker", NoOpLogger.getInstance())) {
-        return SpanUtils.ignoredSpanOriginsForOpenTelemetry(SentryOpenTelemetryMode.AGENT);
+        options
+            .getLogger()
+            .log(SentryLevel.DEBUG, "openTelemetryMode has been inferred from AUTO to AGENT");
+        options.setOpenTelemetryMode(SentryOpenTelemetryMode.AGENT);
+        return;
       }
       if (loadClass.isClassAvailable(
           "io.sentry.opentelemetry.agent.AgentlessMarker", NoOpLogger.getInstance())) {
-        return SpanUtils.ignoredSpanOriginsForOpenTelemetry(SentryOpenTelemetryMode.AGENTLESS);
+        options
+            .getLogger()
+            .log(SentryLevel.DEBUG, "openTelemetryMode has been inferred from AUTO to AGENTLESS");
+        options.setOpenTelemetryMode(SentryOpenTelemetryMode.AGENTLESS);
+        return;
       }
       if (loadClass.isClassAvailable(
           "io.sentry.opentelemetry.agent.AgentlessSpringMarker", NoOpLogger.getInstance())) {
-        return SpanUtils.ignoredSpanOriginsForOpenTelemetry(
-            SentryOpenTelemetryMode.AGENTLESS_SPRING);
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "openTelemetryMode has been inferred from AUTO to AGENTLESS_SPRING");
+        options.setOpenTelemetryMode(SentryOpenTelemetryMode.AGENTLESS_SPRING);
+        return;
       }
-    } else {
-      return SpanUtils.ignoredSpanOriginsForOpenTelemetry(openTelemetryMode);
+    }
+  }
+
+  private static @NotNull List<String> ignoredSpanOrigins(final @NotNull SentryOptions options) {
+    final @NotNull SentryOpenTelemetryMode openTelemetryMode = options.getOpenTelemetryMode();
+
+    if (SentryOpenTelemetryMode.OFF.equals(openTelemetryMode)) {
+      return Collections.emptyList();
     }
 
-    return Collections.emptyList();
+    return SpanUtils.ignoredSpanOriginsForOpenTelemetry(openTelemetryMode);
   }
 }


### PR DESCRIPTION
Log debug messages giving info about OpenTelemetry related config settings

## :scroll: Description
<!--- Describe your changes in detail -->
example output

```
DEBUG: openTelemetryMode has been inferred from AUTO to AGENT
INFO: Initializing SDK with DSN: 'https://502f25099c204a2fbf4cb16edc5975d1@o447951.ingest.sentry.io/5428563'
...
DEBUG: Using openTelemetryMode AGENT
DEBUG: Using span factory io.sentry.opentelemetry.OtelSpanFactory
DEBUG: Using scopes storage io.sentry.opentelemetry.OtelContextScopesStorage
...
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
