### PR TITLE
Use logger from options for JVM profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,7 @@
 
 ## 8.23.0
 
-### Various fixes & improvements
-
-- Add session replay id to Sentry Logs (#4740) by @stefanosiano
-- Feat/poc continuous profiling (#4556) by @lbloder
-- Start performance collection on AppStart continuous profiling (#4752) by @stefanosiano
-- Fix(compose): Preserve modifiers in SentryNavigable (#4757) by @VleemingM
-- build(deps): bump github/codeql-action from 3.30.3 to 3.30.5 (#4761) by @dependabot
-- Handle `RejectedExecutionException` everywhere (#4747) by @lcian
-- Mark `SentryEnvelope` as not internal (#4748) by @lcian
-
-## Features
+### Features
 
 - Add session replay id to Sentry Logs ([#4740](https://github.com/getsentry/sentry-java/pull/4740))
 - Add support for continuous profiling of JVM applications on macOS and Linux ([#4556](https://github.com/getsentry/sentry-java/pull/4556))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use logger from options for JVM profiler ([#4771](https://github.com/getsentry/sentry-java/pull/4771))
+
 ## 8.23.0
 
 ### Features

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -710,7 +710,7 @@ public final class Sentry {
 
         final IContinuousProfiler continuousProfiler =
             ProfilingServiceLoader.loadContinuousProfiler(
-                new SystemOutLogger(),
+                options.getLogger(),
                 profilingTracesDirPath,
                 options.getProfilingTracesHz(),
                 options.getExecutorService());


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Use the logger from options when loading and running the profiler.
Otherwise, you would log everything to stdout even if `debug: false`.

Close https://github.com/getsentry/sentry-java/issues/4772
Close JAVA-193