### PR TITLE
fix(replay): Change bitmap config to `ARGB_8888` for screenshots (#4282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: Change bitmap config to `ARGB_8888` for screenshots ([#4282](https://github.com/getsentry/sentry-java/pull/4282))
+
 ## 7.22.4
 
 ### Fixes

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -53,13 +53,13 @@ internal class ScreenshotRecorder(
         Bitmap.createBitmap(
             1,
             1,
-            Bitmap.Config.RGB_565
+            Bitmap.Config.ARGB_8888
         )
     }
     private val screenshot = Bitmap.createBitmap(
         config.recordingWidth,
         config.recordingHeight,
-        Bitmap.Config.RGB_565
+        Bitmap.Config.ARGB_8888
     )
     private val singlePixelBitmapCanvas: Canvas by lazy(NONE) { Canvas(singlePixelBitmap) }
     private val prescaledMatrix by lazy(NONE) {
@@ -217,7 +217,9 @@ internal class ScreenshotRecorder(
     fun close() {
         unbind(rootView?.get())
         rootView?.clear()
-        screenshot.recycle()
+        if (!screenshot.isRecycled) {
+            screenshot.recycle()
+        }
         isCapturing.set(false)
     }
 


### PR DESCRIPTION
#skip-changelog

Cherry-pick https://github.com/getsentry/sentry-java/pull/4282 onto 7.x.x for RN 