### PR TITLE
Remove indirection for integrations and packages via VersionInfoHolder

### DIFF
--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/src/main/java/io/sentry/opentelemetry/SentryAutoConfigurationCustomizerProvider.java
@@ -7,11 +7,9 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.sentry.InitPriority;
 import io.sentry.Sentry;
-import io.sentry.SentryIntegrationPackageStorage;
 import io.sentry.SentryOptions;
 import io.sentry.internal.ManifestVersionReader;
 import io.sentry.protocol.SdkVersion;
-import io.sentry.protocol.SentryPackage;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -44,15 +42,6 @@ public final class SentryAutoConfigurationCustomizerProvider
               options.setSdkVersion(sdkVersion);
             }
           });
-    }
-
-    if (versionInfoHolder != null) {
-      for (SentryPackage pkg : versionInfoHolder.getPackages()) {
-        SentryIntegrationPackageStorage.getInstance().addPackage(pkg.getName(), pkg.getVersion());
-      }
-      for (String integration : versionInfoHolder.getIntegrations()) {
-        SentryIntegrationPackageStorage.getInstance().addIntegration(integration);
-      }
     }
 
     autoConfiguration

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4719,8 +4719,6 @@ public final class io/sentry/internal/ManifestVersionReader {
 
 public final class io/sentry/internal/ManifestVersionReader$VersionInfoHolder {
 	public fun <init> ()V
-	public fun getIntegrations ()Ljava/util/List;
-	public fun getPackages ()Ljava/util/List;
 	public fun getSdkName ()Ljava/lang/String;
 	public fun getSdkVersion ()Ljava/lang/String;
 }

--- a/sentry/src/main/java/io/sentry/internal/ManifestVersionReader.java
+++ b/sentry/src/main/java/io/sentry/internal/ManifestVersionReader.java
@@ -2,13 +2,10 @@ package io.sentry.internal;
 
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryIntegrationPackageStorage;
-import io.sentry.protocol.SentryPackage;
 import io.sentry.util.AutoClosableReentrantLock;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import org.jetbrains.annotations.ApiStatus;
@@ -73,18 +70,18 @@ public final class ManifestVersionReader {
               final @Nullable String otelVersion =
                   mainAttributes.getValue("Sentry-Opentelemetry-Version-Name");
               if (otelVersion != null) {
-                versionInfo.packages.add(
-                    new SentryPackage("maven:io.opentelemetry:opentelemetry-sdk", otelVersion));
-                versionInfo.integrations.add("OpenTelemetry");
+                SentryIntegrationPackageStorage.getInstance()
+                    .addPackage("maven:io.opentelemetry:opentelemetry-sdk", otelVersion);
+                SentryIntegrationPackageStorage.getInstance().addIntegration("OpenTelemetry");
               }
               final @Nullable String otelJavaagentVersion =
                   mainAttributes.getValue("Sentry-Opentelemetry-Javaagent-Version-Name");
               if (otelJavaagentVersion != null) {
-                versionInfo.packages.add(
-                    new SentryPackage(
+                SentryIntegrationPackageStorage.getInstance()
+                    .addPackage(
                         "maven:io.opentelemetry.javaagent:opentelemetry-javaagent",
-                        otelJavaagentVersion));
-                versionInfo.integrations.add("OpenTelemetry-Agent");
+                        otelJavaagentVersion);
+                SentryIntegrationPackageStorage.getInstance().addIntegration("OpenTelemetry-Agent");
               }
               if (name.equals("sentry.java.opentelemetry.agentless")) {
                 SentryIntegrationPackageStorage.getInstance()
@@ -117,8 +114,6 @@ public final class ManifestVersionReader {
   public static final class VersionInfoHolder {
     private volatile @Nullable String sdkName;
     private volatile @Nullable String sdkVersion;
-    private List<SentryPackage> packages = new ArrayList<>();
-    private List<String> integrations = new ArrayList<>();
 
     public @Nullable String getSdkName() {
       return sdkName;
@@ -126,14 +121,6 @@ public final class ManifestVersionReader {
 
     public @Nullable String getSdkVersion() {
       return sdkVersion;
-    }
-
-    public List<SentryPackage> getPackages() {
-      return packages;
-    }
-
-    public List<String> getIntegrations() {
-      return integrations;
     }
   }
 }


### PR DESCRIPTION
#skip-changelog
## :scroll: Description
<!--- Describe your changes in detail -->
Remove indirection for integrations and packages via VersionInfoHolder

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ManifestVersionDetector` expects `ManifestVersionReader` to write to `SentryIntegrationPackageStorage` directly.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
