### PR TITLE
Do not use Sentry logging API in Log4j2 if logs are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Allow multiple UncaughtExceptionHandlerIntegrations to be active at the same time ([#4462](https://github.com/getsentry/sentry-java/pull/4462))
 - Prevent repeated scroll target determination during a single scroll gesture ([#4557](https://github.com/getsentry/sentry-java/pull/4557))
   - This should reduce the number of ANRs seen in `SentryGestureListener`
-- Do not use Sentry logging API if logs are disabled ([#4573](https://github.com/getsentry/sentry-java/pull/4573))
+- Do not use Sentry logging API in Log4j2 if logs are disabled ([#4573](https://github.com/getsentry/sentry-java/pull/4573))
   - This was causing Sentry SDK to log warnings: "Sentry Log is disabled and this 'logger' call is a no-op."
 
 ## 8.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Allow multiple UncaughtExceptionHandlerIntegrations to be active at the same time ([#4462](https://github.com/getsentry/sentry-java/pull/4462))
 - Prevent repeated scroll target determination during a single scroll gesture ([#4557](https://github.com/getsentry/sentry-java/pull/4557))
   - This should reduce the number of ANRs seen in `SentryGestureListener`
+- Do not use Sentry logging API if logs are disabled ([#4573](https://github.com/getsentry/sentry-java/pull/4573))
+  - This was causing Sentry SDK to log warnings: "Sentry Log is disabled and this 'logger' call is a no-op."
 
 ## 8.17.0
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -191,7 +191,8 @@ public class SentryAppender extends AbstractAppender {
 
   @Override
   public void append(final @NotNull LogEvent eventObject) {
-    if (eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
+    if (scopes.getOptions().getLogs().isEnabled()
+      && eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isMoreSpecificThan(minimumEventLevel)) {

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -192,7 +192,7 @@ public class SentryAppender extends AbstractAppender {
   @Override
   public void append(final @NotNull LogEvent eventObject) {
     if (scopes.getOptions().getLogs().isEnabled()
-      && eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
+        && eventObject.getLevel().isMoreSpecificThan(minimumLevel)) {
       captureLog(eventObject);
     }
     if (eventObject.getLevel().isMoreSpecificThan(minimumEventLevel)) {

--- a/sentry-samples/sentry-samples-log4j2/src/main/resources/sentry.properties
+++ b/sentry-samples/sentry-samples-log4j2/src/main/resources/sentry.properties
@@ -1,2 +1,3 @@
 in-app-includes="io.sentry.samples"
 logs.enabled=true
+debug=true


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not use Sentry logging API if logs are disabled

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-java/issues/4571

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
