### PR TITLE
chore(craft): Remove symbol collector step

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,10 +1,6 @@
 minVersion: 0.29.3
 changelogPolicy: auto
 targets:
-  - name: symbol-collector
-    includeNames: /libsentry(-android)?\.so/
-    batchType: android
-    bundleIdPrefix: sentry-android-ndk-
   - name: maven
     includeNames: /^sentry.*$/
     gradleCliPath: ./gradlew


### PR DESCRIPTION
As this is now done within sentry-native

## :scroll: Description

Relevant sentry-native PR: https://github.com/getsentry/sentry-native/pull/1155

#skip-changelog

## :bulb: Motivation and Context

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
