### PR TITLE
fix(ci): Fix update-sentry-native-ndk script to work with libs.versions.toml

### DIFF
--- a/scripts/update-sentry-native-ndk.sh
+++ b/scripts/update-sentry-native-ndk.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 cd $(dirname "$0")/../
-GRADLE_NDK_FILEPATH=buildSrc/src/main/java/Config.kt
+GRADLE_NDK_FILEPATH=gradle/libs.versions.toml
 
 case $1 in
 get-version)
-    perl -ne 'print "$1\n" if ( m/io\.sentry:sentry-native-ndk:([0-9.]+)+/ )' $GRADLE_NDK_FILEPATH
+    perl -ne 'print "$1\n" if ( m/module = "io\.sentry:sentry-native-ndk", version = "([0-9.]+)"/ )' "$GRADLE_NDK_FILEPATH"
     ;;
 get-repo)
     echo "https://github.com/getsentry/sentry-native.git"
@@ -16,8 +16,8 @@ set-version)
 
     echo "Setting sentry-native-ndk version to '$version'"
 
-    PATTERN="io\.sentry:sentry-native-ndk:([0-9.]+)+"
-    perl -pi -e "s/$PATTERN/io.sentry:sentry-native-ndk:$version/g" $GRADLE_NDK_FILEPATH
+    PATTERN='(module = "io\.sentry:sentry-native-ndk", version = ")[0-9.]+(")'
+    perl -pi -e "s/$PATTERN/\${1}$version\${2}/" "$GRADLE_NDK_FILEPATH"
     ;;
 *)
     echo "Unknown argument $1"


### PR DESCRIPTION
_#skip-changelog_

## :scroll: Description
<!--- Describe your changes in detail -->
- The script has been [failing](https://github.com/getsentry/sentry-java/actions/runs/15439442783/job/43453544853) after migrating to `libs.versions.toml`, so this fixes it  

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Manually ran `update-sentry-native-ndk.sh set-version 0.8.5` and `get-version`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
