### PR TITLE
Fix javadoc on TransportResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix javadoc on TransportResult ([#4528](https://github.com/getsentry/sentry-java/pull/4528))
+
 ## 8.16.0
 
 ### Features

--- a/sentry/src/main/java/io/sentry/transport/TransportResult.java
+++ b/sentry/src/main/java/io/sentry/transport/TransportResult.java
@@ -3,7 +3,7 @@ package io.sentry.transport;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A result of {@link ITransport#send(io.sentry.SentryEnvelope)}. Note that this class is
+ * A result of {@link HttpConnection#send(io.sentry.SentryEnvelope)}. Note that this class is
  * intentionally not subclassable and has only two factory methods to capture the 2 possible states
  * - success or error.
  */


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
`ITransport.send` doesn't return a `TransportResult` anymore since [we optimized it for high throughput](https://github.com/getsentry/sentry-java/pull/1114).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4522

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
