### PR TITLE
Send JUL logs to Sentry as logs

### DIFF
--- a/sentry-jul/api/sentry-jul.api
+++ b/sentry-jul/api/sentry-jul.api
@@ -9,14 +9,17 @@ public class io/sentry/jul/SentryHandler : java/util/logging/Handler {
 	public fun <init> ()V
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun <init> (Lio/sentry/SentryOptions;Z)V
+	protected fun captureLog (Ljava/util/logging/LogRecord;)V
 	public fun close ()V
 	public fun flush ()V
 	public fun getMinimumBreadcrumbLevel ()Ljava/util/logging/Level;
 	public fun getMinimumEventLevel ()Ljava/util/logging/Level;
+	public fun getMinimumLevel ()Ljava/util/logging/Level;
 	public fun isPrintfStyle ()Z
 	public fun publish (Ljava/util/logging/LogRecord;)V
 	public fun setMinimumBreadcrumbLevel (Ljava/util/logging/Level;)V
 	public fun setMinimumEventLevel (Ljava/util/logging/Level;)V
+	public fun setMinimumLevel (Ljava/util/logging/Level;)V
 	public fun setPrintfStyle (Z)V
 }
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -9,11 +9,15 @@ import io.sentry.Hint;
 import io.sentry.InitPriority;
 import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
+import io.sentry.SentryAttribute;
+import io.sentry.SentryAttributes;
 import io.sentry.SentryEvent;
 import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryLevel;
+import io.sentry.SentryLogLevel;
 import io.sentry.SentryOptions;
 import io.sentry.exception.ExceptionMechanismException;
+import io.sentry.logger.SentryLogParameters;
 import io.sentry.protocol.Mechanism;
 import io.sentry.protocol.Message;
 import io.sentry.protocol.SdkVersion;
