### PR TITLE
Wrap `Runnable` for usage with Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `SentryWrapper.wrapRunnable` to wrap `Runnable` for use with Sentry ([#4332](https://github.com/getsentry/sentry-java/pull/4332))
+
 ## 8.8.0
 
 ### Features

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3541,6 +3541,7 @@ public final class io/sentry/SentryUUID {
 public final class io/sentry/SentryWrapper {
 	public fun <init> ()V
 	public static fun wrapCallable (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Callable;
+	public static fun wrapRunnable (Ljava/lang/Runnable;)Ljava/lang/Runnable;
 	public static fun wrapSupplier (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
 }
 

--- a/sentry/src/main/java/io/sentry/SentryWrapper.java
+++ b/sentry/src/main/java/io/sentry/SentryWrapper.java
@@ -57,4 +57,23 @@ public final class SentryWrapper {
       }
     };
   }
+
+  /**
+   * Helper method to wrap {@link Runnable}
+   *
+   * <p>Forks current and isolation scope before execution and restores previous state afterwards.
+   * This prevents reused threads (e.g. from thread-pools) from getting an incorrect state.
+   *
+   * @param runnable - the {@link Runnable} to be wrapped
+   * @return the wrapped {@link Runnable}
+   */
+  public static Runnable wrapRunnable(final @NotNull Runnable runnable) {
+    final IScopes newScopes = Sentry.forkedScopes("SentryWrapper.wrapRunnable");
+
+    return () -> {
+      try (ISentryLifecycleToken ignore = newScopes.makeCurrent()) {
+        runnable.run();
+      }
+    };
+  }
 }

--- a/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryWrapperTest.kt
@@ -195,4 +195,85 @@ class SentryWrapperTest {
             assertEquals(threadedScopes, Sentry.getCurrentScopes())
         }.get()
     }
+
+    @Test
+    fun `wrapped runnable isolates Scopes`() {
+        val capturedEvents = mutableListOf<SentryEvent>()
+
+        initForTest {
+            it.dsn = dsn
+            it.beforeSend = SentryOptions.BeforeSendCallback { event, hint ->
+                capturedEvents.add(event)
+                event
+            }
+        }
+
+        Sentry.addBreadcrumb("MyOriginalBreadcrumbBefore")
+        Sentry.captureMessage("OriginalMessageBefore")
+        println(Thread.currentThread().name)
+
+        val future1 = executor.submit(
+            SentryWrapper.wrapRunnable {
+                Thread.sleep(20)
+                Sentry.addBreadcrumb("MyClonedBreadcrumb")
+                Sentry.captureMessage("ClonedMessage")
+                "Result 1"
+            }
+        )
+
+        val future2 = executor.submit(
+            SentryWrapper.wrapRunnable {
+                Thread.sleep(10)
+                Sentry.addBreadcrumb("MyClonedBreadcrumb2")
+                Sentry.captureMessage("ClonedMessage2")
+                "Result 2"
+            }
+        )
+
+        Sentry.addBreadcrumb("MyOriginalBreadcrumb")
+        Sentry.captureMessage("OriginalMessage")
+
+        future1.get()
+        future2.get()
+
+        val mainEvent = capturedEvents.firstOrNull { it.message?.formatted == "OriginalMessage" }
+        val clonedEvent = capturedEvents.firstOrNull { it.message?.formatted == "ClonedMessage" }
+        val clonedEvent2 = capturedEvents.firstOrNull { it.message?.formatted == "ClonedMessage2" }
+
+        assertEquals(2, mainEvent?.breadcrumbs?.size)
+        assertEquals(2, clonedEvent?.breadcrumbs?.size)
+        assertEquals(2, clonedEvent2?.breadcrumbs?.size)
+    }
+
+    @Test
+    fun `scopes is reset to state within the thread after isolated runnable is done`() {
+        initForTest {
+            it.dsn = dsn
+        }
+
+        val mainScopes = Sentry.getCurrentScopes()
+        val threadedScopes = Sentry.getCurrentScopes().forkedCurrentScope("test")
+
+        executor.submit {
+            Sentry.setCurrentScopes(threadedScopes)
+        }.get()
+
+        assertEquals(mainScopes, Sentry.getCurrentScopes())
+
+        val runnableFuture =
+            executor.submit(
+                SentryWrapper.wrapRunnable {
+                    assertNotEquals(mainScopes, Sentry.getCurrentScopes())
+                    assertNotEquals(threadedScopes, Sentry.getCurrentScopes())
+                    "Result 1"
+                }
+            )
+
+        runnableFuture.get()
+
+        executor.submit {
+            assertNotEquals(mainScopes, Sentry.getCurrentScopes())
+            assertEquals(threadedScopes, Sentry.getCurrentScopes())
+        }.get()
+    }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Wrap `Runnable` for usage with Sentry, e.g. when using virtual threads

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4328

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
