### PR TITLE
Create Javadoc overview

### DIFF
--- a/build-logic/src/main/kotlin/io.sentry.javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.javadoc.gradle.kts
@@ -20,6 +20,7 @@ tasks.withType<Javadoc>().configureEach {
         "https://docs.spring.io/spring-framework/docs/current/javadoc-api/",
         "https://docs.spring.io/spring-boot/docs/current/api/"
     )
+    opts.overview = "index.html"
 }
 
 artifacts {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This will create an overview page like this in such that opening the GH pages link opens this one
![Screenshot 2025-07-04 at 11 22 49](https://github.com/user-attachments/assets/a8662c9d-fa4f-469a-9f8c-f5676b75fe33)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Close #4525 

## :green_heart: How did you test it?
Checked the generated pages

#skip-changelog
