### PR TITLE
fix(android): Prevent repeated scroll target logging by updating scroll state

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -139,6 +139,7 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
         options
             .getLogger()
             .log(SentryLevel.DEBUG, "Unable to find scroll target. No breadcrumb captured.");
+        scrollState.type = GestureType.Scroll;
         return false;
       } else {
         options


### PR DESCRIPTION
## :scroll: Description

When ViewUtils.findTarget returns null in SentryGestureListener.onScroll, the code was logging an error but not updating scrollState.type from Unknown. This caused repeated target searches and duplicate log messages on subsequent onScroll calls during the same gesture.

## :bulb: Motivation and Context
Less verbose logging, better performance.

## :green_heart: How did you test it?
Added unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
