### PR TITLE
Make RequestDetailsResolver public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Set `-Dio.opentelemetry.context.contextStorageProvider=io.sentry.opentelemetry.SentryContextStorageProvider` on your `java` command
   - Sentry will then wrap the other `ContextStorageProvider` that has been configured by loading it through SPI
   - If no other `ContextStorageProvider` is available or there are problems loading it, we fall back to using `SentryOtelThreadLocalStorage`
+- Make `RequestDetailsResolver` public ([#4326](https://github.com/getsentry/sentry-java/pull/4326))
+  - `RequestDetailsResolver` is now public and has an additional constructor, making it easier to use a custom `TransportFactory`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Make `RequestDetailsResolver` public ([#4326](https://github.com/getsentry/sentry-java/pull/4326))
+  - `RequestDetailsResolver` is now public and has an additional constructor, making it easier to use a custom `TransportFactory`
+
 ## 8.10.0
 
 ### Features
@@ -9,9 +16,7 @@
   - Set `-Dio.opentelemetry.context.contextStorageProvider=io.sentry.opentelemetry.SentryContextStorageProvider` on your `java` command
   - Sentry will then wrap the other `ContextStorageProvider` that has been configured by loading it through SPI
   - If no other `ContextStorageProvider` is available or there are problems loading it, we fall back to using `SentryOtelThreadLocalStorage`
-- Make `RequestDetailsResolver` public ([#4326](https://github.com/getsentry/sentry-java/pull/4326))
-  - `RequestDetailsResolver` is now public and has an additional constructor, making it easier to use a custom `TransportFactory`
-
+    
 ### Fixes
 
 - Update profile chunk rate limit and client report ([#4353](https://github.com/getsentry/sentry-java/pull/4353))

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2174,6 +2174,12 @@ public final class io/sentry/RequestDetails {
 	public fun getUrl ()Ljava/net/URL;
 }
 
+public final class io/sentry/RequestDetailsResolver {
+	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun resolve ()Lio/sentry/RequestDetails;
+}
+
 public final class io/sentry/SamplingContext {
 	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;)V
 	public fun <init> (Lio/sentry/TransactionContext;Lio/sentry/CustomSamplingContext;Ljava/lang/Double;Ljava/util/Map;)V

--- a/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
+++ b/sentry/src/main/java/io/sentry/RequestDetailsResolver.java
@@ -4,24 +4,39 @@ import io.sentry.util.Objects;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Resolves {@link RequestDetails}. */
-final class RequestDetailsResolver {
+@ApiStatus.Experimental
+public final class RequestDetailsResolver {
   /** HTTP Header for the user agent. */
   private static final String USER_AGENT = "User-Agent";
   /** HTTP Header for the authentication to Sentry. */
   private static final String SENTRY_AUTH = "X-Sentry-Auth";
 
-  private final @NotNull SentryOptions options;
+  private final @NotNull Dsn dsn;
+  private final @Nullable String sentryClientName;
 
+  public RequestDetailsResolver(
+      final @NotNull String dsn, final @Nullable String sentryClientName) {
+    Objects.requireNonNull(dsn, "dsn is required");
+
+    this.dsn = new Dsn(dsn);
+    this.sentryClientName = sentryClientName;
+  }
+
+  @ApiStatus.Internal
   public RequestDetailsResolver(final @NotNull SentryOptions options) {
-    this.options = Objects.requireNonNull(options, "options is required");
+    Objects.requireNonNull(options, "options is required");
+
+    this.dsn = options.retrieveParsedDsn();
+    this.sentryClientName = options.getSentryClientName();
   }
 
   @NotNull
-  RequestDetails resolve() {
-    final Dsn dsn = options.retrieveParsedDsn();
+  public RequestDetails resolve() {
     final URI sentryUri = dsn.getSentryUri();
     final String envelopeUrl = sentryUri.resolve(sentryUri.getPath() + "/envelope/").toString();
 
@@ -33,15 +48,14 @@ final class RequestDetailsResolver {
             + SentryClient.SENTRY_PROTOCOL_VERSION
             + ","
             + "sentry_client="
-            + options.getSentryClientName()
+            + sentryClientName
             + ","
             + "sentry_key="
             + publicKey
             + (secretKey != null && secretKey.length() > 0 ? (",sentry_secret=" + secretKey) : "");
-    final String userAgent = options.getSentryClientName();
 
     final Map<String, String> headers = new HashMap<>();
-    headers.put(USER_AGENT, userAgent);
+    headers.put(USER_AGENT, sentryClientName);
     headers.put(SENTRY_AUTH, authHeader);
 
     return new RequestDetails(envelopeUrl, headers);


### PR DESCRIPTION
## :scroll: Description
Follow up to https://github.com/getsentry/sentry-java/pull/4323

This makes `RequestDetailsResolver` public and adds a constructor which just takes the a DSN and client name.

## :bulb: Motivation and Context
`ITransportFactory.create` currently [receives](https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/ITransportFactory.java#L17) a `RequestDetails`. This means that, when creating a custom transport, you can't change the request details (dsn, auth header, ..) without resorting to ugly rewrites on the url / headers.

Having a public `RequestDetailsResolver` makes it easy to make a new instance with the desired DSN / client name.

Use case (from https://github.com/getsentry/sentry-java/pull/4323) is to make a transport that can send to multiple different DSNs. (Somewhat simplified) example usage for that:
```java
record MultiplexedTransportFactory(List<String> dsns) implements ITransportFactory {
  @Override
  public ITransport create(final SentryOptions options, final RequestDetails requestDetails) {
    final var transports = dsns.stream()
        .map(dsn -> new RequestDetailsResolver(dsn, options.getSentryClientName()).resolve())
        .map(newRequestDetails -> new AsyncHttpTransportFactory().create(options, newRequestDetails))
        .toList();
    return new ITransport() {
      @Override
      public void send(SentryEnvelope envelope, Hint hint) throws IOException {
        for (ITransport transport : transports) {
          transport.send(envelope, hint);
        }
      }

      @Override
      public boolean isHealthy() {
        return transports.stream().allMatch(ITransport::isHealthy);
      }

      @Override
      public void flush(long timeoutMillis) {
        transports.forEach(transport -> transport.flush(timeoutMillis));
      }

      @Override
      public RateLimiter getRateLimiter() {
        return null;
      }

      @Override
      public void close(boolean isRestarting) throws IOException {
        for (ITransport transport : transports) {
          transport.close(isRestarting);
        }
      }

      @Override
      public void close() throws IOException {
        for (ITransport transport : transports) {
          transport.close();
        }
      }
    };
  }
}
```


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
