### PR TITLE
Update API level in UI tests critical

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -59,10 +59,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - api-level: 30 # Android 11
-            target: aosp_atd
-            channel: canary # Necessary for ATDs
-            arch: x86_64
           - api-level: 31 # Android 12
             target: aosp_atd
             channel: canary # Necessary for ATDs
@@ -72,6 +68,10 @@ jobs:
             channel: canary # Necessary for ATDs
             arch: x86_64
           - api-level: 34 # Android 14
+            target: aosp_atd
+            channel: canary # Necessary for ATDs
+            arch: x86_64
+          - api-level: 35 # Android 15
             target: aosp_atd
             channel: canary # Necessary for ATDs
             arch: x86_64


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

#skip-changelog

Testing against a newer Android API-level in CI and dropping the oldest one. At the time the UI tests were added the most recent versions were selected, but since then new versions have been released.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have experienced issues with the API level 30 in the UI tests critical action, resulting in our CI hanging. See the recent cancelled runs: https://github.com/getsentry/sentry-java/actions?query=is%3Acancelled

See related thread: https://github.com/ReactiveCircus/android-emulator-runner/issues/385

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
