### PR TITLE
Aggregate javadoc using build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/sentry.javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/sentry.javadoc.gradle.kts
@@ -1,0 +1,28 @@
+val javadocConfig : Configuration by configurations.creating {
+    isCanBeResolved = false
+    isCanBeConsumed = true
+
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named("javadoc"))
+    }
+}
+
+tasks.withType<Javadoc>().configureEach {
+    setDestinationDir(project.layout.buildDirectory.file("docs/javadoc").get().asFile)
+    title = "${project.name} $version API"
+    val opts = options as StandardJavadocDocletOptions
+    opts.quiet()
+    opts.encoding = "UTF-8"
+    opts.memberLevel = JavadocMemberLevel.PROTECTED
+    opts.stylesheetFile(rootProject.project.layout.projectDirectory.file("docs/stylesheet.css").asFile)
+    opts.links = listOf(
+        "https://docs.oracle.com/javase/8/docs/api/",
+        "https://docs.spring.io/spring-framework/docs/current/javadoc-api/",
+        "https://docs.spring.io/spring-boot/docs/current/api/"
+    )
+}
+
+artifacts {
+    add(javadocConfig.name, tasks.named("javadoc"))
+}

--- a/sentry-apache-http-client-5/build.gradle.kts
+++ b/sentry-apache-http-client-5/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-apollo-3/build.gradle.kts
+++ b/sentry-apollo-3/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-apollo-4/build.gradle.kts
+++ b/sentry-apollo-4/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-apollo/build.gradle.kts
+++ b/sentry-apollo/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-graphql-22/build.gradle.kts
+++ b/sentry-graphql-22/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-graphql-core/build.gradle.kts
+++ b/sentry-graphql-core/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-graphql/build.gradle.kts
+++ b/sentry-graphql/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-jdbc/build.gradle.kts
+++ b/sentry-jdbc/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-jul/build.gradle.kts
+++ b/sentry-jul/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-kotlin-extensions/build.gradle.kts
+++ b/sentry-kotlin-extensions/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-log4j2/build.gradle.kts
+++ b/sentry-log4j2/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-logback/build.gradle.kts
+++ b/sentry-logback/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-okhttp/build.gradle.kts
+++ b/sentry-okhttp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `java-library`
     kotlin("jvm")
     jacoco
+    id("sentry.javadoc")
     alias(libs.plugins.errorprone)
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.buildconfig)

--- a/sentry-openfeign/build.gradle.kts
+++ b/sentry-openfeign/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agent/build.gradle.kts
@@ -2,6 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     id("com.gradleup.shadow") version "8.3.6"
 }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless-spring/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless-spring/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("sentry.javadoc")
     alias(libs.plugins.buildconfig)
 }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentless/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("sentry.javadoc")
     alias(libs.plugins.buildconfig)
 }
 

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-quartz/build.gradle.kts
+++ b/sentry-quartz/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-reactor/build.gradle.kts
+++ b/sentry-reactor/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-servlet-jakarta/build.gradle.kts
+++ b/sentry-servlet-jakarta/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-servlet/build.gradle.kts
+++ b/sentry-servlet/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-spring-boot-jakarta/build.gradle.kts
@@ -4,6 +4,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring-boot-starter-jakarta/build.gradle.kts
+++ b/sentry-spring-boot-starter-jakarta/build.gradle.kts
@@ -4,6 +4,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -4,6 +4,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring-boot/build.gradle.kts
+++ b/sentry-spring-boot/build.gradle.kts
@@ -4,6 +4,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -5,6 +5,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-spring/build.gradle.kts
+++ b/sentry-spring/build.gradle.kts
@@ -5,6 +5,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-system-test-support/build.gradle.kts
+++ b/sentry-system-test-support/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry-test-support/build.gradle.kts
+++ b/sentry-test-support/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `java-library`
+    id("sentry.javadoc")
     kotlin("jvm")
     jacoco
     alias(libs.plugins.errorprone)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "sentry-root"
 rootProject.buildFileName = "build.gradle.kts"
-
+includeBuild("build-logic")
 include(
     "sentry",
     "sentry-kotlin-extensions",


### PR DESCRIPTION
## :scroll: Description

This creates a new convention plugin `sentry.javadoc` that
publishes the javadoc to a consumable configuration. The consumable
configuration is then consumed in the root project in order to aggregate
the javadocs of all subprojects.

The producer/consumer configuration is based on this blog post: https://www.liutikas.net/2024/12/11/Together-In-Isolation.html
It should be project isolation compatible.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
