### PR TITLE
Revert "meta(craft): Remove sentry-android-distribution from registry targets (#4827)"

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -34,6 +34,7 @@ targets:
       maven:io.sentry:sentry-apache-http-client-5:
       maven:io.sentry:sentry-android:
       maven:io.sentry:sentry-android-core:
+      maven:io.sentry:sentry-android-distribution:
       maven:io.sentry:sentry-android-ndk:
       maven:io.sentry:sentry-android-timber:
       maven:io.sentry:sentry-kotlin-extensions:


### PR DESCRIPTION
## Summary
Revert the removal of sentry-android-distribution from the .craft.yml registry targets list.

This reverts commit 565c8510f.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)