### PR TITLE
Handle `RejectedExecutionException` everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Handle `RejectedExecutionException` everywhere ([#4747](https://github.com/getsentry/sentry-java/pull/4747))
+
 ## 8.22.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -71,11 +71,9 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
       this.deviceInfoUtil =
           executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
     } catch (RejectedExecutionException e) {
-      // Fall back to synchronous initialization if executor rejects the task
       options
           .getLogger()
-          .log(SentryLevel.DEBUG, "Device info pre-caching task rejected. Using synchronous initialization.", e);
-      this.deviceInfoUtil = null;
+          .log(SentryLevel.WARNING, "Device info pre-caching task rejected.", e);
     }
     executorService.shutdown();
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -4,18 +4,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import io.sentry.DateUtils;
-import io.sentry.EventProcessor;
-import io.sentry.Hint;
-import io.sentry.IpAddressUtils;
-import io.sentry.NoOpLogger;
-import io.sentry.SentryAttributeType;
-import io.sentry.SentryBaseEvent;
-import io.sentry.SentryEvent;
-import io.sentry.SentryLevel;
-import io.sentry.SentryLogEvent;
-import io.sentry.SentryLogEventAttributeValue;
-import io.sentry.SentryReplayEvent;
+import io.sentry.*;
 import io.sentry.android.core.internal.util.AndroidThreadChecker;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
@@ -66,15 +55,16 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     // don't ref. to method reference, theres a bug on it
     // noinspection Convert2MethodRef
     // some device info performs disk I/O, but it's result is cached, let's pre-cache it
+    @Nullable Future<DeviceInfoUtil> deviceInfoUtil;
     final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
-      this.deviceInfoUtil =
+      deviceInfoUtil =
           executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
     } catch (RejectedExecutionException e) {
-      options
-          .getLogger()
-          .log(SentryLevel.WARNING, "Device info caching task rejected.", e);
+      deviceInfoUtil = null;
+      options.getLogger().log(SentryLevel.WARNING, "Device info caching task rejected.", e);
     }
+    this.deviceInfoUtil = deviceInfoUtil;
     executorService.shutdown();
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -37,7 +37,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   private final @NotNull BuildInfoProvider buildInfoProvider;
   private final @NotNull SentryAndroidOptions options;
