### PR TITLE
Check for mixed SDK versions

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2706,6 +2706,7 @@ public final class io/sentry/SentryInstantDateProvider : io/sentry/SentryDatePro
 public final class io/sentry/SentryIntegrationPackageStorage {
 	public fun addIntegration (Ljava/lang/String;)V
 	public fun addPackage (Ljava/lang/String;Ljava/lang/String;)V
+	public fun checkForMixedVersions (Lio/sentry/ILogger;)Z
 	public fun clearStorage ()V
 	public static fun getInstance ()Lio/sentry/SentryIntegrationPackageStorage;
 	public fun getIntegrations ()Ljava/util/Set;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -767,6 +767,9 @@ public final class SentryClient implements ISentryClient {
             .log(SentryLevel.ERROR, "The BeforeEnvelope callback threw an exception.", e);
       }
     }
+
+    SentryIntegrationPackageStorage.getInstance().checkForMixedVersions(options.getLogger());
+
     if (hint == null) {
       transport.send(envelope);
     } else {

--- a/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
+++ b/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
@@ -5,6 +5,7 @@ import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -15,6 +16,8 @@ public final class SentryIntegrationPackageStorage {
   private static volatile @Nullable SentryIntegrationPackageStorage INSTANCE;
   private static final @NotNull AutoClosableReentrantLock staticLock =
       new AutoClosableReentrantLock();
+  private static volatile @Nullable Boolean mixedVersionsDetected = null;
+  private static final @NotNull AutoClosableReentrantLock mixedVersionsLock = new AutoClosableReentrantLock();
 
   public static @NotNull SentryIntegrationPackageStorage getInstance() {
     if (INSTANCE == null) {
@@ -64,10 +67,40 @@ public final class SentryIntegrationPackageStorage {
 
     SentryPackage newPackage = new SentryPackage(name, version);
     packages.add(newPackage);
+    try (final @NotNull ISentryLifecycleToken ignored = mixedVersionsLock.acquire()) {
+      mixedVersionsDetected = null;
+    }
   }
 
   public @NotNull Set<SentryPackage> getPackages() {
     return packages;
+  }
+
+  public boolean checkForMixedVersions(final @NotNull ILogger logger) {
+    final @Nullable Boolean mixedVersionsDetectedBefore = mixedVersionsDetected;
+    if (mixedVersionsDetectedBefore != null) {
+      return mixedVersionsDetectedBefore;
+    }
+    try (final @NotNull ISentryLifecycleToken ignored = mixedVersionsLock.acquire()) {
+      final @NotNull String sdkVersion = BuildConfig.VERSION_NAME;
+      boolean mixedVersionsDetectedThisCheck = false;
+
+      for (SentryPackage pkg : packages) {
+        if (pkg.getName().startsWith("maven:io.sentry:") && !sdkVersion.equalsIgnoreCase(pkg.getVersion())) {
+          logger.log(SentryLevel.ERROR, "The Sentry SDK has been configured with mixed versions. Expected %s to match core SDK version %s but was %s", pkg.getName(), sdkVersion, pkg.getVersion());
+          mixedVersionsDetectedThisCheck = true;
+        }
+      }
+
+      if (mixedVersionsDetectedThisCheck) {
+        logger.log(SentryLevel.ERROR, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+        logger.log(SentryLevel.ERROR, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+        logger.log(SentryLevel.ERROR, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+        logger.log(SentryLevel.ERROR, "^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+      }
+      mixedVersionsDetected = mixedVersionsDetectedThisCheck;
+      return mixedVersionsDetectedThisCheck;
+    }
   }
 
   @TestOnly

--- a/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
+++ b/sentry/src/main/java/io/sentry/SentryIntegrationPackageStorage.java
@@ -5,7 +5,6 @@ import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +16,8 @@ public final class SentryIntegrationPackageStorage {
   private static final @NotNull AutoClosableReentrantLock staticLock =
       new AutoClosableReentrantLock();
   private static volatile @Nullable Boolean mixedVersionsDetected = null;
-  private static final @NotNull AutoClosableReentrantLock mixedVersionsLock = new AutoClosableReentrantLock();
+  private static final @NotNull AutoClosableReentrantLock mixedVersionsLock =
+      new AutoClosableReentrantLock();
 
   public static @NotNull SentryIntegrationPackageStorage getInstance() {
     if (INSTANCE == null) {
@@ -86,8 +86,14 @@ public final class SentryIntegrationPackageStorage {
       boolean mixedVersionsDetectedThisCheck = false;
 
       for (SentryPackage pkg : packages) {
-        if (pkg.getName().startsWith("maven:io.sentry:") && !sdkVersion.equalsIgnoreCase(pkg.getVersion())) {
-          logger.log(SentryLevel.ERROR, "The Sentry SDK has been configured with mixed versions. Expected %s to match core SDK version %s but was %s", pkg.getName(), sdkVersion, pkg.getVersion());
+        if (pkg.getName().startsWith("maven:io.sentry:")
+            && !sdkVersion.equalsIgnoreCase(pkg.getVersion())) {
+          logger.log(
+              SentryLevel.ERROR,
+              "The Sentry SDK has been configured with mixed versions. Expected %s to match core SDK version %s but was %s",
+              pkg.getName(),
+              sdkVersion,
+              pkg.getVersion());
           mixedVersionsDetectedThisCheck = true;
         }
       }


### PR DESCRIPTION
#skip-changelog
Changelog is written in a follow up PR

## :scroll: Description
<!--- Describe your changes in detail -->
- Checks `SentryIntegrationPackageStorage.packages` for mixed versions when sending out an envelope.
- Caches the decision so the check is only performed once*
- * invalidates the cache when a new package is added

This is only the first step where we log when mixed versions have been detected.
Next step is to not enable the SDK in that case.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
First step for solving https://github.com/getsentry/sentry-java/issues/4132

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
