### PR TITLE
fix(replay): Change bitmap config to `ARGB_8888` for screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Do not override user-defined `SentryOptions` ([#4262](https://github.com/getsentry/sentry-java/pull/4262))
+- Session Replay: Change bitmap config to `ARGB_8888` for screenshots ([#4282](https://github.com/getsentry/sentry-java/pull/4282))
 
 ### Dependencies
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -52,13 +52,13 @@ internal class ScreenshotRecorder(
         Bitmap.createBitmap(
             1,
             1,
-            Bitmap.Config.RGB_565
+            Bitmap.Config.ARGB_8888
         )
     }
     private val screenshot = Bitmap.createBitmap(
         config.recordingWidth,
         config.recordingHeight,
-        Bitmap.Config.RGB_565
+        Bitmap.Config.ARGB_8888
     )
     private val singlePixelBitmapCanvas: Canvas by lazy(NONE) { Canvas(singlePixelBitmap) }
     private val prescaledMatrix by lazy(NONE) {
@@ -216,7 +216,9 @@ internal class ScreenshotRecorder(
     fun close() {
         unbind(rootView?.get())
         rootView?.clear()
-        screenshot.recycle()
+        if (!screenshot.isRecycled) {
+            screenshot.recycle()
+        }
         isCapturing.set(false)
     }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
An attempt to fix SIGSEGV which seems to be happening when we stop the replay after 30s the app has been backgrounded. I traced it down to [this call](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/libs/hwui/jni/Bitmap.cpp;l=47) which is where the exception `(SkColorInfo::operator=(SkColorInfo const&)+32)` is happening. This `mInfo` is set from the `Bitmap.Config` value that we pass upon constructing a bitmap. My theory is that it doesn't work well with the `RGB_565` config, especially when we're reusing the same bitmap to capture screenshots.

Also it could be a combination of RN and some device vendors having tweaks to the AOSP code, not sure.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4228 

## :green_heart: How did you test it?
no way to test this sadly as I couldn't reproduce on my devices

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
