### PR TITLE
Move SentryLogs out of experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Move SentryLogs out of experimental ([#4710](https://github.com/getsentry/sentry-java/pull/4710))
 - Add support for w3c traceparent header ([#4671](https://github.com/getsentry/sentry-java/pull/4671))
   - This feature is disabled by default. If enabled, outgoing requests will include the w3c `traceparent` header.
   - See https://develop.sentry.dev/sdk/telemetry/traces/distributed-tracing/#w3c-trace-context-header for more details.

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -522,12 +522,10 @@ public final class ExternalOptions {
     return captureOpenTelemetryEvents;
   }
 
-  @ApiStatus.Experimental
   public void setEnableLogs(final @Nullable Boolean enableLogs) {
     this.enableLogs = enableLogs;
   }
 
-  @ApiStatus.Experimental
   public @Nullable Boolean isEnableLogs() {
     return enableLogs;
   }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -384,7 +384,6 @@ public final class HubAdapter implements IHub {
     return Sentry.getCurrentScopes().getRateLimiter();
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull ILoggerApi logger() {
     return Sentry.getCurrentScopes().logger();

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -370,7 +370,6 @@ public final class HubScopesWrapper implements IHub {
     return scopes.captureReplay(replay, hint);
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull ILoggerApi logger() {
     return scopes.logger();

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -742,7 +742,6 @@ public interface IScopes {
   @NotNull
   SentryId captureReplay(@NotNull SentryReplayEvent replay, @Nullable Hint hint);
 
-  @ApiStatus.Experimental
   @NotNull
   ILoggerApi logger();
 }

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -304,7 +304,6 @@ public interface ISentryClient {
   @ApiStatus.Experimental
   SentryId captureCheckIn(@NotNull CheckIn checkIn, @Nullable IScope scope, @Nullable Hint hint);
 
-  @ApiStatus.Experimental
   void captureLog(@NotNull SentryLogEvent logEvent, @Nullable IScope scope);
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -327,7 +327,6 @@ public final class NoOpHub implements IHub {
     return true;
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull ILoggerApi logger() {
     return NoOpLoggerApi.getInstance();

--- a/sentry/src/main/java/io/sentry/NoOpScopes.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopes.java
@@ -324,7 +324,6 @@ public final class NoOpScopes implements IScopes {
     return SentryId.EMPTY_ID;
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull ILoggerApi logger() {
     return NoOpLoggerApi.getInstance();

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -84,7 +84,6 @@ final class NoOpSentryClient implements ISentryClient {
     return SentryId.EMPTY_ID;
   }
 
-  @ApiStatus.Experimental
   @Override
   public void captureLog(@NotNull SentryLogEvent logEvent, @Nullable IScope scope) {
     // do nothing

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -381,7 +381,6 @@ public final class ScopesAdapter implements IScopes {
     return Sentry.getCurrentScopes().captureReplay(replay, hint);
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull ILoggerApi logger() {
     return Sentry.getCurrentScopes().logger();

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1291,7 +1291,6 @@ public final class Sentry {
     return getCurrentScopes().captureCheckIn(checkIn);
   }
 
-  @ApiStatus.Experimental
   @NotNull
   public static ILoggerApi logger() {
     return getCurrentScopes().logger();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3476,20 +3476,19 @@ public class SentryOptions {
   public static final class Logs {
 
     /** Whether Sentry Logs feature is enabled and Sentry.logger() usages are sent to Sentry. */
-    @ApiStatus.Experimental private boolean enable = false;
+    private boolean enable = false;
 
     /**
      * This function is called with an SDK specific log event object and can return a modified event
      * object or nothing to skip reporting the log item
      */
-    @ApiStatus.Experimental private @Nullable BeforeSendLogCallback beforeSend;
+    private @Nullable BeforeSendLogCallback beforeSend;
 
     /**
      * Whether Sentry Logs feature is enabled and Sentry.logger() usages are sent to Sentry.
      *
      * @return true if Sentry Logs should be enabled
      */
-    @ApiStatus.Experimental
     public boolean isEnabled() {
       return enable;
     }
@@ -3499,7 +3498,6 @@ public class SentryOptions {
      *
      * @param enableLogs true if Sentry Logs should be enabled
      */
-    @ApiStatus.Experimental
     public void setEnabled(boolean enableLogs) {
       this.enable = enableLogs;
     }
@@ -3509,7 +3507,6 @@ public class SentryOptions {
      *
      * @return the beforeSendLog callback or null if not set
      */
-    @ApiStatus.Experimental
     public @Nullable BeforeSendLogCallback getBeforeSend() {
       return beforeSend;
     }
@@ -3519,7 +3516,6 @@ public class SentryOptions {
      *
      * @param beforeSendLog the beforeSendLog callback
      */
-    @ApiStatus.Experimental
     public void setBeforeSend(@Nullable BeforeSendLogCallback beforeSendLog) {
       this.beforeSend = beforeSendLog;
     }

--- a/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/ILoggerApi.java
@@ -2,11 +2,9 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public interface ILoggerApi {
 
   void trace(final @Nullable String message, @Nullable Object... args);

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -21,11 +21,9 @@ import io.sentry.protocol.User;
 import io.sentry.util.Platform;
 import io.sentry.util.TracingUtils;
 import java.util.HashMap;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public final class LoggerApi implements ILoggerApi {
 
   private final @NotNull Scopes scopes;

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerApi.java
@@ -2,11 +2,9 @@ package io.sentry.logger;
 
 import io.sentry.SentryDate;
 import io.sentry.SentryLogLevel;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public final class NoOpLoggerApi implements ILoggerApi {
 
   private static final NoOpLoggerApi instance = new NoOpLoggerApi();

--- a/sentry/src/main/java/io/sentry/logger/NoOpLoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/NoOpLoggerBatchProcessor.java
@@ -1,10 +1,8 @@
 package io.sentry.logger;
 
 import io.sentry.SentryLogEvent;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-@ApiStatus.Experimental
 public final class NoOpLoggerBatchProcessor implements ILoggerBatchProcessor {
 
   private static final NoOpLoggerBatchProcessor instance = new NoOpLoggerBatchProcessor();


### PR DESCRIPTION
## :scroll: Description
removed all @Experimental annotations from SentryLogs code


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
