### PR TITLE
Add option to mask widgets by package name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# sentry-java Development Guide for Claude
+
+## Overview
+
+sentry-java is the Java and Android SDK for Sentry. This repository contains the source code and examples for SDK usage.
+
+## Tech Stack
+
+- **Language**: Java and Kotlin
+- **Build Framework**: Gradle
+
+## Key Commands
+
+```bash
+# Format Code and regenerate .api file
+./gradlew spotlessApply apiDump
+
+# Run tests and lint
+./gradlew check
+```
+
+## Contributing Guidelines
+
+1. Before implementing a new feature, checkout main, pull the latest changes and branch-off
+```bash
+git checkout main
+git pull origin main
+git checkout -b markushi/[fix/feat]/[feature-name]
+```
+2. Follow existing code style and language
+3. Do not modify the API files (e.g. sentry.api) manually, instead run `./gradlew  apiDump` to regenerate them
+4. Write comprehensive tests
+5. Use Kotlin only for test code and Android modules which already use Kotlin, otherwise use Java
+6. New features should be opt-in by default, extend `SentryOptions` with getters and setters to enable/disable a new feature
+7. Consider backwards compatibility
+
+## Useful Resources
+
+- Main Documentation: https://docs.sentry.io/
+- Internal Contributing Guide: https://docs.sentry.io/internal/contributing/
+- Git Commit messages https://develop.sentry.dev/engineering-practices/commit-messages/

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ViewHierarchyNode.kt
@@ -14,6 +14,7 @@ import io.sentry.android.replay.util.isMaskable
 import io.sentry.android.replay.util.isVisibleToUser
 import io.sentry.android.replay.util.toOpaque
 import io.sentry.android.replay.util.totalPaddingTopSafe
