### PR TITLE
Add origin to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Session Replay: Use main thread looper to schedule replay capture ([#4542](https://github.com/getsentry/sentry-java/pull/4542))
 - Use single `LifecycleObserver` and multi-cast it to the integrations interested in lifecycle states ([#4567](https://github.com/getsentry/sentry-java/pull/4567))
+- Add `sentry.origin` attribute to logs ([#4618](https://github.com/getsentry/sentry-java/pull/4618))
+  - This helps identify which integration captured a log event
 
 ### Fixes
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryLogcatAdapter.java
@@ -6,6 +6,7 @@ import io.sentry.ScopesAdapter;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryLogLevel;
+import io.sentry.logger.SentryLogParameters;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,10 +57,13 @@ public final class SentryLogcatAdapter {
       return;
     }
     final @Nullable String trMessage = tr != null ? tr.getMessage() : null;
+    final @NotNull SentryLogParameters params = new SentryLogParameters();
+    params.setOrigin("auto.log.logcat");
+
     if (tr == null || trMessage == null) {
-      scopes.logger().log(level, msg);
+      scopes.logger().log(level, params, msg);
     } else {
-      scopes.logger().log(level, msg != null ? (msg + "\n" + trMessage) : trMessage);
+      scopes.logger().log(level, params, msg != null ? (msg + "\n" + trMessage) : trMessage);
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryLogcatAdapterTest.kt
@@ -64,6 +64,7 @@ class SentryLogcatAdapterTest {
     SentryLogcatAdapter.v(tag, "$commonMsg verbose")
     fixture.breadcrumbs.first().assert(tag, "$commonMsg verbose", SentryLevel.DEBUG)
     fixture.logs.first().assert("$commonMsg verbose", SentryLogLevel.TRACE)
+    assertEquals("auto.log.logcat", fixture.logs.first().attributes?.get("sentry.origin")?.value)
   }
 
   @Test

--- a/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
+++ b/sentry-android-timber/src/main/java/io/sentry/android/timber/SentryTimberTree.kt
@@ -6,6 +6,7 @@ import io.sentry.IScopes
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryLogLevel
+import io.sentry.logger.SentryLogParameters
 import io.sentry.protocol.Message
 import timber.log.Timber
 
@@ -244,12 +245,15 @@ public class SentryTimberTree(
   ) {
     // checks the log level
     if (isLoggable(sentryLogLevel, minLogLevel)) {
+      val params = SentryLogParameters()
+      params.origin = "auto.log.timber"
+
       val throwableMsg = throwable?.message
       when {
         msg != null && throwableMsg != null ->
-          scopes.logger().log(sentryLogLevel, "$msg\n$throwableMsg", *args)
-        msg != null -> scopes.logger().log(sentryLogLevel, msg, *args)
-        throwableMsg != null -> scopes.logger().log(sentryLogLevel, throwableMsg, *args)
+          scopes.logger().log(sentryLogLevel, params, "$msg\n$throwableMsg", *args)
+        msg != null -> scopes.logger().log(sentryLogLevel, params, msg, *args)
+        throwableMsg != null -> scopes.logger().log(sentryLogLevel, params, throwableMsg, *args)
       }
     }
   }

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -5,6 +5,7 @@ import io.sentry.Scopes
 import io.sentry.SentryLevel
 import io.sentry.SentryLogLevel
 import io.sentry.logger.ILoggerApi
+import io.sentry.logger.SentryLogParameters
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -248,21 +249,28 @@ class SentryTimberTreeTest {
     val sut = fixture.getSut()
     sut.e("test count: %d %d", 32, 5)
 
-    verify(fixture.logs).log(eq(SentryLogLevel.ERROR), eq("test count: %d %d"), eq(32), eq(5))
+    verify(fixture.logs)
+      .log(
+        eq(SentryLogLevel.ERROR),
+        check<SentryLogParameters> { assertEquals("auto.log.timber", it.origin) },
+        eq("test count: %d %d"),
+        eq(32),
+        eq(5),
+      )
   }
 
   @Test
   fun `Tree adds a log if min level is equal`() {
     val sut = fixture.getSut()
     sut.i(Throwable("test"))
-    verify(fixture.logs).log(any(), any())
+    verify(fixture.logs).log(any(), any<SentryLogParameters>(), any<String>())
   }
 
   @Test
   fun `Tree adds a log if min level is higher`() {
     val sut = fixture.getSut()
     sut.e(Throwable("test"))
-    verify(fixture.logs).log(any(), any<String>(), any())
+    verify(fixture.logs).log(any(), any<SentryLogParameters>(), any<String>(), any())
   }
 
   @Test
@@ -277,7 +285,12 @@ class SentryTimberTreeTest {
     val sut = fixture.getSut()
     sut.i("message")
 
-    verify(fixture.logs).log(eq(SentryLogLevel.INFO), eq("message"))
+    verify(fixture.logs)
+      .log(
+        eq(SentryLogLevel.INFO),
+        check<SentryLogParameters> { assertEquals("auto.log.timber", it.origin) },
+        eq("message"),
+      )
   }
 
   @Test
@@ -285,7 +298,12 @@ class SentryTimberTreeTest {
     val sut = fixture.getSut()
     sut.e(Throwable("test"))
 
-    verify(fixture.logs).log(eq(SentryLogLevel.ERROR), eq("test"))
+    verify(fixture.logs)
+      .log(
+        eq(SentryLogLevel.ERROR),
+        check<SentryLogParameters> { assertEquals("auto.log.timber", it.origin) },
+        eq("test"),
+      )
   }
 
   @Test
@@ -300,7 +318,12 @@ class SentryTimberTreeTest {
     val sut = fixture.getSut()
     sut.e(Throwable("throwable message"))
 
-    verify(fixture.logs).log(eq(SentryLogLevel.ERROR), eq("throwable message"))
+    verify(fixture.logs)
+      .log(
+        eq(SentryLogLevel.ERROR),
+        check<SentryLogParameters> { assertEquals("auto.log.timber", it.origin) },
+        eq("throwable message"),
+      )
   }
 
   @Test
@@ -308,6 +331,11 @@ class SentryTimberTreeTest {
     val sut = fixture.getSut()
     sut.e(Throwable("throwable message"), "My message")
 
-    verify(fixture.logs).log(eq(SentryLogLevel.ERROR), eq("My message\nthrowable message"))
+    verify(fixture.logs)
+      .log(
+        eq(SentryLogLevel.ERROR),
+        check<SentryLogParameters> { assertEquals("auto.log.timber", it.origin) },
+        eq("My message\nthrowable message"),
+      )
   }
 }

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -158,6 +158,7 @@ public class SentryHandler extends Handler {
 
     final @NotNull String formattedMessage = maybeFormatted(arguments, message);
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
+    params.setOrigin("auto.log.jul");
 
     Sentry.logger().log(sentryLevel, params, formattedMessage, arguments);
   }

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -414,7 +414,12 @@ class SentryHandlerTest {
     Sentry.flush(1000)
 
     verify(fixture.transport)
-      .send(checkLogs { event -> assertEquals(SentryLogLevel.TRACE, event.items.first().level) })
+      .send(
+        checkLogs { event ->
+          assertEquals(SentryLogLevel.TRACE, event.items.first().level)
+          assertEquals("auto.log.jul", event.items.first().attributes?.get("sentry.origin")?.value)
+        }
+      )
   }
 
   @Test

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -228,6 +228,7 @@ public class SentryAppender extends AbstractAppender {
 
     final @NotNull String formattedMessage = loggingEvent.getMessage().getFormattedMessage();
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
+    params.setOrigin("auto.log.log4j2");
 
     Sentry.logger().log(sentryLevel, params, formattedMessage, arguments);
   }

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -251,7 +251,15 @@ class SentryAppenderTest {
     Sentry.flush(1000)
 
     verify(fixture.transport)
-      .send(checkLogs { event -> assertEquals(SentryLogLevel.TRACE, event.items.first().level) })
+      .send(
+        checkLogs { event ->
+          assertEquals(SentryLogLevel.TRACE, event.items.first().level)
+          assertEquals(
+            "auto.log.log4j2",
+            event.items.first().attributes?.get("sentry.origin")?.value,
+          )
+        }
+      )
   }
 
   @Test

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -193,6 +193,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     final @NotNull String formattedMessage = formatted(loggingEvent);
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
+    params.setOrigin("auto.log.logback");
 
     Sentry.logger().log(sentryLevel, params, formattedMessage, arguments);
   }

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -382,6 +382,7 @@ class SentryAppenderTest {
           val attributes = log.attributes!!
           assertEquals("Testing {} level", attributes["sentry.message.template"]?.value)
           assertEquals("TRACE", attributes["sentry.message.parameter.0"]?.value)
+          assertEquals("auto.log.logback", attributes["sentry.origin"]?.value)
         }
       )
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4868,8 +4868,10 @@ public final class io/sentry/logger/SentryLogParameters {
 	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
 	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/logger/SentryLogParameters;
 	public fun getAttributes ()Lio/sentry/SentryAttributes;
+	public fun getOrigin ()Ljava/lang/String;
 	public fun getTimestamp ()Lio/sentry/SentryDate;
 	public fun setAttributes (Lio/sentry/SentryAttributes;)V
+	public fun setOrigin (Ljava/lang/String;)V
 	public fun setTimestamp (Lio/sentry/SentryDate;)V
 }
 

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -133,7 +133,7 @@ public final class LoggerApi implements ILoggerApi {
           span == null ? propagationContext.getSpanId() : span.getSpanContext().getSpanId();
       final SentryLogEvent logEvent =
           new SentryLogEvent(traceId, timestampToUse, messageToUse, level);
-      logEvent.setAttributes(createAttributes(params.getAttributes(), message, spanId, args));
+      logEvent.setAttributes(createAttributes(params, message, spanId, args));
       logEvent.setSeverityNumber(level.getSeverityNumber());
 
       scopes.getClient().captureLog(logEvent, combinedScope);
@@ -160,11 +160,16 @@ public final class LoggerApi implements ILoggerApi {
   }
 
   private @NotNull HashMap<String, SentryLogEventAttributeValue> createAttributes(
-      final @Nullable SentryAttributes incomingAttributes,
+      final @NotNull SentryLogParameters params,
       final @NotNull String message,
       final @NotNull SpanId spanId,
       final @Nullable Object... args) {
     final @NotNull HashMap<String, SentryLogEventAttributeValue> attributes = new HashMap<>();
+    attributes.put(
+        "sentry.origin",
+        new SentryLogEventAttributeValue(SentryAttributeType.STRING, params.getOrigin()));
+
+    final @Nullable SentryAttributes incomingAttributes = params.getAttributes();
 
     if (incomingAttributes != null) {
       for (SentryAttribute attribute : incomingAttributes.getAttributes().values()) {

--- a/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
+++ b/sentry/src/main/java/io/sentry/logger/SentryLogParameters.java
@@ -9,6 +9,7 @@ public final class SentryLogParameters {
 
   private @Nullable SentryDate timestamp;
   private @Nullable SentryAttributes attributes;
+  private @NotNull String origin = "manual";
 
   public @Nullable SentryDate getTimestamp() {
     return timestamp;
@@ -24,6 +25,14 @@ public final class SentryLogParameters {
 
   public void setAttributes(final @Nullable SentryAttributes attributes) {
     this.attributes = attributes;
+  }
+
+  public @NotNull String getOrigin() {
+    return origin;
+  }
+
+  public void setOrigin(final @NotNull String origin) {
+    this.origin = origin;
   }
 
   public static @NotNull SentryLogParameters create(


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Sends the `sentry.origin` attribute to Sentry.
For integrations this is set to e.g. `sentry.log.logcat`, `sentry.log.logback`, ...
The default is `manual`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So we know what's creating logs.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
