### PR TITLE
Fix `aggregateJavadocs` task name

### DIFF
--- a/build-logic/src/main/kotlin/io.sentry.javadoc.aggregate.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.javadoc.aggregate.gradle.kts
@@ -20,7 +20,7 @@ subprojects {
 
 val javadocCollection = javadocPublisher.incoming.artifactView { lenient(true) }.files
 
-tasks.register("aggregateJavadoc", AggregateJavadoc::class) {
+tasks.register("aggregateJavadocs", AggregateJavadoc::class) {
     group = "documentation"
     description = "Aggregates Javadocs from all subprojects into a single directory."
     javadocFiles.set(javadocCollection)


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Add `s` to the name of the task as we seem to be referencing `aggregateJavadocs` everywhere.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`make format` and `./gradlew aggregateJavadocs` failed without this change.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
