### PR TITLE
Only set log template if message differs from template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Only set log template for logging integrations if formatted message differs from template ([#4682](https://github.com/getsentry/sentry-java/pull/4682))
+
 ### Features
 
 - Add support for Spring Boot 4 and Spring 7 ([#4601](https://github.com/getsentry/sentry-java/pull/4601))

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -154,16 +154,9 @@ public class SentryHandler extends Handler {
       message = loggingEvent.getResourceBundle().getString(loggingEvent.getMessage());
     }
 
-    String formattedMessage = null;
-    boolean formattingFailed = false;
-    try {
-      formattedMessage = maybeFormatted(arguments, message);
-    } catch (RuntimeException e) {
-      formattedMessage = message;
-      formattingFailed = true;
-    }
+    final @NotNull String formattedMessage = maybeFormatted(arguments, message);
 
-    if (formattingFailed || !formattedMessage.equals(message)) {
+    if (!formattedMessage.equals(message)) {
       attributes.add(SentryAttribute.stringAttribute("sentry.message.template", message));
     }
 
@@ -180,7 +173,6 @@ public class SentryHandler extends Handler {
         return formatMessage(message, arguments);
       } catch (RuntimeException e) {
         // local formatting failed, sending raw message instead of formatted message
-        throw e;
       }
     }
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -154,9 +154,16 @@ public class SentryHandler extends Handler {
       message = loggingEvent.getResourceBundle().getString(loggingEvent.getMessage());
     }
 
-    final @NotNull String formattedMessage = maybeFormatted(arguments, message);
+    String formattedMessage = null;
+    boolean formattingFailed = false;
+    try {
+      formattedMessage = maybeFormatted(arguments, message);
+    } catch (RuntimeException e) {
+      formattedMessage = message;
+      formattingFailed = true;
+    }
 
-    if (!formattedMessage.equals(message)) {
+    if (formattingFailed || !formattedMessage.equals(message)) {
       attributes.add(SentryAttribute.stringAttribute("sentry.message.template", message));
     }
 
@@ -173,6 +180,7 @@ public class SentryHandler extends Handler {
         return formatMessage(message, arguments);
       } catch (RuntimeException e) {
         // local formatting failed, sending raw message instead of formatted message
+        throw e;
       }
     }
 

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -154,9 +154,12 @@ public class SentryHandler extends Handler {
       message = loggingEvent.getResourceBundle().getString(loggingEvent.getMessage());
     }
 
-    attributes.add(SentryAttribute.stringAttribute("sentry.message.template", message));
-
     final @NotNull String formattedMessage = maybeFormatted(arguments, message);
+
+    if (!formattedMessage.equals(message)) {
+      attributes.add(SentryAttribute.stringAttribute("sentry.message.template", message));
+    }
+
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
     params.setOrigin("auto.log.jul");
 

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -555,22 +555,4 @@ class SentryHandlerTest {
         }
       )
   }
-
-  @Test
-  fun `sets template on log when logging message with parameters and formatting fails due to 0 args`() {
-    fixture = Fixture(minimumLevel = Level.SEVERE, printfStyle = true)
-    fixture.logger.log(Level.SEVERE, "testing message %d", emptyArray())
-
-    Sentry.flush(1000)
-
-    verify(fixture.transport)
-      .send(
-        checkLogs { logs ->
-          val log = logs.items.first()
-          assertEquals("testing message %d", log.body)
-          assertEquals("testing message %d", log.attributes?.get("sentry.message.template")?.value)
-          assertNull(log.attributes?.get("sentry.message.parameter.0"))
-        }
-      )
-  }
 }

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -35,7 +35,7 @@ class SentryHandlerTest {
     val configureWithLogManager: Boolean = false,
     val transport: ITransport = mock(),
     contextTags: List<String>? = null,
-    printfStyle: Boolean = true,
+    printfStyle: Boolean? = null,
   ) {
     var logger: Logger
     var handler: SentryHandler
@@ -50,7 +50,9 @@ class SentryHandlerTest {
       handler.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
       handler.setMinimumEventLevel(minimumEventLevel)
       handler.setMinimumLevel(minimumLevel)
-      handler.setPrintfStyle(printfStyle)
+      if (printfStyle == true) {
+        handler.setPrintfStyle(printfStyle)
+      }
       handler.level = Level.ALL
       logger.handlers.forEach { logger.removeHandler(it) }
       logger.addHandler(handler)
@@ -534,8 +536,8 @@ class SentryHandlerTest {
 
   @Test
   fun `sets template on log when logging message with parameters and formatting fails`() {
-    fixture = Fixture(minimumLevel = Level.SEVERE)
-    fixture.logger.log(Level.SEVERE, "testing message {0} {1}", arrayOf(1))
+    fixture = Fixture(minimumLevel = Level.SEVERE, printfStyle = true)
+    fixture.logger.log(Level.SEVERE, "testing message %d %d", arrayOf(1))
 
     Sentry.flush(1000)
 
@@ -543,9 +545,9 @@ class SentryHandlerTest {
       .send(
         checkLogs { logs ->
           val log = logs.items.first()
-          assertEquals("testing message {0} {1}", log.body)
+          assertEquals("testing message %d %d", log.body)
           assertEquals(
-            "testing message {0} {1}",
+            "testing message %d %d",
             log.attributes?.get("sentry.message.template")?.value,
           )
           assertEquals(1, log.attributes?.get("sentry.message.parameter.0")?.value)

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -35,6 +35,7 @@ class SentryHandlerTest {
     val configureWithLogManager: Boolean = false,
     val transport: ITransport = mock(),
     contextTags: List<String>? = null,
+    printfStyle: Boolean = true,
   ) {
     var logger: Logger
     var handler: SentryHandler
@@ -49,6 +50,7 @@ class SentryHandlerTest {
       handler.setMinimumBreadcrumbLevel(minimumBreadcrumbLevel)
       handler.setMinimumEventLevel(minimumEventLevel)
       handler.setMinimumLevel(minimumLevel)
+      handler.setPrintfStyle(printfStyle)
       handler.level = Level.ALL
       logger.handlers.forEach { logger.removeHandler(it) }
       logger.addHandler(handler)
@@ -475,5 +477,95 @@ class SentryHandlerTest {
 
     verify(fixture.transport)
       .send(checkLogs { event -> assertEquals(SentryLogLevel.ERROR, event.items.first().level) })
+  }
+
+  @Test
+  fun `does not set template on log when logging message without parameters`() {
+    fixture = Fixture(minimumLevel = Level.SEVERE)
+    fixture.logger.severe("testing message without parameters")
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message without parameters", log.body)
+          assertNull(log.attributes?.get("sentry.message.template"))
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters`() {
+    fixture = Fixture(minimumLevel = Level.SEVERE)
+    fixture.logger.log(Level.SEVERE, "testing message {0}", arrayOf("param"))
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message param", log.body)
+          assertEquals("testing message {0}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals("param", log.attributes?.get("sentry.message.parameter.0")?.value)
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters and using printfStyle`() {
+    fixture = Fixture(minimumLevel = Level.SEVERE, printfStyle = true)
+    fixture.logger.log(Level.SEVERE, "testing message %s", arrayOf("param"))
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message param", log.body)
+          assertEquals("testing message %s", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals("param", log.attributes?.get("sentry.message.parameter.0")?.value)
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters and formatting fails`() {
+    fixture = Fixture(minimumLevel = Level.SEVERE)
+    fixture.logger.log(Level.SEVERE, "testing message {0} {1}", arrayOf(1))
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message {0} {1}", log.body)
+          assertEquals("testing message {0} {1}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals(1, log.attributes?.get("sentry.message.parameter.0")?.value)
+          assertNull(log.attributes?.get("sentry.message.parameter.1"))
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters and formatting fails due to 0 args`() {
+    fixture = Fixture(minimumLevel = Level.SEVERE, printfStyle = true)
+    fixture.logger.log(Level.SEVERE, "testing message %d", emptyArray())
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message %d", log.body)
+          assertEquals("testing message %d", log.attributes?.get("sentry.message.template")?.value)
+          assertNull(log.attributes?.get("sentry.message.parameter.0"))
+        }
+      )
   }
 }

--- a/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
+++ b/sentry-jul/src/test/kotlin/io/sentry/jul/SentryHandlerTest.kt
@@ -544,7 +544,10 @@ class SentryHandlerTest {
         checkLogs { logs ->
           val log = logs.items.first()
           assertEquals("testing message {0} {1}", log.body)
-          assertEquals("testing message {0} {1}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals(
+            "testing message {0} {1}",
+            log.attributes?.get("sentry.message.template")?.value,
+          )
           assertEquals(1, log.attributes?.get("sentry.message.parameter.0")?.value)
           assertNull(log.attributes?.get("sentry.message.parameter.1"))
         }

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -222,11 +222,14 @@ public class SentryAppender extends AbstractAppender {
     final @Nullable Object[] arguments = loggingEvent.getMessage().getParameters();
     final @NotNull SentryAttributes attributes = SentryAttributes.of();
 
-    attributes.add(
-        SentryAttribute.stringAttribute(
-            "sentry.message.template", loggingEvent.getMessage().getFormat()));
-
+    final @Nullable String nonFormattedMessage = loggingEvent.getMessage().getFormat();
     final @NotNull String formattedMessage = loggingEvent.getMessage().getFormattedMessage();
+
+    if (nonFormattedMessage != null && !formattedMessage.equals(nonFormattedMessage)) {
+      attributes.add(
+          SentryAttribute.stringAttribute("sentry.message.template", nonFormattedMessage));
+    }
+
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
     params.setOrigin("auto.log.log4j2");
 

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.config.AppenderRef
 import org.apache.logging.log4j.core.config.Configuration
 import org.apache.logging.log4j.core.config.LoggerConfig
-import org.apache.logging.log4j.core.layout.PatternLayout
 import org.apache.logging.log4j.spi.ExtendedLogger
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -583,7 +582,10 @@ class SentryAppenderTest {
         checkLogs { logs ->
           val log = logs.items.first()
           assertEquals("testing message param1 param2 {}", log.body)
-          assertEquals("testing message {} {} {}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals(
+            "testing message {} {} {}",
+            log.attributes?.get("sentry.message.template")?.value,
+          )
           assertEquals("param1", log.attributes?.get("sentry.message.parameter.0")?.value)
           assertEquals("param2", log.attributes?.get("sentry.message.parameter.1")?.value)
           assertNull(log.attributes?.get("sentry.message.parameter.2"))

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -60,7 +60,6 @@ class SentryAppenderTest {
       }
       loggerContext.start()
       val config: Configuration = loggerContext.configuration
-
       val appender =
         SentryAppender(
           "sentry",

--- a/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
+++ b/sentry-log4j2/src/test/kotlin/io/sentry/log4j2/SentryAppenderTest.kt
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.config.AppenderRef
 import org.apache.logging.log4j.core.config.Configuration
 import org.apache.logging.log4j.core.config.LoggerConfig
+import org.apache.logging.log4j.core.layout.PatternLayout
 import org.apache.logging.log4j.spi.ExtendedLogger
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -60,6 +61,7 @@ class SentryAppenderTest {
       }
       loggerContext.start()
       val config: Configuration = loggerContext.configuration
+
       val appender =
         SentryAppender(
           "sentry",
@@ -532,5 +534,60 @@ class SentryAppenderTest {
   fun `sets the debug mode`() {
     fixture.getSut(debug = true)
     assertTrue(ScopesAdapter.getInstance().options.isDebug)
+  }
+
+  @Test
+  fun `does not set template on log when logging message without parameters`() {
+    val logger = fixture.getSut(minimumLevel = Level.ERROR)
+    logger.error("testing message without parameters")
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message without parameters", log.body)
+          assertNull(log.attributes?.get("sentry.message.template"))
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters`() {
+    val logger = fixture.getSut(minimumLevel = Level.ERROR)
+    logger.error("testing message {}", "param")
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message param", log.body)
+          assertEquals("testing message {}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals("param", log.attributes?.get("sentry.message.parameter.0")?.value)
+        }
+      )
+  }
+
+  @Test
+  fun `sets template on log when logging message with parameters and number of parameters is wrong`() {
+    val logger = fixture.getSut(minimumLevel = Level.ERROR)
+    logger.error("testing message {} {} {}", "param1", "param2")
+
+    Sentry.flush(1000)
+
+    verify(fixture.transport)
+      .send(
+        checkLogs { logs ->
+          val log = logs.items.first()
+          assertEquals("testing message param1 param2 {}", log.body)
+          assertEquals("testing message {} {} {}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals("param1", log.attributes?.get("sentry.message.parameter.0")?.value)
+          assertEquals("param2", log.attributes?.get("sentry.message.parameter.1")?.value)
+          assertNull(log.attributes?.get("sentry.message.parameter.2"))
+        }
+      )
   }
 }

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -183,15 +183,18 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     @Nullable Object[] arguments = null;
     final @NotNull SentryAttributes attributes = SentryAttributes.of();
+    final @NotNull String formattedMessage = formatted(loggingEvent);
 
     // if encoder is set we treat message+params as PII as encoders may be used to mask/strip PII
     if (encoder == null || ScopesAdapter.getInstance().getOptions().isSendDefaultPii()) {
-      attributes.add(
-          SentryAttribute.stringAttribute("sentry.message.template", loggingEvent.getMessage()));
+      final @Nullable String nonFormattedMessage = loggingEvent.getMessage();
+      if (nonFormattedMessage != null && !formattedMessage.equals(nonFormattedMessage)) {
+        attributes.add(
+            SentryAttribute.stringAttribute("sentry.message.template", nonFormattedMessage));
+      }
       arguments = loggingEvent.getArgumentArray();
     }
 
-    final @NotNull String formattedMessage = formatted(loggingEvent);
     final @NotNull SentryLogParameters params = SentryLogParameters.create(attributes);
     params.setOrigin("auto.log.logback");
 

--- a/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
+++ b/sentry-logback/src/test/kotlin/io/sentry/logback/SentryAppenderTest.kt
@@ -759,7 +759,10 @@ class SentryAppenderTest {
         checkLogs { logs ->
           val log = logs.items.first()
           assertEquals("testing message param1 param2 {}", log.body)
-          assertEquals("testing message {} {} {}", log.attributes?.get("sentry.message.template")?.value)
+          assertEquals(
+            "testing message {} {} {}",
+            log.attributes?.get("sentry.message.template")?.value,
+          )
           assertEquals("param1", log.attributes?.get("sentry.message.parameter.0")?.value)
           assertEquals("param2", log.attributes?.get("sentry.message.parameter.1")?.value)
           assertNull(log.attributes?.get("sentry.message.parameter.2"))
@@ -771,7 +774,13 @@ class SentryAppenderTest {
   fun `does not set template or attributes on log with encoder when sendDefaultPii is false`() {
     var encoder = PatternLayoutEncoder()
     encoder.pattern = "encoded %msg"
-    fixture = Fixture(minimumLevel = Level.ERROR, enableLogs = true, encoder = encoder, sendDefaultPii = false)
+    fixture =
+      Fixture(
+        minimumLevel = Level.ERROR,
+        enableLogs = true,
+        encoder = encoder,
+        sendDefaultPii = false,
+      )
     fixture.logger.error("testing message {}", "param")
 
     Sentry.flush(1000)
@@ -791,7 +800,13 @@ class SentryAppenderTest {
   fun `sets template and attributes on log with encoder when sendDefaultPii is true`() {
     var encoder = PatternLayoutEncoder()
     encoder.pattern = "encoded %msg"
-    fixture = Fixture(minimumLevel = Level.ERROR, enableLogs = true, encoder = encoder, sendDefaultPii = true)
+    fixture =
+      Fixture(
+        minimumLevel = Level.ERROR,
+        enableLogs = true,
+        encoder = encoder,
+        sendDefaultPii = true,
+      )
     fixture.logger.error("testing message {}", "param")
 
     Sentry.flush(1000)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Only set template attribute for logging integrations if the formatted message differs from the template.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-java/issues/4675

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
