### PR TITLE
Add `SentryAttribute.flattened`

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1250,6 +1250,7 @@ public final class io/sentry/JsonObjectWriter : io/sentry/ObjectWriter {
 }
 
 public final class io/sentry/JsonReflectionObjectSerializer {
+	public fun <init> (I)V
 	public fun serialize (Ljava/lang/Object;Lio/sentry/ILogger;)Ljava/lang/Object;
 	public fun serializeObject (Ljava/lang/Object;Lio/sentry/ILogger;)Ljava/util/Map;
 }
@@ -2661,6 +2662,9 @@ public final class io/sentry/SentryAppStartProfilingOptions$JsonKeys {
 public final class io/sentry/SentryAttribute {
 	public static fun booleanAttribute (Ljava/lang/String;Ljava/lang/Boolean;)Lio/sentry/SentryAttribute;
 	public static fun doubleAttribute (Ljava/lang/String;Ljava/lang/Double;)Lio/sentry/SentryAttribute;
+	public static fun flattened (Ljava/lang/String;Ljava/lang/Object;)Lio/sentry/SentryAttribute;
+	public static fun flattened (Ljava/lang/String;Ljava/lang/Object;I)Lio/sentry/SentryAttribute;
+	public fun getFlattenDepth ()I
 	public fun getName ()Ljava/lang/String;
 	public fun getType ()Lio/sentry/SentryAttributeType;
 	public fun getValue ()Ljava/lang/Object;

--- a/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonReflectionObjectSerializer.java
@@ -33,7 +33,7 @@ public final class JsonReflectionObjectSerializer {
   private final Set<Object> visiting = new HashSet<>();
   private final int maxDepth;
 
-  JsonReflectionObjectSerializer(int maxDepth) {
+  public JsonReflectionObjectSerializer(int maxDepth) {
     this.maxDepth = maxDepth;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryAttribute.java
+++ b/sentry/src/main/java/io/sentry/SentryAttribute.java
@@ -8,14 +8,17 @@ public final class SentryAttribute {
   private final @NotNull String name;
   private final @Nullable SentryAttributeType type;
   private final @Nullable Object value;
+  private final int flattenDepth;
 
   private SentryAttribute(
       final @NotNull String name,
       final @Nullable SentryAttributeType type,
-      final @Nullable Object value) {
+      final @Nullable Object value,
+      final int flattenDepth) {
     this.name = name;
     this.type = type;
     this.value = value;
+    this.flattenDepth = flattenDepth;
   }
 
   public @NotNull String getName() {
@@ -30,28 +33,42 @@ public final class SentryAttribute {
     return value;
   }
 
+  public int getFlattenDepth() {
+    return flattenDepth;
+  }
+
   public static @NotNull SentryAttribute named(
       final @NotNull String name, final @Nullable Object value) {
-    return new SentryAttribute(name, null, value);
+    return new SentryAttribute(name, null, value, 0);
+  }
+
+  public static @NotNull SentryAttribute flattened(
+      final @NotNull String name, final @Nullable Object value) {
+    return new SentryAttribute(name, null, value, 1);
+  }
+
+  public static @NotNull SentryAttribute flattened(
+      final @NotNull String name, final @Nullable Object value, final int flattenDepth) {
+    return new SentryAttribute(name, null, value, flattenDepth);
   }
 
   public static @NotNull SentryAttribute booleanAttribute(
       final @NotNull String name, final @Nullable Boolean value) {
-    return new SentryAttribute(name, SentryAttributeType.BOOLEAN, value);
+    return new SentryAttribute(name, SentryAttributeType.BOOLEAN, value, 0);
   }
 
   public static @NotNull SentryAttribute integerAttribute(
       final @NotNull String name, final @Nullable Integer value) {
-    return new SentryAttribute(name, SentryAttributeType.INTEGER, value);
+    return new SentryAttribute(name, SentryAttributeType.INTEGER, value, 0);
   }
 
   public static @NotNull SentryAttribute doubleAttribute(
       final @NotNull String name, final @Nullable Double value) {
-    return new SentryAttribute(name, SentryAttributeType.DOUBLE, value);
+    return new SentryAttribute(name, SentryAttributeType.DOUBLE, value, 0);
   }
 
   public static @NotNull SentryAttribute stringAttribute(
       final @NotNull String name, final @Nullable String value) {
-    return new SentryAttribute(name, SentryAttributeType.STRING, value);
+    return new SentryAttribute(name, SentryAttributeType.STRING, value, 0);
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `SentryAttribute.flattened` to allow flattening objects into separate key/value pairs of simple types. e.g.:

`SentryAttribute.flattened("p", new Point(10, 20))` will add multiple attributes under the hood: `p.x=10` and `p.y=20`.

This is currently done only for a single level, however we can expand it to more depth if needed.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide API that takes care of flattening without having to manually set each attribute.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
