### PR TITLE
fix(compose): Switch to compileOnly dependency for compose-ui-material

### DIFF
--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -43,8 +43,8 @@ kotlin {
       dependencies {
         api(projects.sentry)
         api(projects.sentryAndroidNavigation)
-        implementation(libs.androidx.compose.material3)
 
+        compileOnly(libs.androidx.compose.material3)
         compileOnly(libs.androidx.navigation.compose)
         implementation(libs.androidx.lifecycle.common.java8)
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #4587 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
