### PR TITLE
Fix properly reset application/content-provider timespans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix Ensure app start type is set, even when ActivityLifecycleIntegration is not running ([#4216](https://github.com/getsentry/sentry-java/pull/4216))
+- Fix properly reset application/content-provider timespans for warm app starts ([#4244](https://github.com/getsentry/sentry-java/pull/4244))
 
 ## 7.22.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -318,6 +318,8 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
         appStartSpan.start();
         appStartSpan.setStartedAt(nowUptimeMs);
         CLASS_LOADED_UPTIME_MS = nowUptimeMs;
+        contentProviderOnCreates.clear();
+        applicationOnCreate.reset();
       } else {
         appStartType = savedInstanceState == null ? AppStartType.COLD : AppStartType.WARM;
       }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTest.kt
@@ -154,6 +154,19 @@ class AppStartMetricsTest {
         val metrics = AppStartMetrics.getInstance()
         metrics.registerLifecycleCallbacks(mock<Application>())
 
+        metrics.contentProviderOnCreateTimeSpans.add(
+            TimeSpan().apply {
+                description = "ExampleContentProvider"
+                setStartedAt(1)
+                setStoppedAt(2)
+            }
+        )
+
+        metrics.applicationOnCreateTimeSpan.apply {
+            setStartedAt(3)
+            setStoppedAt(4)
+        }
+
         // when the looper runs
         Shadows.shadowOf(Looper.getMainLooper()).idle()
 
@@ -173,6 +186,8 @@ class AppStartMetricsTest {
         assertTrue(metrics.shouldSendStartMeasurements())
         assertTrue(metrics.appStartTimeSpan.hasStarted())
         assertEquals(now, metrics.appStartTimeSpan.startUptimeMs)
+        assertFalse(metrics.applicationOnCreateTimeSpan.hasStarted())
+        assertTrue(metrics.contentProviderOnCreateTimeSpans.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
As otherwise they would happen before application init.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
