### PR TITLE
chore(breadcrumbs): Add an option to disable reporting system events extras for breadcrumbs

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -336,6 +336,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableRootCheck ()Z
 	public fun isEnableScopeSync ()Z
 	public fun isEnableSystemEventBreadcrumbs ()Z
+	public fun isEnableSystemEventBreadcrumbsExtras ()Z
 	public fun isReportHistoricalAnrs ()Z
 	public fun setAnrEnabled (Z)V
 	public fun setAnrReportInDebug (Z)V
@@ -360,6 +361,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableRootCheck (Z)V
 	public fun setEnableScopeSync (Z)V
 	public fun setEnableSystemEventBreadcrumbs (Z)V
+	public fun setEnableSystemEventBreadcrumbsExtras (Z)V
 	public fun setFrameMetricsCollector (Lio/sentry/android/core/internal/util/SentryFrameMetricsCollector;)V
 	public fun setNativeHandlerStrategy (Lio/sentry/android/core/NdkHandlerStrategy;)V
 	public fun setNativeSdkName (Ljava/lang/String;)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -177,6 +177,9 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   private boolean enableAutoTraceIdGeneration = true;
 
+  /** Enable or disable intent extras reporting for system event breadcrumbs. Default is false. */
+  private boolean enableSystemEventBreadcrumbsExtras = false;
+
   public interface BeforeCaptureCallback {
 
     /**
@@ -612,6 +615,14 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   public void setEnableAutoTraceIdGeneration(final boolean enableAutoTraceIdGeneration) {
     this.enableAutoTraceIdGeneration = enableAutoTraceIdGeneration;
+  }
+
+  public boolean isEnableSystemEventBreadcrumbsExtras() {
+    return enableSystemEventBreadcrumbsExtras;
+  }
+
+  public void setEnableSystemEventBreadcrumbsExtras(boolean enableSystemEventBreadcrumbsExtras) {
+    this.enableSystemEventBreadcrumbsExtras = enableSystemEventBreadcrumbsExtras;
   }
 
   static class AndroidUserFeedbackIDialogHandler implements SentryFeedbackOptions.IDialogHandler {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -370,7 +370,7 @@ public final class SystemEventsBreadcrumbsIntegration
         if (batteryState.charging != null) {
           breadcrumb.setData("charging", batteryState.charging);
         }
-      } else {
+      } else if (options.isEnableSystemEventBreadcrumbsExtras()) {
         final Bundle extras = intent.getExtras();
         if (extras != null && !extras.isEmpty()) {
           final Map<String, String> newExtras = new HashMap<>(extras.size());

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -181,6 +181,20 @@ class SentryAndroidOptionsTest {
     )
   }
 
+  @Test
+  fun `system event breadcrumbs extras disabled by default`() {
+    val sentryOptions = SentryAndroidOptions()
+
+    assertFalse(sentryOptions.isEnableSystemEventBreadcrumbsExtras)
+  }
+
+  @Test
+  fun `system event breadcrumbs extras can be enabled`() {
+    val sentryOptions = SentryAndroidOptions()
+    sentryOptions.isEnableSystemEventBreadcrumbsExtras = true
+    assertTrue(sentryOptions.isEnableSystemEventBreadcrumbsExtras)
+  }
+
   private class CustomDebugImagesLoader : IDebugImagesLoader {
     override fun loadDebugImages(): List<DebugImage>? = null
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegrationTest.kt
@@ -51,11 +51,13 @@ class SystemEventsBreadcrumbsIntegrationTest {
 
     fun getSut(
       enableSystemEventBreadcrumbs: Boolean = true,
+      enableSystemEventBreadcrumbsExtras: Boolean = false,
       executorService: ISentryExecutorService = ImmediateExecutorService(),
     ): SystemEventsBreadcrumbsIntegration {
       options =
         SentryAndroidOptions().apply {
           isEnableSystemEventBreadcrumbs = enableSystemEventBreadcrumbs
+          isEnableSystemEventBreadcrumbsExtras = enableSystemEventBreadcrumbsExtras
           this.executorService = executorService
         }
       return SystemEventsBreadcrumbsIntegration(
@@ -527,5 +529,60 @@ class SystemEventsBreadcrumbsIntegrationTest {
     sut.register(fixture.scopes, fixture.options)
 
     assertNull(sut.receiver)
+  }
+
+  @Test
+  fun `system event breadcrumbs include extras when enableSystemEventBreadcrumbsExtras is true`() {
+    val sut = fixture.getSut(enableSystemEventBreadcrumbsExtras = true)
+
+    sut.register(fixture.scopes, fixture.options)
+    val intent =
+      Intent().apply {
+        action = Intent.ACTION_TIME_CHANGED
+        putExtra("test", 10)
+        putExtra("test2", 20)
+      }
+    sut.receiver!!.onReceive(fixture.context, intent)
+
+    verify(fixture.scopes)
+      .addBreadcrumb(
+        check<Breadcrumb> {
+          assertEquals("device.event", it.category)
+          assertEquals("system", it.type)
+          assertEquals(SentryLevel.INFO, it.level)
+          assertEquals("TIME_SET", it.data["action"])
+          assertNotNull(it.data["extras"])
+          val extras = it.data["extras"] as Map<String, String>
+          assertEquals("10", extras["test"])
+          assertEquals("20", extras["test2"])
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `system event breadcrumbs do not include extras when enableSystemEventBreadcrumbsExtras is false`() {
+    val sut = fixture.getSut(enableSystemEventBreadcrumbsExtras = false)
+
+    sut.register(fixture.scopes, fixture.options)
+    val intent =
+      Intent().apply {
+        action = Intent.ACTION_TIME_CHANGED
+        putExtra("test", 10)
+        putExtra("test2", 20)
+      }
+    sut.receiver!!.onReceive(fixture.context, intent)
+
+    verify(fixture.scopes)
+      .addBreadcrumb(
+        check<Breadcrumb> {
+          assertEquals("device.event", it.category)
+          assertEquals("system", it.type)
+          assertEquals(SentryLevel.INFO, it.level)
+          assertEquals("TIME_SET", it.data["action"])
+          assertNull(it.data["extras"])
+        },
+        anyOrNull(),
+      )
   }
 }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Adds an `isEnableSystemEventBreadcrumbsExtras` option to disable reporting extras which is potentially a heavy operation due to unmarshalling Parcelables 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
