### PR TITLE
Add `user.id`, `user.name` and `user.email` to log attributes

### DIFF
--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -17,6 +17,7 @@ import io.sentry.SentryOptions;
 import io.sentry.SpanId;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryId;
+import io.sentry.protocol.User;
 import io.sentry.util.Platform;
 import io.sentry.util.TracingUtils;
 import java.util.HashMap;
@@ -213,6 +214,10 @@ public final class LoggerApi implements ILoggerApi {
       setServerName(attributes);
     }
 
+    if (scopes.getOptions().isSendDefaultPii()) {
+      setUser(attributes);
+    }
+
     return attributes;
   }
 
@@ -227,6 +232,24 @@ public final class LoggerApi implements ILoggerApi {
       final @Nullable String hostname = HostnameCache.getInstance().getHostname();
       if (hostname != null) {
         attributes.put("server.address", new SentryLogEventAttributeValue("string", hostname));
+      }
+    }
+  }
+
+  private void setUser(final @NotNull HashMap<String, SentryLogEventAttributeValue> attributes) {
+    final @Nullable User user = scopes.getCombinedScopeView().getUser();
+    if (user != null) {
+      final @Nullable String id = user.getId();
+      if (id != null) {
+        attributes.put("user.id", new SentryLogEventAttributeValue("string", id));
+      }
+      final @Nullable String username = user.getUsername();
+      if (username != null) {
+        attributes.put("user.name", new SentryLogEventAttributeValue("string", username));
+      }
+      final @Nullable String email = user.getEmail();
+      if (email != null) {
+        attributes.put("user.email", new SentryLogEventAttributeValue("string", email));
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/protocol/User.java
+++ b/sentry/src/main/java/io/sentry/protocol/User.java
@@ -37,8 +37,10 @@ public final class User implements JsonUnknown, JsonSerializable {
   /** Remote IP address of the user. */
   private @Nullable String ipAddress;
 
-  /** Human readable name. */
-  private @Nullable String name;
+  /**
+   * @deprecated please use {@link User#username} Human readable name.
+   */
+  @Deprecated private @Nullable String name;
 
   /** User geo location. */
   private @Nullable Geo geo;
@@ -215,7 +217,9 @@ public final class User implements JsonUnknown, JsonSerializable {
    * Get human readable name.
    *
    * @return Human readable name
+   * @deprecated please use {@link User#getUsername()}
    */
+  @Deprecated
   public @Nullable String getName() {
     return name;
   }
@@ -224,7 +228,9 @@ public final class User implements JsonUnknown, JsonSerializable {
    * Set human readable name.
    *
    * @param name Human readable name
+   * @deprecated please use {@link User#setUsername(String)}
    */
+  @Deprecated
   public void setName(final @Nullable String name) {
     this.name = name;
   }

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -2851,6 +2851,69 @@ class ScopesTest {
         )
     }
 
+    @Test
+    fun `adds user fields to log attributes if sendDefaultPii is true`() {
+        val (sut, mockClient) = getEnabledScopes {
+            it.logs.isEnabled = true
+            it.isSendDefaultPii = true
+        }
+
+        sut.configureScope { scope ->
+            scope.user = User().also {
+                it.id = "usrid"
+                it.username = "usrname"
+                it.email = "user@sentry.io"
+            }
+        }
+        sut.logger().log(SentryLogLevel.WARN, "log message")
+
+        verify(mockClient).captureLog(
+            check {
+                assertEquals("log message", it.body)
+
+                val userId = it.attributes?.get("user.id")!!
+                assertEquals("usrid", userId.value)
+                assertEquals("string", userId.type)
+
+                val userName = it.attributes?.get("user.name")!!
+                assertEquals("usrname", userName.value)
+                assertEquals("string", userName.type)
+
+                val userEmail = it.attributes?.get("user.email")!!
+                assertEquals("user@sentry.io", userEmail.value)
+                assertEquals("string", userEmail.type)
+            },
+            anyOrNull()
+        )
+    }
+
+    @Test
+    fun `does not add user fields to log attributes by default`() {
+        val (sut, mockClient) = getEnabledScopes {
+            it.logs.isEnabled = true
+        }
+
+        sut.configureScope { scope ->
+            scope.user = User().also {
+                it.id = "usrid"
+                it.username = "usrname"
+                it.email = "user@sentry.io"
+            }
+        }
+        sut.logger().log(SentryLogLevel.WARN, "log message")
+
+        verify(mockClient).captureLog(
+            check {
+                assertEquals("log message", it.body)
+
+                assertNull(it.attributes?.get("user.id"))
+                assertNull(it.attributes?.get("user.name"))
+                assertNull(it.attributes?.get("user.email"))
+            },
+            anyOrNull()
+        )
+    }
+
     //endregion
 
     @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `user.id`, `user.name` and `user.email` to log attributes

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4459

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