-  private final @NotNull Future<DeviceInfoUtil> deviceInfoUtil;
+  private final @Nullable Future<DeviceInfoUtil> deviceInfoUtil;
   private final @NotNull LazyEvaluator<String> deviceFamily =
       new LazyEvaluator<>(() -> ContextUtils.getFamily(NoOpLogger.getInstance()));
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -19,7 +19,6 @@ import io.sentry.protocol.User;
 import io.sentry.util.HintUtils;
 import io.sentry.util.LazyEvaluator;
 import io.sentry.util.Objects;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -28,31 +27,29 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 final class DefaultAndroidEventProcessor implements EventProcessor {
 
-  @TestOnly
-  final Context context;
+  @TestOnly final Context context;
 
   private final @NotNull BuildInfoProvider buildInfoProvider;
   private final @NotNull SentryAndroidOptions options;
   private final @Nullable Future<DeviceInfoUtil> deviceInfoUtil;
   private final @NotNull LazyEvaluator<String> deviceFamily =
-    new LazyEvaluator<>(() -> ContextUtils.getFamily(NoOpLogger.getInstance()));
+      new LazyEvaluator<>(() -> ContextUtils.getFamily(NoOpLogger.getInstance()));
 
   public DefaultAndroidEventProcessor(
-    final @NotNull Context context,
-    final @NotNull BuildInfoProvider buildInfoProvider,
-    final @NotNull SentryAndroidOptions options) {
+      final @NotNull Context context,
+      final @NotNull BuildInfoProvider buildInfoProvider,
+      final @NotNull SentryAndroidOptions options) {
     this.context =
-      Objects.requireNonNull(
-        ContextUtils.getApplicationContext(context), "The application context is required.");
+        Objects.requireNonNull(
+            ContextUtils.getApplicationContext(context), "The application context is required.");
     this.buildInfoProvider =
-      Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
+        Objects.requireNonNull(buildInfoProvider, "The BuildInfoProvider is required.");
     this.options = Objects.requireNonNull(options, "The options object is required.");
 
     // don't ref. to method reference, theres a bug on it
@@ -62,7 +59,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
       deviceInfoUtil =
-        executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
+          executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
     } catch (RejectedExecutionException e) {
       deviceInfoUtil = null;
       options.getLogger().log(SentryLevel.WARNING, "Device info caching task rejected.", e);
@@ -121,7 +118,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
           if (frames != null) {
             for (final @NotNull SentryStackFrame frame : frames) {
               if ("com.android.internal.os.RuntimeInit$MethodAndArgsCaller"
-                .equals(frame.getModule())) {
+                  .equals(frame.getModule())) {
                 reverseExceptions = true;
                 break;
               }
@@ -137,25 +134,25 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setCommons(
-    final @NotNull SentryBaseEvent event,
-    final boolean errorEvent,
-    final boolean applyScopeData) {
+      final @NotNull SentryBaseEvent event,
+      final boolean errorEvent,
+      final boolean applyScopeData) {
     mergeUser(event);
     setDevice(event, errorEvent, applyScopeData);
     setSideLoadedInfo(event);
   }
 
   private boolean shouldApplyScopeData(
-    final @NotNull SentryBaseEvent event, final @NotNull Hint hint) {
+      final @NotNull SentryBaseEvent event, final @NotNull Hint hint) {
     if (HintUtils.shouldApplyScopeData(hint)) {
       return true;
     } else {
       options
-        .getLogger()
-        .log(
-          SentryLevel.DEBUG,
-          "Event was cached so not applying data relevant to the current app execution/version: %s",
-          event.getEventId());
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Event was cached so not applying data relevant to the current app execution/version: %s",
+              event.getEventId());
       return false;
     }
   }
@@ -177,15 +174,15 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   }
 
   private void setDevice(
-    final @NotNull SentryBaseEvent event,
-    final boolean errorEvent,
-    final boolean applyScopeData) {
+      final @NotNull SentryBaseEvent event,
+      final boolean errorEvent,
+      final boolean applyScopeData) {
     if (event.getContexts().getDevice() == null) {
       if (deviceInfoUtil != null) {
         try {
           event
-            .getContexts()
-            .setDevice(deviceInfoUtil.get().collectDeviceInformation(errorEvent, applyScopeData));
+              .getContexts()
+              .setDevice(deviceInfoUtil.get().collectDeviceInformation(errorEvent, applyScopeData));
         } catch (Throwable e) {
           options.getLogger().log(SentryLevel.ERROR, "Failed to retrieve device info", e);
         }
@@ -226,14 +223,14 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setDevice(final @NotNull SentryLogEvent event) {
     try {
       event.setAttribute(
-        "device.brand",
-        new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.BRAND));
+          "device.brand",
+          new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.BRAND));
       event.setAttribute(
-        "device.model",
-        new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.MODEL));
+          "device.model",
+          new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.MODEL));
       event.setAttribute(
-        "device.family",
-        new SentryLogEventAttributeValue(SentryAttributeType.STRING, deviceFamily.getValue()));
+          "device.family",
+          new SentryLogEventAttributeValue(SentryAttributeType.STRING, deviceFamily.getValue()));
     } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to retrieve device info", e);
     }
@@ -242,10 +239,10 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setOs(final @NotNull SentryLogEvent event) {
     try {
       event.setAttribute(
-        "os.name", new SentryLogEventAttributeValue(SentryAttributeType.STRING, "Android"));
+          "os.name", new SentryLogEventAttributeValue(SentryAttributeType.STRING, "Android"));
       event.setAttribute(
-        "os.version",
-        new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.VERSION.RELEASE));
+          "os.version",
+          new SentryLogEventAttributeValue(SentryAttributeType.STRING, Build.VERSION.RELEASE));
     } catch (Throwable e) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to retrieve os system", e);
     }
