### PR TITLE
feat(android-distribution): add httpclient for checking for build distribution updates

### DIFF
--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     libs.jetbrains.annotations
   ) // Use implementation instead of compileOnly to override kotlin stdlib's version
   implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  testImplementation(libs.androidx.test.ext.junit)
 }

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -11,6 +11,13 @@ android {
 
   defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
   buildFeatures { buildConfig = false }
+
+  testOptions {
+    unitTests.apply {
+      isReturnDefaultValues = true
+      isIncludeAndroidResources = true
+    }
+  }
 }
 
 kotlin {
@@ -30,4 +37,7 @@ dependencies {
   ) // Use implementation instead of compileOnly to override kotlin stdlib's version
   implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
   testImplementation(libs.androidx.test.ext.junit)
+  testImplementation(libs.roboelectric)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.androidx.test.core)
 }

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -24,7 +24,7 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
     val mainBinaryIdentifier: String,
     val appId: String,
     val platform: String = "android",
-    val versionCode: Int,
+    val versionCode: Long,
     val versionName: String,
   )
 

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -1,0 +1,124 @@
+package io.sentry.android.distribution
+
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import javax.net.ssl.HttpsURLConnection
+
+/** HTTP client for making requests to Sentry's distribution API. */
+internal class DistributionHttpClient(private val options: SentryOptions) {
+
+  /** Represents the result of an HTTP request. */
+  data class HttpResponse(
+    val statusCode: Int,
+    val body: String,
+    val isSuccessful: Boolean = statusCode in 200..299,
+  )
+
+  /** Parameters for checking updates. */
+  data class UpdateCheckParams(
+    val mainBinaryIdentifier: String,
+    val appId: String,
+    val platform: String = "android",
+    val version: String,
+  )
+
+  /**
+   * Makes a GET request to the distribution API to check for updates.
+   *
+   * @param params Update check parameters
+   * @return HttpResponse containing the response details
+   */
+  fun checkForUpdates(params: UpdateCheckParams): HttpResponse {
+    val distributionOptions = options.distribution
+    val orgSlug = distributionOptions.orgSlug
+    val projectSlug = distributionOptions.projectSlug
+    val authToken = distributionOptions.orgAuthToken
+    val baseUrl = distributionOptions.sentryBaseUrl
+
+    if (orgSlug.isEmpty() || projectSlug.isEmpty() || authToken.isEmpty()) {
+      throw IllegalStateException(
+        "Missing required distribution configuration: orgSlug, projectSlug, or orgAuthToken"
+      )
+    }
+
+    val queryParams = buildQueryParams(params)
+    val url =
+      URL(
+        "$baseUrl/api/0/projects/$orgSlug/$projectSlug/preprodartifacts/check-for-updates/?$queryParams"
+      )
+
+    return try {
+      makeRequest(url, authToken)
+    } catch (e: IOException) {
+      options.logger.log(SentryLevel.ERROR, e, "Network error while checking for updates")
+      throw e
+    }
+  }
+
+  private fun makeRequest(url: URL, authToken: String): HttpResponse {
+    val connection = url.openConnection() as HttpURLConnection
+
+    try {
+      // Configure connection
+      connection.requestMethod = "GET"
+      connection.setRequestProperty("Authorization", "Bearer $authToken")
+      connection.setRequestProperty("Accept", "application/json")
+      connection.setRequestProperty(
+        "User-Agent",
+        options.sentryClientName ?: "sentry-android-distribution",
+      )
+      connection.connectTimeout = options.connectionTimeoutMillis
+      connection.readTimeout = options.readTimeoutMillis
+
+      // Set SSL socket factory if available
+      if (connection is HttpsURLConnection && options.sslSocketFactory != null) {
+        connection.sslSocketFactory = options.sslSocketFactory
+      }
+
+      // Get response
+      val responseCode = connection.responseCode
+      val responseBody = readResponse(connection)
+
+      options.logger.log(
+        SentryLevel.DEBUG,
+        "Distribution API request completed with status: $responseCode",
+      )
+
+      return HttpResponse(responseCode, responseBody)
+    } finally {
+      connection.disconnect()
+    }
+  }
+
+  private fun readResponse(connection: HttpURLConnection): String {
+    val inputStream =
+      if (connection.responseCode in 200..299) {
+        connection.inputStream
+      } else {
+        connection.errorStream ?: connection.inputStream
+      }
+
+    return inputStream?.use { stream ->
+      BufferedReader(InputStreamReader(stream, "UTF-8")).use { reader -> reader.readText() }
+    } ?: ""
+  }
+
+  private fun buildQueryParams(params: UpdateCheckParams): String {
+    val queryParams = mutableListOf<String>()
+
+    queryParams.add(
+      "main_binary_identifier=${URLEncoder.encode(params.mainBinaryIdentifier, "UTF-8")}"
+    )
+    queryParams.add("app_id=${URLEncoder.encode(params.appId, "UTF-8")}")
+    queryParams.add("platform=${URLEncoder.encode(params.platform, "UTF-8")}")
+    queryParams.add("version=${URLEncoder.encode(params.version, "UTF-8")}")
+
+    return queryParams.joinToString("&")
+  }
+}

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -7,6 +7,7 @@ import java.io.IOException
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
 import javax.net.ssl.HttpsURLConnection
 
 /** HTTP client for making requests to Sentry's distribution API. */
