### PR TITLE
Improve Profiling changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - [Sentry continuous profiling](https://docs.sentry.io/product/explore/profiling/) on the JVM is using async-profiler under the hood.
   - By default this feature is disabled. Set a profile sample rate and chose a lifecycle (see below) to enable it.
   - Add the `sentry-async-profiler` dependency to your project
-  - Set a sample rate for profiles, e.g. `1.0` to send all of them. You may use `options.setProfilesSampleRate(1.0)` in code or `profiles-sample-rate=1.0` in `sentry.properties`
+  - Set a sample rate for profiles, e.g. `1.0` to send all of them. You may use `options.setProfileSessionSampleRate(1.0)` in code or `profile-session-sample-rate=1.0` in `sentry.properties`
   - Set a profile lifecycle via `options.setProfileLifecycle(ProfileLifecycle.TRACE)` in code or `profile-lifecycle=TRACE` in `sentry.properties`
     - By default the lifecycle is set to `MANUAL`, meaning you have to explicitly call `Sentry.startProfiler()` and `Sentry.stopProfiler()`
     - You may change it to `TRACE` which will create a profile for each transaction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@
 
 - Add session replay id to Sentry Logs ([#4740](https://github.com/getsentry/sentry-java/pull/4740))
 - Add support for continuous profiling of JVM applications on macOS and Linux ([#4556](https://github.com/getsentry/sentry-java/pull/4556))
-  - Sentry continuous profiling on the JVM is using async-profiler under the hood.
+  - [Sentry continuous profiling](https://docs.sentry.io/product/explore/profiling/) on the JVM is using async-profiler under the hood.
+  - By default this feature is disabled. Set a profile sample rate and chose a lifecycle (see below) to enable it.
+  - Add the `sentry-async-profiler` dependency to your project
+  - Set a sample rate for profiles, e.g. `1.0` to send all of them. You may use `options.setProfilesSampleRate(1.0)` in code or `profiles-sample-rate=1.0` in `sentry.properties`
+  - Set a profile lifecycle via `options.setProfileLifecycle(ProfileLifecycle.TRACE)` in code or `profile-lifecycle=TRACE` in `sentry.properties`
+    - By default the lifecycle is set to `MANUAL`, meaning you have to explicitly call `Sentry.startProfiler()` and `Sentry.stopProfiler()`
+    - You may change it to `TRACE` which will create a profile for each transaction
+  - To automatically upload Profiles for each transaction in a Spring Boot application
+    - set `sentry.profile-session-sample-rate=1.0` and `sentry.profile-lifecycle=TRACE` in `application.properties`
+    - or set `sentry.profile-session-sample-rate: 1.0` and `sentry.profile-lifecycle: TRACE` in `application.yml`
+  - Profiling can also be combined with our OpenTelemetry integration
 
 ### Fixes
 


### PR DESCRIPTION
#skip-changelog
Expanded details on Sentry continuous profiling feature, including configuration options and default settings.

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