@@ -253,7 +250,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   // Data to be applied to events that was created in the running process
   private void processNonCachedEvent(
-    final @NotNull SentryBaseEvent event, final @NotNull Hint hint) {
+      final @NotNull SentryBaseEvent event, final @NotNull Hint hint) {
     App app = event.getContexts().getApp();
     if (app == null) {
       app = new App();
@@ -285,8 +282,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   private void setPackageInfo(final @NotNull SentryBaseEvent event, final @NotNull App app) {
     final PackageInfo packageInfo =
-      ContextUtils.getPackageInfo(
-        context, PackageManager.GET_PERMISSIONS, options.getLogger(), buildInfoProvider);
+        ContextUtils.getPackageInfo(
+            context, PackageManager.GET_PERMISSIONS, options.getLogger(), buildInfoProvider);
     if (packageInfo != null) {
       String versionCode = ContextUtils.getVersionCode(packageInfo, buildInfoProvider);
 
@@ -316,7 +313,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   private void setAppExtras(final @NotNull App app, final @NotNull Hint hint) {
     app.setAppName(ContextUtils.getApplicationName(context));
     final @NotNull TimeSpan appStartTimeSpan =
-      AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options);
+        AppStartMetrics.getInstance().getAppStartTimeSpanWithFallback(options);
     if (appStartTimeSpan.hasStarted()) {
       app.setAppStartTime(DateUtils.toUtilDate(appStartTimeSpan.getStartTimestamp()));
     }
@@ -363,7 +360,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @Override
   public @NotNull SentryTransaction process(
-    final @NotNull SentryTransaction transaction, final @NotNull Hint hint) {
+      final @NotNull SentryTransaction transaction, final @NotNull Hint hint) {
     final boolean applyScopeData = shouldApplyScopeData(transaction, hint);
 
     if (applyScopeData) {
@@ -377,7 +374,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
 
   @Override
   public @NotNull SentryReplayEvent process(
-    final @NotNull SentryReplayEvent event, final @NotNull Hint hint) {
+      final @NotNull SentryReplayEvent event, final @NotNull Hint hint) {
     final boolean applyScopeData = shouldApplyScopeData(event, hint);
     if (applyScopeData) {
       processNonCachedEvent(event, hint);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -73,7 +73,7 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     } catch (RejectedExecutionException e) {
       options
           .getLogger()
-          .log(SentryLevel.WARNING, "Device info pre-caching task rejected.", e);
+          .log(SentryLevel.WARNING, "Device info caching task rejected.", e);
     }
     executorService.shutdown();
   }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -12,8 +12,6 @@ import io.sentry.util.Objects;
 import io.sentry.util.SpanUtils;
 import io.sentry.util.TracingUtils;
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.ApiStatus;

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -5,17 +5,17 @@ import io.sentry.hints.SessionEndHint;
 import io.sentry.hints.SessionStartHint;
 import io.sentry.logger.ILoggerApi;
 import io.sentry.logger.LoggerApi;
-import io.sentry.protocol.Feedback;
-import io.sentry.protocol.SentryId;
-import io.sentry.protocol.SentryTransaction;
-import io.sentry.protocol.User;
+import io.sentry.protocol.*;
 import io.sentry.transport.RateLimiter;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.SpanUtils;
 import io.sentry.util.TracingUtils;
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -449,8 +449,18 @@ public final class Scopes implements IScopes {
         getOptions().getConnectionStatusProvider().close();
         final @NotNull ISentryExecutorService executorService = getOptions().getExecutorService();
         if (isRestarting) {
-          executorService.submit(
-              () -> executorService.close(getOptions().getShutdownTimeoutMillis()));
+          try {
+            executorService.submit(
+                () -> executorService.close(getOptions().getShutdownTimeoutMillis()));
+          } catch (RejectedExecutionException e) {
+            getOptions()
+                .getLogger()
+                .log(
+                    SentryLevel.DEBUG,
+                    "Failed to submit executor service shutdown task during restart. Shutting down synchronously.",
+                    e);
+            executorService.close(getOptions().getShutdownTimeoutMillis());
+          }
         } else {
           executorService.close(getOptions().getShutdownTimeoutMillis());
         }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -456,7 +456,7 @@ public final class Scopes implements IScopes {
             getOptions()
                 .getLogger()
                 .log(
-                    SentryLevel.DEBUG,
+                    SentryLevel.WARNING,
                     "Failed to submit executor service shutdown task during restart. Shutting down synchronously.",
                     e);
             executorService.close(getOptions().getShutdownTimeoutMillis());

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -54,7 +54,8 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull Future<?> submit(final @NotNull Runnable runnable) throws RejectedExecutionException {
+  public @NotNull Future<?> submit(final @NotNull Runnable runnable)
+      throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
       return executorService.submit(runnable);
     }
@@ -67,7 +68,8 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull <T> Future<T> submit(final @NotNull Callable<T> callable) throws RejectedExecutionException {
+  public @NotNull <T> Future<T> submit(final @NotNull Callable<T> callable)
+      throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
       return executorService.submit(callable);
     }
@@ -80,7 +82,8 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis) throws RejectedExecutionException {
+  public @NotNull Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis)
+      throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
       return executorService.schedule(runnable, delayMillis, TimeUnit.MILLISECONDS);
     }
@@ -124,10 +127,12 @@ public final class SentryExecutorService implements ISentryExecutorService {
       executorService.submit(
           () -> {
             try {
-              // schedule a bunch of dummy runnables in the future that will never execute to trigger
+              // schedule a bunch of dummy runnables in the future that will never execute to
+              // trigger
               // queue growth and then purge the queue
               for (int i = 0; i < INITIAL_QUEUE_SIZE; i++) {
-                final Future<?> future = executorService.schedule(dummyRunnable, 365L, TimeUnit.DAYS);
+                final Future<?> future =
+                    executorService.schedule(dummyRunnable, 365L, TimeUnit.DAYS);
                 future.cancel(true);
               }
               executorService.purge();

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -143,7 +143,7 @@ public final class SentryExecutorService implements ISentryExecutorService {
       if (options != null) {
         options
             .getLogger()
-            .log(SentryLevel.DEBUG, "Prewarm task rejected from " + executorService, e);
+            .log(SentryLevel.WARNING, "Prewarm task rejected from " + executorService, e);
       }
     }
   }

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -54,18 +54,9 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull Future<?> submit(final @NotNull Runnable runnable) {
+  public @NotNull Future<?> submit(final @NotNull Runnable runnable) throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
-      try {
-        return executorService.submit(runnable);
-      } catch (RejectedExecutionException e) {
-        if (options != null) {
-          options
-              .getLogger()
-              .log(SentryLevel.WARNING, "Task " + runnable + " rejected from " + executorService, e);
-        }
-        return new CancelledFuture<>();
-      }
+      return executorService.submit(runnable);
     }
     if (options != null) {
       options
@@ -76,18 +67,9 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull <T> Future<T> submit(final @NotNull Callable<T> callable) {
+  public @NotNull <T> Future<T> submit(final @NotNull Callable<T> callable) throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
-      try {
-        return executorService.submit(callable);
-      } catch (RejectedExecutionException e) {
-        if (options != null) {
-          options
-              .getLogger()
-              .log(SentryLevel.WARNING, "Task " + callable + " rejected from " + executorService, e);
-        }
-        return new CancelledFuture<>();
-      }
+      return executorService.submit(callable);
     }
     if (options != null) {
       options
@@ -98,7 +80,7 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   @Override
-  public @NotNull Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis) {
+  public @NotNull Future<?> schedule(final @NotNull Runnable runnable, final long delayMillis) throws RejectedExecutionException {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
       return executorService.schedule(runnable, delayMillis, TimeUnit.MILLISECONDS);
     }

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -87,7 +87,6 @@ public final class SentryExecutorService implements ISentryExecutorService {
     if (executorService.getQueue().size() < MAX_QUEUE_SIZE) {
       return executorService.schedule(runnable, delayMillis, TimeUnit.MILLISECONDS);
     }
-    // TODO: maybe RejectedExecutionException?
     if (options != null) {
       options
           .getLogger()

--- a/sentry/src/main/java/io/sentry/SentryValues.java
+++ b/sentry/src/main/java/io/sentry/SentryValues.java
@@ -1,6 +1,7 @@
 package io.sentry;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,7 +17,10 @@ final class SentryValues<T> {
   }
 
   public @NotNull List<T> getValues() {
-    return values;
+    ArrayList<T> result = new ArrayList<>(values.size());
+    result.addAll(values);
+    //Collections.reverse(result);
+    return result;
   }
 
   public static final class JsonKeys {

--- a/sentry/src/main/java/io/sentry/SentryValues.java
+++ b/sentry/src/main/java/io/sentry/SentryValues.java
@@ -1,7 +1,6 @@
 package io.sentry;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,10 +16,7 @@ final class SentryValues<T> {
   }
 
   public @NotNull List<T> getValues() {
-    ArrayList<T> result = new ArrayList<>(values.size());
-    result.addAll(values);
-    //Collections.reverse(result);
-    return result;
+    return values;
   }
 
   public static final class JsonKeys {

--- a/sentry/src/main/java/io/sentry/backpressure/BackpressureMonitor.java
+++ b/sentry/src/main/java/io/sentry/backpressure/BackpressureMonitor.java
@@ -85,7 +85,7 @@ public final class BackpressureMonitor implements IBackpressureMonitor, Runnable
         } catch (RejectedExecutionException e) {
           sentryOptions
               .getLogger()
-              .log(SentryLevel.DEBUG, "Backpressure monitor reschedule task rejected", e);
+              .log(SentryLevel.WARNING, "Backpressure monitor reschedule task rejected", e);
         }
       }
     }

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -80,6 +80,7 @@ public final class LoggerBatchProcessor implements ILoggerBatchProcessor {
         try {
           scheduledFlush = executorService.schedule(new BatchRunnable(), flushAfterMs);
         } catch (RejectedExecutionException e) {
+          hasScheduled = false;
           options
               .getLogger()
               .log(SentryLevel.WARNING, "Logs batch processor flush task rejected", e);

--- a/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
+++ b/sentry/src/main/java/io/sentry/logger/LoggerBatchProcessor.java
@@ -82,7 +82,7 @@ public final class LoggerBatchProcessor implements ILoggerBatchProcessor {
         } catch (RejectedExecutionException e) {
           options
               .getLogger()
-              .log(SentryLevel.DEBUG, "Logger batch flush task rejected", e);
+              .log(SentryLevel.WARNING, "Logs batch processor flush task rejected", e);
         }
       }
     }

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -69,6 +69,7 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
       try {
         return super.submit(task);
       } catch (RejectedExecutionException e) {
+        unfinishedTasksCount.decrement();
         lastRejectTimestamp = dateProvider.now();
         logger.log(SentryLevel.WARNING, "Submit rejected by thread pool executor", e);
         return new CancelledFuture<>();

--- a/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
+++ b/sentry/src/main/java/io/sentry/transport/QueuedThreadPoolExecutor.java
@@ -69,7 +69,7 @@ final class QueuedThreadPoolExecutor extends ThreadPoolExecutor {
       try {
         return super.submit(task);
       } catch (RejectedExecutionException e) {
-        unfinishedTasksCount.decrement();
+        lastRejectTimestamp = dateProvider.now();
         logger.log(SentryLevel.WARNING, "Submit rejected by thread pool executor", e);
         return new CancelledFuture<>();
       }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- Handle `RejectedExecutionException` on `submit` where it was previously unhandled
- Log the failure with `WARNING` level everywhere
- Change the signature of methods in `SentryExecutorService` to `throws RejectedExecutionException` (not sure if this is effective because it's a `RuntimeException` anyway)
	- An alternative would be to handle the exception e.g. in the `submit` method itself of `SentryExecutorService`, but then we wouldn't throw it to the caller which can log a more specific message
- Change `deviceInfoUtil` to be nullable in `DefaultAndroidEventProcessor`. Upon accessing it, if it's null it will still trigger an NPE and log things like `options.getLogger().log(SentryLevel.ERROR, "Failed to retrieve device info", e);`
	- Perhaps here it's better to check for null instead of relying on the NPE to avoid the performance hit of the exception throwing and handling flow, to the expense of some DRYness
	-> ended up changing it as described (with null checks)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: https://github.com/getsentry/sentry-java/issues/4660
Closes: JAVA-144

## :green_heart: How did you test it?
All tests pass

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
