### PR TITLE
Keep baggage sample rate/rand as doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Increase http timeouts from 5s to 30s to have a better chance of events being delivered without retry ([#4276](https://github.com/getsentry/sentry-java/pull/4276))
+- Retain baggage sample rate/rand values as doubles ([#4279](https://github.com/getsentry/sentry-java/pull/4279))
 
 ### Fixes
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -523,8 +523,8 @@ class InternalSentrySdkTest {
             val propagationContext = scope.propagationContext
             assertEquals(SentryId(traceId), propagationContext.traceId)
             assertEquals(SpanId(spanId), propagationContext.parentSpanId)
-            assertEquals(sampleRate, propagationContext.baggage.sampleRateDouble)
-            assertEquals(sampleRand, propagationContext.baggage.sampleRandDouble)
+            assertEquals(sampleRate, propagationContext.baggage.sampleRate!!, 0.0001)
+            assertEquals(sampleRand, propagationContext.baggage.sampleRand!!, 0.0001)
         }
     }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SentrySpanProcessorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SentrySpanProcessorTest.kt
@@ -406,7 +406,7 @@ class SentrySpanProcessorTest {
                     assertTrue(it.parentSamplingDecision!!.sampled)
                     if (continuesWithFilledBaggage) {
                         assertEquals("2722d9f6ec019ade60c776169d9a8904", it.baggage?.traceId)
-                        assertEquals("1", it.baggage?.sampleRate)
+                        assertEquals(1.0, it.baggage?.sampleRate)
                         assertEquals("HTTP GET", it.baggage?.transaction)
                         assertEquals("502f25099c204a2fbf4cb16edc5975d1", it.baggage?.publicKey)
                         assertFalse(it.baggage!!.isMutable)

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -32,8 +32,8 @@ public abstract interface class io/sentry/BackfillingEventProcessor : io/sentry/
 public final class io/sentry/Baggage {
 	public fun <init> (Lio/sentry/Baggage;)V
 	public fun <init> (Lio/sentry/ILogger;)V
-	public fun <init> (Ljava/util/Map;Ljava/lang/String;ZZLio/sentry/ILogger;)V
-	public fun forceSetSampleRate (Ljava/lang/String;)V
+	public fun <init> (Ljava/util/Map;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;ZZLio/sentry/ILogger;)V
+	public fun forceSetSampleRate (Ljava/lang/Double;)V
 	public fun freeze ()V
 	public static fun fromEvent (Lio/sentry/SentryEvent;Lio/sentry/SentryOptions;)Lio/sentry/Baggage;
 	public static fun fromHeader (Ljava/lang/String;)Lio/sentry/Baggage;
@@ -47,10 +47,8 @@ public final class io/sentry/Baggage {
 	public fun getPublicKey ()Ljava/lang/String;
 	public fun getRelease ()Ljava/lang/String;
 	public fun getReplayId ()Ljava/lang/String;
-	public fun getSampleRand ()Ljava/lang/String;
-	public fun getSampleRandDouble ()Ljava/lang/Double;
-	public fun getSampleRate ()Ljava/lang/String;
-	public fun getSampleRateDouble ()Ljava/lang/Double;
+	public fun getSampleRand ()Ljava/lang/Double;
+	public fun getSampleRate ()Ljava/lang/Double;
 	public fun getSampled ()Ljava/lang/String;
 	public fun getThirdPartyHeader ()Ljava/lang/String;
 	public fun getTraceId ()Ljava/lang/String;
@@ -64,9 +62,8 @@ public final class io/sentry/Baggage {
 	public fun setPublicKey (Ljava/lang/String;)V
 	public fun setRelease (Ljava/lang/String;)V
 	public fun setReplayId (Ljava/lang/String;)V
-	public fun setSampleRand (Ljava/lang/String;)V
-	public fun setSampleRandDouble (Ljava/lang/Double;)V
-	public fun setSampleRate (Ljava/lang/String;)V
+	public fun setSampleRand (Ljava/lang/Double;)V
+	public fun setSampleRate (Ljava/lang/Double;)V
 	public fun setSampled (Ljava/lang/String;)V
 	public fun setTraceId (Ljava/lang/String;)V
 	public fun setTransaction (Ljava/lang/String;)V

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -493,7 +493,7 @@ public final class Baggage {
     }
     setSampleRate(sampleRate(samplingDecision));
     setSampled(StringUtils.toString(sampled(samplingDecision)));
-    setSampleRand(sampleRand(samplingDecision)); // TODO check
+    setSampleRand(sampleRand(samplingDecision));
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/PropagationContext.java
+++ b/sentry/src/main/java/io/sentry/PropagationContext.java
@@ -135,11 +135,7 @@ public final class PropagationContext {
   }
 
   public @Nullable TraceContext traceContext() {
-    if (baggage != null) {
-      return baggage.toTraceContext();
-    }
-
-    return null;
+    return baggage.toTraceContext();
   }
 
   public @NotNull SpanContext toSpanContext() {
@@ -149,7 +145,7 @@ public final class PropagationContext {
   }
 
   public @NotNull Double getSampleRand() {
-    final @Nullable Double sampleRand = baggage.getSampleRandDouble();
+    final @Nullable Double sampleRand = baggage.getSampleRand();
     // should never be null since we ensure it in ctor
     return sampleRand == null ? 0.0 : sampleRand;
   }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -941,7 +941,7 @@ public final class Scopes implements IScopes {
   private @NotNull Double getSampleRand(final @NotNull TransactionContext transactionContext) {
     final @Nullable Baggage baggage = transactionContext.getBaggage();
     if (baggage != null) {
-      final @Nullable Double sampleRandFromBaggageMaybe = baggage.getSampleRandDouble();
+      final @Nullable Double sampleRandFromBaggageMaybe = baggage.getSampleRand();
       if (sampleRandFromBaggageMaybe != null) {
         return sampleRandFromBaggageMaybe;
       }

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -23,7 +23,7 @@ public final class TransactionContext extends SpanContext {
       final @NotNull PropagationContext propagationContext) {
     final @Nullable Boolean parentSampled = propagationContext.isSampled();
     final @NotNull Baggage baggage = propagationContext.getBaggage();
-    final @Nullable Double sampleRate = baggage.getSampleRateDouble();
+    final @Nullable Double sampleRate = baggage.getSampleRate();
     final @Nullable TracesSamplingDecision samplingDecision =
         parentSampled == null
             ? null

--- a/sentry/src/main/java/io/sentry/util/TracingUtils.java
+++ b/sentry/src/main/java/io/sentry/util/TracingUtils.java
@@ -204,13 +204,13 @@ public final class TracingUtils {
         incomingBaggage == null ? new Baggage(NoOpLogger.getInstance()) : incomingBaggage;
 
     if (baggage.getSampleRand() == null) {
-      final @Nullable Double baggageSampleRate = baggage.getSampleRateDouble();
+      final @Nullable Double baggageSampleRate = baggage.getSampleRate();
       final @Nullable Double sampleRateMaybe =
           baggageSampleRate == null ? decisionSampleRate : baggageSampleRate;
       final @NotNull Double sampleRand =
           SampleRateUtils.backfilledSampleRand(
               decisionSampleRand, sampleRateMaybe, decisionSampled);
-      baggage.setSampleRandDouble(sampleRand);
+      baggage.setSampleRand(sampleRand);
     }
     if (baggage.isMutable()) {
       if (baggage.isShouldFreeze()) {

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -318,7 +318,7 @@ class BaggageTest {
         baggage.setEnvironment("production")
         baggage.setTransaction("TX")
         baggage.setUserId(userId)
-        baggage.setSampleRate((1.0 / 3.0).toString())
+        baggage.setSampleRate((1.0 / 3.0))
         baggage.setSampled("true")
 
         assertEquals("sentry-environment=production,sentry-public_key=$publicKey,sentry-release=1.0-rc.1,sentry-sample_rate=0.3333333333333333,sentry-sampled=true,sentry-trace_id=$traceId,sentry-transaction=TX,sentry-user_id=$userId", baggage.toHeaderString(null))
@@ -577,8 +577,8 @@ class BaggageTest {
         baggage.setValuesFromSamplingDecision(TracesSamplingDecision(true, 0.021, 0.025))
 
         assertEquals("true", baggage.sampled)
-        assertEquals("0.021", baggage.sampleRate)
-        assertEquals("0.025", baggage.sampleRand)
+        assertEquals(0.021, baggage.sampleRate!!, 0.0001)
+        assertEquals(0.025, baggage.sampleRand!!, 0.0001)
     }
 
     @Test
@@ -594,8 +594,8 @@ class BaggageTest {
         baggage.setValuesFromSamplingDecision(TracesSamplingDecision(false, null, null))
 
         assertEquals("false", baggage.sampled)
-        assertEquals("0.021", baggage.sampleRate)
-        assertEquals("0.025", baggage.sampleRand)
+        assertEquals(0.021, baggage.sampleRate!!, 0.0001)
+        assertEquals(0.025, baggage.sampleRand!!, 0.0001)
     }
 
     @Test
@@ -606,42 +606,36 @@ class BaggageTest {
         baggage.setValuesFromSamplingDecision(TracesSamplingDecision(false, 0.121, 0.125))
 
         assertEquals("true", baggage.sampled)
-        assertEquals("0.121", baggage.sampleRate)
-        assertEquals("0.025", baggage.sampleRand)
+        assertEquals(0.121, baggage.sampleRate!!, 0.0001)
+        assertEquals(0.025, baggage.sampleRand!!, 0.0001)
     }
 
+    @Test
     fun `sample rate can be retrieved as double`() {
         val baggage = Baggage.fromHeader("a=b,c=d")
-        baggage.sampleRate = "0.1"
-        assertEquals(0.1, baggage.sampleRateDouble)
+        baggage.sampleRate = 0.1
+        assertEquals(0.1, baggage.sampleRate!!, 0.0001)
     }
 
     @Test
     fun `sample rand can be retrieved as double`() {
         val baggage = Baggage.fromHeader("a=b,c=d")
-        baggage.sampleRand = "0.1"
-        assertEquals(0.1, baggage.sampleRandDouble)
+        baggage.sampleRand = 0.1
+        assertEquals(0.1, baggage.sampleRand!!, 0.0001)
     }
 
     @Test
-    fun `sample rand can be set as double`() {
+    fun `null sample rand returns null double`() {
         val baggage = Baggage.fromHeader("a=b,c=d")
-        baggage.sampleRandDouble = 0.1
-        assertEquals("0.1", baggage.sampleRand)
+        baggage.sampleRand = null
+        assertNull(baggage.sampleRand)
     }
 
     @Test
-    fun `broken sample rand returns null double`() {
+    fun `null sample rate returns null double`() {
         val baggage = Baggage.fromHeader("a=b,c=d")
-        baggage.sampleRand = "a0.1"
-        assertNull(baggage.sampleRandDouble)
-    }
-
-    @Test
-    fun `broken sample rate returns null double`() {
-        val baggage = Baggage.fromHeader("a=b,c=d")
-        baggage.sampleRate = "a0.1"
-        assertNull(baggage.sampleRateDouble)
+        baggage.sampleRate = null
+        assertNull(baggage.sampleRate)
     }
 
     /**

--- a/sentry/src/test/java/io/sentry/SpanContextTest.kt
+++ b/sentry/src/test/java/io/sentry/SpanContextTest.kt
@@ -36,8 +36,8 @@ class SpanContextTest {
         trace.samplingDecision = TracesSamplingDecision(true, 0.1, 0.2)
 
         assertEquals("true", trace.baggage?.sampled)
-        assertEquals("0.1", trace.baggage?.sampleRate)
-        assertEquals("0.2", trace.baggage?.sampleRand)
+        assertEquals(0.1, trace.baggage?.sampleRate!!, 0.0001)
+        assertEquals(0.2, trace.baggage?.sampleRand!!, 0.0001)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/TransactionContextTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionContextTest.kt
@@ -105,7 +105,7 @@ class TransactionContextTest {
     fun `when passing null baggage creates a new one and uses parent sampling decision`() {
         val context = TransactionContext(SentryId(), SpanId(), null, TracesSamplingDecision(true, 0.1, 0.2), null)
         assertNotNull(context.baggage)
-        assertEquals("0.2", context.baggage?.sampleRand)
+        assertEquals(0.2, context.baggage?.sampleRand!!, 0.0001)
     }
 
     @Test
@@ -119,6 +119,6 @@ class TransactionContextTest {
     fun `when using few param ctor creates a new baggage and uses sampling decision`() {
         val context = TransactionContext("name", TransactionNameSource.CUSTOM, "op", TracesSamplingDecision(true, 0.1, 0.2))
         assertNotNull(context.baggage)
-        assertEquals("0.2", context.baggage?.sampleRand)
+        assertEquals(0.2, context.baggage?.sampleRand!!, 0.0001)
     }
 }

--- a/sentry/src/test/java/io/sentry/util/TracingUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/TracingUtilsTest.kt
@@ -274,13 +274,13 @@ class TracingUtilsTest {
     @Test
     fun `keeps sampleRand on passed in baggage if present`() {
         val incomingBaggage = Baggage(NoOpLogger.getInstance())
-        incomingBaggage.sampleRand = "0.3"
+        incomingBaggage.sampleRand = 0.3
         val baggage = TracingUtils.ensureBaggage(
             incomingBaggage,
             null as? TracesSamplingDecision?
         )
         assertSame(incomingBaggage, baggage)
-        assertEquals("0.3", baggage.sampleRand)
+        assertEquals(0.3, baggage.sampleRand!!, 0.0001)
         assertTrue(baggage.isMutable)
     }
 
@@ -331,7 +331,7 @@ class TracingUtilsTest {
             TracesSamplingDecision(true, null, 0.123)
         )
         assertSame(incomingBaggage, baggage)
-        assertEquals("0.123", baggage.sampleRand)
+        assertEquals(0.123, baggage.sampleRand!!, 0.0001)
     }
 
     @Test
@@ -342,7 +342,7 @@ class TracingUtilsTest {
             TracesSamplingDecision(true, 0.0001, null)
         )
         assertSame(incomingBaggage, baggage)
-        val sampleRand = baggage.sampleRandDouble
+        val sampleRand = baggage.sampleRand
         assertNotNull(sampleRand)
         assertTrue(sampleRand < 0.0001)
         assertTrue(sampleRand >= 0.0)
@@ -356,7 +356,7 @@ class TracingUtilsTest {
             TracesSamplingDecision(false, 0.9999, null)
         )
         assertSame(incomingBaggage, baggage)
-        val sampleRand = baggage.sampleRandDouble
+        val sampleRand = baggage.sampleRand
         assertNotNull(sampleRand)
         assertTrue(sampleRand < 1.0)
         assertTrue(sampleRand >= 0.9999)


### PR DESCRIPTION
## :scroll: Description
Keeps the rate / rand values as doubles, until being transferred to `TraceContext`.

## :bulb: Motivation and Context

We seem to be hitting some performance regression with 8.x.x where formatting the sample rate/rand seems to have some impact. I don't trust the profiled app fully, be there seems to be something to it:

Before:
![sentry-android-init-8 x x](https://github.com/user-attachments/assets/28082fc6-0e71-405c-8b9a-1a0c8b986a94)

After:
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/536183f1-94f6-483b-abe9-9d7ce34e79bd" />


TODO: Check why this even being called 3 times (assuming it's for every scope right now)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
