### PR TITLE
Migrate Androidx dependencies to version catalog

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -24,18 +24,9 @@ object Config {
 
     object Libs {
         val okHttpVersion = "4.9.2"
-        val appCompat = "androidx.appcompat:appcompat:1.3.0"
         val timber = "com.jakewharton.timber:timber:4.7.1"
         val okhttp = "com.squareup.okhttp3:okhttp:$okHttpVersion"
         val leakCanary = "com.squareup.leakcanary:leakcanary-android:2.14"
-        val constraintLayout = "androidx.constraintlayout:constraintlayout:2.1.3"
-
-        private val lifecycleVersion = "2.2.0"
-        val lifecycleProcess = "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
-        val lifecycleCommonJava8 = "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
-        val androidxSqlite = "androidx.sqlite:sqlite:2.3.1"
-        val androidxRecylerView = "androidx.recyclerview:recyclerview:1.2.1"
-        val androidxAnnotation = "androidx.annotation:annotation:1.9.1"
 
         val slf4jApi = "org.slf4j:slf4j-api:1.7.30"
         val slf4jApi2 = "org.slf4j:slf4j-api:2.0.5"
@@ -70,8 +61,6 @@ object Config {
         val coroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
 
         val coroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1"
-
-        val fragment = "androidx.fragment:fragment-ktx:1.3.5"
 
         val reactorCore = "io.projectreactor:reactor-core:3.5.3"
         val contextPropagation = "io.micrometer:context-propagation:1.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+androidxLifecycle = "2.2.0"
 androidxNavigation = "2.4.2"
 androidxTestCore = "1.6.1"
 androidxCompose = "1.6.3"
@@ -42,6 +43,8 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 gretty = { id = "org.gretty", version = "4.0.0" }
 
 [libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.3.0" }
+androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.8.2" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose" }
 androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidxCompose" }
@@ -49,10 +52,16 @@ androidx-compose-material3 = { module = "androidx.compose.material3:material3", 
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxCompose" }
 # Note: don't change without testing forwards compatibility
 androidx-compose-ui-replay = { module = "androidx.compose.ui:ui", version = "1.5.0" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.3" }
 androidx-core = { module = "androidx.core:core", version = "1.3.2" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.7.0" }
+androidx-fragment = { module = "androidx.fragment:fragment", version = "1.3.5" }
+androidx-lifecycle-common-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidxLifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidxNavigation" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
+androidx-sqlite = { module = "androidx.sqlite:sqlite", version = "2.3.1" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.2.1" }
 coil-compose = { module = "io.coil-kt:coil-compose", version = "2.6.0" }
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version = "2.11.0" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "23.0.0"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ androidx-compose-ui-replay = { module = "androidx.compose.ui:ui", version = "1.5
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.1.3" }
 androidx-core = { module = "androidx.core:core", version = "1.3.2" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.7.0" }
-androidx-fragment = { module = "androidx.fragment:fragment", version = "1.3.5" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version = "1.3.5" }
 androidx-lifecycle-common-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidxLifecycle" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidxLifecycle" }
 androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidxNavigation" }

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -85,8 +85,8 @@ dependencies {
     compileOnly(projects.sentryCompose)
 
     // lifecycle processor, session tracking
-    implementation(Config.Libs.lifecycleProcess)
-    implementation(Config.Libs.lifecycleCommonJava8)
+    implementation(libs.androidx.lifecycle.common.java8)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.core)
 
     errorprone(libs.errorprone.core)
@@ -111,6 +111,6 @@ dependencies {
     testImplementation(projects.sentryCompose)
     testImplementation(projects.sentryAndroidNdk)
     testRuntimeOnly(libs.androidx.compose.ui)
+    testRuntimeOnly(libs.androidx.fragment)
     testRuntimeOnly(Config.Libs.timber)
-    testRuntimeOnly(Config.Libs.fragment)
 }

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -111,6 +111,6 @@ dependencies {
     testImplementation(projects.sentryCompose)
     testImplementation(projects.sentryAndroidNdk)
     testRuntimeOnly(libs.androidx.compose.ui)
-    testRuntimeOnly(libs.androidx.fragment)
+    testRuntimeOnly(libs.androidx.fragment.ktx)
     testRuntimeOnly(Config.Libs.timber)
 }

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -65,10 +65,10 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    compileOnly(libs.androidx.fragment)
+    compileOnly(libs.androidx.fragment.ktx)
 
     // tests
-    testImplementation(libs.androidx.fragment)
+    testImplementation(libs.androidx.fragment.ktx)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockito.inline)

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -65,10 +65,10 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    compileOnly(Config.Libs.fragment)
+    compileOnly(libs.androidx.fragment)
 
     // tests
-    testImplementation(Config.Libs.fragment)
+    testImplementation(libs.androidx.fragment)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockito.inline)

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -86,10 +86,10 @@ android {
 dependencies {
     implementation(kotlin(Config.kotlinStdLib, org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION))
     implementation(projects.sentryAndroid)
-    implementation(Config.Libs.appCompat)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core)
-    implementation(Config.Libs.androidxRecylerView)
-    implementation(Config.Libs.constraintLayout)
+    implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.test.espresso.idling.resource)
 
     compileOnly(libs.nopen.annotations)

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
@@ -49,11 +49,11 @@ android {
 
 dependencies {
     implementation(kotlin(Config.kotlinStdLib, org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION))
-    implementation(libs.androidx.core)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
-    implementation(Config.Libs.constraintLayout)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.core)
     implementation(projects.sentryAndroidCore)
 }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -100,13 +100,13 @@ dependencies {
     } else {
         implementation(projects.sentryAndroidCore)
     }
-    implementation(Config.Libs.appCompat)
-    implementation(libs.androidx.core)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
-    implementation(Config.Libs.androidxRecylerView)
-    implementation(Config.Libs.constraintLayout)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.test.espresso.idling.resource)
     implementation(Config.Libs.leakCanary)
 

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -67,12 +67,12 @@ kotlin {
 dependencies {
     api(projects.sentry)
 
-    compileOnly(Config.Libs.androidxSqlite)
+    compileOnly(libs.androidx.sqlite)
 
     implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))
 
     // tests
-    testImplementation(Config.Libs.androidxSqlite)
+    testImplementation(libs.androidx.sqlite)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.mockito.kotlin)

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
                 api(projects.sentryAndroidNavigation)
 
                 compileOnly(libs.androidx.navigation.compose)
-                implementation(Config.Libs.lifecycleCommonJava8)
+                implementation(libs.androidx.lifecycle.common.java8)
             }
         }
         val androidUnitTest by getting {

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -163,7 +163,7 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.fragment)
+    implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.androidx.compose.material3)

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -145,8 +145,8 @@ dependencies {
     implementation(projects.sentryAndroidFragment)
     implementation(projects.sentryAndroidTimber)
     implementation(projects.sentryCompose)
+    implementation(projects.sentryKotlinExtensions)
     implementation(projects.sentryOkhttp)
-    implementation(Config.Libs.fragment)
     implementation(Config.Libs.timber)
 
 //    how to exclude androidx if release health feature is disabled
@@ -156,21 +156,20 @@ dependencies {
 //        exclude(group = "androidx.core", module = "core")
 //    }
 
-    implementation(Config.Libs.appCompat)
-    implementation(Config.Libs.androidxRecylerView)
+    implementation(Config.Libs.coroutinesAndroid)
     implementation(Config.Libs.retrofit2)
     implementation(Config.Libs.retrofit2Gson)
-
-    implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.compose.foundation)
-    implementation(libs.androidx.compose.foundation.layout)
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.coil.compose)
     implementation(Config.Libs.sentryNativeNdk)
 
-    implementation(projects.sentryKotlinExtensions)
-    implementation(Config.Libs.coroutinesAndroid)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.fragment)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.foundation.layout)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.recyclerview)
+    implementation(libs.coil.compose)
 
     debugImplementation(Config.Libs.leakCanary)
 }


### PR DESCRIPTION
## :scroll: Description
Version catalog adoption cont'd

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
