### PR TITLE
Determine recording size based on active window

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -50,7 +50,7 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 	public static synthetic fun createVideoOf$default (Lio/sentry/android/replay/ReplayCache;JJIIIIILjava/io/File;ILjava/lang/Object;)Lio/sentry/android/replay/GeneratedVideo;
 }
 
-public final class io/sentry/android/replay/ReplayIntegration : android/content/ComponentCallbacks, io/sentry/IConnectionStatusProvider$IConnectionStatusObserver, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, io/sentry/android/replay/gestures/TouchRecorderCallback, io/sentry/transport/RateLimiter$IRateLimitObserver, java/io/Closeable {
+public final class io/sentry/android/replay/ReplayIntegration : android/content/ComponentCallbacks, io/sentry/IConnectionStatusProvider$IConnectionStatusObserver, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, io/sentry/android/replay/WindowCallback, io/sentry/android/replay/gestures/TouchRecorderCallback, io/sentry/transport/RateLimiter$IRateLimitObserver, java/io/Closeable {
 	public static final field $stable I
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
@@ -68,6 +68,7 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 	public fun onScreenshotRecorded (Ljava/io/File;J)V
 	public fun onTouchEvent (Landroid/view/MotionEvent;)V
+	public fun onWindowSizeChanged (II)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IScopes;Lio/sentry/SentryOptions;)V
 	public fun resume ()V
@@ -119,6 +120,10 @@ public final class io/sentry/android/replay/SessionReplayOptionsKt {
 public final class io/sentry/android/replay/ViewExtensionsKt {
 	public static final fun sentryReplayMask (Landroid/view/View;)V
 	public static final fun sentryReplayUnmask (Landroid/view/View;)V
+}
+
+public abstract interface class io/sentry/android/replay/WindowCallback {
+	public abstract fun onWindowSizeChanged (II)V
 }
 
 public abstract interface class io/sentry/android/replay/gestures/TouchRecorderCallback {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -1,10 +1,15 @@
 package io.sentry.android.replay
 
 import android.annotation.TargetApi
+import android.graphics.Point
 import android.view.View
+import android.view.ViewTreeObserver
 import io.sentry.SentryOptions
 import io.sentry.android.replay.util.MainLooperHandler
+import io.sentry.android.replay.util.addOnDrawListenerSafe
 import io.sentry.android.replay.util.gracefullyShutdown
+import io.sentry.android.replay.util.hasSize
+import io.sentry.android.replay.util.removeOnDrawListenerSafe
 import io.sentry.android.replay.util.scheduleAtFixedRateSafely
 import io.sentry.util.AutoClosableReentrantLock
 import java.lang.ref.WeakReference
@@ -19,9 +24,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class WindowRecorder(
     private val options: SentryOptions,
     private val screenshotRecorderCallback: ScreenshotRecorderCallback? = null,
+    private val windowCallback: WindowCallback,
     private val mainLooperHandler: MainLooperHandler,
     private val replayExecutor: ScheduledExecutorService
-) : Recorder, OnRootViewsChangedListener {
+) : Recorder, OnRootViewsChangedListener, ConfigurationChangedListener {
 
     internal companion object {
         private const val TAG = "WindowRecorder"
@@ -29,6 +35,7 @@ internal class WindowRecorder(
 
     private val isRecording = AtomicBoolean(false)
     private val rootViews = ArrayList<WeakReference<View>>()
+    private var lastKnownWindowSize: Point = Point()
     private val rootViewsLock = AutoClosableReentrantLock()
     private var recorder: ScreenshotRecorder? = null
     private var capturingTask: ScheduledFuture<*>? = null
@@ -41,6 +48,7 @@ internal class WindowRecorder(
             if (added) {
                 rootViews.add(WeakReference(root))
                 recorder?.bind(root)
+                determineWindowSize(root)
             } else {
                 recorder?.unbind(root)
                 rootViews.removeAll { it.get() == root }
@@ -48,10 +56,36 @@ internal class WindowRecorder(
                 val newRoot = rootViews.lastOrNull()?.get()
                 if (newRoot != null && root != newRoot) {
                     recorder?.bind(newRoot)
+                    determineWindowSize(newRoot)
                 } else {
                     Unit // synchronized block wants us to return something lol
                 }
             }
+        }
+    }
+
+    fun determineWindowSize(root: View) {
+        if (root.hasSize()) {
+            if (root.width != lastKnownWindowSize.x && root.height != lastKnownWindowSize.y) {
+                lastKnownWindowSize.set(root.width, root.height)
+                windowCallback.onWindowSizeChanged(root.width, root.height)
+            }
+        } else {
+            root.addOnDrawListenerSafe(object : ViewTreeObserver.OnDrawListener {
+                override fun onDraw() {
+                    val currentRoot = rootViews.lastOrNull()?.get()
+                    if (root != currentRoot) {
+                        return
+                    }
+                    if (root.hasSize()) {
+                        if (root.width != lastKnownWindowSize.x && root.height != lastKnownWindowSize.y) {
+                            lastKnownWindowSize.set(root.width, root.height)
+                            windowCallback.onWindowSizeChanged(root.width, root.height)
+                        }
+                        root.removeOnDrawListenerSafe(this)
+                    }
+                }
+            })
         }
     }
 
@@ -60,7 +94,18 @@ internal class WindowRecorder(
             return
         }
 
-        recorder = ScreenshotRecorder(recorderConfig, options, mainLooperHandler, replayExecutor, screenshotRecorderCallback)
+        recorder = ScreenshotRecorder(
+            recorderConfig,
+            options,
+            mainLooperHandler,
+            replayExecutor,
+            screenshotRecorderCallback
+        )
+
+        val newRoot = rootViews.lastOrNull()?.get()
+        if (newRoot != null) {
+            recorder?.bind(newRoot)
+        }
         // TODO: change this to use MainThreadHandler and just post on the main thread with delay
         // to avoid thread context switch every time
         capturingTask = capturer.scheduleAtFixedRateSafely(
@@ -77,15 +122,12 @@ internal class WindowRecorder(
     override fun resume() {
         recorder?.resume()
     }
+
     override fun pause() {
         recorder?.pause()
     }
 
     override fun stop() {
-        rootViewsLock.acquire().use {
-            rootViews.forEach { recorder?.unbind(it.get()) }
-            rootViews.clear()
-        }
         recorder?.close()
         recorder = null
         capturingTask?.cancel(false)
@@ -94,8 +136,17 @@ internal class WindowRecorder(
     }
 
     override fun close() {
+        onConfigurationChanged()
         stop()
         capturer.gracefullyShutdown(options)
+    }
+
+    override fun onConfigurationChanged() {
+        lastKnownWindowSize.set(0, 0)
+        rootViewsLock.acquire().use {
+            rootViews.forEach { recorder?.unbind(it.get()) }
+            rootViews.clear()
+        }
     }
 
     private class RecorderExecutorServiceThreadFactory : ThreadFactory {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/Windows.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/Windows.kt
@@ -118,6 +118,13 @@ internal fun interface OnRootViewsChangedListener {
     )
 }
 
+internal fun interface ConfigurationChangedListener {
+    /**
+     * Called whenever the device configuration changes
+     */
+    fun onConfigurationChanged()
+}
+
 /**
  * A utility that holds the list of root views that WindowManager updates.
  */

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -201,3 +201,7 @@ internal fun View?.removeOnDrawListenerSafe(listener: ViewTreeObserver.OnDrawLis
         // viewTreeObserver is already dead
     }
 }
+
+internal fun View.hasSize(): Boolean {
+    return width != 0 && height != 0
+}

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -3,6 +3,7 @@ package io.sentry.samples.android;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import io.sentry.Attachment;
 import io.sentry.ISpan;
@@ -273,6 +274,19 @@ public class MainActivity extends AppCompatActivity {
     binding.throwInCoroutine.setOnClickListener(
         view -> {
           CoroutinesUtil.INSTANCE.throwInCoroutine();
+        });
+
+    binding.showDialog.setOnClickListener(
+        view -> {
+          new AlertDialog.Builder(MainActivity.this)
+              .setTitle("Example Title")
+              .setMessage("Example Message")
+              .setPositiveButton(
+                  "Close",
+                  (dialog, which) -> {
+                    dialog.dismiss();
+                  })
+              .show();
         });
 
     setContentView(binding.getRoot());

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/compose/ComposeActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/compose/ComposeActivity.kt
@@ -8,9 +8,18 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -55,11 +64,14 @@ class ComposeActivity : ComponentActivity() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Landing(
     navigateGithub: () -> Unit,
     navigateGithubWithArgs: () -> Unit
 ) {
+    var showDialog by remember { mutableStateOf(false) }
+
     SentryTraced(tag = "buttons_page") {
         Column(
             verticalArrangement = Arrangement.Center,
@@ -91,6 +103,46 @@ fun Landing(
                 ) {
                     Text("Crash from Compose")
                 }
+            }
+            SentryTraced(tag = "button_dialog") {
+                Button(
+                    onClick = {
+                        showDialog = true
+                    },
+                    modifier = Modifier
+                        .testTag("button_show_dialog")
+                        .padding(top = 32.dp)
+                ) {
+                    Text("Show Dialog", modifier = Modifier.sentryReplayUnmask())
+                }
+            }
+            if (showDialog) {
+                BasicAlertDialog(
+                    onDismissRequest = {
+                        showDialog = false
+                    },
+                    content = {
+                        Surface(
+                            modifier = Modifier
+                                .wrapContentWidth()
+                                .wrapContentHeight(),
+                            shape = MaterialTheme.shapes.large,
+                            tonalElevation = AlertDialogDefaults.TonalElevation
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(20.dp),
+                                content = {
+                                    Text(
+                                        "Dialog Title",
+                                        style = MaterialTheme.typography.titleLarge
+                                    )
+                                    Spacer(Modifier.size(20.dp))
+                                    Text("Dialog Content")
+                                }
+                            )
+                        }
+                    }
+                )
             }
         }
     }

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -154,6 +154,12 @@
       android:layout_height="wrap_content"
       android:text="@string/throw_in_coroutine"/>
 
+    <Button
+      android:id="@+id/show_dialog"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/show_dialog"/>
+
   </LinearLayout>
 
 </ScrollView>

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
   <string name="open_metrics">Delightful Developer Metrics</string>
   <string name="test_timber_integration">Test Timber</string>
   <string name="throw_in_coroutine">Throw exception in coroutine</string>
+  <string name="show_dialog">Show Dialog</string>
   <string name="back_main">Back to Main Activity</string>
   <string name="tap_me">text</string>
   <string name="lipsum">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nibh lorem, venenatis sed nulla vel, venenatis sodales augue. Mauris varius elit eu ligula volutpat, sed tincidunt orci porttitor. Donec et dignissim lacus, sed luctus ipsum. Praesent ornare luctus tortor sit amet ultricies. Cras iaculis et diam et vulputate. Cras ut iaculis mauris, non pellentesque diam. Nunc in laoreet diam, vitae accumsan eros. Morbi non nunc ac eros molestie placerat vitae id dolor. Quisque ornare aliquam ipsum, a dapibus tortor. In eu sodales tellus.


### PR DESCRIPTION
## :scroll: Description
Instead of relying on the window metrics, we now determine the size based on the top level Window View, once determined the `RecordingConfig` is created and actual recording is started.

I couldn't re-use the `onConfigurationChanged` hook, as it removes all `rootViews`. But in case of Dialogs, the root views are stacked and as soon as the dialog is popped, no more root view would be available.

I tried to apply my changes with minimal impact to the existing structure, happy to restructure it in a better way too, I simply wasn't sure how hybrids consume the existing APIs.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-java/issues/3574


## :green_heart: How did you test it?
Manual testing, see e.g. https://sentry-sdks.sentry.io/replays/f278df82391b4b30a7b1cb8b99b15578/?project=5428559&query=&referrer=%2Freplays%2F&statsPeriod=10m&yAxis=count%28%29

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
