### PR TITLE
Add support for reading distribution options from properties

### DIFF
--- a/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
+++ b/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
@@ -99,28 +99,37 @@ public final class DebugMetaPropertiesApplier {
       final @Nullable String orgAuthToken = getDistributionOrgAuthToken(properties);
       final @Nullable String buildConfiguration = getDistributionBuildConfiguration(properties);
 
-      if (orgSlug != null || projectSlug != null || orgAuthToken != null) {
+      if (orgSlug != null
+          || projectSlug != null
+          || orgAuthToken != null
+          || buildConfiguration != null) {
         final @NotNull SentryOptions.DistributionOptions distributionOptions =
             options.getDistribution();
 
-        if (orgSlug != null && distributionOptions.orgSlug.isEmpty()) {
+        if (orgSlug != null && !orgSlug.isEmpty() && distributionOptions.orgSlug.isEmpty()) {
           options.getLogger().log(SentryLevel.DEBUG, "Distribution org slug found: %s", orgSlug);
           distributionOptions.orgSlug = orgSlug;
         }
 
-        if (projectSlug != null && distributionOptions.projectSlug.isEmpty()) {
+        if (projectSlug != null
+            && !projectSlug.isEmpty()
+            && distributionOptions.projectSlug.isEmpty()) {
           options
               .getLogger()
               .log(SentryLevel.DEBUG, "Distribution project slug found: %s", projectSlug);
           distributionOptions.projectSlug = projectSlug;
         }
 
-        if (orgAuthToken != null && distributionOptions.orgAuthToken.isEmpty()) {
+        if (orgAuthToken != null
+            && !orgAuthToken.isEmpty()
+            && distributionOptions.orgAuthToken.isEmpty()) {
           options.getLogger().log(SentryLevel.DEBUG, "Distribution org auth token found");
           distributionOptions.orgAuthToken = orgAuthToken;
         }
 
-        if (buildConfiguration != null && distributionOptions.buildConfiguration == null) {
+        if (buildConfiguration != null
+            && !buildConfiguration.isEmpty()
+            && distributionOptions.buildConfiguration == null) {
           options
               .getLogger()
               .log(
@@ -130,6 +139,8 @@ public final class DebugMetaPropertiesApplier {
           distributionOptions.buildConfiguration = buildConfiguration;
         }
 
+        // We only process the first properties file that contains distribution options
+        // to maintain consistency with other properties like proguardUuid
         break;
       }
     }

--- a/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
+++ b/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
@@ -17,6 +17,7 @@ public final class DebugMetaPropertiesApplier {
     if (debugMetaProperties != null) {
       applyToOptions(options, debugMetaProperties);
       applyBuildTool(options, debugMetaProperties);
+      applyDistributionOptions(options, debugMetaProperties);
     }
   }
 
@@ -88,5 +89,69 @@ public final class DebugMetaPropertiesApplier {
   public static @Nullable String getBuildToolVersion(
       final @NotNull Properties debugMetaProperties) {
     return debugMetaProperties.getProperty("io.sentry.build-tool-version");
+  }
+
+  private static void applyDistributionOptions(
+      final @NotNull SentryOptions options, final @NotNull List<Properties> debugMetaProperties) {
+    for (Properties properties : debugMetaProperties) {
+      final @Nullable String orgSlug = getDistributionOrgSlug(properties);
+      final @Nullable String projectSlug = getDistributionProjectSlug(properties);
+      final @Nullable String orgAuthToken = getDistributionOrgAuthToken(properties);
+      final @Nullable String buildConfiguration = getDistributionBuildConfiguration(properties);
+
+      if (orgSlug != null || projectSlug != null || orgAuthToken != null) {
+        final @NotNull SentryOptions.DistributionOptions distributionOptions =
+            options.getDistribution();
+
+        if (orgSlug != null && distributionOptions.orgSlug.isEmpty()) {
+          options.getLogger().log(SentryLevel.DEBUG, "Distribution org slug found: %s", orgSlug);
+          distributionOptions.orgSlug = orgSlug;
+        }
+
+        if (projectSlug != null && distributionOptions.projectSlug.isEmpty()) {
+          options
+              .getLogger()
+              .log(SentryLevel.DEBUG, "Distribution project slug found: %s", projectSlug);
+          distributionOptions.projectSlug = projectSlug;
+        }
+
+        if (orgAuthToken != null && distributionOptions.orgAuthToken.isEmpty()) {
+          options.getLogger().log(SentryLevel.DEBUG, "Distribution org auth token found");
+          distributionOptions.orgAuthToken = orgAuthToken;
+        }
+
+        if (buildConfiguration != null && distributionOptions.buildConfiguration == null) {
+          options
+              .getLogger()
+              .log(
+                  SentryLevel.DEBUG,
+                  "Distribution build configuration found: %s",
+                  buildConfiguration);
+          distributionOptions.buildConfiguration = buildConfiguration;
+        }
+
+        break;
+      }
+    }
+  }
+
+  private static @Nullable String getDistributionOrgSlug(
+      final @NotNull Properties debugMetaProperties) {
+    return debugMetaProperties.getProperty("io.sentry.distribution.org-slug");
+  }
+
+  private static @Nullable String getDistributionProjectSlug(
+      final @NotNull Properties debugMetaProperties) {
+    return debugMetaProperties.getProperty("io.sentry.distribution.project-slug");
+  }
+
+  private static @Nullable String getDistributionOrgAuthToken(
+      final @NotNull Properties debugMetaProperties) {
+    return debugMetaProperties.getProperty("io.sentry.distribution.org-auth-token");
+  }
+
+  private static @Nullable String getDistributionBuildConfiguration(
+      final @NotNull Properties debugMetaProperties) {
+    return debugMetaProperties.getProperty("io.sentry.distribution.build-configuration");
   }
 }

--- a/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
+++ b/sentry/src/main/java/io/sentry/util/DebugMetaPropertiesApplier.java
@@ -96,7 +96,7 @@ public final class DebugMetaPropertiesApplier {
     for (Properties properties : debugMetaProperties) {
       final @Nullable String orgSlug = getDistributionOrgSlug(properties);
       final @Nullable String projectSlug = getDistributionProjectSlug(properties);
-      final @Nullable String orgAuthToken = getDistributionOrgAuthToken(properties);
+      final @Nullable String orgAuthToken = getDistributionAuthToken(properties);
       final @Nullable String buildConfiguration = getDistributionBuildConfiguration(properties);
 
       if (orgSlug != null
@@ -156,9 +156,9 @@ public final class DebugMetaPropertiesApplier {
     return debugMetaProperties.getProperty("io.sentry.distribution.project-slug");
   }
 
-  private static @Nullable String getDistributionOrgAuthToken(
+  private static @Nullable String getDistributionAuthToken(
       final @NotNull Properties debugMetaProperties) {
-    return debugMetaProperties.getProperty("io.sentry.distribution.org-auth-token");
+    return debugMetaProperties.getProperty("io.sentry.distribution.auth-token");
   }
 
   private static @Nullable String getDistributionBuildConfiguration(

--- a/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
+++ b/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
@@ -99,4 +99,35 @@ class DebugMetaPropertiesApplierTest {
     assertEquals(originalOrgSlug, options.distribution.orgSlug)
     assertEquals(originalProjectSlug, options.distribution.projectSlug)
   }
+
+  @Test
+  fun `applies buildConfiguration only when it is the only property set`() {
+    val properties = Properties()
+    properties.setProperty("io.sentry.distribution.build-configuration", "debug")
+
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties))
+
+    assertEquals("debug", options.distribution.buildConfiguration)
+    assertEquals("", options.distribution.orgSlug)
+    assertEquals("", options.distribution.projectSlug)
+    assertEquals("", options.distribution.orgAuthToken)
+  }
+
+  @Test
+  fun `does not apply empty string values`() {
+    val properties = Properties()
+    properties.setProperty("io.sentry.distribution.org-slug", "")
+    properties.setProperty("io.sentry.distribution.project-slug", "")
+    properties.setProperty("io.sentry.distribution.org-auth-token", "")
+    properties.setProperty("io.sentry.distribution.build-configuration", "")
+
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties))
+
+    assertEquals("", options.distribution.orgSlug)
+    assertEquals("", options.distribution.projectSlug)
+    assertEquals("", options.distribution.orgAuthToken)
+    assertNull(options.distribution.buildConfiguration)
+  }
 }

--- a/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
+++ b/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
@@ -1,0 +1,102 @@
+package io.sentry.util
+
+import io.sentry.SentryOptions
+import java.util.Properties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DebugMetaPropertiesApplierTest {
+
+  @Test
+  fun `applies distribution options from properties`() {
+    val properties = Properties()
+    properties.setProperty("io.sentry.distribution.org-slug", "test-org")
+    properties.setProperty("io.sentry.distribution.project-slug", "test-project")
+    properties.setProperty("io.sentry.distribution.org-auth-token", "test-token")
+    properties.setProperty("io.sentry.distribution.build-configuration", "debug")
+
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties))
+
+    assertEquals("test-org", options.distribution.orgSlug)
+    assertEquals("test-project", options.distribution.projectSlug)
+    assertEquals("test-token", options.distribution.orgAuthToken)
+    assertEquals("debug", options.distribution.buildConfiguration)
+  }
+
+  @Test
+  fun `applies partial distribution options from properties`() {
+    val properties = Properties()
+    properties.setProperty("io.sentry.distribution.org-slug", "test-org")
+    properties.setProperty("io.sentry.distribution.project-slug", "test-project")
+
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties))
+
+    assertEquals("test-org", options.distribution.orgSlug)
+    assertEquals("test-project", options.distribution.projectSlug)
+    assertEquals("", options.distribution.orgAuthToken)
+    assertNull(options.distribution.buildConfiguration)
+  }
+
+  @Test
+  fun `does not override existing distribution options`() {
+    val properties = Properties()
+    properties.setProperty("io.sentry.distribution.org-slug", "properties-org")
+    properties.setProperty("io.sentry.distribution.project-slug", "properties-project")
+    properties.setProperty("io.sentry.distribution.org-auth-token", "properties-token")
+    properties.setProperty("io.sentry.distribution.build-configuration", "properties-config")
+
+    val options = SentryOptions()
+    options.distribution.orgSlug = "existing-org"
+    options.distribution.projectSlug = "existing-project"
+    options.distribution.orgAuthToken = "existing-token"
+    options.distribution.buildConfiguration = "existing-config"
+
+    DebugMetaPropertiesApplier.apply(options, listOf(properties))
+
+    assertEquals("existing-org", options.distribution.orgSlug)
+    assertEquals("existing-project", options.distribution.projectSlug)
+    assertEquals("existing-token", options.distribution.orgAuthToken)
+    assertEquals("existing-config", options.distribution.buildConfiguration)
+  }
+
+  @Test
+  fun `applies distribution options from first properties file with values`() {
+    val properties1 = Properties()
+    val properties2 = Properties()
+    properties2.setProperty("io.sentry.distribution.org-slug", "org-from-second")
+    properties2.setProperty("io.sentry.distribution.project-slug", "project-from-second")
+
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties1, properties2))
+
+    assertEquals("org-from-second", options.distribution.orgSlug)
+    assertEquals("project-from-second", options.distribution.projectSlug)
+  }
+
+  @Test
+  fun `does nothing when properties list is empty`() {
+    val options = SentryOptions()
+    val originalOrgSlug = options.distribution.orgSlug
+    val originalProjectSlug = options.distribution.projectSlug
+
+    DebugMetaPropertiesApplier.apply(options, emptyList())
+
+    assertEquals(originalOrgSlug, options.distribution.orgSlug)
+    assertEquals(originalProjectSlug, options.distribution.projectSlug)
+  }
+
+  @Test
+  fun `does nothing when properties list is null`() {
+    val options = SentryOptions()
+    val originalOrgSlug = options.distribution.orgSlug
+    val originalProjectSlug = options.distribution.projectSlug
+
+    DebugMetaPropertiesApplier.apply(options, null)
+
+    assertEquals(originalOrgSlug, options.distribution.orgSlug)
+    assertEquals(originalProjectSlug, options.distribution.projectSlug)
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
+++ b/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
@@ -13,7 +13,7 @@ class DebugMetaPropertiesApplierTest {
     val properties = Properties()
     properties.setProperty("io.sentry.distribution.org-slug", "test-org")
     properties.setProperty("io.sentry.distribution.project-slug", "test-project")
-    properties.setProperty("io.sentry.distribution.org-auth-token", "test-token")
+    properties.setProperty("io.sentry.distribution.auth-token", "test-token")
     properties.setProperty("io.sentry.distribution.build-configuration", "debug")
 
     val options = SentryOptions()
@@ -45,7 +45,7 @@ class DebugMetaPropertiesApplierTest {
     val properties = Properties()
     properties.setProperty("io.sentry.distribution.org-slug", "properties-org")
     properties.setProperty("io.sentry.distribution.project-slug", "properties-project")
-    properties.setProperty("io.sentry.distribution.org-auth-token", "properties-token")
+    properties.setProperty("io.sentry.distribution.auth-token", "properties-token")
     properties.setProperty("io.sentry.distribution.build-configuration", "properties-config")
 
     val options = SentryOptions()
@@ -66,13 +66,20 @@ class DebugMetaPropertiesApplierTest {
   fun `applies distribution options from first properties file with values`() {
     val properties1 = Properties()
     val properties2 = Properties()
-    properties2.setProperty("io.sentry.distribution.org-slug", "org-from-second")
+    val properties3 = Properties()
+
+    // properties1 has non-distribution properties so is ignored:
+    properties1.setProperty("io.sentry.unrelated", "unrelated")
+
+    // properties2 should end up being the ones set
     properties2.setProperty("io.sentry.distribution.project-slug", "project-from-second")
 
-    val options = SentryOptions()
-    DebugMetaPropertiesApplier.apply(options, listOf(properties1, properties2))
+    // properties3 also has distribution properties but since properties2 was first they are ignored.
+    properties3.setProperty("io.sentry.distribution.project-slug", "project-from-third")
 
-    assertEquals("org-from-second", options.distribution.orgSlug)
+    val options = SentryOptions()
+    DebugMetaPropertiesApplier.apply(options, listOf(properties1, properties2, properties3))
+
     assertEquals("project-from-second", options.distribution.projectSlug)
   }
 
@@ -119,7 +126,7 @@ class DebugMetaPropertiesApplierTest {
     val properties = Properties()
     properties.setProperty("io.sentry.distribution.org-slug", "")
     properties.setProperty("io.sentry.distribution.project-slug", "")
-    properties.setProperty("io.sentry.distribution.org-auth-token", "")
+    properties.setProperty("io.sentry.distribution.auth-token", "")
     properties.setProperty("io.sentry.distribution.build-configuration", "")
 
     val options = SentryOptions()

--- a/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
+++ b/sentry/src/test/java/io/sentry/util/DebugMetaPropertiesApplierTest.kt
@@ -74,7 +74,8 @@ class DebugMetaPropertiesApplierTest {
     // properties2 should end up being the ones set
     properties2.setProperty("io.sentry.distribution.project-slug", "project-from-second")
 
-    // properties3 also has distribution properties but since properties2 was first they are ignored.
+    // properties3 also has distribution properties but since properties2 was first they are
+    // ignored.
     properties3.setProperty("io.sentry.distribution.project-slug", "project-from-third")
 
     val options = SentryOptions()


### PR DESCRIPTION
## Summary

Extends `DebugMetaPropertiesApplier` to read and apply distribution configuration from properties files bundled in the APK. This is part of [EME-397](https://linear.app/getsentry/issue/EME-397) to allow the Sentry Android Gradle Plugin to automatically populate `SentryOptions.DistributionOptions` fields.

## Integration

This allows the Gradle plugin ([implemented here](https://github.com/getsentry/sentry-android-gradle-plugin/pull/999)) to generate these properties at build time and bundle them into the APK. The SDK will automatically load them when initializing, making distribution configuration seamless for developers.

There are probably many ways of passing these options to the client but using properties files doesn't require the client to recompile resources or code and there is already an existing mechanism in the codebase to do this so I just piggy-backed on that mechanism.


## Notes

- Properties are only applied if the corresponding option is empty/null
- Supports multiple properties files (uses first one with values)
- Follows the same pattern as existing properties (bundle IDs, proguard UUID, build tool)

#skip-changelog This feature is not released or published yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)