### PR TITLE
fix(android): Remove unused method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Cache network capabilities and status to reduce IPC calls ([#4560](https://github.com/getsentry/sentry-java/pull/4560))
 - Deduplicate battery breadcrumbs ([#4561](https://github.com/getsentry/sentry-java/pull/4561))
+- Remove unused method in ManifestMetadataReader ([#4585](https://github.com/getsentry/sentry-java/pull/4585))
 
 
 ## 8.18.0

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -532,23 +532,6 @@ final class ManifestMetadataReader {
     return value;
   }
 
-  @SuppressWarnings("deprecation")
-  private static @Nullable Boolean readBoolNullable(
-      final @NotNull Bundle metadata,
-      final @NotNull ILogger logger,
-      final @NotNull String key,
-      final @Nullable Boolean defaultValue) {
-    if (metadata.getSerializable(key) != null) {
-      final boolean nonNullDefault = defaultValue == null ? false : true;
-      final boolean bool = metadata.getBoolean(key, nonNullDefault);
-      logger.log(SentryLevel.DEBUG, key + " read: " + bool);
-      return bool;
-    } else {
-      logger.log(SentryLevel.DEBUG, key + " used default " + defaultValue);
-      return defaultValue;
-    }
-  }
-
   private static @Nullable String readString(
       final @NotNull Bundle metadata,
       final @NotNull ILogger logger,


### PR DESCRIPTION
## :scroll: Description

Calling `Bundle.getSerializable(key)` without specifying the serializable class as a second argument [is considered unsafe](https://developer.android.com/privacy-and-security/risks/unsafe-deserialization). Luckily this was the only occurrence and the method wasn't even used, so we can just remove it.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
