### PR TITLE
Pass OpenTelemetry span attributes into TracesSampler callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Fix "class ch.qos.logback.classic.spi.ThrowableProxyVO cannot be cast to class ch.qos.logback.classic.spi.ThrowableProxy" ([#4206](https://github.com/getsentry/sentry-java/pull/4206))
   - In this case we cannot report the `Throwable` to Sentry as it's not available
   - If you are using OpenTelemetry v1 `OpenTelemetryAppender`, please consider upgrading to v2
+- Pass OpenTelemetry span attributes into TracesSampler callback ([#4253](https://github.com/getsentry/sentry-java/pull/4253))
+  - `SamplingContext` now has a `getAttribute` method that grants access to OpenTelemetry span attributes via their String key (e.g. `http.request.method`)
 
 ### Features
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySampler.java
@@ -23,11 +23,9 @@ import io.sentry.TracesSamplingDecision;
 import io.sentry.TransactionContext;
 import io.sentry.clientreport.DiscardReason;
 import io.sentry.protocol.SentryId;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,7 +72,9 @@ public final class SentrySampler implements Sampler {
   }
 
   private @NotNull SamplingResult handleRootOtelSpan(
-      final @NotNull String traceId, final @NotNull Context parentContext, final @NotNull Attributes attributes) {
+      final @NotNull String traceId,
+      final @NotNull Context parentContext,
+      final @NotNull Attributes attributes) {
     if (!scopes.getOptions().isTracingEnabled()) {
       return SamplingResult.create(SamplingDecision.RECORD_ONLY);
     }
@@ -100,7 +100,11 @@ public final class SentrySampler implements Sampler {
             .getOptions()
             .getInternalTracesSampler()
             .sample(
-                new SamplingContext(transactionContext, null, propagationContext.getSampleRand(), toMapWithStringKeys(attributes)));
+                new SamplingContext(
+                    transactionContext,
+                    null,
+                    propagationContext.getSampleRand(),
+                    toMapWithStringKeys(attributes)));
 
     if (!sentryDecision.getSampled()) {
       scopes
@@ -144,12 +148,12 @@ public final class SentrySampler implements Sampler {
 
     if (attributes != null) {
       attributes.forEach(
-        (key, value) -> {
-          if (key != null) {
-            final @NotNull String stringKey = key.getKey();
+          (key, value) -> {
+            if (key != null) {
+              final @NotNull String stringKey = key.getKey();
               mapWithStringKeys.put(stringKey, value);
             }
-        });
+          });
     }
 
     return mapWithStringKeys;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2023,7 +2023,8 @@ public final class io/sentry/RequestDetails {
 
 public final class io/sentry/SamplingContext {
 	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)V
-	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Ljava/lang/Double;)V
+	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Ljava/lang/Double;Ljava/util/Map;)V
+	public fun getAttribute (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getCustomSamplingContext ()Lio/sentry/CustomSamplingContext;
 	public fun getSampleRand ()Ljava/lang/Double;
 	public fun getTransactionContext ()Lio/sentry/TransactionContext;

--- a/sentry/src/main/java/io/sentry/SamplingContext.java
+++ b/sentry/src/main/java/io/sentry/SamplingContext.java
@@ -2,12 +2,11 @@ package io.sentry;
 
 import io.sentry.util.Objects;
 import io.sentry.util.SentryRandom;
+import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Context used by {@link io.sentry.SentryOptions.TracesSamplerCallback} to determine if transaction

--- a/sentry/src/main/java/io/sentry/SamplingContext.java
+++ b/sentry/src/main/java/io/sentry/SamplingContext.java
@@ -6,6 +6,9 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Context used by {@link io.sentry.SentryOptions.TracesSamplerCallback} to determine if transaction
  * is going to be sampled.
@@ -14,6 +17,7 @@ public final class SamplingContext {
   private final @NotNull TransactionContext transactionContext;
   private final @Nullable CustomSamplingContext customSamplingContext;
   private final @NotNull Double sampleRand;
+  private final @NotNull Map<String, Object> attributes;
 
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
@@ -23,18 +27,20 @@ public final class SamplingContext {
   public SamplingContext(
       final @NotNull TransactionContext transactionContext,
       final @Nullable CustomSamplingContext customSamplingContext) {
-    this(transactionContext, customSamplingContext, SentryRandom.current().nextDouble());
+    this(transactionContext, customSamplingContext, SentryRandom.current().nextDouble(), null);
   }
 
   @ApiStatus.Internal
   public SamplingContext(
       final @NotNull TransactionContext transactionContext,
       final @Nullable CustomSamplingContext customSamplingContext,
-      final @NotNull Double sampleRand) {
+      final @NotNull Double sampleRand,
+      final @Nullable Map<String, Object> attributes) {
     this.transactionContext =
         Objects.requireNonNull(transactionContext, "transactionContexts is required");
     this.customSamplingContext = customSamplingContext;
     this.sampleRand = sampleRand;
+    this.attributes = attributes == null ? Collections.emptyMap() : attributes;
   }
 
   public @Nullable CustomSamplingContext getCustomSamplingContext() {
@@ -47,5 +53,12 @@ public final class SamplingContext {
 
   public @NotNull Double getSampleRand() {
     return sampleRand;
+  }
+
+  public @Nullable Object getAttribute(final @Nullable String key) {
+    if (key == null) {
+      return null;
+    }
+    return this.attributes.get(key);
   }
 }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -860,7 +860,7 @@ public final class Scopes implements IScopes {
       final Double sampleRand = getSampleRand(transactionContext);
       final SamplingContext samplingContext =
           new SamplingContext(
-              transactionContext, transactionOptions.getCustomSamplingContext(), sampleRand);
+              transactionContext, transactionOptions.getCustomSamplingContext(), sampleRand, null);
       final @NotNull TracesSampler tracesSampler = getOptions().getInternalTracesSampler();
       @NotNull TracesSamplingDecision samplingDecision = tracesSampler.sample(samplingContext);
       transactionContext.setSamplingDecision(samplingDecision);

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -460,7 +460,7 @@ public final class Sentry {
     TransactionContext appStartTransactionContext = new TransactionContext("app.launch", "profile");
     appStartTransactionContext.setForNextAppStart(true);
     SamplingContext appStartSamplingContext =
-        new SamplingContext(appStartTransactionContext, null, SentryRandom.current().nextDouble());
+        new SamplingContext(appStartTransactionContext, null, SentryRandom.current().nextDouble(), null);
     return options.getInternalTracesSampler().sample(appStartSamplingContext);
   }
 

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -460,7 +460,8 @@ public final class Sentry {
     TransactionContext appStartTransactionContext = new TransactionContext("app.launch", "profile");
     appStartTransactionContext.setForNextAppStart(true);
     SamplingContext appStartSamplingContext =
-        new SamplingContext(appStartTransactionContext, null, SentryRandom.current().nextDouble(), null);
+        new SamplingContext(
+            appStartTransactionContext, null, SentryRandom.current().nextDouble(), null);
     return options.getInternalTracesSampler().sample(appStartSamplingContext);
   }
 

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -46,7 +46,7 @@ class TracesSamplerTest {
     @Test
     fun `when tracesSampleRate is set and random returns greater number returns false`() {
         val sampler = fixture.getSut(tracesSampleRate = 0.2, profilesSampleRate = 0.2)
-        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.9))
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.9, null))
         assertFalse(samplingDecision.sampled)
         assertEquals(0.2, samplingDecision.sampleRate)
         assertEquals(0.9, samplingDecision.sampleRand)
@@ -55,7 +55,7 @@ class TracesSamplerTest {
     @Test
     fun `when tracesSampleRate is set and random returns lower number returns true`() {
         val sampler = fixture.getSut(tracesSampleRate = 0.2, profilesSampleRate = 0.2)
-        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.1))
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.1, null))
         assertTrue(samplingDecision.sampled)
         assertEquals(0.2, samplingDecision.sampleRate)
         assertEquals(0.1, samplingDecision.sampleRand)
@@ -64,7 +64,7 @@ class TracesSamplerTest {
     @Test
     fun `when profilesSampleRate is set and random returns greater number returns false`() {
         val sampler = fixture.getSut(tracesSampleRate = 1.0, profilesSampleRate = 0.2)
-        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.9))
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.9, null))
         assertTrue(samplingDecision.sampled)
         assertFalse(samplingDecision.profileSampled)
         assertEquals(0.2, samplingDecision.profileSampleRate)
@@ -74,7 +74,7 @@ class TracesSamplerTest {
     @Test
     fun `when profilesSampleRate is set and random returns lower number returns true`() {
         val sampler = fixture.getSut(tracesSampleRate = 1.0, profilesSampleRate = 0.2)
-        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.1))
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.1, null))
         assertTrue(samplingDecision.sampled)
         assertTrue(samplingDecision.profileSampled)
         assertEquals(0.2, samplingDecision.profileSampleRate)
@@ -84,7 +84,7 @@ class TracesSamplerTest {
     @Test
     fun `when trace is not sampled, profile is not sampled`() {
         val sampler = fixture.getSut(tracesSampleRate = 0.0, profilesSampleRate = 1.0)
-        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.3))
+        val samplingDecision = sampler.sample(SamplingContext(TransactionContext("name", "op"), null, 0.3, null))
         assertFalse(samplingDecision.sampled)
         assertFalse(samplingDecision.profileSampled)
         assertEquals(1.0, samplingDecision.profileSampleRate)
@@ -101,7 +101,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -116,7 +117,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -132,7 +134,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.9
+                0.9,
+                null
             )
         )
         assertFalse(samplingDecision.sampled)
