### PR TITLE
Start adopting version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id(Config.QualityPlugins.jacocoAndroid) version Config.QualityPlugins.jacocoAndroidVersion apply false
     id(Config.QualityPlugins.kover) version Config.QualityPlugins.koverVersion apply false
     id(Config.BuildPlugins.gradleMavenPublishPlugin) version Config.BuildPlugins.gradleMavenPublishPluginVersion apply false
+    alias(libs.plugins.kotlin.android) apply false
 }
 
 buildscript {
@@ -26,7 +27,6 @@ buildscript {
     }
     dependencies {
         classpath(Config.BuildPlugins.androidGradle)
-        classpath(kotlin(Config.BuildPlugins.kotlinGradlePlugin, version = Config.kotlinVersion))
         // dokka is required by gradle-maven-publish-plugin.
         classpath(Config.BuildPlugins.dokkaPlugin)
         classpath(Config.QualityPlugins.errorpronePlugin)
@@ -205,7 +205,6 @@ subprojects {
         afterEvaluate {
             apply<MavenPublishPlugin>()
 
-            @Suppress("UnstableApiUsage")
             configure<MavenPublishBaseExtension> {
                 assignAarTypes()
             }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -3,7 +3,6 @@ import java.math.BigDecimal
 
 object Config {
     val AGP = System.getenv("VERSION_AGP") ?: "8.6.0"
-    val kotlinVersion = "1.9.24"
     val kotlinStdLib = "stdlib-jdk8"
 
     val springBootVersion = "2.7.18"
@@ -17,7 +16,6 @@ object Config {
 
     object BuildPlugins {
         val androidGradle = "com.android.tools.build:gradle:$AGP"
-        val kotlinGradlePlugin = "gradle-plugin"
         val buildConfig = "com.github.gmazzo.buildconfig"
         val buildConfigVersion = "3.0.3"
         val springBoot = "org.springframework.boot"
@@ -193,7 +191,6 @@ object Config {
         private val espressoVersion = "3.5.0"
 
         val androidJUnitRunner = "androidx.test.runner.AndroidJUnitRunner"
-        val kotlinTestJunit = "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
         val androidxCore = "androidx.test:core:1.6.1"
         val androidxRunner = "androidx.test:runner:1.6.2"
         val androidxTestCoreKtx = "androidx.test:core-ktx:1.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+kotlin = "1.9.24"
+
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+
+[libraries]
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     // tests
     testImplementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
     testImplementation(Config.TestLibs.robolectric)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.androidxCore)
     testImplementation(Config.TestLibs.androidxRunner)
     testImplementation(Config.TestLibs.androidxJunit)

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
 
     // tests
     testImplementation(Config.Libs.fragment)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
 }

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
     errorprone(Config.CompileOnly.errorProneNullAway)
 
     androidTestImplementation(projects.sentryTestSupport)
-    androidTestImplementation(Config.TestLibs.kotlinTestJunit)
+    androidTestImplementation(libs.kotlin.test.junit)
     androidTestImplementation(Config.TestLibs.espressoCore)
     androidTestImplementation(Config.TestLibs.androidxTestCoreKtx)
     androidTestImplementation(Config.TestLibs.androidxRunner)

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -116,7 +116,7 @@ dependencies {
     errorprone(Config.CompileOnly.errorProneNullAway)
 
     androidTestImplementation(projects.sentryTestSupport)
-    androidTestImplementation(Config.TestLibs.kotlinTestJunit)
+    androidTestImplementation(libs.kotlin.test.junit)
     androidTestImplementation(Config.TestLibs.espressoCore)
     androidTestImplementation(Config.TestLibs.androidxRunner)
     androidTestImplementation(Config.TestLibs.androidxTestRules)

--- a/sentry-android-navigation/build.gradle.kts
+++ b/sentry-android-navigation/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     // tests
     testImplementation(Config.Libs.navigationRuntime)
 
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
 

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -88,7 +88,7 @@ dependencies {
     compileOnly(Config.CompileOnly.jetbrainsAnnotations)
 
     testImplementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(projects.sentryTestSupport)
 }

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(projects.sentryAndroidCore)
     testImplementation(Config.TestLibs.robolectric)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.androidxRunner)
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies {
 
     // tests
     testImplementation(Config.Libs.androidxSqlite)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
 
     // tests
     testImplementation(Config.Libs.timber)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.androidxJunit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)

--- a/sentry-apache-http-client-5/build.gradle.kts
+++ b/sentry-apache-http-client-5/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(Config.Libs.apacheHttpClient)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
 }
 

--- a/sentry-apollo-3/build.gradle.kts
+++ b/sentry-apollo-3/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(Config.Libs.coroutinesCore)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-apollo-4/build.gradle.kts
+++ b/sentry-apollo-4/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(Config.Libs.coroutinesCore)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-apollo/build.gradle.kts
+++ b/sentry-apollo/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(Config.Libs.coroutinesCore)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 kotlin {
     explicitApi()
 
-    android {
+    androidTarget {
         publishLibraryVariants("release")
         compilations.all {
             kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
@@ -55,7 +55,7 @@ kotlin {
         }
         val androidUnitTest by getting {
             dependencies {
-                implementation(Config.TestLibs.kotlinTestJunit)
+                implementation(libs.kotlin.test.junit)
                 implementation(Config.TestLibs.mockitoKotlin)
                 implementation(Config.TestLibs.mockitoInline)
                 implementation(Config.Libs.composeNavigation)

--- a/sentry-graphql-22/build.gradle.kts
+++ b/sentry-graphql-22/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     testImplementation(projects.sentry)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-graphql-core/build.gradle.kts
+++ b/sentry-graphql-core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(projects.sentry)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-graphql/build.gradle.kts
+++ b/sentry-graphql/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     testImplementation(projects.sentry)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-jdbc/build.gradle.kts
+++ b/sentry-jdbc/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.awaitility)

--- a/sentry-jul/build.gradle.kts
+++ b/sentry-jul/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.Libs.logbackClassic)
     testImplementation(Config.Libs.slf4jApi)

--- a/sentry-kotlin-extensions/build.gradle.kts
+++ b/sentry-kotlin-extensions/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.Libs.coroutinesCore)
     testImplementation(Config.TestLibs.coroutinesTest)

--- a/sentry-log4j2/build.gradle.kts
+++ b/sentry-log4j2/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.Libs.log4j2Api)
     testImplementation(Config.Libs.log4j2Core)

--- a/sentry-logback/build.gradle.kts
+++ b/sentry-logback/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.Libs.logbackClassic)
 }

--- a/sentry-okhttp/build.gradle.kts
+++ b/sentry-okhttp/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(Config.Libs.okhttp)
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-openfeign/build.gradle.kts
+++ b/sentry-openfeign/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
     testImplementation(Config.TestLibs.mockWebserver)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
 

--- a/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     testImplementation(projects.sentryOpentelemetry.sentryOpentelemetryBootstrap)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
 

--- a/sentry-quartz/build.gradle.kts
+++ b/sentry-quartz/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(projects.sentry)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
 }

--- a/sentry-reactor/build.gradle.kts
+++ b/sentry-reactor/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
 
     testImplementation(Config.Libs.reactorCore)

--- a/sentry-samples/sentry-samples-netflix-dgs/build.gradle.kts
+++ b/sentry-samples/sentry-samples-netflix-dgs/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -6,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"
@@ -61,7 +61,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"
@@ -63,7 +63,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"
@@ -61,7 +61,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot"
@@ -62,7 +62,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot"
@@ -63,7 +63,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot-webflux-jakarta"
@@ -34,7 +34,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot"
@@ -32,7 +32,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
 }
 
 group = "io.sentry.sample.spring-boot"
@@ -60,7 +60,7 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation("ch.qos.logback:logback-classic:1.5.16")
     testImplementation("ch.qos.logback:logback-core:1.5.16")
     testImplementation(Config.Libs.slf4jApi2)

--- a/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBoot3Version apply false
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
     id("war")
     id(Config.BuildPlugins.gretty) version Config.BuildPlugins.grettyVersion
 }

--- a/sentry-samples/sentry-samples-spring/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id(Config.BuildPlugins.springBoot) version Config.springBootVersion apply false
     id(Config.BuildPlugins.springDependencyManagement) version Config.BuildPlugins.springDependencyManagementVersion
     kotlin("jvm")
-    kotlin("plugin.spring") version Config.kotlinVersion
+    alias(libs.plugins.kotlin.spring)
     id("war")
     id(Config.BuildPlugins.gretty) version Config.BuildPlugins.grettyVersion
 }

--- a/sentry-servlet-jakarta/build.gradle.kts
+++ b/sentry-servlet-jakarta/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation(Config.Libs.servletApiJakarta)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
 }

