### PR TITLE
Add new modules for Spring 7 and Spring Boot 4

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanAdvice.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanAdvice.java
@@ -22,7 +22,7 @@ import org.springframework.util.StringUtils;
  */
 @Open
 public class SentrySpanAdvice implements MethodInterceptor {
-  private static final String TRACE_ORIGIN = "auto.function.spring_jakarta.advice";
+  private static final String TRACE_ORIGIN = "auto.function.spring7.advice";
   private final @NotNull IScopes scopes;
 
   public SentrySpanAdvice() {

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanClientHttpRequestInterceptor.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanClientHttpRequestInterceptor.java
@@ -28,8 +28,8 @@ import org.springframework.http.client.ClientHttpResponse;
 
 @Open
 public class SentrySpanClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-  private static final String TRACE_ORIGIN_REST_TEMPLATE = "auto.http.spring_jakarta.resttemplate";
-  private static final String TRACE_ORIGIN_REST_CLIENT = "auto.http.spring_jakarta.restclient";
+  private static final String TRACE_ORIGIN_REST_TEMPLATE = "auto.http.spring7.resttemplate";
+  private static final String TRACE_ORIGIN_REST_CLIENT = "auto.http.spring7.restclient";
   private final @NotNull IScopes scopes;
   private final @NotNull String traceOrigin;
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanClientWebRequestFilter.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentrySpanClientWebRequestFilter.java
@@ -26,7 +26,7 @@ import reactor.core.publisher.Mono;
 
 @Open
 public class SentrySpanClientWebRequestFilter implements ExchangeFilterFunction {
-  private static final String TRACE_ORIGIN = "auto.http.spring_jakarta.webclient";
+  private static final String TRACE_ORIGIN = "auto.http.spring7.webclient";
   private final @NotNull IScopes scopes;
 
   public SentrySpanClientWebRequestFilter(final @NotNull IScopes scopes) {

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentryTracingFilter.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentryTracingFilter.java
@@ -36,7 +36,7 @@ public class SentryTracingFilter extends OncePerRequestFilter {
   /** Operation used by {@link SentryTransaction} created in {@link SentryTracingFilter}. */
   private static final String TRANSACTION_OP = "http.server";
 
-  private static final String TRACE_ORIGIN = "auto.http.spring_jakarta.webmvc";
+  private static final String TRACE_ORIGIN = "auto.http.spring7.webmvc";
   private static final String TRANSACTION_ATTR = "sentry.transaction";
 
   private final @NotNull TransactionNameProvider transactionNameProvider;

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentryTransactionAdvice.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/tracing/SentryTransactionAdvice.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
 @ApiStatus.Internal
 @Open
 public class SentryTransactionAdvice implements MethodInterceptor {
-  private static final String TRACE_ORIGIN = "auto.function.spring_jakarta.advice";
+  private static final String TRACE_ORIGIN = "auto.function.spring7.advice";
 
   private final @NotNull IScopes scopesBeforeForking;
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryWebFilter.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryWebFilter.java
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono;
 @Open
 public class SentryWebFilter extends AbstractSentryWebFilter {
 
-  private static final String TRACE_ORIGIN = "auto.spring_jakarta.webflux";
+  private static final String TRACE_ORIGIN = "auto.spring7.webflux";
 
   public SentryWebFilter(final @NotNull IScopes scopes) {
     super(scopes);

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryWebFilterWithThreadLocalAccessor.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/webflux/SentryWebFilterWithThreadLocalAccessor.java
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono;
 @ApiStatus.Experimental
 public final class SentryWebFilterWithThreadLocalAccessor extends AbstractSentryWebFilter {
 
-  public static final String TRACE_ORIGIN = "auto.spring_jakarta.webflux";
+  public static final String TRACE_ORIGIN = "auto.spring7.webflux";
 
   public SentryWebFilterWithThreadLocalAccessor(final @NotNull IScopes scopes) {
     super(scopes);

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentrySpanAdviceTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentrySpanAdviceTest.kt
@@ -52,7 +52,7 @@ class SentrySpanAdviceTest {
     assertEquals(1, result)
     assertEquals(1, tx.spans.size)
     assertNull(tx.spans.first().description)
-    assertEquals("auto.function.spring_jakarta.advice", tx.spans.first().spanContext.origin)
+    assertEquals("auto.function.spring7.advice", tx.spans.first().spanContext.origin)
     assertEquals("ClassAnnotatedSampleService.hello", tx.spans.first().operation)
   }
 

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentryTracingFilterTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentryTracingFilterTest.kt
@@ -122,7 +122,7 @@ class SentryTracingFilterTest {
           assertNotNull(it.customSamplingContext?.get("request"))
           assertTrue(it.customSamplingContext?.get("request") is HttpServletRequest)
           assertTrue(it.isBindToScope)
-          assertThat(it.origin).isEqualTo("auto.http.spring_jakarta.webmvc")
+          assertThat(it.origin).isEqualTo("auto.http.spring7.webmvc")
         },
       )
     verify(fixture.chain).doFilter(fixture.request, fixture.response)
@@ -325,7 +325,7 @@ class SentryTracingFilterTest {
         "sentry-public_key=502f25099c204a2fbf4cb16edc5975d1,sentry-sample_rate=1,sentry-trace_id=2722d9f6ec019ade60c776169d9a8904,sentry-transaction=HTTP%20GET"
       )
     fixture.options.tracesSampleRate = null
-    fixture.options.setIgnoredSpanOrigins(listOf("auto.http.spring_jakarta.webmvc"))
+    fixture.options.setIgnoredSpanOrigins(listOf("auto.http.spring7.webmvc"))
     val filter =
       fixture.getSut(
         sentryTraceHeader = sentryTraceHeaderString,
@@ -384,7 +384,7 @@ class SentryTracingFilterTest {
           assertNotNull(it.customSamplingContext?.get("request"))
           assertTrue(it.customSamplingContext?.get("request") is HttpServletRequest)
           assertTrue(it.isBindToScope)
-          assertThat(it.origin).isEqualTo("auto.http.spring_jakarta.webmvc")
+          assertThat(it.origin).isEqualTo("auto.http.spring7.webmvc")
         },
       )
     verify(asyncChain).doFilter(fixture.request, fixture.response)
@@ -443,7 +443,7 @@ class SentryTracingFilterTest {
           assertNotNull(it.customSamplingContext?.get("request"))
           assertTrue(it.customSamplingContext?.get("request") is HttpServletRequest)
           assertTrue(it.isBindToScope)
-          assertThat(it.origin).isEqualTo("auto.http.spring_jakarta.webmvc")
+          assertThat(it.origin).isEqualTo("auto.http.spring7.webmvc")
         },
       )
     verify(fixture.scopes).continueTrace(eq(sentryTrace), eq(baggage))

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentryTransactionAdviceTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/tracing/SentryTransactionAdviceTest.kt
@@ -53,7 +53,7 @@ class SentryTransactionAdviceTest {
           any(),
           check<TransactionOptions> {
             assertTrue(it.isBindToScope)
-            assertThat(it.origin).isEqualTo("auto.function.spring_jakarta.advice")
+            assertThat(it.origin).isEqualTo("auto.function.spring7.advice")
           },
         )
       )

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/webflux/SentryWebFluxTracingFilterTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/webflux/SentryWebFluxTracingFilterTest.kt
@@ -131,7 +131,7 @@ class SentryWebFluxTracingFilterTest {
             assertNotNull(it.customSamplingContext?.get("request"))
             assertTrue(it.customSamplingContext?.get("request") is ServerHttpRequest)
             assertTrue(it.isBindToScope)
-            assertThat(it.origin).isEqualTo("auto.spring_jakarta.webflux")
+            assertThat(it.origin).isEqualTo("auto.spring7.webflux")
           },
         )
       verify(fixture.chain).filter(fixture.exchange)
@@ -360,7 +360,7 @@ class SentryWebFluxTracingFilterTest {
         "sentry-public_key=502f25099c204a2fbf4cb16edc5975d1,sentry-sample_rate=1,sentry-trace_id=2722d9f6ec019ade60c776169d9a8904,sentry-transaction=HTTP%20GET"
       )
     fixture.options.tracesSampleRate = null
-    fixture.options.setIgnoredSpanOrigins(listOf("auto.spring_jakarta.webflux"))
+    fixture.options.setIgnoredSpanOrigins(listOf("auto.spring7.webflux"))
     val filter =
       fixture.getSut(
         sentryTraceHeader = sentryTraceHeaderString,

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanRestClientCustomizerTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanRestClientCustomizerTest.kt
@@ -276,7 +276,7 @@ class SentrySpanRestClientCustomizerTest {
 
   @Test
   fun `does not add sentry-trace header if span origin is ignored`() {
-    fixture.sentryOptions.setIgnoredSpanOrigins(listOf("auto.http.spring_jakarta.restclient"))
+    fixture.sentryOptions.setIgnoredSpanOrigins(listOf("auto.http.spring7.restclient"))
     val sut = fixture.getSut(isTransactionActive = false)
     val headers = HttpHeaders()
 

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanRestTemplateCustomizerTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanRestTemplateCustomizerTest.kt
@@ -234,7 +234,7 @@ class SentrySpanRestTemplateCustomizerTest {
 
   @Test
   fun `does not add sentry-trace header when span origin is ignored`() {
-    fixture.sentryOptions.setIgnoredSpanOrigins(listOf("auto.http.spring_jakarta.resttemplate"))
+    fixture.sentryOptions.setIgnoredSpanOrigins(listOf("auto.http.spring7.resttemplate"))
     val sut = fixture.getSut(isTransactionActive = false)
     val headers = HttpHeaders()
     val requestEntity = HttpEntity<Unit>(headers)

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanWebClientCustomizerTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentrySpanWebClientCustomizerTest.kt
@@ -194,7 +194,7 @@ class SentrySpanWebClientCustomizerTest {
     val sut =
       fixture.getSut(isTransactionActive = false, includeMockServerInTracingOrigins = true) {
         options ->
-        options.setIgnoredSpanOrigins(listOf("auto.http.spring_jakarta.webclient"))
+        options.setIgnoredSpanOrigins(listOf("auto.http.spring7.webclient"))
       }
     sut
       .get()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Update [trace origins](https://develop.sentry.dev/sdk/telemetry/traces/trace-origin/) to use the new module names instead of the old ones.
Occurences were found and replaced with:
```
rg --pcre2 'jakarta(?!\.servlet)' -g '*.kt' -g '*.java' -l | xargs sed -i '' 's/spring_jakarta/spring7/g'
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Correct trace origins.

## :green_heart: How did you test it?
Updated occurences in tests too.
