### PR TITLE
Bump Spring Boot 4 to M2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ retrofit = "2.9.0"
 slf4j = "1.7.30"
 springboot2 = "2.7.18"
 springboot3 = "3.5.0"
-springboot4 = "4.0.0-M1"
+springboot4 = "4.0.0-M2"
 # Android
 targetSdk = "34"
 compileSdk = "34"

--- a/sentry-spring-7/build.gradle.kts
+++ b/sentry-spring-7/build.gradle.kts
@@ -28,10 +28,9 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
   api(projects.sentry)
+
   compileOnly(platform(SpringBootPlugin.BOM_COORDINATES))
 
-  // Force all Netty modules to use the same version to avoid version conflicts
-  testImplementation(platform("io.netty:netty-bom:4.2.4.Final"))
   compileOnly(Config.Libs.springWeb)
   compileOnly(Config.Libs.springAop)
   compileOnly(Config.Libs.springSecurityWeb)
@@ -57,6 +56,7 @@ dependencies {
   errorprone(libs.nopen.checker)
   errorprone(libs.nullaway)
 
+  testImplementation(platform(SpringBootPlugin.BOM_COORDINATES))
   // tests
   testImplementation(projects.sentryTestSupport)
   testImplementation(projects.sentryGraphql)

--- a/sentry-spring-7/build.gradle.kts
+++ b/sentry-spring-7/build.gradle.kts
@@ -29,6 +29,9 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
   api(projects.sentry)
   compileOnly(platform(SpringBootPlugin.BOM_COORDINATES))
+
+  // Force all Netty modules to use the same version to avoid version conflicts
+  testImplementation(platform("io.netty:netty-bom:4.2.4.Final"))
   compileOnly(Config.Libs.springWeb)
   compileOnly(Config.Libs.springAop)
   compileOnly(Config.Libs.springSecurityWeb)

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/mvc/SentrySpringIntegrationTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/mvc/SentrySpringIntegrationTest.kt
@@ -389,21 +389,21 @@ open class App {
   @Bean
   open fun sentryUserFilter(scopes: IScopes, @Lazy sentryUserProviders: List<SentryUserProvider>) =
     FilterRegistrationBean<SentryUserFilter>().apply {
-      this.filter = SentryUserFilter(scopes, sentryUserProviders)
+      this.setFilter(SentryUserFilter(scopes, sentryUserProviders))
       this.order = Ordered.LOWEST_PRECEDENCE
     }
 
   @Bean
   open fun sentrySpringFilter(scopes: IScopes) =
     FilterRegistrationBean<SentrySpringFilter>().apply {
-      this.filter = SentrySpringFilter(scopes)
+      this.setFilter(SentrySpringFilter(scopes))
       this.order = Ordered.HIGHEST_PRECEDENCE
     }
 
   @Bean
   open fun sentryTracingFilter(scopes: IScopes) =
     FilterRegistrationBean<SentryTracingFilter>().apply {
-      this.filter = SentryTracingFilter(scopes)
+      this.setFilter(SentryTracingFilter(scopes))
       this.order = Ordered.HIGHEST_PRECEDENCE + 1 // must run after SentrySpringFilter
     }
 


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Spring Boot 4 M2 has been released, this PR bumps our used version and fixes some problems that showed up.

We should try to replace the explicit dependency version pin.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
