### PR TITLE
Add support for setting in-app-includes/in-app-excludes via AndroidManifest.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add support for setting in-app-includes/in-app-excludes via AndroidManifest.xml ([#4240](https://github.com/getsentry/sentry-java/pull/4240))
+
 ### Features
 
 - The SDK now automatically propagates the trace-context to the native layer. This allows to connect errors on different layers of the application. ([#4137](https://github.com/getsentry/sentry-java/pull/4137))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -107,6 +107,10 @@ final class ManifestMetadataReader {
 
   static final String IGNORED_ERRORS = "io.sentry.ignored-errors";
 
+  static final String IN_APP_INCLUDES = "io.sentry.in-app-includes";
+
+  static final String IN_APP_EXCLUDES = "io.sentry.in-app-excludes";
+
   static final String ENABLE_AUTO_TRACE_ID_GENERATION =
       "io.sentry.traces.enable-auto-id-generation";
 
@@ -414,8 +418,21 @@ final class ManifestMetadataReader {
             .setMaskAllImages(readBool(metadata, logger, REPLAYS_MASK_ALL_IMAGES, true));
 
         options.setIgnoredErrors(readList(metadata, logger, IGNORED_ERRORS));
-      }
 
+        final @Nullable List<String> includes = readList(metadata, logger, IN_APP_INCLUDES);
+        if (includes != null && !includes.isEmpty()) {
+          for (final @NotNull String include : includes) {
+            options.addInAppInclude(include);
+          }
+        }
+
+        final @Nullable List<String> excludes = readList(metadata, logger, IN_APP_EXCLUDES);
+        if (excludes != null && !excludes.isEmpty()) {
+          for (final @NotNull String exclude : excludes) {
+            options.addInAppExclude(exclude);
+          }
+        }
+      }
       options
           .getLogger()
           .log(SentryLevel.INFO, "Retrieving configuration from AndroidManifest.xml");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -1447,4 +1447,54 @@ class ManifestMetadataReaderTest {
         // Assert
         assertEquals(listOf(FilterString("Some error"), FilterString("Another .*")), fixture.options.ignoredErrors)
     }
+
+    @Test
+    fun `applyMetadata reads inAppIncludes to options and sets the value if found`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.IN_APP_INCLUDES to "com.example.package1,com.example.package2")
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(listOf("com.example.package1", "com.example.package2"), fixture.options.inAppIncludes)
+    }
+
+    @Test
+    fun `applyMetadata reads inAppIncludes to options and keeps empty if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.inAppIncludes.isEmpty())
+    }
+
+    @Test
+    fun `applyMetadata reads inAppExcludes to options and sets the value if found`() {
+        // Arrange
+        val bundle = bundleOf(ManifestMetadataReader.IN_APP_EXCLUDES to "com.example.excluded1,com.example.excluded2")
+        val context = fixture.getContext(metaData = bundle)
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertEquals(listOf("com.example.excluded1", "com.example.excluded2"), fixture.options.inAppExcludes)
+    }
+
+    @Test
+    fun `applyMetadata reads inAppExcludes to options and keeps empty if not found`() {
+        // Arrange
+        val context = fixture.getContext()
+
+        // Act
+        ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+        // Assert
+        assertTrue(fixture.options.inAppExcludes.isEmpty())
+    }
 }


### PR DESCRIPTION
## :scroll: Description
We officially support it [according to our docs](https://docs.sentry.io/platforms/android/configuration/options/#in-app-include), but actually it's not implemented.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2617

## :green_heart: How did you test it?
Added tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
