### PR TITLE
fix(breadcrumbs): Unregister SystemEventsBroadcastReceiver when entering background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@
 
 - Make `SystemEventsBreadcrumbsIntegration` faster ([#4330](https://github.com/getsentry/sentry-java/pull/4330))
 
-### Improvements
-
-- Make `SystemEventsBreadcrumbsIntegration` faster ([#4330](https://github.com/getsentry/sentry-java/pull/4330))
 
 ## 8.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 
 - Make `SystemEventsBreadcrumbsIntegration` faster ([#4330](https://github.com/getsentry/sentry-java/pull/4330))
 
-
 ## 8.7.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Make `SystemEventsBreadcrumbsIntegration` faster ([#4330](https://github.com/getsentry/sentry-java/pull/4330))
+
 ### Fixes
 
 - Use thread context classloader when available ([#4320](https://github.com/getsentry/sentry-java/pull/4320))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixes
 
 - Fix TTFD measurement when API called too early ([#4297](https://github.com/getsentry/sentry-java/pull/4297))
+- Fix unregister `SystemEventsBroadcastReceiver` when entering background ([#4338](https://github.com/getsentry/sentry-java/pull/4338))
+  - This should reduce ANRs seen with this class in the stack trace for Android 14 and above
 
 ## 8.8.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java
@@ -69,9 +69,8 @@ public final class AppLifecycleIntegration implements Integration, Closeable {
         options
             .getLogger()
             .log(
-                SentryLevel.INFO,
-                "androidx.lifecycle is not available, AppLifecycleIntegration won't be installed",
-                e);
+                SentryLevel.WARNING,
+                "androidx.lifecycle is not available, AppLifecycleIntegration won't be installed");
       } catch (IllegalStateException e) {
         options
             .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -67,6 +67,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
   private @Nullable IScopes scopes;
 
   private final @NotNull String[] actions;
+  private volatile boolean isClosed = false;
   private volatile boolean isStopped = false;
   private volatile IntentFilter filter = null;
   private final @NotNull AutoClosableReentrantLock receiverLock = new AutoClosableReentrantLock();
@@ -129,7 +130,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     }
 
     try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
-      if (isStopped || receiver != null) {
+      if (isClosed || isStopped || receiver != null) {
         return;
       }
     }
@@ -140,7 +141,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
           .submit(
               () -> {
                 try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
-                  if (isStopped || receiver != null) {
+                  if (isClosed || isStopped || receiver != null) {
                     return;
                   }
 
@@ -265,6 +266,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
   @Override
   public void close() throws IOException {
     try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+      isClosed = true;
       filter = null;
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -65,13 +65,13 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull String[] actions) {
-    this.context = context;
+    this.context = ContextUtils.getApplicationContext(context);
     this.actions = actions;
   }
 
   public SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull List<String> actions) {
-    this.context = context;
+    this.context = ContextUtils.getApplicationContext(context);
     this.actions = new String[actions.size()];
     actions.toArray(this.actions);
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -25,6 +25,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IScopes;
@@ -33,6 +37,7 @@ import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.android.core.internal.util.AndroidCurrentDateProvider;
+import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.internal.util.Debouncer;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
@@ -51,13 +56,20 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private final @NotNull Context context;
 
-  @TestOnly @Nullable SystemEventsBroadcastReceiver receiver;
+  @TestOnly @Nullable volatile SystemEventsBroadcastReceiver receiver;
+
+  @TestOnly @Nullable volatile ReceiverLifecycleHandler lifecycleHandler;
+
+  private final @NotNull MainLooperHandler handler;
 
   private @Nullable SentryAndroidOptions options;
 
+  private @Nullable IScopes scopes;
+
   private final @NotNull String[] actions;
-  private boolean isClosed = false;
-  private final @NotNull AutoClosableReentrantLock startLock = new AutoClosableReentrantLock();
+  private volatile boolean isStopped = false;
+  private volatile IntentFilter filter = null;
+  private final @NotNull AutoClosableReentrantLock receiverLock = new AutoClosableReentrantLock();
 
   public SystemEventsBreadcrumbsIntegration(final @NotNull Context context) {
     this(context, getDefaultActionsInternal());
@@ -65,8 +77,16 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull String[] actions) {
+    this(context, actions, new MainLooperHandler());
+  }
+
+  SystemEventsBreadcrumbsIntegration(
+      final @NotNull Context context,
+      final @NotNull String[] actions,
+      final @NotNull MainLooperHandler handler) {
     this.context = ContextUtils.getApplicationContext(context);
     this.actions = actions;
+    this.handler = handler;
   }
 
   public SystemEventsBreadcrumbsIntegration(
@@ -74,6 +94,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     this.context = ContextUtils.getApplicationContext(context);
     this.actions = new String[actions.size()];
     actions.toArray(this.actions);
+    this.handler = new MainLooperHandler();
   }
 
   @Override
@@ -83,6 +104,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
         Objects.requireNonNull(
             (options instanceof SentryAndroidOptions) ? (SentryAndroidOptions) options : null,
             "SentryAndroidOptions is required");
+    this.scopes = scopes;
 
     this.options
         .getLogger()
@@ -92,46 +114,165 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
             this.options.isEnableSystemEventBreadcrumbs());
 
     if (this.options.isEnableSystemEventBreadcrumbs()) {
+      addLifecycleObserver(this.options);
+      registerReceiver(this.scopes, this.options, /* newIntegration = */ true);
+    }
+  }
 
-      try {
-        options
-            .getExecutorService()
-            .submit(
-                () -> {
-                  try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
-                    if (!isClosed) {
-                      startSystemEventsReceiver(scopes, (SentryAndroidOptions) options);
+  private void registerReceiver(
+      final @NotNull IScopes scopes,
+      final @NotNull SentryAndroidOptions options,
+      final boolean newIntegration) {
+
+    if (!options.isEnableSystemEventBreadcrumbs()) {
+      return;
+    }
+
+    try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+      if (isStopped || receiver != null) {
+        return;
+      }
+    }
+
+    try {
+      options
+          .getExecutorService()
+          .submit(
+              () -> {
+                try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+                  if (isStopped || receiver != null) {
+                    return;
+                  }
+
+                  receiver = new SystemEventsBroadcastReceiver(scopes, options);
+                  if (filter == null) {
+                    filter = new IntentFilter();
+                    for (String item : actions) {
+                      filter.addAction(item);
                     }
                   }
-                });
-      } catch (Throwable e) {
-        options
-            .getLogger()
-            .log(
-                SentryLevel.DEBUG,
-                "Failed to start SystemEventsBreadcrumbsIntegration on executor thread.",
-                e);
+                  try {
+                    // registerReceiver can throw SecurityException but it's not documented in the
+                    // official docs
+                    ContextUtils.registerReceiver(context, options, receiver, filter);
+                    if (newIntegration) {
+                      options
+                          .getLogger()
+                          .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
+                      addIntegrationToSdkVersion("SystemEventsBreadcrumbs");
+                    }
+                  } catch (Throwable e) {
+                    options.setEnableSystemEventBreadcrumbs(false);
+                    options
+                        .getLogger()
+                        .log(
+                            SentryLevel.ERROR,
+                            "Failed to initialize SystemEventsBreadcrumbsIntegration.",
+                            e);
+                  }
+                }
+              });
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "Failed to start SystemEventsBreadcrumbsIntegration on executor thread.");
+    }
+  }
+
+  private void unregisterReceiver() {
+    try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+      isStopped = true;
+    }
+
+    if (receiver != null) {
+      context.unregisterReceiver(receiver);
+      receiver = null;
+    }
+  }
+
+  private void addLifecycleObserver(final @NotNull SentryAndroidOptions options) {
+    try {
+      Class.forName("androidx.lifecycle.DefaultLifecycleObserver");
+      Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
+      if (AndroidThreadChecker.getInstance().isMainThread()) {
+        addObserverInternal(options);
+      } else {
+        // some versions of the androidx lifecycle-process require this to be executed on the main
+        // thread.
+        handler.post(() -> addObserverInternal(options));
+      }
+    } catch (ClassNotFoundException e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "androidx.lifecycle is not available, SystemEventsBreadcrumbsIntegration won't be able"
+                  + " to register/unregister an internal BroadcastReceiver. This may result in an"
+                  + "increased ANR rate on Android 14 and above.");
+    } catch (Throwable e) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "SystemEventsBreadcrumbsIntegration could not register lifecycle observer",
+              e);
+    }
+  }
+
+  private void addObserverInternal(final @NotNull SentryAndroidOptions options) {
+    lifecycleHandler = new ReceiverLifecycleHandler();
+
+    try {
+      ProcessLifecycleOwner.get().getLifecycle().addObserver(lifecycleHandler);
+    } catch (Throwable e) {
+      // This is to handle a potential 'AbstractMethodError' gracefully. The error is triggered in
+      // connection with conflicting dependencies of the androidx.lifecycle.
+      // //See the issue here: https://github.com/getsentry/sentry-java/pull/2228
+      lifecycleHandler = null;
+      options
+          .getLogger()
+          .log(
+              SentryLevel.ERROR,
+              "SystemEventsBreadcrumbsIntegration failed to get Lifecycle and could not install lifecycle observer.",
+              e);
+    }
+  }
+
+  private void removeLifecycleObserver() {
+    if (lifecycleHandler != null) {
+      if (AndroidThreadChecker.getInstance().isMainThread()) {
+        removeObserverInternal();
+      } else {
+        // some versions of the androidx lifecycle-process require this to be executed on the main
+        // thread.
+        // avoid method refs on Android due to some issues with older AGP setups
+        // noinspection Convert2MethodRef
+        handler.post(() -> removeObserverInternal());
       }
     }
   }
 
-  private void startSystemEventsReceiver(
-      final @NotNull IScopes scopes, final @NotNull SentryAndroidOptions options) {
-    receiver = new SystemEventsBroadcastReceiver(scopes, options);
-    final IntentFilter filter = new IntentFilter();
-    for (String item : actions) {
-      filter.addAction(item);
+  private void removeObserverInternal() {
+    final @Nullable ReceiverLifecycleHandler watcherRef = lifecycleHandler;
+    if (watcherRef != null) {
+      ProcessLifecycleOwner.get().getLifecycle().removeObserver(watcherRef);
     }
-    try {
-      // registerReceiver can throw SecurityException but it's not documented in the official docs
-      ContextUtils.registerReceiver(context, options, receiver, filter);
-      options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
-      addIntegrationToSdkVersion("SystemEventsBreadcrumbs");
-    } catch (Throwable e) {
-      options.setEnableSystemEventBreadcrumbs(false);
-      options
-          .getLogger()
-          .log(SentryLevel.ERROR, "Failed to initialize SystemEventsBreadcrumbsIntegration.", e);
+    lifecycleHandler = null;
+  }
+
+  @Override
+  public void close() throws IOException {
+    try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+      filter = null;
+    }
+
+    removeLifecycleObserver();
+    unregisterReceiver();
+
+    if (options != null) {
+      options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration remove.");
     }
   }
 
@@ -164,18 +305,23 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     return actions;
   }
 
-  @Override
-  public void close() throws IOException {
-    try (final @NotNull ISentryLifecycleToken ignored = startLock.acquire()) {
-      isClosed = true;
-    }
-    if (receiver != null) {
-      context.unregisterReceiver(receiver);
-      receiver = null;
-
-      if (options != null) {
-        options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration remove.");
+  final class ReceiverLifecycleHandler implements DefaultLifecycleObserver {
+    @Override
+    public void onStart(@NonNull LifecycleOwner owner) {
+      if (scopes == null || options == null) {
+        return;
       }
+
+      try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+        isStopped = false;
+      }
+
+      registerReceiver(scopes, options, /* newIntegration = */ false);
+    }
+
+    @Override
+    public void onStop(@NonNull LifecycleOwner owner) {
+      unregisterReceiver();
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -39,7 +39,7 @@ import io.sentry.util.Objects;
 import io.sentry.util.StringUtils;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,19 +55,25 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
   private @Nullable SentryAndroidOptions options;
 
-  private final @NotNull List<String> actions;
+  private final @NotNull String[] actions;
   private boolean isClosed = false;
   private final @NotNull AutoClosableReentrantLock startLock = new AutoClosableReentrantLock();
 
   public SystemEventsBreadcrumbsIntegration(final @NotNull Context context) {
-    this(context, getDefaultActions());
+    this(context, getDefaultActionsInternal());
+  }
+
+  private SystemEventsBreadcrumbsIntegration(
+      final @NotNull Context context, final @NotNull String[] actions) {
+    this.context = context;
+    this.actions = actions;
   }
 
   public SystemEventsBreadcrumbsIntegration(
       final @NotNull Context context, final @NotNull List<String> actions) {
-    this.context =
-        Objects.requireNonNull(ContextUtils.getApplicationContext(context), "Context is required");
-    this.actions = Objects.requireNonNull(actions, "Actions list is required");
+    this.context = context;
+    this.actions = new String[actions.size()];
+    actions.toArray(this.actions);
   }
 
   @Override
@@ -129,28 +135,32 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     }
   }
 
-  @SuppressWarnings("deprecation")
   public static @NotNull List<String> getDefaultActions() {
-    final List<String> actions = new ArrayList<>();
-    actions.add(ACTION_SHUTDOWN);
-    actions.add(ACTION_AIRPLANE_MODE_CHANGED);
-    actions.add(ACTION_BATTERY_CHANGED);
-    actions.add(ACTION_CAMERA_BUTTON);
-    actions.add(ACTION_CONFIGURATION_CHANGED);
-    actions.add(ACTION_DATE_CHANGED);
-    actions.add(ACTION_DEVICE_STORAGE_LOW);
-    actions.add(ACTION_DEVICE_STORAGE_OK);
-    actions.add(ACTION_DOCK_EVENT);
-    actions.add(ACTION_DREAMING_STARTED);
-    actions.add(ACTION_DREAMING_STOPPED);
-    actions.add(ACTION_INPUT_METHOD_CHANGED);
-    actions.add(ACTION_LOCALE_CHANGED);
-    actions.add(ACTION_SCREEN_OFF);
-    actions.add(ACTION_SCREEN_ON);
-    actions.add(ACTION_TIMEZONE_CHANGED);
-    actions.add(ACTION_TIME_CHANGED);
-    actions.add("android.os.action.DEVICE_IDLE_MODE_CHANGED");
-    actions.add("android.os.action.POWER_SAVE_MODE_CHANGED");
+    return Arrays.asList(getDefaultActionsInternal());
+  }
+
+  @SuppressWarnings("deprecation")
+  private static @NotNull String[] getDefaultActionsInternal() {
+    final String[] actions = new String[19];
+    actions[0] = ACTION_SHUTDOWN;
+    actions[1] = ACTION_AIRPLANE_MODE_CHANGED;
+    actions[2] = ACTION_BATTERY_CHANGED;
+    actions[3] = ACTION_CAMERA_BUTTON;
+    actions[4] = ACTION_CONFIGURATION_CHANGED;
+    actions[5] = ACTION_DATE_CHANGED;
+    actions[6] = ACTION_DEVICE_STORAGE_LOW;
+    actions[7] = ACTION_DEVICE_STORAGE_OK;
+    actions[8] = ACTION_DOCK_EVENT;
+    actions[9] = ACTION_DREAMING_STARTED;
+    actions[10] = ACTION_DREAMING_STOPPED;
+    actions[11] = ACTION_INPUT_METHOD_CHANGED;
+    actions[12] = ACTION_LOCALE_CHANGED;
+    actions[13] = ACTION_SCREEN_OFF;
+    actions[14] = ACTION_SCREEN_ON;
+    actions[15] = ACTION_TIMEZONE_CHANGED;
+    actions[16] = ACTION_TIME_CHANGED;
+    actions[17] = "android.os.action.DEVICE_IDLE_MODE_CHANGED";
+    actions[18] = "android.os.action.POWER_SAVE_MODE_CHANGED";
     return actions;
   }
 
@@ -206,10 +216,43 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
                   scopes.addBreadcrumb(breadcrumb, hint);
                 });
       } catch (Throwable t) {
-        options
-            .getLogger()
-            .log(SentryLevel.ERROR, t, "Failed to submit system event breadcrumb action.");
+        // ignored
       }
+    }
+
+    // in theory this should be ThreadLocal, but we won't have more than 1 thread accessing it,
+    // so we save some memory here and CPU cycles. 64 is because all intent actions we subscribe for
+    // are less than 64 chars. We also don't care about encoding as those are always UTF.
+    // TODO: _MULTI_THREADED_EXECUTOR_
+    private final char[] buf = new char[64];
+
+    @TestOnly
+    @Nullable
+    String getStringAfterDotFast(final @Nullable String str) {
+      if (str == null) {
+        return null;
+      }
+
+      final int len = str.length();
+      int bufIndex = buf.length;
+
+      // the idea here is to iterate from the end of the string and copy the characters to a
+      // pre-allocated buffer in reverse order. When we find a dot, we create a new string
+      // from the buffer. This way we use a fixed size buffer and do a bare minimum of iterations.
+      for (int i = len - 1; i >= 0; i--) {
+        final char c = str.charAt(i);
+        if (c == '.') {
+          return new String(buf, bufIndex, buf.length - bufIndex);
+        }
+        if (bufIndex == 0) {
+          // Overflow — fallback to safe version
+          return StringUtils.getStringAfterDot(str);
+        }
+        buf[--bufIndex] = c;
+      }
+
+      // No dot found — return original
+      return str;
     }
 
     private @NotNull Breadcrumb createBreadcrumb(
@@ -220,7 +263,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       final Breadcrumb breadcrumb = new Breadcrumb(timeMs);
       breadcrumb.setType("system");
       breadcrumb.setCategory("device.event");
-      final String shortAction = StringUtils.getStringAfterDot(action);
+      final String shortAction = getStringAfterDotFast(action);
       if (shortAction != null) {
         breadcrumb.setData("action", shortAction);
       }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -207,10 +207,10 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
       options
           .getLogger()
           .log(
-              SentryLevel.DEBUG,
+              SentryLevel.WARNING,
               "androidx.lifecycle is not available, SystemEventsBreadcrumbsIntegration won't be able"
                   + " to register/unregister an internal BroadcastReceiver. This may result in an"
-                  + "increased ANR rate on Android 14 and above.");
+                  + " increased ANR rate on Android 14 and above.");
     } catch (Throwable e) {
       options
           .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -183,13 +183,15 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
   }
 
   private void unregisterReceiver() {
+    final @Nullable SystemEventsBroadcastReceiver receiverRef;
     try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
       isStopped = true;
+      receiverRef = receiver;
+      receiver = null;
     }
 
-    if (receiver != null) {
-      context.unregisterReceiver(receiver);
-      receiver = null;
+    if (receiverRef != null) {
+      context.unregisterReceiver(receiverRef);
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -116,14 +116,14 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
 
     if (this.options.isEnableSystemEventBreadcrumbs()) {
       addLifecycleObserver(this.options);
-      registerReceiver(this.scopes, this.options, /* newIntegration = */ true);
+      registerReceiver(this.scopes, this.options, /* reportAsNewIntegration = */ true);
     }
   }
 
   private void registerReceiver(
       final @NotNull IScopes scopes,
       final @NotNull SentryAndroidOptions options,
-      final boolean newIntegration) {
+      final boolean reportAsNewIntegration) {
 
     if (!options.isEnableSystemEventBreadcrumbs()) {
       return;
@@ -156,7 +156,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
                     // registerReceiver can throw SecurityException but it's not documented in the
                     // official docs
                     ContextUtils.registerReceiver(context, options, receiver, filter);
-                    if (newIntegration) {
+                    if (reportAsNewIntegration) {
                       options
                           .getLogger()
                           .log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration installed.");
@@ -320,7 +320,7 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
         isStopped = false;
       }
 
-      registerReceiver(scopes, options, /* newIntegration = */ false);
+      registerReceiver(scopes, options, /* reportAsNewIntegration = */ false);
     }
 
     @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -193,6 +193,8 @@ public final class SystemEventsBreadcrumbsIntegration implements Integration, Cl
     }
   }
 
+  // TODO: this duplicates a lot of AppLifecycleIntegration. We should register once on init
+  //  and multiplex to different listeners rather.
   private void addLifecycleObserver(final @NotNull SentryAndroidOptions options) {
     try {
       Class.forName("androidx.lifecycle.DefaultLifecycleObserver");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
@@ -25,7 +25,6 @@ import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryTransaction
 import io.sentry.transport.RateLimiter
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 import org.robolectric.annotation.Config
 import java.util.LinkedList
 import kotlin.test.BeforeTest

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.Lifecycle.Event.ON_START
 import androidx.lifecycle.Lifecycle.Event.ON_STOP
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.CheckIn
@@ -116,7 +117,7 @@ class SessionTrackingIntegrationTest {
     }
 
     private fun setupLifecycle(options: SentryOptions): LifecycleRegistry {
-        val lifecycle = LifecycleRegistry(mock())
+        val lifecycle = LifecycleRegistry(ProcessLifecycleOwner.get())
         val lifecycleWatcher = (
             options.integrations.find {
                 it is AppLifecycleIntegration

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.BatteryManager
 import android.os.Build
+import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.Breadcrumb
 import io.sentry.IScopes
@@ -17,10 +18,13 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.check
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -35,13 +39,23 @@ class SystemEventsBreadcrumbsIntegrationTest {
         val context = mock<Context>()
         var options = SentryAndroidOptions()
         val scopes = mock<IScopes>()
+        lateinit var handler: MainLooperHandler
 
-        fun getSut(enableSystemEventBreadcrumbs: Boolean = true, executorService: ISentryExecutorService = ImmediateExecutorService()): SystemEventsBreadcrumbsIntegration {
+        fun getSut(
+            enableSystemEventBreadcrumbs: Boolean = true,
+            executorService: ISentryExecutorService = ImmediateExecutorService(),
+            mockHandler: Boolean = true
+        ): SystemEventsBreadcrumbsIntegration {
+            handler = if (mockHandler) mock() else MainLooperHandler()
             options = SentryAndroidOptions().apply {
                 isEnableSystemEventBreadcrumbs = enableSystemEventBreadcrumbs
                 this.executorService = executorService
             }
-            return SystemEventsBreadcrumbsIntegration(context)
+            return SystemEventsBreadcrumbsIntegration(
+                context,
+                SystemEventsBreadcrumbsIntegration.getDefaultActions().toTypedArray(),
+                handler
+            )
         }
     }
 
@@ -230,5 +244,149 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.register(fixture.scopes, fixture.options)
 
         assertEquals("iosentry", sut.receiver?.getStringAfterDotFast("iosentry"))
+    }
+
+    @Test
+    fun `When integration is added, lifecycle handler should be started`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNotNull(sut.lifecycleHandler)
+    }
+
+    @Test
+    fun `When system events breadcrumbs are disabled, lifecycle handler should not be started`() {
+        val sut = fixture.getSut()
+        fixture.options.apply {
+            isEnableSystemEventBreadcrumbs = false
+        }
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNull(sut.lifecycleHandler)
+    }
+
+    @Test
+    fun `When integration is closed, lifecycle handler should be closed`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNotNull(sut.lifecycleHandler)
+
+        sut.close()
+
+        assertNull(sut.lifecycleHandler)
+    }
+
+    @Test
+    fun `When integration is registered from a background thread, post on the main thread`() {
+        val sut = fixture.getSut()
+        val latch = CountDownLatch(1)
+
+        Thread {
+            sut.register(fixture.scopes, fixture.options)
+            latch.countDown()
+        }.start()
+
+        latch.await()
+
+        verify(fixture.handler).post(any())
+    }
+
+    @Test
+    fun `When integration is closed from a background thread, post on the main thread`() {
+        val sut = fixture.getSut()
+        val latch = CountDownLatch(1)
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNotNull(sut.lifecycleHandler)
+
+        Thread {
+            sut.close()
+            latch.countDown()
+        }.start()
+
+        latch.await()
+
+        verify(fixture.handler).post(any())
+    }
+
+    @Test
+    fun `When integration is closed from a background thread, watcher is set to null`() {
+        val sut = fixture.getSut(mockHandler = false)
+        val latch = CountDownLatch(1)
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNotNull(sut.lifecycleHandler)
+
+        Thread {
+            sut.close()
+            latch.countDown()
+        }.start()
+
+        latch.await()
+
+        // ensure all messages on main looper got processed
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertNull(sut.lifecycleHandler)
+    }
+
+    @Test
+    fun `when enters background unregisters receiver`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        sut.lifecycleHandler!!.onStop(mock())
+
+        verify(fixture.context).unregisterReceiver(any())
+        assertNull(sut.receiver)
+    }
+
+    @Test
+    fun `when enters foreground registers receiver`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+        verify(fixture.context).registerReceiver(any(), any(), any())
+
+        sut.lifecycleHandler!!.onStop(mock())
+        sut.lifecycleHandler!!.onStart(mock())
+
+        verify(fixture.context, times(2)).registerReceiver(any(), any(), any())
+        assertNotNull(sut.receiver)
+    }
+
+    @Test
+    fun `when enters foreground after register does not recreate the receiver`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+        verify(fixture.context).registerReceiver(any(), any(), any())
+        val receiver = sut.receiver
+
+        sut.lifecycleHandler!!.onStart(mock())
+        assertEquals(receiver, sut.receiver)
+    }
+
+    @Test
+    fun `when goes background right after entering foreground, receiver is not registered`() {
+        val deferredExecutorService = DeferredExecutorService()
+        val sut = fixture.getSut(executorService = deferredExecutorService)
+        sut.register(fixture.scopes, fixture.options)
+        deferredExecutorService.runAll()
+        assertNotNull(sut.receiver)
+
+        sut.lifecycleHandler!!.onStop(mock())
+        sut.lifecycleHandler!!.onStart(mock())
+        assertNull(sut.receiver)
+        sut.lifecycleHandler!!.onStop(mock())
+        deferredExecutorService.runAll()
+        assertNull(sut.receiver)
     }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -105,6 +105,8 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.register(fixture.scopes, fixture.options)
         val intent = Intent().apply {
             action = Intent.ACTION_TIME_CHANGED
+            putExtra("test", 10)
+            putExtra("test2", 20)
         }
         sut.receiver!!.onReceive(fixture.context, intent)
 
@@ -182,5 +184,51 @@ class SystemEventsBreadcrumbsIntegrationTest {
         sut.register(fixture.scopes, fixture.options)
 
         assertFalse(fixture.options.isEnableSystemEventBreadcrumbs)
+    }
+
+    @Test
+    fun `when str has full package, return last string after dot`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("DEVICE_IDLE_MODE_CHANGED", sut.receiver?.getStringAfterDotFast("io.sentry.DEVICE_IDLE_MODE_CHANGED"))
+        assertEquals("POWER_SAVE_MODE_CHANGED", sut.receiver?.getStringAfterDotFast("io.sentry.POWER_SAVE_MODE_CHANGED"))
+    }
+
+    @Test
+    fun `when str is null, return null`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertNull(sut.receiver?.getStringAfterDotFast(null))
+    }
+
+    @Test
+    fun `when str is empty, return the original str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("", sut.receiver?.getStringAfterDotFast(""))
+    }
+
+    @Test
+    fun `when str ends with a dot, return empty str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("", sut.receiver?.getStringAfterDotFast("io.sentry."))
+    }
+
+    @Test
+    fun `when str has no dots, return the original str`() {
+        val sut = fixture.getSut()
+
+        sut.register(fixture.scopes, fixture.options)
+
+        assertEquals("iosentry", sut.receiver?.getStringAfterDotFast("iosentry"))
     }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

### Some background
Android 14 introduced new behavior for broadcast receivers, and our SystemEvents receiver (used to add breadcrumbs like screen on/off, airplane mode change, etc.) is falling under this. What's happening is the process gets cached for some period of time (can be hours or days) and after getting uncached it receives all those pending broadcasts in a quick succession which most likely causes ANRs. This also correlates with the numbers we see in SDKCD where the biggest number of ANRs is coming from Android 14+. 

I did some tests locally and it is indeed happening as described on the screenshot. 

---

- `SystemEventsBreadcrumbsIntegration` is now lifecycle-aware:
  -  When an app enters background we unregister the receiver
  -  When it enters foreground back, we enqueue a task to register the receiver again
  - This way we avoid being registered in the OS for all those broadcasts and do not receive all the pending ones after the app gets uncached 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4294 
Internal customer case

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
