### PR TITLE
perf(user-interactions): Make user interaction tracing faster and allocate less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fix unregister `SystemEventsBroadcastReceiver` when entering background ([#4338](https://github.com/getsentry/sentry-java/pull/4338))
   - This should reduce ANRs seen with this class in the stack trace for Android 14 and above
 
+### Improvements
+
+- Make user interaction tracing faster and do fewer allocations ([#4347](https://github.com/getsentry/sentry-java/pull/4347))
+
 ## 8.8.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
@@ -8,6 +8,7 @@ import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.gestures.UiElement;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -60,6 +61,7 @@ public final class ViewUtils {
       final float y,
       final UiElement.Type targetType) {
 
+    final List<GestureTargetLocator> locators = options.getGestureTargetLocators();
     final Queue<View> queue = new LinkedList<>();
     queue.add(decorView);
 
@@ -79,7 +81,8 @@ public final class ViewUtils {
         }
       }
 
-      for (GestureTargetLocator locator : options.getGestureTargetLocators()) {
+      for (int i = 0; i < locators.size(); i++) {
+        final GestureTargetLocator locator = locators.get(i);
         final @Nullable UiElement newTarget = locator.locate(view, x, y, targetType);
         if (newTarget != null) {
           if (targetType == UiElement.Type.CLICKABLE) {

--- a/sentry-compose/proguard-rules.pro
+++ b/sentry-compose/proguard-rules.pro
@@ -13,7 +13,7 @@
 -keepnames class androidx.compose.foundation.CombinedClickableElement
 -keepnames class androidx.compose.foundation.ScrollingLayoutElement
 -keepnames class androidx.compose.ui.platform.TestTagElement { *; }
--keepnames class io.sentry.compose.SentryModifier.SentryTagModifierNodeElement { *; }
+-keepnames class io.sentry.compose.SentryModifier$SentryTagModifierNodeElement { *; }
 
 # R8 will warn about missing classes if people don't have androidx.compose-navigation on their
 # classpath, but this is fine, these classes are used in an internal class which is only used when

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeHelper.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeHelper.kt
@@ -18,10 +18,10 @@ internal class SentryComposeHelper(logger: ILogger) {
         loadField(logger, "androidx.compose.ui.platform.TestTagElement", "tag")
 
     private val sentryTagElementField: Field? =
-        loadField(logger, "io.sentry.compose.SentryModifier.SentryTagModifierNodeElement", "tag")
+        loadField(logger, "io.sentry.compose.SentryModifier${'$'}SentryTagModifierNodeElement", "tag")
 
     fun extractTag(modifier: Modifier): String? {
-        val type = modifier.javaClass.canonicalName
+        val type = modifier.javaClass.name
         // Newer Jetpack Compose uses TestTagElement as node elements
         // See
         // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/TestTag.kt;l=34;drc=dcaa116fbfda77e64a319e1668056ce3b032469f
@@ -31,7 +31,7 @@ internal class SentryComposeHelper(logger: ILogger) {
             ) {
                 val value = testTagElementField.get(modifier)
                 return value as String?
-            } else if ("io.sentry.compose.SentryModifier.SentryTagModifierNodeElement" == type &&
+            } else if ("io.sentry.compose.SentryModifier${'$'}SentryTagModifierNodeElement" == type &&
                 sentryTagElementField != null
             ) {
                 val value = sentryTagElementField.get(modifier)

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
@@ -70,7 +70,8 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
                 var isScrollable = false
 
                 val modifiers = node.getModifierInfo()
-                for (modifierInfo in modifiers) {
+                for (index in modifiers.indices) {
+                    val modifierInfo = modifiers[index]
                     val tag = composeHelper!!.extractTag(modifierInfo.modifier)
                     if (tag != null) {
                         lastKnownTag = tag
@@ -93,7 +94,7 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
                     } else {
                         val modifier = modifierInfo.modifier
                         // Newer Jetpack Compose 1.5 uses Node modifiers for clicks/scrolls
-                        val type = modifier.javaClass.canonicalName
+                        val type = modifier.javaClass.name
                         if ("androidx.compose.foundation.ClickableElement" == type ||
                             "androidx.compose.foundation.CombinedClickableElement" == type
                         ) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Use `class.getName` instead of `class.getCanonicalName` as it's almost ~2x faster, and there's almost no difference in what it returns except for inner classes (tested 10k iterations over 10 times)

<img width="836" alt="Google Chrome 2025-04-21 10 46 11" src="https://github.com/user-attachments/assets/76025fba-eb99-41ff-8a70-4423cf5d320b" />

- Fix `SentryTag` extraction for compose, because `SentryTagModifierNodeElement` is an inner class and we have to use a dollar-sign to properly get its class name.

- Use `fori` instead of `foreach` loop to avoid allocating an Iterator in hot paths (e.g. when traversing the view hierarchy which can happen 100s of times for complex UIs). Reduced allocations by almost 2x doing the same user flow (launch -> scroll -> button click)

### Before
![Android Studio 2025-04-21 23 12 32](https://github.com/user-attachments/assets/1280d012-9075-45b3-b262-447b2551400f)


### After

![Android Studio 2025-04-21 23 15 46](https://github.com/user-attachments/assets/0e8d99c2-c54c-460f-ab1c-e686e541c135)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve perf of user interaction tracing

## :green_heart: How did you test it?
existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
