### PR TITLE
Send logs in batches

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SessionTrackingIntegrationTest.kt
@@ -17,6 +17,7 @@ import io.sentry.Sentry
 import io.sentry.SentryEnvelope
 import io.sentry.SentryEvent
 import io.sentry.SentryLogEvent
+import io.sentry.SentryLogEvents
 import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent
 import io.sentry.Session
@@ -187,6 +188,10 @@ class SessionTrackingIntegrationTest {
         }
 
         override fun captureLog(event: SentryLogEvent, scope: IScope?, hint: Hint?) {
+            TODO("Not yet implemented")
+        }
+
+        override fun captureBatchedLogEvents(logEvents: SentryLogEvents) {
             TODO("Not yet implemented")
         }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -987,6 +987,7 @@ public abstract interface class io/sentry/IScopesStorage {
 }
 
 public abstract interface class io/sentry/ISentryClient {
+	public abstract fun captureBatchedLogEvents (Lio/sentry/SentryLogEvents;)V
 	public abstract fun captureCheckIn (Lio/sentry/CheckIn;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;)Lio/sentry/protocol/SentryId;
 	public abstract fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
@@ -2718,6 +2719,7 @@ public final class io/sentry/SentryBaseEvent$Serializer {
 
 public final class io/sentry/SentryClient : io/sentry/ISentryClient {
 	public fun <init> (Lio/sentry/SentryOptions;)V
+	public fun captureBatchedLogEvents (Lio/sentry/SentryLogEvents;)V
 	public fun captureCheckIn (Lio/sentry/CheckIn;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun captureEvent (Lio/sentry/SentryEvent;Lio/sentry/IScope;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
@@ -3071,6 +3073,7 @@ public final class io/sentry/SentryLogEventAttributeValue$JsonKeys {
 
 public final class io/sentry/SentryLogEvents : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
 	public fun <init> (Ljava/util/List;)V
+	public fun getItems ()Ljava/util/List;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setUnknown (Ljava/util/Map;)V
@@ -4666,6 +4669,11 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public abstract interface class io/sentry/logger/ILoggerBatchProcessor {
+	public abstract fun add (Lio/sentry/SentryLogEvent;)V
+	public abstract fun close (Z)V
+}
+
 public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun <init> (Lio/sentry/Scopes;)V
 	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4678,6 +4686,14 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
 
+public final class io/sentry/logger/LoggerBatchProcessor : io/sentry/logger/ILoggerBatchProcessor {
+	public static final field FLUSH_AFTER_MS I
+	public static final field MAX_BATCH_SIZE I
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/ISentryClient;)V
+	public fun add (Lio/sentry/SentryLogEvent;)V
+	public fun close (Z)V
+}
+
 public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi {
 	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun error (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4688,6 +4704,12 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class io/sentry/logger/NoOpLoggerBatchProcessor : io/sentry/logger/ILoggerBatchProcessor {
+	public fun add (Lio/sentry/SentryLogEvent;)V
+	public fun close (Z)V
+	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerBatchProcessor;
 }
 
 public final class io/sentry/opentelemetry/OpenTelemetryUtil {

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -295,6 +295,9 @@ public interface ISentryClient {
   @ApiStatus.Experimental
   void captureLog(@NotNull SentryLogEvent logEvent, @Nullable IScope scope, @Nullable Hint hint);
 
+  @ApiStatus.Experimental
+  void captureBatchedLogEvents(@NotNull SentryLogEvents logEvents);
+
   @ApiStatus.Internal
   @Nullable
   RateLimiter getRateLimiter();

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -84,6 +84,12 @@ final class NoOpSentryClient implements ISentryClient {
     // do nothing
   }
 
+  @ApiStatus.Experimental
+  @Override
+  public void captureBatchedLogEvents(@NotNull SentryLogEvents logEvents) {
+    // do nothing
+  }
+
   @Override
   public @Nullable RateLimiter getRateLimiter() {
     return null;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -6,6 +6,9 @@ import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.DiskFlushNotification;
 import io.sentry.hints.TransactionEnd;
+import io.sentry.logger.ILoggerBatchProcessor;
+import io.sentry.logger.LoggerBatchProcessor;
+import io.sentry.logger.NoOpLoggerBatchProcessor;
 import io.sentry.protocol.Contexts;
 import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.SentryId;
@@ -16,7 +19,6 @@ import io.sentry.util.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,6 +38,7 @@ public final class SentryClient implements ISentryClient {
   private final @NotNull SentryOptions options;
   private final @NotNull ITransport transport;
   private final @NotNull SortBreadcrumbsByDate sortBreadcrumbsByDate = new SortBreadcrumbsByDate();
+  private final @NotNull ILoggerBatchProcessor loggerBatchProcessor;
 
   @Override
   public boolean isEnabled() {
@@ -55,6 +58,11 @@ public final class SentryClient implements ISentryClient {
 
     final RequestDetailsResolver requestDetailsResolver = new RequestDetailsResolver(options);
     transport = transportFactory.create(options, requestDetailsResolver.resolve());
+    if (options.getExperimental().getLogs().isEnabled()) {
+      loggerBatchProcessor = new LoggerBatchProcessor(options, this);
+    } else {
+      loggerBatchProcessor = NoOpLoggerBatchProcessor.getInstance();
+    }
   }
 
   private boolean shouldApplyScopeData(
@@ -625,8 +633,7 @@ public final class SentryClient implements ISentryClient {
     return new SentryEnvelope(envelopeHeader, envelopeItems);
   }
 
-  private @NotNull SentryEnvelope buildEnvelope(
-      final @NotNull SentryLogEvents logEvents, final @Nullable TraceContext traceContext) {
+  private @NotNull SentryEnvelope buildEnvelope(final @NotNull SentryLogEvents logEvents) {
     final List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 
     final SentryEnvelopeItem logItem =
@@ -634,7 +641,7 @@ public final class SentryClient implements ISentryClient {
     envelopeItems.add(logItem);
 
     final SentryEnvelopeHeader envelopeHeader =
-        new SentryEnvelopeHeader(null, options.getSdkVersion(), traceContext);
+        new SentryEnvelopeHeader(null, options.getSdkVersion(), null);
 
     return new SentryEnvelope(envelopeHeader, envelopeItems);
   }
@@ -1018,17 +1025,17 @@ public final class SentryClient implements ISentryClient {
       hint = new Hint();
     }
 
-    @Nullable TraceContext traceContext = null;
-    if (scope != null) {
-      final @Nullable ITransaction transaction = scope.getTransaction();
-      if (transaction != null) {
-        traceContext = transaction.traceContext();
-      } else {
-        final @NotNull PropagationContext propagationContext =
-            TracingUtils.maybeUpdateBaggage(scope, options);
-        traceContext = propagationContext.traceContext();
-      }
-    }
+    //    @Nullable TraceContext traceContext = null;
+    //    if (scope != null) {
+    //      final @Nullable ITransaction transaction = scope.getTransaction();
+    //      if (transaction != null) {
+    //        traceContext = transaction.traceContext();
+    //      } else {
+    //        final @NotNull PropagationContext propagationContext =
+    //            TracingUtils.maybeUpdateBaggage(scope, options);
+    //        traceContext = propagationContext.traceContext();
+    //      }
+    //    }
 
     if (logEvent != null) {
       logEvent = executeBeforeSendLog(logEvent, hint);
@@ -1040,15 +1047,18 @@ public final class SentryClient implements ISentryClient {
             .recordLostEvent(DiscardReason.BEFORE_SEND, DataCategory.LogItem);
         return;
       }
+
+      loggerBatchProcessor.add(logEvent);
     }
 
-    try {
-      final @NotNull SentryEnvelope envelope =
-          buildEnvelope(new SentryLogEvents(Arrays.asList(logEvent)), traceContext);
+    hint.clear();
+  }
 
-      hint.clear();
-      // TODO buffer
-      sendEnvelope(envelope, hint);
+  @Override
+  public void captureBatchedLogEvents(final @NotNull SentryLogEvents logEvents) {
+    try {
+      final @NotNull SentryEnvelope envelope = buildEnvelope(logEvents);
+      sendEnvelope(envelope, null);
     } catch (IOException e) {
       options.getLogger().log(SentryLevel.WARNING, e, "Capturing log failed.");
     }
@@ -1307,6 +1317,7 @@ public final class SentryClient implements ISentryClient {
     options.getLogger().log(SentryLevel.INFO, "Closing SentryClient.");
     try {
       flush(isRestarting ? 0 : options.getShutdownTimeoutMillis());
+      loggerBatchProcessor.close(isRestarting);
       transport.close(isRestarting);
     } catch (IOException e) {
       options

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -503,7 +503,7 @@ public final class SentryEnvelopeItem {
             null,
             null,
             null,
-            1);
+            logEvents.getItems().size());
 
     // avoid method refs on Android due to some issues with older AGP setups
     // noinspection Convert2MethodRef

--- a/sentry/src/main/java/io/sentry/SentryLogEvents.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEvents.java
@@ -17,6 +17,10 @@ public final class SentryLogEvents implements JsonUnknown, JsonSerializable {
     this.items = items;
   }
 
+  public @NotNull List<SentryLogEvent> getItems() {
+    return items;
+  }
+
   // region json
   public static final class JsonKeys {
     public static final String ITEMS = "items";

--- a/sentry/src/main/java/io/sentry/logger/ILoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerBatchProcessor.java
@@ -1,0 +1,10 @@
+package io.sentry.logger;
+
+import io.sentry.SentryLogEvent;
+import org.jetbrains.annotations.NotNull;
+
+public interface ILoggerBatchProcessor {
+  void add(@NotNull SentryLogEvent event);
+
+  void close(boolean isRestarting);
+}

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -32,8 +32,8 @@ public final class LoggerApi implements ILoggerApi {
 
   @Override
   public void trace(final @Nullable String message, final @Nullable Object... args) {
-    // TODO SentryLevel.TRACE does not exists yet
-    //    log(SentryLevel.TRACE, message, args);
+    // TODO SentryLevel.TRACE does not exists yet so we just report it as DEBUG for now
+    log(SentryLevel.DEBUG, message, args);
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -1,0 +1,101 @@
+package io.sentry.logger;
+
+import io.sentry.ISentryClient;
+import io.sentry.ISentryLifecycleToken;
+import io.sentry.SentryLogEvent;
+import io.sentry.SentryLogEvents;
+import io.sentry.SentryOptions;
+import io.sentry.util.AutoClosableReentrantLock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class LoggerBatchProcessor implements ILoggerBatchProcessor {
+
+  public static final int FLUSH_AFTER_MS = 5000;
+  public static final int MAX_BATCH_SIZE = 100;
+
+  private final @NotNull SentryOptions options;
+  private final @NotNull ISentryClient client;
+  private final @NotNull Queue<SentryLogEvent> queue;
+  private volatile @Nullable Future<?> scheduledFlush;
+  private static final @NotNull AutoClosableReentrantLock scheduleLock =
+      new AutoClosableReentrantLock();
+
+  public LoggerBatchProcessor(
+      final @NotNull SentryOptions options, final @NotNull ISentryClient client) {
+    this.options = options;
+    this.client = client;
+    this.queue = new ConcurrentLinkedQueue<>();
+  }
+
+  @Override
+  public void add(final @NotNull SentryLogEvent logEvent) {
+    queue.offer(logEvent);
+    maybeSchedule(false, false);
+  }
+
+  @Override
+  public void close(final boolean isRestarting) {
+    if (isRestarting) {
+      maybeSchedule(true, true);
+    } else {
+      while (!queue.isEmpty()) {
+        flushBatch();
+      }
+    }
+  }
+
+  private void maybeSchedule(boolean forceSchedule, boolean immediately) {
+    try (final @NotNull ISentryLifecycleToken ignored = scheduleLock.acquire()) {
+      final @Nullable Future<?> latestScheduledFlush = scheduledFlush;
+      if (forceSchedule
+          || latestScheduledFlush == null
+          || latestScheduledFlush.isDone()
+          || latestScheduledFlush.isCancelled()) {
+        final int flushAfterMs = immediately ? 0 : FLUSH_AFTER_MS;
+        scheduledFlush = options.getExecutorService().schedule(new BatchRunnable(), flushAfterMs);
+      }
+    }
+  }
+
+  private void flush() {
+    flushInternal();
+    try (final @NotNull ISentryLifecycleToken ignored = scheduleLock.acquire()) {
+      if (!queue.isEmpty()) {
+        maybeSchedule(true, false);
+      }
+    }
+  }
+
+  private void flushInternal() {
+    flushBatch();
+    if (queue.size() >= MAX_BATCH_SIZE) {
+      flushInternal();
+    }
+  }
+
+  private void flushBatch() {
+    final @NotNull List<SentryLogEvent> logEvents = new ArrayList<>(MAX_BATCH_SIZE);
+    do {
+      final @Nullable SentryLogEvent logEvent = queue.poll();
+      if (logEvent != null) {
+        logEvents.add(logEvent);
+      }
+    } while (!queue.isEmpty() && logEvents.size() < MAX_BATCH_SIZE);
+
+    client.captureBatchedLogEvents(new SentryLogEvents(logEvents));
+  }
+
+  private class BatchRunnable implements Runnable {
+
+    @Override
+    public void run() {
+      flush();
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerBatchProcessor.java
@@ -1,0 +1,27 @@
+package io.sentry.logger;
+
+import io.sentry.SentryLogEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Experimental
+public final class NoOpLoggerBatchProcessor implements ILoggerBatchProcessor {
+
+  private static final NoOpLoggerBatchProcessor instance = new NoOpLoggerBatchProcessor();
+
+  private NoOpLoggerBatchProcessor() {}
+
+  public static NoOpLoggerBatchProcessor getInstance() {
+    return instance;
+  }
+
+  @Override
+  public void add(@NotNull SentryLogEvent event) {
+    // do nothing
+  }
+
+  @Override
+  public void close(final boolean isRestarting) {
+    // do nothing
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Instead of sending each log event on its own immediately, we now batch them and send after 5s.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
