### PR TITLE
feat: Frame vars

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5933,6 +5933,7 @@ public final class io/sentry/protocol/SentryStackFrame$JsonKeys {
 	public static final field RAW_FUNCTION Ljava/lang/String;
 	public static final field SYMBOL Ljava/lang/String;
 	public static final field SYMBOL_ADDR Ljava/lang/String;
+	public static final field VARS Ljava/lang/String;
 	public fun <init> ()V
 }
 

--- a/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryStackFrame.java
@@ -29,7 +29,7 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
   private @Nullable List<String> postContext;
 
   /** Mapping of local variables and expression names that were available in this frame. */
-  private @Nullable Map<String, String> vars;
+  private @Nullable Map<String, Object> vars;
 
   private @Nullable List<Integer> framesOmitted;
 
@@ -170,11 +170,11 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     this.postContext = postContext;
   }
 
-  public @Nullable Map<String, String> getVars() {
+  public @Nullable Map<String, Object> getVars() {
     return vars;
   }
 
-  public void setVars(final @Nullable Map<String, String> vars) {
+  public void setVars(final @Nullable Map<String, Object> vars) {
     this.vars = vars;
   }
 
@@ -366,6 +366,7 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     public static final String LOCK = "lock";
     public static final String PRE_CONTEXT = "pre_context";
     public static final String POST_CONTEXT = "post_context";
+    public static final String VARS = "vars";
   }
 
   @Override
@@ -431,6 +432,9 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
     }
     if (postContext != null && !postContext.isEmpty()) {
       writer.name(JsonKeys.POST_CONTEXT).value(logger, postContext);
+    }
+    if (vars != null && !vars.isEmpty()) {
+      writer.name(JsonKeys.VARS).value(logger, vars);
     }
     if (unknown != null) {
       for (String key : unknown.keySet()) {
@@ -512,6 +516,9 @@ public final class SentryStackFrame implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.POST_CONTEXT:
             sentryStackFrame.postContext = (List<String>) reader.nextObjectOrNull();
+            break;
+          case JsonKeys.VARS:
+            sentryStackFrame.vars = (Map<String, Object>) reader.nextObjectOrNull();
             break;
           default:
             if (unknown == null) {

--- a/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryStackFrameSerializationTest.kt
@@ -54,6 +54,19 @@ class SentryStackFrameSerializationTest {
             "0a959b53-6bdf-45d1-93ca-936281d7897a",
             "4e6085a3-1e44-4aa2-b3d9-9b79dca970ed",
           )
+        vars =
+          mapOf<String, Any?>(
+            "int_var" to 42,
+            "array_var" to listOf<Any?>(true, 17, "7a3750d1-9177-4ee2-8016-3ba02fa90291"),
+            "string_var" to "325ad70e-1a8b-4d2d-ba92-182ee49448b7",
+            "object_var" to
+              mapOf<String, Any?>(
+                "int_prop" to 53,
+                "string_prop" to "93db3ec5-b1ec-4e95-b6d0-b9633c9e03cd",
+                "bool_prop" to false,
+              ),
+            "bool_var" to false,
+          )
       }
   }
 

--- a/sentry/src/test/resources/json/sentry_stack_frame.json
+++ b/sentry/src/test/resources/json/sentry_stack_frame.json
@@ -31,5 +31,20 @@
       "2153c99d-2f17-45f1-a173-69e08cc6a219",
       "0a959b53-6bdf-45d1-93ca-936281d7897a",
       "4e6085a3-1e44-4aa2-b3d9-9b79dca970ed"
-    ]
+    ],
+    "vars": {
+      "int_var": 42,
+      "array_var": [
+        true,
+        17,
+        "7a3750d1-9177-4ee2-8016-3ba02fa90291"
+      ],
+      "string_var": "325ad70e-1a8b-4d2d-ba92-182ee49448b7",
+      "object_var": {
+        "int_prop": 53,
+        "string_prop": "93db3ec5-b1ec-4e95-b6d0-b9633c9e03cd",
+        "bool_prop": false
+      },
+      "bool_var": false
+    }
 }


### PR DESCRIPTION
## :scroll: Description

This PR introduces the `vars` attribute to the `SentryFrame` class. While it existed previously, it wasn’t serialized and had a String->String mapping type.

## :bulb: Motivation and Context

These changes are necessary for the [Godot SDK](https://github.com/getsentry/sentry-godot) to capture script variables on Android. For GDScript errors, we construct a stack trace and attach variables for each frame. There is a similar setup with Sentry Native and Cocoa backend SDKs.

## :green_heart: How did you test it?

I've added serialization tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
