### PR TITLE
No longer send out empty log envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- No longer send out empty log envelopes ([#4497](https://github.com/getsentry/sentry-java/pull/4497))
+
 ## 8.14.0
 
 ### Fixes

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -101,7 +101,9 @@ public final class LoggerBatchProcessor implements ILoggerBatchProcessor {
       }
     } while (!queue.isEmpty() && logEvents.size() < MAX_BATCH_SIZE);
 
-    client.captureBatchedLogEvents(new SentryLogEvents(logEvents));
+    if (!logEvents.isEmpty()) {
+      client.captureBatchedLogEvents(new SentryLogEvents(logEvents));
+    }
   }
 
   private class BatchRunnable implements Runnable {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Check item count before invoking `SentryClient.captureBatchedLogEvents`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`LoggerBatchProcessor` sent out empty envelopes which
- caused problems in relay (which have already been fixed)
- is unnecessary work

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
