### PR TITLE
Fix do not initialize SDK for Jetpack Compose Preview builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix do not initialize SDK for Jetpack Compose Preview builds ([#4324](https://github.com/getsentry/sentry-java/pull/4324))
+
 ## 8.7.0
 
 ### Features

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -185,6 +185,7 @@ public final class io/sentry/android/core/BuildInfoProvider {
 }
 
 public final class io/sentry/android/core/ContextUtils {
+	public static fun appIsLibraryForComposePreview (Landroid/content/Context;)Z
 	public static fun getApplicationContext (Landroid/content/Context;)Landroid/content/Context;
 	public static fun isForegroundImportance ()Z
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryInitProvider.java
@@ -21,7 +21,9 @@ public final class SentryInitProvider extends EmptySecureContentProvider {
       logger.log(SentryLevel.FATAL, "App. Context from ContentProvider is null");
       return false;
     }
-    if (ManifestMetadataReader.isAutoInit(context, logger)) {
+
+    if (ManifestMetadataReader.isAutoInit(context, logger)
+        && !ContextUtils.appIsLibraryForComposePreview(context)) {
       SentryAndroid.init(context, logger);
       SentryIntegrationPackageStorage.getInstance().addIntegration("AutoInit");
     }


### PR DESCRIPTION
## :scroll: Description
If you launch a Jetpack Compose Preview for a `@Composable` within a library, the library will be packaged as an app (`androidTest` flavor) and the Compose Tooling will add a [preview activity](https://developer.android.com/reference/kotlin/androidx/compose/ui/tooling/PreviewActivity).

If the library has a dependency to Sentry, this will cause the preview-app to crash, as typically no DSN is set within the library and our SDK will try to auto-init.

There's no easy way around this, but we can detect at runtime if the app is a preview app.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/2904

## :green_heart: How did you test it?
Added unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
