### PR TITLE
Restore span names for GraphQL on the new version of OpenTelemetry (by changing OpenTelemetry defaults)

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -31,7 +31,8 @@ public final class SpanDescriptionExtractor {
       return descriptionForDbSystem(otelSpan);
     }
 
-    final @Nullable String graphqlOperationType = attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE);
+    final @Nullable String graphqlOperationType =
+        attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE);
     if (graphqlOperationType != null) {
       return descriptionForGraphql(otelSpan);
     }
@@ -114,8 +115,12 @@ public final class SpanDescriptionExtractor {
 
   private OtelSpanInfo descriptionForGraphql(final @NotNull SpanData otelSpan) {
     final @NotNull Attributes attributes = otelSpan.getAttributes();
-    @Nullable String graphqlOperationType = attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE);
-    @Nullable String graphqlOperationName = attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME);
+    @Nullable
+    String graphqlOperationType =
+        attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE);
+    @Nullable
+    String graphqlOperationName =
+        attributes.get(GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME);
     if (graphqlOperationType != null && graphqlOperationName != null) {
       String description = graphqlOperationType + " " + graphqlOperationName;
       return new OtelSpanInfo(description, description, TransactionNameSource.TASK);

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SpanDescriptionExtractorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SpanDescriptionExtractorTest.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.UrlAttributes
 import io.opentelemetry.semconv.incubating.DbIncubatingAttributes
+import io.opentelemetry.semconv.incubating.GraphqlIncubatingAttributes
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes
 import io.sentry.protocol.TransactionNameSource
 import kotlin.test.Test
@@ -251,6 +252,22 @@ class SpanDescriptionExtractorTest {
     assertEquals("span name", info.op)
     assertEquals("span description", info.description)
     assertEquals(TransactionNameSource.CUSTOM, info.transactionNameSource)
+  }
+
+  @Test
+  fun `sets op to graphql for span with graphql operation type`() {
+    givenAttributes(
+      mapOf(
+        GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE to "query",
+        GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME to "GreetingQuery",
+      )
+    )
+
+    val info = whenExtractingSpanInfo()
+
+    assertEquals("query GreetingQuery", info.op)
+    assertEquals("query GreetingQuery", info.description)
+    assertEquals(TransactionNameSource.TASK, info.transactionNameSource)
   }
 
   private fun createSpanContext(

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SpanDescriptionExtractorTest.kt
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/test/kotlin/SpanDescriptionExtractorTest.kt
@@ -270,6 +270,23 @@ class SpanDescriptionExtractorTest {
     assertEquals(TransactionNameSource.TASK, info.transactionNameSource)
   }
 
+  @Test
+  fun `does not set op to graphql for span with graphql operation type if span name has been overridden`() {
+    givenAttributes(
+      mapOf(
+        GraphqlIncubatingAttributes.GRAPHQL_OPERATION_TYPE to "query",
+        GraphqlIncubatingAttributes.GRAPHQL_OPERATION_NAME to "GreetingQuery",
+      )
+    )
+    givenSpanName("my-custom-span-name")
+
+    val info = whenExtractingSpanInfo()
+
+    assertEquals("my-custom-span-name", info.op)
+    assertEquals("my-custom-span-name", info.description)
+    assertEquals(TransactionNameSource.CUSTOM, info.transactionNameSource)
+  }
+
   private fun createSpanContext(
     isRemote: Boolean,
     traceId: String = "f9118105af4a2d42b4124532cd1065ff",


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
GraphQL span names in OpenTelemetry have been changed to just `query` from e.g. `query GreetingQuery` for this query:
```
query GreetingQuery($name: String) {
    greeting(name: $name)
}
```

This PR uses span attributes to restore the previous `op` and `description` for Sentry spans by changing the following config of the OpenTelemetry SDK to restore previous behaviour:
```
System.setProperty("otel.instrumentation.graphql.add-operation-name-to-span-name.enabled", "true");
```

More info:
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13794
- https://github.com/open-telemetry/semantic-conventions/pull/1389

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
