### PR TITLE
Remove mention of sentry-native submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,17 +100,6 @@ This repo uses the following ways to release SDK updates:
 * [Sample App. with Sentry Java SDK](https://github.com/getsentry/examples/tree/master/java).
 * [Sample for Development](https://github.com/getsentry/sentry-java/tree/main/sentry-samples).
 
-# Development
-
-This repository includes [`sentry-native`](https://github.com/getsentry/sentry-native/) as a git submodule.
-To build against `sentry-native` checked-out elsewhere in your file system, create a symlink `sentry-android-ndk/sentry-native-local` that points to your `sentry-native` directory.
-For example, if you had `sentry-native` checked-out in a sibling directory to this repo:
-
-`ln -s ../../sentry-native sentry-android-ndk/sentry-native-local`
-
-which will be picked up by `gradle` and used instead of the git submodule.
-This directory is also included in `.gitignore` not to be shown as pending changes.
-
 # Sentry Self Hosted Compatibility
 
 Since version 3.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to self-hosted Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.


### PR DESCRIPTION
_#skip-changelog_

As far as I can tell the Android NDK support was moved from sentry-java to sentry-native in #3189 and since then sentry-java has not had submodules.

## :green_heart: How did you test it?
Pure docs change so no tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes. 
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

