### PR TITLE
feat(android-distribution): Use ProGuard UUID for build identification

### DIFF
--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/internal/DistributionInternal.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/internal/DistributionInternal.kt
@@ -1,6 +1,7 @@
 package io.sentry.android.distribution.internal
 
 import android.content.Context
+import io.sentry.Sentry
 import io.sentry.android.distribution.DistributionOptions
 import io.sentry.android.distribution.UpdateStatus
 
@@ -19,10 +20,22 @@ internal object DistributionInternal {
   }
 
   fun checkForUpdateBlocking(context: Context): UpdateStatus {
-    return UpdateStatus.Error("Implementation coming in future PR")
+    val buildIdentifier = Sentry.getCurrentScopes().options.proguardUuid
+    return if (!buildIdentifier.isNullOrEmpty()) {
+      UpdateStatus.Error(
+        "Build identifier from ProGuard UUID: $buildIdentifier. HTTP client and API models coming in future PRs."
+      )
+    } else {
+      UpdateStatus.Error(
+        "No ProGuard UUID found. Ensure sentry-debug-meta.properties contains io.sentry.ProguardUuids or set via manifest."
+      )
+    }
   }
 
   fun checkForUpdateAsync(context: Context, onResult: (UpdateStatus) -> Unit) {
-    throw NotImplementedError()
+    // For now, just call the blocking version and return the result
+    // In future PRs, this will be truly async
+    val result = checkForUpdateBlocking(context)
+    onResult(result)
   }
 }


### PR DESCRIPTION
Use existing ProGuard UUID system for build identification instead of custom APK parsing.

Uses: `Sentry.getCurrentScopes().options.proguardUuid`

#skip-changelog
