### PR TITLE
Fix connection status provider exceptions and api inconsistencies

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -169,7 +169,11 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
 
               try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
                 for (final @NotNull NetworkCallback cb : childCallbacks) {
-                  cb.onAvailable(network);
+                  try {
+                    cb.onAvailable(network);
+                  } catch (Throwable t) {
+                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onAvailable", t);
+                  }
                 }
               }
             }
@@ -179,9 +183,16 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
             public void onUnavailable() {
               clearCacheAndNotifyObservers();
 
-              try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
-                for (final @NotNull NetworkCallback cb : childCallbacks) {
-                  cb.onUnavailable();
+              // Only call onUnavailable on child callbacks if we're on API 26+ to maintain compatibility
+              if (buildInfoProvider.getSdkInfoVersion() >= Build.VERSION_CODES.O) {
+                try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
+                  for (final @NotNull NetworkCallback cb : childCallbacks) {
+                    try {
+                      cb.onUnavailable();
+                    } catch (Throwable t) {
+                      options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onUnavailable", t);
+                    }
+                  }
                 }
               }
             }
@@ -195,7 +206,11 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
 
               try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
                 for (final @NotNull NetworkCallback cb : childCallbacks) {
-                  cb.onLost(network);
+                  try {
+                    cb.onLost(network);
+                  } catch (Throwable t) {
+                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onLost", t);
+                  }
                 }
               }
             }
@@ -230,7 +245,11 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
 
               try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
                 for (final @NotNull NetworkCallback cb : childCallbacks) {
-                  cb.onCapabilitiesChanged(network, networkCapabilities);
+                  try {
+                    cb.onCapabilitiesChanged(network, networkCapabilities);
+                  } catch (Throwable t) {
+                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onCapabilitiesChanged", t);
+                  }
                 }
               }
             }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProvider.java
@@ -172,7 +172,12 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
                   try {
                     cb.onAvailable(network);
                   } catch (Throwable t) {
-                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onAvailable", t);
+                    options
+                        .getLogger()
+                        .log(
+                            SentryLevel.WARNING,
+                            "Exception in child NetworkCallback.onAvailable",
+                            t);
                   }
                 }
               }
@@ -183,14 +188,20 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
             public void onUnavailable() {
               clearCacheAndNotifyObservers();
 
-              // Only call onUnavailable on child callbacks if we're on API 26+ to maintain compatibility
+              // Only call onUnavailable on child callbacks if we're on API 26+ to maintain
+              // compatibility
               if (buildInfoProvider.getSdkInfoVersion() >= Build.VERSION_CODES.O) {
                 try (final @NotNull ISentryLifecycleToken ignored = childCallbacksLock.acquire()) {
                   for (final @NotNull NetworkCallback cb : childCallbacks) {
                     try {
                       cb.onUnavailable();
                     } catch (Throwable t) {
-                      options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onUnavailable", t);
+                      options
+                          .getLogger()
+                          .log(
+                              SentryLevel.WARNING,
+                              "Exception in child NetworkCallback.onUnavailable",
+                              t);
                     }
                   }
                 }
@@ -209,7 +220,9 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
                   try {
                     cb.onLost(network);
                   } catch (Throwable t) {
-                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onLost", t);
+                    options
+                        .getLogger()
+                        .log(SentryLevel.WARNING, "Exception in child NetworkCallback.onLost", t);
                   }
                 }
               }
@@ -248,7 +261,12 @@ public final class AndroidConnectionStatusProvider implements IConnectionStatusP
                   try {
                     cb.onCapabilitiesChanged(network, networkCapabilities);
                   } catch (Throwable t) {
-                    options.getLogger().log(SentryLevel.WARNING, "Exception in child NetworkCallback.onCapabilitiesChanged", t);
+                    options
+                        .getLogger()
+                        .log(
+                            SentryLevel.WARNING,
+                            "Exception in child NetworkCallback.onCapabilitiesChanged",
+                            t);
                   }
                 }
               }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/AndroidConnectionStatusProviderTest.kt
