### PR TITLE
Improve Log Attributes API

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2682,7 +2682,7 @@ public final class io/sentry/SentryAttributeType : java/lang/Enum {
 public final class io/sentry/SentryAttributes {
 	public fun add (Lio/sentry/SentryAttribute;)V
 	public static fun fromMap (Ljava/util/Map;)Lio/sentry/SentryAttributes;
-	public fun getAttributes ()Ljava/util/List;
+	public fun getAttributes ()Ljava/util/Map;
 	public static fun of ([Lio/sentry/SentryAttribute;)Lio/sentry/SentryAttributes;
 }
 
@@ -4740,7 +4740,7 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4751,16 +4751,6 @@ public abstract interface class io/sentry/logger/ILoggerBatchProcessor {
 	public abstract fun close (Z)V
 }
 
-public final class io/sentry/logger/LogParams {
-	public fun <init> ()V
-	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/logger/LogParams;
-	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/logger/LogParams;
-	public fun getAttributes ()Lio/sentry/SentryAttributes;
-	public fun getTimestamp ()Lio/sentry/SentryDate;
-	public fun setAttributes (Lio/sentry/SentryAttributes;)V
-	public fun setTimestamp (Lio/sentry/SentryDate;)V
-}
-
 public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun <init> (Lio/sentry/Scopes;)V
 	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4768,7 +4758,7 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4789,7 +4779,7 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerApi;
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/SentryLogParameters;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4799,6 +4789,16 @@ public final class io/sentry/logger/NoOpLoggerBatchProcessor : io/sentry/logger/
 	public fun add (Lio/sentry/SentryLogEvent;)V
 	public fun close (Z)V
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerBatchProcessor;
+}
+
+public final class io/sentry/logger/SentryLogParameters {
+	public fun <init> ()V
+	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
+	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
+	public fun getAttributes ()Lio/sentry/SentryAttributes;
+	public fun getTimestamp ()Lio/sentry/SentryDate;
+	public fun setAttributes (Lio/sentry/SentryAttributes;)V
+	public fun setTimestamp (Lio/sentry/SentryDate;)V
 }
 
 public final class io/sentry/opentelemetry/OpenTelemetryUtil {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2658,6 +2658,34 @@ public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
 	public fun <init> ()V
 }
 
+public final class io/sentry/SentryAttribute {
+	public static fun booleanAttribute (Ljava/lang/String;Ljava/lang/Boolean;)Lio/sentry/SentryAttribute;
+	public static fun doubleAttribute (Ljava/lang/String;Ljava/lang/Double;)Lio/sentry/SentryAttribute;
+	public fun getName ()Ljava/lang/String;
+	public fun getType ()Lio/sentry/SentryAttributeType;
+	public fun getValue ()Ljava/lang/Object;
+	public static fun integerAttribute (Ljava/lang/String;Ljava/lang/Integer;)Lio/sentry/SentryAttribute;
+	public static fun named (Ljava/lang/String;Ljava/lang/Object;)Lio/sentry/SentryAttribute;
+	public static fun stringAttribute (Ljava/lang/String;Ljava/lang/String;)Lio/sentry/SentryAttribute;
+}
+
+public final class io/sentry/SentryAttributeType : java/lang/Enum {
+	public static final field BOOLEAN Lio/sentry/SentryAttributeType;
+	public static final field DOUBLE Lio/sentry/SentryAttributeType;
+	public static final field INTEGER Lio/sentry/SentryAttributeType;
+	public static final field STRING Lio/sentry/SentryAttributeType;
+	public fun apiName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/SentryAttributeType;
+	public static fun values ()[Lio/sentry/SentryAttributeType;
+}
+
+public final class io/sentry/SentryAttributes {
+	public fun add (Lio/sentry/SentryAttribute;)V
+	public static fun fromMap (Ljava/util/Map;)Lio/sentry/SentryAttributes;
+	public fun getAttributes ()Ljava/util/List;
+	public static fun of ([Lio/sentry/SentryAttribute;)Lio/sentry/SentryAttributes;
+}
+
 public final class io/sentry/SentryAutoDateProvider : io/sentry/SentryDateProvider {
 	public fun <init> ()V
 	public fun now ()Lio/sentry/SentryDate;
@@ -3077,6 +3105,7 @@ public final class io/sentry/SentryLogEvent$JsonKeys {
 }
 
 public final class io/sentry/SentryLogEventAttributeValue : io/sentry/JsonSerializable, io/sentry/JsonUnknown {
+	public fun <init> (Lio/sentry/SentryAttributeType;Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
 	public fun getType ()Ljava/lang/String;
 	public fun getUnknown ()Ljava/util/Map;
@@ -4711,9 +4740,8 @@ public abstract interface class io/sentry/logger/ILoggerApi {
 	public abstract fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public abstract fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public abstract fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4723,6 +4751,16 @@ public abstract interface class io/sentry/logger/ILoggerBatchProcessor {
 	public abstract fun close (Z)V
 }
 
+public final class io/sentry/logger/LogParams {
+	public fun <init> ()V
+	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/logger/LogParams;
+	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/logger/LogParams;
+	public fun getAttributes ()Lio/sentry/SentryAttributes;
+	public fun getTimestamp ()Lio/sentry/SentryDate;
+	public fun setAttributes (Lio/sentry/SentryAttributes;)V
+	public fun setTimestamp (Lio/sentry/SentryDate;)V
+}
+
 public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun <init> (Lio/sentry/Scopes;)V
 	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
@@ -4730,9 +4768,8 @@ public final class io/sentry/logger/LoggerApi : io/sentry/logger/ILoggerApi {
 	public fun fatal (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }
@@ -4752,9 +4789,8 @@ public final class io/sentry/logger/NoOpLoggerApi : io/sentry/logger/ILoggerApi 
 	public static fun getInstance ()Lio/sentry/logger/NoOpLoggerApi;
 	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun log (Lio/sentry/SentryLogLevel;Lio/sentry/logger/LogParams;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun log (Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Lio/sentry/SentryDate;Ljava/lang/String;[Ljava/lang/Object;)V
-	public fun log (Ljava/util/Map;Lio/sentry/SentryLogLevel;Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
 	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
 }

--- a/sentry/src/main/java/io/sentry/SentryAttribute.java
+++ b/sentry/src/main/java/io/sentry/SentryAttribute.java
@@ -1,0 +1,57 @@
+package io.sentry;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class SentryAttribute {
+
+  private final @NotNull String name;
+  private final @Nullable SentryAttributeType type;
+  private final @Nullable Object value;
+
+  private SentryAttribute(
+      final @NotNull String name,
+      final @Nullable SentryAttributeType type,
+      final @Nullable Object value) {
+    this.name = name;
+    this.type = type;
+    this.value = value;
+  }
+
+  public @NotNull String getName() {
+    return name;
+  }
+
+  public @Nullable SentryAttributeType getType() {
+    return type;
+  }
+
+  public @Nullable Object getValue() {
+    return value;
+  }
+
+  public static @NotNull SentryAttribute named(
+      final @NotNull String name, final @Nullable Object value) {
+    return new SentryAttribute(name, null, value);
+  }
+
+  public static @NotNull SentryAttribute booleanAttribute(
+      final @NotNull String name, final @Nullable Boolean value) {
+    return new SentryAttribute(name, SentryAttributeType.BOOLEAN, value);
+  }
+
+  public static @NotNull SentryAttribute integerAttribute(
+      final @NotNull String name, final @Nullable Integer value) {
+    return new SentryAttribute(name, SentryAttributeType.INTEGER, value);
+  }
+
+  public static @NotNull SentryAttribute doubleAttribute(
+      final @NotNull String name, final @Nullable Double value) {
+    return new SentryAttribute(name, SentryAttributeType.DOUBLE, value);
+  }
+
+  public static @NotNull SentryAttribute stringAttribute(
+      final @NotNull String name, final @Nullable String value) {
+    return new SentryAttribute(name, SentryAttributeType.STRING, value);
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryAttributeType.java
+++ b/sentry/src/main/java/io/sentry/SentryAttributeType.java
@@ -1,0 +1,15 @@
+package io.sentry;
+
+import java.util.Locale;
+import org.jetbrains.annotations.NotNull;
+
+public enum SentryAttributeType {
+  STRING,
+  BOOLEAN,
+  INTEGER,
+  DOUBLE;
+
+  public @NotNull String apiName() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryAttributes.java
+++ b/sentry/src/main/java/io/sentry/SentryAttributes.java
@@ -1,0 +1,44 @@
+package io.sentry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class SentryAttributes {
+
+  private final @NotNull List<SentryAttribute> attributes;
+
+  private SentryAttributes(final @NotNull List<SentryAttribute> attributes) {
+    this.attributes = attributes;
+  }
+
+  public void add(final @Nullable SentryAttribute attribute) {
+    if (attribute == null) {
+      return;
+    }
+    attributes.add(attribute);
+  }
+
+  public @NotNull List<SentryAttribute> getAttributes() {
+    return attributes;
+  }
+
+  public static @NotNull SentryAttributes of(SentryAttribute... attributes) {
+    return new SentryAttributes(Arrays.asList(attributes));
+  }
+
+  public static @NotNull SentryAttributes fromMap(final @Nullable Map<String, Object> attributes) {
+    if (attributes == null) {
+      return new SentryAttributes(new ArrayList<>());
+    }
+    SentryAttributes sentryAttributes = new SentryAttributes(new ArrayList<>(attributes.size()));
+    for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
+      sentryAttributes.add(SentryAttribute.named(attribute.getKey(), attribute.getValue()));
+    }
+
+    return sentryAttributes;
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryAttributes.java
+++ b/sentry/src/main/java/io/sentry/SentryAttributes.java
@@ -1,17 +1,15 @@
 package io.sentry;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class SentryAttributes {
 
-  private final @NotNull List<SentryAttribute> attributes;
+  private final @NotNull Map<String, SentryAttribute> attributes;
 
-  private SentryAttributes(final @NotNull List<SentryAttribute> attributes) {
+  private SentryAttributes(final @NotNull Map<String, SentryAttribute> attributes) {
     this.attributes = attributes;
   }
 
@@ -19,24 +17,36 @@ public final class SentryAttributes {
     if (attribute == null) {
       return;
     }
-    attributes.add(attribute);
+    attributes.put(attribute.getName(), attribute);
   }
 
-  public @NotNull List<SentryAttribute> getAttributes() {
+  public @NotNull Map<String, SentryAttribute> getAttributes() {
     return attributes;
   }
 
-  public static @NotNull SentryAttributes of(SentryAttribute... attributes) {
-    return new SentryAttributes(Arrays.asList(attributes));
+  public static @NotNull SentryAttributes of(final @Nullable SentryAttribute... attributes) {
+    if (attributes == null) {
+      return new SentryAttributes(new ConcurrentHashMap<>());
+    }
+    final @NotNull SentryAttributes sentryAttributes =
+        new SentryAttributes(new ConcurrentHashMap<>(attributes.length));
+    for (SentryAttribute attribute : attributes) {
+      sentryAttributes.add(attribute);
+    }
+    return sentryAttributes;
   }
 
   public static @NotNull SentryAttributes fromMap(final @Nullable Map<String, Object> attributes) {
     if (attributes == null) {
-      return new SentryAttributes(new ArrayList<>());
+      return new SentryAttributes(new ConcurrentHashMap<>());
     }
-    SentryAttributes sentryAttributes = new SentryAttributes(new ArrayList<>(attributes.size()));
+    final @NotNull SentryAttributes sentryAttributes =
+        new SentryAttributes(new ConcurrentHashMap<>(attributes.size()));
     for (Map.Entry<String, Object> attribute : attributes.entrySet()) {
-      sentryAttributes.add(SentryAttribute.named(attribute.getKey(), attribute.getValue()));
+      final @Nullable String key = attribute.getKey();
+      if (key != null) {
+        sentryAttributes.add(SentryAttribute.named(key, attribute.getValue()));
+      }
     }
 
     return sentryAttributes;

--- a/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
+++ b/sentry/src/main/java/io/sentry/SentryLogEventAttributeValue.java
@@ -18,6 +18,12 @@ public final class SentryLogEventAttributeValue implements JsonUnknown, JsonSeri
     this.value = value;
   }
 
+  public SentryLogEventAttributeValue(
+      final @NotNull SentryAttributeType type, final @Nullable Object value) {
+    this.type = type.apiName();
+    this.value = value;
+  }
+
   public @NotNull String getType() {
     return type;
   }

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -2,7 +2,6 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,15 +30,8 @@ public interface ILoggerApi {
       @Nullable Object... args);
 
   void log(
-      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
-      @Nullable String message,
-      @Nullable Object... args);
-
-  void log(
-      @Nullable Map<String, Object> attributes,
-      @NotNull SentryLogLevel level,
-      @Nullable SentryDate timestamp,
+      @NotNull LogParams params,
       @Nullable String message,
       @Nullable Object... args);
 }

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -31,7 +31,7 @@ public interface ILoggerApi {
 
   void log(
       @NotNull SentryLogLevel level,
-      @NotNull LogParams params,
+      @NotNull SentryLogParameters params,
       @Nullable String message,
       @Nullable Object... args);
 }

--- a/sentry/src/main/java/io/sentry/logger/LogParams.java
+++ b/sentry/src/main/java/io/sentry/logger/LogParams.java
@@ -1,0 +1,42 @@
+package io.sentry.logger;
+
+import io.sentry.SentryAttributes;
+import io.sentry.SentryDate;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class LogParams {
+
+  private @Nullable SentryDate timestamp;
+  private @Nullable SentryAttributes attributes;
+
+  public @Nullable SentryDate getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(final @Nullable SentryDate timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public @Nullable SentryAttributes getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(final @Nullable SentryAttributes attributes) {
+    this.attributes = attributes;
+  }
+
+  public static @NotNull LogParams create(
+      final @Nullable SentryDate timestamp, final @Nullable SentryAttributes attributes) {
+    final @NotNull LogParams params = new LogParams();
+
+    params.setTimestamp(timestamp);
+    params.setAttributes(attributes);
+
+    return params;
+  }
+
+  public static @NotNull LogParams create(final @Nullable SentryAttributes attributes) {
+    return create(null, attributes);
+  }
+}

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -68,7 +68,7 @@ public final class LoggerApi implements ILoggerApi {
       final @NotNull SentryLogLevel level,
       final @Nullable String message,
       final @Nullable Object... args) {
-    captureLog(level, LogParams.create(null, null), message, args);
+    captureLog(level, SentryLogParameters.create(null, null), message, args);
   }
 
   @Override
@@ -77,13 +77,13 @@ public final class LoggerApi implements ILoggerApi {
       final @Nullable SentryDate timestamp,
       final @Nullable String message,
       final @Nullable Object... args) {
-    captureLog(level, LogParams.create(timestamp, null), message, args);
+    captureLog(level, SentryLogParameters.create(timestamp, null), message, args);
   }
 
   @Override
   public void log(
       final @NotNull SentryLogLevel level,
-      final @NotNull LogParams params,
+      final @NotNull SentryLogParameters params,
       final @Nullable String message,
       final @Nullable Object... args) {
     captureLog(level, params, message, args);
@@ -92,7 +92,7 @@ public final class LoggerApi implements ILoggerApi {
   @SuppressWarnings("AnnotateFormatMethod")
   private void captureLog(
       final @NotNull SentryLogLevel level,
-      final @NotNull LogParams params,
+      final @NotNull SentryLogParameters params,
       final @Nullable String message,
       final @Nullable Object... args) {
     final @NotNull SentryOptions options = scopes.getOptions();
@@ -166,7 +166,7 @@ public final class LoggerApi implements ILoggerApi {
     final @NotNull HashMap<String, SentryLogEventAttributeValue> attributes = new HashMap<>();
 
     if (incomingAttributes != null) {
-      for (SentryAttribute attribute : incomingAttributes.getAttributes()) {
+      for (SentryAttribute attribute : incomingAttributes.getAttributes().values()) {
         final @Nullable Object value = attribute.getValue();
         final @NotNull SentryAttributeType type =
             attribute.getType() == null ? getType(value) : attribute.getType();

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -65,7 +65,7 @@ public final class NoOpLoggerApi implements ILoggerApi {
   @Override
   public void log(
       @NotNull SentryLogLevel level,
-      @NotNull LogParams params,
+      @NotNull SentryLogParameters params,
       @Nullable String message,
       @Nullable Object... args) {
     // do nothing

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -2,7 +2,6 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,18 +64,8 @@ public final class NoOpLoggerApi implements ILoggerApi {
 
   @Override
   public void log(
-      @Nullable Map<String, Object> attributes,
       @NotNull SentryLogLevel level,
-      @Nullable String message,
-      @Nullable Object... args) {
-    // do nothing
-  }
-
-  @Override
-  public void log(
-      @Nullable Map<String, Object> attributes,
-      @NotNull SentryLogLevel level,
-      @Nullable SentryDate timestamp,
+      @NotNull LogParams params,
       @Nullable String message,
       @Nullable Object... args) {
     // do nothing

--- a/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
+++ b/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
@@ -5,7 +5,7 @@ import io.sentry.SentryDate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public final class LogParams {
+public final class SentryLogParameters {
 
   private @Nullable SentryDate timestamp;
   private @Nullable SentryAttributes attributes;
@@ -26,9 +26,9 @@ public final class LogParams {
     this.attributes = attributes;
   }
 
-  public static @NotNull LogParams create(
+  public static @NotNull SentryLogParameters create(
       final @Nullable SentryDate timestamp, final @Nullable SentryAttributes attributes) {
-    final @NotNull LogParams params = new LogParams();
+    final @NotNull SentryLogParameters params = new SentryLogParameters();
 
     params.setTimestamp(timestamp);
     params.setAttributes(attributes);
@@ -36,7 +36,7 @@ public final class LogParams {
     return params;
   }
 
-  public static @NotNull LogParams create(final @Nullable SentryAttributes attributes) {
+  public static @NotNull SentryLogParameters create(final @Nullable SentryAttributes attributes) {
     return create(null, attributes);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Improve Log Attributes API:
- Add `Sentry.logger().log()` overload that takes a `LogParams` param object
	- This avoids having tons of overloads and creating a large pyramid of methods
	- Having multiple overloads is especially problematic with varargs since it can easily become ambiguous
- Add `SentryAttributes` and `SentryAttribute`
- `SentryAttributeType` enum

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
