### PR TITLE
New User Feedback Widget

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -394,6 +394,14 @@ public final class io/sentry/android/core/SentryUserFeedbackDialog : android/app
 	public fun show ()V
 }
 
+public class io/sentry/android/core/SentryUserFeedbackWidget : android/widget/Button {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public fun setOnClickListener (Landroid/view/View$OnClickListener;)V
+}
+
 public class io/sentry/android/core/SpanFrameMetricsCollector : io/sentry/IPerformanceContinuousCollector, io/sentry/android/core/internal/util/SentryFrameMetricsCollector$FrameMetricsCollectorListener {
 	protected final field lock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/android/core/internal/util/SentryFrameMetricsCollector;)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackWidget.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackWidget.java
@@ -1,0 +1,121 @@
+package io.sentry.android.core;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.widget.Button;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SentryUserFeedbackWidget extends Button {
+
+  private @Nullable OnClickListener delegate;
+
+  public SentryUserFeedbackWidget(Context context) {
+    super(context);
+    init(context, null, 0, 0);
+  }
+
+  public SentryUserFeedbackWidget(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    init(context, attrs, 0, 0);
+  }
+
+  public SentryUserFeedbackWidget(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    init(context, attrs, defStyleAttr, 0);
+  }
+
+  public SentryUserFeedbackWidget(
+      Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(context, attrs, defStyleAttr, defStyleRes);
+    init(context, attrs, defStyleAttr, defStyleRes);
+  }
+
+  @SuppressLint("SetTextI18n")
+  @SuppressWarnings("deprecation")
+  private void init(
+      final @NotNull Context context,
+      final @Nullable AttributeSet attrs,
+      final int defStyleAttr,
+      final int defStyleRes) {
+    try (final @NotNull TypedArray typedArray =
+            context.obtainStyledAttributes(
+                attrs, R.styleable.SentryUserFeedbackWidget, defStyleAttr, defStyleRes)) {
+      final float dimensionScale = context.getResources().getDisplayMetrics().density;
+      final float drawablePadding =
+          typedArray.getDimension(R.styleable.SentryUserFeedbackWidget_android_drawablePadding, -1);
+      final int drawableStart =
+          typedArray.getResourceId(R.styleable.SentryUserFeedbackWidget_android_drawableStart, -1);
+      final boolean textAllCaps =
+          typedArray.getBoolean(R.styleable.SentryUserFeedbackWidget_android_textAllCaps, false);
+      final int background =
+          typedArray.getResourceId(R.styleable.SentryUserFeedbackWidget_android_background, -1);
+      final float padding =
+          typedArray.getDimension(R.styleable.SentryUserFeedbackWidget_android_padding, -1);
+      final int textColor =
+          typedArray.getColor(R.styleable.SentryUserFeedbackWidget_android_textColor, -1);
+      final @Nullable String text =
+          typedArray.getString(R.styleable.SentryUserFeedbackWidget_android_text);
+
+      // If the drawable padding is not set, set it to 4dp
+      if (drawablePadding == -1) {
+        setCompoundDrawablePadding((int) (4 * dimensionScale));
+      }
+
+      // If the drawable start is not set, set it to the default drawable
+      if (drawableStart == -1) {
+        setCompoundDrawablesRelativeWithIntrinsicBounds(R.drawable.baseline_campaign_24, 0, 0, 0);
+      }
+
+      // Set the text all caps
+      setAllCaps(textAllCaps);
+
+      // If the background is not set, set it to the default background
+      if (background == -1) {
+        setBackgroundResource(R.drawable.oval_button_ripple_background);
+      }
+
+      // If the padding is not set, set it to 12dp
+      if (padding == -1) {
+        int defaultPadding = (int) (12 * dimensionScale);
+        setPadding(defaultPadding, defaultPadding, defaultPadding, defaultPadding);
+      }
+
+      // If the text color is not set, set it to the default text color
+      if (textColor == -1) {
+        // We need the TypedValue to resolve the color from the theme
+        final @NotNull TypedValue typedValue = new TypedValue();
+        context.getTheme().resolveAttribute(android.R.attr.colorForeground, typedValue, true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          setTextColor(context.getResources().getColor(typedValue.resourceId, context.getTheme()));
+        } else {
+          setTextColor(context.getResources().getColor(typedValue.resourceId));
+        }
+      }
+
+      // If the text is not set, set it to "Report a Bug"
+      if (text == null) {
+        setText("Report a Bug");
+      }
+    }
+
+    // Set the default ClickListener to open the SentryUserFeedbackDialog
+    setOnClickListener(delegate);
+  }
+
+  @Override
+  public void setOnClickListener(final @Nullable OnClickListener listener) {
+    delegate = listener;
+    super.setOnClickListener(
+        v -> {
+          new SentryUserFeedbackDialog(getContext()).show();
+          if (delegate != null) {
+            delegate.onClick(v);
+          }
+        });
+  }
+}

