### PR TITLE
Fix config cache for build command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,13 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # Workaround for https://github.com/gradle/actions/issues/21 to use config cache
+      - name: Cache buildSrc
+        uses: actions/cache@v4
+        with:
+          path: buildSrc/build
+          key: build-logic-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts','buildSrc/settings.gradle.kts') }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@aa23778d2dc6f6556fcc7164e99babbd8c3134e4 # pin@v3
         with:

--- a/.github/workflows/system-tests-backend.yml
+++ b/.github/workflows/system-tests-backend.yml
@@ -16,6 +16,7 @@ jobs:
     continue-on-error: true
     env:
       SENTRY_URL: http://127.0.0.1:8000
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -59,6 +60,7 @@ jobs:
         uses: gradle/actions/setup-gradle@aa23778d2dc6f6556fcc7164e99babbd8c3134e4 # pin@v3
         with:
           gradle-home-cache-cleanup: true
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Exclude android modules from build
         run: |

--- a/.github/workflows/system-tests-backend.yml
+++ b/.github/workflows/system-tests-backend.yml
@@ -91,11 +91,11 @@ jobs:
 
       - name: Build server jar
         run: |
-          ./gradlew :sentry-samples:${{ matrix.sample }}:bootJar --no-configuration-cache
+          ./gradlew :sentry-samples:${{ matrix.sample }}:bootJar
 
       - name: Build agent jar
         run: |
