### PR TITLE
Remove buildscript block from root build.gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,20 +27,10 @@ plugins {
     alias(libs.plugins.errorprone) apply false
     alias(libs.plugins.gradle.versions) apply false
     alias(libs.plugins.spring.dependency.management) apply false
-}
-
-buildscript {
-    repositories {
-        google()
-    }
-    dependencies {
-        classpath(Config.BuildPlugins.androidGradle)
-
-        // add classpath of sentry android gradle plugin
-        // classpath("io.sentry:sentry-android-gradle-plugin:{version}")
-
-        classpath(Config.BuildPlugins.commonsCompressOverride)
-    }
+    id("com.android.library") version Config.AGP apply false
+    id("com.android.application") version Config.AGP apply false
+    // add classpath of sentry android gradle plugin
+    // id("io.sentry.android.gradle") version "5.6.0" apply false
 }
 
 apiValidation {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -11,11 +11,6 @@ object Config {
 
     val androidComposeCompilerVersion = "1.5.14"
 
-    object BuildPlugins {
-        val androidGradle = "com.android.tools.build:gradle:$AGP"
-        val commonsCompressOverride = "org.apache.commons:commons-compress:1.25.0"
-    }
-
     object Android {
         val abiFilters = listOf("x86", "armeabi-v7a", "x86_64", "arm64-v8a")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        google()
     }
 }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This also removes the commons library. Do we know why that was there?


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