+import io.sentry.util.PatternUtils
 
 @TargetApi(26)
 internal sealed class ViewHierarchyNode(
@@ -308,6 +309,17 @@ internal sealed class ViewHierarchyNode(
       }
 
       if (this.javaClass.isAssignableFrom(options.sessionReplay.unmaskViewClasses)) {
+        return false
+      }
+
+      // Check package-based masking patterns
+      val className = this.javaClass.name
+      if (PatternUtils.matchesAnyPattern(className, options.sessionReplay.maskPackagePatterns)) {
+        return true
+      }
+      
+      // Check package-based unmasking patterns
+      if (PatternUtils.matchesAnyPattern(className, options.sessionReplay.unmaskPackagePatterns)) {
         return false
       }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3665,10 +3665,13 @@ public final class io/sentry/SentryReplayOptions {
 	public static final field WEB_VIEW_CLASS_NAME Ljava/lang/String;
 	public fun <init> (Ljava/lang/Double;Ljava/lang/Double;Lio/sentry/protocol/SdkVersion;)V
 	public fun <init> (ZLio/sentry/protocol/SdkVersion;)V
+	public fun addMaskPackage (Ljava/lang/String;)V
 	public fun addMaskViewClass (Ljava/lang/String;)V
+	public fun addUnmaskPackage (Ljava/lang/String;)V
 	public fun addUnmaskViewClass (Ljava/lang/String;)V
 	public fun getErrorReplayDuration ()J
 	public fun getFrameRate ()I
+	public fun getMaskPackagePatterns ()Ljava/util/Set;
 	public fun getMaskViewClasses ()Ljava/util/Set;
 	public fun getMaskViewContainerClass ()Ljava/lang/String;
 	public fun getOnErrorSampleRate ()Ljava/lang/Double;
@@ -3677,6 +3680,7 @@ public final class io/sentry/SentryReplayOptions {
 	public fun getSessionDuration ()J
 	public fun getSessionSampleRate ()Ljava/lang/Double;
 	public fun getSessionSegmentDuration ()J
+	public fun getUnmaskPackagePatterns ()Ljava/util/Set;
 	public fun getUnmaskViewClasses ()Ljava/util/Set;
 	public fun getUnmaskViewContainerClass ()Ljava/lang/String;
 	public fun isDebug ()Z

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -91,6 +91,30 @@ public final class SentryReplayOptions {
    */
   private Set<String> unmaskViewClasses = new CopyOnWriteArraySet<>();
 
+  /**
+   * Mask all views with the specified package name patterns. The package name pattern can include
+   * wildcards (*) to match multiple packages. For example, "com.thirdparty.*" will mask all
+   * views from packages starting with "com.thirdparty.".
+   *
+   * <p>If you're using an obfuscation tool, make sure to add the respective proguard rules to keep
+   * the package names.
+   *
+   * <p>Default is empty.
+   */
+  private Set<String> maskPackagePatterns = new CopyOnWriteArraySet<>();
+
+  /**
+   * Ignore all views with the specified package name patterns from masking. The package name pattern can include
+   * wildcards (*) to match multiple packages. For example, "com.myapp.*" will unmask all
+   * views from packages starting with "com.myapp.".
+   *
+   * <p>If you're using an obfuscation tool, make sure to add the respective proguard rules to keep
+   * the package names.
+   *
+   * <p>Default is empty.
+   */
+  private Set<String> unmaskPackagePatterns = new CopyOnWriteArraySet<>();
+
   /** The class name of the view container that masks all of its children. */
   private @Nullable String maskViewContainerClass = null;
 
@@ -250,6 +274,24 @@ public final class SentryReplayOptions {
 
   public void addUnmaskViewClass(final @NotNull String className) {
     this.unmaskViewClasses.add(className);
+  }
+
+  @NotNull
+  public Set<String> getMaskPackagePatterns() {
+    return this.maskPackagePatterns;
+  }
+
+  public void addMaskPackage(final @NotNull String packagePattern) {
+    this.maskPackagePatterns.add(packagePattern);
+  }
+
+  @NotNull
+  public Set<String> getUnmaskPackagePatterns() {
+    return this.unmaskPackagePatterns;
+  }
+
+  public void addUnmaskPackage(final @NotNull String packagePattern) {
+    this.unmaskPackagePatterns.add(packagePattern);
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/rrweb/RRWebOptionsEvent.java
+++ b/sentry/src/main/java/io/sentry/rrweb/RRWebOptionsEvent.java
@@ -52,6 +52,8 @@ public final class RRWebOptionsEvent extends RRWebEvent implements JsonSerializa
     optionsPayload.put("quality", replayOptions.getQuality().serializedName());
     optionsPayload.put("maskedViewClasses", replayOptions.getMaskViewClasses());
     optionsPayload.put("unmaskedViewClasses", replayOptions.getUnmaskViewClasses());
+    optionsPayload.put("maskedPackagePatterns", replayOptions.getMaskPackagePatterns());
+    optionsPayload.put("unmaskedPackagePatterns", replayOptions.getUnmaskPackagePatterns());
   }
 
   @NotNull

--- a/sentry/src/main/java/io/sentry/util/PatternUtils.java
+++ b/sentry/src/main/java/io/sentry/util/PatternUtils.java
@@ -1,0 +1,59 @@
+package io.sentry.util;
+
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Utility class for pattern matching operations, primarily used for Session Replay masking.
+ */
+public final class PatternUtils {
+
+  private PatternUtils() {}
+
+  /**
+   * Checks if a given string matches a pattern. The pattern can contain wildcards (*) only at the
+   * end to match any sequence of characters as a suffix.
+   *
+   * @param input the string to check
+   * @param pattern the pattern to match against (only suffix wildcards are supported)
+   * @return true if the input matches the pattern, false otherwise
+   */
+  public static boolean matchesPattern(final @NotNull String input, final @NotNull String pattern) {
+    // If pattern doesn't contain wildcard, do exact match
+    if (!pattern.contains("*")) {
+      return input.equals(pattern);
+    }
+    
+    // Only support suffix wildcards (pattern ending with *)
+    if (!pattern.endsWith("*")) {
+      return false;
+    }
+    
+    // Check if pattern has wildcards in the middle or beginning (not supported)
+    final String prefix = pattern.substring(0, pattern.length() - 1);
+    if (prefix.contains("*")) {
+      return false;
+    }
+    
+    // Check if input starts with the prefix
+    return input.startsWith(prefix);
+  }
+
+  /**
+   * Checks if a given string matches any of the provided patterns. Patterns can contain wildcards
+   * (*) only at the end to match any sequence of characters as a suffix.
+   *
+   * @param input the string to check
+   * @param patterns the set of patterns to match against
+   * @return true if the input matches any of the patterns, false otherwise
+   */
+  public static boolean matchesAnyPattern(
+      final @NotNull String input, final @NotNull Set<String> patterns) {
+    for (final String pattern : patterns) {
+      if (matchesPattern(input, pattern)) {
+        return true;
+      }
+    }
+    return false;
+  }
+} 

--- a/sentry/src/test/java/io/sentry/util/PatternUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/PatternUtilsTest.kt
@@ -1,0 +1,87 @@
+package io.sentry.util
+
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PatternUtilsTest {
+
+    @Test
+    fun `matchesPattern returns true for exact match`() {
+        assertTrue(PatternUtils.matchesPattern("com.example.app", "com.example.app"))
+    }
+
+    @Test
+    fun `matchesPattern returns false for non-matching strings`() {
+        assertFalse(PatternUtils.matchesPattern("com.example.app", "com.other.app"))
+    }
+
+    @Test
+    fun `matchesPattern returns true for suffix wildcard matching prefix`() {
+        assertTrue(PatternUtils.matchesPattern("com.example.app", "com.example.*"))
+        assertTrue(PatternUtils.matchesPattern("com.example.app.MainActivity", "com.example.*"))
+        assertTrue(PatternUtils.matchesPattern("com.example.SomeClass", "com.example.*"))
+    }
+
+    @Test
+    fun `matchesPattern returns false for suffix wildcard not matching prefix`() {
+        assertFalse(PatternUtils.matchesPattern("com.other.app", "com.example.*"))
+        assertFalse(PatternUtils.matchesPattern("org.example.app", "com.example.*"))
+        // Exact package name should not match suffix wildcard
+        assertFalse(PatternUtils.matchesPattern("com.example", "com.example.*"))
+    }
+
+    @Test
+    fun `matchesPattern returns true for empty prefix with suffix wildcard`() {
+        assertTrue(PatternUtils.matchesPattern("anything", "*"))
+        assertTrue(PatternUtils.matchesPattern("", "*"))
+        assertTrue(PatternUtils.matchesPattern("com.example.app", "*"))
+    }
+
+    @Test
+    fun `matchesPattern returns false for wildcards in middle or beginning`() {
+        // Wildcards in the middle are not supported
+        assertFalse(PatternUtils.matchesPattern("com.example.pdf.viewer", "*pdf*"))
+        assertFalse(PatternUtils.matchesPattern("com.example.pdf.viewer", "com.*.pdf"))
+        assertFalse(PatternUtils.matchesPattern("com.example.pdf.viewer", "com.*pdf*"))
+        
+        // Wildcards at the beginning (not at the end) are not supported
+        assertFalse(PatternUtils.matchesPattern("com.example.app", "*example"))
+        assertFalse(PatternUtils.matchesPattern("com.example.app", "*example.app"))
+    }
+
+    @Test
+    fun `matchesPattern handles complex package names with suffix wildcards`() {
+        assertTrue(PatternUtils.matchesPattern("com.thirdparty.pdf.renderer.PdfView", "com.thirdparty.*"))
+        assertTrue(PatternUtils.matchesPattern("com.thirdparty.trusted.TrustedView", "com.thirdparty.*"))
+        assertTrue(PatternUtils.matchesPattern("com.thirdparty.pdf.ExactPdfView", "com.thirdparty.pdf.*"))
+        
+        assertFalse(PatternUtils.matchesPattern("com.thirdparty.pdf.renderer.PdfView", "com.other.*"))
+        assertFalse(PatternUtils.matchesPattern("org.thirdparty.SomeView", "com.thirdparty.*"))
+    }
+
+    @Test
+    fun `matchesAnyPattern returns true when input matches any pattern`() {
+        val patterns = setOf("com.example.*", "com.thirdparty.*", "org.test.ExactClass")
+        
+        assertTrue(PatternUtils.matchesAnyPattern("com.example.app", patterns))
+        assertTrue(PatternUtils.matchesAnyPattern("com.thirdparty.pdf.PdfView", patterns))
+        assertTrue(PatternUtils.matchesAnyPattern("org.test.ExactClass", patterns))
+    }
+
+    @Test
+    fun `matchesAnyPattern returns false when input matches no patterns`() {
+        val patterns = setOf("com.example.*", "com.thirdparty.*", "org.test.ExactClass")
+        
+        assertFalse(PatternUtils.matchesAnyPattern("com.other.app", patterns))
+        assertFalse(PatternUtils.matchesAnyPattern("org.test.OtherClass", patterns))
+        assertFalse(PatternUtils.matchesAnyPattern("net.example.app", patterns))
+    }
+
+    @Test
+    fun `matchesAnyPattern returns false for empty patterns`() {
+        val patterns = emptySet<String>()
+        
+        assertFalse(PatternUtils.matchesAnyPattern("com.example.app", patterns))
+    }
+} 


### PR DESCRIPTION
## :scroll: Description
Extends `SentryReplayOptions` to allow package names for masking.

## :bulb: Motivation and Context
Implements https://github.com/getsentry/sentry-java/issues/4393

## :green_heart: How did you test it?
Added tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
