### PR TITLE
fix(ci): remove obsolete NDK debug symbols

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -39,4 +39,3 @@ jobs:
           path: |
             ./*/build/distributions/*.zip
             ./sentry-opentelemetry/*/build/distributions/*.zip
-            ./sentry-android-ndk/build/intermediates/merged_native_libs/release/out/lib/*


### PR DESCRIPTION
## :scroll: Description

As they don't exist anymore and this is done within sentry-native directly: https://github.com/getsentry/sentry-native/pull/1327/files

#skip-changelog


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
