### PR TITLE
Improve SentryTraceHeader constructor parameter validation

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryTraceHeader.java
+++ b/sentry/src/main/java/io/sentry/SentryTraceHeader.java
@@ -2,6 +2,8 @@ package io.sentry;
 
 import io.sentry.exception.InvalidSentryTraceHeaderException;
 import io.sentry.protocol.SentryId;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,6 +15,11 @@ public final class SentryTraceHeader {
   private final @NotNull SpanId spanId;
   private final @Nullable Boolean sampled;
 
+  final Pattern SENTRY_TRACEPARENT_HEADER_REGEX =
+      Pattern.compile(
+          "^[ \\t]*(?<traceId>[0-9a-f]{32})-(?<spanId>[0-9a-f]{16})-?(?<sampled>[01])?[ \\t]*$",
+          Pattern.CASE_INSENSITIVE);
+
   public SentryTraceHeader(
       final @NotNull SentryId traceId,
       final @NotNull SpanId spanId,
@@ -23,20 +30,16 @@ public final class SentryTraceHeader {
   }
 
   public SentryTraceHeader(final @NotNull String value) throws InvalidSentryTraceHeaderException {
-    final String[] parts = value.split("-", -1);
-    if (parts.length < 2) {
+    Matcher matcher = SENTRY_TRACEPARENT_HEADER_REGEX.matcher(value);
+    boolean matchesExist = matcher.matches();
+
+    if (!matchesExist || matcher.group("traceId") == null || matcher.group("spanId") == null) {
       throw new InvalidSentryTraceHeaderException(value);
-    } else if (parts.length == 3) {
-      this.sampled = "1".equals(parts[2]);
-    } else {
-      this.sampled = null;
     }
-    try {
-      this.traceId = new SentryId(parts[0]);
-      this.spanId = new SpanId(parts[1]);
-    } catch (Throwable e) {
-      throw new InvalidSentryTraceHeaderException(value, e);
-    }
+
+    this.traceId = new SentryId(matcher.group("traceId"));
+    this.spanId = new SpanId(matcher.group("spanId"));
+    this.sampled = matcher.group("sampled") == null ? null : "1".equals(matcher.group("sampled"));
   }
 
   public @NotNull String getName() {

--- a/sentry/src/test/java/io/sentry/SentryTraceHeaderTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTraceHeaderTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.text.substring
 
 class SentryTraceHeaderTest {
   @Test
@@ -13,6 +14,80 @@ class SentryTraceHeaderTest {
     val sentryId = SentryId()
     val ex = assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId") }
     assertEquals("sentry-trace header does not conform to expected format: $sentryId", ex.message)
+  }
+
+  @Test
+  fun `when trace-id has less than 32 characters throws exception`() {
+    val sentryId = SentryId().toString().substring(0, 8)
+    val spanId = SpanId()
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
+  }
+
+  @Test
+  fun `when trace-id has more than 32 characters throws exception`() {
+    val sentryId = SentryId().toString() + "abc"
+    val spanId = SpanId()
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
+  }
+
+  @Test
+  fun `when trace-id contains invalid characters throws exception`() {
+    var sentryId = SentryId().toString()
+    sentryId = sentryId.substring(0, 8) + "g" + sentryId.substring(8)
+    val spanId = SpanId()
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
+  }
+
+  @Test
+  fun `when span-id has less than 16 characters throws exception`() {
+    val sentryId = SentryId()
+    val spanId = SpanId().toString().substring(0, 8)
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
+  }
+
+  @Test
+  fun `when span-id has more than 32 characters throws exception`() {
+    val sentryId = SentryId()
+    val spanId = SpanId().toString() + "abc"
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
+  }
+
+  @Test
+  fun `when span-id contains invalid characters throws exception`() {
+    val sentryId = SentryId()
+    var spanId = SpanId().toString()
+    spanId = spanId.substring(0, 8) + "g" + spanId.substring(8)
+    val ex =
+      assertFailsWith<InvalidSentryTraceHeaderException> { SentryTraceHeader("$sentryId-$spanId") }
+    assertEquals(
+      "sentry-trace header does not conform to expected format: $sentryId-$spanId",
+      ex.message,
+    )
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Use similar, regex-based, validation logic to the PHP SDK for the sentry-trace HTTP header: https://github.com/getsentry/sentry-php/blob/master/src/Tracing/TransactionContext.php#L9

#skip-changelog

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Alert the user early with an exception when a malformed header is received.
- https://github.com/getsentry/sentry-java/issues/2799

## :green_heart: How did you test it?

Added test cases with malformed arguments, which would have caused errors later on previously. These include tests with IDs that are too short or too long, and IDs with invalid characters.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
