### PR TITLE
Change continuous profiling API names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     - This enables symbolication for stripped native code in ANRs
 - Add Continuous Profiling Support ([#3710](https://github.com/getsentry/sentry-java/pull/3710))
 
-  To enable Continuous Profiling use the `Sentry.startProfileSession` and `Sentry.stopProfileSession` experimental APIs. Sampling rate can be set through `options.profileSessionSampleRate`, which defaults to null (disabled).   
+  To enable Continuous Profiling use the `Sentry.startProfiler` and `Sentry.stopProfiler` experimental APIs. Sampling rate can be set through `options.profileSessionSampleRate`, which defaults to null (disabled).   
   Note: Both `options.profilesSampler` and `options.profilesSampleRate` must **not** be set to enable Continuous Profiling.
 
   ```java
@@ -19,15 +19,15 @@
    
     // Currently under experimental options:
     options.getExperimental().setProfileSessionSampleRate(1.0);
-    // In manual mode, you need to start and stop the profiler manually using Sentry.startProfileSession and Sentry.stopProfileSession
+    // In manual mode, you need to start and stop the profiler manually using Sentry.startProfiler and Sentry.stopProfiler
     // In trace mode, the profiler will start and stop automatically whenever a sampled trace starts and finishes
     options.getExperimental().setProfileLifecycle(ProfileLifecycle.MANUAL);
   }
   // Start profiling
-  Sentry.startProfileSession();
+  Sentry.startProfiler();
   
   // After all profiling is done, stop the profiler. Profiles can last indefinitely if not stopped.
-  Sentry.stopProfileSession();
+  Sentry.stopProfiler();
   ```
   ```kotlin
   import io.sentry.ProfileLifecycle
@@ -37,15 +37,15 @@
    
     // Currently under experimental options:
     options.experimental.profileSessionSampleRate = 1.0
-    // In manual mode, you need to start and stop the profiler manually using Sentry.startProfileSession and Sentry.stopProfileSession
+    // In manual mode, you need to start and stop the profiler manually using Sentry.startProfiler and Sentry.stopProfiler
     // In trace mode, the profiler will start and stop automatically whenever a sampled trace starts and finishes
     options.experimental.profileLifecycle = ProfileLifecycle.MANUAL
   }
   // Start profiling
-  Sentry.startProfileSession()
+  Sentry.startProfiler()
   
   // After all profiling is done, stop the profiler. Profiles can last indefinitely if not stopped.
-  Sentry.stopProfileSession()
+  Sentry.stopProfiler()
   ```
 
   To learn more visit [Sentry's Continuous Profiling](https://docs.sentry.io/product/explore/profiling/transaction-vs-continuous-profiling/#continuous-profiling-mode) documentation page.

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -48,8 +48,8 @@ public class io/sentry/android/core/AndroidContinuousProfiler : io/sentry/IConti
 	public fun isRunning ()Z
 	public fun onRateLimitChanged (Lio/sentry/transport/RateLimiter;)V
 	public fun reevaluateSampling ()V
-	public fun startProfileSession (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
-	public fun stopProfileSession (Lio/sentry/ProfileLifecycle;)V
+	public fun startProfiler (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
+	public fun stopProfiler (Lio/sentry/ProfileLifecycle;)V
 }
 
 public final class io/sentry/android/core/AndroidCpuCollector : io/sentry/IPerformanceSnapshotCollector {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -106,7 +106,7 @@ public class AndroidContinuousProfiler
   }
 
   @Override
-  public synchronized void startProfileSession(
+  public synchronized void startProfiler(
       final @NotNull ProfileLifecycle profileLifecycle,
       final @NotNull TracesSampler tracesSampler) {
     if (shouldSample) {
@@ -217,7 +217,7 @@ public class AndroidContinuousProfiler
   }
 
   @Override
-  public synchronized void stopProfileSession(final @NotNull ProfileLifecycle profileLifecycle) {
+  public synchronized void stopProfiler(final @NotNull ProfileLifecycle profileLifecycle) {
     switch (profileLifecycle) {
       case TRACE:
         rootSpanCounter--;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -178,7 +178,7 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     sentryOptions
         .getExperimental()
         .setProfileSessionSampleRate(profilingOptions.isContinuousProfileSampled() ? 1.0 : 0.0);
-    appStartContinuousProfiler.startProfileSession(
+    appStartContinuousProfiler.startProfiler(
         profilingOptions.getProfileLifecycle(), new TracesSampler(sentryOptions));
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
@@ -149,19 +149,19 @@ class AndroidContinuousProfilerTest {
     @Test
     fun `isRunning reflects profiler status`() {
         val profiler = fixture.getSut()
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         assertFalse(profiler.isRunning)
     }
 
     @Test
     fun `profiler multiple starts are ignored in manual mode`() {
         val profiler = fixture.getSut()
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
         verify(fixture.mockLogger, never()).log(eq(SentryLevel.DEBUG), eq("Profiler is already running."))
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockLogger).log(eq(SentryLevel.DEBUG), eq("Profiler is already running."))
         assertTrue(profiler.isRunning)
         assertEquals(0, profiler.rootSpanCounter)
@@ -173,21 +173,21 @@ class AndroidContinuousProfilerTest {
 
         // rootSpanCounter is incremented when the profiler starts in trace mode
         assertEquals(0, profiler.rootSpanCounter)
-        profiler.startProfileSession(ProfileLifecycle.TRACE, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.TRACE, fixture.mockTracesSampler)
         assertEquals(1, profiler.rootSpanCounter)
         assertTrue(profiler.isRunning)
-        profiler.startProfileSession(ProfileLifecycle.TRACE, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.TRACE, fixture.mockTracesSampler)
         verify(fixture.mockLogger, never()).log(eq(SentryLevel.DEBUG), eq("Profiler is already running."))
         assertTrue(profiler.isRunning)
         assertEquals(2, profiler.rootSpanCounter)
 
         // rootSpanCounter is decremented when the profiler stops in trace mode, and keeps running until rootSpanCounter is 0
-        profiler.stopProfileSession(ProfileLifecycle.TRACE)
+        profiler.stopProfiler(ProfileLifecycle.TRACE)
         assertEquals(1, profiler.rootSpanCounter)
         assertTrue(profiler.isRunning)
 
         // only when rootSpanCounter is 0 the profiler stops
-        profiler.stopProfileSession(ProfileLifecycle.TRACE)
+        profiler.stopProfiler(ProfileLifecycle.TRACE)
         assertEquals(0, profiler.rootSpanCounter)
         assertFalse(profiler.isRunning)
     }
@@ -196,7 +196,7 @@ class AndroidContinuousProfilerTest {
     fun `profiler logs a warning on start if not sampled`() {
         val profiler = fixture.getSut()
         whenever(fixture.mockTracesSampler.sampleSessionProfile(any())).thenReturn(false)
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
         verify(fixture.mockLogger).log(eq(SentryLevel.DEBUG), eq("Profiler was not started due to sampling decision."))
     }
@@ -206,10 +206,10 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut()
         verify(fixture.mockTracesSampler, never()).sampleSessionProfile(any())
         // The first time the profiler is started, the sessionSampleRate is evaluated
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockTracesSampler, times(1)).sampleSessionProfile(any())
         // Then, the sessionSampleRate is not evaluated again
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockTracesSampler, times(1)).sampleSessionProfile(any())
     }
 
@@ -218,13 +218,13 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut()
         verify(fixture.mockTracesSampler, never()).sampleSessionProfile(any())
         // The first time the profiler is started, the sessionSampleRate is evaluated
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockTracesSampler, times(1)).sampleSessionProfile(any())
         // When reevaluateSampling is called, the sessionSampleRate is not evaluated immediately
         profiler.reevaluateSampling()
         verify(fixture.mockTracesSampler, times(1)).sampleSessionProfile(any())
         // Then, when the profiler starts again, the sessionSampleRate is reevaluated
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockTracesSampler, times(2)).sampleSessionProfile(any())
     }
 
@@ -234,7 +234,7 @@ class AndroidContinuousProfilerTest {
             whenever(it.sdkInfoVersion).thenReturn(Build.VERSION_CODES.LOLLIPOP)
         }
         val profiler = fixture.getSut(buildInfo)
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
     }
 
@@ -243,7 +243,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.profilesSampleRate = 0.0
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
     }
 
@@ -259,8 +259,8 @@ class AndroidContinuousProfilerTest {
         )
 
         // Regardless of how many times the profiler is started, the option is evaluated and logged only once
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockLogger, times(1)).log(
             SentryLevel.WARNING,
             "Disabling profiling because no profiling traces dir path is defined in options."
@@ -280,8 +280,8 @@ class AndroidContinuousProfilerTest {
         )
 
         // Regardless of how many times the profiler is started, the option is evaluated and logged only once
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.mockLogger, times(1)).log(
             SentryLevel.WARNING,
             "Disabling profiling because trace rate is set to %d",
@@ -294,7 +294,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.cacheDirPath = null
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
     }
 
@@ -303,7 +303,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.cacheDirPath = ""
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
     }
 
@@ -312,7 +312,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.profilingTracesHz = 0
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
     }
 
@@ -323,9 +323,9 @@ class AndroidContinuousProfilerTest {
             it.executorService = mockExecutorService
         }
         whenever(mockExecutorService.submit(any<Callable<*>>())).thenReturn(mock())
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(mockExecutorService, never()).submit(any<Runnable>())
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         verify(mockExecutorService, never()).submit(any<Callable<*>>())
     }
 
