### PR TITLE
Start performance collection on AppStart continuous profiling

### DIFF
--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -43,6 +43,7 @@ public final class io/sentry/android/core/ActivityLifecycleIntegration : android
 public class io/sentry/android/core/AndroidContinuousProfiler : io/sentry/IContinuousProfiler, io/sentry/transport/RateLimiter$IRateLimitObserver {
 	public fun <init> (Lio/sentry/android/core/BuildInfoProvider;Lio/sentry/android/core/internal/util/SentryFrameMetricsCollector;Lio/sentry/ILogger;Ljava/lang/String;ILio/sentry/ISentryExecutorService;)V
 	public fun close (Z)V
+	public fun getChunkId ()Lio/sentry/protocol/SentryId;
 	public fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public fun getRootSpanCounter ()I
 	public fun isRunning ()Z

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -208,11 +208,11 @@ public class AndroidContinuousProfiler
 
     isRunning = true;
 
-    if (profilerId == SentryId.EMPTY_ID) {
+    if (profilerId.equals(SentryId.EMPTY_ID)) {
       profilerId = new SentryId();
     }
 
-    if (chunkId == SentryId.EMPTY_ID) {
+    if (chunkId.equals(SentryId.EMPTY_ID)) {
       chunkId = new SentryId();
     }
 
@@ -342,6 +342,11 @@ public class AndroidContinuousProfiler
   @Override
   public @NotNull SentryId getProfilerId() {
     return profilerId;
+  }
+
+  @Override
+  public @NotNull SentryId getChunkId() {
+    return chunkId;
   }
 
   private void sendChunks(final @NotNull IScopes scopes, final @NotNull SentryOptions options) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -5,6 +5,7 @@ import static io.sentry.android.core.NdkIntegration.SENTRY_NDK_CLASS_NAME;
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageInfo;
+import io.sentry.CompositePerformanceCollector;
 import io.sentry.DeduplicateMultithreadedEventProcessor;
 import io.sentry.DefaultCompositePerformanceCollector;
 import io.sentry.DefaultVersionDetector;
@@ -45,6 +46,7 @@ import io.sentry.internal.debugmeta.NoOpDebugMetaLoader;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.modules.NoOpModulesLoader;
 import io.sentry.internal.viewhierarchy.ViewHierarchyExporter;
+import io.sentry.protocol.SentryId;
 import io.sentry.transport.CurrentDateProvider;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.transport.NoOpTransportGate;
@@ -180,26 +182,6 @@ final class AndroidOptionsInitializer {
       options.setTransportGate(new AndroidTransportGate(options));
     }
 
-    // Check if the profiler was already instantiated in the app start.
-    // We use the Android profiler, that uses a global start/stop api, so we need to preserve the
-    // state of the profiler, and it's only possible retaining the instance.
-    final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
-    final @Nullable ITransactionProfiler appStartTransactionProfiler;
-    final @Nullable IContinuousProfiler appStartContinuousProfiler;
-    try (final @NotNull ISentryLifecycleToken ignored = AppStartMetrics.staticLock.acquire()) {
-      appStartTransactionProfiler = appStartMetrics.getAppStartProfiler();
-      appStartContinuousProfiler = appStartMetrics.getAppStartContinuousProfiler();
-      appStartMetrics.setAppStartProfiler(null);
-      appStartMetrics.setAppStartContinuousProfiler(null);
-    }
-
-    setupProfiler(
-        options,
-        context,
-        buildInfoProvider,
-        appStartTransactionProfiler,
-        appStartContinuousProfiler);
-
     if (options.getModulesLoader() instanceof NoOpModulesLoader) {
       options.setModulesLoader(new AssetsModulesLoader(context, options.getLogger()));
     }
@@ -262,6 +244,27 @@ final class AndroidOptionsInitializer {
     if (options.getCompositePerformanceCollector() instanceof NoOpCompositePerformanceCollector) {
       options.setCompositePerformanceCollector(new DefaultCompositePerformanceCollector(options));
     }
+
+    // Check if the profiler was already instantiated in the app start.
+    // We use the Android profiler, that uses a global start/stop api, so we need to preserve the
+    // state of the profiler, and it's only possible retaining the instance.
+    final @NotNull AppStartMetrics appStartMetrics = AppStartMetrics.getInstance();
+    final @Nullable ITransactionProfiler appStartTransactionProfiler;
+    final @Nullable IContinuousProfiler appStartContinuousProfiler;
+    try (final @NotNull ISentryLifecycleToken ignored = AppStartMetrics.staticLock.acquire()) {
+      appStartTransactionProfiler = appStartMetrics.getAppStartProfiler();
+      appStartContinuousProfiler = appStartMetrics.getAppStartContinuousProfiler();
+      appStartMetrics.setAppStartProfiler(null);
+      appStartMetrics.setAppStartContinuousProfiler(null);
+    }
+
+    setupProfiler(
+        options,
+        context,
+        buildInfoProvider,
+        appStartTransactionProfiler,
+        appStartContinuousProfiler,
+        options.getCompositePerformanceCollector());
   }
 
   /** Setup the correct profiler (transaction or continuous) based on the options. */
@@ -270,7 +273,8 @@ final class AndroidOptionsInitializer {
       final @NotNull Context context,
       final @NotNull BuildInfoProvider buildInfoProvider,
       final @Nullable ITransactionProfiler appStartTransactionProfiler,
-      final @Nullable IContinuousProfiler appStartContinuousProfiler) {
+      final @Nullable IContinuousProfiler appStartContinuousProfiler,
+      final @NotNull CompositePerformanceCollector performanceCollector) {
     if (options.isProfilingEnabled() || options.getProfilesSampleRate() != null) {
       options.setContinuousProfiler(NoOpContinuousProfiler.getInstance());
       // This is a safeguard, but it should never happen, as the app start profiler should be the
@@ -299,6 +303,12 @@ final class AndroidOptionsInitializer {
       }
       if (appStartContinuousProfiler != null) {
         options.setContinuousProfiler(appStartContinuousProfiler);
+        // If the profiler is running, we start the performance collector too, otherwise we'd miss
+        // measurements in app launch profiles
+        final @NotNull SentryId chunkId = appStartContinuousProfiler.getChunkId();
+        if (appStartContinuousProfiler.isRunning() && !chunkId.equals(SentryId.EMPTY_ID)) {
+          performanceCollector.start(chunkId.toString());
+        }
       } else {
         options.setContinuousProfiler(
             new AndroidContinuousProfiler(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -167,9 +168,13 @@ class AndroidContinuousProfilerTest {
     // We are scheduling the profiler to stop at the end of the chunk, so it should still be running
     profiler.stopProfiler(ProfileLifecycle.MANUAL)
     assertTrue(profiler.isRunning)
+    assertNotEquals(SentryId.EMPTY_ID, profiler.profilerId)
+    assertNotEquals(SentryId.EMPTY_ID, profiler.chunkId)
     // We run the executor service to trigger the chunk finish, and the profiler shouldn't restart
     fixture.executor.runAll()
     assertFalse(profiler.isRunning)
+    assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
+    assertEquals(SentryId.EMPTY_ID, profiler.chunkId)
   }
 
   @Test
@@ -397,6 +402,7 @@ class AndroidContinuousProfilerTest {
     val profiler = fixture.getSut()
     profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
     assertTrue(profiler.isRunning)
+    val oldChunkId = profiler.chunkId
 
     fixture.executor.runAll()
     verify(fixture.mockLogger)
@@ -407,6 +413,7 @@ class AndroidContinuousProfilerTest {
     verify(fixture.mockLogger, times(2))
       .log(eq(SentryLevel.DEBUG), eq("Profile chunk finished. Starting a new one."))
     assertTrue(profiler.isRunning)
+    assertNotEquals(oldChunkId, profiler.chunkId)
   }
 
   @Test
@@ -508,6 +515,7 @@ class AndroidContinuousProfilerTest {
     profiler.onRateLimitChanged(rateLimiter)
     assertFalse(profiler.isRunning)
     assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
+    assertEquals(SentryId.EMPTY_ID, profiler.chunkId)
     verify(fixture.mockLogger)
       .log(eq(SentryLevel.WARNING), eq("SDK is rate limited. Stopping profiler."))
   }
@@ -523,6 +531,7 @@ class AndroidContinuousProfilerTest {
     profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
     assertFalse(profiler.isRunning)
     assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
+    assertEquals(SentryId.EMPTY_ID, profiler.chunkId)
     verify(fixture.mockLogger)
       .log(eq(SentryLevel.WARNING), eq("SDK is rate limited. Stopping profiler."))
   }
@@ -541,6 +550,7 @@ class AndroidContinuousProfilerTest {
     profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
     assertFalse(profiler.isRunning)
     assertEquals(SentryId.EMPTY_ID, profiler.profilerId)
+    assertEquals(SentryId.EMPTY_ID, profiler.chunkId)
     verify(fixture.mockLogger)
       .log(eq(SentryLevel.WARNING), eq("Device is offline. Stopping profiler."))
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -760,6 +760,7 @@ public abstract interface class io/sentry/IConnectionStatusProvider$IConnectionS
 
 public abstract interface class io/sentry/IContinuousProfiler {
 	public abstract fun close (Z)V
+	public abstract fun getChunkId ()Lio/sentry/protocol/SentryId;
 	public abstract fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public abstract fun isRunning ()Z
 	public abstract fun reevaluateSampling ()V
@@ -1471,6 +1472,7 @@ public final class io/sentry/NoOpConnectionStatusProvider : io/sentry/IConnectio
 
 public final class io/sentry/NoOpContinuousProfiler : io/sentry/IContinuousProfiler {
 	public fun close (Z)V
+	public fun getChunkId ()Lio/sentry/protocol/SentryId;
 	public static fun getInstance ()Lio/sentry/NoOpContinuousProfiler;
 	public fun getProfilerId ()Lio/sentry/protocol/SentryId;
 	public fun isRunning ()Z

--- a/sentry/src/main/java/io/sentry/IContinuousProfiler.java
+++ b/sentry/src/main/java/io/sentry/IContinuousProfiler.java
@@ -25,4 +25,7 @@ public interface IContinuousProfiler {
 
   @NotNull
   SentryId getProfilerId();
+
+  @NotNull
+  SentryId getChunkId();
 }

--- a/sentry/src/main/java/io/sentry/NoOpContinuousProfiler.java
+++ b/sentry/src/main/java/io/sentry/NoOpContinuousProfiler.java
@@ -36,4 +36,9 @@ public final class NoOpContinuousProfiler implements IContinuousProfiler {
   public @NotNull SentryId getProfilerId() {
     return SentryId.EMPTY_ID;
   }
+
+  @Override
+  public @NotNull SentryId getChunkId() {
+    return SentryId.EMPTY_ID;
+  }
 }

--- a/sentry/src/test/java/io/sentry/NoOpContinuousProfilerTest.kt
+++ b/sentry/src/test/java/io/sentry/NoOpContinuousProfilerTest.kt
@@ -26,6 +26,11 @@ class NoOpContinuousProfilerTest {
   }
 
   @Test
+  fun `getChunkId returns Empty SentryId`() {
+    assertEquals(profiler.chunkId, SentryId.EMPTY_ID)
+  }
+
+  @Test
   fun `reevaluateSampling does not throw`() {
     profiler.reevaluateSampling()
   }


### PR DESCRIPTION
## :scroll: Description
app start continuous profiler will now start performance collection when the SDK inits


## :bulb: Motivation and Context
app start continuous profiles were missing performance data on first chunk (cpu and ram)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
