### PR TITLE
Mark SentryClient(SentryOptions) constructor as not internal

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -48,7 +48,6 @@ public final class SentryClient implements ISentryClient {
     return enabled;
   }
 
-  @ApiStatus.Internal
   public SentryClient(final @NotNull SentryOptions options) {
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
     this.enabled = true;


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
We document [here](https://docs.sentry.io/platforms/android/configuration/shared-environments/) to use this constructor, but it's marked as internal.
This removes the internal annotation.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->
Close https://github.com/getsentry/sentry-java/issues/4780
Close JAVA-196

