### PR TITLE
refactor: use `java.net.URI` for parsing URLs in `UrlUtils`

### DIFF
--- a/sentry/src/main/java/io/sentry/util/UrlUtils.java
+++ b/sentry/src/main/java/io/sentry/util/UrlUtils.java
@@ -3,10 +3,7 @@ package io.sentry.util;
 import io.sentry.ISpan;
 import io.sentry.SpanDataConvention;
 import io.sentry.protocol.Request;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.net.URI;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -15,123 +12,55 @@ import org.jetbrains.annotations.Nullable;
 public final class UrlUtils {
 
   public static final @NotNull String SENSITIVE_DATA_SUBSTITUTE = "[Filtered]";
-  private static final @NotNull Pattern AUTH_REGEX = Pattern.compile("(.+://)(.*@)(.*)");
 
   public static @Nullable UrlDetails parseNullable(final @Nullable String url) {
-    if (url == null) {
-      return null;
-    }
-
-    return parse(url);
+    return url == null ? null : parse(url);
   }
 
   public static @NotNull UrlDetails parse(final @NotNull String url) {
-    if (isAbsoluteUrl(url)) {
-      return splitAbsoluteUrl(url);
-    } else {
-      return splitRelativeUrl(url);
-    }
-  }
-
-  private static boolean isAbsoluteUrl(@NotNull String url) {
-    return url.contains("://");
-  }
-
-  private static @NotNull UrlDetails splitRelativeUrl(final @NotNull String url) {
-    final int queryParamSeparatorIndex = url.indexOf("?");
-    final int fragmentSeparatorIndex = url.indexOf("#");
-
-    final @Nullable String baseUrl =
-        extractBaseUrl(url, queryParamSeparatorIndex, fragmentSeparatorIndex);
-    final @Nullable String query =
-        extractQuery(url, queryParamSeparatorIndex, fragmentSeparatorIndex);
-    final @Nullable String fragment = extractFragment(url, fragmentSeparatorIndex);
-
-    return new UrlDetails(baseUrl, query, fragment);
-  }
-
-  private static @Nullable String extractBaseUrl(
-      final @NotNull String url,
-      final int queryParamSeparatorIndex,
-      final int fragmentSeparatorIndex) {
-    if (queryParamSeparatorIndex >= 0) {
-      return url.substring(0, queryParamSeparatorIndex).trim();
-    } else if (fragmentSeparatorIndex >= 0) {
-      return url.substring(0, fragmentSeparatorIndex).trim();
-    } else {
-      return url;
-    }
-  }
-
-  private static @Nullable String extractQuery(
-      final @NotNull String url,
-      final int queryParamSeparatorIndex,
-      final int fragmentSeparatorIndex) {
-    if (queryParamSeparatorIndex > 0) {
-      if (fragmentSeparatorIndex > 0 && fragmentSeparatorIndex > queryParamSeparatorIndex) {
-        return url.substring(queryParamSeparatorIndex + 1, fragmentSeparatorIndex).trim();
-      } else {
-        return url.substring(queryParamSeparatorIndex + 1).trim();
-      }
-    } else {
-      return null;
-    }
-  }
-
-  private static @Nullable String extractFragment(
-      final @NotNull String url, final int fragmentSeparatorIndex) {
-    if (fragmentSeparatorIndex > 0) {
-      return url.substring(fragmentSeparatorIndex + 1).trim();
-    } else {
-      return null;
-    }
-  }
-
-  private static @NotNull UrlDetails splitAbsoluteUrl(final @NotNull String url) {
     try {
-      final @NotNull String filteredUrl = urlWithAuthRemoved(url);
-      final @NotNull URL urlObj = new URL(url);
-      final @NotNull String baseUrl = baseUrlOnly(filteredUrl);
-      if (baseUrl.contains("#")) {
-        // url considered malformed because it has fragment
+      URI uri = new URI(url);
+      if (uri.isAbsolute() && !isValidAbsoluteUrl(uri)) {
         return new UrlDetails(null, null, null);
-      } else {
-        final @Nullable String query = urlObj.getQuery();
-        final @Nullable String fragment = urlObj.getRef();
-        return new UrlDetails(baseUrl, query, fragment);
       }
-    } catch (MalformedURLException e) {
+
+      final @NotNull String schemeAndSeparator =
+          uri.getScheme() == null ? "" : (uri.getScheme() + "://");
+      final @NotNull String authority = uri.getRawAuthority() == null ? "" : uri.getRawAuthority();
+      final @NotNull String path = uri.getRawPath() == null ? "" : uri.getRawPath();
+      final @Nullable String query = uri.getRawQuery();
+      final @Nullable String fragment = uri.getRawFragment();
+
+      final @NotNull String filteredUrl = schemeAndSeparator + filterUserInfo(authority) + path;
+
+      return new UrlDetails(filteredUrl, query, fragment);
+    } catch (Exception e) {
       return new UrlDetails(null, null, null);
     }
   }
 
-  private static @NotNull String urlWithAuthRemoved(final @NotNull String url) {
-    final @NotNull Matcher userInfoMatcher = AUTH_REGEX.matcher(url);
-    if (userInfoMatcher.matches() && userInfoMatcher.groupCount() == 3) {
-      final @NotNull String userInfoString = userInfoMatcher.group(2);
-      final @NotNull String replacementString =
-          userInfoString.contains(":")
-              ? (SENSITIVE_DATA_SUBSTITUTE + ":" + SENSITIVE_DATA_SUBSTITUTE + "@")
-              : (SENSITIVE_DATA_SUBSTITUTE + "@");
-      return userInfoMatcher.group(1) + replacementString + userInfoMatcher.group(3);
-    } else {
-      return url;
+  private static boolean isValidAbsoluteUrl(final @NotNull URI uri) {
+    try {
+      uri.toURL();
+    } catch (Exception e) {
+      return false;
     }
+    return true;
   }
 
-  private static @NotNull String baseUrlOnly(final @NotNull String url) {
-    final int queryParamSeparatorIndex = url.indexOf("?");
-
-    if (queryParamSeparatorIndex >= 0) {
-      return url.substring(0, queryParamSeparatorIndex).trim();
-    } else {
-      final int fragmentSeparatorIndex = url.indexOf("#");
-      if (fragmentSeparatorIndex >= 0) {
-        return url.substring(0, fragmentSeparatorIndex).trim();
-      } else {
-        return url;
-      }
+  private static @NotNull String filterUserInfo(final @NotNull String url) {
+    if (!url.contains("@")) {
+      return url;
     }
+    if (url.startsWith("@")) {
+      return SENSITIVE_DATA_SUBSTITUTE + url;
+    }
+    final @NotNull String userInfo = url.substring(0, url.indexOf('@') - 1);
+    final @NotNull String filteredUserInfo =
+        userInfo.contains(":")
+            ? (SENSITIVE_DATA_SUBSTITUTE + ":" + SENSITIVE_DATA_SUBSTITUTE)
+            : SENSITIVE_DATA_SUBSTITUTE;
+    return filteredUserInfo + url.substring(url.indexOf('@'));
   }
 
   public static final class UrlDetails {

--- a/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
@@ -319,4 +319,24 @@ class UrlUtilsTest {
         assertEquals("email=user@sentry.io&b=c", urlDetails.query)
         assertEquals("fragment?q=1&s=2&email=user@sentry.io", urlDetails.fragment)
     }
+
+    @Test
+    fun `extracts path from file url`() {
+        val urlDetails = UrlUtils.parse(
+            "file:///users/sentry/text.txt"
+        )
+        assertEquals("file:///users/sentry/text.txt", urlDetails.url)
+        assertNull(urlDetails.query)
+        assertNull(urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not extract details from websockets url`() {
+        val urlDetails = UrlUtils.parse(
+            "wss://example.com/socket"
+        )
+        assertNull(urlDetails.url)
+        assertNull(urlDetails.query)
+        assertNull(urlDetails.fragment)
+    }
 }

--- a/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.util
 
+import java.net.URL
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -9,6 +10,32 @@ class UrlUtilsTest {
     @Test
     fun `returns null for null`() {
         assertNull(UrlUtils.parseNullable(null))
+    }
+
+    @Test
+    fun `i null for null`() {
+        val url = URL("https://www.example.com/search?q=hello%20world%21")
+        var uri = url.toURI()
+    }
+
+    @Test
+    fun `filters auth`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://user:password@sentry.io?q=1&s=2&token=secret"
+        )!!
+        assertEquals("https://[Filtered]:[Filtered]@sentry.io", urlDetails.url)
+        assertEquals("q=1&s=2&token=secret", urlDetails.query)
+        assertNull(urlDetails.fragment)
+    }
+
+    @Test
+    fun `filters auth with fragment`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://user:password@sentry.io?q=1&s=2&token=secret#top"
+        )!!
+        assertEquals("https://[Filtered]:[Filtered]@sentry.io", urlDetails.url)
+        assertEquals("q=1&s=2&token=secret", urlDetails.query)
+        assertEquals("top", urlDetails.fragment)
     }
 
     @Test
@@ -161,20 +188,62 @@ class UrlUtilsTest {
         assertEquals("top", urlDetails.fragment)
     }
 
+    // Fragment is allowed to contain '?' according to RFC 3986
+    // See https://datatracker.ietf.org/doc/html/rfc3986#section-3.5
     @Test
-    fun `no details extracted with query after fragment`() {
+    fun `extracts details with question mark after fragment`() {
         val urlDetails = UrlUtils.parse(
             "https://user:password@sentry.io#fragment?q=1&s=2&token=secret"
         )
-        assertNull(urlDetails.url)
+        assertEquals("https://[Filtered]:[Filtered]@sentry.io", urlDetails.url)
         assertNull(urlDetails.query)
-        assertNull(urlDetails.fragment)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
     }
 
     @Test
-    fun `no details extracted with query after fragment without authority`() {
+    fun `extracts details with question mark after fragment without user info`() {
         val urlDetails = UrlUtils.parse(
             "https://sentry.io#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("https://sentry.io", urlDetails.url)
+        assertNull(urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `filters empty user info`() {
+        val urlDetails = UrlUtils.parse(
+            "https://@sentry.io?query=a#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("https://[Filtered]@sentry.io", urlDetails.url)
+        assertEquals("query=a", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `extracts details from relative url with leading @ symbol`() {
+        val urlDetails = UrlUtils.parse(
+            "@@sentry.io/pages/10?query=a#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("@@sentry.io/pages/10", urlDetails.url)
+        assertEquals("query=a", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `extracts details from relative url with leading question mark`() {
+        val urlDetails = UrlUtils.parse(
+            "?query=a#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("", urlDetails.url)
+        assertEquals("query=a", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `no details extracted from malformed url due to # symbol in fragment`() {
+        val urlDetails = UrlUtils.parse(
+            "https://example.com#hello#fragment"
         )
         assertNull(urlDetails.url)
         assertNull(urlDetails.query)
@@ -182,12 +251,100 @@ class UrlUtilsTest {
     }
 
     @Test
-    fun `no details extracted from malformed url`() {
+    fun `no details extracted from malformed url due to invalid protocol`() {
         val urlDetails = UrlUtils.parse(
             "htps://user@sentry.io#fragment?q=1&s=2&token=secret"
         )
         assertNull(urlDetails.url)
         assertNull(urlDetails.query)
         assertNull(urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not filter email address in path`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com/api/v4/auth/password/reset/email@example.com"
+        )!!
+        assertEquals("https://staging.server.com/api/v4/auth/password/reset/email@example.com", urlDetails.url)
+        assertNull(urlDetails.query)
+        assertNull(urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not filter email address in path with fragment`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com/api/v4/auth/password/reset/email@example.com#top"
+        )!!
+        assertEquals("https://staging.server.com/api/v4/auth/password/reset/email@example.com", urlDetails.url)
+        assertNull(urlDetails.query)
+        assertEquals("top", urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not filter email address in path with query and fragment`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com/api/v4/auth/password/reset/email@example.com?a=b&c=d#top"
+        )!!
+        assertEquals("https://staging.server.com/api/v4/auth/password/reset/email@example.com", urlDetails.url)
+        assertEquals("a=b&c=d", urlDetails.query)
+        assertEquals("top", urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not filter email address in query`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com/?email=someone@example.com"
+        )!!
+        assertEquals("https://staging.server.com/", urlDetails.url)
+        assertEquals("email=someone@example.com", urlDetails.query)
+    }
+
+    @Test
+    fun `does not filter email address in fragment`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com#email=someone@example.com"
+        )!!
+        assertEquals("https://staging.server.com", urlDetails.url)
+        assertEquals("email=someone@example.com", urlDetails.fragment)
+    }
+
+    @Test
+    fun `does not filter email address in fragment with query`() {
+        val urlDetails = UrlUtils.parseNullable(
+            "https://staging.server.com?q=a&b=c#email=someone@example.com"
+        )!!
+        assertEquals("https://staging.server.com", urlDetails.url)
+        assertEquals("q=a&b=c", urlDetails.query)
+        assertEquals("email=someone@example.com", urlDetails.fragment)
+    }
+
+    @Test
+    fun `extracts details from relative url with email in path`() {
+        val urlDetails = UrlUtils.parse(
+            "/emails/user@sentry.io?query=a&b=c#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("/emails/user@sentry.io", urlDetails.url)
+        assertEquals("query=a&b=c", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `extracts details from relative url with email in query`() {
+        val urlDetails = UrlUtils.parse(
+            "users/10?email=user@sentry.io&b=c#fragment?q=1&s=2&token=secret"
+        )
+        assertEquals("users/10", urlDetails.url)
+        assertEquals("email=user@sentry.io&b=c", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&token=secret", urlDetails.fragment)
+    }
+
+    @Test
+    fun `extracts details from relative url with email in fragment`() {
+        val urlDetails = UrlUtils.parse(
+            "users/10?email=user@sentry.io&b=c#fragment?q=1&s=2&email=user@sentry.io"
+        )
+        assertEquals("users/10", urlDetails.url)
+        assertEquals("email=user@sentry.io&b=c", urlDetails.query)
+        assertEquals("fragment?q=1&s=2&email=user@sentry.io", urlDetails.fragment)
     }
 }

--- a/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/UrlUtilsTest.kt
@@ -331,7 +331,7 @@ class UrlUtilsTest {
     }
 
     @Test
-    fun `does not extract details from websockets url`() {
+    fun `does not extract details from websockets uri`() {
         val urlDetails = UrlUtils.parse(
             "wss://example.com/socket"
         )


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This changes the internal logic used for parsing URLs in `UrlUtils` from regex based to using `java.net.URI`.
This will allow the SDK to handle the cases described in https://github.com/getsentry/sentry-java/issues/2690 and https://github.com/getsentry/team-sdks/issues/39.
`java.net.URI` is known to still not be fully compliant with RFCs 3986 and 3987 (https://cr.openjdk.org/%7Edfuchs/writeups/updating-uri/) but this is still an improvement with respect to the cases described in the issues linked above, and could also ensure correct handling for other corner cases that we are not aware of.
We still use `java.net.URL` but just for validating that an URI is a valid URL.

This could affect grouping for existing issues that use (parts of) an URL as the message when the URL falls in the affected corner cases.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/2690

## :green_heart: How did you test it?
Added some tests and changed existing ones

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
