### PR TITLE
Extend Logs API to allow passing in `attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 - Add debug mode for Session Replay masking ([#4357](https://github.com/getsentry/sentry-java/pull/4357))
     - Use `Sentry.replay().enableDebugMaskingOverlay()` to overlay the screen with the Session Replay masks.
     - The masks will be invalidated at most once per `frameRate` (default 1 fps).
+- Extend Logs API to allow passing in `attributes` ([#4402](https://github.com/getsentry/sentry-java/pull/4402))
+  - `Sentry.logger.log` now takes a `SentryLogParameters`
+  - Use `SentryLogParameters.create(SentryAttributes.of(...))` to pass attributes
+    - Attribute values may be of type `string`, `boolean`, `integer` or `double`.
+    - Other types will be converted to `string`. Currently we simply call `toString()` but we might offer more in the future.
+    - You may manually flatten complex types into multiple separate attributes of simple types.
+      - e.g. intead of `SentryAttribute.named("point", Point(10, 20))` you may store it as `SentryAttribute.integerAttribute("point.x", point.x)` and `SentryAttribute.integerAttribute("point.y", point.y)`
+    - `SentryAttribute.named()` will automatically infer the type or fall back to `string`.
+    - `SentryAttribute.booleanAttribute()` takes a `Boolean` value
+    - `SentryAttribute.integerAttribute()` takes a `Integer` value
+    - `SentryAttribute.doubleAttribute()` takes a `Double` value
+    - `SentryAttribute.stringAttribute()` takes a `String` value
+  - We opted for handling parameters via `SentryLogParameters` to avoid creating tons of overloads that are ambiguous.
 
 ## 8.12.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2658,6 +2658,34 @@ public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
 	public fun <init> ()V
 }
 
+public final class io/sentry/SentryAttribute {
+	public static fun booleanAttribute (Ljava/lang/String;Ljava/lang/Boolean;)Lio/sentry/SentryAttribute;
+	public static fun doubleAttribute (Ljava/lang/String;Ljava/lang/Double;)Lio/sentry/SentryAttribute;
+	public fun getName ()Ljava/lang/String;
+	public fun getType ()Lio/sentry/SentryAttributeType;
+	public fun getValue ()Ljava/lang/Object;
+	public static fun integerAttribute (Ljava/lang/String;Ljava/lang/Integer;)Lio/sentry/SentryAttribute;
+	public static fun named (Ljava/lang/String;Ljava/lang/Object;)Lio/sentry/SentryAttribute;
+	public static fun stringAttribute (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/SentryAttribute;
+}
+
+public final class io/sentry/SentryAttributeType : java/lang/Enum {
+	public static final field BOOLEAN Lio/sentry/SentryAttributeType;
+	public static final field DOUBLE Lio/sentry/SentryAttributeType;
+	public static final field INTEGER Lio/sentry/SentryAttributeType;
+	public static final field STRING Lio/sentry/SentryAttributeType;
+	public fun apiName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryAttributeType;
+	public static fun values ()[Lio/sentry/SentryAttributeType;
+}
+
+public final class io/sentry/SentryAttributes {
+	public fun add (Lio/sentry/SentryAttribute;)V
+	public static fun fromMap (Ljava/util/Map;)Lio/sentry/SentryAttributes;
+	public fun getAttributes ()Ljava/util/Map;
+	public static fun of ([Lio/sentry/SentryAttribute;)Lio/sentry/SentryAttributes;
+}
+
 public final class io/sentry/SentryAutoDateProvider : io/sentry/SentryDateProvider {
 	public fun <init> ()V
 	public fun now ()Lio/sentry/SentryDate;
@@ -3077,6 +3105,7 @@ public final class io/sentry/SentryLogEvent$JsonKeys {
 }
 
 public final class io/sentry/SentryLogEventAttributeValue : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> (Lio/sentry/SentryAttributeType;Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun getType ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
@@ -4711,9 +4740,8 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4730,9 +4758,8 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4752,9 +4779,8 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerApi;
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4763,6 +4789,16 @@ public final class io/sentry/logger/NoOpLoggerBatchProcessor : io/sentry/logger/
 	public fun add (Lio/sentry/SentryLogEvent;)V
 	public fun close (Z)V
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerBatchProcessor;
+}
+
+public final class io/sentry/logger/SentryLogParameters {
+	public fun <init> ()V
+	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
+	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
+	public fun getAttributes ()Lio/sentry/SentryAttributes;
+	public fun getTimestamp ()Lio/sentry/SentryDate;
+	public fun setAttributes (Lio/sentry/SentryAttributes;)V
+	public fun setTimestamp (Lio/sentry/SentryDate;)V
 }
 
 public final class io/sentry/opentelemetry/OpenTelemetryUtil {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4712,6 +4712,8 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4729,6 +4731,8 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4749,6 +4753,8 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }

--- a/sentry/src/main/java/io/sentry/SentryAttribute.java
+++ b/sentry/src/main/java/io/sentry/SentryAttribute.java
@@ -1,0 +1,57 @@
+package io.sentry;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class SentryAttribute {
+
+  private final @NotNull String name;
+  private final @Nullable SentryAttributeType type;
+  private final @Nullable Object value;
+
+  private SentryAttribute(
+      final @NotNull String name,
+      final @Nullable SentryAttributeType type,
+      final @Nullable Object value) {
+    this.name = name;
+    this.type = type;
+    this.value = value;
+  }
+
+  public @NotNull String getName() {
+    return name;
+  }
+
+  public @Nullable SentryAttributeType getType() {
+    return type;
+  }
+
+  public @Nullable Object getValue() {
+    return value;
+  }
+
+  public static @NotNull SentryAttribute named(
+      final @NotNull String name, final @Nullable Object value) {
+    return new SentryAttribute(name, null, value);
+  }
+
+  public static @NotNull SentryAttribute booleanAttribute(
+      final @NotNull String name, final @Nullable Boolean value) {
+    return new SentryAttribute(name, SentryAttributeType.BOOLEAN, value);
+  }
+
+  public static @NotNull SentryAttribute integerAttribute(
+      final @NotNull String name, final @Nullable Integer value) {
+    return new SentryAttribute(name, SentryAttributeType.INTEGER, value);
+  }
+
+  public static @NotNull SentryAttribute doubleAttribute(
+      final @NotNull String name, final @Nullable Double value) {
+    return new SentryAttribute(name, SentryAttributeType.DOUBLE, value);
+  }
+
+  public static @NotNull SentryAttribute stringAttribute(
+      final @NotNull String name, final @Nullable String value) {
+    return new SentryAttribute(name, SentryAttributeType.STRING, value);
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryAttributeType.java
+++ b/sentry/src/main/java/io/sentry/SentryAttributeType.java
@@ -1,0 +1,15 @@
+package io.sentry;
+
+import java.util.Locale;
+import org.jetbrains.annotations.NotNull;
+
+public enum SentryAttributeType {
+  STRING,
+  BOOLEAN,
+  INTEGER,
+  DOUBLE;
+
+  public @NotNull String apiName() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryAttributes.java
+++ b/sentry/src/main/java/io/sentry/SentryAttributes.java
@@ -1,0 +1,54 @@
+package io.sentry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class SentryAttributes {
+
+  private final @NotNull Map<String, SentryAttribute> attributes;
+
+  private SentryAttributes(final @NotNull Map<String, SentryAttribute> attributes) {
+    this.attributes = attributes;
+  }
+
+  public void add(final @Nullable SentryAttribute attribute) {
+    if (attribute == null) {
+      return;
+    }
+    attributes.put(attribute.getName(), attribute);
+  }
+
+  public @NotNull Map<String, SentryAttribute> getAttributes() {
+    return attributes;
+  }
+
+  public static @NotNull SentryAttributes of(final @Nullable SentryAttribute... attributes) {
+    if (attributes == null) {
+      return new SentryAttributes(new ConcurrentHashMap<>());
+    }
+    final @NotNull SentryAttributes sentryAttributes =
+        new SentryAttributes(new ConcurrentHashMap<>(attributes.length));
+    for (SentryAttribute attribute : attributes) {
+      sentryAttributes.add(attribute);
+    }
+    return sentryAttributes;
+  }
+
+  public static @NotNull SentryAttributes fromMap(final @Nullable Map<String, Object> attributes) {
+    if (attributes == null) {
+      return new SentryAttributes(new ConcurrentHashMap<>());
+    }
+    final @NotNull SentryAttributes sentryAttributes =
+        new SentryAttributes(new ConcurrentHashMap<>(attributes.size()));
+    for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
+      final @Nullable String key = attribute.getKey();
+      if (key != null) {
+        sentryAttributes.add(SentryAttribute.named(key, attribute.getValue()));
+      }
+    }
+
+    return sentryAttributes;
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
@@ -22,6 +22,12 @@ public final class SentryLogEventAttributeValue implements JsonUnknown, JsonSeri
     }
   }
 
+  public SentryLogEventAttributeValue(
+      final @NotNull SentryAttributeType type, final @Nullable Object value) {
+    this.type = type.apiName();
+    this.value = value;
+  }
+
   public @NotNull String getType() {
     return type;
   }

--- a/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
@@ -15,7 +15,11 @@ public final class SentryLogEventAttributeValue implements JsonUnknown, JsonSeri
 
   public SentryLogEventAttributeValue(final @NotNull String type, final @Nullable Object value) {
     this.type = type;
-    this.value = value;
+    if (value != null && type.equals("string")) {
+      this.value = value.toString();
+    } else {
+      this.value = value;
+    }
   }
 
   public @NotNull String getType() {

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -2,7 +2,6 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,15 +30,8 @@ public interface ILoggerApi {
       @Nullable Object... args);
 
   void log(
-      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
-      @Nullable String message,
-      @Nullable Object... args);
-
-  void log(
-      @Nullable Map<String, Object> attributes,
-      @NotNull SentryLogLevel level,
-      @Nullable SentryDate timestamp,
+      @NotNull SentryLogParameters params,
       @Nullable String message,
       @Nullable Object... args);
 }

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -2,6 +2,7 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +25,19 @@ public interface ILoggerApi {
   void log(@NotNull SentryLogLevel level, @Nullable String message, @Nullable Object... args);
 
   void log(
+      @NotNull SentryLogLevel level,
+      @Nullable SentryDate timestamp,
+      @Nullable String message,
+      @Nullable Object... args);
+
+  void log(
+      @Nullable Map<String, Object> attributes,
+      @NotNull SentryLogLevel level,
+      @Nullable String message,
+      @Nullable Object... args);
+
+  void log(
+      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
       @Nullable SentryDate timestamp,
       @Nullable String message,

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -5,6 +5,9 @@ import io.sentry.IScope;
 import io.sentry.ISpan;
 import io.sentry.PropagationContext;
 import io.sentry.Scopes;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributeType;
+import io.sentry.SentryAttributes;
 import io.sentry.SentryDate;
 import io.sentry.SentryLevel;
 import io.sentry.SentryLogEvent;
@@ -17,7 +20,6 @@ import io.sentry.protocol.SentryId;
 import io.sentry.util.Platform;
 import io.sentry.util.TracingUtils;
 import java.util.HashMap;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,7 +68,7 @@ public final class LoggerApi implements ILoggerApi {
       final @NotNull SentryLogLevel level,
       final @Nullable String message,
       final @Nullable Object... args) {
-    captureLog(null, level, null, message, args);
+    captureLog(level, SentryLogParameters.create(null, null), message, args);
   }
 
   @Override
@@ -75,33 +77,22 @@ public final class LoggerApi implements ILoggerApi {
       final @Nullable SentryDate timestamp,
       final @Nullable String message,
       final @Nullable Object... args) {
-    captureLog(null, level, timestamp, message, args);
+    captureLog(level, SentryLogParameters.create(timestamp, null), message, args);
   }
 
   @Override
   public void log(
-      final @Nullable Map<String, Object> attributes,
       final @NotNull SentryLogLevel level,
-      final @Nullable SentryDate timestamp,
+      final @NotNull SentryLogParameters params,
       final @Nullable String message,
       final @Nullable Object... args) {
-    captureLog(attributes, level, timestamp, message, args);
-  }
-
-  @Override
-  public void log(
-      final @Nullable Map<String, Object> attributes,
-      final @NotNull SentryLogLevel level,
-      final @Nullable String message,
-      final @Nullable Object... args) {
-    captureLog(attributes, level, null, message, args);
+    captureLog(level, params, message, args);
   }
 
   @SuppressWarnings("AnnotateFormatMethod")
   private void captureLog(
-      final @Nullable Map<String, Object> attributes,
       final @NotNull SentryLogLevel level,
-      final @Nullable SentryDate timestamp,
+      final @NotNull SentryLogParameters params,
       final @Nullable String message,
       final @Nullable Object... args) {
     final @NotNull SentryOptions options = scopes.getOptions();
@@ -124,6 +115,7 @@ public final class LoggerApi implements ILoggerApi {
         return;
       }
 
+      final @Nullable SentryDate timestamp = params.getTimestamp();
       final @NotNull SentryDate timestampToUse =
           timestamp == null ? options.getDateProvider().now() : timestamp;
       final @NotNull String messageToUse = maybeFormatMessage(message, args);
@@ -140,7 +132,7 @@ public final class LoggerApi implements ILoggerApi {
           span == null ? propagationContext.getSpanId() : span.getSpanContext().getSpanId();
       final SentryLogEvent logEvent =
           new SentryLogEvent(traceId, timestampToUse, messageToUse, level);
-      logEvent.setAttributes(createAttributes(attributes, message, spanId, args));
+      logEvent.setAttributes(createAttributes(params.getAttributes(), message, spanId, args));
       logEvent.setSeverityNumber(level.getSeverityNumber());
 
       scopes.getClient().captureLog(logEvent, combinedScope);
@@ -167,24 +159,25 @@ public final class LoggerApi implements ILoggerApi {
   }
 
   private @NotNull HashMap<String, SentryLogEventAttributeValue> createAttributes(
-      final @Nullable Map<String, Object> incomingAttributes,
+      final @Nullable SentryAttributes incomingAttributes,
       final @NotNull String message,
       final @NotNull SpanId spanId,
       final @Nullable Object... args) {
     final @NotNull HashMap<String, SentryLogEventAttributeValue> attributes = new HashMap<>();
 
     if (incomingAttributes != null) {
-      for (Map.Entry<String, Object> attributeEntry : incomingAttributes.entrySet()) {
-        final @Nullable Object value = attributeEntry.getValue();
-        final @NotNull String type = getType(value);
-        attributes.put(attributeEntry.getKey(), new SentryLogEventAttributeValue(type, value));
+      for (SentryAttribute attribute : incomingAttributes.getAttributes().values()) {
+        final @Nullable Object value = attribute.getValue();
+        final @NotNull SentryAttributeType type =
+            attribute.getType() == null ? getType(value) : attribute.getType();
+        attributes.put(attribute.getName(), new SentryLogEventAttributeValue(type, value));
       }
     }
 
     if (args != null) {
       int i = 0;
       for (Object arg : args) {
-        final @NotNull String type = getType(arg);
+        final @NotNull SentryAttributeType type = getType(arg);
         attributes.put(
             "sentry.message.parameter." + i, new SentryLogEventAttributeValue(type, arg));
         i++;
@@ -238,16 +231,16 @@ public final class LoggerApi implements ILoggerApi {
     }
   }
 
-  private @NotNull String getType(final @Nullable Object arg) {
+  private @NotNull SentryAttributeType getType(final @Nullable Object arg) {
     if (arg instanceof Boolean) {
-      return "boolean";
+      return SentryAttributeType.BOOLEAN;
     }
     if (arg instanceof Integer) {
-      return "integer";
+      return SentryAttributeType.INTEGER;
     }
     if (arg instanceof Number) {
-      return "double";
+      return SentryAttributeType.DOUBLE;
     }
-    return "string";
+    return SentryAttributeType.STRING;
   }
 }

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -2,6 +2,7 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
+import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -55,6 +56,25 @@ public final class NoOpLoggerApi implements ILoggerApi {
 
   @Override
   public void log(
+      @NotNull SentryLogLevel level,
+      @Nullable SentryDate timestamp,
+      @Nullable String message,
+      @Nullable Object... args) {
+    // do nothing
+  }
+
+  @Override
+  public void log(
+      @Nullable Map<String, Object> attributes,
+      @NotNull SentryLogLevel level,
+      @Nullable String message,
+      @Nullable Object... args) {
+    // do nothing
+  }
+
+  @Override
+  public void log(
+      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
       @Nullable SentryDate timestamp,
       @Nullable String message,

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -2,7 +2,6 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,18 +64,8 @@ public final class NoOpLoggerApi implements ILoggerApi {
 
   @Override
   public void log(
-      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
-      @Nullable String message,
-      @Nullable Object... args) {
-    // do nothing
-  }
-
-  @Override
-  public void log(
-      @Nullable Map<String, Object> attributes,
-      @NotNull SentryLogLevel level,
-      @Nullable SentryDate timestamp,
+      @NotNull SentryLogParameters params,
       @Nullable String message,
       @Nullable Object... args) {
     // do nothing

--- a/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
+++ b/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
@@ -1,0 +1,42 @@
+package io.sentry.logger;
+
+import io.sentry.SentryAttributes;
+import io.sentry.SentryDate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class SentryLogParameters {
+
+  private @Nullable SentryDate timestamp;
+  private @Nullable SentryAttributes attributes;
+
+  public @Nullable SentryDate getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(final @Nullable SentryDate timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public @Nullable SentryAttributes getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(final @Nullable SentryAttributes attributes) {
+    this.attributes = attributes;
+  }
+
+  public static @NotNull SentryLogParameters create(
+      final @Nullable SentryDate timestamp, final @Nullable SentryAttributes attributes) {
+    final @NotNull SentryLogParameters params = new SentryLogParameters();
+
+    params.setTimestamp(timestamp);
+    params.setAttributes(attributes);
+
+    return params;
+  }
+
+  public static @NotNull SentryLogParameters create(final @Nullable SentryAttributes attributes) {
+    return create(null, attributes);
+  }
+}

--- a/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryLogsSerializationTest.kt
@@ -32,7 +32,11 @@ class SentryLogsSerializationTest {
                         "sentry.sdk.name" to SentryLogEventAttributeValue("string", "sentry.java.spring-boot.jakarta"),
                         "sentry.environment" to SentryLogEventAttributeValue("string", "production"),
                         "sentry.sdk.version" to SentryLogEventAttributeValue("string", "8.11.1"),
-                        "sentry.trace.parent_span_id" to SentryLogEventAttributeValue("string", "f28b86350e534671")
+                        "sentry.trace.parent_span_id" to SentryLogEventAttributeValue("string", "f28b86350e534671"),
+                        "custom.boolean" to SentryLogEventAttributeValue("boolean", true),
+                        "custom.double" to SentryLogEventAttributeValue("double", 11.12.toDouble()),
+                        "custom.point" to SentryLogEventAttributeValue("string", Point(20, 30)),
+                        "custom.integer" to SentryLogEventAttributeValue("integer", 10)
                     )
                     it.severityNumber = 10
                 }
@@ -74,5 +78,13 @@ class SentryLogsSerializationTest {
     private fun deserialize(json: String): SentryLogEvents {
         val reader = JsonObjectReader(StringReader(json))
         return SentryLogEvents.Deserializer().deserialize(reader, fixture.logger)
+    }
+
+    companion object {
+        data class Point(val x: Int, val y: Int) {
+            override fun toString(): String {
+                return "Point{x:$x,y:$y}-Hello"
+            }
+        }
     }
 }

--- a/sentry/src/test/resources/json/sentry_logs.json
+++ b/sentry/src/test/resources/json/sentry_logs.json
@@ -28,6 +28,24 @@
         {
           "type": "string",
           "value": "f28b86350e534671"
+        },
+        "custom.boolean":
+        {
+          "type": "boolean",
+          "value": true
+        },
+        "custom.double": {
+          "type": "double",
+          "value": 11.12
+        },
+        "custom.point": {
+          "type": "string",
+          "value": "Point{x:20,y:30}-Hello"
+        },
+        "custom.integer":
+        {
+          "type": "integer",
+          "value": 10
         }
       }
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Extend Logs API to allow passing in `attributes`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Filtering Logs in Sentry via custom attributes.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