--- a/sentry-android-core/src/main/res/drawable/baseline_campaign_24.xml
+++ b/sentry-android-core/src/main/res/drawable/baseline_campaign_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?android:attr/colorForeground" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="?android:attr/colorForeground" android:pathData="M18,11v2h4v-2h-4zM16,17.61c0.96,0.71 2.21,1.65 3.2,2.39 0.4,-0.53 0.8,-1.07 1.2,-1.6 -0.99,-0.74 -2.24,-1.68 -3.2,-2.4 -0.4,0.54 -0.8,1.08 -1.2,1.61zM20.4,5.6c-0.4,-0.53 -0.8,-1.07 -1.2,-1.6 -0.99,0.74 -2.24,1.68 -3.2,2.4 0.4,0.53 0.8,1.07 1.2,1.6 0.96,-0.72 2.21,-1.65 3.2,-2.4zM4,9c-1.1,0 -2,0.9 -2,2v2c0,1.1 0.9,2 2,2h1v4h2v-4h1l5,3L13,6L8,9L4,9zM15.5,12c0,-1.33 -0.58,-2.53 -1.5,-3.35v6.69c0.92,-0.81 1.5,-2.01 1.5,-3.34z"/>
+
+</vector>

--- a/sentry-android-core/src/main/res/drawable/oval_button_ripple_background.xml
+++ b/sentry-android-core/src/main/res/drawable/oval_button_ripple_background.xml
@@ -1,0 +1,10 @@
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+  android:color="?android:attr/colorControlHighlight">
+
+  <item>
+    <shape android:shape="rectangle">
+      <solid android:color="?android:attr/colorBackground" />
+      <corners android:radius="50dp" />
+    </shape>
+  </item>
+</ripple>

--- a/sentry-android-core/src/main/res/values/attrs.xml
+++ b/sentry-android-core/src/main/res/values/attrs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="SentryUserFeedbackWidget" >
+    <attr name="android:drawableStart" format="reference" />
+    <attr name="android:drawablePadding" format="dimension" />
+    <attr name="android:padding" format="dimension" />
+    <attr name="android:textAllCaps" format="boolean" />
+    <attr name="android:background" format="reference|color" />
+    <attr name="android:textColor" format="reference|color" />
+    <attr name="android:text" format="string" />
+  </declare-styleable>
+</resources>

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
@@ -1,7 +1,10 @@
 package io.sentry.uitest.android
 
+import android.graphics.Color
+import android.util.TypedValue
 import android.view.View
 import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -24,8 +27,10 @@ import io.sentry.SentryOptions
 import io.sentry.android.core.AndroidLogger
 import io.sentry.android.core.R
 import io.sentry.android.core.SentryUserFeedbackDialog
+import io.sentry.android.core.SentryUserFeedbackWidget
 import io.sentry.assertEnvelopeFeedback
 import io.sentry.protocol.User
+import io.sentry.test.getProperty
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -34,6 +39,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -517,6 +523,95 @@ class UserFeedbackUiTest : BaseUiTest() {
         }
     }
 
