### PR TITLE
Fix flaky SdkInitTests

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SystemEventsBreadcrumbsIntegration.java
@@ -189,23 +189,28 @@ public final class SystemEventsBreadcrumbsIntegration
 
     try {
       options
-        .getExecutorService()
-        .submit(
-          () -> {
-            final @Nullable SystemEventsBroadcastReceiver receiverRef;
-            try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
-              isStopped = true;
-              receiverRef = receiver;
-              receiver = null;
-            }
+          .getExecutorService()
+          .submit(
+              () -> {
+                final @Nullable SystemEventsBroadcastReceiver receiverRef;
+                try (final @NotNull ISentryLifecycleToken ignored = receiverLock.acquire()) {
+                  isStopped = true;
+                  receiverRef = receiver;
+                  receiver = null;
+                }
 
-            if (receiverRef != null) {
-              context.unregisterReceiver(receiverRef);
-            }
-          });
+                if (receiverRef != null) {
+                  context.unregisterReceiver(receiverRef);
+                }
+              });
     } catch (RejectedExecutionException e) {
       if (options != null) {
-        options.getLogger().log(SentryLevel.DEBUG, "SystemEventsBreadcrumbsIntegration was unable to unregister receiver.", e);
+        options
+            .getLogger()
+            .log(
+                SentryLevel.DEBUG,
+                "SystemEventsBreadcrumbsIntegration was unable to unregister receiver.",
+                e);
       }
     }
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Set a mocked online status provider that always returns `CONNECTED`
- Set lower `connectionTimeoutMillis` and `readTimeoutMillis` (500ms)

Also handle `RejectedExecutionException` in `SystemEventsBreadcrumbIntegration`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests could make Sentry think it's offline due to NO_RESPONSE thus directly using offline disk cache and never decrementing `relayIdlingResource`. Or they would run into the default timeout of 30s whereas the test only waits for 10s.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
