### PR TITLE
Update profile chunk rate limit and client report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Update profile chunk rate limit and client report ([#4353](https://github.com/getsentry/sentry-java/pull/4353))
+
 ## 8.9.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -178,7 +178,7 @@ public class AndroidContinuousProfiler
       final @Nullable RateLimiter rateLimiter = scopes.getRateLimiter();
       if (rateLimiter != null
           && (rateLimiter.isActiveForCategory(All)
-              || rateLimiter.isActiveForCategory(DataCategory.ProfileChunk))) {
+              || rateLimiter.isActiveForCategory(DataCategory.ProfileChunkUi))) {
         logger.log(SentryLevel.WARNING, "SDK is rate limited. Stopping profiler.");
         // Let's stop and reset profiler id, as the profile is now broken anyway
         stop(false);
@@ -385,7 +385,7 @@ public class AndroidContinuousProfiler
   public void onRateLimitChanged(@NotNull RateLimiter rateLimiter) {
     // We stop the profiler as soon as we are rate limited, to avoid the performance overhead
     if (rateLimiter.isActiveForCategory(All)
-        || rateLimiter.isActiveForCategory(DataCategory.ProfileChunk)) {
+        || rateLimiter.isActiveForCategory(DataCategory.ProfileChunkUi)) {
       logger.log(SentryLevel.WARNING, "SDK is rate limited. Stopping profiler.");
       stop(false);
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
@@ -505,7 +505,7 @@ class AndroidContinuousProfilerTest {
     fun `profiler stops when rate limited`() {
         val profiler = fixture.getSut()
         val rateLimiter = mock<RateLimiter>()
-        whenever(rateLimiter.isActiveForCategory(DataCategory.ProfileChunk)).thenReturn(true)
+        whenever(rateLimiter.isActiveForCategory(DataCategory.ProfileChunkUi)).thenReturn(true)
 
         profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
         assertTrue(profiler.isRunning)
@@ -521,7 +521,7 @@ class AndroidContinuousProfilerTest {
     fun `profiler does not start when rate limited`() {
         val profiler = fixture.getSut()
         val rateLimiter = mock<RateLimiter>()
-        whenever(rateLimiter.isActiveForCategory(DataCategory.ProfileChunk)).thenReturn(true)
+        whenever(rateLimiter.isActiveForCategory(DataCategory.ProfileChunkUi)).thenReturn(true)
         whenever(fixture.scopes.rateLimiter).thenReturn(rateLimiter)
 
         // If the SDK is rate limited, the profiler should never start

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -354,7 +354,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static final field Error Lio/sentry/DataCategory;
 	public static final field Monitor Lio/sentry/DataCategory;
 	public static final field Profile Lio/sentry/DataCategory;
-	public static final field ProfileChunk Lio/sentry/DataCategory;
+	public static final field ProfileChunkUi Lio/sentry/DataCategory;
 	public static final field Replay Lio/sentry/DataCategory;
 	public static final field Security Lio/sentry/DataCategory;
 	public static final field Session Lio/sentry/DataCategory;

--- a/sentry/src/main/java/io/sentry/DataCategory.java
+++ b/sentry/src/main/java/io/sentry/DataCategory.java
@@ -12,7 +12,7 @@ public enum DataCategory {
   Attachment("attachment"),
   Monitor("monitor"),
   Profile("profile"),
-  ProfileChunk("profile_chunk"),
+  ProfileChunkUi("profile_chunk_ui"),
   Transaction("transaction"),
   Replay("replay"),
   Span("span"),

--- a/sentry/src/main/java/io/sentry/SentryItemType.java
+++ b/sentry/src/main/java/io/sentry/SentryItemType.java
@@ -15,7 +15,7 @@ public enum SentryItemType implements JsonSerializable {
   Attachment("attachment"),
   Transaction("transaction"),
   Profile("profile"),
-  ProfileChunk("profile_chunk"),
+  ProfileChunk("profile_chunk_ui"),
   ClientReport("client_report"),
   ReplayEvent("replay_event"),
   ReplayRecording("replay_recording"),

--- a/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
+++ b/sentry/src/main/java/io/sentry/clientreport/ClientReportRecorder.java
@@ -166,7 +166,7 @@ public final class ClientReportRecorder implements IClientReportRecorder {
       return DataCategory.Profile;
     }
     if (SentryItemType.ProfileChunk.equals(itemType)) {
-      return DataCategory.ProfileChunk;
+      return DataCategory.ProfileChunkUi;
     }
     if (SentryItemType.Attachment.equals(itemType)) {
       return DataCategory.Attachment;

--- a/sentry/src/main/java/io/sentry/transport/RateLimiter.java
+++ b/sentry/src/main/java/io/sentry/transport/RateLimiter.java
@@ -191,8 +191,8 @@ public final class RateLimiter implements Closeable {
         return DataCategory.Attachment;
       case "profile":
         return DataCategory.Profile;
-      case "profile_chunk":
-        return DataCategory.ProfileChunk;
+      case "profile_chunk_ui":
+        return DataCategory.ProfileChunkUi;
       case "transaction":
         return DataCategory.Transaction;
       case "check_in":

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -344,7 +344,7 @@ class RateLimiterTest {
         val attachmentItem = SentryEnvelopeItem.fromAttachment(fixture.serializer, NoOpLogger.getInstance(), Attachment("{ \"number\": 10 }".toByteArray(), "log.json"), 1000)
         val envelope = SentryEnvelope(SentryEnvelopeHeader(), arrayListOf(profileChunkItem, attachmentItem))
 
-        rateLimiter.updateRetryAfterLimits("60:profile_chunk:key", null, 1)
+        rateLimiter.updateRetryAfterLimits("60:profile_chunk_ui:key", null, 1)
         val result = rateLimiter.filter(envelope, Hint())
 
         assertNotNull(result)


### PR DESCRIPTION
## :scroll: Description
update rate limiting and client reports for profile chunks from `profile_chunk` to `profile_chunk_ui`


## :bulb: Motivation and Context
Rate limiting is different for UI and backend profiling, so they have different keys


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
