### PR TITLE
Use thread context classloader when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use thread context classloader when available ([#4320](https://github.com/getsentry/sentry-java/pull/4320))
+  - This ensures correct resource loading in environments like Spring Boot where the thread context classloader is used for resource loading.
+
+## 8.7.0
+
 ### Features
 
 - Continuous Profiling - stop when app goes in background ([#4311](https://github.com/getsentry/sentry-java/pull/4311))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 8.7.0
+## Unreleased
 
 ### Fixes
 

--- a/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
@@ -8,6 +8,12 @@ public final class ClassLoaderUtils {
   public static @NotNull ClassLoader classLoaderOrDefault(final @Nullable ClassLoader classLoader) {
     // bootstrap classloader is represented as null, so using system classloader instead
     if (classLoader == null) {
+      // try thread context classloader
+      final @Nullable ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+      if (contextClassLoader != null) {
+        return contextClassLoader;
+      }
+      // fallback to system classloader
       return ClassLoader.getSystemClassLoader();
     } else {
       return classLoader;

--- a/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
+++ b/sentry/src/main/java/io/sentry/util/ClassLoaderUtils.java
@@ -9,7 +9,8 @@ public final class ClassLoaderUtils {
     // bootstrap classloader is represented as null, so using system classloader instead
     if (classLoader == null) {
       // try thread context classloader
-      final @Nullable ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+      final @Nullable ClassLoader contextClassLoader =
+          Thread.currentThread().getContextClassLoader();
       if (contextClassLoader != null) {
         return contextClassLoader;
       }


### PR DESCRIPTION
## :scroll: Description
Prioritizes the thread context classloader over the system classloader when the bootstrap classloader is null.
This ensures correct resource loading in environments like Spring Boot where the thread context classloader is used for resource loading.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/4318

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
