### PR TITLE
Add constructor to JUL `SentryHandler` for disabling external config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `enableTraceIdGeneration` to the AndroidOptions. This allows Hybrid SDKs to "freeze" and control the trace and connect errors on different layers of the application ([4188](https://github.com/getsentry/sentry-java/pull/4188))
 - Move to a single NetworkCallback listener to reduce number of IPC calls on Android ([#4164](https://github.com/getsentry/sentry-java/pull/4164))
 - Add GraphQL Apollo Kotlin 4 integration ([#4166](https://github.com/getsentry/sentry-java/pull/4166))
+- Add constructor to JUL `SentryHandler` for disabling external config ([#4208](https://github.com/getsentry/sentry-java/pull/4208))
 
 ### Fixes
 

--- a/sentry-jul/api/sentry-jul.api
+++ b/sentry-jul/api/sentry-jul.api
@@ -8,6 +8,7 @@ public class io/sentry/jul/SentryHandler : java/util/logging/Handler {
 	public static final field THREAD_ID Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun <init> (Lio/sentry/SentryOptions;Z)V
 	public fun close ()V
 	public fun flush ()V
 	public fun getMinimumBreadcrumbLevel ()Ljava/util/logging/Level;

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -51,7 +51,7 @@ public class SentryHandler extends Handler {
 
   /** Creates an instance of SentryHandler. */
   public SentryHandler() {
-    this(new SentryOptions(), true);
+    this(new SentryOptions());
   }
 
   /**
@@ -60,17 +60,32 @@ public class SentryHandler extends Handler {
    * @param options the SentryOptions
    */
   public SentryHandler(final @NotNull SentryOptions options) {
-    this(options, true);
+    this(options, true, true);
+  }
+
+  /**
+   * Creates an instance of SentryHandler.
+   *
+   * @param options the SentryOptions
+   * @param enableExternalConfiguration whether external options like sentry.properties and ENV vars
+   *     should be parsed
+   */
+  public SentryHandler(
+      final @NotNull SentryOptions options, final boolean enableExternalConfiguration) {
+    this(options, true, enableExternalConfiguration);
   }
 
   /** Creates an instance of SentryHandler. */
   @TestOnly
-  SentryHandler(final @NotNull SentryOptions options, final boolean configureFromLogManager) {
+  SentryHandler(
+      final @NotNull SentryOptions options,
+      final boolean configureFromLogManager,
+      final boolean enableExternalConfiguration) {
     setFilter(new DropSentryFilter());
     if (configureFromLogManager) {
       retrieveProperties();
     }
-    options.setEnableExternalConfiguration(true);
+    options.setEnableExternalConfiguration(enableExternalConfiguration);
     options.setInitPriority(InitPriority.LOWEST);
     options.setSdkVersion(createSdkVersion(options));
     Sentry.init(options);

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -36,7 +36,7 @@ class SentryHandlerTest {
             options.setTransportFactory { _, _ -> transport }
             contextTags?.forEach { options.addContextTag(it) }
             logger = Logger.getLogger("jul.SentryHandlerTest")
-            handler = SentryHandler(options, configureWithLogManager)
+            handler = SentryHandler(options, configureWithLogManager, true)
             handler.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
             handler.setMinimumEventLevel(minimumEventLevel)
             handler.level = Level.ALL


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add another constructor to `SentryHandler` that allows passing `enableExternalConfiguration` to disable parsing of external configuration (by passing `false`). This defaults to `true` when using other constructors.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Came up in https://github.com/getsentry/sentry-java/issues/4205 where Quarkus is trying to disable parsing of external config like `sentry.properties` or ENV vars.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
