### PR TITLE
Remove ApiStatus.Experimental annotations from check-in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Improvements
 
 - Remove internal API status from get/setDistinctId ([#4708](https://github.com/getsentry/sentry-java/pull/4708))
+- Remove ApiStatus.Experimental annotation from check-in API ([#4721](https://github.com/getsentry/sentry-java/pull/4721))
 
 ## 8.21.1
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckIn.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckIn.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.jetbrains.annotations.ApiStatus;
 import org.springframework.core.annotation.AliasFor;
 
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckIn.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckIn.java
@@ -10,7 +10,6 @@ import org.springframework.core.annotation.AliasFor;
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@ApiStatus.Experimental
 public @interface SentryCheckIn {
 
   /**

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
@@ -28,7 +28,6 @@ import org.springframework.util.StringValueResolver;
  * check-in.
  */
 @ApiStatus.Internal
-@ApiStatus.Experimental
 @Open
 public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueResolverAware {
   private final @NotNull IScopes scopes;

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdviceConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInAdviceConfiguration {
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdviceConfiguration.java
@@ -2,7 +2,6 @@ package io.sentry.spring7.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
 import org.aopalliance.aop.Advice;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInPointcutConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 /** AOP pointcut configuration for {@link SentryCheckIn}. */
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInPointcutConfiguration {
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInPointcutConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring7.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckIn.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckIn.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.jetbrains.annotations.ApiStatus;
 import org.springframework.core.annotation.AliasFor;
 
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckIn.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckIn.java
@@ -10,7 +10,6 @@ import org.springframework.core.annotation.AliasFor;
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@ApiStatus.Experimental
 public @interface SentryCheckIn {
 
   /**

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -28,7 +28,6 @@ import org.springframework.util.StringValueResolver;
  * check-in.
  */
 @ApiStatus.Internal
-@ApiStatus.Experimental
 @Open
 public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueResolverAware {
   private final @NotNull IScopes scopes;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
@@ -2,7 +2,6 @@ package io.sentry.spring.jakarta.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
 import org.aopalliance.aop.Advice;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdviceConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInAdviceConfiguration {
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 /** AOP pointcut configuration for {@link SentryCheckIn}. */
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInPointcutConfiguration {
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInPointcutConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckIn.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckIn.java
@@ -4,7 +4,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.jetbrains.annotations.ApiStatus;
 import org.springframework.core.annotation.AliasFor;
 
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckIn.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckIn.java
@@ -10,7 +10,6 @@ import org.springframework.core.annotation.AliasFor;
 /** Sends a {@link io.sentry.CheckIn} for the annotated method. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-@ApiStatus.Experimental
 public @interface SentryCheckIn {
 
   /**

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -28,7 +28,6 @@ import org.springframework.util.StringValueResolver;
  * check-in.
  */
 @ApiStatus.Internal
-@ApiStatus.Experimental
 @Open
 public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueResolverAware {
   private final @NotNull IScopes scopes;

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInAdviceConfiguration {
 

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdviceConfiguration.java
@@ -2,7 +2,6 @@ package io.sentry.spring.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
 import org.aopalliance.aop.Advice;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.Pointcut;

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Role;
 /** AOP pointcut configuration for {@link SentryCheckIn}. */
 @Configuration(proxyBeanMethods = false)
 @Open
-@ApiStatus.Experimental
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class SentryCheckInPointcutConfiguration {
 

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInPointcutConfiguration.java
@@ -1,7 +1,6 @@
 package io.sentry.spring.checkin;
 
 import com.jakewharton.nopen.annotation.Open;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.ComposablePointcut;

--- a/sentry/src/main/java/io/sentry/CheckIn.java
+++ b/sentry/src/main/java/io/sentry/CheckIn.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 /** A check-in for a monitor (CRON). */
 public final class CheckIn implements JsonUnknown, JsonSerializable {
 

--- a/sentry/src/main/java/io/sentry/CheckInStatus.java
+++ b/sentry/src/main/java/io/sentry/CheckInStatus.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Status of a CheckIn */
-@ApiStatus.Experimental
 public enum CheckInStatus {
   IN_PROGRESS,
   OK,

--- a/sentry/src/main/java/io/sentry/CheckInStatus.java
+++ b/sentry/src/main/java/io/sentry/CheckInStatus.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import java.util.Locale;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Status of a CheckIn */

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -437,12 +437,10 @@ public final class ExternalOptions {
     this.sendDefaultPii = sendDefaultPii;
   }
 
-  @ApiStatus.Experimental
   public void setIgnoredCheckIns(final @Nullable List<String> ignoredCheckIns) {
     this.ignoredCheckIns = ignoredCheckIns;
   }
 
-  @ApiStatus.Experimental
   public @Nullable List<String> getIgnoredCheckIns() {
     return ignoredCheckIns;
   }
@@ -482,12 +480,10 @@ public final class ExternalOptions {
     return forceInit;
   }
 
-  @ApiStatus.Experimental
   public @Nullable SentryOptions.Cron getCron() {
     return cron;
   }
 
-  @ApiStatus.Experimental
   public void setCron(final @Nullable SentryOptions.Cron cron) {
     this.cron = cron;
   }

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -353,7 +353,6 @@ public final class HubScopesWrapper implements IHub {
     return scopes.getBaggage();
   }
 
-  @ApiStatus.Experimental
   @Override
   public @NotNull SentryId captureCheckIn(@NotNull CheckIn checkIn) {
     return scopes.captureCheckIn(checkIn);

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -727,7 +727,6 @@ public interface IScopes {
   @Nullable
   BaggageHeader getBaggage();
 
-  @ApiStatus.Experimental
   @NotNull
   SentryId captureCheckIn(final @NotNull CheckIn checkIn);
 

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -301,7 +301,6 @@ public interface ISentryClient {
       final @NotNull ProfileChunk profilingContinuousData, final @Nullable IScope scope);
 
   @NotNull
-  @ApiStatus.Experimental
   SentryId captureCheckIn(@NotNull CheckIn checkIn, @Nullable IScope scope, @Nullable Hint hint);
 
   void captureLog(@NotNull SentryLogEvent logEvent, @Nullable IScope scope);

--- a/sentry/src/main/java/io/sentry/MonitorConfig.java
+++ b/sentry/src/main/java/io/sentry/MonitorConfig.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public final class MonitorConfig implements JsonUnknown, JsonSerializable {
 
   private @NotNull MonitorSchedule schedule;

--- a/sentry/src/main/java/io/sentry/MonitorConfig.java
+++ b/sentry/src/main/java/io/sentry/MonitorConfig.java
@@ -4,7 +4,6 @@ import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/sentry/src/main/java/io/sentry/MonitorContexts.java
+++ b/sentry/src/main/java/io/sentry/MonitorContexts.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public final class MonitorContexts extends ConcurrentHashMap<String, Object>
     implements JsonSerializable {
   private static final long serialVersionUID = 3987329379811822556L;

--- a/sentry/src/main/java/io/sentry/MonitorContexts.java
+++ b/sentry/src/main/java/io/sentry/MonitorContexts.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/sentry/src/main/java/io/sentry/MonitorSchedule.java
+++ b/sentry/src/main/java/io/sentry/MonitorSchedule.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Experimental
 public final class MonitorSchedule implements JsonUnknown, JsonSerializable {
 
   public static @NotNull MonitorSchedule crontab(final @NotNull String value) {

--- a/sentry/src/main/java/io/sentry/MonitorScheduleType.java
+++ b/sentry/src/main/java/io/sentry/MonitorScheduleType.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import java.util.Locale;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Type of a monitor schedule */

--- a/sentry/src/main/java/io/sentry/MonitorScheduleType.java
+++ b/sentry/src/main/java/io/sentry/MonitorScheduleType.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Type of a monitor schedule */
-@ApiStatus.Experimental
 public enum MonitorScheduleType {
   CRONTAB,
   INTERVAL;

--- a/sentry/src/main/java/io/sentry/MonitorScheduleUnit.java
+++ b/sentry/src/main/java/io/sentry/MonitorScheduleUnit.java
@@ -5,7 +5,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Time unit of a monitor schedule. */
-@ApiStatus.Experimental
 public enum MonitorScheduleUnit {
   MINUTE,
   HOUR,

--- a/sentry/src/main/java/io/sentry/MonitorScheduleUnit.java
+++ b/sentry/src/main/java/io/sentry/MonitorScheduleUnit.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import java.util.Locale;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Time unit of a monitor schedule. */

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -307,7 +307,6 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
-  @ApiStatus.Experimental
   public @NotNull SentryId captureCheckIn(final @NotNull CheckIn checkIn) {
     return SentryId.EMPTY_ID;
   }

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -72,7 +72,6 @@ final class NoOpSentryClient implements ISentryClient {
   }
 
   @Override
-  @ApiStatus.Experimental
   public @NotNull SentryId captureCheckIn(
       @NotNull CheckIn checkIn, @Nullable IScope scope, @Nullable Hint hint) {
     return SentryId.EMPTY_ID;

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -1155,7 +1155,6 @@ public final class Scopes implements IScopes {
   }
 
   @Override
-  @ApiStatus.Experimental
   public @NotNull SentryId captureCheckIn(final @NotNull CheckIn checkIn) {
     SentryId sentryId = SentryId.EMPTY_ID;
     if (!isEnabled()) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1286,7 +1286,6 @@ public final class Sentry {
     return getCurrentScopes().getBaggage();
   }
 
-  @ApiStatus.Experimental
   public static @NotNull SentryId captureCheckIn(final @NotNull CheckIn checkIn) {
     return getCurrentScopes().captureCheckIn(checkIn);
   }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -998,7 +998,6 @@ public final class SentryClient implements ISentryClient {
   }
 
   @Override
-  @ApiStatus.Experimental
   public @NotNull SentryId captureCheckIn(
       @NotNull CheckIn checkIn, final @Nullable IScope scope, @Nullable Hint hint) {
     if (hint == null) {


### PR DESCRIPTION
Removes `@ApiStatus.Experimental` from the whole Check-in API.
Keeps `@ApiStatus.Internal` where present.

Close #4673 