### PR TITLE
added `platform` to SentryEnvelopeItemHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Do not override user-defined `SentryOptions` ([#4262](https://github.com/getsentry/sentry-java/pull/4262))
 - Session Replay: Change bitmap config to `ARGB_8888` for screenshots ([#4282](https://github.com/getsentry/sentry-java/pull/4282))
 
+### Internal
+
+- Added `platform` to SentryEnvelopeItemHeader ([#4287](https://github.com/getsentry/sentry-java/pull/4287))
+  - Set `android` platform to ProfileChunk envelope item header
+
 ### Dependencies
 
 - Bump Native SDK from v0.8.1 to v0.8.2 ([#4267](https://github.com/getsentry/sentry-java/pull/4267))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2762,11 +2762,12 @@ public final class io/sentry/SentryEnvelopeItem {
 }
 
 public final class io/sentry/SentryEnvelopeItemHeader : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
-	public fun <init> (Lio/sentry/SentryItemType;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lio/sentry/SentryItemType;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun getAttachmentType ()Ljava/lang/String;
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFileName ()Ljava/lang/String;
 	public fun getLength ()I
+	public fun getPlatform ()Ljava/lang/String;
 	public fun getType ()Lio/sentry/SentryItemType;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
@@ -2784,6 +2785,7 @@ public final class io/sentry/SentryEnvelopeItemHeader$JsonKeys {
 	public static final field CONTENT_TYPE Ljava/lang/String;
 	public static final field FILENAME Ljava/lang/String;
 	public static final field LENGTH Ljava/lang/String;
+	public static final field PLATFORM Ljava/lang/String;
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V
 }

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -302,7 +302,9 @@ public final class SentryEnvelopeItem {
             SentryItemType.ProfileChunk,
             () -> cachedItem.getBytes().length,
             "application-json",
-            traceFile.getName());
+            traceFile.getName(),
+            null,
+            "android");
 
     // avoid method refs on Android due to some issues with older AGP setups
     // noinspection Convert2MethodRef

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -304,7 +304,7 @@ public final class SentryEnvelopeItem {
             "application-json",
             traceFile.getName(),
             null,
-            "android");
+            profileChunk.getPlatform());
 
     // avoid method refs on Android due to some issues with older AGP setups
     // noinspection Convert2MethodRef

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java
@@ -15,6 +15,7 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
 
   private final @Nullable String contentType;
   private final @Nullable String fileName;
+  private final @Nullable String platform;
   private final @NotNull SentryItemType type;
   private final int length;
   @Nullable private final Callable<Integer> getLength;
@@ -46,19 +47,25 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
     return fileName;
   }
 
+  public @Nullable String getPlatform() {
+    return platform;
+  }
+
   @ApiStatus.Internal
   public SentryEnvelopeItemHeader(
       final @NotNull SentryItemType type,
       int length,
       final @Nullable String contentType,
       final @Nullable String fileName,
-      final @Nullable String attachmentType) {
+      final @Nullable String attachmentType,
+      final @Nullable String platform) {
     this.type = Objects.requireNonNull(type, "type is required");
     this.contentType = contentType;
     this.length = length;
     this.fileName = fileName;
     this.getLength = null;
     this.attachmentType = attachmentType;
+    this.platform = platform;
   }
 
   SentryEnvelopeItemHeader(
@@ -67,12 +74,23 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
       final @Nullable String contentType,
       final @Nullable String fileName,
       final @Nullable String attachmentType) {
+    this(type, getLength, contentType, fileName, attachmentType, null);
+  }
+
+  SentryEnvelopeItemHeader(
+      final @NotNull SentryItemType type,
+      final @Nullable Callable<Integer> getLength,
+      final @Nullable String contentType,
+      final @Nullable String fileName,
+      final @Nullable String attachmentType,
+      final @Nullable String platform) {
     this.type = Objects.requireNonNull(type, "type is required");
     this.contentType = contentType;
     this.length = -1;
     this.fileName = fileName;
     this.getLength = getLength;
     this.attachmentType = attachmentType;
+    this.platform = platform;
   }
 
   SentryEnvelopeItemHeader(
@@ -100,6 +118,7 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
     public static final String TYPE = "type";
     public static final String ATTACHMENT_TYPE = "attachment_type";
     public static final String LENGTH = "length";
+    public static final String PLATFORM = "platform";
   }
 
   @Override
@@ -115,6 +134,9 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
     writer.name(JsonKeys.TYPE).value(logger, type);
     if (attachmentType != null) {
       writer.name(JsonKeys.ATTACHMENT_TYPE).value(attachmentType);
+    }
+    if (platform != null) {
+      writer.name(JsonKeys.PLATFORM).value(platform);
     }
     writer.name(JsonKeys.LENGTH).value(getLength());
     if (unknown != null) {
@@ -138,6 +160,7 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
       SentryItemType type = null;
       int length = 0;
       String attachmentType = null;
+      String platform = null;
       Map<String, Object> unknown = null;
 
       while (reader.peek() == JsonToken.NAME) {
@@ -158,6 +181,9 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
           case JsonKeys.ATTACHMENT_TYPE:
             attachmentType = reader.nextStringOrNull();
             break;
+          case JsonKeys.PLATFORM:
+            platform = reader.nextStringOrNull();
+            break;
           default:
             if (unknown == null) {
               unknown = new HashMap<>();
@@ -170,7 +196,8 @@ public final class SentryEnvelopeItemHeader implements JsonSerializable, JsonUnk
         throw missingRequiredFieldException(JsonKeys.TYPE, logger);
       }
       SentryEnvelopeItemHeader sentryEnvelopeItemHeader =
-          new SentryEnvelopeItemHeader(type, length, contentType, fileName, attachmentType);
+          new SentryEnvelopeItemHeader(
+              type, length, contentType, fileName, attachmentType, platform);
       sentryEnvelopeItemHeader.setUnknown(unknown);
       reader.endObject();
       return sentryEnvelopeItemHeader;

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -467,10 +467,11 @@ class SentryEnvelopeItemTest {
         val file = File(fixture.pathname)
         val profileChunk = mock<ProfileChunk> {
             whenever(it.traceFile).thenReturn(file)
+            whenever(it.platform).thenReturn("chunk platform")
         }
 
         val chunk = SentryEnvelopeItem.fromProfileChunk(profileChunk, mock())
-        assertEquals("android", chunk.header.platform)
+        assertEquals("chunk platform", chunk.header.platform)
     }
 
     @Test

--- a/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEnvelopeItemTest.kt
@@ -463,6 +463,17 @@ class SentryEnvelopeItemTest {
     }
 
     @Test
+    fun `fromProfileChunk sets platform header`() {
+        val file = File(fixture.pathname)
+        val profileChunk = mock<ProfileChunk> {
+            whenever(it.traceFile).thenReturn(file)
+        }
+
+        val chunk = SentryEnvelopeItem.fromProfileChunk(profileChunk, mock())
+        assertEquals("android", chunk.header.platform)
+    }
+
+    @Test
     fun `fromProfileChunk saves file as Base64`() {
         val file = File(fixture.pathname)
         val profileChunk = mock<ProfileChunk> {

--- a/sentry/src/test/java/io/sentry/protocol/SentryEnvelopeItemHeaderSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryEnvelopeItemHeaderSerializationTest.kt
@@ -23,7 +23,8 @@ class SentryEnvelopeItemHeaderSerializationTest {
             345,
             "5def420f-3dac-4d7b-948b-49de6e551aef",
             "54cf4644-8610-4ff3-a535-34ac1f367501",
-            "6f49ad85-a017-4d94-a5d7-6477251da602"
+            "6f49ad85-a017-4d94-a5d7-6477251da602",
+            "android"
         )
     }
     private val fixture = Fixture()

--- a/sentry/src/test/resources/json/sentry_envelope_item_header.json
+++ b/sentry/src/test/resources/json/sentry_envelope_item_header.json
@@ -3,5 +3,6 @@
     "filename": "54cf4644-8610-4ff3-a535-34ac1f367501",
     "type": "event",
     "attachment_type": "6f49ad85-a017-4d94-a5d7-6477251da602",
+    "platform": "android",
     "length": 345
 }


### PR DESCRIPTION
## :scroll: Description
Added `platform` to SentryEnvelopeItemHeader
Added platform "android" in ProfileChunk envelope items


## :bulb: Motivation and Context
Implements client side of https://github.com/getsentry/team-ingest/issues/679
We want to rate limit UI and backend profile chunks differently.
In order to avoid having to maintain a list of sdk names, we are required to send the platform in the item header.


## :green_heart: How did you test it?
Unit tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
