### PR TITLE
Reduce useless io calls

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -156,8 +156,8 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
       new String(buf, 0, 0);
       if (e instanceof FileNotFoundException) {
         options
-          .getLogger()
-          .log(DEBUG, "Last ANR marker does not exist. %s.", lastAnrMarker.getAbsolutePath());
+            .getLogger()
+            .log(DEBUG, "Last ANR marker does not exist. %s.", lastAnrMarker.getAbsolutePath());
       } else {
         options.getLogger().log(ERROR, "Error reading last ANR marker", e);
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/CpuInfoUtils.java
@@ -51,8 +51,6 @@ public final class CpuInfoUtils {
         if (!cpuDir.getName().matches("cpu[0-9]+")) continue;
         File cpuMaxFreqFile = new File(cpuDir, CPUINFO_MAX_FREQ_PATH);
 
-        if (!cpuMaxFreqFile.exists() || !cpuMaxFreqFile.canRead()) continue;
-
         long khz;
         try {
           String content = FileUtils.readText(cpuMaxFreqFile);

--- a/sentry/src/main/java/io/sentry/DirectoryProcessor.java
+++ b/sentry/src/main/java/io/sentry/DirectoryProcessor.java
@@ -40,34 +40,19 @@ abstract class DirectoryProcessor {
     try {
       logger.log(SentryLevel.DEBUG, "Processing dir. %s", directory.getAbsolutePath());
 
-      if (!directory.exists()) {
-        logger.log(
-            SentryLevel.WARNING,
-            "Directory '%s' doesn't exist. No cached events to send.",
-            directory.getAbsolutePath());
-        return;
-      }
-      if (!directory.isDirectory()) {
-        logger.log(
-            SentryLevel.ERROR, "Cache dir %s is not a directory.", directory.getAbsolutePath());
-        return;
-      }
-
-      final File[] listFiles = directory.listFiles();
-      if (listFiles == null) {
+      final File[] filteredListFiles = directory.listFiles((d, name) -> isRelevantFileName(name));
+      if (filteredListFiles == null) {
         logger.log(SentryLevel.ERROR, "Cache dir %s is null.", directory.getAbsolutePath());
         return;
       }
 
-      final File[] filteredListFiles = directory.listFiles((d, name) -> isRelevantFileName(name));
-
       logger.log(
           SentryLevel.DEBUG,
           "Processing %d items from cache dir %s",
-          filteredListFiles != null ? filteredListFiles.length : 0,
+          filteredListFiles.length,
           directory.getAbsolutePath());
 
-      for (File file : listFiles) {
+      for (File file : filteredListFiles) {
         // it ignores .sentry-native database folder and new ones that might come up
         if (!file.isFile()) {
           logger.log(SentryLevel.DEBUG, "File %s is not a File.", file.getAbsolutePath());

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -345,7 +345,12 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
           .getLogger()
           .log(DEBUG, "Discarding envelope from cache: %s", envelopeFile.getAbsolutePath());
     } else {
-      options.getLogger().log(DEBUG, "Envelope was not cached or could not be deleted: %s", envelopeFile.getAbsolutePath());
+      options
+          .getLogger()
+          .log(
+              DEBUG,
+              "Envelope was not cached or could not be deleted: %s",
+              envelopeFile.getAbsolutePath());
     }
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -340,18 +340,12 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
     final File envelopeFile = getEnvelopeFile(envelope);
-    if (envelopeFile.exists()) {
+    if (envelopeFile.delete()) {
       options
           .getLogger()
           .log(DEBUG, "Discarding envelope from cache: %s", envelopeFile.getAbsolutePath());
-
-      if (!envelopeFile.delete()) {
-        options
-            .getLogger()
-            .log(ERROR, "Failed to delete envelope: %s", envelopeFile.getAbsolutePath());
-      }
     } else {
-      options.getLogger().log(DEBUG, "Envelope was not cached: %s", envelopeFile.getAbsolutePath());
+      options.getLogger().log(DEBUG, "Envelope was not cached or could not be deleted: %s", envelopeFile.getAbsolutePath());
     }
   }
 


### PR DESCRIPTION
## :scroll: Description
Reduce useless io calls, to mitigate StrictMode warnings.



## :bulb: Motivation and Context
Relates to https://github.com/getsentry/sentry-java/issues/4261


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
