### PR TITLE
Add Continuous Profiling isStartProfilerOnAppStart option

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -70,6 +70,8 @@ final class ManifestMetadataReader {
 
   static final String PROFILE_LIFECYCLE = "io.sentry.traces.profiling.lifecycle";
 
+  static final String PROFILER_START_ON_APP_START = "io.sentry.traces.profiling.start-on-app-start";
+
   @ApiStatus.Experimental static final String TRACE_SAMPLING = "io.sentry.traces.trace-sampling";
   static final String TRACE_PROPAGATION_TARGETS = "io.sentry.traces.trace-propagation-targets";
 
@@ -341,6 +343,10 @@ final class ManifestMetadataReader {
               .setProfileLifecycle(
                   ProfileLifecycle.valueOf(profileLifecycle.toUpperCase(Locale.ROOT)));
         }
+
+        options.getExperimental().setStartProfilerOnAppStart(
+          readBool(
+            metadata, logger, PROFILER_START_ON_APP_START, options.isStartProfilerOnAppStart()));
 
         options.setEnableUserInteractionTracing(
             readBool(metadata, logger, TRACES_UI_ENABLE, options.isEnableUserInteractionTracing()));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -344,9 +344,14 @@ final class ManifestMetadataReader {
                   ProfileLifecycle.valueOf(profileLifecycle.toUpperCase(Locale.ROOT)));
         }
 
-        options.getExperimental().setStartProfilerOnAppStart(
-          readBool(
-            metadata, logger, PROFILER_START_ON_APP_START, options.isStartProfilerOnAppStart()));
+        options
+            .getExperimental()
+            .setStartProfilerOnAppStart(
+                readBool(
+                    metadata,
+                    logger,
+                    PROFILER_START_ON_APP_START,
+                    options.isStartProfilerOnAppStart()));
 
         options.setEnableUserInteractionTracing(
             readBool(metadata, logger, TRACES_UI_ENABLE, options.isEnableUserInteractionTracing()));

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -869,6 +869,31 @@ class ManifestMetadataReaderTest {
     }
 
     @Test
