### PR TITLE
feat(distribution): Mark build distribution APIs as experimental

### DIFF
--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -25,5 +25,8 @@ androidComponents.beforeVariants {
 
 dependencies {
   implementation(projects.sentry)
+  implementation(
+    libs.jetbrains.annotations
+  ) // Use implementation instead of compileOnly to override kotlin stdlib's version
   implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
 }

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -9,6 +9,7 @@ import io.sentry.Integration
 import io.sentry.SentryOptions
 import io.sentry.UpdateInfo
 import io.sentry.UpdateStatus
+import org.jetbrains.annotations.ApiStatus
 
 /**
  * The public Android SDK for Sentry Build Distribution.
@@ -16,6 +17,7 @@ import io.sentry.UpdateStatus
  * Provides functionality to check for app updates and download new versions from Sentry's preprod
  * artifacts system.
  */
+@ApiStatus.Experimental
 public class DistributionIntegration(context: Context) : Integration, IDistributionApi {
 
   private lateinit var scopes: IScopes

--- a/sentry/src/main/java/io/sentry/IDistributionApi.java
+++ b/sentry/src/main/java/io/sentry/IDistributionApi.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -8,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>Provides methods to check for app updates and download new versions from Sentry's preprod
  * artifacts system.
  */
+@ApiStatus.Experimental
 public interface IDistributionApi {
 
   /**

--- a/sentry/src/main/java/io/sentry/NoOpDistributionApi.java
+++ b/sentry/src/main/java/io/sentry/NoOpDistributionApi.java
@@ -1,8 +1,10 @@
 package io.sentry;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** No-op implementation of IDistributionApi. Used when distribution module is not available. */
+@ApiStatus.Experimental
 public final class NoOpDistributionApi implements IDistributionApi {
 
   private static final NoOpDistributionApi instance = new NoOpDistributionApi();

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -602,6 +602,7 @@ public class SentryOptions {
    * SentryAndroidOptions, but there's a circular dependency issue between sentry-android-core and
    * sentry-android-distribution modules.
    */
+  @ApiStatus.Experimental
   public static final class DistributionOptions {
     /** Organization authentication token for API access */
     public String orgAuthToken = "";
@@ -2848,10 +2849,12 @@ public class SentryOptions {
         replayController != null ? replayController : NoOpReplayController.getInstance();
   }
 
+  @ApiStatus.Experimental
   public @NotNull IDistributionApi getDistributionController() {
     return distributionController;
   }
 
+  @ApiStatus.Experimental
   public void setDistributionController(final @Nullable IDistributionApi distributionController) {
     this.distributionController =
         distributionController != null ? distributionController : NoOpDistributionApi.getInstance();
@@ -3567,10 +3570,12 @@ public class SentryOptions {
     }
   }
 
+  @ApiStatus.Experimental
   public @NotNull DistributionOptions getDistribution() {
     return distribution;
   }
 
+  @ApiStatus.Experimental
   public void setDistribution(final @NotNull DistributionOptions distribution) {
     this.distribution = distribution != null ? distribution : new DistributionOptions();
   }

--- a/sentry/src/main/java/io/sentry/UpdateInfo.java
+++ b/sentry/src/main/java/io/sentry/UpdateInfo.java
@@ -1,8 +1,10 @@
 package io.sentry;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Information about an available app update. */
+@ApiStatus.Experimental
 public final class UpdateInfo {
   private final @NotNull String id;
   private final @NotNull String buildVersion;

--- a/sentry/src/main/java/io/sentry/UpdateStatus.java
+++ b/sentry/src/main/java/io/sentry/UpdateStatus.java
@@ -1,8 +1,10 @@
 package io.sentry;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /** Represents the result of checking for app updates. */
+@ApiStatus.Experimental
 public abstract class UpdateStatus {
 
   /** Current app version is up to date, no update available. */


### PR DESCRIPTION
## Summary
- Mark all build distribution APIs with `@ApiStatus.Experimental`


There was a dependency conflict because the kotlin-stdlib bring in 13.0 of the annotations. 
Adjusted `compileOnly(libs.jetbrains.annotations)` to `implementation(libs.jetbrains.annotations)` in the sentry-android-distribution module. 

Closes EME-281

#skip-changelog since it isn't released

🤖 Generated with [Claude Code](https://claude.ai/code)