### PR TITLE
Support `globalHubMode` for OpenTelemetry

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/api/sentry-opentelemetry-bootstrap.api
@@ -1,6 +1,7 @@
 public abstract interface class io/sentry/opentelemetry/IOtelSpanWrapper : io/sentry/ISpan {
 	public abstract fun getData ()Ljava/util/Map;
 	public abstract fun getMeasurements ()Ljava/util/Map;
+	public abstract fun getOpenTelemetrySpan ()Lio/opentelemetry/api/trace/Span;
 	public abstract fun getOpenTelemetrySpanAttributes ()Lio/opentelemetry/api/common/Attributes;
 	public abstract fun getScopes ()Lio/sentry/IScopes;
 	public abstract fun getTags ()Ljava/util/Map;
@@ -8,6 +9,7 @@ public abstract interface class io/sentry/opentelemetry/IOtelSpanWrapper : io/se
 	public abstract fun getTransactionName ()Ljava/lang/String;
 	public abstract fun getTransactionNameSource ()Lio/sentry/protocol/TransactionNameSource;
 	public abstract fun isProfileSampled ()Ljava/lang/Boolean;
+	public abstract fun isRoot ()Z
 	public abstract fun setTransactionName (Ljava/lang/String;)V
 	public abstract fun setTransactionName (Ljava/lang/String;Lio/sentry/protocol/TransactionNameSource;)V
 	public abstract fun storeInContext (Lio/opentelemetry/context/Context;)Lio/opentelemetry/context/Context;
@@ -52,6 +54,7 @@ public final class io/sentry/opentelemetry/OtelStrongRefSpanWrapper : io/sentry/
 	public fun getDescription ()Ljava/lang/String;
 	public fun getFinishDate ()Lio/sentry/SentryDate;
 	public fun getMeasurements ()Ljava/util/Map;
+	public fun getOpenTelemetrySpan ()Lio/opentelemetry/api/trace/Span;
 	public fun getOpenTelemetrySpanAttributes ()Lio/opentelemetry/api/common/Attributes;
 	public fun getOperation ()Ljava/lang/String;
 	public fun getSamplingDecision ()Lio/sentry/TracesSamplingDecision;
@@ -68,6 +71,7 @@ public final class io/sentry/opentelemetry/OtelStrongRefSpanWrapper : io/sentry/
 	public fun isFinished ()Z
 	public fun isNoOp ()Z
 	public fun isProfileSampled ()Ljava/lang/Boolean;
+	public fun isRoot ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
 	public fun makeCurrent ()Lio/sentry/ISentryLifecycleToken;
 	public fun setContext (Ljava/lang/String;Ljava/lang/Object;)V
@@ -151,6 +155,7 @@ public final class io/sentry/opentelemetry/SentryContextStorage : io/opentelemet
 	public fun <init> (Lio/opentelemetry/context/ContextStorage;)V
 	public fun attach (Lio/opentelemetry/context/Context;)Lio/opentelemetry/context/Scope;
 	public fun current ()Lio/opentelemetry/context/Context;
+	public fun root ()Lio/opentelemetry/context/Context;
 }
 
 public final class io/sentry/opentelemetry/SentryContextStorageProvider : io/opentelemetry/context/ContextStorageProvider {
@@ -181,6 +186,7 @@ public final class io/sentry/opentelemetry/SentryOtelThreadLocalStorage : io/ope
 public final class io/sentry/opentelemetry/SentryWeakSpanStorage {
 	public fun clear ()V
 	public static fun getInstance ()Lio/sentry/opentelemetry/SentryWeakSpanStorage;
+	public fun getLastKnownUnfinishedRootSpan ()Lio/sentry/opentelemetry/IOtelSpanWrapper;
 	public fun getSentrySpan (Lio/opentelemetry/api/trace/SpanContext;)Lio/sentry/opentelemetry/IOtelSpanWrapper;
 	public fun storeSentrySpan (Lio/opentelemetry/api/trace/SpanContext;Lio/sentry/opentelemetry/IOtelSpanWrapper;)V
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/IOtelSpanWrapper.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/IOtelSpanWrapper.java
@@ -1,6 +1,7 @@
 package io.sentry.opentelemetry;
 
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.sentry.IScopes;
 import io.sentry.ISpan;
@@ -52,4 +53,9 @@ public interface IOtelSpanWrapper extends ISpan {
   @ApiStatus.Internal
   @Nullable
   Attributes getOpenTelemetrySpanAttributes();
+
+  boolean isRoot();
+
+  @Nullable
+  Span getOpenTelemetrySpan();
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OtelStrongRefSpanWrapper.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/OtelStrongRefSpanWrapper.java
@@ -310,4 +310,14 @@ public final class OtelStrongRefSpanWrapper implements IOtelSpanWrapper {
   public @Nullable Attributes getOpenTelemetrySpanAttributes() {
     return delegate.getOpenTelemetrySpanAttributes();
   }
+
+  @Override
+  public boolean isRoot() {
+    return delegate.isRoot();
+  }
+
+  @Override
+  public @Nullable Span getOpenTelemetrySpan() {
+    return delegate.getOpenTelemetrySpan();
+  }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorage.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorage.java
@@ -3,6 +3,7 @@ package io.sentry.opentelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.Scope;
+import io.sentry.Sentry;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,5 +38,16 @@ public final class SentryContextStorage implements ContextStorage {
   @Override
   public Context current() {
     return contextStorage.current();
+  }
+
+  @Override
+  public Context root() {
+    final @NotNull Context originalRoot = ContextStorage.super.root();
+
+    if (Sentry.isGlobalHubMode()) {
+      return SentryContextWrapper.wrap(originalRoot);
+    }
+
+    return originalRoot;
   }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/api/sentry-opentelemetry-core.api
@@ -61,6 +61,7 @@ public final class io/sentry/opentelemetry/OtelSpanWrapper : io/sentry/opentelem
 	public fun getDescription ()Ljava/lang/String;
 	public fun getFinishDate ()Lio/sentry/SentryDate;
 	public fun getMeasurements ()Ljava/util/Map;
+	public fun getOpenTelemetrySpan ()Lio/opentelemetry/api/trace/Span;
 	public fun getOpenTelemetrySpanAttributes ()Lio/opentelemetry/api/common/Attributes;
 	public fun getOperation ()Ljava/lang/String;
 	public fun getSamplingDecision ()Lio/sentry/TracesSamplingDecision;
@@ -77,6 +78,7 @@ public final class io/sentry/opentelemetry/OtelSpanWrapper : io/sentry/opentelem
 	public fun isFinished ()Z
 	public fun isNoOp ()Z
 	public fun isProfileSampled ()Ljava/lang/Boolean;
+	public fun isRoot ()Z
 	public fun isSampled ()Ljava/lang/Boolean;
 	public fun makeCurrent ()Lio/sentry/ISentryLifecycleToken;
 	public fun setContext (Ljava/lang/String;Ljava/lang/Object;)V

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanWrapper.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/OtelSpanWrapper.java
@@ -515,6 +515,25 @@ public final class OtelSpanWrapper implements IOtelSpanWrapper {
     }
   }
 
+  @Override
+  public boolean isRoot() {
+    if (context.getParentSpanId() == null) {
+      return true;
+    }
+
+    final @Nullable ReadWriteSpan readWriteSpan = span.get();
+    if (readWriteSpan != null) {
+      return readWriteSpan.getParentSpanContext().isRemote();
+    }
+
+    return false;
+  }
+
+  @Override
+  public @Nullable Span getOpenTelemetrySpan() {
+    return span.get();
+  }
+
   @SuppressWarnings("MustBeClosedChecker")
   @ApiStatus.Internal
   @Override

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2529,6 +2529,7 @@ public final class io/sentry/Sentry {
 	public static fun init (Ljava/lang/String;)V
 	public static fun isCrashedLastRun ()Ljava/lang/Boolean;
 	public static fun isEnabled ()Z
+	public static fun isGlobalHubMode ()Z
 	public static fun isHealthy ()Z
 	public static fun popScope ()V
 	public static fun pushIsolationScope ()Lio/sentry/ISentryLifecycleToken;

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1225,4 +1225,8 @@ public final class Sentry {
   public static @NotNull SentryId captureCheckIn(final @NotNull CheckIn checkIn) {
     return getCurrentScopes().captureCheckIn(checkIn);
   }
+
+  public static boolean isGlobalHubMode() {
+    return globalHubMode;
+  }
 }


### PR DESCRIPTION
**We're planning to release an alpha version from this branch so this PR shouldn't be merged to `main` yet.**

## :scroll: Description
<!--- Describe your changes in detail -->
- Always returns a wrapped `Context` from OpenTelemetry `ContextStorage` if `globalHubMode` is enabled
- Returns the last known unfinished root span / transaction from `Context.get` if there is no (valid) span stored on the context

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using Sentry with OpenTelemetry for Java Desktop apps where customers have no control over their scheduling requires `globalHubMode` to ensure e.g. outgoing HTTP client spans are attached to the root span / transaction that is currently running.

Without this fix, HTTP client spans are recorded as separate Sentry transactions due to OpenTelemetry `Context` not being propagated e.g. when using `new Thread(new Runnable() { ... }).start()`.

To fix this it's also possible to manually transfer the OpenTelemetry `Context` but not every customer has control over their scheduling:

```
    private void fetchTodo() {
        fetchButton.setEnabled(false);

        final Context opentelemetryContext = Context.current(); // <----------------- remember Context ------------------------

        Runnable r = new Runnable() {
            @Override
            public void run() {
                try (Scope scope = opentelemetryContext.makeCurrent()) {   // <------------------ make Context current in thread -----------------------
                    HttpClient client = HttpClient.newHttpClient();
                    HttpRequest request = HttpRequest.newBuilder()
                            .uri(URI.create("https://jsonplaceholder.typicode.com/todos/1"))
                            .build();

                    try {
                        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
                        String prettyJson = gson.toJson(
                                gson.fromJson(response.body(), Object.class)
                        );
                        resultArea.setText(prettyJson);
                    } catch (Exception e) {
                        resultArea.setText("Error: " + e.getMessage());
                    } finally {
                        fetchButton.setEnabled(true);
                    }
                }
            }
        };
        new Thread(r).start();
    }
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
