### PR TITLE
perf(breadcrumbs): Make SystemEventsBreadcrumbsIntegration faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Make `SystemEventsBreadcrumbsIntegration` faster ([#4330](https://github.com/getsentry/sentry-java/pull/4330))
+
 ### Fixes
 
 - Use thread context classloader when available ([#4320](https://github.com/getsentry/sentry-java/pull/4320))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -65,13 +65,13 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull String[] actions) {
-    this.context = context;
+    this.context = ContextUtils.getApplicationContext(context);
     this.actions = actions;
   }
 
   public SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull List<String> actions) {
-    this.context = context;
+    this.context = ContextUtils.getApplicationContext(context);
     this.actions = new String[actions.size()];
     actions.toArray(this.actions);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -39,7 +39,7 @@ import io.sentry.util.Objects;
 import io.sentry.util.StringUtils;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,19 +55,25 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private @Nullable SentryAndroidOptions options;
 
-  private final @NotNull List<String> actions;
+  private final @NotNull String[] actions;
   private boolean isClosed = false;
   private final @NotNull AutoClosableReentrantLock startLock = new AutoClosableReentrantLock();
 
   public SystemEventsBreadcrumbsIntegration(final @NotNull Context context) {
-    this(context, getDefaultActions());
+    this(context, getDefaultActionsInternal());
+  }
+
+  private SystemEventsBreadcrumbsIntegration(
+      final @NotNull Context context, final @NotNull String[] actions) {
+    this.context = context;
+    this.actions = actions;
   }
 
   public SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull List<String> actions) {
-    this.context =
-        Objects.requireNonNull(ContextUtils.getApplicationContext(context), "Context is required");
-    this.actions = Objects.requireNonNull(actions, "Actions list is required");
+    this.context = context;
+    this.actions = new String[actions.size()];
+    actions.toArray(this.actions);
   }
 
   @Override
@@ -129,28 +135,32 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     }
   }
 
-  @SuppressWarnings("deprecation")
   public static @NotNull List<String> getDefaultActions() {
-    final List<String> actions = new ArrayList<>();
-    actions.add(ACTION_SHUTDOWN);
-    actions.add(ACTION_AIRPLANE_MODE_CHANGED);
-    actions.add(ACTION_BATTERY_CHANGED);
-    actions.add(ACTION_CAMERA_BUTTON);
-    actions.add(ACTION_CONFIGURATION_CHANGED);
-    actions.add(ACTION_DATE_CHANGED);
-    actions.add(ACTION_DEVICE_STORAGE_LOW);
-    actions.add(ACTION_DEVICE_STORAGE_OK);
-    actions.add(ACTION_DOCK_EVENT);
-    actions.add(ACTION_DREAMING_STARTED);
-    actions.add(ACTION_DREAMING_STOPPED);
-    actions.add(ACTION_INPUT_METHOD_CHANGED);
-    actions.add(ACTION_LOCALE_CHANGED);
-    actions.add(ACTION_SCREEN_OFF);
-    actions.add(ACTION_SCREEN_ON);
-    actions.add(ACTION_TIMEZONE_CHANGED);
-    actions.add(ACTION_TIME_CHANGED);
-    actions.add("android.os.action.DEVICE_IDLE_MODE_CHANGED");
-    actions.add("android.os.action.POWER_SAVE_MODE_CHANGED");
+    return Arrays.asList(getDefaultActionsInternal());
+  }
+
+  @SuppressWarnings("deprecation")
+  private static @NotNull String[] getDefaultActionsInternal() {
+    final String[] actions = new String[19];
+    actions[0] = ACTION_SHUTDOWN;
+    actions[1] = ACTION_AIRPLANE_MODE_CHANGED;
+    actions[2] = ACTION_BATTERY_CHANGED;
+    actions[3] = ACTION_CAMERA_BUTTON;
+    actions[4] = ACTION_CONFIGURATION_CHANGED;
+    actions[5] = ACTION_DATE_CHANGED;
+    actions[6] = ACTION_DEVICE_STORAGE_LOW;
+    actions[7] = ACTION_DEVICE_STORAGE_OK;
+    actions[8] = ACTION_DOCK_EVENT;
+    actions[9] = ACTION_DREAMING_STARTED;
+    actions[10] = ACTION_DREAMING_STOPPED;
+    actions[11] = ACTION_INPUT_METHOD_CHANGED;
+    actions[12] = ACTION_LOCALE_CHANGED;
+    actions[13] = ACTION_SCREEN_OFF;
+    actions[14] = ACTION_SCREEN_ON;
+    actions[15] = ACTION_TIMEZONE_CHANGED;
+    actions[16] = ACTION_TIME_CHANGED;
+    actions[17] = "android.os.action.DEVICE_IDLE_MODE_CHANGED";
+    actions[18] = "android.os.action.POWER_SAVE_MODE_CHANGED";
     return actions;
   }
 
