### PR TITLE
Add session replay id to Sentry Logs

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -208,11 +208,11 @@ public class AndroidContinuousProfiler
 
     isRunning = true;
 
-    if (profilerId == SentryId.EMPTY_ID) {
+    if (profilerId.equals(SentryId.EMPTY_ID)) {
       profilerId = new SentryId();
     }
 
-    if (chunkId == SentryId.EMPTY_ID) {
+    if (chunkId.equals(SentryId.EMPTY_ID)) {
       chunkId = new SentryId();
     }
 

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.java
@@ -11,6 +11,7 @@ import io.sentry.Attachment;
 import io.sentry.ISpan;
 import io.sentry.MeasurementUnit;
 import io.sentry.Sentry;
+import io.sentry.SentryLogLevel;
 import io.sentry.instrumentation.file.SentryFileOutputStream;
 import io.sentry.protocol.Feedback;
 import io.sentry.protocol.User;
@@ -304,7 +305,10 @@ public class MainActivity extends AppCompatActivity {
           Sentry.replay().enableDebugMaskingOverlay();
         });
 
+    Sentry.logger().log(SentryLogLevel.INFO, "Creating content view");
     setContentView(binding.getRoot());
+
+    Sentry.logger().log(SentryLogLevel.INFO, "MainActivity created");
   }
 
   private void stackOverflow() {

--- a/sentry/src/main/java/io/sentry/logger/LoggerApi.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerApi.java
@@ -211,6 +211,14 @@ public final class LoggerApi implements ILoggerApi {
           "sentry.environment",
           new SentryLogEventAttributeValue(SentryAttributeType.STRING, environment));
     }
+
+    final @Nullable SentryId replayId = scopes.getScope().getReplayId();
+    if (!replayId.equals(SentryId.EMPTY_ID)) {
+      attributes.put(
+          "sentry.replay_id",
+          new SentryLogEventAttributeValue(SentryAttributeType.STRING, replayId.toString()));
+    }
+
     final @Nullable String release = scopes.getOptions().getRelease();
     if (release != null) {
       attributes.put(


### PR DESCRIPTION
## :scroll: Description
added session replay id to logs, if a replay is running


## :bulb: Motivation and Context
Resolves https://linear.app/getsentry/issue/ANDROID-210/add-sentryreplay-id-to-android-logs

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