-          ./gradlew :sentry-opentelemetry:sentry-opentelemetry-agent:assemble --no-configuration-cache
+          ./gradlew :sentry-opentelemetry:sentry-opentelemetry-agent:assemble
 
       - name: Start server and run integration test for sentry-cli commands
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,8 +179,8 @@ subprojects {
 
         tasks.named("distZip").configure {
             this.dependsOn("publishToMavenLocal")
+            val file = this.project.layout.buildDirectory.file("distributions${sep}${this.project.name}-${this.project.version}.zip").get().asFile
             this.doLast {
-                val file = this.project.layout.buildDirectory.file("distributions${sep}${this.project.name}-${this.project.version}.zip").get().asFile
                 if (!file.exists()) throw IllegalStateException("Distribution file: ${file.absolutePath} does not exist")
                 if (file.length() == 0L) throw IllegalStateException("Distribution file: ${file.absolutePath} is empty")
             }
@@ -300,21 +300,6 @@ gradle.taskGraph.whenReady {
     }
 }
 
-private val androidLibs = setOf(
-    "sentry-android-core",
-    "sentry-android-ndk",
-    "sentry-android-fragment",
-    "sentry-android-navigation",
-    "sentry-android-timber",
-    "sentry-compose-android",
-    "sentry-android-sqlite",
-    "sentry-android-replay"
-)
-
-private val androidXLibs = listOf(
-    "androidx.core:core"
-)
-
 /*
  * Adapted from https://github.com/androidx/androidx/blob/c799cba927a71f01ea6b421a8f83c181682633fb/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt#L524-L549
  *
@@ -334,7 +319,6 @@ private val androidXLibs = listOf(
  */
 
 // Workaround for https://github.com/gradle/gradle/issues/3170
-@Suppress("UnstableApiUsage")
 fun MavenPublishBaseExtension.assignAarTypes() {
     pom {
         withXml {
@@ -356,9 +340,9 @@ fun MavenPublishBaseExtension.assignAarTypes() {
                 } as? Node
                 val artifactIdValue = artifactId?.children()?.firstOrNull() as? String
 
-                if (artifactIdValue in androidLibs) {
+                if (artifactIdValue in Config.BuildScript.androidLibs) {
                     dep.appendNode("type", "aar")
-                } else if ("$groupValue:$artifactIdValue" in androidXLibs) {
+                } else if ("$groupValue:$artifactIdValue" in Config.BuildScript.androidXLibs) {
                     dep.appendNode("type", "aar")
                 }
             }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -27,8 +27,9 @@ object Config {
         val grettyVersion = "4.0.0"
         val gradleMavenPublishPlugin = "com.vanniktech.maven.publish"
         val gradleMavenPublishPluginVersion = "0.30.0"
-        val dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.9.20"
+        val dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:2.0.0"
         val dokkaPluginAlias = "org.jetbrains.dokka"
+        val dokkaPluginJavadocAlias = "org.jetbrains.dokka-javadoc"
         val composeGradlePlugin = "org.jetbrains.compose:compose-gradle-plugin:$composeVersion"
         val commonsCompressOverride = "org.apache.commons:commons-compress:1.25.0"
     }
@@ -270,5 +271,22 @@ object Config {
         val nopenChecker = "com.jakewharton.nopen:nopen-checker:$nopenVersion"
         val errorprone = "com.google.errorprone:error_prone_core:2.11.0"
         val errorProneNullAway = "com.uber.nullaway:nullaway:0.9.5"
+    }
+
+    object BuildScript {
+        val androidLibs = setOf(
+            "sentry-android-core",
+            "sentry-android-ndk",
+            "sentry-android-fragment",
+            "sentry-android-navigation",
+            "sentry-android-timber",
+            "sentry-compose-android",
+            "sentry-android-sqlite",
+            "sentry-android-replay"
+        )
+
+        val androidXLibs = listOf(
+            "androidx.core:core"
+        )
     }
 }

--- a/buildSrc/src/main/java/Publication.kt
+++ b/buildSrc/src/main/java/Publication.kt
@@ -11,10 +11,11 @@ private object Consts {
 fun DistributionContainer.configureForMultiplatform(project: Project) {
     val sep = File.separator
     val version = project.properties["versionName"].toString()
+    val name = project.name
 
     this.maybeCreate("android").contents {
         from("build${sep}publications${sep}androidRelease") {
-            renameModule(project.name, "android", version = version)
+            renameModule(name, "android", version = version)
         }
         from("build${sep}outputs${sep}aar") {
             include("*-release*")
@@ -32,7 +33,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
     }
     this.getByName("main").contents {
         from("build${sep}publications${sep}kotlinMultiplatform") {
-            renameModule(project.name, version = version)
+            renameModule(name, version = version)
         }
         from("build${sep}kotlinToolingMetadata")
         from("build${sep}libs") {
@@ -48,7 +49,7 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
     this.maybeCreate("desktop").contents {
         // kotlin multiplatform modules
         from("build${sep}publications${sep}desktop") {
-            renameModule(project.name, "desktop", version = version)
+            renameModule(name, "desktop", version = version)
         }
         from("build${sep}libs") {
             include("*desktop*")
@@ -69,27 +70,28 @@ fun DistributionContainer.configureForMultiplatform(project: Project) {
 fun DistributionContainer.configureForJvm(project: Project) {
     val sep = File.separator
     val version = project.properties["versionName"].toString()
+    val name = project.name
 
     this.getByName("main").contents {
         // non android modules
         from("build${sep}libs")
         from("build${sep}publications${sep}maven") {
-            renameModule(project.name, version = version)
+            renameModule(name, version = version)
         }
         // android modules
         from("build${sep}outputs${sep}aar") {
             include("*-release*")
         }
         from("build${sep}publications${sep}release") {
-            renameModule(project.name, version = version)
+            renameModule(name, version = version)
         }
         from("build${sep}intermediates${sep}java_doc_jar${sep}release") {
             include("*javadoc*")
-            rename { it.replace("release", "${project.name}-$version") }
+            rename { it.replace("release", "$name-$version") }
         }
         from("build${sep}intermediates${sep}source_jar${sep}release") {
             include("*sources*")
-            rename { it.replace("release", "${project.name}-$version") }
+            rename { it.replace("release", "$name-$version") }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,8 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+
 # Daemons workers
 org.gradle.workers.max=2
 

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -26,7 +26,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -21,7 +21,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-navigation/build.gradle.kts
+++ b/sentry-android-navigation/build.gradle.kts
@@ -21,7 +21,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -26,7 +26,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -35,7 +35,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -22,7 +22,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -25,7 +25,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-android/build.gradle.kts
+++ b/sentry-android/build.gradle.kts
@@ -18,7 +18,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id(Config.QualityPlugins.gradleVersions)
     id(Config.QualityPlugins.detektPlugin)
     id(Config.BuildPlugins.dokkaPluginAlias)
+    id(Config.BuildPlugins.dokkaPluginJavadocAlias)
     `maven-publish` // necessary for publishMavenLocal task to publish correct artifacts
 }
 
@@ -81,7 +82,9 @@ android {
     }
 
     buildTypes {
-        getByName("debug")
+        getByName("debug") {
+            consumerProguardFiles("proguard-rules.pro")
+        }
         getByName("release") {
             consumerProguardFiles("proguard-rules.pro")
         }

--- a/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     `java-library`
-    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.gradleup.shadow") version "9.0.0-beta8"
 }
 
 fun relocatePackages(shadowJar: ShadowJar) {
@@ -89,7 +89,7 @@ tasks {
     // building the final javaagent jar is done in 3 steps:
 
     // 1. all distro specific javaagent libs are relocated
-    create("relocateJavaagentLibs", ShadowJar::class.java) {
+    register("relocateJavaagentLibs", ShadowJar::class.java) {
         configurations = listOf(javaagentLibs)
 
         duplicatesStrategy = DuplicatesStrategy.FAIL
@@ -114,7 +114,7 @@ tasks {
     // having a separate task for isolating javaagent libs is required to avoid duplicates with the upstream javaagent
     // duplicatesStrategy in shadowJar won't be applied when adding files with with(CopySpec) because each CopySpec has
     // its own duplicatesStrategy
-    create("isolateJavaagentLibs", Copy::class.java) {
+    register("isolateJavaagentLibs", Copy::class.java) {
         dependsOn(findByName("relocateJavaagentLibs"))
         with(isolateClasses(findByName("relocateJavaagentLibs")!!.outputs.files))
 

--- a/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     `java-library`
-    id("com.gradleup.shadow") version "9.0.0-beta8"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 fun relocatePackages(shadowJar: ShadowJar) {
@@ -123,8 +123,8 @@ tasks {
 
     // 3. the relocated and isolated javaagent libs are merged together with the bootstrap libs (which undergo relocation
     // in this task) and the upstream javaagent jar; duplicates are removed
-    shadowJar {
-        configurations = listOf(bootstrapLibs, upstreamAgent)
+    named("shadowJar", ShadowJar::class) {
+        configurations = listOf(bootstrapLibs) + listOf(upstreamAgent)
 
         dependsOn(findByName("isolateJavaagentLibs"))
         from(findByName("isolateJavaagentLibs")!!.outputs)


### PR DESCRIPTION
Follow up to #3936

When running `./gradlew build` there were still some leftovers that resulted in config cache errors, so this PR just fixes them.

_#skip-changelog_