### PR TITLE
[Logs 8] Use a separate enum for `SentryLogLevel`

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3023,17 +3023,17 @@ public final class io/sentry/SentryLockReason$JsonKeys {
 }
 
 public final class io/sentry/SentryLogEvent : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
-	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/SentryLevel;)V
-	public fun <init> (Lio/sentry/protocol/SentryId;Ljava/lang/Double;Ljava/lang/String;Lio/sentry/SentryLevel;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/SentryLogLevel;)V
+	public fun <init> (Lio/sentry/protocol/SentryId;Ljava/lang/Double;Ljava/lang/String;Lio/sentry/SentryLogLevel;)V
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getBody ()Ljava/lang/String;
-	public fun getLevel ()Lio/sentry/SentryLevel;
+	public fun getLevel ()Lio/sentry/SentryLogLevel;
 	public fun getTimestamp ()Ljava/lang/Double;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setAttributes (Ljava/util/Map;)V
 	public fun setBody (Ljava/lang/String;)V
-	public fun setLevel (Lio/sentry/SentryLevel;)V
+	public fun setLevel (Lio/sentry/SentryLogLevel;)V
 	public fun setTimestamp (Ljava/lang/Double;)V
 	public fun setUnknown (Ljava/util/Map;)V
 }
@@ -3089,6 +3089,25 @@ public final class io/sentry/SentryLogEvents$Deserializer : io/sentry/JsonDeseri
 public final class io/sentry/SentryLogEvents$JsonKeys {
 	public static final field ITEMS Ljava/lang/String;
 	public fun <init> ()V
+}
+
+public final class io/sentry/SentryLogLevel : java/lang/Enum, io/sentry/JsonSerializable {
+	public static final field DEBUG Lio/sentry/SentryLogLevel;
+	public static final field ERROR Lio/sentry/SentryLogLevel;
+	public static final field FATAL Lio/sentry/SentryLogLevel;
+	public static final field INFO Lio/sentry/SentryLogLevel;
+	public static final field TRACE Lio/sentry/SentryLogLevel;
+	public static final field WARN Lio/sentry/SentryLogLevel;
+	public fun getSeverityNumber ()I
+	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryLogLevel;
+	public static fun values ()[Lio/sentry/SentryLogLevel;
+}
+
+public final class io/sentry/SentryLogLevel$Deserializer : io/sentry/JsonDeserializer {
+	public fun <init> ()V
+	public fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Lio/sentry/SentryLogLevel;
+	public synthetic fun deserialize (Lio/sentry/ObjectReader;Lio/sentry/ILogger;)Ljava/lang/Object;
 }
 
 public final class io/sentry/SentryLongDate : io/sentry/SentryDate {
@@ -4664,8 +4683,8 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun error (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun info (Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Lio/sentry/SentryLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
-	public abstract fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4681,8 +4700,8 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun error (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4701,8 +4720,8 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerApi;
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;Lio/sentry/Hint;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }

--- a/sentry/src/main/java/io/sentry/SentryLogEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEvent.java
@@ -15,7 +15,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
   private @NotNull SentryId traceId;
   private @NotNull Double timestamp;
   private @NotNull String body;
-  private @NotNull SentryLevel level;
+  private @NotNull SentryLogLevel level;
 
   private @Nullable Map<String, SentryLogEventAttributeValue> attributes;
   private @Nullable Map<String, Object> unknown;
@@ -24,7 +24,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
       final @NotNull SentryId traceId,
       final @NotNull SentryDate timestamp,
       final @NotNull String body,
-      final @NotNull SentryLevel level) {
+      final @NotNull SentryLogLevel level) {
     this(traceId, DateUtils.nanosToSeconds(timestamp.nanoTimestamp()), body, level);
   }
 
@@ -32,7 +32,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
       final @NotNull SentryId traceId,
       final @NotNull Double timestamp,
       final @NotNull String body,
-      final @NotNull SentryLevel level) {
+      final @NotNull SentryLogLevel level) {
     this.traceId = traceId;
     this.timestamp = timestamp;
     this.body = body;
@@ -56,11 +56,11 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
     this.body = body;
   }
 
-  public @NotNull SentryLevel getLevel() {
+  public @NotNull SentryLogLevel getLevel() {
     return level;
   }
 
-  public void setLevel(final @NotNull SentryLevel level) {
+  public void setLevel(final @NotNull SentryLogLevel level) {
     this.level = level;
   }
 
@@ -123,7 +123,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
       @Nullable SentryId traceId = null;
       @Nullable Double timestamp = null;
       @Nullable String body = null;
-      @Nullable SentryLevel level = null;
+      @Nullable SentryLogLevel level = null;
       @Nullable Map<String, SentryLogEventAttributeValue> attributes = null;
 
       reader.beginObject();
@@ -140,7 +140,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
             body = reader.nextStringOrNull();
             break;
           case JsonKeys.LEVEL:
-            level = reader.nextOrNull(logger, new SentryLevel.Deserializer());
+            level = reader.nextOrNull(logger, new SentryLogLevel.Deserializer());
             break;
           case JsonKeys.ATTRIBUTES:
             attributes =

--- a/sentry/src/main/java/io/sentry/SentryLogLevel.java
+++ b/sentry/src/main/java/io/sentry/SentryLogLevel.java
@@ -1,0 +1,40 @@
+package io.sentry;
+
+import java.io.IOException;
+import java.util.Locale;
+import org.jetbrains.annotations.NotNull;
+
+/** the SentryLevel for Logs */
+public enum SentryLogLevel implements JsonSerializable {
+  TRACE(1),
+  DEBUG(5),
+  INFO(9),
+  WARN(13),
+  ERROR(17),
+  FATAL(21);
+
+  private final int severityNumber;
+
+  private SentryLogLevel(int severityNumber) {
+    this.severityNumber = severityNumber;
+  }
+
+  public int getSeverityNumber() {
+    return severityNumber;
+  }
+
+  @Override
+  public void serialize(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
+      throws IOException {
+    writer.value(name().toLowerCase(Locale.ROOT));
+  }
+
+  public static final class Deserializer implements JsonDeserializer<SentryLogLevel> {
+
+    @Override
+    public @NotNull SentryLogLevel deserialize(
+        @NotNull ObjectReader reader, @NotNull ILogger logger) throws Exception {
+      return SentryLogLevel.valueOf(reader.nextString().toUpperCase(Locale.ROOT));
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -2,7 +2,7 @@ package io.sentry.logger;
 
 import io.sentry.Hint;
 import io.sentry.SentryDate;
-import io.sentry.SentryLevel;
+import io.sentry.SentryLogLevel;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,10 +22,10 @@ public interface ILoggerApi {
 
   void fatal(final @Nullable String message, @Nullable Object... args);
 
-  void log(@NotNull SentryLevel level, @Nullable String message, @Nullable Object... args);
+  void log(@NotNull SentryLogLevel level, @Nullable String message, @Nullable Object... args);
 
   void log(
-      @NotNull SentryLevel level,
+      @NotNull SentryLogLevel level,
       @Nullable SentryDate timestamp,
       @Nullable String message,
       final @Nullable Hint hint,

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -9,6 +9,7 @@ import io.sentry.SentryDate;
 import io.sentry.SentryLevel;
 import io.sentry.SentryLogEvent;
 import io.sentry.SentryLogEventAttributeValue;
+import io.sentry.SentryLogLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SpanId;
 import io.sentry.clientreport.DiscardReason;
@@ -33,37 +34,37 @@ public final class LoggerApi implements ILoggerApi {
   @Override
   public void trace(final @Nullable String message, final @Nullable Object... args) {
     // TODO SentryLevel.TRACE does not exists yet so we just report it as DEBUG for now
-    log(SentryLevel.DEBUG, message, args);
+    log(SentryLogLevel.DEBUG, message, args);
   }
 
   @Override
   public void debug(final @Nullable String message, final @Nullable Object... args) {
-    log(SentryLevel.DEBUG, message, args);
+    log(SentryLogLevel.DEBUG, message, args);
   }
 
   @Override
   public void info(final @Nullable String message, final @Nullable Object... args) {
-    log(SentryLevel.INFO, message, args);
+    log(SentryLogLevel.INFO, message, args);
   }
 
   @Override
   public void warn(final @Nullable String message, final @Nullable Object... args) {
-    log(SentryLevel.WARNING, message, args);
+    log(SentryLogLevel.WARN, message, args);
   }
 
   @Override
   public void error(final @Nullable String message, final @Nullable Object... args) {
-    log(SentryLevel.ERROR, message, args);
+    log(SentryLogLevel.ERROR, message, args);
   }
 
   @Override
   public void fatal(final @Nullable String message, final @Nullable Object... args) {
-    log(SentryLevel.FATAL, message, args);
+    log(SentryLogLevel.FATAL, message, args);
   }
 
   @Override
   public void log(
-      final @NotNull SentryLevel level,
+      final @NotNull SentryLogLevel level,
       final @Nullable String message,
       final @Nullable Object... args) {
     log(level, null, message, null, args);
@@ -71,7 +72,7 @@ public final class LoggerApi implements ILoggerApi {
 
   @Override
   public void log(
-      final @NotNull SentryLevel level,
+      final @NotNull SentryLogLevel level,
       final @Nullable SentryDate timestamp,
       final @Nullable String message,
       final @Nullable Hint hint,
@@ -81,7 +82,7 @@ public final class LoggerApi implements ILoggerApi {
 
   @SuppressWarnings("AnnotateFormatMethod")
   private void captureLog(
-      final @NotNull SentryLevel level,
+      final @NotNull SentryLogLevel level,
       final @Nullable SentryDate timestamp,
       final @Nullable Hint hint,
       final @Nullable String message,

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -2,7 +2,7 @@ package io.sentry.logger;
 
 import io.sentry.Hint;
 import io.sentry.SentryDate;
-import io.sentry.SentryLevel;
+import io.sentry.SentryLogLevel;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,13 +49,14 @@ public final class NoOpLoggerApi implements ILoggerApi {
   }
 
   @Override
-  public void log(@NotNull SentryLevel level, @Nullable String message, @Nullable Object... args) {
+  public void log(
+      @NotNull SentryLogLevel level, @Nullable String message, @Nullable Object... args) {
     // do nothing
   }
 
   @Override
   public void log(
-      @NotNull SentryLevel level,
+      @NotNull SentryLogLevel level,
       @Nullable SentryDate timestamp,
       @Nullable String message,
       final @Nullable Hint hint,

--- a/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
@@ -6,10 +6,10 @@ import io.sentry.ILogger
 import io.sentry.JsonObjectReader
 import io.sentry.JsonObjectWriter
 import io.sentry.JsonSerializable
-import io.sentry.SentryLevel
 import io.sentry.SentryLogEvent
 import io.sentry.SentryLogEventAttributeValue
 import io.sentry.SentryLogEvents
+import io.sentry.SentryLogLevel
 import org.junit.Test
 import org.mockito.kotlin.mock
 import java.io.StringReader
@@ -26,7 +26,7 @@ class SentryLogsSerializationTest {
                     SentryId("5c1f73d39486827b9e60ceb1fc23277a"),
                     DateUtils.dateToSeconds(DateUtils.getDateTime("2004-04-10T18:24:03.000Z")),
                     "42e6bd2a-c45e-414d-8066-ed5196fbc686",
-                    SentryLevel.INFO
+                    SentryLogLevel.INFO
                 ).also {
                     it.attributes = mutableMapOf(
                         "sentry.sdk.name" to SentryLogEventAttributeValue("string", "sentry.java.spring-boot.jakarta"),

--- a/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
+++ b/sentry/src/test/java/io/sentry/transport/RateLimiterTest.kt
@@ -16,9 +16,9 @@ import io.sentry.SentryEnvelope
 import io.sentry.SentryEnvelopeHeader
 import io.sentry.SentryEnvelopeItem
 import io.sentry.SentryEvent
-import io.sentry.SentryLevel
 import io.sentry.SentryLogEvent
 import io.sentry.SentryLogEvents
+import io.sentry.SentryLogLevel
 import io.sentry.SentryLongDate
 import io.sentry.SentryOptions
 import io.sentry.SentryOptionsManipulator
@@ -350,7 +350,7 @@ class RateLimiterTest {
             fixture.serializer,
             SentryLogEvents(
                 listOf(
-                    SentryLogEvent(SentryId(), SentryLongDate(0), "hello", SentryLevel.INFO)
+                    SentryLogEvent(SentryId(), SentryLongDate(0), "hello", SentryLogLevel.INFO)
                 )
             )
         )


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use a new enum `SentryLogLevel` for Logs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`SentryLevel` which is used by error events and breadcrumbs does not support level `TRACE`, therefore we need to use a separate enum for the log level of the Logs feature.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
