### PR TITLE
Fix `SentryUserFilter` in `spring` and `spring-jakarta` samples

### DIFF
--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/AppConfig.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/AppConfig.java
@@ -1,6 +1,6 @@
 package io.sentry.samples.spring.jakarta;
 
-import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.spring.jakarta.SentryUserFilter;
 import io.sentry.spring.jakarta.SentryUserProvider;
 import java.util.List;
@@ -13,8 +13,7 @@ import org.springframework.context.annotation.Import;
 public class AppConfig {
 
   @Bean
-  SentryUserFilter sentryUserFilter(
-      final IScopes scopes, final List<SentryUserProvider> sentryUserProviders) {
-    return new SentryUserFilter(scopes, sentryUserProviders);
+  SentryUserFilter sentryUserFilter(final List<SentryUserProvider> sentryUserProviders) {
+    return new SentryUserFilter(ScopesAdapter.getInstance(), sentryUserProviders);
   }
 }

--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/AppConfig.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/AppConfig.java
@@ -1,9 +1,11 @@
 package io.sentry.samples.spring.jakarta;
 
-import io.sentry.ScopesAdapter;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.SentryUserFilter;
 import io.sentry.spring.jakarta.SentryUserProvider;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -12,8 +14,10 @@ import org.springframework.context.annotation.Import;
 @Import(SentryConfig.class)
 public class AppConfig {
 
+  @Autowired private ApplicationContext applicationContext;
+
   @Bean
   SentryUserFilter sentryUserFilter(final List<SentryUserProvider> sentryUserProviders) {
-    return new SentryUserFilter(ScopesAdapter.getInstance(), sentryUserProviders);
+    return new SentryUserFilter(applicationContext.getBean(IScopes.class), sentryUserProviders);
   }
 }

--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/WebConfig.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/WebConfig.java
@@ -1,6 +1,6 @@
 package io.sentry.samples.spring.jakarta;
 
-import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.Collections;
 import org.springframework.context.annotation.Bean;
@@ -20,14 +20,13 @@ public class WebConfig {
    * Creates a {@link RestTemplate} which calls are intercepted with {@link
    * SentrySpanClientHttpRequestInterceptor} to create spans around HTTP calls.
    *
-   * @param scopes - sentry scopes
    * @return RestTemplate
    */
   @Bean
-  RestTemplate restTemplate(IScopes scopes) {
+  RestTemplate restTemplate() {
     RestTemplate restTemplate = new RestTemplate();
     SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
-        new SentrySpanClientHttpRequestInterceptor(scopes);
+        new SentrySpanClientHttpRequestInterceptor(ScopesAdapter.getInstance());
     restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
     return restTemplate;
   }

--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/WebConfig.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/WebConfig.java
@@ -1,8 +1,10 @@
 package io.sentry.samples.spring.jakarta;
 
-import io.sentry.ScopesAdapter;
+import io.sentry.IScopes;
 import io.sentry.spring.jakarta.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,8 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 public class WebConfig {
 
+  @Autowired private ApplicationContext applicationContext;
+
   /**
    * Creates a {@link RestTemplate} which calls are intercepted with {@link
    * SentrySpanClientHttpRequestInterceptor} to create spans around HTTP calls.
@@ -26,7 +30,7 @@ public class WebConfig {
   RestTemplate restTemplate() {
     RestTemplate restTemplate = new RestTemplate();
     SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
-        new SentrySpanClientHttpRequestInterceptor(ScopesAdapter.getInstance());
+        new SentrySpanClientHttpRequestInterceptor(applicationContext.getBean(IScopes.class));
     restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
     return restTemplate;
   }

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
@@ -1,9 +1,11 @@
 package io.sentry.samples.spring;
 
-import io.sentry.ScopesAdapter;
+import io.sentry.IScopes;
 import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -12,8 +14,10 @@ import org.springframework.context.annotation.Import;
 @Import(SentryConfig.class)
 public class AppConfig {
 
+  @Autowired private ApplicationContext applicationContext;
+
   @Bean
   SentryUserFilter sentryUserFilter(final List<SentryUserProvider> sentryUserProviders) {
-    return new SentryUserFilter(ScopesAdapter.getInstance(), sentryUserProviders);
+    return new SentryUserFilter(applicationContext.getBean(IScopes.class), sentryUserProviders);
   }
 }

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/AppConfig.java
@@ -1,6 +1,6 @@
 package io.sentry.samples.spring;
 
-import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.spring.SentryUserFilter;
 import io.sentry.spring.SentryUserProvider;
 import java.util.List;
@@ -13,8 +13,7 @@ import org.springframework.context.annotation.Import;
 public class AppConfig {
 
   @Bean
-  SentryUserFilter sentryUserFilter(
-      final IScopes scopes, final List<SentryUserProvider> sentryUserProviders) {
-    return new SentryUserFilter(scopes, sentryUserProviders);
+  SentryUserFilter sentryUserFilter(final List<SentryUserProvider> sentryUserProviders) {
+    return new SentryUserFilter(ScopesAdapter.getInstance(), sentryUserProviders);
   }
 }

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
@@ -1,8 +1,10 @@
 package io.sentry.samples.spring;
 
-import io.sentry.ScopesAdapter;
+import io.sentry.IScopes;
 import io.sentry.spring.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,8 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 public class WebConfig {
 
+  @Autowired private ApplicationContext applicationContext;
+
   /**
    * Creates a {@link RestTemplate} which calls are intercepted with {@link
    * SentrySpanClientHttpRequestInterceptor} to create spans around HTTP calls.
@@ -26,7 +30,7 @@ public class WebConfig {
   RestTemplate restTemplate() {
     RestTemplate restTemplate = new RestTemplate();
     SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
-        new SentrySpanClientHttpRequestInterceptor(ScopesAdapter.getInstance());
+        new SentrySpanClientHttpRequestInterceptor(applicationContext.getBean(IScopes.class));
     restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
     return restTemplate;
   }

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/WebConfig.java
@@ -1,6 +1,6 @@
 package io.sentry.samples.spring;
 
-import io.sentry.IScopes;
+import io.sentry.ScopesAdapter;
 import io.sentry.spring.tracing.SentrySpanClientHttpRequestInterceptor;
 import java.util.Collections;
 import org.springframework.context.annotation.Bean;
@@ -20,14 +20,13 @@ public class WebConfig {
    * Creates a {@link RestTemplate} which calls are intercepted with {@link
    * SentrySpanClientHttpRequestInterceptor} to create spans around HTTP calls.
    *
-   * @param scopes - sentry scopes
    * @return RestTemplate
    */
   @Bean
-  RestTemplate restTemplate(IScopes scopes) {
+  RestTemplate restTemplate() {
     RestTemplate restTemplate = new RestTemplate();
     SentrySpanClientHttpRequestInterceptor sentryRestTemplateInterceptor =
-        new SentrySpanClientHttpRequestInterceptor(scopes);
+        new SentrySpanClientHttpRequestInterceptor(ScopesAdapter.getInstance());
     restTemplate.setInterceptors(Collections.singletonList(sentryRestTemplateInterceptor));
     return restTemplate;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Previously this was 
```
  @Bean
  SentryUserFilter sentryUserFilter(
      final IScopes scopes, final List<SentryUserProvider> sentryUserProviders) {
    return new SentryUserFilter(scopes, sentryUserProviders);
  }
```
This didn't register the bean because "Could not autowire. No beans of 'IScopes' type found. ".

This seems to work, not sure if it's the correct approach.

#skip-changelog