### PR TITLE
Prevent duplicate screen capture loops

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/WindowRecorder.kt
@@ -50,6 +50,8 @@ internal class WindowRecorder(
       }
       recorder?.resume()
       isRecording.getAndSet(true)
+      // Remove any existing callbacks to prevent concurrent capture loops
+      mainLooperHandler.removeCallbacks(this)
       val posted = mainLooperHandler.post(this)
       if (!posted) {
         options.logger.log(
@@ -183,6 +185,9 @@ internal class WindowRecorder(
     if (newRoot != null) {
       capturer?.recorder?.bind(newRoot)
     }
+
+    // Remove any existing callbacks to prevent concurrent capture loops
+    mainLooperHandler.removeCallbacks(capturer)
 
     val posted =
       mainLooperHandler.postDelayed(


### PR DESCRIPTION
<pr_request_template>## :scroll: Description
Ensured that only one screen capture loop is active at a time by removing existing `Capturer` callbacks before scheduling new ones in `onConfigurationChanged` and `Capturer.resume()`.

## :bulb: Motivation and Context
The `onConfigurationChanged` and `Capturer.resume()` methods were causing multiple concurrent screen capture loops. This occurred because they would schedule or re-post the `Capturer` runnable via `mainLooperHandler` without first removing any existing or previously scheduled callbacks. This led to redundant capture attempts and potential performance issues. The fix prevents this by clearing previous callbacks before posting new ones.

## :green_heart: How did you test it?
The fix was implemented based on code analysis to prevent redundant callback scheduling.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-e45f6820-c068-4c66-bdec-bdb3ee9eca74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e45f6820-c068-4c66-bdec-bdb3ee9eca74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>