### PR TITLE
fix(replay): Fix `IllegalArgumentException` when `Bitmap` is initialized with non-positive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Optimize scope when maxBreadcrumb is 0 ([#4504](https://github.com/getsentry/sentry-java/pull/4504))
 - Fix javadoc on TransportResult ([#4528](https://github.com/getsentry/sentry-java/pull/4528))
+- Session Replay: Fix `IllegalArgumentException` when `Bitmap` is initialized with non-positive values ([#4536](https://github.com/getsentry/sentry-java/pull/4536))
 
 ### Internal
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Views.kt
@@ -245,4 +245,4 @@ internal fun View?.removeOnPreDrawListenerSafe(listener: ViewTreeObserver.OnPreD
   }
 }
 
-internal fun View.hasSize(): Boolean = width != 0 && height != 0
+internal fun View.hasSize(): Boolean = width > 0 && height > 0

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
@@ -1,13 +1,12 @@
 package io.sentry.android.replay.util
 
 import android.view.View
-import android.view.ViewGroup
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ViewsTest {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
@@ -1,0 +1,37 @@
+package io.sentry.android.replay.util
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class ViewsTest {
+  @Test
+  fun `hasSize returns true for positive values`() {
+    val view = View(ApplicationProvider.getApplicationContext())
+    view.right = 100
+    view.bottom = 100
+    assertTrue(view.hasSize())
+  }
+
+  @Test
+  fun `hasSize returns false for null values`() {
+    val view = View(ApplicationProvider.getApplicationContext())
+    view.right = 0
+    view.bottom = 0
+    assertFalse(view.hasSize())
+  }
+
+  @Test
+  fun `hasSize returns false for negative values`() {
+    val view = View(ApplicationProvider.getApplicationContext())
+    view.right = -1
+    view.bottom = -1
+    assertFalse(view.hasSize())
+  }
+}


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Apparently `width` and `height` can return negative values, so our != 0 check was not enough 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://sentry.sentry.io/issues/6713535878/events/318005d8a00a468abccdd5f4f5576f28/

## :green_heart: How did you test it?
With tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
