### PR TITLE
meta(craft): Remove sentry-android-distribution from registry targets

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -34,7 +34,6 @@ targets:
       maven:io.sentry:sentry-apache-http-client-5:
       maven:io.sentry:sentry-android:
       maven:io.sentry:sentry-android-core:
-      maven:io.sentry:sentry-android-distribution:
       maven:io.sentry:sentry-android-ndk:
       maven:io.sentry:sentry-android-timber:
       maven:io.sentry:sentry-kotlin-extensions:


### PR DESCRIPTION
## Summary
Remove sentry-android-distribution from the .craft.yml registry targets list.

We do want to release this module but apparently we need to do this before the release and then add it back afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)