### PR TITLE
Flush logs on crash

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -245,6 +245,12 @@ public final class SentryClient implements ISentryClient {
       finalizeTransaction(scope, hint);
     }
 
+    // if event is backfillable or cached we don't need to flush the logs, because it's an event
+    // from the past. Otherwise we need to flush the logs to ensure they are sent on crash
+    if (event != null && !isBackfillable && !isCached && event.isCrashed()) {
+      loggerBatchProcessor.flush(options.getFlushTimeoutMillis());
+    }
+
     return sentryId;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3024,6 +3024,25 @@ class SentryClientTest {
   }
 
   @Test
+  fun `flush logs for crash events`() {
+    val sut = fixture.getSut()
+    val batchProcessor = mock<ILoggerBatchProcessor>()
+    sut.injectForField("loggerBatchProcessor", batchProcessor)
+    sut.captureLog(
+      SentryLogEvent(SentryId(), SentryNanotimeDate(), "message", SentryLogLevel.WARN),
+      fixture.scopes.scope,
+    )
+
+    sut.captureEvent(
+      SentryEvent().apply {
+        exceptions =
+          listOf(SentryException().apply { mechanism = Mechanism().apply { isHandled = false } })
+      }
+    )
+    verify(batchProcessor).flush(any())
+  }
+
+  @Test
   fun `cleans up replay folder for Backfillable replay events`() {
     val dir = File(tmpDir.newFolder().absolutePath)
     val sut = fixture.getSut()


### PR DESCRIPTION
## :scroll: Description
When a crash occurs, logs are flushed


## :bulb: Motivation and Context
We ensure to store logs to disk (or even send them) instead of losing them due to being only in memory when a crash occurs


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
