### PR TITLE
[SR] Remove configuration from start() method

### DIFF
--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -52,11 +52,11 @@ public final class io/sentry/android/replay/ReplayCache : java/io/Closeable {
 	public static synthetic fun createVideoOf$default (Lio/sentry/android/replay/ReplayCache;JJIIIIILjava/io/File;ILjava/lang/Object;)Lio/sentry/android/replay/GeneratedVideo;
 }
 
-public final class io/sentry/android/replay/ReplayIntegration : android/content/ComponentCallbacks, io/sentry/IConnectionStatusProvider$IConnectionStatusObserver, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, io/sentry/android/replay/WindowCallback, io/sentry/android/replay/gestures/TouchRecorderCallback, io/sentry/transport/RateLimiter$IRateLimitObserver, java/io/Closeable {
+public final class io/sentry/android/replay/ReplayIntegration : io/sentry/IConnectionStatusProvider$IConnectionStatusObserver, io/sentry/Integration, io/sentry/ReplayController, io/sentry/android/replay/ScreenshotRecorderCallback, io/sentry/android/replay/WindowCallback, io/sentry/android/replay/gestures/TouchRecorderCallback, io/sentry/transport/RateLimiter$IRateLimitObserver, java/io/Closeable {
 	public static final field $stable I
 	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;)V
-	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Landroid/content/Context;Lio/sentry/transport/ICurrentDateProvider;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun captureReplay (Ljava/lang/Boolean;)V
 	public fun close ()V
 	public fun disableDebugMaskingOverlay ()V
@@ -66,9 +66,8 @@ public final class io/sentry/android/replay/ReplayIntegration : android/content/
 	public fun getReplayId ()Lio/sentry/protocol/SentryId;
 	public fun isDebugMaskingOverlayEnabled ()Z
 	public fun isRecording ()Z
-	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
+	public final fun onConfigurationChanged (Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
 	public fun onConnectionStatusChanged (Lio/sentry/IConnectionStatusProvider$ConnectionStatus;)V
-	public fun onLowMemory ()V
 	public fun onRateLimitChanged (Lio/sentry/transport/RateLimiter;)V
 	public fun onScreenshotRecorded (Landroid/graphics/Bitmap;)V
 	public fun onScreenshotRecorded (Ljava/io/File;J)V

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -34,10 +34,11 @@ public final class io/sentry/android/replay/ModifierExtensionsKt {
 }
 
 public abstract interface class io/sentry/android/replay/Recorder : java/io/Closeable {
+	public abstract fun onConfigurationChanged (Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
 	public abstract fun pause ()V
 	public abstract fun reset ()V
 	public abstract fun resume ()V
-	public abstract fun start (Lio/sentry/android/replay/ScreenshotRecorderConfig;)V
+	public abstract fun start ()V
 	public abstract fun stop ()V
 }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/Recorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/Recorder.kt
@@ -8,7 +8,9 @@ public interface Recorder : Closeable {
      * at which the screenshots should be taken, and the screenshots size/resolution, which can
      * change e.g. in the case of orientation change or window size change
      */
-    public fun start(recorderConfig: ScreenshotRecorderConfig)
+    public fun start()
+
+    public fun onConfigurationChanged(config: ScreenshotRecorderConfig)
 
     public fun resume()
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -190,6 +190,9 @@ public class ReplayIntegration(
             } else {
                 BufferCaptureStrategy(options, scopes, dateProvider, random, replayExecutor, replayCacheProvider)
             }
+            recorder?.start()
+            captureStrategy?.start()
+
             registerRootViewListeners()
         }
     }
@@ -331,9 +334,6 @@ public class ReplayIntegration(
         }
 
         recorder?.stop()
-
-        // once the window size is determined
-        // onWindowSizeChanged is triggered and we'll start the actual capturing
     }
 
     override fun onConnectionStatusChanged(status: ConnectionStatus) {
@@ -470,18 +470,9 @@ public class ReplayIntegration(
             return
         }
 
-        recorder?.stop()
-
         val recorderConfig = recorderConfigProvider?.invoke(true) ?: ScreenshotRecorderConfig.fromSize(context, options.sessionReplay, width, height)
-
-        captureStrategy?.let { capture ->
-            if (capture.currentReplayId == SentryId.EMPTY_ID) {
-                capture.start(recorderConfig)
-            } else {
-                capture.onConfigurationChanged(recorderConfig)
-            }
-        }
-        recorder?.start(recorderConfig)
+        captureStrategy?.onConfigurationChanged(recorderConfig)
+        recorder?.onConfigurationChanged(recorderConfig)
 
         // we have to restart recorder with a new config and pause immediately if the replay is paused
         if (lifecycle.currentState == PAUSED) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -1,8 +1,6 @@
 package io.sentry.android.replay
 
-import android.content.ComponentCallbacks
 import android.content.Context
-import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.os.Build
 import android.view.MotionEvent
@@ -60,14 +58,12 @@ public class ReplayIntegration(
     private val context: Context,
     private val dateProvider: ICurrentDateProvider,
     private val recorderProvider: (() -> Recorder)? = null,
-    private val recorderConfigProvider: ((configChanged: Boolean) -> ScreenshotRecorderConfig)? = null,
     private val replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null
 ) : Integration,
     Closeable,
     ScreenshotRecorderCallback,
     TouchRecorderCallback,
     ReplayController,
-    ComponentCallbacks,
     IConnectionStatusObserver,
     IRateLimitObserver,
     WindowCallback {
@@ -84,7 +80,6 @@ public class ReplayIntegration(
         context.appContext(),
         dateProvider,
         null,
-        null,
         null
     )
 
@@ -92,12 +87,11 @@ public class ReplayIntegration(
         context: Context,
         dateProvider: ICurrentDateProvider,
         recorderProvider: (() -> Recorder)?,
-        recorderConfigProvider: ((configChanged: Boolean) -> ScreenshotRecorderConfig)?,
         replayCacheProvider: ((replayId: SentryId) -> ReplayCache)?,
         replayCaptureStrategyProvider: ((isFullSession: Boolean) -> CaptureStrategy)? = null,
         mainLooperHandler: MainLooperHandler? = null,
         gestureRecorderProvider: (() -> GestureRecorder)? = null
-    ) : this(context.appContext(), dateProvider, recorderProvider, recorderConfigProvider, replayCacheProvider) {
+    ) : this(context.appContext(), dateProvider, recorderProvider, replayCacheProvider) {
         this.replayCaptureStrategyProvider = replayCaptureStrategyProvider
         this.mainLooperHandler = mainLooperHandler ?: MainLooperHandler()
         this.gestureRecorderProvider = gestureRecorderProvider
@@ -146,16 +140,6 @@ public class ReplayIntegration(
 
         options.connectionStatusProvider.addConnectionStatusObserver(this)
         scopes.rateLimiter?.addRateLimitObserver(this)
-        if (options.sessionReplay.isTrackOrientationChange) {
-            try {
-                context.registerComponentCallbacks(this)
-            } catch (e: Throwable) {
-                options.logger.log(
-                    INFO,
-                    "ComponentCallbacks is not available, orientation changes won't be handled by Session replay"
-                )
-            }
-        }
 
         addIntegrationToSdkVersion("Replay")
 
@@ -313,12 +297,6 @@ public class ReplayIntegration(
 
             options.connectionStatusProvider.removeConnectionStatusObserver(this)
             scopes?.rateLimiter?.removeRateLimitObserver(this)
-            if (options.sessionReplay.isTrackOrientationChange) {
-                try {
-                    context.unregisterComponentCallbacks(this)
-                } catch (ignored: Throwable) {
-                }
-            }
             stop()
             recorder?.close()
             recorder = null
@@ -326,14 +304,6 @@ public class ReplayIntegration(
             replayExecutor.gracefullyShutdown(options)
             lifecycle.currentState = CLOSED
         }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        if (!isEnabled.get() || !isRecording()) {
-            return
-        }
-
-        recorder?.stop()
     }
 
     override fun onConnectionStatusChanged(status: ConnectionStatus) {
@@ -362,8 +332,6 @@ public class ReplayIntegration(
             resumeInternal()
         }
     }
-
-    override fun onLowMemory(): Unit = Unit
 
     override fun onTouchEvent(event: MotionEvent) {
         if (!isEnabled.get() || !lifecycle.isTouchRecordingAllowed()) {
@@ -469,10 +437,19 @@ public class ReplayIntegration(
         if (!isEnabled.get() || !isRecording()) {
             return
         }
+        if (options.sessionReplay.isTrackConfiguration) {
+            val recorderConfig =
+                ScreenshotRecorderConfig.fromSize(context, options.sessionReplay, width, height)
+            onConfigurationChanged(recorderConfig)
+        }
+    }
 
-        val recorderConfig = recorderConfigProvider?.invoke(true) ?: ScreenshotRecorderConfig.fromSize(context, options.sessionReplay, width, height)
-        captureStrategy?.onConfigurationChanged(recorderConfig)
-        recorder?.onConfigurationChanged(recorderConfig)
+    public fun onConfigurationChanged(config: ScreenshotRecorderConfig) {
+        if (!isEnabled.get() || !isRecording()) {
+            return
+        }
+        captureStrategy?.onConfigurationChanged(config)
+        recorder?.onConfigurationChanged(config)
 
         // we have to restart recorder with a new config and pause immediately if the replay is paused
         if (lifecycle.currentState == PAUSED) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -96,13 +96,13 @@ internal class WindowRecorder(
         isRecording.getAndSet(true)
     }
 
-    override fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig) {
+    override fun onConfigurationChanged(config: ScreenshotRecorderConfig) {
         if (!isRecording.get()) {
             return
         }
 
         recorder = ScreenshotRecorder(
-            recorderConfig,
+            config,
             options,
             mainLooperHandler,
             replayExecutor,
@@ -119,7 +119,7 @@ internal class WindowRecorder(
             options,
             "$TAG.capture",
             100L, // delay the first run by a bit, to allow root view listener to register
-            1000L / recorderConfig.frameRate,
+            1000L / config.frameRate,
             MILLISECONDS
         ) {
             recorder?.capture()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -92,8 +92,12 @@ internal class WindowRecorder(
         }
     }
 
-    override fun start(recorderConfig: ScreenshotRecorderConfig) {
-        if (isRecording.getAndSet(true)) {
+    override fun start() {
+        isRecording.getAndSet(true)
+    }
+
+    override fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig) {
+        if (!isRecording.get()) {
             return
         }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -61,7 +61,7 @@ internal abstract class BaseCaptureStrategy(
 
     protected val isTerminating = AtomicBoolean(false)
     protected var cache: ReplayCache? = null
-    protected var recorderConfig: ScreenshotRecorderConfig by persistableAtomic { _, _, newValue ->
+    protected var recorderConfig: ScreenshotRecorderConfig? by persistableAtomic { _, _, newValue ->
         if (newValue == null) {
             // recorderConfig is only nullable on init, but never after
             return@persistableAtomic
@@ -85,7 +85,6 @@ internal abstract class BaseCaptureStrategy(
     protected val currentEvents: Deque<RRWebEvent> = ConcurrentLinkedDeque()
 
     override fun start(
-        recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int,
         replayId: SentryId,
         replayType: ReplayType?
@@ -95,7 +94,6 @@ internal abstract class BaseCaptureStrategy(
         this.currentReplayId = replayId
         this.currentSegment = segmentId
         this.replayType = replayType ?: (if (this is SessionCaptureStrategy) SESSION else BUFFER)
-        this.recorderConfig = recorderConfig
 
         segmentTimestamp = DateUtils.getCurrentDateTime()
         replayStartTimestamp.set(dateProvider.currentTimeMillis)
@@ -122,10 +120,10 @@ internal abstract class BaseCaptureStrategy(
         segmentId: Int,
         height: Int,
         width: Int,
+        frameRate: Int,
+        bitRate: Int,
         replayType: ReplayType = this.replayType,
         cache: ReplayCache? = this.cache,
-        frameRate: Int = recorderConfig.frameRate,
-        bitRate: Int = recorderConfig.bitRate,
         screenAtStart: String? = this.screenAtStart,
         breadcrumbs: List<Breadcrumb>? = null,
         events: Deque<RRWebEvent> = this.currentEvents
@@ -153,9 +151,11 @@ internal abstract class BaseCaptureStrategy(
     }
 
     override fun onTouchEvent(event: MotionEvent) {
-        val rrwebEvents = gestureConverter.convert(event, recorderConfig)
-        if (rrwebEvents != null) {
-            currentEvents += rrwebEvents
+        recorderConfig?.let { config ->
+            val rrwebEvents = gestureConverter.convert(event, config)
+            if (rrwebEvents != null) {
+                currentEvents += rrwebEvents
+            }
         }
     }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -61,7 +61,7 @@ internal abstract class BaseCaptureStrategy(
 
     protected val isTerminating = AtomicBoolean(false)
     protected var cache: ReplayCache? = null
-    protected var recorderConfig: ScreenshotRecorderConfig? by persistableAtomic { _, _, newValue ->
+    protected var recorderConfig by persistableAtomicNullable<ScreenshotRecorderConfig> { _, _, newValue ->
         if (newValue == null) {
             // recorderConfig is only nullable on init, but never after
             return@persistableAtomic

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -61,10 +61,10 @@ internal abstract class BaseCaptureStrategy(
 
     protected val isTerminating = AtomicBoolean(false)
     protected var cache: ReplayCache? = null
-    protected var recorderConfig by persistableAtomicNullable<ScreenshotRecorderConfig> { _, _, newValue ->
+    protected var recorderConfig: ScreenshotRecorderConfig? by persistableAtomicNullable(propertyName = "") { _, _, newValue ->
         if (newValue == null) {
             // recorderConfig is only nullable on init, but never after
-            return@persistableAtomic
+            return@persistableAtomicNullable
         }
         cache?.persistSegmentValues(SEGMENT_KEY_HEIGHT, newValue.recordingHeight.toString())
         cache?.persistSegmentValues(SEGMENT_KEY_WIDTH, newValue.recordingWidth.toString())
@@ -210,9 +210,4 @@ internal abstract class BaseCaptureStrategy(
         }
     ): ReadWriteProperty<Any?, T> =
         persistableAtomicNullable<T>(initialValue, propertyName, onChange) as ReadWriteProperty<Any?, T>
-
-    private inline fun <T> persistableAtomic(
-        crossinline onChange: (propertyName: String?, oldValue: T?, newValue: T?) -> Unit
-    ): ReadWriteProperty<Any?, T> =
-        persistableAtomicNullable<T>(null, "", onChange) as ReadWriteProperty<Any?, T>
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -224,5 +224,4 @@ internal class BufferCaptureStrategy(
             onSegmentCreated(segment)
         }
     }
-
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -31,7 +31,6 @@ internal interface CaptureStrategy {
     var segmentTimestamp: Date?
 
     fun start(
-        recorderConfig: ScreenshotRecorderConfig,
         segmentId: Int = 0,
         replayId: SentryId = SentryId(),
         replayType: ReplayType? = null

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -141,26 +141,33 @@ internal class SessionCaptureStrategy(
     override fun convert(): CaptureStrategy = this
 
     private fun createCurrentSegment(taskName: String, onSegmentCreated: (ReplaySegment) -> Unit) {
-        recorderConfig?.let { config ->
-            val now = dateProvider.currentTimeMillis
-            val currentSegmentTimestamp = segmentTimestamp ?: return
-            val segmentId = currentSegment
-            val duration = now - currentSegmentTimestamp.time
-            val replayId = currentReplayId
-            replayExecutor.submitSafely(options, "$TAG.$taskName") {
-                val segment =
-                    createSegmentInternal(
-                        duration,
-                        currentSegmentTimestamp,
-                        replayId,
-                        segmentId,
-                        config.recordingHeight,
-                        config.recordingWidth,
-                        config.frameRate,
-                        config.bitRate
-                    )
-                onSegmentCreated(segment)
-            }
+        val currentConfig = recorderConfig
+        if (currentConfig == null) {
+            options.logger.log(
+                DEBUG,
+                "Recorder config is not set, not creating segment for task: $taskName"
+            )
+            return
+        }
+
+        val now = dateProvider.currentTimeMillis
+        val currentSegmentTimestamp = segmentTimestamp ?: return
+        val segmentId = currentSegment
+        val duration = now - currentSegmentTimestamp.time
+        val replayId = currentReplayId
+        replayExecutor.submitSafely(options, "$TAG.$taskName") {
+            val segment =
+                createSegmentInternal(
+                    duration,
+                    currentSegmentTimestamp,
+                    replayId,
+                    segmentId,
+                    currentConfig.recordingHeight,
+                    currentConfig.recordingWidth,
+                    currentConfig.frameRate,
+                    currentConfig.bitRate
+                )
+            onSegmentCreated(segment)
         }
     }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -62,7 +62,6 @@ import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -187,7 +186,7 @@ class ReplayIntegrationTest {
 
         replay.start()
 
-        verify(captureStrategy, never()).start(any(), any(), any(), anyOrNull())
+        verify(captureStrategy, never()).start(any(), any(), anyOrNull())
     }
 
     @Test
@@ -204,17 +203,13 @@ class ReplayIntegrationTest {
     @Test
     fun `starting two times does nothing`() {
         val captureStrategy = mock<CaptureStrategy>()
-        whenever(captureStrategy.currentReplayId).thenReturn(SentryId.EMPTY_ID)
-
         val replay = fixture.getSut(context, replayCaptureStrategyProvider = { captureStrategy })
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
         replay.start()
 
         verify(captureStrategy, times(1)).start(
-            any(),
             eq(0),
             argThat { this != SentryId.EMPTY_ID },
             anyOrNull()
@@ -230,7 +225,6 @@ class ReplayIntegrationTest {
         replay.start()
 
         verify(captureStrategy, never()).start(
-            any(),
             eq(0),
             argThat { this != SentryId.EMPTY_ID },
             anyOrNull()
@@ -240,16 +234,12 @@ class ReplayIntegrationTest {
     @Test
     fun `still starts replay when errorsSampleRate is set`() {
         val captureStrategy = mock<CaptureStrategy>()
-        whenever(captureStrategy.currentReplayId).thenReturn(SentryId.EMPTY_ID)
-
         val replay = fixture.getSut(context, sessionSampleRate = 0.0, replayCaptureStrategyProvider = { captureStrategy })
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
 
         verify(captureStrategy, times(1)).start(
-            any(),
             eq(0),
             argThat { this != SentryId.EMPTY_ID },
             anyOrNull()
@@ -263,9 +253,8 @@ class ReplayIntegrationTest {
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
 
-        verify(recorder).start(any())
+        verify(recorder).start()
     }
 
     @Test
@@ -453,14 +442,12 @@ class ReplayIntegrationTest {
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(480, 640)
-
         replay.onConfigurationChanged(mock())
         replay.onWindowSizeChanged(640, 480)
 
-        verify(recorder, times(3)).stop()
-        verify(captureStrategy, times(2)).onConfigurationChanged(eq(recorderConfig))
-        verify(recorder, times(2)).start(eq(recorderConfig))
+        verify(recorder).stop()
+        verify(captureStrategy).onConfigurationChanged(eq(recorderConfig))
+        verify(recorder, times(1)).start()
         assertTrue(configChanged)
     }
 
@@ -610,8 +597,6 @@ class ReplayIntegrationTest {
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
-
         replay.onScreenshotRecorded(mock<Bitmap>())
 
         verify(recorder).pause()
@@ -630,7 +615,6 @@ class ReplayIntegrationTest {
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
         replay.onScreenshotRecorded(mock<Bitmap>())
 
         verify(recorder).pause()
@@ -727,8 +711,6 @@ class ReplayIntegrationTest {
         var configChanged = false
         val recorderConfig = mock<ScreenshotRecorderConfig>()
         val captureStrategy = mock<CaptureStrategy>()
-        whenever(captureStrategy.currentReplayId).thenReturn(SentryId(UUID.randomUUID()))
-
         val recorder = mock<Recorder>()
         val replay = fixture.getSut(
             context,
@@ -739,15 +721,13 @@ class ReplayIntegrationTest {
 
         replay.register(fixture.scopes, fixture.options)
         replay.start()
-        replay.onWindowSizeChanged(640, 480)
-
         replay.pause()
         replay.onConfigurationChanged(mock())
-        replay.onWindowSizeChanged(480, 640)
+        replay.onWindowSizeChanged(640, 480)
 
-        verify(recorder, times(3)).stop()
-        verify(captureStrategy, times(2)).onConfigurationChanged(eq(recorderConfig))
-        verify(recorder, times(2)).start(eq(recorderConfig))
+        verify(recorder, times(1)).stop()
+        verify(captureStrategy).onConfigurationChanged(eq(recorderConfig))
+        verify(recorder, times(1)).start()
         verify(recorder, times(2)).pause()
         assertTrue(configChanged)
     }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -98,8 +98,12 @@ class ReplayIntegrationWithRecorderTest {
         val recorder = object : Recorder {
             var state: LifecycleState = INITALIZED
 
-            override fun start(recorderConfig: ScreenshotRecorderConfig) {
+            override fun start() {
                 state = STARTED
+            }
+
+            override fun onConfigurationChanged(config: ScreenshotRecorderConfig) {
+                // no-op
             }
 
             override fun resume() {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -57,14 +57,12 @@ class ReplayIntegrationWithRecorderTest {
         fun getSut(
             context: Context,
             recorder: Recorder,
-            recorderConfig: ScreenshotRecorderConfig,
             dateProvider: ICurrentDateProvider = CurrentDateProvider.getInstance()
         ): ReplayIntegration {
             return ReplayIntegration(
                 context,
                 dateProvider,
-                recorderProvider = { recorder },
-                recorderConfigProvider = { recorderConfig }
+                recorderProvider = { recorder }
             )
         }
     }
@@ -90,11 +88,11 @@ class ReplayIntegrationWithRecorderTest {
             System.currentTimeMillis() + fixture.options.sessionReplay.sessionSegmentDuration
         }
 
+        fixture.options.sessionReplay.isTrackConfiguration = false
         fixture.options.sessionReplay.sessionSampleRate = 1.0
         fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
 
         val replay: ReplayIntegration
-        val recorderConfig = ScreenshotRecorderConfig(100, 200, 1f, 1f, 1, 20_000)
         val recorder = object : Recorder {
             var state: LifecycleState = INITALIZED
 
@@ -127,27 +125,10 @@ class ReplayIntegrationWithRecorderTest {
             }
         }
 
-        replay = fixture.getSut(context, recorder, recorderConfig, dateProvider)
+        replay = fixture.getSut(context, recorder, dateProvider)
         replay.register(fixture.scopes, fixture.options)
 
         assertEquals(INITALIZED, recorder.state)
-
-        replay.start()
-        replay.onWindowSizeChanged(640, 480)
-        assertEquals(STARTED, recorder.state)
-
-        replay.pause()
-        assertEquals(PAUSED, recorder.state)
-
-        replay.resume()
-        assertEquals(RESUMED, recorder.state)
-
-        replay.stop()
-        assertEquals(STOPPED, recorder.state)
-
-        // start again and capture some frames
-        replay.start()
-        replay.onWindowSizeChanged(640, 480)
 
         // have to access 'replayCacheDir' after calling replay.start(), BUT can already be accessed
         // inside recorder.start()
@@ -157,6 +138,31 @@ class ReplayIntegrationWithRecorderTest {
             Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)
             it.flush()
         }
+
+        replay.start()
+
+        replay.onWindowSizeChanged(640, 480)
+        assertEquals(STARTED, recorder.state)
+
+        replay.pause()
+        assertEquals(PAUSED, recorder.state)
+
+        replay.resume()
+        assertEquals(RESUMED, recorder.state)
+
+        // this should be ignored, as no manual onConfigurationChanged was called so far
+        replay.onScreenshotRecorded(screenshot, frameTimestamp = 1)
+
+        replay.stop()
+        assertEquals(STOPPED, recorder.state)
+
+        // start again and capture some frames
+        replay.start()
+
+        // E.g. Flutter will trigger onConfigurationChanged
+        val flutterConfig = ScreenshotRecorderConfig(100, 200, 1f, 1f, 1, 20_000)
+        replay.onConfigurationChanged(flutterConfig)
+
         replay.onScreenshotRecorded(screenshot, frameTimestamp = 1)
 
         // verify
@@ -171,12 +177,12 @@ class ReplayIntegrationWithRecorderTest {
             },
             check {
                 val metaEvents = it.replayRecording?.payload?.filterIsInstance<RRWebMetaEvent>()
-                assertEquals(200, metaEvents?.first()?.height)
-                assertEquals(100, metaEvents?.first()?.width)
+                assertEquals(flutterConfig.recordingHeight, metaEvents?.first()?.height)
+                assertEquals(flutterConfig.recordingWidth, metaEvents?.first()?.width)
 
                 val videoEvents = it.replayRecording?.payload?.filterIsInstance<RRWebVideoEvent>()
-                assertEquals(200, videoEvents?.first()?.height)
-                assertEquals(100, videoEvents?.first()?.width)
+                assertEquals(flutterConfig.recordingHeight, videoEvents?.first()?.height)
+                assertEquals(flutterConfig.recordingWidth, videoEvents?.first()?.width)
                 assertEquals(5000, videoEvents?.first()?.durationMs)
                 assertEquals(5, videoEvents?.first()?.frameCount)
                 assertEquals(1, videoEvents?.first()?.frameRate)

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -130,6 +130,8 @@ class ReplayIntegrationWithRecorderTest {
 
         assertEquals(INITALIZED, recorder.state)
 
+        replay.start()
+
         // have to access 'replayCacheDir' after calling replay.start(), BUT can already be accessed
         // inside recorder.start()
         val screenshot = File(replay.replayCacheDir, "1.jpg").also { it.createNewFile() }
@@ -138,8 +140,6 @@ class ReplayIntegrationWithRecorderTest {
             Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)
             it.flush()
         }
-
-        replay.start()
 
         replay.onWindowSizeChanged(640, 480)
         assertEquals(STARTED, recorder.state)

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
@@ -78,7 +78,6 @@ class ReplaySmokeTest {
                 context,
                 dateProvider,
                 recorderProvider = null,
-                recorderConfigProvider = null,
                 replayCaptureStrategyProvider = null,
                 replayCacheProvider = null,
                 mainLooperHandler = mock {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -123,7 +123,7 @@ class BufferCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         assertEquals(SentryId.EMPTY_ID, fixture.scope.replayId)
         assertEquals(replayId, strategy.currentReplayId)
@@ -135,7 +135,7 @@ class BufferCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         assertEquals("0", fixture.persistedSegment[SEGMENT_KEY_ID])
         assertEquals(replayId.toString(), fixture.persistedSegment[SEGMENT_KEY_REPLAY_ID])
@@ -149,7 +149,8 @@ class BufferCaptureStrategyTest {
     @Test
     fun `pause creates but does not capture current segment`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig, 0, SentryId())
+        strategy.start(0, SentryId())
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.pause()
 
@@ -166,7 +167,7 @@ class BufferCaptureStrategyTest {
             File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
 
         val strategy = fixture.getSut(replayCacheDir = currentReplay)
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         strategy.stop()
 
@@ -185,7 +186,7 @@ class BufferCaptureStrategyTest {
         val strategy = fixture.getSut(
             dateProvider = { now }
         )
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) { frameTimestamp ->
             assertEquals(now, frameTimestamp)
@@ -199,7 +200,7 @@ class BufferCaptureStrategyTest {
         val strategy = fixture.getSut(
             dateProvider = { now }
         )
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) { frameTimestamp ->
             assertEquals(now, frameTimestamp)
@@ -210,7 +211,8 @@ class BufferCaptureStrategyTest {
     @Test
     fun `onConfigurationChanged creates new segment and updates config`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         val newConfig = fixture.recorderConfig.copy(recordingHeight = 1080, recordingWidth = 1920)
         strategy.onConfigurationChanged(newConfig)
@@ -224,7 +226,7 @@ class BufferCaptureStrategyTest {
     @Test
     fun `convert does nothing when process is terminating`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.captureReplay(true) {}
 
@@ -235,7 +237,7 @@ class BufferCaptureStrategyTest {
     @Test
     fun `convert converts to session strategy and sets replayId to scope`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         val converted = strategy.convert()
         assertTrue(converted is SessionCaptureStrategy)
@@ -245,7 +247,7 @@ class BufferCaptureStrategyTest {
     @Test
     fun `convert persists buffer replayType when converting to session strategy`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         val converted = strategy.convert()
         assertEquals(
@@ -257,7 +259,7 @@ class BufferCaptureStrategyTest {
     @Test
     fun `captureReplay does not replayId to scope when not sampled`() {
         val strategy = fixture.getSut(onErrorSampleRate = 0.0)
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.captureReplay(false) {}
 
@@ -268,7 +270,9 @@ class BufferCaptureStrategyTest {
     fun `captureReplay sets replayId to scope and captures buffered segments`() {
         var called = false
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
+
         strategy.pause()
 
         strategy.captureReplay(false) {
@@ -284,7 +288,9 @@ class BufferCaptureStrategyTest {
     @Test
     fun `captureReplay sets new segment timestamp to new strategy after successful creation`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
+
         val oldTimestamp = strategy.segmentTimestamp
 
         strategy.captureReplay(false) { newTimestamp ->
@@ -299,7 +305,7 @@ class BufferCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         assertEquals(
             replayId.toString(),

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -277,6 +277,7 @@ class SessionCaptureStrategyTest {
             }
         )
         strategy.start()
+        strategy.onConfigurationChanged(mock<ScreenshotRecorderConfig>())
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -122,7 +122,7 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         assertEquals(replayId, fixture.scope.replayId)
         assertEquals(replayId, strategy.currentReplayId)
@@ -134,7 +134,8 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         assertEquals("0", fixture.persistedSegment[SEGMENT_KEY_ID])
         assertEquals(replayId.toString(), fixture.persistedSegment[SEGMENT_KEY_REPLAY_ID])
@@ -164,7 +165,8 @@ class SessionCaptureStrategyTest {
     @Test
     fun `pause creates and captures current segment`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig, 0, SentryId())
+        strategy.start(0, SentryId())
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.pause()
 
@@ -184,7 +186,8 @@ class SessionCaptureStrategyTest {
             File(fixture.options.cacheDirPath, "replay_$replayId").also { it.mkdirs() }
 
         val strategy = fixture.getSut(replayCacheDir = currentReplay)
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.stop()
 
@@ -204,7 +207,7 @@ class SessionCaptureStrategyTest {
     @Test
     fun `captureReplay does nothing for non-crashed event`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.captureReplay(false) {}
 
@@ -218,7 +221,7 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut(
             dateProvider = { now }
         )
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.captureReplay(true) {}
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
@@ -233,7 +236,8 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut(
             dateProvider = { now }
         )
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) { frameTimestamp ->
             assertEquals(now, frameTimestamp)
@@ -272,7 +276,7 @@ class SessionCaptureStrategyTest {
                 }
             }
         )
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 
@@ -282,7 +286,8 @@ class SessionCaptureStrategyTest {
     @Test
     fun `onConfigurationChanged creates new segment and updates config`() {
         val strategy = fixture.getSut()
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         val newConfig = fixture.recorderConfig.copy(recordingHeight = 1080, recordingWidth = 1920)
         strategy.onConfigurationChanged(newConfig)
@@ -317,7 +322,8 @@ class SessionCaptureStrategyTest {
         val now =
             System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
         val strategy = fixture.getSut(dateProvider = { now })
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         fixture.scope.addBreadcrumb(Breadcrumb.navigation("from", "to"))
 
@@ -341,7 +347,8 @@ class SessionCaptureStrategyTest {
         val now =
             System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
         val strategy = fixture.getSut(dateProvider = { now })
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         fixture.scope.addBreadcrumb(Breadcrumb().apply { category = "navigation" })
 
@@ -367,7 +374,8 @@ class SessionCaptureStrategyTest {
         val now =
             System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
         val strategy = fixture.getSut(dateProvider = { now })
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 
@@ -388,7 +396,7 @@ class SessionCaptureStrategyTest {
         val strategy = fixture.getSut()
         val replayId = SentryId()
 
-        strategy.start(fixture.recorderConfig, 0, replayId)
+        strategy.start(0, replayId)
 
         assertEquals(
             replayId.toString(),
@@ -408,7 +416,8 @@ class SessionCaptureStrategyTest {
         val now =
             System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
         val strategy = fixture.getSut(dateProvider = { now })
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
 
@@ -452,7 +461,8 @@ class SessionCaptureStrategyTest {
         val now =
             System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
         val strategy = fixture.getSut(dateProvider = { now })
-        strategy.start(fixture.recorderConfig)
+        strategy.start()
+        strategy.onConfigurationChanged(fixture.recorderConfig)
 
         strategy.onScreenshotRecorded(mock<Bitmap>()) {}
         verify(fixture.scopes).captureReplay(

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3610,7 +3610,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun isDebug ()Z
 	public fun isSessionReplayEnabled ()Z
 	public fun isSessionReplayForErrorsEnabled ()Z
-	public fun isTrackOrientationChange ()Z
+	public fun isTrackConfiguration ()Z
 	public fun setDebug (Z)V
 	public fun setMaskAllImages (Z)V
 	public fun setMaskAllText (Z)V
@@ -3619,7 +3619,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun setQuality (Lio/sentry/SentryReplayOptions$SentryReplayQuality;)V
 	public fun setSdkVersion (Lio/sentry/protocol/SdkVersion;)V
 	public fun setSessionSampleRate (Ljava/lang/Double;)V
-	public fun setTrackOrientationChange (Z)V
+	public fun setTrackConfiguration (Z)V
 	public fun setUnmaskViewContainerClass (Ljava/lang/String;)V
 }
 

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -119,10 +119,13 @@ public final class SentryReplayOptions {
   private long sessionDuration = 60 * 60 * 1000L;
 
   /**
-   * Whether to track orientation changes in session replay. Used in Flutter as it has its own
-   * callbacks to determine the orientation change.
+   * Whether to track the screen configuration (e.g. window size, orientation, etc.) automatically.
+   * A valid configuration is required to capture a session replay. If set to false,
+   * ReplayIntegration.onConfigurationChanged() must be called manually to update the configuration.
+   *
+   * <p>Defaults to true.
    */
-  private boolean trackOrientationChange = true;
+  private boolean trackConfiguration = true;
 
   /**
    * SdkVersion object that contains the Sentry Client Name and its version. This object is only
@@ -300,13 +303,13 @@ public final class SentryReplayOptions {
   }
 
   @ApiStatus.Internal
-  public boolean isTrackOrientationChange() {
-    return trackOrientationChange;
+  public boolean isTrackConfiguration() {
+    return trackConfiguration;
   }
 
   @ApiStatus.Internal
-  public void setTrackOrientationChange(final boolean trackOrientationChange) {
-    this.trackOrientationChange = trackOrientationChange;
+  public void setTrackConfiguration(final boolean trackConfiguration) {
+    this.trackConfiguration = trackConfiguration;
   }
 
   @ApiStatus.Internal


### PR DESCRIPTION
## :scroll: Description

As we anyway have `onConfigurationChanged` now. This removes the need for odd constructs like this one

```Kotlin
captureStrategy?.let { capture ->
    if (capture.currentReplayId == SentryId.EMPTY_ID) {
        capture.start(recorderConfig)
    } else {
        capture.onConfigurationChanged(recorderConfig)
    }
}
```

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