+    fun `applyMetadata without specifying isStartProfilerOnAppStart, stays false`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertFalse(fixture.options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `applyMetadata reads isStartProfilerOnAppStart from metadata`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.PROFILER_START_ON_APP_START to true)
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.isStartProfilerOnAppStart)
+    }
+
+    @Test
     fun `applyMetadata reads tracePropagationTargets to options`() {
         // Arrange
         val bundle = bundleOf(ManifestMetadataReader.TRACE_PROPAGATION_TARGETS to """localhost,^(http|https)://api\..*$""")

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -446,9 +446,11 @@ public final class io/sentry/ExperimentalOptions {
 	public fun getProfileLifecycle ()Lio/sentry/ProfileLifecycle;
 	public fun getProfileSessionSampleRate ()Ljava/lang/Double;
 	public fun getSessionReplay ()Lio/sentry/SentryReplayOptions;
+	public fun isStartProfilerOnAppStart ()Z
 	public fun setProfileLifecycle (Lio/sentry/ProfileLifecycle;)V
 	public fun setProfileSessionSampleRate (Ljava/lang/Double;)V
 	public fun setSessionReplay (Lio/sentry/SentryReplayOptions;)V
+	public fun setStartProfilerOnAppStart (Z)V
 }
 
 public final class io/sentry/ExternalOptions {
@@ -2506,18 +2508,22 @@ public final class io/sentry/SentryAppStartProfilingOptions : io/sentry/JsonSeri
 	public fun getUnknown ()Ljava/util/Map;
 	public fun isContinuousProfileSampled ()Z
 	public fun isContinuousProfilingEnabled ()Z
+	public fun isEnableAppStartProfiling ()Z
 	public fun isProfileSampled ()Z
 	public fun isProfilingEnabled ()Z
+	public fun isStartProfilerOnAppStart ()Z
 	public fun isTraceSampled ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setContinuousProfileSampled (Z)V
 	public fun setContinuousProfilingEnabled (Z)V
+	public fun setEnableAppStartProfiling (Z)V
 	public fun setProfileLifecycle (Lio/sentry/ProfileLifecycle;)V
 	public fun setProfileSampleRate (Ljava/lang/Double;)V
 	public fun setProfileSampled (Z)V
 	public fun setProfilingEnabled (Z)V
 	public fun setProfilingTracesDirPath (Ljava/lang/String;)V
 	public fun setProfilingTracesHz (I)V
+	public fun setStartProfilerOnAppStart (Z)V
 	public fun setTraceSampleRate (Ljava/lang/Double;)V
 	public fun setTraceSampled (Z)V
 	public fun setUnknown (Ljava/util/Map;)V
@@ -2532,7 +2538,9 @@ public final class io/sentry/SentryAppStartProfilingOptions$Deserializer : io/se
 public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
 	public static final field CONTINUOUS_PROFILE_SAMPLED Ljava/lang/String;
 	public static final field IS_CONTINUOUS_PROFILING_ENABLED Ljava/lang/String;
+	public static final field IS_ENABLE_APP_START_PROFILING Ljava/lang/String;
 	public static final field IS_PROFILING_ENABLED Ljava/lang/String;
+	public static final field IS_START_PROFILER_ON_APP_START Ljava/lang/String;
 	public static final field PROFILE_LIFECYCLE Ljava/lang/String;
 	public static final field PROFILE_SAMPLED Ljava/lang/String;
 	public static final field PROFILE_SAMPLE_RATE Ljava/lang/String;
@@ -3065,6 +3073,7 @@ public class io/sentry/SentryOptions {
 	public fun isSendClientReports ()Z
 	public fun isSendDefaultPii ()Z
 	public fun isSendModules ()Z
+	public fun isStartProfilerOnAppStart ()Z
 	public fun isTraceOptionsRequests ()Z
 	public fun isTraceSampling ()Z
 	public fun isTracingEnabled ()Z

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -28,9 +28,13 @@ public final class ExperimentalOptions {
   private @NotNull ProfileLifecycle profileLifecycle = ProfileLifecycle.MANUAL;
 
   /**
-   * Whether profiling can automatically be started as early as possible during the app lifecycle, to capture more of app startup.
-   * If {@link ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfileSession must be called manually whenever the app startup is completed
-   * If {@link ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#TRACE} Profiling is started automatically on startup, and will automatically be stopped when the root span that is associated with app startup ends
+   * Whether profiling can automatically be started as early as possible during the app lifecycle,
+   * to capture more of app startup. If {@link ExperimentalOptions#profileLifecycle} is {@link
+   * ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfileSession
+   * must be called manually whenever the app startup is completed If {@link
+   * ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#TRACE} Profiling is started
+   * automatically on startup, and will automatically be stopped when the root span that is
+   * associated with app startup ends
    */
   private boolean startProfilerOnAppStart = false;
 

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -27,6 +27,13 @@ public final class ExperimentalOptions {
    */
   private @NotNull ProfileLifecycle profileLifecycle = ProfileLifecycle.MANUAL;
 
+  /**
+   * Whether profiling can automatically be started as early as possible during the app lifecycle, to capture more of app startup.
+   * If {@link ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfileSession must be called manually whenever the app startup is completed
+   * If {@link ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#TRACE} Profiling is started automatically on startup, and will automatically be stopped when the root span that is associated with app startup ends
+   */
+  private boolean startProfilerOnAppStart = false;
+
   public ExperimentalOptions(final boolean empty) {
     this.sessionReplay = new SentryReplayOptions(empty);
   }
@@ -73,5 +80,15 @@ public final class ExperimentalOptions {
               + " is not valid. Use values between 0.0 and 1.0.");
     }
     this.profileSessionSampleRate = profileSessionSampleRate;
+  }
+
+  @ApiStatus.Experimental
+  public boolean isStartProfilerOnAppStart() {
+    return startProfilerOnAppStart;
+  }
+
+  @ApiStatus.Experimental
+  public void setStartProfilerOnAppStart(boolean startProfilerOnAppStart) {
+    this.startProfilerOnAppStart = startProfilerOnAppStart;
   }
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -370,9 +370,10 @@ public final class Sentry {
               try {
                 // We always delete the config file for app start profiling
                 FileUtils.deleteRecursively(appStartProfilingConfigFile);
-                if (!options.isEnableAppStartProfiling()) {
+                if (!options.isEnableAppStartProfiling() && !options.isStartProfilerOnAppStart()) {
                   return;
                 }
+                todo isStartProfilerOnAppStart doesn't need tracing! - SentryTest takes hours to run!
                 if (!options.isTracingEnabled()) {
                   options
                       .getLogger()
@@ -382,8 +383,8 @@ public final class Sentry {
                   return;
                 }
                 if (appStartProfilingConfigFile.createNewFile()) {
-                  final @NotNull TracesSamplingDecision appStartSamplingDecision =
-                      sampleAppStartProfiling(options);
+                  // If old app start profiling is false, it means the transaction will not be sampled, but we create the file anyway to allow continuous profiling on app start
+                  final @NotNull TracesSamplingDecision appStartSamplingDecision = options.isEnableAppStartProfiling() ? sampleAppStartProfiling(options) : new TracesSamplingDecision(false);
                   final @NotNull SentryAppStartProfilingOptions appStartProfilingOptions =
                       new SentryAppStartProfilingOptions(options, appStartSamplingDecision);
                   try (final OutputStream outputStream =

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -373,8 +373,9 @@ public final class Sentry {
                 if (!options.isEnableAppStartProfiling() && !options.isStartProfilerOnAppStart()) {
                   return;
                 }
-                todo isStartProfilerOnAppStart doesn't need tracing! - SentryTest takes hours to run!
-                if (!options.isTracingEnabled()) {
+                // isStartProfilerOnAppStart doesn't need tracing, as it can be started/stopped
+                // manually
+                if (!options.isStartProfilerOnAppStart() && !options.isTracingEnabled()) {
                   options
                       .getLogger()
                       .log(
@@ -383,8 +384,13 @@ public final class Sentry {
                   return;
                 }
                 if (appStartProfilingConfigFile.createNewFile()) {
-                  // If old app start profiling is false, it means the transaction will not be sampled, but we create the file anyway to allow continuous profiling on app start
-                  final @NotNull TracesSamplingDecision appStartSamplingDecision = options.isEnableAppStartProfiling() ? sampleAppStartProfiling(options) : new TracesSamplingDecision(false);
+                  // If old app start profiling is false, it means the transaction will not be
+                  // sampled, but we create the file anyway to allow continuous profiling on app
+                  // start
+                  final @NotNull TracesSamplingDecision appStartSamplingDecision =
+                      options.isEnableAppStartProfiling()
+                          ? sampleAppStartProfiling(options)
+                          : new TracesSamplingDecision(false);
                   final @NotNull SentryAppStartProfilingOptions appStartProfilingOptions =
                       new SentryAppStartProfilingOptions(options, appStartSamplingDecision);
                   try (final OutputStream outputStream =

--- a/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryAppStartProfilingOptions.java
@@ -21,6 +21,8 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
   boolean isContinuousProfilingEnabled;
   int profilingTracesHz;
   boolean continuousProfileSampled;
+  boolean isEnableAppStartProfiling;
+  boolean isStartProfilerOnAppStart;
   @NotNull ProfileLifecycle profileLifecycle;
 
   private @Nullable Map<String, Object> unknown;
@@ -37,6 +39,8 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     isContinuousProfilingEnabled = false;
     profileLifecycle = ProfileLifecycle.MANUAL;
     profilingTracesHz = 0;
+    isEnableAppStartProfiling = true;
+    isStartProfilerOnAppStart = false;
   }
 
   SentryAppStartProfilingOptions(
@@ -52,6 +56,8 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     isContinuousProfilingEnabled = options.isContinuousProfilingEnabled();
     profileLifecycle = options.getProfileLifecycle();
     profilingTracesHz = options.getProfilingTracesHz();
+    isEnableAppStartProfiling = options.isEnableAppStartProfiling();
+    isStartProfilerOnAppStart = options.isStartProfilerOnAppStart();
   }
 
   public void setProfileSampled(final boolean profileSampled) {
@@ -134,6 +140,22 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     return profilingTracesHz;
   }
 
+  public void setEnableAppStartProfiling(final boolean enableAppStartProfiling) {
+    isEnableAppStartProfiling = enableAppStartProfiling;
+  }
+
+  public boolean isEnableAppStartProfiling() {
+    return isEnableAppStartProfiling;
+  }
+
+  public void setStartProfilerOnAppStart(final boolean startProfilerOnAppStart) {
+    isStartProfilerOnAppStart = startProfilerOnAppStart;
+  }
+
+  public boolean isStartProfilerOnAppStart() {
+    return isStartProfilerOnAppStart;
+  }
+
   // JsonSerializable
 
   public static final class JsonKeys {
@@ -147,6 +169,8 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
     public static final String IS_CONTINUOUS_PROFILING_ENABLED = "is_continuous_profiling_enabled";
     public static final String PROFILE_LIFECYCLE = "profile_lifecycle";
     public static final String PROFILING_TRACES_HZ = "profiling_traces_hz";
+    public static final String IS_ENABLE_APP_START_PROFILING = "is_enable_app_start_profiling";
+    public static final String IS_START_PROFILER_ON_APP_START = "is_start_profiler_on_app_start";
   }
 
   @Override
@@ -165,6 +189,8 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
         .value(logger, isContinuousProfilingEnabled);
     writer.name(JsonKeys.PROFILE_LIFECYCLE).value(logger, profileLifecycle.name());
     writer.name(JsonKeys.PROFILING_TRACES_HZ).value(logger, profilingTracesHz);
+    writer.name(JsonKeys.IS_ENABLE_APP_START_PROFILING).value(logger, isEnableAppStartProfiling);
+    writer.name(JsonKeys.IS_START_PROFILER_ON_APP_START).value(logger, isStartProfilerOnAppStart);
 
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -264,6 +290,18 @@ public final class SentryAppStartProfilingOptions implements JsonUnknown, JsonSe
             Integer profilingTracesHz = reader.nextIntegerOrNull();
             if (profilingTracesHz != null) {
               options.profilingTracesHz = profilingTracesHz;
+            }
+            break;
+          case JsonKeys.IS_ENABLE_APP_START_PROFILING:
+            Boolean isEnableAppStartProfiling = reader.nextBooleanOrNull();
+            if (isEnableAppStartProfiling != null) {
+              options.isEnableAppStartProfiling = isEnableAppStartProfiling;
+            }
+            break;
+          case JsonKeys.IS_START_PROFILER_ON_APP_START:
+            Boolean isStartProfilerOnAppStart = reader.nextBooleanOrNull();
+            if (isStartProfilerOnAppStart != null) {
+              options.isStartProfilerOnAppStart = isStartProfilerOnAppStart;
             }
             break;
           default:

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1813,7 +1813,9 @@ public class SentryOptions {
     return experimental.getProfileLifecycle();
   }
 
-  /** Whether profiling can automatically be started as early as possible during the app lifecycle. */
+  /**
+   * Whether profiling can automatically be started as early as possible during the app lifecycle.
+   */
   @ApiStatus.Experimental
   public boolean isStartProfilerOnAppStart() {
     return experimental.isStartProfilerOnAppStart();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1813,6 +1813,12 @@ public class SentryOptions {
     return experimental.getProfileLifecycle();
   }
 
+  /** Whether profiling can automatically be started as early as possible during the app lifecycle. */
+  @ApiStatus.Experimental
+  public boolean isStartProfilerOnAppStart() {
+    return experimental.isStartProfilerOnAppStart();
+  }
+
   /**
    * Returns the profiling traces dir. path if set
    *

--- a/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonSerializerTest.kt
@@ -1234,8 +1234,8 @@ class JsonSerializerTest {
 
         val expected = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"continuous_profile_sampled\":true," +
             "\"trace_sampled\":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false," +
-            "\"is_continuous_profiling_enabled\":false,\"profile_lifecycle\":\"TRACE\",\"profiling_traces_hz\":65}"
-
+            "\"is_continuous_profiling_enabled\":false,\"profile_lifecycle\":\"TRACE\",\"profiling_traces_hz\":65," +
+            "\"is_enable_app_start_profiling\":false,\"is_start_profiler_on_app_start\":true}"
         assertEquals(expected, actual)
     }
 
@@ -1243,7 +1243,8 @@ class JsonSerializerTest {
     fun `deserializing SentryAppStartProfilingOptions`() {
         val jsonAppStartProfilingOptions = "{\"profile_sampled\":true,\"profile_sample_rate\":0.8,\"trace_sampled\"" +
             ":false,\"trace_sample_rate\":0.1,\"profiling_traces_dir_path\":null,\"is_profiling_enabled\":false," +
-            "\"profile_lifecycle\":\"TRACE\",\"profiling_traces_hz\":65,\"continuous_profile_sampled\":true}"
+            "\"profile_lifecycle\":\"TRACE\",\"profiling_traces_hz\":65,\"continuous_profile_sampled\":true," +
+            "\"is_enable_app_start_profiling\":false,\"is_start_profiler_on_app_start\":true}"
 
         val actual = fixture.serializer.deserialize(StringReader(jsonAppStartProfilingOptions), SentryAppStartProfilingOptions::class.java)
         assertNotNull(actual)
@@ -1257,6 +1258,8 @@ class JsonSerializerTest {
         assertEquals(appStartProfilingOptions.profilingTracesHz, actual.profilingTracesHz)
         assertEquals(appStartProfilingOptions.profilingTracesDirPath, actual.profilingTracesDirPath)
         assertEquals(appStartProfilingOptions.profileLifecycle, actual.profileLifecycle)
+        assertEquals(appStartProfilingOptions.isEnableAppStartProfiling, actual.isEnableAppStartProfiling)
+        assertEquals(appStartProfilingOptions.isStartProfilerOnAppStart, actual.isStartProfilerOnAppStart)
         assertNull(actual.unknown)
     }
 
@@ -1562,6 +1565,8 @@ class JsonSerializerTest {
         isContinuousProfilingEnabled = false
         profilingTracesHz = 65
         profileLifecycle = ProfileLifecycle.TRACE
+        isEnableAppStartProfiling = false
+        isStartProfilerOnAppStart = true
     }
 
     private fun createSpan(): ISpan {

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -304,6 +304,20 @@ class SentryOptionsTest {
     }
 
     @Test
+    fun `when isStartProfilerOnAppStart is set to a value, value is set`() {
+        val options = SentryOptions().apply {
+            this.experimental.isStartProfilerOnAppStart = true
+        }
+        assertTrue(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `isStartProfilerOnAppStart defaults to false`() {
+        val options = SentryOptions()
+        assertFalse(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
     fun `when options is initialized, compositePerformanceCollector is set`() {
         assertIs<CompositePerformanceCollector>(SentryOptions().compositePerformanceCollector)
     }


### PR DESCRIPTION
## :scroll: Description
added isStartProfilerOnAppStart

#skip-changelog

## :bulb: Motivation and Context
We are adding isStartProfilerOnAppStart, as per [docs](https://www.notion.so/sentry/Continuous-UI-Profiling-SDK-API-Spec-17e8b10e4b5d80c59a40c6e114470934)


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