@@ -206,10 +216,43 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
                   scopes.addBreadcrumb(breadcrumb, hint);
                 });
       } catch (Throwable t) {
-        options
-            .getLogger()
-            .log(SentryLevel.ERROR, t, "Failed to submit system event breadcrumb action.");
+        // ignored
       }
+    }
+
+    // in theory this should be ThreadLocal, but we won't have more than 1 thread accessing it,
+    // so we save some memory here and CPU cycles. 64 is because all intent actions we subscribe for
+    // are less than 64 chars. We also don't care about encoding as those are always UTF.
+    // TODO: _MULTI_THREADED_EXECUTOR_
+    private final char[] buf = new char[64];
+
+    @TestOnly
+    @Nullable
+    String getStringAfterDotFast(final @Nullable String str) {
+      if (str == null) {
+        return null;
+      }
+
+      final int len = str.length();
+      int bufIndex = buf.length;
+
+      // the idea here is to iterate from the end of the string and copy the characters to a
+      // pre-allocated buffer in reverse order. When we find a dot, we create a new string
+      // from the buffer. This way we use a fixed size buffer and do a bare minimum of iterations.
+      for (int i = len - 1; i >= 0; i--) {
+        final char c = str.charAt(i);
+        if (c == '.') {
+          return new String(buf, bufIndex, buf.length - bufIndex);
+        }
+        if (bufIndex == 0) {
+          // Overflow — fallback to safe version
+          return StringUtils.getStringAfterDot(str);
+        }
+        buf[--bufIndex] = c;
+      }
+
+      // No dot found — return original
+      return str;
     }
 
     private @NotNull Breadcrumb createBreadcrumb(
@@ -220,7 +263,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       final Breadcrumb breadcrumb = new Breadcrumb(timeMs);
       breadcrumb.setType("system");
       breadcrumb.setCategory("device.event");
-      final String shortAction = StringUtils.getStringAfterDot(action);
+      final String shortAction = getStringAfterDotFast(action);
       if (shortAction != null) {
         breadcrumb.setData("action", shortAction);
       }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -105,6 +105,8 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.register(fixture.scopes, fixture.options)
         val intent = Intent().apply {
             action = Intent.ACTION_TIME_CHANGED
+            putExtra("test", 10)
+            putExtra("test2", 20)
         }
         sut.receiver!!.onReceive(fixture.context, intent)
 
@@ -182,5 +184,51 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.register(fixture.scopes, fixture.options)
 
         assertFalse(fixture.options.isEnableSystemEventBreadcrumbs)
+    }
+
+    @Test
+    fun `when str has full package, return last string after dot`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("DEVICE_IDLE_MODE_CHANGED", sut.receiver?.getStringAfterDotFast("io.sentry.DEVICE_IDLE_MODE_CHANGED"))
+        assertEquals("POWER_SAVE_MODE_CHANGED", sut.receiver?.getStringAfterDotFast("io.sentry.POWER_SAVE_MODE_CHANGED"))
+    }
+
+    @Test
+    fun `when str is null, return null`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNull(sut.receiver?.getStringAfterDotFast(null))
+    }
+
+    @Test
+    fun `when str is empty, return the original str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("", sut.receiver?.getStringAfterDotFast(""))
+    }
+
+    @Test
+    fun `when str ends with a dot, return empty str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("", sut.receiver?.getStringAfterDotFast("io.sentry."))
+    }
+
+    @Test
+    fun `when str has no dots, return the original str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("iosentry", sut.receiver?.getStringAfterDotFast("iosentry"))
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
The PR attempts to make `SystemEventsBreadcrumbsIntegration` faster by:
- Using a fixed-size array for storing default actions we're subscribing for
  - This will avoid growing (previously unbounded) array list
  - But also will avoid allocating a new iterator in the for-loop
- Improve `getStringAfterDot` by using a pre-allocated buffer and iterating from the end of the string until the first dot to create a String after that. This yielded ~2x faster results on Android (10k iterations x 3 times):

![Google Chrome 2025-04-10 23 50 17](https://github.com/user-attachments/assets/76bd03ab-c51f-4487-abe1-c9504b13b746)


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
