### PR TITLE
Ref(android-distribution): Remove main_binary_identifier parameter (EME-391)

### DIFF
--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -22,7 +22,6 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
 
   /** Parameters for checking updates. */
   data class UpdateCheckParams(
-    val mainBinaryIdentifier: String,
     val appId: String,
     val platform: String = "android",
     val versionCode: Long,
@@ -53,8 +52,7 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
       append(
         "/api/0/projects/${URLEncoder.encode(orgSlug, "UTF-8")}/${URLEncoder.encode(projectSlug, "UTF-8")}/preprodartifacts/check-for-updates/"
       )
-      append("?main_binary_identifier=${URLEncoder.encode(params.mainBinaryIdentifier, "UTF-8")}")
-      append("&app_id=${URLEncoder.encode(params.appId, "UTF-8")}")
+      append("?app_id=${URLEncoder.encode(params.appId, "UTF-8")}")
       append("&platform=${URLEncoder.encode(params.platform, "UTF-8")}")
       append("&build_number=${URLEncoder.encode(params.versionCode.toString(), "UTF-8")}")
       append("&build_version=${URLEncoder.encode(params.versionName, "UTF-8")}")

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionIntegration.kt
@@ -133,7 +133,6 @@ public class DistributionIntegration(context: Context) : Integration, IDistribut
       val appId = context.applicationInfo.packageName
 
       DistributionHttpClient.UpdateCheckParams(
-        mainBinaryIdentifier = appId,
         appId = appId,
         platform = "android",
         versionCode = versionCode,

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/DistributionHttpClientTest.kt
@@ -34,7 +34,6 @@ class DistributionHttpClientTest {
   fun `test checkForUpdates with real API`() {
     val params =
       DistributionHttpClient.UpdateCheckParams(
-        mainBinaryIdentifier = "com.emergetools.hackernews",
         appId = "com.emergetools.hackernews",
         versionName = "1.0.0",
         versionCode = 5L,


### PR DESCRIPTION
## Summary

Removes the redundant `main_binary_identifier` parameter from the Build Distribution feature. This parameter was always set to the same value as `app_id`, making it redundant.

## Changes

- Removed `mainBinaryIdentifier` field from `UpdateCheckParams` data class
- Removed `main_binary_identifier` query parameter from API URL construction
- Updated `DistributionIntegration` to no longer pass the redundant parameter
- Updated test to reflect the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)