@@ -648,9 +648,8 @@ class AndroidConnectionStatusProviderTest {
     // Configure the throwing callback to throw an exception
     whenever(throwingCallback.onAvailable(any())).thenThrow(RuntimeException("Test exception"))
 
-    AndroidConnectionStatusProvider.getChildCallbacks().addAll(
-      listOf(throwingCallback, goodCallback1, goodCallback2)
-    )
+    AndroidConnectionStatusProvider.getChildCallbacks()
+      .addAll(listOf(throwingCallback, goodCallback1, goodCallback2))
 
     // Simulate event - should not fail despite throwing callback
     mainCallback.onAvailable(network)
@@ -661,11 +660,12 @@ class AndroidConnectionStatusProviderTest {
     verify(goodCallback2).onAvailable(network)
 
     // Verify the exception was logged
-    verify(logger).log(
-      eq(io.sentry.SentryLevel.WARNING),
-      eq("Exception in child NetworkCallback.onAvailable"),
-      any<Throwable>()
-    )
+    verify(logger)
+      .log(
+        eq(io.sentry.SentryLevel.WARNING),
+        eq("Exception in child NetworkCallback.onAvailable"),
+        any<Throwable>(),
+      )
   }
 
   @Test
@@ -686,9 +686,8 @@ class AndroidConnectionStatusProviderTest {
     // Configure the throwing callback to throw an exception
     whenever(throwingCallback.onLost(any())).thenThrow(RuntimeException("Test exception"))
 
-    AndroidConnectionStatusProvider.getChildCallbacks().addAll(
-      listOf(throwingCallback, goodCallback1, goodCallback2)
-    )
+    AndroidConnectionStatusProvider.getChildCallbacks()
+      .addAll(listOf(throwingCallback, goodCallback1, goodCallback2))
 
     // Simulate event - should not fail despite throwing callback
     mainCallback.onLost(network)
@@ -699,11 +698,12 @@ class AndroidConnectionStatusProviderTest {
     verify(goodCallback2).onLost(network)
 
     // Verify the exception was logged
-    verify(logger).log(
-      eq(io.sentry.SentryLevel.WARNING),
-      eq("Exception in child NetworkCallback.onLost"),
-      any<Throwable>()
-    )
+    verify(logger)
+      .log(
+        eq(io.sentry.SentryLevel.WARNING),
+        eq("Exception in child NetworkCallback.onLost"),
+        any<Throwable>(),
+      )
   }
 
   @Test
@@ -722,11 +722,11 @@ class AndroidConnectionStatusProviderTest {
     val goodCallback2 = mock<NetworkCallback>()
 
     // Configure the throwing callback to throw an exception
-    whenever(throwingCallback.onCapabilitiesChanged(any(), any())).thenThrow(RuntimeException("Test exception"))
+    whenever(throwingCallback.onCapabilitiesChanged(any(), any()))
+      .thenThrow(RuntimeException("Test exception"))
 
-    AndroidConnectionStatusProvider.getChildCallbacks().addAll(
-      listOf(throwingCallback, goodCallback1, goodCallback2)
-    )
+    AndroidConnectionStatusProvider.getChildCallbacks()
+      .addAll(listOf(throwingCallback, goodCallback1, goodCallback2))
 
     // Simulate event - should not fail despite throwing callback
     mainCallback.onCapabilitiesChanged(network, networkCapabilities)
@@ -737,11 +737,12 @@ class AndroidConnectionStatusProviderTest {
     verify(goodCallback2).onCapabilitiesChanged(network, networkCapabilities)
 
     // Verify the exception was logged
-    verify(logger).log(
-      eq(io.sentry.SentryLevel.WARNING),
-      eq("Exception in child NetworkCallback.onCapabilitiesChanged"),
-      any<Throwable>()
-    )
+    verify(logger)
+      .log(
+        eq(io.sentry.SentryLevel.WARNING),
+        eq("Exception in child NetworkCallback.onCapabilitiesChanged"),
+        any<Throwable>(),
+      )
   }
 
   @Test
@@ -795,9 +796,8 @@ class AndroidConnectionStatusProviderTest {
     // Configure the throwing callback to throw an exception
     whenever(throwingCallback.onUnavailable()).thenThrow(RuntimeException("Test exception"))
 
-    AndroidConnectionStatusProvider.getChildCallbacks().addAll(
-      listOf(throwingCallback, goodCallback1, goodCallback2)
-    )
+    AndroidConnectionStatusProvider.getChildCallbacks()
+      .addAll(listOf(throwingCallback, goodCallback1, goodCallback2))
 
     // Simulate event - should not fail despite throwing callback
     mainCallback.onUnavailable()
@@ -808,10 +808,11 @@ class AndroidConnectionStatusProviderTest {
     verify(goodCallback2).onUnavailable()
 
     // Verify the exception was logged
-    verify(logger).log(
-      eq(io.sentry.SentryLevel.WARNING),
-      eq("Exception in child NetworkCallback.onUnavailable"),
-      any<Throwable>()
-    )
+    verify(logger)
+      .log(
+        eq(io.sentry.SentryLevel.WARNING),
+        eq("Exception in child NetworkCallback.onUnavailable"),
+        any<Throwable>(),
+      )
   }
 }


### PR DESCRIPTION
<pr_request_template>## :scroll: Description
This PR addresses two issues in `AndroidConnectionStatusProvider`:
1.  **Exception Handling**: Added `try-catch` blocks around all child `NetworkCallback` invocations (`onAvailable`, `onLost`, `onCapabilitiesChanged`, `onUnavailable`) to prevent uncaught exceptions from halting the event dispatch loop. Exceptions are now logged as warnings.
2.  **API Compatibility**: Implemented an API level check within `onUnavailable()` to ensure child callbacks are only invoked on API 26 (Oreo) and above, aligning with its `@RequiresApi(Build.VERSION_CODES.O)` annotation and preventing inconsistent behavior on API 24-25 devices.

## :bulb: Motivation and Context
This change is required to:
- Improve the robustness of the `AndroidConnectionStatusProvider` by ensuring that a misbehaving `NetworkCallback` does not prevent other callbacks from receiving network status updates.
- Resolve an inconsistency where `NetworkCallback.onUnavailable()` was registered on API 24+ but only invoked by the system on API 26+, leading to unexpected behavior on lower API levels.

## :green_heart: How did you test it?
Comprehensive unit tests were added to verify:
- That exceptions thrown by individual child callbacks do not halt the dispatch loop for `onAvailable`, `onLost`, `onCapabilitiesChanged`, and `onUnavailable`.
- That `onUnavailable()` correctly invokes child callbacks on API 26+ devices.
- That `onUnavailable()` does *not* invoke child callbacks on API 24-25 devices.
- That exception handling still functions correctly for `onUnavailable()` on API 26+.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps</pr_request_template>

---
<a href="https://cursor.com/background-agent?bcId=bc-e1436c3e-8a96-46cf-af3d-06a10d130e9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1436c3e-8a96-46cf-af3d-06a10d130e9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>