### PR TITLE
Also use port when checking if a request is made to Sentry DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Also use port when checking if a request is made to Sentry DSN ([#4231](https://github.com/getsentry/sentry-java/pull/4231))
+  - For our OpenTelemetry integration we check if a span is for a request to Sentry
+  - We now also consider the port when performing this check
+
 ## 8.3.0
 
 ### Features

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OpenTelemetryAttributesExtractor.java
@@ -105,11 +105,18 @@ public final class OpenTelemetryAttributesExtractor {
     return headers;
   }
 
+  @SuppressWarnings("deprecation")
   public @Nullable String extractUrl(
       final @NotNull Attributes attributes, final @NotNull SentryOptions options) {
     final @Nullable String urlFull = attributes.get(UrlAttributes.URL_FULL);
     if (urlFull != null) {
       return urlFull;
+    }
+
+    final @Nullable String deprecatedUrl =
+        attributes.get(io.opentelemetry.semconv.SemanticAttributes.HTTP_URL);
+    if (deprecatedUrl != null) {
+      return deprecatedUrl;
     }
 
     final String urlString = buildUrlString(attributes, options);

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OpenTelemetryAttributesExtractorTest.kt
@@ -4,6 +4,7 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.internal.AttributesMap
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.SemanticAttributes
 import io.opentelemetry.semconv.ServerAttributes
 import io.opentelemetry.semconv.UrlAttributes
 import io.sentry.Scope
@@ -194,6 +195,19 @@ class OpenTelemetryAttributesExtractorTest {
         givenAttributes(
             mapOf(
                 UrlAttributes.URL_FULL to "https://sentry.io/some/path"
+            )
+        )
+
+        val url = whenExtractingUrl()
+
+        assertEquals("https://sentry.io/some/path", url)
+    }
+
+    @Test
+    fun `returns deprecated URL if present`() {
+        givenAttributes(
+            mapOf(
+                SemanticAttributes.HTTP_URL to "https://sentry.io/some/path"
             )
         )
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OtelInternalSpanDetectionUtilTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/OtelInternalSpanDetectionUtilTest.kt
@@ -1,0 +1,251 @@
+package io.sentry.opentelemetry
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.sdk.internal.AttributesMap
+import io.opentelemetry.semconv.HttpAttributes
+import io.opentelemetry.semconv.SemanticAttributes
+import io.opentelemetry.semconv.ServerAttributes
+import io.opentelemetry.semconv.UrlAttributes
+import io.sentry.IScopes
+import io.sentry.SentryOptions
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OtelInternalSpanDetectionUtilTest {
+
+    private class Fixture {
+        val scopes = mock<IScopes>()
+        val attributes = AttributesMap.create(100, 100)
+        val options = SentryOptions.empty()
+        var spanKind: SpanKind = SpanKind.INTERNAL
+
+        init {
+            whenever(scopes.options).thenReturn(options)
+        }
+    }
+
+    private val fixture = Fixture()
+
+    @Test
+    fun `detects split url as internal (span kind client)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+                UrlAttributes.URL_SCHEME to "https",
+                UrlAttributes.URL_PATH to "/path/to/123",
+                UrlAttributes.URL_QUERY to "q=123456&b=X",
+                ServerAttributes.SERVER_ADDRESS to "io.sentry",
+                ServerAttributes.SERVER_PORT to 8081L
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects full url as internal (span kind client)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects deprecated url as internal (span kind client)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                SemanticAttributes.HTTP_URL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects split url as internal (span kind internal)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.INTERNAL)
+        givenAttributes(
+            mapOf(
+                HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+                UrlAttributes.URL_SCHEME to "https",
+                UrlAttributes.URL_PATH to "/path/to/123",
+                UrlAttributes.URL_QUERY to "q=123456&b=X",
+                ServerAttributes.SERVER_ADDRESS to "io.sentry",
+                ServerAttributes.SERVER_PORT to 8081L
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects full url as internal (span kind internal)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.INTERNAL)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects deprecated url as internal (span kind internal)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.INTERNAL)
+        givenAttributes(
+            mapOf(
+                SemanticAttributes.HTTP_URL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `does not detect full url as internal (span kind server)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.SERVER)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsNotConsideredInternal()
+    }
+
+    @Test
+    fun `does not detect full url as internal (span kind producer)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.PRODUCER)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsNotConsideredInternal()
+    }
+
+    @Test
+    fun `does not detect full url as internal (span kind consumer)`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpanKind(SpanKind.CONSUMER)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "https://io.sentry:8081"
+            )
+        )
+
+        thenRequestIsNotConsideredInternal()
+    }
+
+    @Test
+    fun `detects full spotlight url as internal`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpotlightEnabled(true)
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "http://localhost:8969/stream"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `detects full spotlight url as internal with custom spotlight url`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpotlightEnabled(true)
+        givenSpotlightUrl("http://localhost:8090/stream")
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "http://localhost:8090/stream"
+            )
+        )
+
+        thenRequestIsConsideredInternal()
+    }
+
+    @Test
+    fun `does not detect mismatching full spotlight url as internal`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpotlightEnabled(true)
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "http://localhost:8080/stream"
+            )
+        )
+
+        thenRequestIsNotConsideredInternal()
+    }
+
+    @Test
+    fun `does not detect mismatching full customized spotlight url as internal`() {
+        givenDsn("https://publicKey:secretKey@io.sentry:8081/path/id?sample.rate=0.1")
+        givenSpotlightEnabled(true)
+        givenSpotlightUrl("http://localhost:8090/stream")
+        givenSpanKind(SpanKind.CLIENT)
+        givenAttributes(
+            mapOf(
+                UrlAttributes.URL_FULL to "http://localhost:8091/stream"
+            )
+        )
+
+        thenRequestIsNotConsideredInternal()
+    }
+
+    private fun givenAttributes(map: Map<AttributeKey<out Any>, Any>) {
+        map.forEach { k, v ->
+            fixture.attributes.put(k, v)
+        }
+    }
+
+    private fun givenDsn(dsn: String) {
+        fixture.options.dsn = dsn
+    }
+
+    private fun givenSpotlightEnabled(enabled: Boolean) {
+        fixture.options.isEnableSpotlight = enabled
+    }
+
+    private fun givenSpotlightUrl(url: String) {
+        fixture.options.spotlightConnectionUrl = url
+    }
+
+    private fun givenSpanKind(spanKind: SpanKind) {
+        fixture.spanKind = spanKind
+    }
+
+    private fun thenRequestIsConsideredInternal() {
+        assertTrue(checkIfInternal())
+    }
+
+    private fun thenRequestIsNotConsideredInternal() {
+        assertFalse(checkIfInternal())
+    }
+
+    private fun checkIfInternal(): Boolean {
+        return OtelInternalSpanDetectionUtil.isSentryRequest(fixture.scopes, fixture.spanKind, fixture.attributes)
+    }
+}

--- a/sentry/src/main/java/io/sentry/DsnUtil.java
+++ b/sentry/src/main/java/io/sentry/DsnUtil.java
@@ -31,6 +31,13 @@ public final class DsnUtil {
       return false;
     }
 
-    return url.toLowerCase(Locale.ROOT).contains(dsnHost.toLowerCase(Locale.ROOT));
+    final @NotNull String lowerCaseHost = dsnHost.toLowerCase(Locale.ROOT);
+    final int dsnPort = sentryUri.getPort();
+
+    if (dsnPort > 0) {
+      return url.toLowerCase(Locale.ROOT).contains(lowerCaseHost + ":" + dsnPort);
+    } else {
+      return url.toLowerCase(Locale.ROOT).contains(lowerCaseHost);
+    }
   }
 }

--- a/sentry/src/test/java/io/sentry/DsnUtilTest.kt
+++ b/sentry/src/test/java/io/sentry/DsnUtilTest.kt
@@ -40,6 +40,16 @@ class DsnUtilTest {
         assertFalse(DsnUtil.urlContainsDsnHost(optionsWithDsn(DSN), null))
     }
 
+    @Test
+    fun `returns false for same host but different port`() {
+        assertFalse(DsnUtil.urlContainsDsnHost(optionsWithDsn("http://publicKey:secretKey@localhost:8080/path/id?sample.rate=0.1"), "localhost:8081"))
+    }
+
+    @Test
+    fun `returns true for same host and port`() {
+        assertTrue(DsnUtil.urlContainsDsnHost(optionsWithDsn("http://publicKey:secretKey@localhost:8080/path/id?sample.rate=0.1"), "localhost:8080"))
+    }
+
     private fun optionsWithDsn(dsn: String?): SentryOptions {
         return SentryOptions().also {
             it.dsn = dsn


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We now check the hostname and port to see if a request is being made to Sentry.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running tests, we set the DSN to a localhost URL which then disabled injection of tracing information for requests that also go to localhost.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
