### PR TITLE
ref: Add Nullable for setSampleRate in Options

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1061,7 +1061,7 @@ public class SentryOptions {
    *
    * @param sampleRate the sample rate
    */
-  public void setSampleRate(Double sampleRate) {
+  public void setSampleRate(@Nullable Double sampleRate) {
     if (!SampleRateUtils.isValidSampleRate(sampleRate)) {
       throw new IllegalArgumentException(
           "The value "


### PR DESCRIPTION
The sampleRate is nullable and the setSampleRate method didn't have the `@Nullable` annotation.
This is fixed now.

#skip-changelog