### PR TITLE
Log a warning when envelope or items are dropped due to rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- Log a warning when envelope or items are dropped due to rate limiting ([#4148](https://github.com/getsentry/sentry-java/pull/4148))
 - Do not log if `OtelContextScopesStorage` cannot be found ([#4127](https://github.com/getsentry/sentry-java/pull/4127))
   - Previously `java.lang.ClassNotFoundException: io.sentry.opentelemetry.OtelContextScopesStorage` was shown in the log if the class could not be found.
   - This is just a lookup the SDK performs to configure itself. The SDK also works without OpenTelemetry.

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -75,7 +75,10 @@ public final class RateLimiter implements Closeable {
     if (dropItems != null) {
       options
           .getLogger()
-          .log(SentryLevel.INFO, "%d items will be dropped due rate limiting.", dropItems.size());
+          .log(
+              SentryLevel.WARNING,
+              "%d envelope items will be dropped due rate limiting.",
+              dropItems.size());
 
       //       Need a new envelope
       List<SentryEnvelopeItem> toSend = new ArrayList<>();
@@ -87,7 +90,9 @@ public final class RateLimiter implements Closeable {
 
       // no reason to continue
       if (toSend.isEmpty()) {
-        options.getLogger().log(SentryLevel.INFO, "Envelope discarded due all items rate limited.");
+        options
+            .getLogger()
+            .log(SentryLevel.WARNING, "Envelope discarded due all items rate limited.");
 
         markHintWhenSendingFailed(hint, false);
         return null;


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-java/issues/3817