### PR TITLE
fix(session-replay):  Do not crash if navigation breadcrumb has no destination (#4185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: Fix crash when a navigation breadcrumb does not have "to" destination ([#4185](https://github.com/getsentry/sentry-java/pull/4185))
+- Session Replay: Cap video segment duration to maximum 5 minutes to prevent endless video encoding in background ([#4185](https://github.com/getsentry/sentry-java/pull/4185))
+
 ## 7.22.3
 
 ### Fixes

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -58,6 +58,10 @@ internal interface CaptureStrategy {
     companion object {
         private const val BREADCRUMB_START_OFFSET = 100L
 
+        // 5 minutes, otherwise relay will just drop it. Can prevent the case where the device
+        // time is wrong and the segment is too long.
+        private const val MAX_SEGMENT_DURATION = 1000L * 60 * 5
+
         fun createSegment(
             hub: IHub?,
             options: SentryOptions,
@@ -76,7 +80,7 @@ internal interface CaptureStrategy {
             events: Deque<RRWebEvent>
         ): ReplaySegment {
             val generatedVideo = cache?.createVideoOf(
-                duration,
+                minOf(duration, MAX_SEGMENT_DURATION),
                 currentSegmentTimestamp.time,
                 segmentId,
                 height,
@@ -179,7 +183,9 @@ internal interface CaptureStrategy {
                         recordingPayload += rrwebEvent
 
                         // fill in the urls array from navigation breadcrumbs
-                        if ((rrwebEvent as? RRWebBreadcrumbEvent)?.category == "navigation") {
+                        if ((rrwebEvent as? RRWebBreadcrumbEvent)?.category == "navigation" &&
+                            rrwebEvent.data?.getOrElse("to", { null }) is String
+                        ) {
                             urls.add(rrwebEvent.data!!["to"] as String)
                         }
                     }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -337,6 +337,30 @@ class SessionCaptureStrategyTest {
     }
 
     @Test
+    fun `does not throw when navigation destination is not a String`() {
+        val now =
+            System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
+        val strategy = fixture.getSut(dateProvider = { now })
+        strategy.start(fixture.recorderConfig)
+
+        fixture.scope.addBreadcrumb(Breadcrumb().apply { category = "navigation" })
+
+        strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+        verify(fixture.scopes).captureReplay(
+            check {
+                assertNull(it.urls?.firstOrNull())
+            },
+            check {
+                val breadcrumbEvents =
+                    it.replayRecording?.payload?.filterIsInstance<RRWebBreadcrumbEvent>()
+                assertEquals("navigation", breadcrumbEvents?.first()?.category)
+                assertNull(breadcrumbEvents?.first()?.data?.get("to"))
+            }
+        )
+    }
+
+    @Test
     fun `sets screen from scope as replay url`() {
         fixture.scope.screen = "MainActivity"
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -347,7 +347,7 @@ class SessionCaptureStrategyTest {
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 
-        verify(fixture.scopes).captureReplay(
+        verify(fixture.hub).captureReplay(
             check {
                 assertNull(it.urls?.firstOrNull())
             },


### PR DESCRIPTION
_#skip-changelog_

Cherry-pick #4185 onto `7.x.x` for RN https://github.com/getsentry/sentry-react-native/issues/4659