--- a/sentry-servlet/build.gradle.kts
+++ b/sentry-servlet/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     // tests
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.awaitility)
     testImplementation(Config.Libs.springBootStarterTest)

--- a/sentry-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-spring-boot-jakarta/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     testImplementation(projects.sentryApacheHttpClient5)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockWebserver)
 

--- a/sentry-spring-boot/build.gradle.kts
+++ b/sentry-spring-boot/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     testImplementation(projects.sentryApacheHttpClient5)
     testImplementation(projects.sentryTestSupport)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockWebserver)
     testImplementation(Config.Libs.okhttp)

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(projects.sentryGraphql)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.Libs.springBoot3StarterTest)

--- a/sentry-spring/build.gradle.kts
+++ b/sentry-spring/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     testImplementation(projects.sentryTestSupport)
     testImplementation(projects.sentryGraphql)
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.Libs.springBootStarterTest)

--- a/sentry-system-test-support/build.gradle.kts
+++ b/sentry-system-test-support/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     // tests
     implementation(kotlin(Config.kotlinStdLib))
-    implementation(Config.TestLibs.kotlinTestJunit)
+    implementation(libs.kotlin.test.junit)
     implementation(Config.TestLibs.mockitoKotlin)
 }
 

--- a/sentry-test-support/build.gradle.kts
+++ b/sentry-test-support/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
     // tests
     implementation(kotlin(Config.kotlinStdLib))
-    implementation(Config.TestLibs.kotlinTestJunit)
+    implementation(libs.kotlin.test.junit)
     implementation(Config.TestLibs.mockitoKotlin)
 }
 

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     errorprone(Config.CompileOnly.errorProneNullAway)
     // tests
     testImplementation(kotlin(Config.kotlinStdLib))
-    testImplementation(Config.TestLibs.kotlinTestJunit)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(Config.TestLibs.mockitoKotlin)
     testImplementation(Config.TestLibs.mockitoInline)
     testImplementation(Config.TestLibs.awaitility)


### PR DESCRIPTION
This just starts the adoption, with just a few entries in the catalog.
The rest will come in separate PRs

#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
