### PR TITLE
Fix Ensure app start type is set, even when ActivityLifecycleIntegration is not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Ensure app start type is set, even when ActivityLifecycleIntegration is not running ([#4216](https://github.com/getsentry/sentry-java/pull/4216))
+
 ## 7.22.0
 
 ### Fixes

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -462,6 +462,7 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
 	public fun setClassLoadedUptimeMs (J)V
 	public fun shouldSendStartMeasurements ()Z
+	public fun updateAppStartType (ZJ)V
 }
 
 public final class io/sentry/android/core/performance/AppStartMetrics$AppStartType : java/lang/Enum {

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -447,14 +447,15 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public static fun getInstance ()Lio/sentry/android/core/performance/AppStartMetrics;
 	public fun getSdkInitTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
 	public fun isAppLaunchedInForeground ()Z
-	public fun isColdStartValid ()Z
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
 	public fun onAppStartSpansSent ()V
 	public static fun onApplicationCreate (Landroid/app/Application;)V
 	public static fun onApplicationPostCreate (Landroid/app/Application;)V
 	public static fun onContentProviderCreate (Landroid/content/ContentProvider;)V
 	public static fun onContentProviderPostCreate (Landroid/content/ContentProvider;)V
-	public fun registerApplicationForegroundCheck (Landroid/app/Application;)V
+	public fun registerLifecycleCallbacks (Landroid/app/Application;)V
 	public fun restartAppStart (J)V
 	public fun setAppLaunchedInForeground (Z)V
 	public fun setAppStartProfiler (Lio/sentry/ITransactionProfiler;)V
@@ -462,7 +463,6 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
 	public fun setClassLoadedUptimeMs (J)V
 	public fun shouldSendStartMeasurements ()Z
-	public fun updateAppStartType (ZJ)V
 }
 
 public final class io/sentry/android/core/performance/AppStartMetrics$AppStartType : java/lang/Enum {

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -456,7 +456,6 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public static fun onContentProviderCreate (Landroid/content/ContentProvider;)V
 	public static fun onContentProviderPostCreate (Landroid/content/ContentProvider;)V
 	public fun registerLifecycleCallbacks (Landroid/app/Application;)V
-	public fun restartAppStart (J)V
 	public fun setAppLaunchedInForeground (Z)V
 	public fun setAppStartProfiler (Lio/sentry/ITransactionProfiler;)V
 	public fun setAppStartSamplingDecision (Lio/sentry/TracesSamplingDecision;)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -552,6 +552,17 @@ public final class ActivityLifecycleIntegration
     // activity stack still.
     // if the activity is opened again and not in memory, transactions will be created normally.
     activitiesWithOngoingTransactions.remove(activity);
+
+    if (activitiesWithOngoingTransactions.isEmpty() && !activity.isChangingConfigurations()) {
+      clear();
+    }
+  }
+
+  private void clear() {
+    firstActivityCreated = false;
+    lastPausedTime = new SentryNanotimeDate(new Date(0), 0);
+    lastPausedUptimeMillis = 0;
+    activityLifecycleMap.clear();
   }
 
   private void finishSpan(final @Nullable ISpan span) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -397,7 +397,6 @@ public final class ActivityLifecycleIntegration
     if (!isAllActivityCallbacksAvailable) {
       onActivityPreCreated(activity, savedInstanceState);
     }
-    setColdStart(savedInstanceState != null);
     if (hub != null && options != null && options.isEnableScreenTracking()) {
       final @Nullable String activityClassName = ClassUtil.getClassName(activity);
       hub.configureScope(scope -> scope.setScreen(activityClassName));
@@ -553,17 +552,6 @@ public final class ActivityLifecycleIntegration
     // activity stack still.
     // if the activity is opened again and not in memory, transactions will be created normally.
     activitiesWithOngoingTransactions.remove(activity);
-
-    if (activitiesWithOngoingTransactions.isEmpty()) {
-      clear();
-    }
-  }
-
-  private void clear() {
-    firstActivityCreated = false;
-    lastPausedTime = new SentryNanotimeDate(new Date(0), 0);
-    lastPausedUptimeMillis = 0;
-    activityLifecycleMap.clear();
   }
 
   private void finishSpan(final @Nullable ISpan span) {
@@ -703,12 +691,6 @@ public final class ActivityLifecycleIntegration
   @NotNull
   WeakHashMap<Activity, ISpan> getTtfdSpanMap() {
     return ttfdSpanMap;
-  }
-
-  private void setColdStart(final boolean hasBundle) {
-    if (!firstActivityCreated) {
-      AppStartMetrics.getInstance().updateAppStartType(hasBundle, lastPausedUptimeMillis);
-    }
   }
 
   private @NotNull String getTtidDesc(final @NotNull String activityName) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -562,6 +562,7 @@ public final class ActivityLifecycleIntegration
     firstActivityCreated = false;
     activityLifecycleMap.clear();
   }
+
   private void finishSpan(final @Nullable ISpan span) {
     if (span != null && !span.isFinished()) {
       span.finish();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -560,18 +560,6 @@ public final class ActivityLifecycleIntegration
 
   private void clear() {
     firstActivityCreated = false;
-    lastPausedTime = new SentryNanotimeDate(new Date(0), 0);
-    lastPausedUptimeMillis = 0;
-    activityLifecycleMap.clear();
-  }
-
-    if (activitiesWithOngoingTransactions.isEmpty() && !activity.isChangingConfigurations()) {
-      clear();
-    }
-  }
-
-  private void clear() {
-    firstActivityCreated = false;
     activityLifecycleMap.clear();
   }
   private void finishSpan(final @Nullable ISpan span) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -152,7 +152,7 @@ public final class SentryAndroid {
               }
             }
             if (context.getApplicationContext() instanceof Application) {
-              appStartMetrics.registerApplicationForegroundCheck(
+              appStartMetrics.registerLifecycleCallbacks(
                   (Application) context.getApplicationContext());
             }
             final @NotNull TimeSpan sdkInitTimeSpan = appStartMetrics.getSdkInitTimeSpan();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -209,6 +209,10 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
           @Override
           public void onActivityCreated(
               @NotNull Activity activity, @Nullable Bundle savedInstanceState) {
+            // In case the SDK gets initialized async or the
+            // ActivityLifecycleIntegration is not enabled (e.g on RN due to Context not being
+            // instanceof Application)
+            // the app start type never gets set
             if (appStartMetrics.getAppStartType() == AppStartMetrics.AppStartType.UNKNOWN) {
               // We consider pre-loaded application loads as warm starts
               // This usually happens e.g. due to BroadcastReceivers triggering

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -155,7 +155,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   }
 
   public boolean shouldSendStartMeasurements() {
-    return shouldSendStartMeasurements;
+    return shouldSendStartMeasurements && appLaunchedInForeground;
   }
 
   public void restartAppStart(final long uptimeMillis) {
@@ -344,7 +344,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     // as the next Activity is considered like a new app start
     if (remainingActivities == 0 && !activity.isChangingConfigurations()) {
       appLaunchedInForeground = false;
-      shouldSendStartMeasurements = true;
+      shouldSendStartMeasurements = false;
       firstDrawDone.set(false);
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -305,7 +305,6 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   @Override
   public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
     final long nowUptimeMs = SystemClock.uptimeMillis();
-    activeActivitiesCounter.incrementAndGet();
 
     // the first activity determines the app start type
     if (activeActivitiesCounter.get() == 1 && !firstDrawDone.get()) {
@@ -313,6 +312,12 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       final long durationSinceAppStartMillis = nowUptimeMs - appStartSpan.getStartUptimeMs();
       if (!appLaunchedInForeground || durationSinceAppStartMillis > TimeUnit.MINUTES.toMillis(1)) {
         appStartType = AppStartType.WARM;
+
+        shouldSendStartMeasurements = true;
+        appStartSpan.reset();
+        appStartSpan.start();
+        appStartSpan.setStartedAt(nowUptimeMs);
+        CLASS_LOADED_UPTIME_MS = nowUptimeMs;
       } else {
         appStartType = savedInstanceState == null ? AppStartType.COLD : AppStartType.WARM;
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -306,18 +306,18 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
     final long nowUptimeMs = SystemClock.uptimeMillis();
     activeActivitiesCounter.incrementAndGet();
-    appLaunchedInForeground = true;
 
-    // the first undrawn activity determines the app start type
+    // the first activity determines the app start type
     if (activeActivitiesCounter.get() == 1 && !firstDrawDone.get()) {
       // If the app (process) was launched more than 1 minute ago, it's likely wrong
       final long durationSinceAppStartMillis = nowUptimeMs - appStartSpan.getStartUptimeMs();
-      if (durationSinceAppStartMillis > TimeUnit.MINUTES.toMillis(1)) {
+      if (!appLaunchedInForeground || durationSinceAppStartMillis > TimeUnit.MINUTES.toMillis(1)) {
         appStartType = AppStartType.WARM;
       } else {
         appStartType = savedInstanceState == null ? AppStartType.COLD : AppStartType.WARM;
       }
     }
+    appLaunchedInForeground = true;
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -354,4 +354,26 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       measurement.setStoppedAt(now);
     }
   }
+
+  /**
+   * @param hasBundle true if the activity onCreate had a non-null bundle
+   * @param lastKnownStart in case the app start is too long, resets the app start timestamp to this
+   *     value
+   */
+  public void updateAppStartType(final boolean hasBundle, final long lastKnownStart) {
+    final @NotNull TimeSpan appStartSpan = getInstance().getAppStartTimeSpan();
+    // If the app start span already started and stopped, it means the app restarted without
+    //  killing the process, so we are in a warm start
+    // If the app has an invalid cold start, it means it was started in the background, like
+    //  via BroadcastReceiver, so we consider it a warm start
+    if ((appStartSpan.hasStarted() && appStartSpan.hasStopped())
+        || (!getInstance().isColdStartValid())) {
+      getInstance().restartAppStart(lastKnownStart);
+      getInstance().setAppStartType(AppStartMetrics.AppStartType.WARM);
+    } else {
+      getInstance()
+          .setAppStartType(
+              hasBundle ? AppStartMetrics.AppStartType.WARM : AppStartMetrics.AppStartType.COLD);
+    }
+  }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -307,7 +307,7 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     final long nowUptimeMs = SystemClock.uptimeMillis();
 
     // the first activity determines the app start type
-    if (activeActivitiesCounter.get() == 1 && !firstDrawDone.get()) {
+    if (activeActivitiesCounter.incrementAndGet() == 1 && !firstDrawDone.get()) {
       // If the app (process) was launched more than 1 minute ago, it's likely wrong
       final long durationSinceAppStartMillis = nowUptimeMs - appStartSpan.getStartUptimeMs();
       if (!appLaunchedInForeground || durationSinceAppStartMillis > TimeUnit.MINUTES.toMillis(1)) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/PerformanceAndroidEventProcessorTest.kt
@@ -75,7 +75,7 @@ class PerformanceAndroidEventProcessorTest {
         null,
         null
     ).also {
-        AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
+        AppStartMetrics.getInstance().onActivityCreated(mock(), if (coldStart) null else mock())
     }
 
     @BeforeTest
@@ -225,6 +225,7 @@ class PerformanceAndroidEventProcessorTest {
     fun `adds app start metrics to app start txn`() {
         // given some app start metrics
         val appStartMetrics = AppStartMetrics.getInstance()
+        appStartMetrics.isAppLaunchedInForeground = true
         appStartMetrics.appStartType = AppStartType.COLD
         appStartMetrics.appStartTimeSpan.setStartedAt(123)
         appStartMetrics.appStartTimeSpan.setStoppedAt(456)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -1,9 +1,12 @@
 package io.sentry.android.core.performance
 
+import android.app.Activity
 import android.app.Application
 import android.content.ContentProvider
 import android.os.Build
+import android.os.Bundle
 import android.os.Looper
+import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ITransactionProfiler
 import io.sentry.android.core.SentryAndroidOptions
@@ -75,6 +78,7 @@ class AppStartMetricsTest {
     @Test
     fun `if perf-2 is enabled and app start time span is started, appStartTimeSpanWithFallback returns it`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
+        AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.WARM
         appStartTimeSpan.start()
 
         val options = SentryAndroidOptions().apply {
@@ -88,6 +92,8 @@ class AppStartMetricsTest {
     @Test
     fun `if perf-2 is disabled but app start time span has started, appStartTimeSpanWithFallback returns the sdk init span instead`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
+        AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.COLD
+
         appStartTimeSpan.start()
 
         val options = SentryAndroidOptions().apply {
@@ -102,6 +108,7 @@ class AppStartMetricsTest {
     @Test
     fun `if perf-2 is enabled but app start time span has not started, appStartTimeSpanWithFallback returns the sdk init span instead`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
+        AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.COLD
         assertTrue(appStartTimeSpan.hasNotStarted())
 
         val options = SentryAndroidOptions().apply {
@@ -121,6 +128,8 @@ class AppStartMetricsTest {
     @Test
     fun `if app is launched in background, appStartTimeSpanWithFallback returns an empty span`() {
         AppStartMetrics.getInstance().isAppLaunchedInForeground = false
+        AppStartMetrics.getInstance().appStartType = AppStartMetrics.AppStartType.COLD
+
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
         appStartTimeSpan.start()
         assertTrue(appStartTimeSpan.hasStarted())
@@ -172,14 +181,15 @@ class AppStartMetricsTest {
 
     @Test
     fun `if activity is never started, returns an empty span`() {
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(mock())
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(mock())
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
         appStartTimeSpan.setStartedAt(1)
         assertTrue(appStartTimeSpan.hasStarted())
         // Job on main thread checks if activity was launched
         Shadows.shadowOf(Looper.getMainLooper()).idle()
 
-        val timeSpan = AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(SentryAndroidOptions())
+        val timeSpan =
+            AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(SentryAndroidOptions())
         assertFalse(timeSpan.hasStarted())
     }
 
@@ -189,7 +199,7 @@ class AppStartMetricsTest {
         whenever(profiler.isRunning).thenReturn(true)
         AppStartMetrics.getInstance().appStartProfiler = profiler
 
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(mock())
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(mock())
         // Job on main thread checks if activity was launched
         Shadows.shadowOf(Looper.getMainLooper()).idle()
 
@@ -203,7 +213,7 @@ class AppStartMetricsTest {
         AppStartMetrics.getInstance().appStartProfiler = profiler
         AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
 
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(mock())
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(mock())
         // Job on main thread checks if activity was launched
         Shadows.shadowOf(Looper.getMainLooper()).idle()
 
@@ -231,33 +241,26 @@ class AppStartMetricsTest {
     @Test
     fun `when multiple registerApplicationForegroundCheck, only one callback is registered to application`() {
         val application = mock<Application>()
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
-        verify(application, times(1)).registerActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(application)
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(application)
+        verify(
+            application,
+            times(1)
+        ).registerActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
     }
 
     @Test
     fun `when registerApplicationForegroundCheck, a callback is registered to application`() {
         val application = mock<Application>()
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(application)
         verify(application).registerActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
-    }
-
-    @Test
-    fun `when registerApplicationForegroundCheck, a job is posted on main thread to unregistered the callback`() {
-        val application = mock<Application>()
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
-        verify(application).registerActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
-        verify(application, never()).unregisterActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
-        verify(application).unregisterActivityLifecycleCallbacks(eq(AppStartMetrics.getInstance()))
     }
 
     @Test
     fun `registerApplicationForegroundCheck set foreground state to false if no activity is running`() {
         val application = mock<Application>()
         AppStartMetrics.getInstance().isAppLaunchedInForeground = true
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(application)
         assertTrue(AppStartMetrics.getInstance().isAppLaunchedInForeground)
         // Main thread performs the check and sets the flag to false if no activity was created
         Shadows.shadowOf(Looper.getMainLooper()).idle()
@@ -268,19 +271,13 @@ class AppStartMetricsTest {
     fun `registerApplicationForegroundCheck keeps foreground state to true if an activity is running`() {
         val application = mock<Application>()
         AppStartMetrics.getInstance().isAppLaunchedInForeground = true
-        AppStartMetrics.getInstance().registerApplicationForegroundCheck(application)
+        AppStartMetrics.getInstance().registerLifecycleCallbacks(application)
         assertTrue(AppStartMetrics.getInstance().isAppLaunchedInForeground)
         // An activity was created
         AppStartMetrics.getInstance().onActivityCreated(mock(), null)
         // Main thread performs the check and keeps the flag to true
         Shadows.shadowOf(Looper.getMainLooper()).idle()
         assertTrue(AppStartMetrics.getInstance().isAppLaunchedInForeground)
-    }
-
-    @Test
-    fun `isColdStartValid is false if app was launched in background`() {
-        AppStartMetrics.getInstance().isAppLaunchedInForeground = false
-        assertFalse(AppStartMetrics.getInstance().isColdStartValid)
     }
 
     @Test
@@ -291,7 +288,6 @@ class AppStartMetricsTest {
         appStartTimeSpan.setStartedAt(1)
         appStartTimeSpan.setStoppedAt(TimeUnit.MINUTES.toMillis(1) + 2)
         AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
-        assertFalse(AppStartMetrics.getInstance().isColdStartValid)
     }
 
     @Test
@@ -312,14 +308,89 @@ class AppStartMetricsTest {
         appStartMetrics.onAppStartSpansSent()
         appStartMetrics.isAppLaunchedInForeground = false
         assertFalse(appStartMetrics.shouldSendStartMeasurements())
-        assertFalse(appStartMetrics.isColdStartValid)
 
         appStartMetrics.restartAppStart(10)
 
         assertTrue(appStartMetrics.shouldSendStartMeasurements())
-        assertTrue(appStartMetrics.isColdStartValid)
         assertTrue(appStartMetrics.appStartTimeSpan.hasStarted())
         assertTrue(appStartMetrics.appStartTimeSpan.hasNotStopped())
         assertEquals(10, appStartMetrics.appStartTimeSpan.startUptimeMs)
+    }
+
+    @Test
+    fun `provider sets both appstart and sdk init start + end times`() {
+        val metrics = AppStartMetrics.getInstance()
+        metrics.appStartTimeSpan.start()
+        metrics.sdkInitTimeSpan.start()
+
+        assertFalse(metrics.appStartTimeSpan.hasStopped())
+        assertFalse(metrics.sdkInitTimeSpan.hasStopped())
+
+        metrics.onFirstFrameDrawn()
+
+        assertTrue(metrics.appStartTimeSpan.hasStopped())
+        assertTrue(metrics.sdkInitTimeSpan.hasStopped())
+    }
+
+    @Test
+    fun `Sets app launch type to cold`() {
+        val metrics = AppStartMetrics.getInstance()
+        assertEquals(
+            AppStartMetrics.AppStartType.UNKNOWN,
+            AppStartMetrics.getInstance().appStartType
+        )
+
+        val app = mock<Application>()
+        metrics.registerLifecycleCallbacks(app)
+        metrics.onActivityCreated(mock<Activity>(), null)
+
+        // then the app start is considered cold
+        assertEquals(AppStartMetrics.AppStartType.COLD, AppStartMetrics.getInstance().appStartType)
+
+        // when any subsequent activity launches
+        metrics.onActivityCreated(mock<Activity>(), mock<Bundle>())
+
+        // then the app start is still considered cold
+        assertEquals(AppStartMetrics.AppStartType.COLD, AppStartMetrics.getInstance().appStartType)
+    }
+
+    @Test
+    fun `Sets app launch type to warm if process init was too long ago`() {
+        val metrics = AppStartMetrics.getInstance()
+        assertEquals(
+            AppStartMetrics.AppStartType.UNKNOWN,
+            AppStartMetrics.getInstance().appStartType
+        )
+        val app = mock<Application>()
+        metrics.registerLifecycleCallbacks(app)
+
+        // when an activity is created later with a null bundle
+        SystemClock.setCurrentTimeMillis(TimeUnit.MINUTES.toMillis(2))
+        metrics.onActivityCreated(mock<Activity>(), null)
+
+        // then the app start is considered warm
+        assertEquals(AppStartMetrics.AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
+    }
+
+    @Test
+    fun `Sets app launch type to warm`() {
+        val metrics = AppStartMetrics.getInstance()
+        assertEquals(
+            AppStartMetrics.AppStartType.UNKNOWN,
+            AppStartMetrics.getInstance().appStartType
+        )
+
+        val app = mock<Application>()
+        metrics.registerLifecycleCallbacks(app)
+        metrics.onActivityCreated(mock<Activity>(), mock<Bundle>())
+
+        // then the app start is considered warm
+        assertEquals(AppStartMetrics.AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
+
+        // when any subsequent activity launches
+        metrics.onActivityCreated(mock<Activity>(), null)
+
+        // then the app start is still considered warm
+        assertEquals(AppStartMetrics.AppStartType.WARM, AppStartMetrics.getInstance().appStartType)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -150,6 +150,27 @@ class AppStartMetricsTest {
     }
 
     @Test
+    fun `if app is launched in background, the first created activity assumes a warm start`() {
+        val metrics = AppStartMetrics.getInstance()
+        metrics.appStartTimeSpan.start()
+        metrics.sdkInitTimeSpan.start()
+        metrics.registerLifecycleCallbacks(mock<Application>())
+
+        // when the handler callback is executed and no activity was launched
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        // isAppLaunchedInForeground should be false
+        assertFalse(metrics.isAppLaunchedInForeground)
+
+        // but when the first activity launches
+        metrics.onActivityCreated(mock<Activity>(), null)
+
+        // then a warm start should be set
+        assertTrue(metrics.isAppLaunchedInForeground)
+        assertEquals(AppStartMetrics.AppStartType.WARM, metrics.appStartType)
+    }
+
+    @Test
     fun `if app start span is at most 1 minute, appStartTimeSpanWithFallback returns the app start span`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
         appStartTimeSpan.start()

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -145,22 +145,6 @@ class AppStartMetricsTest {
     }
 
     @Test
-    fun `if app is launched in background with perfV2, appStartTimeSpanWithFallback returns an empty span`() {
-        val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
-        appStartTimeSpan.start()
-        assertTrue(appStartTimeSpan.hasStarted())
-        AppStartMetrics.getInstance().isAppLaunchedInForeground = false
-        AppStartMetrics.getInstance().onActivityCreated(mock(), mock())
-
-        val options = SentryAndroidOptions().apply {
-            isEnablePerformanceV2 = true
-        }
-
-        val timeSpan = AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options)
-        assertFalse(timeSpan.hasStarted())
-    }
-
-    @Test
     fun `if app start span is at most 1 minute, appStartTimeSpanWithFallback returns the app start span`() {
         val appStartTimeSpan = AppStartMetrics.getInstance().appStartTimeSpan
         appStartTimeSpan.start()

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -28,6 +28,8 @@ import io.sentry.metrics.EncodedMetrics
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.protocol.User
+import io.sentry.test.getProperty
+import io.sentry.test.injectForField
 import org.awaitility.kotlin.await
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -37,6 +39,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import java.io.File
+import java.util.Timer
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
@@ -412,18 +415,16 @@ class RateLimiterTest {
     @Test
     fun `close cancels the timer`() {
         val rateLimiter = fixture.getSUT()
-        whenever(fixture.currentDateProvider.currentTimeMillis).thenReturn(0, 1, 2001)
+        val timer = mock<Timer>()
+        rateLimiter.injectForField("timer", timer)
 
-        val applied = AtomicBoolean(true)
-        rateLimiter.addRateLimitObserver {
-            applied.set(rateLimiter.isActiveForCategory(Replay))
-        }
-
-        rateLimiter.updateRetryAfterLimits("1:replay:key", null, 1)
+        // When the rate limiter is closed
         rateLimiter.close()
 
-        // wait for 1.5s to ensure the timer has run after 1s
-        await.untilTrue(applied)
-        assertTrue(applied.get())
+        // Then the timer is cancelled
+        verify(timer).cancel()
+
+        // And is removed by the rateLimiter
+        assertNull(rateLimiter.getProperty("timer"))
     }
 }


### PR DESCRIPTION
Fix Ensure app start type is set, even when ActivityLifecycleIntegration is not running or init is deferred.

Fixes https://github.com/getsentry/sentry-react-native/issues/4598