### PR TITLE
Disable Gradle configuration cache and add missing ProGuard rules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx12g -XX:MaxMetaspaceSize=4g -XX:+CrashOnOutOfMemoryError 
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 
 # Daemons workers
 org.gradle.workers.max=2

--- a/sentry-android-integration-tests/sentry-uitest-android/proguard-rules.pro
+++ b/sentry-android-integration-tests/sentry-uitest-android/proguard-rules.pro
@@ -40,4 +40,6 @@
 -dontwarn org.mockito.internal.**
 -dontwarn org.jetbrains.annotations.**
 -dontwarn io.sentry.android.replay.ReplayIntegration
+-dontwarn io.sentry.android.fragment.FragmentLifecycleIntegration
+-dontwarn io.sentry.android.timber.SentryTimberIntegration
 -keep class curtains.** { *; }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
Disables Gradle configuration cache and adds missing ProGuard rules.

## :bulb: Motivation and Context

When checking out the current commit on main (https://github.com/getsentry/sentry-java/commit/95020ab9497f96b8f000386f422630ee4459c812), the build fails with two separate errors:
- `... missing classes when running R8 ...`
- `... X problems were found storing the configuration cache ...`, listing a number of tasks

This fixes those problems.

## :green_heart: How did you test it?

With these changes I can build successfully.