### PR TITLE
Propagate modifications of OkHttp requests to the affected spans / breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Modifications to OkHttp requests are now properly propagated to the affected span / breadcrumbs ([#4238](https://github.com/getsentry/sentry-java/pull/4238))
+  - Please ensure the SentryOkHttpInterceptor is added last to your OkHttpClient, as otherwise changes to the `Request`  by subsequent interceptors won't be considered
+ 
 ### Features
 
 - The SDK now automatically propagates the trace-context to the native layer. This allows to connect errors on different layers of the application. ([#4137](https://github.com/getsentry/sentry-java/pull/4137))

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpEvent.kt
@@ -28,28 +28,59 @@ internal class SentryOkHttpEvent(private val scopes: IScopes, private val reques
     private var response: Response? = null
     private var clientErrorResponse: Response? = null
     private val isEventFinished = AtomicBoolean(false)
-    private val url: String
-    private val method: String
+    private var url: String
+    private var method: String
 
     init {
         val urlDetails = UrlUtils.parse(request.url.toString())
         url = urlDetails.urlOrFallback
-        val host: String = request.url.host
-        val encodedPath: String = request.url.encodedPath
         method = request.method
 
         // We start the call span that will contain all the others
         val parentSpan = if (Platform.isAndroid()) scopes.transaction else scopes.span
-        callSpan = parentSpan?.startChild("http.client", "$method $url")
+        callSpan = parentSpan?.startChild("http.client")
         callSpan?.spanContext?.origin = TRACE_ORIGIN
+
+        breadcrumb = Breadcrumb().apply {
+            type = "http"
+            category = "http"
+            // needs this as unix timestamp for rrweb
+            setData(
+                SpanDataConvention.HTTP_START_TIMESTAMP,
+                CurrentDateProvider.getInstance().currentTimeMillis
+            )
+        }
+
+        setRequest(request)
+    }
+
+    /**
+     * Sets the request.
+     * This function may be called multiple times in case the request changes e.g. due to interceptors.
+     */
+    fun setRequest(request: Request) {
+        val urlDetails = UrlUtils.parse(request.url.toString())
+        url = urlDetails.urlOrFallback
+
+        val host: String = request.url.host
+        val encodedPath: String = request.url.encodedPath
+        method = request.method
+
+        callSpan?.description = "$method $url"
         urlDetails.applyToSpan(callSpan)
 
-        // We setup a breadcrumb with all meaningful data
-        breadcrumb = Breadcrumb.http(url, method)
         breadcrumb.setData("host", host)
         breadcrumb.setData("path", encodedPath)
-        // needs this as unix timestamp for rrweb
-        breadcrumb.setData(SpanDataConvention.HTTP_START_TIMESTAMP, CurrentDateProvider.getInstance().currentTimeMillis)
+        if (urlDetails.url != null) {
+            breadcrumb.setData("url", urlDetails.url!!)
+        }
+        breadcrumb.setData("method", method.uppercase())
+        if (urlDetails.query != null) {
+            breadcrumb.setData("http.query", urlDetails.query!!)
+        }
+        if (urlDetails.fragment != null) {
+            breadcrumb.setData("http.fragment", urlDetails.fragment!!)
+        }
 
         // We add the same data to the call span
         callSpan?.setData("url", url)

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -82,9 +82,6 @@ public open class SentryOkHttpInterceptor(
             span = parentSpan?.startChild("http.client", "$method $url")
         }
 
-        // interceptors may change the request details, so let's update it here
-        // this only works correctly if SentryOkHttpInterceptor is the last one in the chain
-        okHttpEvent?.setRequest(request)
         val startTimestamp = CurrentDateProvider.getInstance().currentTimeMillis
 
         span?.spanContext?.origin = TRACE_ORIGIN
@@ -145,6 +142,10 @@ public open class SentryOkHttpInterceptor(
             }
             throw e
         } finally {
+            // interceptors may change the request details, so let's update it here
+            // this only works correctly if SentryOkHttpInterceptor is the last one in the chain
+            okHttpEvent?.setRequest(request)
+
             finishSpan(span, request, response, isFromEventListener, okHttpEvent)
 
             // The SentryOkHttpEventListener will send the breadcrumb itself if used for this call

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -81,6 +81,10 @@ public open class SentryOkHttpInterceptor(
             val parentSpan = if (Platform.isAndroid()) scopes.transaction else scopes.span
             span = parentSpan?.startChild("http.client", "$method $url")
         }
+
+        // interceptors may change the request details, so let's update it here
+        // this only works correctly if SentryOkHttpInterceptor is the last one in the chain
+        okHttpEvent?.setRequest(request)
         val startTimestamp = CurrentDateProvider.getInstance().currentTimeMillis
 
         span?.spanContext?.origin = TRACE_ORIGIN


### PR DESCRIPTION
## :scroll: Description
Makes span/breadcrumb data mutable, so we can update it whenever the underlying http request changes.

Unfortunately the okhttp `EventListener` always gets the _original_ request in most of it's callbacks, even though interceptors have changed the request already. Only when a response is received (e.g. `responseHeadersStart()`) the `response.request.call` would contain the actual request, which probably isn't always called due to caching / errors, etc..

Thus we need to wire the update logic into our interceptor instead - and assume it's running last in the chain.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/3610


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
