### PR TITLE
fix(sessions): Move and flush unfinished previous session on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Ensure frame metrics listeners are registered/unregistered on the main thread ([#4582](https://github.com/getsentry/sentry-java/pull/4582))
 - Do not report cached events as lost ([#4575](https://github.com/getsentry/sentry-java/pull/4575))
   - Previously events were recorded as lost early despite being retried later through the cache
+- Move and flush unfinished previous session on init ([#4624](https://github.com/getsentry/sentry-java/pull/4624))
+  - This removes the need for unnecessary blocking our background queue for 15 seconds in the case of a background app start
 
 ## 8.18.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4346,6 +4346,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	public static final field SUFFIX_ENVELOPE_FILE Ljava/lang/String;
 	protected static final field UTF_8 Ljava/nio/charset/Charset;
 	protected final field cacheLock Lio/sentry/util/AutoClosableReentrantLock;
+	protected final field sessionLock Lio/sentry/util/AutoClosableReentrantLock;
 	public fun <init> (Lio/sentry/SentryOptions;Ljava/lang/String;I)V
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/cache/IEnvelopeCache;
 	public fun discard (Lio/sentry/SentryEnvelope;)V
@@ -4353,6 +4354,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	public static fun getCurrentSessionFile (Ljava/lang/String;)Ljava/io/File;
 	public static fun getPreviousSessionFile (Ljava/lang/String;)Ljava/io/File;
 	public fun iterator ()Ljava/util/Iterator;
+	public fun movePreviousSession (Ljava/io/File;Ljava/io/File;)V
 	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 	public fun waitPreviousSessionFlush ()Z
 }

--- a/sentry/src/main/java/io/sentry/MovePreviousSession.java
+++ b/sentry/src/main/java/io/sentry/MovePreviousSession.java
@@ -1,0 +1,44 @@
+package io.sentry;
+
+import static io.sentry.SentryLevel.DEBUG;
+import static io.sentry.SentryLevel.INFO;
+
+import io.sentry.cache.EnvelopeCache;
+import io.sentry.cache.IEnvelopeCache;
+import java.io.File;
+import org.jetbrains.annotations.NotNull;
+
+final class MovePreviousSession implements Runnable {
+
+  private final @NotNull SentryOptions options;
+
+  MovePreviousSession(final @NotNull SentryOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public void run() {
+    final String cacheDirPath = options.getCacheDirPath();
+    if (cacheDirPath == null) {
+      options.getLogger().log(INFO, "Cache dir is not set, not moving the previous session.");
+      return;
+    }
+
+    if (!options.isEnableAutoSessionTracking()) {
+      options
+          .getLogger()
+          .log(DEBUG, "Session tracking is disabled, bailing from previous session mover.");
+      return;
+    }
+
+    final IEnvelopeCache cache = options.getEnvelopeDiskCache();
+    if (cache instanceof EnvelopeCache) {
+      final File currentSessionFile = EnvelopeCache.getCurrentSessionFile(cacheDirPath);
+      final File previousSessionFile = EnvelopeCache.getPreviousSessionFile(cacheDirPath);
+
+      ((EnvelopeCache) cache).movePreviousSession(currentSessionFile, previousSessionFile);
+
+      ((EnvelopeCache) cache).flushPreviousSession();
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -346,6 +346,8 @@ public final class Sentry {
           options.setExecutorService(new SentryExecutorService(options));
           options.getExecutorService().prewarm();
         }
+
+        movePreviousSession(options);
         // when integrations are registered on Scopes ctor and async integrations are fired,
         // it might and actually happened that integrations called captureSomething
         // and Scopes was still NoOp.
@@ -495,6 +497,16 @@ public final class Sentry {
         new SamplingContext(
             appStartTransactionContext, null, SentryRandom.current().nextDouble(), null);
     return options.getInternalTracesSampler().sample(appStartSamplingContext);
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  private static void movePreviousSession(final @NotNull SentryOptions options) {
+    // enqueue a task to move previous unfinished session to its own file
+    try {
+      options.getExecutorService().submit(new MovePreviousSession(options));
+    } catch (Throwable e) {
+      options.getLogger().log(SentryLevel.DEBUG, "Failed to move previous session.", e);
+    }
   }
 
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -442,8 +442,12 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       final @NotNull File currentSessionFile, final @NotNull File previousSessionFile) {
     try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
       if (previousSessionFile.exists()) {
-        options.getLogger().log(DEBUG, "Previous session file already exists.");
-        return;
+        options.getLogger().log(DEBUG, "Previous session file already exists, deleting it.");
+        if (!previousSessionFile.delete()) {
+          options
+              .getLogger()
+              .log(WARNING, "Unable to delete previous session file: %s", previousSessionFile);
+        }
       }
 
       if (currentSessionFile.exists()) {

--- a/sentry/src/test/java/io/sentry/MovePreviousSessionTest.kt
+++ b/sentry/src/test/java/io/sentry/MovePreviousSessionTest.kt
@@ -150,11 +150,10 @@ class MovePreviousSessionTest {
 
     (fixture.options.envelopeDiskCache as EnvelopeCache).waitPreviousSessionFlush()
 
-    // Files should remain unchanged when previous already exists
-    assertTrue(currentSessionFile.exists())
+    // Current session file should have been moved to previous
+    assertFalse(currentSessionFile.exists())
     assertTrue(previousSessionFile.exists())
-    assert(currentSessionFile.readText() == "current session")
-    assert(previousSessionFile.readText() == "previous session")
+    assert(previousSessionFile.readText() == "current session")
 
     fixture.cleanup()
   }

--- a/sentry/src/test/java/io/sentry/MovePreviousSessionTest.kt
+++ b/sentry/src/test/java/io/sentry/MovePreviousSessionTest.kt
@@ -1,0 +1,161 @@
+package io.sentry
+
+import io.sentry.cache.EnvelopeCache
+import io.sentry.cache.IEnvelopeCache
+import io.sentry.transport.NoOpEnvelopeCache
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class MovePreviousSessionTest {
+
+  private class Fixture {
+    val tempDir: Path = Files.createTempDirectory("sentry-move-session-test")
+    val options =
+      SentryOptions().apply {
+        isDebug = true
+        setLogger(SystemOutLogger())
+      }
+    val cache = mock<EnvelopeCache>()
+
+    fun getSUT(
+      cacheDirPath: String? = tempDir.toAbsolutePath().toFile().absolutePath,
+      isEnableSessionTracking: Boolean = true,
+      envelopeCache: IEnvelopeCache? = null,
+    ): MovePreviousSession {
+      options.cacheDirPath = cacheDirPath
+      options.isEnableAutoSessionTracking = isEnableSessionTracking
+      options.setEnvelopeDiskCache(envelopeCache ?: EnvelopeCache.create(options))
+      return MovePreviousSession(options)
+    }
+
+    fun cleanup() {
+      tempDir.toFile().deleteRecursively()
+    }
+  }
+
+  private lateinit var fixture: Fixture
+
+  @BeforeTest
+  fun setup() {
+    fixture = Fixture()
+  }
+
+  @AfterTest
+  fun teardown() {
+    fixture.cleanup()
+  }
+
+  @Test
+  fun `when cache dir is null, logs and returns early`() {
+    val sut = fixture.getSUT(cacheDirPath = null, envelopeCache = fixture.cache)
+
+    sut.run()
+
+    verify(fixture.cache, never()).movePreviousSession(any(), any())
+    verify(fixture.cache, never()).flushPreviousSession()
+  }
+
+  @Test
+  fun `when session tracking is disabled, logs and returns early`() {
+    val sut = fixture.getSUT(isEnableSessionTracking = false, envelopeCache = fixture.cache)
+
+    sut.run()
+
+    verify(fixture.cache, never()).movePreviousSession(any(), any())
+    verify(fixture.cache, never()).flushPreviousSession()
+  }
+
+  @Test
+  fun `when envelope cache is not EnvelopeCache instance, does nothing`() {
+    val sut = fixture.getSUT(envelopeCache = NoOpEnvelopeCache.getInstance())
+
+    sut.run()
+
+    verify(fixture.cache, never()).movePreviousSession(any(), any())
+    verify(fixture.cache, never()).flushPreviousSession()
+  }
+
+  @Test
+  fun `integration test with real EnvelopeCache`() {
+    val sut = fixture.getSUT()
+
+    // Create a current session file
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    currentSessionFile.createNewFile()
+    currentSessionFile.writeText("session content")
+
+    assertTrue(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+
+    sut.run()
+
+    // Wait for flush to complete
+    (fixture.options.envelopeDiskCache as EnvelopeCache).waitPreviousSessionFlush()
+
+    // Current session file should have been moved to previous
+    assertFalse(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+    assert(previousSessionFile.readText() == "session content")
+
+    fixture.cleanup()
+  }
+
+  @Test
+  fun `integration test when current session file does not exist`() {
+    val sut = fixture.getSUT()
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    assertFalse(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+
+    sut.run()
+
+    (fixture.options.envelopeDiskCache as EnvelopeCache).waitPreviousSessionFlush()
+
+    assertFalse(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+
+    fixture.cleanup()
+  }
+
+  @Test
+  fun `integration test when previous session file already exists`() {
+    val sut = fixture.getSUT()
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    currentSessionFile.createNewFile()
+    currentSessionFile.writeText("current session")
+    previousSessionFile.createNewFile()
+    previousSessionFile.writeText("previous session")
+
+    assertTrue(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+
+    sut.run()
+
+    (fixture.options.envelopeDiskCache as EnvelopeCache).waitPreviousSessionFlush()
+
+    // Files should remain unchanged when previous already exists
+    assertTrue(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+    assert(currentSessionFile.readText() == "current session")
+    assert(previousSessionFile.readText() == "previous session")
+
+    fixture.cleanup()
+  }
+}

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -957,9 +957,6 @@ class SentryTest {
       }
     }
 
-    // to trigger previous session flush
-    Sentry.startSession()
-
     await.untilTrue(triggered)
     assertFalse(previousSessionFile.exists())
   }

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -52,6 +52,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -917,13 +918,6 @@ class SentryTest {
           .deserialize(previousSessionFile.bufferedReader(), Session::class.java)!!
           .environment,
       )
-
-      it.addIntegration { scopes, _ ->
-        // this is just a hack to trigger the previousSessionFlush latch, so the finalizer
-        // does not time out waiting. We have to do it as integration, because this is where
-        // the scopes is already initialized
-        scopes.startSession()
-      }
       it.sessionFlushTimeoutMillis = 100
     }
 
@@ -1538,6 +1532,73 @@ class SentryTest {
     }
     Sentry.showUserFeedbackDialog(associatedEventId, configurator)
     verify(mockDialogHandler).showDialog(eq(associatedEventId), eq(configurator))
+  }
+
+  @Test
+  fun `init calls movePreviousSession before registering integrations`() {
+    val mockExecutorService = mock<ISentryExecutorService>()
+    val mockIntegration = mock<Integration>()
+
+    initForTest {
+      it.dsn = dsn
+      it.cacheDirPath = getTempPath()
+      it.isEnableAutoSessionTracking = true
+      it.executorService = mockExecutorService
+      it.addIntegration(mockIntegration)
+    }
+
+    // Verify that movePreviousSession is called before integration registration
+    // This ensures the session move happens early in the init process
+    val inOrder = inOrder(mockExecutorService, mockIntegration)
+    inOrder.verify(mockExecutorService).submit(any<MovePreviousSession>())
+    inOrder.verify(mockIntegration).register(any(), any())
+  }
+
+  @Test
+  fun `init moves previous session to its own file`() {
+    val cacheDir = tmpDir.newFolder().absolutePath
+    lateinit var currentSessionFile: File
+
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(cacheDir)
+    assertFalse(previousSessionFile.exists())
+
+    initForTest {
+      it.dsn = dsn
+      it.isDebug = true
+      it.setLogger(SystemOutLogger())
+
+      it.release = "io.sentry.sample@2.0"
+
+      it.cacheDirPath = tmpDir.newFolder().absolutePath
+      it.executorService = ImmediateExecutorService()
+
+      currentSessionFile = EnvelopeCache.getCurrentSessionFile(it.cacheDirPath!!)
+      currentSessionFile.parentFile.mkdirs()
+      it.serializer.serialize(
+        Session(null, null, "release", "io.sentry.samples@2.0"),
+        currentSessionFile.bufferedWriter(),
+      )
+      assertEquals(
+        "release",
+        it.serializer
+          .deserialize(currentSessionFile.bufferedReader(), Session::class.java)!!
+          .environment,
+      )
+
+      it.addIntegration { scopes, _ ->
+        // this is just a hack to assert previous session has been moved to its own file.
+        // Integrations are being registered after moving but before finalizing previous session
+        // (== deleting the file) so we can check it's been moved here
+        assertFalse(currentSessionFile.exists())
+        assertTrue(previousSessionFile.exists())
+        assertEquals(
+          "release",
+          it.serializer
+            .deserialize(previousSessionFile.bufferedReader(), Session::class.java)!!
+            .environment,
+        )
+      }
+    }
   }
 
   private class InMemoryOptionsObserver : IOptionsObserver {

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -377,4 +377,71 @@ class EnvelopeCacheTest {
 
     assertEquals(2, cache.directory.list()?.size)
   }
+
+  @Test
+  fun `movePreviousSession moves current session file to previous session file`() {
+    val cache = fixture.getSUT()
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    // Create a current session file
+    currentSessionFile.createNewFile()
+    currentSessionFile.writeText("current session content")
+
+    assertTrue(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+
+    // Call movePreviousSession directly
+    cache.movePreviousSession(currentSessionFile, previousSessionFile)
+
+    // Current file should be moved to previous
+    assertFalse(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+    assertEquals("current session content", previousSessionFile.readText())
+  }
+
+  @Test
+  fun `movePreviousSession does nothing when current session file does not exist`() {
+    val cache = fixture.getSUT()
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    assertFalse(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+
+    // Call movePreviousSession when no files exist
+    cache.movePreviousSession(currentSessionFile, previousSessionFile)
+
+    // Nothing should happen
+    assertFalse(currentSessionFile.exists())
+    assertFalse(previousSessionFile.exists())
+  }
+
+  @Test
+  fun `movePreviousSession does nothing when previous session file already exists`() {
+    val cache = fixture.getSUT()
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+
+    // Create both files
+    currentSessionFile.createNewFile()
+    currentSessionFile.writeText("current session content")
+    previousSessionFile.createNewFile()
+    previousSessionFile.writeText("existing previous content")
+
+    assertTrue(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+
+    // Call movePreviousSession when previous already exists
+    cache.movePreviousSession(currentSessionFile, previousSessionFile)
+
+    // Both files should remain unchanged
+    assertTrue(currentSessionFile.exists())
+    assertTrue(previousSessionFile.exists())
+    assertEquals("current session content", currentSessionFile.readText())
+    assertEquals("existing previous content", previousSessionFile.readText())
+  }
 }

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -447,7 +447,7 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `movePreviousSession does nothing when previous session file already exists`() {
+  fun `movePreviousSession deletes file and moves session when previous session file already exists`() {
     val cache = fixture.getSUT()
 
     val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
@@ -465,10 +465,9 @@ class EnvelopeCacheTest {
     // Call movePreviousSession when previous already exists
     cache.movePreviousSession(currentSessionFile, previousSessionFile)
 
-    // Both files should remain unchanged
-    assertTrue(currentSessionFile.exists())
+    // Current session should be moved to previous
+    assertFalse(currentSessionFile.exists())
     assertTrue(previousSessionFile.exists())
-    assertEquals("current session content", currentSessionFile.readText())
-    assertEquals("existing previous content", previousSessionFile.readText())
+    assertEquals("current session content", previousSessionFile.readText())
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Previously, we were waiting on previous session flush latch on our background queue when processing ANRs or finalizing previous session for 15 seconds to give it a good chance to be flushed. However, the trigger for the flush was actually a new session start:
  - We start a new session on foreground
  - We see that there's an existing unfinished session
  - We move it to its own file
  - We flush the latch
However this was not working well for background app starts. Since there's no foreground event, a new session would not be started and we were waiting for 15 seconds for nothing (on a background thread, but still). So this PR addresses it by moving any unfinished session to its own file right away on `init` (but before any of the integrations are registered, so those that rely on the previous session latch (like ANRs), do not need to wait for it).

- We also just rename `session.json` to `previous_session.json` now, as opposed to ser/deserializing the session multiple times from/into different files

### Before (perfetto trace of a background app start)
<img width="847" height="153" alt="Google Chrome 2025-08-08 16 14 48" src="https://github.com/user-attachments/assets/638ec18d-fa5f-48ec-84cf-f228f4beefcf" />

### After (perfetto trace of a background app start)

<img width="255" height="104" alt="Screenshot 2025-08-08 at 11 14 24" src="https://github.com/user-attachments/assets/250d0342-c66f-4e32-9b9a-d847eb64724c" />


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Speed up things on our background queue

## :green_heart: How did you test it?
Manually + automated

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
