### PR TITLE
fix(replay): Expand fix for crash on devices to all Unisoc/Spreadtrum chipsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - No longer send out empty log envelopes ([#4497](https://github.com/getsentry/sentry-java/pull/4497))
+- Session Replay: Expand fix for crash on devices to all Unisoc/Spreadtrum chipsets ([#4510](https://github.com/getsentry/sentry-java/pull/4510))
 
 ### Dependencies
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -161,15 +161,15 @@ internal class SimpleVideoEncoder(
          * ---
          * Same for Motorola devices.
          * ---
-         * As for the T606, it's a Spreadtrum/Unisoc chipset and can be spread across various
-         * devices, so we have to check the SOC_MODEL property, as the manufacturer name might have
-         * changed.
+         * As for the Spreadtrum/Unisoc chipset, it can be spread across various devices, so we have
+         * to check the SOC_MANUFACTURER property, as the manufacturer name might have changed.
          * https://github.com/getsentry/sentry-android-gradle-plugin/issues/861#issuecomment-2867021256
          */
         val canvas = if (
             Build.MANUFACTURER.contains("xiaomi", ignoreCase = true) ||
             Build.MANUFACTURER.contains("motorola", ignoreCase = true) ||
-            SystemProperties.get(SystemProperties.Property.SOC_MODEL).equals("T606", ignoreCase = true)
+            SystemProperties.get(SystemProperties.Property.SOC_MANUFACTURER).equals("spreadtrum", ignoreCase = true) ||
+            SystemProperties.get(SystemProperties.Property.SOC_MANUFACTURER).equals("unisoc", ignoreCase = true)
         ) {
             surface?.lockCanvas(null)
         } else {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This applies the T606 chipset fix for all spreadtrum/unisoc chipsets because there are still crashes coming from e.g. this [device](https://www.gsmarena.com/tecno_spark_go_1-13274.php) which has a T615 chip

See replay: https://sentry-sdks.sentry.io/replays/f7d9309ffba843e68ff9c6285ab84970/

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal customer reports

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