@@ -50,6 +54,7 @@ public class SentryHandler extends Handler {
 
   private @NotNull Level minimumBreadcrumbLevel = Level.INFO;
   private @NotNull Level minimumEventLevel = Level.SEVERE;
+  private @NotNull Level minimumLevel = Level.INFO;
 
   static {
     SentryIntegrationPackageStorage.getInstance()
@@ -106,6 +111,9 @@ public class SentryHandler extends Handler {
       return;
     }
     try {
+      if (record.getLevel().intValue() >= minimumLevel.intValue()) {
+        captureLog(record);
+      }
       if (record.getLevel().intValue() >= minimumEventLevel.intValue()) {
         final Hint hint = new Hint();
         hint.set(SENTRY_SYNTHETIC_EXCEPTION, record);
@@ -126,6 +134,46 @@ public class SentryHandler extends Handler {
     }
   }
 
+  /**
+   * Captures a Sentry log from JULs {@link LogRecord}.
+   *
+   * @param loggingEvent the JUL log record
+   */
+  // for the Android compatibility we must use old Java Date class
+  @SuppressWarnings("JdkObsolete")
+  protected void captureLog(@NotNull LogRecord loggingEvent) {
+    final @NotNull SentryLogLevel sentryLevel = toSentryLogLevel(loggingEvent.getLevel());
+
+    final @Nullable Object[] arguments = loggingEvent.getParameters();
+    final @NotNull SentryAttributes attributes = SentryAttributes.of();
+
+    @NotNull String message = loggingEvent.getMessage();
+    if (loggingEvent.getResourceBundle() != null
+        && loggingEvent.getResourceBundle().containsKey(loggingEvent.getMessage())) {
+      message = loggingEvent.getResourceBundle().getString(loggingEvent.getMessage());
+    }
+
+    attributes.add(SentryAttribute.stringAttribute("sentry.message.template", message));
+
+    final @NotNull String formattedMessage = maybeFormatted(arguments, message);
+    final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
+
+    Sentry.logger().log(sentryLevel, params, formattedMessage, arguments);
+  }
+
+  private @NotNull String maybeFormatted(
+      final @NotNull Object[] arguments, final @NotNull String message) {
+    if (arguments != null) {
+      try {
+        return formatMessage(message, arguments);
+      } catch (RuntimeException e) {
+        // local formatting failed, sending raw message instead of formatted message
+      }
+    }
+
+    return message;
+  }
+
   /** Retrieves the properties of the logger. */
   private void retrieveProperties() {
     final LogManager manager = LogManager.getLogManager();
@@ -140,6 +188,10 @@ public class SentryHandler extends Handler {
     final String minimumEventLevel = manager.getProperty(className + ".minimumEventLevel");
     if (minimumEventLevel != null) {
       setMinimumEventLevel(parseLevelOrDefault(minimumEventLevel));
+    }
+    final String minimumLevel = manager.getProperty(className + ".minimumLevel");
+    if (minimumLevel != null) {
+      setMinimumLevel(parseLevelOrDefault(minimumLevel));
     }
   }
 
@@ -160,6 +212,26 @@ public class SentryHandler extends Handler {
       return SentryLevel.DEBUG;
     } else {
       return null;
+    }
+  }
+
+  /**
+   * Transforms a {@link Level} into an {@link SentryLogLevel}.
+   *
+   * @param level original level as defined in JUL.
+   * @return log level used within sentry logs.
+   */
+  private static @NotNull SentryLogLevel toSentryLogLevel(final @NotNull Level level) {
+    if (level.intValue() >= Level.SEVERE.intValue()) {
+      return SentryLogLevel.ERROR;
+    } else if (level.intValue() >= Level.WARNING.intValue()) {
+      return SentryLogLevel.WARN;
+    } else if (level.intValue() >= Level.INFO.intValue()) {
+      return SentryLogLevel.INFO;
+    } else if (level.intValue() >= Level.FINE.intValue()) {
+      return SentryLogLevel.DEBUG;
+    } else {
+      return SentryLogLevel.TRACE;
     }
   }
 
@@ -337,6 +409,16 @@ public class SentryHandler extends Handler {
 
   public @NotNull Level getMinimumEventLevel() {
     return minimumEventLevel;
+  }
+
+  public void setMinimumLevel(final @Nullable Level minimumLevel) {
+    if (minimumLevel != null) {
+      this.minimumLevel = minimumLevel;
+    }
+  }
+
+  public @NotNull Level getMinimumLevel() {
+    return minimumLevel;
   }
 
   public boolean isPrintfStyle() {

--- a/sentry-jul/src/test/resources/logging.properties
+++ b/sentry-jul/src/test/resources/logging.properties
@@ -1,6 +1,7 @@
 io.sentry.jul.SentryHandler.level=ALL
 io.sentry.jul.SentryHandler.minimumEventLevel=WARNING
 io.sentry.jul.SentryHandler.minimumBreadcrumbLevel=CONFIG
+io.sentry.jul.SentryHandler.minimumLevel=CONFIG
 io.sentry.jul.SentryHandler.printfStyle=true
 
 jul.SentryHandlerTest.handlers=java.util.logging.ConsoleHandler, io.sentry.jul.SentryHandler

--- a/sentry-jul/src/test/resources/sentry.properties
+++ b/sentry-jul/src/test/resources/sentry.properties
@@ -1,1 +1,2 @@
 release=release from sentry.properties
+logs.enabled=true

--- a/sentry-samples/sentry-samples-jul/src/main/resources/logging.properties
+++ b/sentry-samples/sentry-samples-jul/src/main/resources/logging.properties
@@ -1,5 +1,6 @@
-io.sentry.jul.SentryHandler.minimumEventLevel=DEBUG
+io.sentry.jul.SentryHandler.minimumEventLevel=FINE
 io.sentry.jul.SentryHandler.minimumBreadcrumbLevel=CONFIG
+io.sentry.jul.SentryHandler.minimumLevel=FINE
 io.sentry.jul.SentryHandler.printfStyle=true
 io.sentry.jul.SentryHandler.level=CONFIG
 handlers=io.sentry.jul.SentryHandler

--- a/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-jul/src/main/resources/sentry.properties
@@ -4,3 +4,4 @@ debug=true
 environment=staging
 in-app-includes=io.sentry.samples
 context-tags=userId,requestId
+logs.enabled=true


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allow setting a minimumLevel for our JUL integration which causes logs >= that level to be sent to Sentry as logs.

Setting the minimum level can be done on the handler config in `logging.properties`:
```
io.sentry.jul.SentryHandler.minimumLevel=CONFIG
```

You also have to enable the logs feature:

Either in `sentry.properties`:

```
logs.enabled=true
```


or when calling `Sentry.init`:
```
Sentry.init(options -> {
  ...
  options.getLogs().setEnabled(true);
});
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4405

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