@@ -334,8 +334,8 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             File(it.profilingTracesDirPath!!).setWritable(false)
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         // We assert that no trace files are written
         assertTrue(
             File(fixture.options.profilingTracesDirPath!!)
@@ -351,7 +351,7 @@ class AndroidContinuousProfilerTest {
         fixture.options.compositePerformanceCollector = performanceCollector
         val profiler = fixture.getSut()
         verify(performanceCollector, never()).start(any<String>())
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(performanceCollector).start(any<String>())
     }
 
@@ -360,9 +360,9 @@ class AndroidContinuousProfilerTest {
         val performanceCollector = mock<CompositePerformanceCollector>()
         fixture.options.compositePerformanceCollector = performanceCollector
         val profiler = fixture.getSut()
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(performanceCollector, never()).stop(any<String>())
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         verify(performanceCollector).stop(any<String>())
     }
 
@@ -371,16 +371,16 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut()
         val frameMetricsCollectorId = "id"
         whenever(fixture.frameMetricsCollector.startCollection(any())).thenReturn(frameMetricsCollectorId)
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         verify(fixture.frameMetricsCollector, never()).stopCollection(frameMetricsCollectorId)
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         verify(fixture.frameMetricsCollector).stopCollection(frameMetricsCollectorId)
     }
 
     @Test
     fun `profiler stops profiling and clear scheduled job on close`() {
         val profiler = fixture.getSut()
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
 
         profiler.close()
@@ -402,7 +402,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.executorService = executorService
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
 
         executorService.runAll()
@@ -420,7 +420,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.executorService = executorService
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
         // We run the executor service to trigger the profiler restart (chunk finish)
         executorService.runAll()
@@ -444,8 +444,8 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.executorService = executorService
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         // We run the executor service to send the profile chunk
         executorService.runAll()
         verify(fixture.scopes).captureProfileChunk(
@@ -463,13 +463,13 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.executorService = executorService
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
         // We run the executor service to trigger the profiler restart (chunk finish)
         executorService.runAll()
         verify(fixture.scopes, never()).captureProfileChunk(any())
         // We stop the profiler, which should send an additional chunk
-        profiler.stopProfileSession(ProfileLifecycle.MANUAL)
+        profiler.stopProfiler(ProfileLifecycle.MANUAL)
         // Now the executor is used to send the chunk
         executorService.runAll()
         verify(fixture.scopes, times(2)).captureProfileChunk(any())
@@ -481,7 +481,7 @@ class AndroidContinuousProfilerTest {
         val profiler = fixture.getSut {
             it.executorService = executorService
         }
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
 
         // We close the profiler, which should prevent sending additional chunks
@@ -501,7 +501,7 @@ class AndroidContinuousProfilerTest {
         val rateLimiter = mock<RateLimiter>()
         whenever(rateLimiter.isActiveForCategory(DataCategory.ProfileChunk)).thenReturn(true)
 
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
 
         // If the SDK is rate limited, the profiler should stop
@@ -522,7 +522,7 @@ class AndroidContinuousProfilerTest {
         whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
 
         // If the SDK is rate limited, the profiler should never start
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
         assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
         verify(fixture.mockLogger).log(eq(SentryLevel.WARNING), eq("SDK is rate limited. Stopping profiler."))
@@ -539,7 +539,7 @@ class AndroidContinuousProfilerTest {
         }
 
         // If the device is offline, the profiler should never start
-        profiler.startProfileSession(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+        profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertFalse(profiler.isRunning)
         assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
         verify(fixture.mockLogger).log(eq(SentryLevel.WARNING), eq("Device is offline. Stopping profiler."))

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
@@ -9,7 +9,7 @@ public class MyApplication extends Application {
 
   @Override
   public void onCreate() {
-    Sentry.startProfileSession();
+    Sentry.startProfiler();
     strictMode();
     super.onCreate();
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -652,10 +652,10 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -719,10 +719,10 @@ public final class io/sentry/HubScopesWrapper : io/sentry/IHub {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -752,8 +752,8 @@ public abstract interface class io/sentry/IContinuousProfiler {
 	public abstract fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public abstract fun isRunning ()Z
 	public abstract fun reevaluateSampling ()V
-	public abstract fun startProfileSession (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
-	public abstract fun stopProfileSession (Lio/sentry/ProfileLifecycle;)V
+	public abstract fun startProfiler (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
+	public abstract fun stopProfiler (Lio/sentry/ProfileLifecycle;)V
 }
 
 public abstract interface class io/sentry/IEnvelopeReader {
@@ -958,13 +958,13 @@ public abstract interface class io/sentry/IScopes {
 	public abstract fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setTransaction (Ljava/lang/String;)V
 	public abstract fun setUser (Lio/sentry/protocol/User;)V
-	public abstract fun startProfileSession ()V
+	public abstract fun startProfiler ()V
 	public abstract fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
 	public abstract fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ITransaction;
 	public fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public abstract fun stopProfileSession ()V
+	public abstract fun stopProfiler ()V
 	public abstract fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public abstract fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -1436,8 +1436,8 @@ public final class io/sentry/NoOpContinuousProfiler : io/sentry/IContinuousProfi
 	public fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public fun isRunning ()Z
 	public fun reevaluateSampling ()V
-	public fun startProfileSession (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
-	public fun stopProfileSession (Lio/sentry/ProfileLifecycle;)V
+	public fun startProfiler (Lio/sentry/ProfileLifecycle;Lio/sentry/TracesSampler;)V
+	public fun stopProfiler (Lio/sentry/ProfileLifecycle;)V
 }
 
 public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
@@ -1505,10 +1505,10 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -1667,10 +1667,10 @@ public final class io/sentry/NoOpScopes : io/sentry/IScopes {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -2344,10 +2344,10 @@ public final class io/sentry/Scopes : io/sentry/IScopes {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -2411,10 +2411,10 @@ public final class io/sentry/ScopesAdapter : io/sentry/IScopes {
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V
 	public fun setUser (Lio/sentry/protocol/User;)V
-	public fun startProfileSession ()V
+	public fun startProfiler ()V
 	public fun startSession ()V
 	public fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public fun stopProfileSession ()V
+	public fun stopProfiler ()V
 	public fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public fun withScope (Lio/sentry/ScopeCallback;)V
 }
@@ -2517,14 +2517,14 @@ public final class io/sentry/Sentry {
 	public static fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public static fun setTransaction (Ljava/lang/String;)V
 	public static fun setUser (Lio/sentry/protocol/User;)V
-	public static fun startProfileSession ()V
+	public static fun startProfiler ()V
 	public static fun startSession ()V
 	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
 	public static fun startTransaction (Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
 	public static fun startTransaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;
-	public static fun stopProfileSession ()V
+	public static fun stopProfiler ()V
 	public static fun withIsolationScope (Lio/sentry/ScopeCallback;)V
 	public static fun withScope (Lio/sentry/ScopeCallback;)V
 }

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -30,8 +30,8 @@ public final class ExperimentalOptions {
   /**
    * Whether profiling can automatically be started as early as possible during the app lifecycle,
    * to capture more of app startup. If {@link ExperimentalOptions#profileLifecycle} is {@link
-   * ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfileSession
-   * must be called manually whenever the app startup is completed If {@link
+   * ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfiler must be
+   * called manually whenever the app startup is completed If {@link
    * ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#TRACE} Profiling is started
    * automatically on startup, and will automatically be stopped when the root span that is
    * associated with app startup ends

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -278,13 +278,13 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
-  public void startProfileSession() {
-    Sentry.startProfileSession();
+  public void startProfiler() {
+    Sentry.startProfiler();
   }
 
   @Override
-  public void stopProfileSession() {
-    Sentry.stopProfileSession();
+  public void stopProfiler() {
+    Sentry.stopProfiler();
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -278,13 +278,13 @@ public final class HubScopesWrapper implements IHub {
   }
 
   @Override
-  public void startProfileSession() {
-    scopes.startProfileSession();
+  public void startProfiler() {
+    scopes.startProfiler();
   }
 
   @Override
-  public void stopProfileSession() {
-    scopes.stopProfileSession();
+  public void stopProfiler() {
+    scopes.stopProfiler();
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/IContinuousProfiler.java
+++ b/sentry/src/main/java/io/sentry/IContinuousProfiler.java
@@ -9,10 +9,10 @@ import org.jetbrains.annotations.NotNull;
 public interface IContinuousProfiler {
   boolean isRunning();
 
-  void startProfileSession(
+  void startProfiler(
       final @NotNull ProfileLifecycle profileLifecycle, final @NotNull TracesSampler tracesSampler);
 
-  void stopProfileSession(final @NotNull ProfileLifecycle profileLifecycle);
+  void stopProfiler(final @NotNull ProfileLifecycle profileLifecycle);
 
   /** Cancel the profiler and stops it. Used on SDK close. */
   void close();

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -592,9 +592,9 @@ public interface IScopes {
       final @NotNull TransactionContext transactionContext,
       final @NotNull TransactionOptions transactionOptions);
 
-  void startProfileSession();
+  void startProfiler();
 
-  void stopProfileSession();
+  void stopProfiler();
 
   /**
    * Associates {@link ISpan} and the transaction name with the {@link Throwable}. Used to determine

--- a/sentry/src/main/java/io/sentry/NoOpContinuousProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpContinuousProfiler.java
@@ -14,7 +14,7 @@ public final class NoOpContinuousProfiler implements IContinuousProfiler {
   }
 
   @Override
-  public void stopProfileSession(final @NotNull ProfileLifecycle profileLifecycle) {}
+  public void stopProfiler(final @NotNull ProfileLifecycle profileLifecycle) {}
 
   @Override
   public boolean isRunning() {
@@ -22,7 +22,7 @@ public final class NoOpContinuousProfiler implements IContinuousProfiler {
   }
 
   @Override
-  public void startProfileSession(
+  public void startProfiler(
       final @NotNull ProfileLifecycle profileLifecycle,
       final @NotNull TracesSampler tracesSampler) {}
 

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -244,10 +244,10 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  public void startProfileSession() {}
+  public void startProfiler() {}
 
   @Override
-  public void stopProfileSession() {}
+  public void stopProfiler() {}
 
   @Override
   public void setSpanContext(

--- a/sentry/src/main/java/io/sentry/NoOpScopes.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopes.java
@@ -239,10 +239,10 @@ public final class NoOpScopes implements IScopes {
   }
 
   @Override
-  public void startProfileSession() {}
+  public void startProfiler() {}
 
   @Override
-  public void stopProfileSession() {}
+  public void stopProfiler() {}
 
   @Override
   public void setSpanContext(

--- a/sentry/src/main/java/io/sentry/ProfileLifecycle.java
+++ b/sentry/src/main/java/io/sentry/ProfileLifecycle.java
@@ -6,8 +6,8 @@ package io.sentry;
  */
 public enum ProfileLifecycle {
   /**
-   * Profiling is controlled manually. You must use the {@link Sentry#startProfileSession()} and
-   * {@link Sentry#stopProfileSession()} APIs to control the lifecycle of the profiler.
+   * Profiling is controlled manually. You must use the {@link Sentry#startProfiler()} and {@link
+   * Sentry#stopProfiler()} APIs to control the lifecycle of the profiler.
    */
   MANUAL,
   /**

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -928,7 +928,7 @@ public final class Scopes implements IScopes {
             && getOptions().getProfileLifecycle() == ProfileLifecycle.TRACE) {
           getOptions()
               .getContinuousProfiler()
-              .startProfileSession(ProfileLifecycle.TRACE, getOptions().getInternalTracesSampler());
+              .startProfiler(ProfileLifecycle.TRACE, getOptions().getInternalTracesSampler());
         }
       }
     }
@@ -951,7 +951,7 @@ public final class Scopes implements IScopes {
   }
 
   @Override
-  public void startProfileSession() {
+  public void startProfiler() {
     if (getOptions().isContinuousProfilingEnabled()) {
       if (getOptions().getProfileLifecycle() != ProfileLifecycle.MANUAL) {
         getOptions()
@@ -964,7 +964,7 @@ public final class Scopes implements IScopes {
       }
       getOptions()
           .getContinuousProfiler()
-          .startProfileSession(ProfileLifecycle.MANUAL, getOptions().getInternalTracesSampler());
+          .startProfiler(ProfileLifecycle.MANUAL, getOptions().getInternalTracesSampler());
     } else if (getOptions().isProfilingEnabled()) {
       getOptions()
           .getLogger()
@@ -975,7 +975,7 @@ public final class Scopes implements IScopes {
   }
 
   @Override
-  public void stopProfileSession() {
+  public void stopProfiler() {
     if (getOptions().isContinuousProfilingEnabled()) {
       if (getOptions().getProfileLifecycle() != ProfileLifecycle.MANUAL) {
         getOptions()
@@ -987,7 +987,7 @@ public final class Scopes implements IScopes {
         return;
       }
       getOptions().getLogger().log(SentryLevel.DEBUG, "Stopped continuous Profiling.");
-      getOptions().getContinuousProfiler().stopProfileSession(ProfileLifecycle.MANUAL);
+      getOptions().getContinuousProfiler().stopProfiler(ProfileLifecycle.MANUAL);
     } else {
       getOptions()
           .getLogger()

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -281,13 +281,13 @@ public final class ScopesAdapter implements IScopes {
   }
 
   @Override
-  public void startProfileSession() {
-    Sentry.startProfileSession();
+  public void startProfiler() {
+    Sentry.startProfiler();
   }
 
   @Override
-  public void stopProfileSession() {
-    Sentry.stopProfileSession();
+  public void stopProfiler() {
+    Sentry.stopProfiler();
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1114,14 +1114,14 @@ public final class Sentry {
 
   /** Starts the continuous profiler, if enabled. */
   @ApiStatus.Experimental
-  public static void startProfileSession() {
-    getCurrentScopes().startProfileSession();
+  public static void startProfiler() {
+    getCurrentScopes().startProfiler();
   }
 
   /** Stops the continuous profiler, if enabled. */
   @ApiStatus.Experimental
-  public static void stopProfileSession() {
-    getCurrentScopes().stopProfileSession();
+  public static void stopProfiler() {
+    getCurrentScopes().stopProfiler();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryTracer.java
+++ b/sentry/src/main/java/io/sentry/SentryTracer.java
@@ -243,7 +243,7 @@ public final class SentryTracer implements ITransaction {
       }
       if (scopes.getOptions().isContinuousProfilingEnabled()
           && scopes.getOptions().getProfileLifecycle() == ProfileLifecycle.TRACE) {
-        scopes.getOptions().getContinuousProfiler().stopProfileSession(ProfileLifecycle.TRACE);
+        scopes.getOptions().getContinuousProfiler().stopProfiler(ProfileLifecycle.TRACE);
       }
       if (performanceCollectionData.get() != null) {
         performanceCollectionData.get().clear();

--- a/sentry/src/test/java/io/sentry/HubAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/HubAdapterTest.kt
@@ -270,13 +270,13 @@ class HubAdapterTest {
         verify(scopes).reportFullyDisplayed()
     }
 
-    @Test fun `startProfileSession calls Hub`() {
-        HubAdapter.getInstance().startProfileSession()
-        verify(scopes).startProfileSession()
+    @Test fun `startProfiler calls Hub`() {
+        HubAdapter.getInstance().startProfiler()
+        verify(scopes).startProfiler()
     }
 
-    @Test fun `stopProfileSession calls Hub`() {
-        HubAdapter.getInstance().stopProfileSession()
-        verify(scopes).stopProfileSession()
+    @Test fun `stopProfiler calls Hub`() {
+        HubAdapter.getInstance().stopProfiler()
+        verify(scopes).stopProfiler()
     }
 }

--- a/sentry/src/test/java/io/sentry/NoOpContinuousProfilerTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpContinuousProfilerTest.kt
@@ -11,11 +11,11 @@ class NoOpContinuousProfilerTest {
 
     @Test
     fun `start does not throw`() =
-        profiler.startProfileSession(mock(), mock())
+        profiler.startProfiler(mock(), mock())
 
     @Test
     fun `stop does not throw`() =
-        profiler.stopProfileSession(mock())
+        profiler.stopProfiler(mock())
 
     @Test
     fun `isRunning returns false`() {

--- a/sentry/src/test/java/io/sentry/NoOpHubTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpHubTest.kt
@@ -117,8 +117,8 @@ class NoOpHubTest {
     }
 
     @Test
-    fun `startProfileSession doesnt throw`() = sut.startProfileSession()
+    fun `startProfiler doesnt throw`() = sut.startProfiler()
 
     @Test
-    fun `stopProfileSession doesnt throw`() = sut.stopProfileSession()
+    fun `stopProfiler doesnt throw`() = sut.stopProfiler()
 }

--- a/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
@@ -270,13 +270,13 @@ class ScopesAdapterTest {
         verify(scopes).reportFullyDisplayed()
     }
 
-    @Test fun `startProfileSession calls Scopes`() {
-        ScopesAdapter.getInstance().startProfileSession()
-        verify(scopes).startProfileSession()
+    @Test fun `startProfiler calls Scopes`() {
+        ScopesAdapter.getInstance().startProfiler()
+        verify(scopes).startProfiler()
     }
 
-    @Test fun `stopProfileSession calls Scopes`() {
-        ScopesAdapter.getInstance().stopProfileSession()
-        verify(scopes).stopProfileSession()
+    @Test fun `stopProfiler calls Scopes`() {
+        ScopesAdapter.getInstance().stopProfiler()
+        verify(scopes).stopProfiler()
     }
 }

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -1898,7 +1898,7 @@ class ScopesTest {
 
         val transaction = scopes.startTransaction("name", "op")
         assertTrue(transaction.isSampled!!)
-        verify(mockProfiler).startProfileSession(eq(ProfileLifecycle.TRACE), any())
+        verify(mockProfiler).startProfiler(eq(ProfileLifecycle.TRACE), any())
     }
 
     @Test
@@ -1912,7 +1912,7 @@ class ScopesTest {
 
         val transaction = scopes.startTransaction("name", "op")
         assertTrue(transaction.isSampled!!)
-        verify(mockProfiler, never()).startProfileSession(any(), any())
+        verify(mockProfiler, never()).startProfiler(any(), any())
     }
 
     @Test
@@ -1927,7 +1927,7 @@ class ScopesTest {
         val transaction = scopes.startTransaction("name", "op")
         transaction.spanContext.setSampled(false, false)
         assertFalse(transaction.isSampled!!)
-        verify(mockProfiler, never()).startProfileSession(any(), any())
+        verify(mockProfiler, never()).startProfiler(any(), any())
     }
     //endregion
 
@@ -2240,18 +2240,18 @@ class ScopesTest {
     //region profileSession
 
     @Test
-    fun `startProfileSession starts the continuous profiler`() {
+    fun `startProfiler starts the continuous profiler`() {
         val profiler = mock<IContinuousProfiler>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
             it.experimental.profileSessionSampleRate = 1.0
         }
-        scopes.startProfileSession()
-        verify(profiler).startProfileSession(eq(ProfileLifecycle.MANUAL), any())
+        scopes.startProfiler()
+        verify(profiler).startProfiler(eq(ProfileLifecycle.MANUAL), any())
     }
 
     @Test
-    fun `startProfileSession logs instructions if continuous profiling is disabled`() {
+    fun `startProfiler logs instructions if continuous profiling is disabled`() {
         val profiler = mock<IContinuousProfiler>()
         val logger = mock<ILogger>()
         val scopes = generateScopes {
@@ -2261,13 +2261,13 @@ class ScopesTest {
             it.setLogger(logger)
             it.isDebug = true
         }
-        scopes.startProfileSession()
-        verify(profiler, never()).startProfileSession(eq(ProfileLifecycle.MANUAL), any())
+        scopes.startProfiler()
+        verify(profiler, never()).startProfiler(eq(ProfileLifecycle.MANUAL), any())
         verify(logger).log(eq(SentryLevel.WARNING), eq("Continuous Profiling is not enabled. Set profilesSampleRate and profilesSampler to null to enable it."))
     }
 
     @Test
-    fun `startProfileSession is ignored on trace lifecycle`() {
+    fun `startProfiler is ignored on trace lifecycle`() {
         val profiler = mock<IContinuousProfiler>()
         val logger = mock<ILogger>()
         val scopes = generateScopes {
@@ -2277,24 +2277,24 @@ class ScopesTest {
             it.setLogger(logger)
             it.isDebug = true
         }
-        scopes.startProfileSession()
+        scopes.startProfiler()
         verify(logger).log(eq(SentryLevel.WARNING), eq("Profiling lifecycle is %s. Profiling cannot be started manually."), eq(ProfileLifecycle.TRACE.name))
-        verify(profiler, never()).startProfileSession(any(), any())
+        verify(profiler, never()).startProfiler(any(), any())
     }
 
     @Test
-    fun `stopProfileSession stops the continuous profiler`() {
+    fun `stopProfiler stops the continuous profiler`() {
         val profiler = mock<IContinuousProfiler>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
             it.experimental.profileSessionSampleRate = 1.0
         }
-        scopes.stopProfileSession()
-        verify(profiler).stopProfileSession(eq(ProfileLifecycle.MANUAL))
+        scopes.stopProfiler()
+        verify(profiler).stopProfiler(eq(ProfileLifecycle.MANUAL))
     }
 
     @Test
-    fun `stopProfileSession logs instructions if continuous profiling is disabled`() {
+    fun `stopProfiler logs instructions if continuous profiling is disabled`() {
         val profiler = mock<IContinuousProfiler>()
         val logger = mock<ILogger>()
         val scopes = generateScopes {
@@ -2304,13 +2304,13 @@ class ScopesTest {
             it.setLogger(logger)
             it.isDebug = true
         }
-        scopes.stopProfileSession()
-        verify(profiler, never()).stopProfileSession(eq(ProfileLifecycle.MANUAL))
+        scopes.stopProfiler()
+        verify(profiler, never()).stopProfiler(eq(ProfileLifecycle.MANUAL))
         verify(logger).log(eq(SentryLevel.WARNING), eq("Continuous Profiling is not enabled. Set profilesSampleRate and profilesSampler to null to enable it."))
     }
 
     @Test
-    fun `stopProfileSession is ignored on trace lifecycle`() {
+    fun `stopProfiler is ignored on trace lifecycle`() {
         val profiler = mock<IContinuousProfiler>()
         val logger = mock<ILogger>()
         val scopes = generateScopes {
@@ -2320,9 +2320,9 @@ class ScopesTest {
             it.setLogger(logger)
             it.isDebug = true
         }
-        scopes.stopProfileSession()
+        scopes.stopProfiler()
         verify(logger).log(eq(SentryLevel.WARNING), eq("Profiling lifecycle is %s. Profiling cannot be stopped manually."), eq(ProfileLifecycle.TRACE.name))
-        verify(profiler, never()).stopProfileSession(any())
+        verify(profiler, never()).stopProfiler(any())
     }
 
     //endregion

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1347,31 +1347,31 @@ class SentryTest {
     }
 
     @Test
-    fun `startProfileSession starts the continuous profiler`() {
+    fun `startProfiler starts the continuous profiler`() {
         val profiler = mock<IContinuousProfiler>()
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
             it.experimental.profileSessionSampleRate = 1.0
         }
-        Sentry.startProfileSession()
-        verify(profiler).startProfileSession(eq(ProfileLifecycle.MANUAL), any())
+        Sentry.startProfiler()
+        verify(profiler).startProfiler(eq(ProfileLifecycle.MANUAL), any())
     }
 
     @Test
-    fun `startProfileSession is ignored when continuous profiling is disabled`() {
+    fun `startProfiler is ignored when continuous profiling is disabled`() {
         val profiler = mock<IContinuousProfiler>()
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
             it.profilesSampleRate = 1.0
         }
-        Sentry.startProfileSession()
-        verify(profiler, never()).startProfileSession(eq(ProfileLifecycle.MANUAL), any())
+        Sentry.startProfiler()
+        verify(profiler, never()).startProfiler(eq(ProfileLifecycle.MANUAL), any())
     }
 
     @Test
-    fun `startProfileSession is ignored when profile lifecycle is TRACE`() {
+    fun `startProfiler is ignored when profile lifecycle is TRACE`() {
         val profiler = mock<IContinuousProfiler>()
         val logger = mock<ILogger>()
         Sentry.init {
@@ -1382,8 +1382,8 @@ class SentryTest {
             it.isDebug = true
             it.setLogger(logger)
         }
-        Sentry.startProfileSession()
-        verify(profiler, never()).startProfileSession(any(), any())
+        Sentry.startProfiler()
+        verify(profiler, never()).startProfiler(any(), any())
         verify(logger).log(
             eq(SentryLevel.WARNING),
             eq("Profiling lifecycle is %s. Profiling cannot be started manually."),
@@ -1392,27 +1392,27 @@ class SentryTest {
     }
 
     @Test
-    fun `stopProfileSession stops the continuous profiler`() {
+    fun `stopProfiler stops the continuous profiler`() {
         val profiler = mock<IContinuousProfiler>()
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
             it.experimental.profileSessionSampleRate = 1.0
         }
-        Sentry.stopProfileSession()
-        verify(profiler).stopProfileSession(eq(ProfileLifecycle.MANUAL))
+        Sentry.stopProfiler()
+        verify(profiler).stopProfiler(eq(ProfileLifecycle.MANUAL))
     }
 
     @Test
-    fun `stopProfileSession is ignored when continuous profiling is disabled`() {
+    fun `stopProfiler is ignored when continuous profiling is disabled`() {
         val profiler = mock<IContinuousProfiler>()
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
             it.profilesSampleRate = 1.0
         }
-        Sentry.stopProfileSession()
-        verify(profiler, never()).stopProfileSession(eq(ProfileLifecycle.MANUAL))
+        Sentry.stopProfiler()
+        verify(profiler, never()).stopProfiler(eq(ProfileLifecycle.MANUAL))
     }
 
     private class InMemoryOptionsObserver : IOptionsObserver {

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -244,7 +244,7 @@ class SentryTracerTest {
         }, samplingDecision = TracesSamplingDecision(false))
         tracer.finish()
         // profiler is never stopped, as it was never started
-        verify(continuousProfiler, never()).stopProfileSession(any())
+        verify(continuousProfiler, never()).stopProfiler(any())
         // profile context is not set
         verify(fixture.scopes).captureTransaction(
             check {
@@ -267,7 +267,7 @@ class SentryTracerTest {
         }, samplingDecision = TracesSamplingDecision(true))
         tracer.finish()
         // profiler is never stopped, as it should be stopped manually
-        verify(continuousProfiler, never()).stopProfileSession(any())
+        verify(continuousProfiler, never()).stopProfiler(any())
     }
 
     @Test


### PR DESCRIPTION
## :scroll: Description
Renamed
Sentry.startProfileSession -> Sentry.startProfiler
Sentry.stopProfileSession -> Sentry.stopProfiler


#skip-changelog

## :bulb: Motivation and Context
Renaming APIs to avoid confusion with sessions and sample rates


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
