### PR TITLE
fix(breadcrumbs): Improve low memory breadcrumb capturing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use thread context classloader when available ([#4320](https://github.com/getsentry/sentry-java/pull/4320))
   - This ensures correct resource loading in environments like Spring Boot where the thread context classloader is used for resource loading.
+- Improve low memory breadcrumb capturing ([#4325](https://github.com/getsentry/sentry-java/pull/4325))
 
 ## 8.7.0
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AppComponentsBreadcrumbsIntegrationTest.kt
@@ -96,24 +96,6 @@ class AppComponentsBreadcrumbsIntegrationTest {
     }
 
     @Test
-    fun `When low memory event, a breadcrumb with type, category and level should be set`() {
-        val sut = fixture.getSut()
-        val options = SentryAndroidOptions().apply {
-            executorService = ImmediateExecutorService()
-        }
-        val scopes = mock<IScopes>()
-        sut.register(scopes, options)
-        sut.onLowMemory()
-        verify(scopes).addBreadcrumb(
-            check<Breadcrumb> {
-                assertEquals("device.event", it.category)
-                assertEquals("system", it.type)
-                assertEquals(SentryLevel.WARNING, it.level)
-            }
-        )
-    }
-
-    @Test
     fun `When trim memory event with level, a breadcrumb with type, category and level should be set`() {
         val sut = fixture.getSut()
         val options = SentryAndroidOptions().apply {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- `onLowMemory` is a deprecated API and should not be used in conjunction with `onTrimMemory`
![image](https://github.com/user-attachments/assets/25f81b0b-7a6f-4925-a086-0e2245f876ec)

- Move the `level` check out of the runnable lambda, so we don't even enqueue a task if the level is not suitable for reporting
- Debounce low memory breadcrumbs by minute

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
