### PR TITLE
fix(replay): Avoid deadlock when pausing replay if no connection

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -307,15 +307,13 @@ public class ReplayIntegration(
     scopes?.configureScope { screen = it.screen?.substringAfterLast('.') }
     captureStrategy?.onScreenshotRecorded(bitmap) { frameTimeStamp ->
       addFrame(bitmap, frameTimeStamp, screen)
-      checkCanRecord()
     }
+    checkCanRecord()
   }
 
   override fun onScreenshotRecorded(screenshot: File, frameTimestamp: Long) {
-    captureStrategy?.onScreenshotRecorded { _ ->
-      addFrame(screenshot, frameTimestamp)
-      checkCanRecord()
-    }
+    captureStrategy?.onScreenshotRecorded { _ -> addFrame(screenshot, frameTimestamp) }
+    checkCanRecord()
   }
 
   override fun close() {


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
- We were calling `pauseInternal` in the case of no internet connection/rate-limit from the replayExecutor thread. However, this might be a heavy operation because we need to encode the current pending segment and therefore we'd be holding the lifecycleLock for too long. Moving `checkCanRecord` off the executor fixes this, because we no longer hold the lock for the entire encoding task, but just for submitting it to the executor

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/4838
<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
