### PR TITLE
Wrap configured `ContextStorageProvider` if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Features
+
+- Wrap configured OpenTelemetry `ContextStorageProvider` if available ([#4359](https://github.com/getsentry/sentry-java/pull/4359))
+  - This is only relevant if you see `java.lang.IllegalStateException: Found multiple ContextStorageProvider. Set the io.opentelemetry.context.ContextStorageProvider property to the fully qualified class name of the provider to use. Falling back to default ContextStorage. Found providers: ...` 
+  - Set `-Dio.opentelemetry.context.contextStorageProvider=io.sentry.opentelemetry.SentryContextStorageProvider` on your `java` command
+  - Sentry will then wrap the other `ContextStorageProvider` that has been configured by loading it through SPI
+  - If no other `ContextStorageProvider` is available or there are problems loading it, we fall back to using `SentryOtelThreadLocalStorage`
+
 ### Fixes
 
 - Update profile chunk rate limit and client report ([#4353](https://github.com/getsentry/sentry-java/pull/4353))

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorageProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorageProvider.java
@@ -1,12 +1,10 @@
 package io.sentry.opentelemetry;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Iterator;
-import java.util.ServiceLoader;
-
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.ContextStorageProvider;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.jetbrains.annotations.NotNull;
 
 public final class SentryContextStorageProvider implements ContextStorageProvider {
   @Override
@@ -16,7 +14,8 @@ public final class SentryContextStorageProvider implements ContextStorageProvide
 
   private @NotNull ContextStorage findStorageToWrap() {
     try {
-      ServiceLoader<ContextStorageProvider> serviceLoader = ServiceLoader.load(ContextStorageProvider.class);
+      ServiceLoader<ContextStorageProvider> serviceLoader =
+          ServiceLoader.load(ContextStorageProvider.class);
       Iterator<ContextStorageProvider> iterator = serviceLoader.iterator();
       while (iterator.hasNext()) {
         ContextStorageProvider contextStorageProvider = iterator.next();

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorageProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/src/main/java/io/sentry/opentelemetry/SentryContextStorageProvider.java
@@ -1,11 +1,34 @@
 package io.sentry.opentelemetry;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.ContextStorageProvider;
 
 public final class SentryContextStorageProvider implements ContextStorageProvider {
   @Override
   public ContextStorage get() {
-    return new SentryContextStorage(new SentryOtelThreadLocalStorage());
+    return new SentryContextStorage(findStorageToWrap());
+  }
+
+  private @NotNull ContextStorage findStorageToWrap() {
+    try {
+      ServiceLoader<ContextStorageProvider> serviceLoader = ServiceLoader.load(ContextStorageProvider.class);
+      Iterator<ContextStorageProvider> iterator = serviceLoader.iterator();
+      while (iterator.hasNext()) {
+        ContextStorageProvider contextStorageProvider = iterator.next();
+        if (!(contextStorageProvider instanceof SentryContextStorageProvider)) {
+          return contextStorageProvider.get();
+        }
+      }
+    } catch (Throwable t) {
+      // ignore and use fallback
+    }
+
+    // using default / fallback storage
+    return new SentryOtelThreadLocalStorage();
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use SPI to search for other `ContextStorageProvider`s and wrap them instead of using `SentryOtelThreadLocalStorage`


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4339

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
