### PR TITLE
Add `ScopesUtil.printScopesChain` for debugging

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -711,6 +711,7 @@ public final class io/sentry/HubScopesWrapper : io/sentry/IHub {
 	public fun getParentScopes ()Lio/sentry/IScopes;
 	public fun getRateLimiter ()Lio/sentry/transport/RateLimiter;
 	public fun getScope ()Lio/sentry/IScope;
+	public fun getScopes ()Lio/sentry/IScopes;
 	public fun getSpan ()Lio/sentry/ISpan;
 	public fun getTraceparent ()Lio/sentry/SentryTraceHeader;
 	public fun getTransaction ()Lio/sentry/ITransaction;
@@ -6919,6 +6920,11 @@ public final class io/sentry/util/SampleRateUtils {
 	public static fun isValidSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;)Z
 	public static fun isValidTracesSampleRate (Ljava/lang/Double;Z)Z
+}
+
+public final class io/sentry/util/ScopesUtil {
+	public fun <init> ()V
+	public static fun printScopesChain (Lio/sentry/IScopes;)V
 }
 
 public final class io/sentry/util/SentryRandom {

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -21,6 +21,10 @@ public final class HubScopesWrapper implements IHub {
     this.scopes = scopes;
   }
 
+  public @NotNull IScopes getScopes() {
+    return scopes;
+  }
+
   @Override
   public boolean isEnabled() {
     return scopes.isEnabled();

--- a/sentry/src/main/java/io/sentry/util/ScopesUtil.java
+++ b/sentry/src/main/java/io/sentry/util/ScopesUtil.java
@@ -1,0 +1,58 @@
+package io.sentry.util;
+
+import io.sentry.IScopes;
+import io.sentry.Scopes;
+import io.sentry.ScopesAdapter;
+import io.sentry.Sentry;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A util for printing the scopes chain from passed in scopes all the way up to its initial
+ * ancestor.
+ *
+ * <p>It walks up the parents of each scopes instance until it reaches a parent of null. The scopes
+ * without a parent are the ones created in Sentry.init.
+ */
+public final class ScopesUtil {
+
+  public static void printScopesChain(final @Nullable IScopes scopes) {
+    System.out.println("==========================================");
+    System.out.println("=============== v Scopes v ===============");
+    System.out.println("==========================================");
+
+    printScopesChainInternal(scopes);
+
+    System.out.println("==========================================");
+    System.out.println("=============== ^ Scopes ^ ===============");
+    System.out.println("==========================================");
+  }
+
+  @SuppressWarnings({"ObjectToString", "deprecation"})
+  private static void printScopesChainInternal(final @Nullable IScopes someScopes) {
+    if (someScopes != null) {
+      if (someScopes instanceof Scopes) {
+        Scopes scopes = (Scopes) someScopes;
+        String info =
+            String.format(
+                "%-25s {g=%-25s, i=%-25s, c=%-25s} [%s]",
+                scopes,
+                scopes.getGlobalScope(),
+                scopes.getIsolationScope(),
+                scopes.getScope(),
+                scopes.getCreator());
+        System.out.println(info);
+        printScopesChainInternal(someScopes.getParentScopes());
+      } else if (someScopes instanceof ScopesAdapter
+          || someScopes instanceof io.sentry.HubAdapter) {
+        printScopesChainInternal(Sentry.getCurrentScopes());
+      } else if (someScopes instanceof io.sentry.HubScopesWrapper) {
+        io.sentry.HubScopesWrapper wrapper = (io.sentry.HubScopesWrapper) someScopes;
+        printScopesChainInternal(wrapper.getScopes());
+      } else {
+        System.out.println("Hit unhandled Scopes class" + someScopes.getClass());
+      }
+    } else {
+      System.out.println("-");
+    }
+  }
+}


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Add `ScopesUtil.printScopesChain` for debugging what the chain of `Scopes` looks like by traversing the `parent` and printing `Scopes` and `Scope` object IDs as well as `creator` string.

Looks like this:
```
==========================================
=============== v Scopes v ===============
==========================================
io.sentry.Scopes@4a8d50aa {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@75d0c553 , c=io.sentry.Scope@77699062 } [contextwrapper.scopeincontext]
io.sentry.Scopes@6711e5b2 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@75d0c553 , c=io.sentry.Scope@47b9e1fa } [contextwrapper.spanancestor]
io.sentry.Scopes@34b05e03 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@75d0c553 , c=io.sentry.Scope@f613277  } [spanprocessor.rootspan]
io.sentry.Scopes@67b57a5c {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@2edea3d9 , c=io.sentry.Scope@6f0be161 } [contextwrapper.scopeincontext]
io.sentry.Scopes@4dee10c8 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@2edea3d9 , c=io.sentry.Scope@38f31f95 } [contextwrapper.scopeincontext]
io.sentry.Scopes@5a62013  {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@2edea3d9 , c=io.sentry.Scope@2e9822e  } [SentrySpringFilter]
io.sentry.Scopes@597229c1 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@79dd9acd , c=io.sentry.Scope@4d4f9b5d } [contextwrapper.scopeincontext]
io.sentry.Scopes@3f98828  {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@79dd9acd , c=io.sentry.Scope@4b0d85b7 } [contextwrapper.spanscope]
io.sentry.Scopes@5e1375e9 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@79dd9acd , c=io.sentry.Scope@6f379805 } [spanprocessor.new]
io.sentry.Scopes@20c0f503 {g=io.sentry.Scope@58dbf263 , i=io.sentry.Scope@7c7fc91  , c=io.sentry.Scope@42be6dbd } [Sentry.init]
-
==========================================
=============== ^ Scopes ^ ===============
==========================================
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps us investigate things like scope forking (or lack thereof) and scope bleeding.
We can use this to ask customers to attach this to GH issues for quicker support and also for making sure we're reproducing what's actually happening.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