+    @Test
+    fun userFeedbackWidgetDefaults() {
+        initSentry()
+        var widgetId = 0
+        showWidgetAndCheck { widget ->
+            widgetId = widget.id
+            val densityScale = context.resources.displayMetrics.density
+            assertEquals((densityScale * 4).toInt(), widget.compoundDrawablePadding)
+
+            assertNotNull(widget.compoundDrawables[0]) // Drawable left
+            assertNull(widget.compoundDrawables[1]) // Drawable top
+            assertNull(widget.compoundDrawables[2]) // Drawable right
+            assertNull(widget.compoundDrawables[3]) // Drawable bottom
+
+            // Couldn't find a reliable way to check the drawable, so i'll skip it
+
+            assertFalse(widget.isAllCaps)
+
+            assertEquals(R.drawable.oval_button_ripple_background, widget.getProperty<Int>("mBackgroundResource"))
+
+            assertEquals((densityScale * 12).toInt(), widget.paddingStart)
+            assertEquals((densityScale * 12).toInt(), widget.paddingEnd)
+            assertEquals((densityScale * 12).toInt(), widget.paddingTop)
+            assertEquals((densityScale * 12).toInt(), widget.paddingBottom)
+
+            val typedValue = TypedValue()
+            widget.context.theme.resolveAttribute(android.R.attr.colorForeground, typedValue, true)
+            assertEquals(typedValue.data, widget.currentTextColor)
+
+            assertEquals("Report a Bug", widget.text)
+        }
+
+        onView(withId(widgetId)).perform(click())
+        // Check that the user feedback dialog is shown
+        checkViewVisibility(R.id.sentry_dialog_user_feedback_layout)
+    }
+
+    @Test
+    fun userFeedbackWidgetDefaultsOverridden() {
+        initSentry()
+        showWidgetAndCheck({ widget ->
+            widget.compoundDrawablePadding = 1
+            widget.setCompoundDrawables(null, null, null, null)
+            widget.isAllCaps = true
+            widget.setBackgroundResource(R.drawable.edit_text_border)
+            widget.setTextColor(Color.RED)
+            widget.text = "My custom text"
+            widget.setPadding(0, 0, 0, 0)
+        }) { widget ->
+            val densityScale = context.resources.displayMetrics.density
+            assertEquals(1, widget.compoundDrawablePadding)
+
+            assertNull(widget.compoundDrawables[0]) // Drawable left
+            assertNull(widget.compoundDrawables[1]) // Drawable top
+            assertNull(widget.compoundDrawables[2]) // Drawable right
+            assertNull(widget.compoundDrawables[3]) // Drawable bottom
+
+            assertTrue(widget.isAllCaps)
+
+            assertEquals(R.drawable.edit_text_border, widget.getProperty<Int>("mBackgroundResource"))
+
+            assertEquals((densityScale * 0).toInt(), widget.paddingStart)
+            assertEquals((densityScale * 0).toInt(), widget.paddingEnd)
+            assertEquals((densityScale * 0).toInt(), widget.paddingTop)
+            assertEquals((densityScale * 0).toInt(), widget.paddingBottom)
+
+            assertEquals(Color.RED, widget.currentTextColor)
+
+            assertEquals("My custom text", widget.text)
+        }
+    }
+
+    @Test
+    fun userFeedbackWidgetShowsDialogOnClickOverridden() {
+        initSentry()
+        var widgetId = 0
+        var customListenerCalled = false
+        showWidgetAndCheck { widget ->
+            widgetId = widget.id
+            widget.setOnClickListener { customListenerCalled = true }
+        }
+
+        onView(withId(widgetId)).perform(click())
+        // Check that the user feedback dialog is shown
+        checkViewVisibility(R.id.sentry_dialog_user_feedback_layout)
+        // And the custom listener is called, too
+        assertTrue(customListenerCalled)
+    }
+
     private fun checkViewVisibility(viewId: Int, isGone: Boolean = false) {
         onView(withId(viewId))
             .check(matches(withEffectiveVisibility(if (isGone) Visibility.GONE else Visibility.VISIBLE)))
@@ -556,6 +651,29 @@ class UserFeedbackUiTest : BaseUiTest() {
             .check(matches(isDisplayed()))
 
         checker(dialog)
+    }
+
+    private fun showWidgetAndCheck(widgetConfig: ((widget: SentryUserFeedbackWidget) -> Unit)? = null, checker: (widget: SentryUserFeedbackWidget) -> Unit = {}) {
+        val buttonId = Int.MAX_VALUE - 1
+        val feedbackScenario = launchActivity<EmptyActivity>()
+        feedbackScenario.onActivity {
+            val view = LinearLayout(it).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(
+                    SentryUserFeedbackWidget(it).apply {
+                        id = buttonId
+                        widgetConfig?.invoke(this)
+                    }
+                )
+            }
+            it.setContentView(view)
+        }
+        checkViewVisibility(buttonId)
+        onView(withId(buttonId))
+            .check(matches(isDisplayed()))
+            .check { view, _ ->
+                checker(view as SentryUserFeedbackWidget)
+            }
     }
 
     fun withError(expectedError: String): Matcher<View> {

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -8,8 +8,8 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.MeasurementUnit;
 import io.sentry.Sentry;
-import io.sentry.android.core.SentryUserFeedbackDialog;
 import io.sentry.instrumentation.file.SentryFileOutputStream;
+import io.sentry.protocol.Feedback;
 import io.sentry.protocol.User;
 import io.sentry.samples.android.compose.ComposeActivity;
 import io.sentry.samples.android.databinding.ActivityMainBinding;
@@ -69,7 +69,11 @@ public class MainActivity extends AppCompatActivity {
 
     binding.sendUserFeedback.setOnClickListener(
         view -> {
-          new SentryUserFeedbackDialog(this).show();
+          Feedback feedback =
+              new Feedback("It broke on Android. I don't know why, but this happens.");
+          feedback.setContactEmail("john@me.com");
+          feedback.setName("John Me");
+          Sentry.captureFeedback(feedback);
         });
 
     binding.addAttachment.setOnClickListener(

--- a/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/layout/activity_main.xml
@@ -22,6 +22,10 @@
       android:layout_height="wrap_content"
       android:text="@string/send_message" />
 
+    <io.sentry.android.core.SentryUserFeedbackWidget
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"/>
+
     <Button
       android:id="@+id/send_user_feedback"
       android:layout_width="wrap_content"


### PR DESCRIPTION
## :scroll: Description
Added SentryUserFeedbackWidget, with styles and icon
MainActivity sendFeedback reverted to call API, with new widget to open dialog
Added widget ui tests


## :bulb: Motivation and Context
Implements last part of https://github.com/getsentry/sentry-java/issues/3613


## :green_heart: How did you test it?
UI tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
