### PR TITLE
[Logs 10] Add `severityNumber` to `SentryLogEvent`

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3024,12 +3024,14 @@ public final class io/sentry/SentryLogEvent : io/sentry/JsonSerializable, io/sen
 	public fun getAttributes ()Ljava/util/Map;
 	public fun getBody ()Ljava/lang/String;
 	public fun getLevel ()Lio/sentry/SentryLogLevel;
+	public fun getSeverityNumber ()Ljava/lang/Integer;
 	public fun getTimestamp ()Ljava/lang/Double;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setAttributes (Ljava/util/Map;)V
 	public fun setBody (Ljava/lang/String;)V
 	public fun setLevel (Lio/sentry/SentryLogLevel;)V
+	public fun setSeverityNumber (Ljava/lang/Integer;)V
 	public fun setTimestamp (Ljava/lang/Double;)V
 	public fun setUnknown (Ljava/util/Map;)V
 }
@@ -3044,6 +3046,7 @@ public final class io/sentry/SentryLogEvent$JsonKeys {
 	public static final field ATTRIBUTES Ljava/lang/String;
 	public static final field BODY Ljava/lang/String;
 	public static final field LEVEL Ljava/lang/String;
+	public static final field SEVERITY_NUMBER Ljava/lang/String;
 	public static final field TIMESTAMP Ljava/lang/String;
 	public static final field TRACE_ID Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/SentryLogEvent.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEvent.java
@@ -16,6 +16,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
   private @NotNull Double timestamp;
   private @NotNull String body;
   private @NotNull SentryLogLevel level;
+  private @Nullable Integer severityNumber;
 
   private @Nullable Map<String, SentryLogEventAttributeValue> attributes;
   private @Nullable Map<String, Object> unknown;
@@ -72,11 +73,20 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
     this.attributes = attributes;
   }
 
+  public @Nullable Integer getSeverityNumber() {
+    return severityNumber;
+  }
+
+  public void setSeverityNumber(@Nullable Integer severityNumber) {
+    this.severityNumber = severityNumber;
+  }
+
   // region json
   public static final class JsonKeys {
     public static final String TIMESTAMP = "timestamp";
     public static final String TRACE_ID = "trace_id";
     public static final String LEVEL = "level";
+    public static final String SEVERITY_NUMBER = "severity_number";
     public static final String BODY = "body";
     public static final String ATTRIBUTES = "attributes";
   }
@@ -90,6 +100,9 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
     writer.name(JsonKeys.TRACE_ID).value(logger, traceId);
     writer.name(JsonKeys.BODY).value(body);
     writer.name(JsonKeys.LEVEL).value(logger, level);
+    if (severityNumber != null) {
+      writer.name(JsonKeys.SEVERITY_NUMBER).value(logger, severityNumber);
+    }
     if (attributes != null) {
       writer.name(JsonKeys.ATTRIBUTES).value(logger, attributes);
     }
@@ -124,6 +137,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
       @Nullable Double timestamp = null;
       @Nullable String body = null;
       @Nullable SentryLogLevel level = null;
+      @Nullable Integer severityNumber = null;
       @Nullable Map<String, SentryLogEventAttributeValue> attributes = null;
 
       reader.beginObject();
@@ -141,6 +155,9 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.LEVEL:
             level = reader.nextOrNull(logger, new SentryLogLevel.Deserializer());
+            break;
+          case JsonKeys.SEVERITY_NUMBER:
+            severityNumber = reader.nextIntegerOrNull();
             break;
           case JsonKeys.ATTRIBUTES:
             attributes =
@@ -187,6 +204,7 @@ public final class SentryLogEvent implements JsonUnknown, JsonSerializable {
       final SentryLogEvent logEvent = new SentryLogEvent(traceId, timestamp, body, level);
 
       logEvent.setAttributes(attributes);
+      logEvent.setSeverityNumber(severityNumber);
       logEvent.setUnknown(unknown);
 
       return logEvent;

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -116,6 +116,7 @@ public final class LoggerApi implements ILoggerApi {
       final SentryLogEvent logEvent =
           new SentryLogEvent(traceId, timestampToUse, messageToUse, level);
       logEvent.setAttributes(createAttributes(message, spanId, args));
+      logEvent.setSeverityNumber(level.getSeverityNumber());
 
       scopes.getClient().captureLog(logEvent, scopes.getCombinedScopeView(), hint);
     } catch (Throwable e) {

--- a/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
@@ -34,6 +34,7 @@ class SentryLogsSerializationTest {
                         "sentry.sdk.version" to SentryLogEventAttributeValue("string", "8.11.1"),
                         "sentry.trace.parent_span_id" to SentryLogEventAttributeValue("string", "f28b86350e534671")
                     )
+                    it.severityNumber = 10
                 }
             )
         )

--- a/sentry/src/test/resources/json/sentry_logs.json
+++ b/sentry/src/test/resources/json/sentry_logs.json
@@ -6,6 +6,7 @@
       "trace_id": "5c1f73d39486827b9e60ceb1fc23277a",
       "body": "42e6bd2a-c45e-414d-8066-ed5196fbc686",
       "level": "info",
+      "severity_number": 10,
       "attributes":
       {
         "sentry.sdk.name":


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Add `severityNumber` to `SentryLogEvent`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
