### PR TITLE
chore(http-client): Increase http timeouts from 5s to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Increase http timeouts from 5s to 30s to have a better chance of events being delivered without retry ([#4276](https://github.com/getsentry/sentry-java/pull/4276))
+
 ### Fixes
 
 - Do not override user-defined `SentryOptions` ([#4262](https://github.com/getsentry/sentry-java/pull/4262))

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -291,10 +291,10 @@ public class SentryOptions {
   private @NotNull ISentryExecutorService executorService = NoOpSentryExecutorService.getInstance();
 
   /** connection timeout in milliseconds. */
-  private int connectionTimeoutMillis = 5000;
+  private int connectionTimeoutMillis = 30_000;
 
   /** read timeout in milliseconds */
-  private int readTimeoutMillis = 5000;
+  private int readTimeoutMillis = 30_000;
 
   /** Reads and caches envelope files in the disk */
   private @NotNull IEnvelopeCache envelopeDiskCache = NoOpEnvelopeCache.getInstance();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
To have a better chance of envelopes being sent without retry

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
