### PR TITLE
Include Android API level 21 device in test matrix

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -59,6 +59,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - api-level: 21 # Android 5.0
+            target: default # ATDs images are only available on api-level 30+, so resort to default ones
+            channel: stable
+            arch: x86_64
           - api-level: 31 # Android 12
             target: aosp_atd
             channel: canary # Necessary for ATDs


### PR DESCRIPTION
## :scroll: Description

#skip-changelog


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
