### PR TITLE
perf(modules): Pre-load modules on a background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Improvements
 
 - Make user interaction tracing faster and do fewer allocations ([#4347](https://github.com/getsentry/sentry-java/pull/4347))
+- Pre-load modules on a background thread upon SDK init ([#4348](https://github.com/getsentry/sentry-java/pull/4348))
 
 ## 8.8.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,6 +23,12 @@ public final class AssetsModulesLoader extends ModulesLoader {
   public AssetsModulesLoader(final @NotNull Context context, final @NotNull ILogger logger) {
     super(logger);
     this.context = ContextUtils.getApplicationContext(context);
+
+    // pre-load modules on a bg thread to avoid doing so on the main thread in case of a crash/error
+    final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
+    //noinspection Convert2MethodRef
+    executorService.submit(() -> getOrLoadModules());
+    executorService.shutdown();
   }
 
   @Override

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/modules/AssetsModulesLoader.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,10 +23,8 @@ public final class AssetsModulesLoader extends ModulesLoader {
     this.context = ContextUtils.getApplicationContext(context);
 
     // pre-load modules on a bg thread to avoid doing so on the main thread in case of a crash/error
-    final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
     //noinspection Convert2MethodRef
-    executorService.submit(() -> getOrLoadModules());
-    executorService.shutdown();
+    new Thread(() -> getOrLoadModules()).start();
   }
 
   @Override


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Pre-load modules on a background thread upon initialization so we don't need to load them when an error/crash happens (could be on the main thread)
- Fix `cachedModules` were not thread-safe

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An actual ANR from GPC originating in `UncaughtExceptionHandler`
https://play.google.com/sdk-console/accounts/3062283563667932501/sdks/5766124106675877123/crashes/44125318/details

## :green_heart: How did you test it?
Manually + existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
