### PR TITLE
Move to a single NetworkCallback listener to reduce number of IPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Move to a single NetworkCallback listener to reduce number of IPC calls ([#4164](https://github.com/getsentry/sentry-java/pull/4164))
+
 ## 8.2.0
 
 ### Breaking Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -106,11 +106,13 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
           if (registerNetworkCallback(context, logger, buildInfoProvider, newNetworkCallback)) {
             networkCallback = newNetworkCallback;
             return true;
+          } else {
+            return false;
           }
         }
-        return true;
       }
     }
+    // networkCallback is already registered, so we can safely return true
     return true;
   }
 


### PR DESCRIPTION
## :scroll: Description

We don't seem to be able to get rid of calling `getConnectionStatus()` on connectivity change, as the NetworkCallback seems to fire for any network, e.g. reporting a disconnect of WIFI, although Cellular connection is still available.

But I noticed every internal `IConnectionStatusObserver` was tied to it's own `NetworkCallback`, causing us to call `getConnectionStatus()` per change per observer - which quickly blows our number of IPC calls up.

So instead let's have a single `NetworkCallback`, call `getConnectionStatus()` once per network change and then broadcast the state to all observers. This should already reduce the number of IPC calls by 3.


## :bulb: Motivation and Context
Less IPC calls
Fixes https://github.com/getsentry/sentry-java/issues/4053


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
