### PR TITLE
Fix(compose): Preserve modifiers in SentryNavigable

### DIFF
--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryComposeTracing.kt
@@ -78,7 +78,7 @@ public fun SentryTraced(
     }
   val firstRendered = remember { ImmutableHolder(false) }
 
-  val baseModifier = if (enableUserInteractionTracing) Modifier.sentryTag(tag) else modifier
+  val baseModifier = if (enableUserInteractionTracing) modifier.sentryTag(tag) else modifier
 
   Box(
     modifier =


### PR DESCRIPTION
## :scroll: Preserve modifier in SentryTraced
When `enableUserInteractionTracing` is true use the provided modifier.

## :bulb: Motivation and Context
When using the enableUserInteractionTracing I noticed my Modifier was ignored. Looking at the git history for this line this looks like an unintended bug.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ x] I updated the docs if needed.
- [ x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
