### PR TITLE
Fix remove javadocs from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all clean compile javadocs dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease assembleUiTestCriticalRelease createCoverageReports runUiTestCritical check preMerge publish
+.PHONY: all clean compile dryRelease update stop checkFormat format api assembleBenchmarkTestRelease assembleUiTestRelease assembleUiTestCriticalRelease createCoverageReports runUiTestCritical check preMerge publish
 
-all: stop clean javadocs compile createCoverageReports
+all: stop clean compile createCoverageReports
 assembleBenchmarks: assembleBenchmarkTestRelease
 assembleUiTests: assembleUiTestRelease
 preMerge: check createCoverageReports
@@ -15,12 +15,9 @@ clean:
 compile:
 	./gradlew build
 
-javadocs:
-	./gradlew aggregateJavadocs
-
 # do a dry release (like a local deploy)
 dryRelease:
-	./gradlew aggregateJavadocs distZip --no-build-cache --no-configuration-cache
+	./gradlew distZip --no-build-cache --no-configuration-cache
 
 # check for dependencies update
 update:


### PR DESCRIPTION
## :scroll: Description
Follow up to https://github.com/getsentry/sentry-java/pull/4445

Note: This is a temporary solution to unblock CI.

## :bulb: Motivation and Context

Working CI

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