@@ -41,7 +42,7 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
     val authToken = distributionOptions.orgAuthToken
     val baseUrl = distributionOptions.sentryBaseUrl
 
-    if (orgSlug.isEmpty() || projectSlug.isEmpty() || authToken.isEmpty()) {
+    if (orgSlug.isNullOrEmpty() || projectSlug.isNullOrEmpty() || authToken.isNullOrEmpty()) {
       throw IllegalStateException(
         "Missing required distribution configuration: orgSlug, projectSlug, or orgAuthToken"
       )
@@ -49,12 +50,14 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
 
     val urlString = buildString {
       append(baseUrl.trimEnd('/'))
-      append("/api/0/projects/$orgSlug/$projectSlug/preprodartifacts/check-for-updates/")
-      append("?main_binary_identifier=${params.mainBinaryIdentifier}")
-      append("&app_id=${params.appId}")
-      append("&platform=${params.platform}")
-      append("&build_number=${params.versionCode}")
-      append("&build_version=${params.versionName}")
+      append(
+        "/api/0/projects/${URLEncoder.encode(orgSlug, "UTF-8")}/${URLEncoder.encode(projectSlug, "UTF-8")}/preprodartifacts/check-for-updates/"
+      )
+      append("?main_binary_identifier=${URLEncoder.encode(params.mainBinaryIdentifier, "UTF-8")}")
+      append("&app_id=${URLEncoder.encode(params.appId, "UTF-8")}")
+      append("&platform=${URLEncoder.encode(params.platform, "UTF-8")}")
+      append("&build_number=${URLEncoder.encode(params.versionCode.toString(), "UTF-8")}")
+      append("&build_version=${URLEncoder.encode(params.versionName, "UTF-8")}")
     }
     val url = URL(urlString)
 

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -81,7 +81,7 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
       connection.setRequestProperty("Accept", "application/json")
       connection.setRequestProperty(
         "User-Agent",
-        options.sentryClientName ?: "sentry-android-distribution",
+        options.sentryClientName ?: throw IllegalStateException("sentryClientName must be set"),
       )
       connection.connectTimeout = options.connectionTimeoutMillis
       connection.readTimeout = options.readTimeoutMillis

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -1,6 +1,5 @@
 package io.sentry.android.distribution
 
-import android.net.Uri
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import java.io.BufferedReader
@@ -25,7 +24,8 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
     val mainBinaryIdentifier: String,
     val appId: String,
     val platform: String = "android",
-    val version: String,
+    val versionCode: Int,
+    val versionName: String,
   )
 
   /**
@@ -47,22 +47,16 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
       )
     }
 
-    val uri =
-      Uri.parse(baseUrl)
-        .buildUpon()
-        .appendPath("api")
-        .appendPath("0")
-        .appendPath("projects")
-        .appendPath(orgSlug)
-        .appendPath(projectSlug)
-        .appendPath("preprodartifacts")
-        .appendPath("check-for-updates")
-        .appendQueryParameter("main_binary_identifier", params.mainBinaryIdentifier)
-        .appendQueryParameter("app_id", params.appId)
-        .appendQueryParameter("platform", params.platform)
-        .appendQueryParameter("version", params.version)
-        .build()
-    val url = URL(uri.toString())
+    val urlString = buildString {
+      append(baseUrl.trimEnd('/'))
+      append("/api/0/projects/$orgSlug/$projectSlug/preprodartifacts/check-for-updates/")
+      append("?main_binary_identifier=${params.mainBinaryIdentifier}")
+      append("&app_id=${params.appId}")
+      append("&platform=${params.platform}")
+      append("&build_number=${params.versionCode}")
+      append("&build_version=${params.versionName}")
+    }
+    val url = URL(urlString)
 
     return try {
       makeRequest(url, authToken)

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -12,8 +12,6 @@ import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.UpdateInfo
 import io.sentry.UpdateStatus
-import java.io.IOException
-import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import org.jetbrains.annotations.ApiStatus
@@ -75,16 +73,10 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
         "DNS lookup failed - check internet connection",
       )
       UpdateStatus.UpdateError("No internet connection or invalid server URL")
-    } catch (e: ConnectException) {
-      sentryOptions.logger.log(SentryLevel.ERROR, e, "Connection refused - server may be down")
-      UpdateStatus.UpdateError("Unable to connect to server")
     } catch (e: SocketTimeoutException) {
       // SocketTimeoutException could indicate either slow network or server issues
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Network request timed out")
-      UpdateStatus.UpdateError("Request timed out - check connection speed")
-    } catch (e: IOException) {
-      sentryOptions.logger.log(SentryLevel.ERROR, e, "Network I/O error occurred")
-      UpdateStatus.UpdateError("Network error occurred")
+      UpdateStatus.UpdateError("Request timed out - check network connection")
     } catch (e: Exception) {
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Unexpected error checking for updates")
       UpdateStatus.UpdateError("Unexpected error: ${e.message}")

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -72,11 +72,11 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
         e,
         "DNS lookup failed - check internet connection",
       )
-      UpdateStatus.UpdateError("No internet connection or invalid server URL")
+      UpdateStatus.NoNetwork("No internet connection or invalid server URL")
     } catch (e: SocketTimeoutException) {
       // SocketTimeoutException could indicate either slow network or server issues
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Network request timed out")
-      UpdateStatus.UpdateError("Request timed out - check network connection")
+      UpdateStatus.NoNetwork("Request timed out - check network connection")
     } catch (e: Exception) {
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Unexpected error checking for updates")
       UpdateStatus.UpdateError("Unexpected error: ${e.message}")
@@ -130,7 +130,8 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
         mainBinaryIdentifier = appId,
         appId = appId,
         platform = "android",
-        version = versionName,
+        versionName = versionName,
+        versionCode = 5,
       )
     } catch (e: PackageManager.NameNotFoundException) {
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Failed to get package info")

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -124,14 +124,20 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
         }
 
       val versionName = packageInfo.versionName ?: "unknown"
+      val versionCode =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          packageInfo.longVersionCode.toInt()
+        } else {
+          @Suppress("DEPRECATION") packageInfo.versionCode
+        }
       val appId = context.applicationInfo.packageName
 
       DistributionHttpClient.UpdateCheckParams(
         mainBinaryIdentifier = appId,
         appId = appId,
         platform = "android",
+        versionCode = versionCode,
         versionName = versionName,
-        versionCode = 5,
       )
     } catch (e: PackageManager.NameNotFoundException) {
       sentryOptions.logger.log(SentryLevel.ERROR, e, "Failed to get package info")

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -126,9 +126,9 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
       val versionName = packageInfo.versionName ?: "unknown"
       val versionCode =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-          packageInfo.longVersionCode.toInt()
+          packageInfo.longVersionCode
         } else {
-          @Suppress("DEPRECATION") packageInfo.versionCode
+          @Suppress("DEPRECATION") packageInfo.versionCode.toLong()
         }
       val appId = context.applicationInfo.packageName
 

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -2,10 +2,13 @@ package io.sentry.android.distribution
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import io.sentry.IDistributionApi
 import io.sentry.IScopes
 import io.sentry.Integration
+import io.sentry.SentryLevel
 import io.sentry.SentryOptions
 import io.sentry.UpdateInfo
 import io.sentry.UpdateStatus
@@ -24,6 +27,9 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
   private lateinit var sentryOptions: SentryOptions
   private val context: Context = context.applicationContext
 
+  private lateinit var httpClient: DistributionHttpClient
+  private lateinit var responseParser: UpdateResponseParser
+
   /**
    * Registers the Distribution integration with Sentry.
    *
@@ -34,6 +40,10 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
     // Store scopes and options for use by distribution functionality
     this.scopes = scopes
     this.sentryOptions = options
+
+    // Initialize HTTP client and response parser
+    this.httpClient = DistributionHttpClient(options)
+    this.responseParser = UpdateResponseParser(options)
   }
 
   /**
@@ -44,7 +54,19 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
    * @return UpdateStatus indicating if an update is available, up to date, or error
    */
   public override fun checkForUpdateBlocking(): UpdateStatus {
-    throw NotImplementedError()
+    return try {
+      sentryOptions.logger.log(SentryLevel.DEBUG, "Checking for distribution updates")
+
+      val params = createUpdateCheckParams()
+      val response = httpClient.checkForUpdates(params)
+      responseParser.parseResponse(response.statusCode, response.body)
+    } catch (e: IllegalStateException) {
+      sentryOptions.logger.log(SentryLevel.WARNING, e.message ?: "Configuration error")
+      UpdateStatus.UpdateError(e.message ?: "Configuration error")
+    } catch (e: Exception) {
+      sentryOptions.logger.log(SentryLevel.ERROR, e, "Failed to check for updates")
+      UpdateStatus.UpdateError("Network error: ${e.message}")
+    }
   }
 
   /**
@@ -73,6 +95,32 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
     } catch (e: android.content.ActivityNotFoundException) {
       // No application can handle the HTTP/HTTPS URL, typically no browser installed
       // Silently fail as this is expected behavior in some environments
+    }
+  }
+
+  private fun createUpdateCheckParams(): DistributionHttpClient.UpdateCheckParams {
+    return try {
+      val packageManager = context.packageManager
+      val packageName = context.packageName
+      val packageInfo =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+          @Suppress("DEPRECATION") packageManager.getPackageInfo(packageName, 0)
+        }
+
+      val versionName = packageInfo.versionName ?: "unknown"
+      val appId = context.applicationInfo.packageName
+
+      DistributionHttpClient.UpdateCheckParams(
+        mainBinaryIdentifier = appId, // Using package name as binary identifier
+        appId = appId,
+        platform = "android",
+        version = versionName,
+      )
+    } catch (e: PackageManager.NameNotFoundException) {
+      sentryOptions.logger.log(SentryLevel.ERROR, e, "Failed to get package info")
+      throw IllegalStateException("Unable to get app package information", e)
     }
   }
 }

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
@@ -58,8 +58,15 @@ internal class UpdateResponseParser(private val options: SentryOptions) {
     val appName = json.optString("appName", "")
     val createdDate = json.optString("createdDate", "")
 
-    // Validate required fields
-    if (id.isEmpty() || buildVersion.isEmpty() || downloadUrl.isEmpty()) {
+    // Validate required fields (optString returns "null" for null values)
+    if (
+      id.isEmpty() ||
+        id == "null" ||
+        buildVersion.isEmpty() ||
+        buildVersion == "null" ||
+        downloadUrl.isEmpty() ||
+        downloadUrl == "null"
+    ) {
       throw IllegalArgumentException("Missing required update information in API response")
     }
 

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
@@ -1,0 +1,68 @@
+package io.sentry.android.distribution
+
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions
+import io.sentry.UpdateInfo
+import io.sentry.UpdateStatus
+import org.json.JSONException
+import org.json.JSONObject
+
+/** Parser for distribution API responses. */
+internal class UpdateResponseParser(private val options: SentryOptions) {
+
+  /**
+   * Parses the API response and returns the appropriate UpdateStatus.
+   *
+   * @param statusCode HTTP status code
+   * @param responseBody Response body as string
+   * @return UpdateStatus indicating the result
+   */
+  fun parseResponse(statusCode: Int, responseBody: String): UpdateStatus {
+    return when (statusCode) {
+      200 -> parseSuccessResponse(responseBody)
+      in 400..499 -> UpdateStatus.UpdateError("Client error: $statusCode")
+      in 500..599 -> UpdateStatus.UpdateError("Server error: $statusCode")
+      else -> UpdateStatus.UpdateError("Unexpected response code: $statusCode")
+    }
+  }
+
+  private fun parseSuccessResponse(responseBody: String): UpdateStatus {
+    return try {
+      val json = JSONObject(responseBody)
+
+      options.logger.log(SentryLevel.DEBUG, "Parsing distribution API response")
+
+      // Check if there's a new release available
+      val updateAvailable = json.optBoolean("updateAvailable", false)
+
+      if (updateAvailable) {
+        val updateInfo = parseUpdateInfo(json)
+        UpdateStatus.NewRelease(updateInfo)
+      } else {
+        UpdateStatus.UpToDate.getInstance()
+      }
+    } catch (e: JSONException) {
+      options.logger.log(SentryLevel.ERROR, e, "Failed to parse API response")
+      UpdateStatus.UpdateError("Invalid response format: ${e.message}")
+    } catch (e: Exception) {
+      options.logger.log(SentryLevel.ERROR, e, "Unexpected error parsing response")
+      UpdateStatus.UpdateError("Failed to parse response: ${e.message}")
+    }
+  }
+
+  private fun parseUpdateInfo(json: JSONObject): UpdateInfo {
+    val id = json.optString("id", "")
+    val buildVersion = json.optString("buildVersion", "")
+    val buildNumber = json.optInt("buildNumber", 0)
+    val downloadUrl = json.optString("downloadUrl", "")
+    val appName = json.optString("appName", "")
+    val createdDate = json.optString("createdDate", "")
+
+    // Validate required fields
+    if (id.isEmpty() || buildVersion.isEmpty() || downloadUrl.isEmpty()) {
+      throw IllegalArgumentException("Missing required update information in API response")
+    }
+
+    return UpdateInfo(id, buildVersion, buildNumber, downloadUrl, appName, createdDate)
+  }
+}

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
@@ -59,15 +59,22 @@ internal class UpdateResponseParser(private val options: SentryOptions) {
     val createdDate = json.optString("createdDate", "")
 
     // Validate required fields (optString returns "null" for null values)
-    if (
-      id.isEmpty() ||
-        id == "null" ||
-        buildVersion.isEmpty() ||
-        buildVersion == "null" ||
-        downloadUrl.isEmpty() ||
-        downloadUrl == "null"
-    ) {
-      throw IllegalArgumentException("Missing required update information in API response")
+    val missingFields = mutableListOf<String>()
+
+    if (id.isEmpty() || id == "null") {
+      missingFields.add("id")
+    }
+    if (buildVersion.isEmpty() || buildVersion == "null") {
+      missingFields.add("buildVersion")
+    }
+    if (downloadUrl.isEmpty() || downloadUrl == "null") {
+      missingFields.add("downloadUrl")
+    }
+
+    if (missingFields.isNotEmpty()) {
+      throw IllegalArgumentException(
+        "Missing required fields in API response: ${missingFields.joinToString(", ")}"
+      )
     }
 
     return UpdateInfo(id, buildVersion, buildNumber, downloadUrl, appName, createdDate)

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
@@ -36,8 +36,8 @@ class DistributionHttpClientTest {
       DistributionHttpClient.UpdateCheckParams(
         mainBinaryIdentifier = "com.emergetools.hackernews",
         appId = "com.emergetools.hackernews",
-        platform = "android",
-        version = "1.0.0",
+        versionName = "1.0.0",
+        versionCode = 5,
       )
 
     val response = httpClient.checkForUpdates(params)

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
@@ -1,0 +1,54 @@
+package io.sentry.android.distribution
+
+import io.sentry.SentryOptions
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+
+class DistributionHttpClientTest {
+
+  private lateinit var options: SentryOptions
+  private lateinit var httpClient: DistributionHttpClient
+
+  @Before
+  fun setUp() {
+    options =
+      SentryOptions().apply {
+        connectionTimeoutMillis = 10000
+        readTimeoutMillis = 10000
+      }
+
+    options.distribution.apply {
+      orgSlug = "sentry"
+      projectSlug = "launchpad-test"
+      orgAuthToken = "DONT_CHECK_THIS_IN"
+      sentryBaseUrl = "https://sentry.io"
+    }
+
+    httpClient = DistributionHttpClient(options)
+  }
+
+  @Test
+  @Ignore("This is just used for testing against the real API.")
+  fun `test checkForUpdates with real API`() {
+    val params =
+      DistributionHttpClient.UpdateCheckParams(
+        mainBinaryIdentifier = "com.emergetools.hackernews",
+        appId = "com.emergetools.hackernews",
+        platform = "android",
+        version = "1.0.0",
+      )
+
+    val response = httpClient.checkForUpdates(params)
+
+    // Print response for debugging
+    println("HTTP Status: ${response.statusCode}")
+    println("Response Body: ${response.body}")
+    println("Is Successful: ${response.isSuccessful}")
+
+    // Basic assertions
+    assertTrue("Response should have a status code", response.statusCode > 0)
+    assertNotNull("Response body should not be null", response.body)
+  }
+}

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
@@ -37,7 +37,7 @@ class DistributionHttpClientTest {
         mainBinaryIdentifier = "com.emergetools.hackernews",
         appId = "com.emergetools.hackernews",
         versionName = "1.0.0",
-        versionCode = 5,
+        versionCode = 5L,
       )
 
     val response = httpClient.checkForUpdates(params)

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
@@ -1,0 +1,201 @@
+package io.sentry.android.distribution
+
+import io.sentry.SentryOptions
+import io.sentry.UpdateStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UpdateResponseParserTest {
+
+  private lateinit var options: SentryOptions
+  private lateinit var parser: UpdateResponseParser
+
+  @Before
+  fun setUp() {
+    options = SentryOptions()
+    parser = UpdateResponseParser(options)
+  }
+
+  @Test
+  fun `parseResponse returns NewRelease when update is available`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": "update-123",
+        "buildVersion": "2.0.0",
+        "buildNumber": 42,
+        "downloadUrl": "https://example.com/download",
+        "appName": "Test App",
+        "createdDate": "2023-10-01T00:00:00Z"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return NewRelease", result is UpdateStatus.NewRelease)
+    val updateInfo = (result as UpdateStatus.NewRelease).info
+    assertEquals("update-123", updateInfo.id)
+    assertEquals("2.0.0", updateInfo.buildVersion)
+    assertEquals(42, updateInfo.buildNumber)
+    assertEquals("https://example.com/download", updateInfo.downloadUrl)
+    assertEquals("Test App", updateInfo.appName)
+    assertEquals("2023-10-01T00:00:00Z", updateInfo.createdDate)
+  }
+
+  @Test
+  fun `parseResponse returns UpToDate when no update is available`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": false
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpToDate", result is UpdateStatus.UpToDate)
+  }
+
+  @Test
+  fun `parseResponse returns UpToDate when updateAvailable is missing`() {
+    val responseBody =
+      """
+      {
+        "someOtherField": "value"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpToDate", result is UpdateStatus.UpToDate)
+  }
+
+  @Test
+  fun `parseResponse returns UpdateError for 4xx status codes`() {
+    val result = parser.parseResponse(404, "Not found")
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertEquals("Client error: 404", error.message)
+  }
+
+  @Test
+  fun `parseResponse returns UpdateError for 5xx status codes`() {
+    val result = parser.parseResponse(500, "Internal server error")
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertEquals("Server error: 500", error.message)
+  }
+
+  @Test
+  fun `parseResponse returns UpdateError for unexpected status codes`() {
+    val result = parser.parseResponse(999, "Unknown status")
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertEquals("Unexpected response code: 999", error.message)
+  }
+
+  @Test
+  fun `parseResponse returns UpdateError for invalid JSON`() {
+    val result = parser.parseResponse(200, "invalid json {")
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention invalid format",
+      error.message.startsWith("Invalid response format:"),
+    )
+  }
+
+  @Test
+  fun `parseResponse returns UpdateError when required fields are missing`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "buildVersion": "2.0.0"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention failed to parse",
+      error.message.startsWith("Failed to parse response:"),
+    )
+  }
+
+  @Test
+  fun `parseResponse handles minimal valid update response`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": "update-123",
+        "buildVersion": "2.0.0",
+        "downloadUrl": "https://example.com/download"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return NewRelease", result is UpdateStatus.NewRelease)
+    val updateInfo = (result as UpdateStatus.NewRelease).info
+    assertEquals("update-123", updateInfo.id)
+    assertEquals("2.0.0", updateInfo.buildVersion)
+    assertEquals(0, updateInfo.buildNumber) // Default value
+    assertEquals("https://example.com/download", updateInfo.downloadUrl)
+    assertEquals("", updateInfo.appName) // Default value
+    assertEquals("", updateInfo.createdDate) // Default value
+  }
+
+  @Test
+  fun `parseResponse handles empty response body`() {
+    val result = parser.parseResponse(200, "")
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention invalid format",
+      error.message.startsWith("Invalid response format:"),
+    )
+  }
+
+  @Test
+  fun `parseResponse handles null values in JSON`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": null,
+        "buildVersion": "2.0.0",
+        "downloadUrl": "https://example.com/download"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention failed to parse",
+      error.message.startsWith("Failed to parse response:"),
+    )
+  }
+}

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
@@ -198,4 +198,116 @@ class UpdateResponseParserTest {
       error.message.startsWith("Failed to parse response:"),
     )
   }
+
+  @Test
+  fun `parseResponse returns specific error message when id is missing`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "buildVersion": "2.0.0",
+        "downloadUrl": "https://example.com/download"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention missing id field",
+      error.message.contains("Missing required fields in API response: id"),
+    )
+  }
+
+  @Test
+  fun `parseResponse returns specific error message when buildVersion is missing`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": "update-123",
+        "downloadUrl": "https://example.com/download"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention missing buildVersion field",
+      error.message.contains("Missing required fields in API response: buildVersion"),
+    )
+  }
+
+  @Test
+  fun `parseResponse returns specific error message when downloadUrl is missing`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": "update-123",
+        "buildVersion": "2.0.0"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention missing downloadUrl field",
+      error.message.contains("Missing required fields in API response: downloadUrl"),
+    )
+  }
+
+  @Test
+  fun `parseResponse returns specific error message when multiple fields are missing`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "buildNumber": 42
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention all missing required fields",
+      error.message.contains(
+        "Missing required fields in API response: id, buildVersion, downloadUrl"
+      ),
+    )
+  }
+
+  @Test
+  fun `parseResponse returns specific error message when field is null string`() {
+    val responseBody =
+      """
+      {
+        "updateAvailable": true,
+        "id": "null",
+        "buildVersion": "2.0.0",
+        "downloadUrl": "https://example.com/download"
+      }
+    """
+        .trimIndent()
+
+    val result = parser.parseResponse(200, responseBody)
+
+    assertTrue("Should return UpdateError", result is UpdateStatus.UpdateError)
+    val error = result as UpdateStatus.UpdateError
+    assertTrue(
+      "Error message should mention missing id field when value is 'null' string",
+      error.message.contains("Missing required fields in API response: id"),
+    )
+  }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4344,6 +4344,11 @@ public final class io/sentry/UpdateStatus$NewRelease : io/sentry/UpdateStatus {
 	public fun getInfo ()Lio/sentry/UpdateInfo;
 }
 
+public final class io/sentry/UpdateStatus$NoNetwork : io/sentry/UpdateStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getMessage ()Ljava/lang/String;
+}
+
 public final class io/sentry/UpdateStatus$UpToDate : io/sentry/UpdateStatus {
 	public static fun getInstance ()Lio/sentry/UpdateStatus$UpToDate;
 }

--- a/sentry/src/main/java/io/sentry/UpdateInfo.java
+++ b/sentry/src/main/java/io/sentry/UpdateInfo.java
@@ -2,6 +2,7 @@ package io.sentry;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Information about an available app update. */
 @ApiStatus.Experimental
@@ -11,7 +12,7 @@ public final class UpdateInfo {
   private final int buildNumber;
   private final @NotNull String downloadUrl;
   private final @NotNull String appName;
-  private final @NotNull String createdDate;
+  private final @Nullable String createdDate;
 
   public UpdateInfo(
       final @NotNull String id,
@@ -19,7 +20,7 @@ public final class UpdateInfo {
       final int buildNumber,
       final @NotNull String downloadUrl,
       final @NotNull String appName,
-      final @NotNull String createdDate) {
+      final @Nullable String createdDate) {
     this.id = id;
     this.buildVersion = buildVersion;
     this.buildNumber = buildNumber;
@@ -48,7 +49,7 @@ public final class UpdateInfo {
     return appName;
   }
 
-  public @NotNull String getCreatedDate() {
+  public @Nullable String getCreatedDate() {
     return createdDate;
   }
 }

--- a/sentry/src/main/java/io/sentry/UpdateStatus.java
+++ b/sentry/src/main/java/io/sentry/UpdateStatus.java
@@ -43,4 +43,17 @@ public abstract class UpdateStatus {
       return message;
     }
   }
+
+  /** No network connection is available to check for updates. */
+  public static final class NoNetwork extends UpdateStatus {
+    private final @NotNull String message;
+
+    public NoNetwork(final @NotNull String message) {
+      this.message = message;
+    }
+
+    public @NotNull String getMessage() {
+      return message;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Implements the `checkForUpdateBlocking` method in `DistributionIntegration` to check for app updates via Sentry's distribution API.

## Why not reuse existing HttpConnection?

The existing `HttpConnection` class is designed specifically for Sentry event transport and is not suitable for distribution API calls:
- Hardcoded for POST requests (we need GET)
- Expects Sentry envelopes with gzip encoding (we need simple JSON)
- Only considers status 200 successful (REST APIs use 200-299 range)
- Includes Sentry-specific rate limiting logic

## Changes

- **DistributionHttpClient**: New HTTP client for distribution API requests
  - Supports GET requests with query parameters (main_binary_identifier, app_id, platform, version)
  - Uses SentryOptions.DistributionOptions for configuration (orgSlug, projectSlug, orgAuthToken)

- **UpdateResponseParser**: JSON response parser for API responses

#skip-changelog

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an HTTP client and JSON parser for distribution update checks, implements checkForUpdateBlocking with network/error handling, updates API types, and adds tests.
> 
> - **Android Distribution**:
>   - **Update Check Flow**: Implements `DistributionIntegration.checkForUpdateBlocking` using new `DistributionHttpClient` and `UpdateResponseParser`; builds params from app package info and opens download via `downloadUpdate`.
>   - **Networking & Errors**: Adds detailed error handling (e.g., `UnknownHostException`, `SocketTimeoutException`) and logs; introduces `UpdateStatus.NoNetwork` result.
>   - **API Changes**: `UpdateInfo.getCreatedDate()` becomes nullable; new `UpdateStatus.NoNetwork` class.
> - **Testing**:
>   - Adds unit tests `DistributionHttpClientTest` (ignored real API test) and `UpdateResponseParserTest` (covers success, errors, edge cases).
> - **Build**:
>   - Enables unit test Android resources/default values and adds test dependencies in `build.gradle.kts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0acf5ed2473f50445a52baa24a81f66e3dc9ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->