### PR TITLE
chore(docs): fix javadoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This repo uses the following ways to release SDK updates:
 # Useful links and docs
 
 * A deep dive into how we built [Session Replay for Android](https://www.droidcon.com/2024/11/22/rewind-and-resolve-a-deep-dive-into-building-session-replay-for-android/) at Droidcon London 2024.
-* Current Javadocs [generated from source code](https://getsentry.github.io/sentry-java/).
+* Current Javadocs [generated from source code](https://javadoc.io/doc/io.sentry/sentry/latest/index.html).
 * Java SDK version 1.x [can still be found here](https://docs.sentry.io/clients/java/).
 * Migration page from [sentry-android 1.x and 2.x to sentry-android 4.x](https://docs.sentry.io/platforms/android/migration/).
 * Migration page from [sentry 1.x to sentry 4.x](https://docs.sentry.io/platforms/java/migration/).


### PR DESCRIPTION
like Roman mentioned below, fixing gh-pages is a better solution 😅 didn't notice we had something being deployed on there, but that it's just the modules overview not existing

---

Just happened to spot a dead link in the Readme pointing to https://getsentry.github.io/sentry-java/ , and saw on [this issue](https://github.com/getsentry/sentry-java/issues/4522) that [javadoc.io](https://javadoc.io/doc/io.sentry/sentry/latest/index.html) has javadocs for the latest release. 

Not sure if we want to point at javadoc.io instead of our own github page, but having a dead link is not much better either :p 

#skip-changelog