### PR TITLE
Remove "not yet implemented" from flush comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - The value of the `Sentry-Version-Name` attribute looks like `sentry-8.5.0-otel-2.10.0`
 - Fix tags missing for compose view hierarchies ([#4275](https://github.com/getsentry/sentry-java/pull/4275))
 - Do not leak SentryFileInputStream/SentryFileOutputStream descriptors and channels ([#4296](https://github.com/getsentry/sentry-java/pull/4296))
+- Remove "not yet implemented" from `Sentry.flush` comment ([#4305](https://github.com/getsentry/sentry-java/pull/4305))
 
 ### Internal
 
@@ -100,7 +101,6 @@
   - In certain cases the SDK was not able to provide a transaction name automatically and thus did not finish the transaction for the request.
   - We now first try `SpringMvcTransactionNameProvider` which would provide the route as transaction name.
   - If that does not return anything, we try `SpringServletTransactionNameProvider` next, which returns the URL of the request.
-- Remove "not yet implemented" from `Sentry.flush` comment ([#4305](https://github.com/getsentry/sentry-java/pull/4305))
 
 ### Behavioral Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
   - In certain cases the SDK was not able to provide a transaction name automatically and thus did not finish the transaction for the request.
   - We now first try `SpringMvcTransactionNameProvider` which would provide the route as transaction name.
   - If that does not return anything, we try `SpringServletTransactionNameProvider` next, which returns the URL of the request.
+- Remove "not yet implemented" from `Sentry.flush` comment ([#4305](https://github.com/getsentry/sentry-java/pull/4305))
 
 ### Behavioral Changes
 

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -376,7 +376,7 @@ public interface IScopes {
   boolean isHealthy();
 
   /**
-   * Flushes events queued up, but keeps the scopes enabled. Not implemented yet.
+   * Flushes events queued up, but keeps the scopes enabled.
    *
    * @param timeoutMillis time in milliseconds
    */

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -40,7 +40,7 @@ public interface ISentryClient {
   void close(boolean isRestarting);
 
   /**
-   * Flushes events queued up, but keeps the client enabled. Not implemented yet.
+   * Flushes events queued up, but keeps the client enabled.
    *
    * @param timeoutMillis time in milliseconds
    */

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1030,7 +1030,7 @@ public final class Sentry {
   }
 
   /**
-   * Flushes events queued up to the current Scopes. Not implemented yet.
+   * Flushes events queued up to the current Scopes.
    *
    * @param timeoutMillis time in milliseconds
    */

--- a/sentry/src/main/java/io/sentry/transport/ITransport.java
+++ b/sentry/src/main/java/io/sentry/transport/ITransport.java
@@ -20,7 +20,7 @@ public interface ITransport extends Closeable {
   }
 
   /**
-   * Flushes events queued up, but keeps the client enabled. Not implemented yet.
+   * Flushes events queued up, but keeps the client enabled.
    *
    * @param timeoutMillis time in milliseconds
    */


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`Sentry.flush` as well as other `flush` methods had a comment saying "Not yet implemented" which is no longer true.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/4304

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