@@ -147,7 +150,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.9
+                0.9,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -165,7 +169,8 @@ class TracesSamplerTest {
             SamplingContext(
                 transactionContextParentSampled,
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -182,7 +187,8 @@ class TracesSamplerTest {
             SamplingContext(
                 transactionContextParentSampled,
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -198,7 +204,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -213,7 +220,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -228,7 +236,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertFalse(samplingDecision.sampled)
@@ -243,7 +252,8 @@ class TracesSamplerTest {
             SamplingContext(
                 TransactionContext("name", "op"),
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecision.sampled)
@@ -261,7 +271,8 @@ class TracesSamplerTest {
             SamplingContext(
                 transactionContextParentNotSampled,
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertFalse(samplingDecision.sampled)
@@ -276,7 +287,8 @@ class TracesSamplerTest {
             SamplingContext(
                 transactionContextParentSampled,
                 CustomSamplingContext(),
-                0.1
+                0.1,
+                null
             )
         )
         assertTrue(samplingDecisionParentSampled.sampled)
@@ -309,7 +321,7 @@ class TracesSamplerTest {
         val transactionContextNotSampled = TransactionContext("name", "op")
         transactionContextNotSampled.sampled = false
         val samplingDecision =
-            sampler.sample(SamplingContext(transactionContextNotSampled, CustomSamplingContext(), 0.1))
+            sampler.sample(SamplingContext(transactionContextNotSampled, CustomSamplingContext(), 0.1, null))
         assertFalse(samplingDecision.sampled)
         assertNull(samplingDecision.sampleRate)
         assertNotNull(samplingDecision.sampleRand)
@@ -319,7 +331,7 @@ class TracesSamplerTest {
         val transactionContextSampled = TransactionContext("name", "op")
         transactionContextSampled.setSampled(true, true)
         val samplingDecisionContextSampled =
-            sampler.sample(SamplingContext(transactionContextSampled, CustomSamplingContext(), 0.1))
+            sampler.sample(SamplingContext(transactionContextSampled, CustomSamplingContext(), 0.1, null))
         assertTrue(samplingDecisionContextSampled.sampled)
         assertNull(samplingDecisionContextSampled.sampleRate)
         assertNotNull(samplingDecisionContextSampled.sampleRand)
@@ -329,7 +341,7 @@ class TracesSamplerTest {
         val transactionContextUnsampledWithProfile = TransactionContext("name", "op")
         transactionContextUnsampledWithProfile.setSampled(false, true)
         val samplingDecisionContextUnsampledWithProfile =
-            sampler.sample(SamplingContext(transactionContextUnsampledWithProfile, CustomSamplingContext(), 0.1))
+            sampler.sample(SamplingContext(transactionContextUnsampledWithProfile, CustomSamplingContext(), 0.1, null))
         assertFalse(samplingDecisionContextUnsampledWithProfile.sampled)
         assertNull(samplingDecisionContextUnsampledWithProfile.sampleRate)
         assertNotNull(samplingDecisionContextUnsampledWithProfile.sampleRand)
@@ -350,7 +362,7 @@ class TracesSamplerTest {
             logger = logger
         )
         val decision = sampler.sample(
-            SamplingContext(TransactionContext("name", "op"), null, 0.1)
+            SamplingContext(TransactionContext("name", "op"), null, 0.1, null)
         )
         assertFalse(decision.profileSampled)
         verify(logger).log(eq(SentryLevel.ERROR), any(), eq(exception))
@@ -367,7 +379,7 @@ class TracesSamplerTest {
             }
         )
         val decision = sampler.sample(
-            SamplingContext(TransactionContext("name", "op"), null, 0.0)
+            SamplingContext(TransactionContext("name", "op"), null, 0.0, null)
         )
         assertTrue(decision.profileSampled)
         assertEquals(0.0, decision.sampleRand)
@@ -385,7 +397,7 @@ class TracesSamplerTest {
             logger = logger
         )
         val decision = sampler.sample(
-            SamplingContext(TransactionContext("name", "op"), null, 0.1)
+            SamplingContext(TransactionContext("name", "op"), null, 0.1, null)
         )
         assertFalse(decision.sampled)
         assertEquals(0.1, decision.sampleRand)
@@ -402,9 +414,60 @@ class TracesSamplerTest {
             }
         )
         val decision = sampler.sample(
-            SamplingContext(TransactionContext("name", "op"), null, 0.0)
+            SamplingContext(TransactionContext("name", "op"), null, 0.0, null)
         )
         assertTrue(decision.sampled)
         assertEquals(0.0, decision.sampleRand)
+    }
+
+    @Test
+    fun `attributes can be accessed in callback`() {
+        val exception = Exception("faulty TracesSamplerCallback")
+        var attributeValue: Any? = null
+        val sampler = fixture.getSut(
+            tracesSamplerCallback = { samplingContext ->
+                attributeValue = samplingContext.getAttribute("attr")
+                1.0
+            }
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null, 0.0, mapOf("attr" to "123"))
+        )
+        assertTrue(decision.sampled)
+        assertEquals("123", attributeValue)
+    }
+
+    @Test
+    fun `non existing attribute returns null in callback`() {
+        val exception = Exception("faulty TracesSamplerCallback")
+        var attributeValue: Any? = null
+        val sampler = fixture.getSut(
+            tracesSamplerCallback = { samplingContext ->
+                attributeValue = samplingContext.getAttribute("i-do-not-exist")
+                1.0
+            }
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null, 0.0, mapOf("attr" to "123"))
+        )
+        assertTrue(decision.sampled)
+        assertNull(attributeValue)
+    }
+
+    @Test
+    fun `null attributes return null`() {
+        val exception = Exception("faulty TracesSamplerCallback")
+        var attributeValue: Any? = null
+        val sampler = fixture.getSut(
+            tracesSamplerCallback = { samplingContext ->
+                attributeValue = samplingContext.getAttribute("i-do-not-exist")
+                1.0
+            }
+        )
+        val decision = sampler.sample(
+            SamplingContext(TransactionContext("name", "op"), null, 0.0, null)
+        )
+        assertTrue(decision.sampled)
+        assertNull(attributeValue)
     }
 }

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -422,7 +422,6 @@ class TracesSamplerTest {
 
     @Test
     fun `attributes can be accessed in callback`() {
-        val exception = Exception("faulty TracesSamplerCallback")
         var attributeValue: Any? = null
         val sampler = fixture.getSut(
             tracesSamplerCallback = { samplingContext ->
@@ -439,7 +438,6 @@ class TracesSamplerTest {
 
     @Test
     fun `non existing attribute returns null in callback`() {
-        val exception = Exception("faulty TracesSamplerCallback")
         var attributeValue: Any? = null
         val sampler = fixture.getSut(
             tracesSamplerCallback = { samplingContext ->
@@ -456,7 +454,6 @@ class TracesSamplerTest {
 
     @Test
     fun `null attributes return null`() {
-        val exception = Exception("faulty TracesSamplerCallback")
         var attributeValue: Any? = null
         val sampler = fixture.getSut(
             tracesSamplerCallback = { samplingContext ->


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`SamplingContext` now has a `getAttribute` method granting access to OpenTelemetry span attributes when Sentry is used in OpenTelemetry mode.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4192

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
