### PR TITLE
Fix AbstractMethodError when using SentryTraced for Jetpack Compose (7.x.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix AbstractMethodError when using SentryTraced for Jetpack Compose ([#4256](https://github.com/getsentry/sentry-java/pull/4256))
+
 ## 7.22.1
 
 ### Fixes

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -51,6 +51,12 @@ public object SentryModifier {
         Modifier.Node(),
         SemanticsModifierNode {
 
+        override val shouldClearDescendantSemantics: Boolean
+            get() = false
+
+        override val shouldMergeDescendantSemantics: Boolean
+            get() = false
+
         override fun SemanticsPropertyReceiver.applySemantics() {
             this[SentryTag] = tag
         }


### PR DESCRIPTION
## :scroll: Description

https://github.com/getsentry/sentry-java/pull/4255 for 7.x.x

## :crystal_ball: Next steps
