### PR TITLE
Ensure tests cover non-error timber tags

### DIFF
--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberTreeTest.kt
@@ -140,6 +140,15 @@ class SentryTimberTreeTest {
   }
 
   @Test
+  fun `Tree captures an event with TimberTag tag for debug events`() {
+    val sut = fixture.getSut(minEventLevel = SentryLevel.INFO)
+    Timber.plant(sut)
+    // only available thru static class
+    Timber.tag("infoTag").i("message")
+    verify(fixture.scopes).captureEvent(check { assertEquals("infoTag", it.getTag("TimberTag")) })
+  }
+
+  @Test
   fun `Tree captures an event without TimberTag tag`() {
     val sut = fixture.getSut()
     Timber.plant(sut)


### PR DESCRIPTION
## :scroll: Description

Add another test to verify that https://github.com/getsentry/sentry-java/issues/4484 should be working as expected. Also ran it locally against the Timber 5.0.1 and still can not reproduce the issue.

#skip-changelog

