### PR TITLE
chore(readme): Update Maven Central badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Sentry SDK for Java and Android
 | sentry-opentelemetry-agentcustomization | ![Maven Central Version](https://img.shields.io/maven-central/v/io.sentry/sentry-opentelemetry-agentcustomization?style=for-the-badge&logo=sentry&color=green) |
 | sentry-opentelemetry-core               | ![Maven Central Version](https://img.shields.io/maven-central/v/io.sentry/sentry-opentelemetry-core?style=for-the-badge&logo=sentry&color=green)                             |
 | sentry-okhttp                           | ![Maven Central Version](https://img.shields.io/maven-central/v/io.sentry/sentry-okhttp?style=for-the-badge&logo=sentry&color=green)                                                     |
-| sentry-reactor                          | ![Maven Central Version](https://img.shields.io/maven-reactor/v/io.sentry/sentry-android?style=for-the-badge&logo=sentry&color=green)                                                   |
+| sentry-reactor                          | ![Maven Central Version](https://img.shields.io/maven-central/v/io.sentry/sentry-reactor?style=for-the-badge&logo=sentry&color=green)                                                   |
 
 # Releases
 


### PR DESCRIPTION
_#skip-changelog_

the service we previously used seems to fail to update badges to the latest version, so I tried to used a difference service instead: https://shields.io/badges/maven-central-version

Closes https://github.com/getsentry/sentry-java/discussions/4821