### PR TITLE
Override default interface impl to fix AbstractMethodError

### DIFF
--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -51,6 +51,12 @@ public object SentryModifier {
         Modifier.Node(),
         SemanticsModifierNode {
 
+        override val shouldClearDescendantSemantics: Boolean
+            get() = false
+
+        override val shouldMergeDescendantSemantics: Boolean
+            get() = false
+
         override fun SemanticsPropertyReceiver.applySemantics() {
             this[SentryTag] = tag
         }


### PR DESCRIPTION
## :scroll: Description

`SemanticsModifierNode` provides default interface implementations, which could cause `AbstractMethodError` if the consuming app doesn't support the Java 1.8 features.

See https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/SemanticsModifierNode.kt;l=37-67;drc=adf6e7487c0412208c2b582e7d572649ab32503f

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/4249

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
