### PR TITLE
Do not use Sentry logging API if logs are disabled for JUL

### DIFF
--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -111,7 +111,8 @@ public class SentryHandler extends Handler {
       return;
     }
     try {
-      if (record.getLevel().intValue() >= minimumLevel.intValue()) {
+      if (ScopesAdapter.getInstance().getOptions().getLogs().isEnabled()
+          && record.getLevel().intValue() >= minimumLevel.intValue()) {
         captureLog(record);
       }
       if (record.getLevel().intValue() >= minimumEventLevel.intValue()) {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Do not use Sentry logging API if logs are disabled for JUL

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Same problem reported for Log4j2 also applies to JUL (https://github.com/getsentry/sentry-java/pull/4573)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
