### PR TITLE
fix(logging): Reduce debug logs verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix TTFD measurement when API called too early ([#4297](https://github.com/getsentry/sentry-java/pull/4297))
+- Reduce debug logs verbosity ([#4341](https://github.com/getsentry/sentry-java/pull/4341))
 
 ## 8.8.0
 

--- a/scripts/toggle-codec-logs.sh
+++ b/scripts/toggle-codec-logs.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# --- Functions ---
+
+print_usage() {
+    echo "Usage: $0 [enable|disable]"
+    exit 1
+}
+
+# Check for adb
+if ! command -v adb &> /dev/null; then
+    echo "❌ adb not found. Please install Android Platform Tools and ensure adb is in your PATH."
+    exit 1
+fi
+
+# Check for connected device
+DEVICE_COUNT=$(adb devices | grep -w "device" | wc -l)
+if [ "$DEVICE_COUNT" -eq 0 ]; then
+    echo "❌ No device connected. Please connect a device and enable USB debugging."
+    exit 1
+fi
+
+# --- Handle Argument ---
+
+ACTION=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+case "$ACTION" in
+    enable)
+        echo "✅ Enabling native logs (DEBUG)..."
+        adb shell setprop log.tag.MPEG4Writer D
+        adb shell setprop log.tag.CCodec D
+        adb shell setprop log.tag.VQApply D
+        adb shell setprop log.tag.ColorUtils D
+        adb shell setprop log.tag.MediaCodec D
+        adb shell setprop log.tag.MediaCodecList D
+        adb shell setprop log.tag.MediaWriter D
+        adb shell setprop log.tag.CCodecConfig D
+        adb shell setprop log.tag.Codec2Client D
+        adb shell setprop log.tag.CCodecBufferChannel D
+        adb shell setprop log.tag.CodecProperties D
+        adb shell setprop log.tag.CodecSeeding D
+        adb shell setprop log.tag.C2Store D
+        adb shell setprop log.tag.C2NodeImpl D
+        adb shell setprop log.tag.GraphicBufferSource D
+        adb shell setprop log.tag.BufferQueueProducer D
+        adb shell setprop log.tag.ReflectedParamUpdater D
+        adb shell setprop log.tag.hw-BpHwBinder D
+        echo "✅ Logs ENABLED"
+        ;;
+    disable)
+        echo "🚫 Disabling native logs (SILENT)..."
+        adb shell setprop log.tag.MPEG4Writer SILENT
+        adb shell setprop log.tag.CCodec SILENT
+        adb shell setprop log.tag.VQApply SILENT
+        adb shell setprop log.tag.ColorUtils SILENT
+        adb shell setprop log.tag.MediaCodec SILENT
+        adb shell setprop log.tag.MediaCodecList SILENT
+        adb shell setprop log.tag.MediaWriter SILENT
+        adb shell setprop log.tag.CCodecConfig SILENT
+        adb shell setprop log.tag.Codec2Client SILENT
+        adb shell setprop log.tag.CCodecBufferChannel SILENT
+        adb shell setprop log.tag.CodecProperties SILENT
+        adb shell setprop log.tag.CodecSeeding SILENT
+        adb shell setprop log.tag.C2Store SILENT
+        adb shell setprop log.tag.C2NodeImpl SILENT
+        adb shell setprop log.tag.GraphicBufferSource SILENT
+        adb shell setprop log.tag.BufferQueueProducer SILENT
+        adb shell setprop log.tag.ReflectedParamUpdater SILENT
+        adb shell setprop log.tag.hw-BpHwBinder SILENT
+        echo "🚫 Logs DISABLED"
+        ;;
+    *)
+        echo "❓ Unknown or missing argument: '$1'"
+        print_usage
+        ;;
+esac

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -109,6 +109,8 @@ final class ManifestMetadataReader {
 
   static final String REPLAYS_MASK_ALL_IMAGES = "io.sentry.session-replay.mask-all-images";
 
+  static final String REPLAYS_DEBUG = "io.sentry.session-replay.debug";
+
   static final String FORCE_INIT = "io.sentry.force-init";
 
   static final String MAX_BREADCRUMBS = "io.sentry.max-breadcrumbs";
@@ -451,6 +453,8 @@ final class ManifestMetadataReader {
         options
             .getSessionReplay()
             .setMaskAllImages(readBool(metadata, logger, REPLAYS_MASK_ALL_IMAGES, true));
+
+        options.getSessionReplay().setDebug(readBool(metadata, logger, REPLAYS_DEBUG, false));
 
         options.setIgnoredErrors(readList(metadata, logger, IGNORED_ERRORS));
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/debugmeta/AssetsDebugMetaLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/debugmeta/AssetsDebugMetaLoader.java
@@ -41,7 +41,7 @@ public final class AssetsDebugMetaLoader implements IDebugMetaLoader {
       properties.load(is);
       return Collections.singletonList(properties);
     } catch (FileNotFoundException e) {
-      logger.log(SentryLevel.INFO, e, "%s file was not found.", DEBUG_META_PROPERTIES_FILENAME);
+      logger.log(SentryLevel.INFO, "%s file was not found.", DEBUG_META_PROPERTIES_FILENAME);
     } catch (IOException e) {
       logger.log(SentryLevel.ERROR, "Error getting Proguard UUIDs.", e);
     } catch (RuntimeException e) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -151,8 +151,7 @@ public class ReplayIntegration(
             } catch (e: Throwable) {
                 options.logger.log(
                     INFO,
-                    "ComponentCallbacks is not available, orientation changes won't be handled by Session replay",
-                    e
+                    "ComponentCallbacks is not available, orientation changes won't be handled by Session replay"
                 )
             }
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ScreenshotRecorder.kt
@@ -72,13 +72,13 @@ internal class ScreenshotRecorder(
 
     fun capture() {
         if (!isCapturing.get()) {
-            options.logger.log(DEBUG, "ScreenshotRecorder is paused, not capturing screenshot")
+            if (options.sessionReplay.isDebug) {
+                options.logger.log(DEBUG, "ScreenshotRecorder is paused, not capturing screenshot")
+            }
             return
         }
 
         if (!contentChanged.get() && lastCaptureSuccessful.get()) {
-            options.logger.log(DEBUG, "Content hasn't changed, repeating last known frame")
-
             screenshotRecorderCallback?.onScreenshotRecorded(screenshot)
             return
         }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -67,7 +67,12 @@ internal class SessionCaptureStrategy(
     }
 
     override fun captureReplay(isTerminating: Boolean, onSegmentSent: (Date) -> Unit) {
-        options.logger.log(DEBUG, "Replay is already running in 'session' mode, not capturing for event")
+        if (options.sessionReplay.isDebug) {
+            options.logger.log(
+                DEBUG,
+                "Replay is already running in 'session' mode, not capturing for event"
+            )
+        }
         this.isTerminating.set(isTerminating)
     }
 

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -118,7 +118,6 @@ android {
         val taskName = "toggle${variant.name.capitalized()}NativeLogging"
         val toggleNativeLoggingTask = project.tasks.register<ToggleNativeLoggingTask>(taskName) {
             mergedManifest.set(variant.artifacts.get(SingleArtifact.MERGED_MANIFEST))
-            output.set(project.layout.buildDirectory.dir("intermediates/$taskName"))
             rootDir.set(project.rootDir.absolutePath)
         }
         project.afterEvaluate {
@@ -180,12 +179,6 @@ dependencies {
 
 abstract class ToggleNativeLoggingTask : Exec() {
 
-    // In order for the task to be up-to-date when the inputs have not changed,
-    // the task must declare an output, even if it's not used. Tasks with no
-    // output are always run regardless of whether the inputs changed
-    @get:OutputDirectory
-    abstract val output: DirectoryProperty
-
     @get:Input
     abstract val rootDir: Property<String>
 
@@ -193,6 +186,7 @@ abstract class ToggleNativeLoggingTask : Exec() {
     abstract val mergedManifest: RegularFileProperty
 
     override fun exec() {
+        isIgnoreExitValue = true
         val manifestFile = mergedManifest.get().asFile
         val manifestContent = manifestFile.readText()
         val match = regex.find(manifestContent)

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -72,6 +72,9 @@
         <!--    how to enable Sentry's debug mode-->
         <meta-data android:name="io.sentry.debug" android:value="${sentryDebug}" />
 
+        <!--    how to disable verbose logging of the session replay feature-->
+        <meta-data android:name="io.sentry.session-replay.debug" android:value="false" />
+
         <!--    how to set a custom debug level-->
         <!--    <meta-data android:name="io.sentry.debug.level" android:value="info" />-->
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1197,6 +1197,7 @@ public final class io/sentry/JsonObjectWriter : io/sentry/ObjectWriter {
 	public synthetic fun endArray ()Lio/sentry/ObjectWriter;
 	public fun endObject ()Lio/sentry/JsonObjectWriter;
 	public synthetic fun endObject ()Lio/sentry/ObjectWriter;
+	public fun getIndent ()Ljava/lang/String;
 	public fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public fun name (Ljava/lang/String;)Lio/sentry/JsonObjectWriter;
 	public synthetic fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
@@ -1854,9 +1855,11 @@ public abstract interface class io/sentry/ObjectWriter {
 	public abstract fun beginObject ()Lio/sentry/ObjectWriter;
 	public abstract fun endArray ()Lio/sentry/ObjectWriter;
 	public abstract fun endObject ()Lio/sentry/ObjectWriter;
+	public abstract fun getIndent ()Ljava/lang/String;
 	public abstract fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public abstract fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public abstract fun nullValue ()Lio/sentry/ObjectWriter;
+	public abstract fun setIndent (Ljava/lang/String;)V
 	public abstract fun setLenient (Z)V
 	public abstract fun value (D)Lio/sentry/ObjectWriter;
 	public abstract fun value (J)Lio/sentry/ObjectWriter;
@@ -3420,9 +3423,11 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getSessionSegmentDuration ()J
 	public fun getUnmaskViewClasses ()Ljava/util/Set;
 	public fun getUnmaskViewContainerClass ()Ljava/lang/String;
+	public fun isDebug ()Z
 	public fun isSessionReplayEnabled ()Z
 	public fun isSessionReplayForErrorsEnabled ()Z
 	public fun isTrackOrientationChange ()Z
+	public fun setDebug (Z)V
 	public fun setMaskAllImages (Z)V
 	public fun setMaskAllText (Z)V
 	public fun setMaskViewContainerClass (Ljava/lang/String;)V
@@ -6522,11 +6527,13 @@ public final class io/sentry/util/MapObjectWriter : io/sentry/ObjectWriter {
 	public fun endArray ()Lio/sentry/util/MapObjectWriter;
 	public synthetic fun endObject ()Lio/sentry/ObjectWriter;
 	public fun endObject ()Lio/sentry/util/MapObjectWriter;
+	public fun getIndent ()Ljava/lang/String;
 	public fun jsonValue (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public synthetic fun name (Ljava/lang/String;)Lio/sentry/ObjectWriter;
 	public fun name (Ljava/lang/String;)Lio/sentry/util/MapObjectWriter;
 	public synthetic fun nullValue ()Lio/sentry/ObjectWriter;
 	public fun nullValue ()Lio/sentry/util/MapObjectWriter;
+	public fun setIndent (Ljava/lang/String;)V
 	public fun setLenient (Z)V
 	public synthetic fun value (D)Lio/sentry/ObjectWriter;
 	public fun value (D)Lio/sentry/util/MapObjectWriter;
@@ -6770,6 +6777,7 @@ public class io/sentry/vendor/gson/stream/JsonWriter : java/io/Closeable, java/i
 	public fun endArray ()Lio/sentry/vendor/gson/stream/JsonWriter;
 	public fun endObject ()Lio/sentry/vendor/gson/stream/JsonWriter;
 	public fun flush ()V
+	public fun getIndent ()Ljava/lang/String;
 	public final fun getSerializeNulls ()Z
 	public final fun isHtmlSafe ()Z
 	public fun isLenient ()Z

--- a/sentry/src/main/java/io/sentry/JsonObjectWriter.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectWriter.java
@@ -114,7 +114,14 @@ public final class JsonObjectWriter implements ObjectWriter {
     jsonWriter.setLenient(lenient);
   }
 
-  public void setIndent(final @NotNull String indent) {
+  @Override
+  public void setIndent(final @Nullable String indent) {
     jsonWriter.setIndent(indent);
+  }
+
+  @Override
+  @Nullable
+  public String getIndent() {
+    return jsonWriter.getIndent();
   }
 }

--- a/sentry/src/main/java/io/sentry/ObjectWriter.java
+++ b/sentry/src/main/java/io/sentry/ObjectWriter.java
@@ -35,4 +35,9 @@ public interface ObjectWriter {
       throws IOException;
 
   void setLenient(boolean lenient);
+
+  void setIndent(final @Nullable String indent);
+
+  @Nullable
+  String getIndent();
 }

--- a/sentry/src/main/java/io/sentry/ProfileChunk.java
+++ b/sentry/src/main/java/io/sentry/ProfileChunk.java
@@ -209,7 +209,12 @@ public final class ProfileChunk implements JsonUnknown, JsonSerializable {
       writer.name(JsonKeys.CLIENT_SDK).value(logger, clientSdk);
     }
     if (!measurements.isEmpty()) {
+      // Measurements can be a very long list which will make it hard to read in logs, so we don't
+      // indent it
+      final String prevIndent = writer.getIndent();
+      writer.setIndent("");
       writer.name(JsonKeys.MEASUREMENTS).value(logger, measurements);
+      writer.setIndent(prevIndent);
     }
     writer.name(JsonKeys.PLATFORM).value(logger, platform);
     writer.name(JsonKeys.RELEASE).value(logger, release);

--- a/sentry/src/main/java/io/sentry/ProfilingTraceData.java
+++ b/sentry/src/main/java/io/sentry/ProfilingTraceData.java
@@ -434,7 +434,12 @@ public final class ProfilingTraceData implements JsonUnknown, JsonSerializable {
     if (sampledProfile != null) {
       writer.name(JsonKeys.SAMPLED_PROFILE).value(sampledProfile);
     }
+    // Measurements can be a very long list which will make it hard to read in logs, so we don't
+    // indent it
+    final String prevIndent = writer.getIndent();
+    writer.setIndent("");
     writer.name(JsonKeys.MEASUREMENTS).value(logger, measurementsMap);
+    writer.setIndent(prevIndent);
     writer.name(JsonKeys.TIMESTAMP).value(logger, timestamp);
     if (unknown != null) {
       for (String key : unknown.keySet()) {

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -130,6 +130,12 @@ public final class SentryReplayOptions {
    */
   private @Nullable SdkVersion sdkVersion;
 
+  /**
+   * Turns debug mode on or off for Session Replay-specific code paths. If debug is enabled SDK will
+   * attempt to print out useful debugging information if something goes wrong. Default is disabled.
+   */
+  private boolean debug = false;
+
   public SentryReplayOptions(final boolean empty, final @Nullable SdkVersion sdkVersion) {
     if (!empty) {
       setMaskAllText(true);
@@ -311,5 +317,23 @@ public final class SentryReplayOptions {
   @ApiStatus.Internal
   public void setSdkVersion(final @Nullable SdkVersion sdkVersion) {
     this.sdkVersion = sdkVersion;
+  }
+
+  /**
+   * Check if debug mode is ON Default is OFF
+   *
+   * @return true if ON or false otherwise
+   */
+  public boolean isDebug() {
+    return debug;
+  }
+
+  /**
+   * Sets the debug mode to ON or OFF Default is OFF
+   *
+   * @param debug true if ON or false otherwise
+   */
+  public void setDebug(final boolean debug) {
+    this.debug = debug;
   }
 }

--- a/sentry/src/main/java/io/sentry/cache/CacheUtils.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheUtils.java
@@ -59,7 +59,7 @@ final class CacheUtils {
     final File file = new File(cacheDir, fileName);
     options.getLogger().log(DEBUG, "Deleting %s from scope cache", fileName);
     if (!file.delete()) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to delete: %s", file.getAbsolutePath());
+      options.getLogger().log(SentryLevel.INFO, "Failed to delete: %s", file.getAbsolutePath());
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -23,7 +23,7 @@ public class LoadClass {
       return Class.forName(clazz);
     } catch (ClassNotFoundException e) {
       if (logger != null) {
-        logger.log(SentryLevel.DEBUG, "Class not available:" + clazz, e);
+        logger.log(SentryLevel.INFO, "Class not available: " + clazz);
       }
     } catch (UnsatisfiedLinkError e) {
       if (logger != null) {

--- a/sentry/src/main/java/io/sentry/util/MapObjectWriter.java
+++ b/sentry/src/main/java/io/sentry/util/MapObjectWriter.java
@@ -126,6 +126,16 @@ public final class MapObjectWriter implements ObjectWriter {
   }
 
   @Override
+  public void setIndent(@Nullable String indent) {
+    // no-op
+  }
+
+  @Override
+  public @Nullable String getIndent() {
+    return null;
+  }
+
+  @Override
   public MapObjectWriter beginArray() throws IOException {
     stack.add(new ArrayList<>());
     return this;

--- a/sentry/src/main/java/io/sentry/vendor/gson/stream/JsonWriter.java
+++ b/sentry/src/main/java/io/sentry/vendor/gson/stream/JsonWriter.java
@@ -220,14 +220,19 @@ public class JsonWriter implements Closeable, Flushable {
    *
    * @param indent a string containing only whitespace.
    */
-  public final void setIndent(String indent) {
-    if (indent.length() == 0) {
+  public final void setIndent(final @Nullable String indent) {
+    if (indent == null || indent.length() == 0) {
       this.indent = null;
       this.separator = ":";
     } else {
       this.indent = indent;
       this.separator = ": ";
     }
+  }
+
+  @Nullable
+  public String getIndent() {
+    return indent;
   }
 
   /**


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Introduce new `debug` option under the session replay sub-options. This controls verbose logging of Session Replay-specific code paths.
  - Introduce a bash script that disables/enables system logs via `adb shell`
  - Hook the script via a Gradle task which reads the `session-replay.debug` manifest option and runs the script for the sample app
- Reduce log levels for some logs
- Get rid of printing Throwables with stacktraces for logs where it's expected to fail in some cases (e.g. no Compose dependency)
- Change `indent` when serializing Profiles' measurements, because the list is too big and makes logcat unreadable

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4307 
Fixes https://github.com/getsentry/sentry-dart/issues/2673

## :green_heart: How did you test it?
Existing tests should cover it

The script I tested manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
