### PR TITLE
Continuous Profiling - Out of Experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Continuous Profiling - Out of Experimental ([#4310](https://github.com/getsentry/sentry-java/pull/4310))
+
 ## 8.6.0
 
 ### Behavioral Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -335,7 +335,7 @@ final class ManifestMetadataReader {
           final double profileSessionSampleRate =
               readDouble(metadata, logger, PROFILE_SESSION_SAMPLE_RATE);
           if (profileSessionSampleRate != -1) {
-            options.getExperimental().setProfileSessionSampleRate(profileSessionSampleRate);
+            options.setProfileSessionSampleRate(profileSessionSampleRate);
           }
         }
 
@@ -346,20 +346,16 @@ final class ManifestMetadataReader {
                 PROFILE_LIFECYCLE,
                 options.getProfileLifecycle().name().toLowerCase(Locale.ROOT));
         if (profileLifecycle != null) {
-          options
-              .getExperimental()
-              .setProfileLifecycle(
-                  ProfileLifecycle.valueOf(profileLifecycle.toUpperCase(Locale.ROOT)));
+          options.setProfileLifecycle(
+              ProfileLifecycle.valueOf(profileLifecycle.toUpperCase(Locale.ROOT)));
         }
 
-        options
-            .getExperimental()
-            .setStartProfilerOnAppStart(
-                readBool(
-                    metadata,
-                    logger,
-                    PROFILER_START_ON_APP_START,
-                    options.isStartProfilerOnAppStart()));
+        options.setStartProfilerOnAppStart(
+            readBool(
+                metadata,
+                logger,
+                PROFILER_START_ON_APP_START,
+                options.isStartProfilerOnAppStart()));
 
         options.setEnableUserInteractionTracing(
             readBool(metadata, logger, TRACES_UI_ENABLE, options.isEnableUserInteractionTracing()));

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -175,9 +175,8 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
     logger.log(SentryLevel.DEBUG, "App start continuous profiling started.");
     SentryOptions sentryOptions = SentryOptions.empty();
     // Let's fake a sampler to accept the sampling decision that was calculated on last run
-    sentryOptions
-        .getExperimental()
-        .setProfileSessionSampleRate(profilingOptions.isContinuousProfileSampled() ? 1.0 : 0.0);
+    sentryOptions.setProfileSessionSampleRate(
+        profilingOptions.isContinuousProfileSampled() ? 1.0 : 0.0);
     appStartContinuousProfiler.startProfiler(
         profilingOptions.getProfileLifecycle(), new TracesSampler(sentryOptions));
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -826,7 +826,7 @@ class ManifestMetadataReaderTest {
     fun `applyMetadata does not override profileSessionSampleRate from options`() {
         // Arrange
         val expectedSampleRate = 0.99f
-        fixture.options.experimental.profileSessionSampleRate = expectedSampleRate.toDouble()
+        fixture.options.profileSessionSampleRate = expectedSampleRate.toDouble()
         val bundle = bundleOf(ManifestMetadataReader.PROFILE_SESSION_SAMPLE_RATE to 0.1f)
         val context = fixture.getContext(metaData = bundle)
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -458,12 +458,6 @@ public abstract interface class io/sentry/EventProcessor {
 
 public final class io/sentry/ExperimentalOptions {
 	public fun <init> (ZLio/sentry/protocol/SdkVersion;)V
-	public fun getProfileLifecycle ()Lio/sentry/ProfileLifecycle;
-	public fun getProfileSessionSampleRate ()Ljava/lang/Double;
-	public fun isStartProfilerOnAppStart ()Z
-	public fun setProfileLifecycle (Lio/sentry/ProfileLifecycle;)V
-	public fun setProfileSessionSampleRate (Ljava/lang/Double;)V
-	public fun setStartProfilerOnAppStart (Z)V
 }
 
 public final class io/sentry/ExternalOptions {
@@ -3222,6 +3216,8 @@ public class io/sentry/SentryOptions {
 	public fun setModulesLoader (Lio/sentry/internal/modules/IModulesLoader;)V
 	public fun setOpenTelemetryMode (Lio/sentry/SentryOpenTelemetryMode;)V
 	public fun setPrintUncaughtStackTrace (Z)V
+	public fun setProfileLifecycle (Lio/sentry/ProfileLifecycle;)V
+	public fun setProfileSessionSampleRate (Ljava/lang/Double;)V
 	public fun setProfilesSampleRate (Ljava/lang/Double;)V
 	public fun setProfilesSampler (Lio/sentry/SentryOptions$ProfilesSamplerCallback;)V
 	public fun setProfilingTracesHz (I)V
@@ -3245,6 +3241,7 @@ public class io/sentry/SentryOptions {
 	public fun setSpanFactory (Lio/sentry/ISpanFactory;)V
 	public fun setSpotlightConnectionUrl (Ljava/lang/String;)V
 	public fun setSslSocketFactory (Ljavax/net/ssl/SSLSocketFactory;)V
+	public fun setStartProfilerOnAppStart (Z)V
 	public fun setTag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setThreadChecker (Lio/sentry/util/thread/IThreadChecker;)V
 	public fun setTraceOptionsRequests (Z)V

--- a/sentry/src/main/java/io/sentry/ExperimentalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExperimentalOptions.java
@@ -1,9 +1,6 @@
 package io.sentry;
 
 import io.sentry.protocol.SdkVersion;
-import io.sentry.util.SampleRateUtils;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -14,74 +11,5 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class ExperimentalOptions {
 
-  /**
-   * Indicates the percentage in which the profiles for the session will be created. Specifying 0
-   * means never, 1.0 means always. The value needs to be >= 0.0 and <= 1.0 The default is null
-   * (disabled).
-   */
-  private @Nullable Double profileSessionSampleRate;
-
-  /**
-   * Whether the profiling lifecycle is controlled manually or based on the trace lifecycle.
-   * Defaults to {@link ProfileLifecycle#MANUAL}.
-   */
-  private @NotNull ProfileLifecycle profileLifecycle = ProfileLifecycle.MANUAL;
-
-  /**
-   * Whether profiling can automatically be started as early as possible during the app lifecycle,
-   * to capture more of app startup. If {@link ExperimentalOptions#profileLifecycle} is {@link
-   * ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfiler must be
-   * called manually whenever the app startup is completed If {@link
-   * ExperimentalOptions#profileLifecycle} is {@link ProfileLifecycle#TRACE} Profiling is started
-   * automatically on startup, and will automatically be stopped when the root span that is
-   * associated with app startup ends
-   */
-  private boolean startProfilerOnAppStart = false;
-
   public ExperimentalOptions(final boolean empty, final @Nullable SdkVersion sdkVersion) {}
-
-  /**
-   * Returns whether the profiling cycle is controlled manually or based on the trace lifecycle.
-   * Defaults to {@link ProfileLifecycle#MANUAL}.
-   *
-   * @return the profile lifecycle
-   */
-  @ApiStatus.Experimental
-  public @NotNull ProfileLifecycle getProfileLifecycle() {
-    return profileLifecycle;
-  }
-
-  /** Sets the profiling lifecycle. */
-  @ApiStatus.Experimental
-  public void setProfileLifecycle(final @NotNull ProfileLifecycle profileLifecycle) {
-    // TODO (when moved to SentryOptions): we should log a message if the user sets this to TRACE
-    // and tracing is disabled
-    this.profileLifecycle = profileLifecycle;
-  }
-
-  @ApiStatus.Experimental
-  public @Nullable Double getProfileSessionSampleRate() {
-    return profileSessionSampleRate;
-  }
-
-  @ApiStatus.Experimental
-  public void setProfileSessionSampleRate(final @Nullable Double profileSessionSampleRate) {
-    if (!SampleRateUtils.isValidContinuousProfilesSampleRate(profileSessionSampleRate)) {
-      throw new IllegalArgumentException(
-          "The value "
-              + profileSessionSampleRate
-              + " is not valid. Use values between 0.0 and 1.0.");
-    }
-    this.profileSessionSampleRate = profileSessionSampleRate;
-  }
-
-  @ApiStatus.Experimental
-  public boolean isStartProfilerOnAppStart() {
-    return startProfilerOnAppStart;
-  }
-
-  @ApiStatus.Experimental
-  public void setStartProfilerOnAppStart(boolean startProfilerOnAppStart) {
-    this.startProfilerOnAppStart = startProfilerOnAppStart;
-  }
 }

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -542,6 +542,30 @@ public class SentryOptions {
   @ApiStatus.Experimental private boolean captureOpenTelemetryEvents = false;
 
   private @NotNull IVersionDetector versionDetector = NoopVersionDetector.getInstance();
+
+  /**
+   * Indicates the percentage in which the profiles for the session will be created. Specifying 0
+   * means never, 1.0 means always. The value needs to be >= 0.0 and <= 1.0 The default is null
+   * (disabled).
+   */
+  private @Nullable Double profileSessionSampleRate;
+
+  /**
+   * Whether the profiling lifecycle is controlled manually or based on the trace lifecycle.
+   * Defaults to {@link ProfileLifecycle#MANUAL}.
+   */
+  private @NotNull ProfileLifecycle profileLifecycle = ProfileLifecycle.MANUAL;
+
+  /**
+   * Whether profiling can automatically be started as early as possible during the app lifecycle,
+   * to capture more of app startup. If {@link SentryOptions#profileLifecycle} is {@link
+   * ProfileLifecycle#MANUAL} Profiling is started automatically on startup and stopProfiler must be
+   * called manually whenever the app startup is completed If {@link SentryOptions#profileLifecycle}
+   * is {@link ProfileLifecycle#TRACE} Profiling is started automatically on startup, and will
+   * automatically be stopped when the root span that is associated with app startup ends
+   */
+  private boolean startProfilerOnAppStart = false;
+
   /**
    * Adds an event processor
    *
@@ -1821,7 +1845,6 @@ public class SentryOptions {
    *
    * @return the continuous profiler.
    */
-  @ApiStatus.Experimental
   public @NotNull IContinuousProfiler getContinuousProfiler() {
     return continuousProfiler;
   }
@@ -1831,7 +1854,6 @@ public class SentryOptions {
    *
    * @param continuousProfiler - the continuous profiler
    */
-  @ApiStatus.Experimental
   public void setContinuousProfiler(final @Nullable IContinuousProfiler continuousProfiler) {
     // We allow to set the profiler only if it was not set before, and we don't allow to unset it.
     if (this.continuousProfiler == NoOpContinuousProfiler.getInstance()
@@ -1859,8 +1881,8 @@ public class SentryOptions {
   public boolean isContinuousProfilingEnabled() {
     return profilesSampleRate == null
         && profilesSampler == null
-        && experimental.getProfileSessionSampleRate() != null
-        && experimental.getProfileSessionSampleRate() > 0;
+        && profileSessionSampleRate != null
+        && profileSessionSampleRate > 0;
   }
 
   /**
@@ -1914,9 +1936,23 @@ public class SentryOptions {
    *
    * @return the sample rate
    */
-  @ApiStatus.Experimental
   public @Nullable Double getProfileSessionSampleRate() {
-    return experimental.getProfileSessionSampleRate();
+    return profileSessionSampleRate;
+  }
+
+  /**
+   * Set the session sample rate. Default is null (disabled). ProfilesSampleRate takes precedence
+   * over this. To enable continuous profiling, don't set profilesSampleRate or profilesSampler, or
+   * set them to null.
+   */
+  public void setProfileSessionSampleRate(final @Nullable Double profileSessionSampleRate) {
+    if (!SampleRateUtils.isValidContinuousProfilesSampleRate(profileSessionSampleRate)) {
+      throw new IllegalArgumentException(
+          "The value "
+              + profileSessionSampleRate
+              + " is not valid. Use values between 0.0 and 1.0.");
+    }
+    this.profileSessionSampleRate = profileSessionSampleRate;
   }
 
   /**
@@ -1925,17 +1961,33 @@ public class SentryOptions {
    *
    * @return the profile lifecycle
    */
-  @ApiStatus.Experimental
   public @NotNull ProfileLifecycle getProfileLifecycle() {
-    return experimental.getProfileLifecycle();
+    return profileLifecycle;
+  }
+
+  /** Sets the profiling lifecycle. */
+  public void setProfileLifecycle(final @NotNull ProfileLifecycle profileLifecycle) {
+    this.profileLifecycle = profileLifecycle;
+    if (profileLifecycle == ProfileLifecycle.TRACE && !isTracingEnabled()) {
+      logger.log(
+          SentryLevel.WARNING,
+          "Profiling lifecycle is set to TRACE but tracing is disabled. "
+              + "Profiling will not be started automatically.");
+    }
   }
 
   /**
    * Whether profiling can automatically be started as early as possible during the app lifecycle.
    */
-  @ApiStatus.Experimental
   public boolean isStartProfilerOnAppStart() {
-    return experimental.isStartProfilerOnAppStart();
+    return startProfilerOnAppStart;
+  }
+
+  /**
+   * Set if profiling can automatically be started as early as possible during the app lifecycle.
+   */
+  public void setStartProfilerOnAppStart(final boolean startProfilerOnAppStart) {
+    this.startProfilerOnAppStart = startProfilerOnAppStart;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -398,7 +398,7 @@ class ScopeTest {
         val options = SentryOptions().apply {
             release = "0.0.1"
             setContinuousProfiler(profiler)
-            experimental.profileSessionSampleRate = 1.0
+            profileSessionSampleRate = 1.0
         }
 
         val scope = Scope(options)
@@ -419,7 +419,7 @@ class ScopeTest {
         val options = SentryOptions().apply {
             release = "0.0.1"
             setContinuousProfiler(profiler)
-            experimental.profileSessionSampleRate = 1.0
+            profileSessionSampleRate = 1.0
         }
 
         val scope = Scope(options)
@@ -435,7 +435,7 @@ class ScopeTest {
         val options = SentryOptions().apply {
             release = "0.0.1"
             setContinuousProfiler(profiler)
-            experimental.profileSessionSampleRate = 1.0
+            profileSessionSampleRate = 1.0
         }
 
         val scope = Scope(options)

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -1818,7 +1818,7 @@ class ScopesTest {
             setTransactionProfiler(profiler)
             compositePerformanceCollector = performanceCollector
             setContinuousProfiler(continuousProfiler)
-            experimental.profileSessionSampleRate = 1.0
+            profileSessionSampleRate = 1.0
             backpressureMonitor = backpressureMonitorMock
         }
         val sut = createScopes(options)
@@ -1892,8 +1892,8 @@ class ScopesTest {
         val scopes = generateScopes {
             it.tracesSampleRate = 1.0
             it.setContinuousProfiler(mockProfiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.TRACE
         }
 
         val transaction = scopes.startTransaction("name", "op")
@@ -1906,8 +1906,8 @@ class ScopesTest {
         val scopes = generateScopes {
             it.tracesSampleRate = 1.0
             it.setContinuousProfiler(mockProfiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.MANUAL
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.MANUAL
         }
 
         val transaction = scopes.startTransaction("name", "op")
@@ -1921,8 +1921,8 @@ class ScopesTest {
             // If transaction is not sampled, profiler should not start
             it.tracesSampleRate = 0.0
             it.setContinuousProfiler(mockProfiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.TRACE
         }
         val transaction = scopes.startTransaction("name", "op")
         transaction.spanContext.setSampled(false, false)
@@ -2244,7 +2244,7 @@ class ScopesTest {
         val profiler = mock<IContinuousProfiler>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
         }
         scopes.startProfiler()
         verify(profiler).startProfiler(eq(ProfileLifecycle.MANUAL), any())
@@ -2256,7 +2256,7 @@ class ScopesTest {
         val logger = mock<ILogger>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
             it.profilesSampleRate = 1.0
             it.setLogger(logger)
             it.isDebug = true
@@ -2272,8 +2272,8 @@ class ScopesTest {
         val logger = mock<ILogger>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.TRACE
             it.setLogger(logger)
             it.isDebug = true
         }
@@ -2287,7 +2287,7 @@ class ScopesTest {
         val profiler = mock<IContinuousProfiler>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
         }
         scopes.stopProfiler()
         verify(profiler).stopProfiler(eq(ProfileLifecycle.MANUAL))
@@ -2299,7 +2299,7 @@ class ScopesTest {
         val logger = mock<ILogger>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
             it.profilesSampleRate = 1.0
             it.setLogger(logger)
             it.isDebug = true
@@ -2315,8 +2315,8 @@ class ScopesTest {
         val logger = mock<ILogger>()
         val scopes = generateScopes {
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.TRACE
             it.setLogger(logger)
             it.isDebug = true
         }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -239,7 +239,7 @@ class SentryOptionsTest {
     @Test
     fun `when profileSessionSampleRate is set to 0, isProfilingEnabled is false and isContinuousProfilingEnabled is false`() {
         val options = SentryOptions().apply {
-            this.experimental.profileSessionSampleRate = 0.0
+            this.profileSessionSampleRate = 0.0
         }
         assertFalse(options.isProfilingEnabled)
         assertFalse(options.isContinuousProfilingEnabled)
@@ -248,7 +248,7 @@ class SentryOptionsTest {
     @Test
     fun `when profileSessionSampleRate is null, isProfilingEnabled is false and isContinuousProfilingEnabled is false`() {
         val options = SentryOptions()
-        assertNull(options.experimental.profileSessionSampleRate)
+        assertNull(options.profileSessionSampleRate)
         assertFalse(options.isProfilingEnabled)
         assertFalse(options.isContinuousProfilingEnabled)
     }
@@ -274,25 +274,25 @@ class SentryOptionsTest {
     @Test
     fun `when profileSessionSampleRate is set to exactly 0, value is set`() {
         val options = SentryOptions().apply {
-            this.experimental.profileSessionSampleRate = 0.0
+            this.profileSessionSampleRate = 0.0
         }
         assertEquals(0.0, options.profileSessionSampleRate)
     }
 
     @Test
     fun `when profileSessionSampleRate is set to higher than 1_0, setter throws`() {
-        assertFailsWith<IllegalArgumentException> { SentryOptions().experimental.profileSessionSampleRate = 1.0000000000001 }
+        assertFailsWith<IllegalArgumentException> { SentryOptions().profileSessionSampleRate = 1.0000000000001 }
     }
 
     @Test
     fun `when profileSessionSampleRate is set to lower than 0, setter throws`() {
-        assertFailsWith<IllegalArgumentException> { SentryOptions().experimental.profileSessionSampleRate = -0.0000000000001 }
+        assertFailsWith<IllegalArgumentException> { SentryOptions().profileSessionSampleRate = -0.0000000000001 }
     }
 
     @Test
     fun `when profileLifecycleSessionSampleRate is set to a value, value is set`() {
         val options = SentryOptions().apply {
-            this.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            this.profileLifecycle = ProfileLifecycle.TRACE
         }
         assertEquals(ProfileLifecycle.TRACE, options.profileLifecycle)
     }
@@ -306,7 +306,7 @@ class SentryOptionsTest {
     @Test
     fun `when isStartProfilerOnAppStart is set to a value, value is set`() {
         val options = SentryOptions().apply {
-            this.experimental.isStartProfilerOnAppStart = true
+            this.isStartProfilerOnAppStart = true
         }
         assertTrue(options.isStartProfilerOnAppStart)
     }
@@ -643,7 +643,7 @@ class SentryOptionsTest {
     fun `when profiling is disabled, isEnableAppStartProfiling is always false`() {
         val options = SentryOptions()
         options.isEnableAppStartProfiling = true
-        options.experimental.profileSessionSampleRate = 0.0
+        options.profileSessionSampleRate = 0.0
         assertFalse(options.isEnableAppStartProfiling)
     }
 
@@ -651,7 +651,7 @@ class SentryOptionsTest {
     fun `when setEnableAppStartProfiling is called and continuous profiling is enabled, isEnableAppStartProfiling is true`() {
         val options = SentryOptions()
         options.isEnableAppStartProfiling = true
-        options.experimental.profileSessionSampleRate = 1.0
+        options.profileSessionSampleRate = 1.0
         assertTrue(options.isEnableAppStartProfiling)
     }
 

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -407,7 +407,7 @@ class SentryTest {
         var sentryOptions: SentryOptions? = null
         Sentry.init {
             it.dsn = dsn
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
             it.cacheDirPath = tempPath
             sentryOptions = it
         }
@@ -422,7 +422,7 @@ class SentryTest {
         var sentryOptions: SentryOptions? = null
         Sentry.init {
             it.dsn = dsn
-            it.experimental.profileSessionSampleRate = 0.0
+            it.profileSessionSampleRate = 0.0
             it.cacheDirPath = tempPath
             sentryOptions = it
         }
@@ -1138,7 +1138,7 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
             it.tracesSampleRate = 1.0
-            it.experimental.isStartProfilerOnAppStart = true
+            it.isStartProfilerOnAppStart = true
             it.profilesSampleRate = 1.0
             it.tracesSampler = mockSampleTracer
             it.profilesSampler = mockProfilesSampler
@@ -1251,7 +1251,7 @@ class SentryTest {
             it.dsn = dsn
             it.cacheDirPath = path
             it.isEnableAppStartProfiling = false
-            it.experimental.isStartProfilerOnAppStart = true
+            it.isStartProfilerOnAppStart = true
             it.tracesSampleRate = 0.0
             it.executorService = ImmediateExecutorService()
         }
@@ -1267,7 +1267,7 @@ class SentryTest {
             it.cacheDirPath = path
             it.tracesSampleRate = 0.5
             it.isEnableAppStartProfiling = true
-            it.experimental.isStartProfilerOnAppStart = true
+            it.isStartProfilerOnAppStart = true
             it.profilesSampleRate = 0.2
             it.executorService = ImmediateExecutorService()
             options = it
@@ -1352,7 +1352,7 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
         }
         Sentry.startProfiler()
         verify(profiler).startProfiler(eq(ProfileLifecycle.MANUAL), any())
@@ -1377,8 +1377,8 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
-            it.experimental.profileLifecycle = ProfileLifecycle.TRACE
+            it.profileSessionSampleRate = 1.0
+            it.profileLifecycle = ProfileLifecycle.TRACE
             it.isDebug = true
             it.setLogger(logger)
         }
@@ -1397,7 +1397,7 @@ class SentryTest {
         Sentry.init {
             it.dsn = dsn
             it.setContinuousProfiler(profiler)
-            it.experimental.profileSessionSampleRate = 1.0
+            it.profileSessionSampleRate = 1.0
         }
         Sentry.stopProfiler()
         verify(profiler).stopProfiler(eq(ProfileLifecycle.MANUAL))

--- a/sentry/src/test/java/io/sentry/SentryTracerTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTracerTest.kt
@@ -263,7 +263,7 @@ class SentryTracerTest {
         whenever(continuousProfiler.profilerId).thenReturn(profilerId)
         val tracer = fixture.getSut(optionsConfiguration = {
             it.setContinuousProfiler(continuousProfiler)
-            it.experimental.profileLifecycle = ProfileLifecycle.MANUAL
+            it.profileLifecycle = ProfileLifecycle.MANUAL
         }, samplingDecision = TracesSamplingDecision(true))
         tracer.finish()
         // profiler is never stopped, as it should be stopped manually

--- a/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
+++ b/sentry/src/test/java/io/sentry/TracesSamplerTest.kt
@@ -30,7 +30,7 @@ class TracesSamplerTest {
                 options.profilesSampleRate = profilesSampleRate
             }
             if (profileSessionSampleRate != null) {
-                options.experimental.profileSessionSampleRate = profileSessionSampleRate
+                options.profileSessionSampleRate = profileSessionSampleRate
             }
             if (tracesSamplerCallback != null) {
                 options.tracesSampler = tracesSamplerCallback


### PR DESCRIPTION
## :scroll: Description
moved continuous profiling out of `ExperimentalOptions` back into `SentryOptions`


## :bulb: Motivation and Context
Continuous Profiling is about to GA


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
