### PR TITLE
Filter strings that cannot be parsed as Regex no longer cause an SDK crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Fixes
 
+- Filter strings that cannot be parsed as Regex no longer cause an SDK crash ([#4213](https://github.com/getsentry/sentry-java/pull/4213))
+  - This was the case e.g. for `ignoredErrors`, `ignoredTransactions` and `ignoredCheckIns`
+  - We now simply don't use such strings for Regex matching and only use them for String comparison
 - `SentryOptions.setTracePropagationTargets` is no longer marked internal ([#4170](https://github.com/getsentry/sentry-java/pull/4170))
 - Session Replay: Fix crash when a navigation breadcrumb does not have "to" destination ([#4185](https://github.com/getsentry/sentry-java/pull/4185))
 - Session Replay: Cap video segment duration to maximum 5 minutes to prevent endless video encoding in background ([#4185](https://github.com/getsentry/sentry-java/pull/4185))

--- a/sentry/src/test/java/io/sentry/FilterStringTest.kt
+++ b/sentry/src/test/java/io/sentry/FilterStringTest.kt
@@ -1,0 +1,24 @@
+package io.sentry
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FilterStringTest {
+
+    @Test
+    fun `turns string into pattern`() {
+        val filterString = FilterString(".*")
+        assertTrue(filterString.matches("anything"))
+        assertEquals(".*", filterString.filterString)
+    }
+
+    @Test
+    fun `skips pattern if not a valid regex`() {
+        // does not throw if the string is not a valid pattern
+        val filterString = FilterString("I love my mustache {")
+        assertFalse(filterString.matches("I love my mustache {"))
+        assertEquals("I love my mustache {", filterString.filterString)
+    }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Fix exception when creating FilterString from string that cannot be parsed as regex.
This was the case e.g. for `ignoredErrors`, `ignoredTransactions`, `ignoredCheckIns`
Catch exception from `Pattern.compile` and skip using the pattern in that case.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/4212

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
