### PR TITLE
Fix Logback with Spring Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Fixes
 
-- Fix Logback with Spring Boot ([#4523](https://github.com/getsentry/sentry-java/pull/4523))
-  - Enabling Sentry Logs in Spring Boot config did not work in 3.15.0
+- Enabling Sentry Logs through Logback in Spring Boot config did not work in 3.15.0 ([#4523](https://github.com/getsentry/sentry-java/pull/4523))
 
 ## 8.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Logback with Spring Boot ([#4523](https://github.com/getsentry/sentry-java/pull/4523))
+  - Enabling Sentry Logs in Spring Boot config did not work in 3.15.0
+
 ## 8.15.0
 
 ### Features

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -83,7 +83,8 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    if (ScopesAdapter.getInstance().getOptions().getLogs().isEnabled() && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
+    if (ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
+        && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -83,7 +83,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
   @Override
   protected void append(@NotNull ILoggingEvent eventObject) {
-    if (options.getLogs().isEnabled() && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
+    if (ScopesAdapter.getInstance().getOptions().getLogs().isEnabled() && eventObject.getLevel().isGreaterOrEqual(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isGreaterOrEqual(minimumEventLevel)) {
@@ -113,7 +113,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final Message message = new Message();
 
     // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
-    if (encoder == null || options.isSendDefaultPii()) {
+    if (encoder == null || ScopesAdapter.getInstance().getOptions().isSendDefaultPii()) {
       message.setMessage(loggingEvent.getMessage());
       message.setParams(toParams(loggingEvent.getArgumentArray()));
     }
@@ -184,7 +184,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     final @NotNull SentryAttributes attributes = SentryAttributes.of();
 
     // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
-    if (encoder == null || options.isSendDefaultPii()) {
+    if (encoder == null || ScopesAdapter.getInstance().getOptions().isSendDefaultPii()) {
       attributes.add(
           SentryAttribute.stringAttribute("sentry.message.template", loggingEvent.getMessage()));
       arguments = loggingEvent.getArgumentArray();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use `ScopesAdapter.getInstance().getOptions()` instead of `this.options` as Spring Boot config does not affect the instances options.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/4521

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
