### PR TITLE
fix(scripts): update-gradle script set-version

### DIFF
--- a/scripts/update-gradle.sh
+++ b/scripts/update-gradle.sh
@@ -32,10 +32,6 @@ set-version)
         version="${version:1}"
     fi
 
-    # Remove trailing ".0" - gradlew expects '7.1' instead of '7.1.0'
-    if [[ "$version" == *".0" ]]; then
-        version="${version:0:${#version}-2}"
-    fi
     echo "Setting gradle version to '$version'"
 
     # This sets version to gradle-wrapper.properties.


### PR DESCRIPTION
_#skip-changelog_

Gradle now uses a proper [semver](https://gradle.org/whats-new/gradle-9/#:~:text=As%20you%20can%20see%2C%20we%20are%20switching%20to%20the%203%2Ddigit%20version%20format.%20Starting%20with%209.0.0%2C%20Gradle%20releases%20will%20follow%20the%20Semantic%20Versioning%20(SemVer)%20specification%20for%20all%20stable%20features%3B%0Aincubating%20features%20and%20internal%20APIs%20might%20have%20a%20different%20lifecycle.) for their versions, so we don't need the workaround for the missing patch version anymore