### PR TITLE
Fix class not found due to OTel not supporting spring boot 4 yet

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
   implementation(libs.springboot4.starter.webflux)
   implementation(libs.springboot4.starter.websocket)
   implementation(libs.springboot4.starter.restclient)
+  implementation(libs.springboot4.starter.webclient)
   implementation(Config.Libs.aspectj)
   implementation(Config.Libs.kotlinReflect)
   implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))

--- a/sentry-spring-boot-4/build.gradle.kts
+++ b/sentry-spring-boot-4/build.gradle.kts
@@ -86,7 +86,12 @@ dependencies {
   testImplementation(libs.okhttp.mockwebserver)
   testImplementation(libs.otel)
   testImplementation(libs.otel.extension.autoconfigure.spi)
-  testImplementation(libs.springboot4.otel)
+  /**
+   * Adding a version of opentelemetry-spring-boot-starter that doesn't support Spring Boot 4 causes
+   * java.lang.IllegalArgumentException: Could not find class [org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration]
+   * https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14363
+   */
+  //  testImplementation(libs.springboot4.otel)
   testImplementation(libs.springboot4.starter)
   testImplementation(libs.springboot4.starter.aop)
   testImplementation(libs.springboot4.starter.graphql)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
OTEL doesn't support Spring Boot 4 yet, removing the dependency for now.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
