### PR TITLE
Use `graphql-java` v24 for Spring Boot 3.5

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -115,6 +115,7 @@ object Config {
 
         val graphQlJava = "com.graphql-java:graphql-java:17.3"
         val graphQlJava22 = "com.graphql-java:graphql-java:22.1"
+        val graphQlJavaNew = "com.graphql-java:graphql-java:24.0"
 
         val quartz = "org.quartz-scheduler:quartz:2.3.0"
 

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     testImplementation(Config.Libs.springBoot3StarterAop)
     testImplementation(Config.Libs.springBoot3StarterGraphql)
     testImplementation(Config.Libs.contextPropagation)
-    testImplementation(Config.Libs.graphQlJava22)
+    testImplementation(Config.Libs.graphQlJavaNew)
     testImplementation(projects.sentryReactor)
 }
 


### PR DESCRIPTION
#skip-changelog
## :scroll: Description
<!--- Describe your changes in detail -->
Use `graphql-java` v24 for Spring Boot 3.5

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Compilation error due to v22 of `graphql-java` being used.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
