### PR TITLE
Report discarded log bytes

### DIFF
--- a/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
+++ b/sentry/src/test/java/io/sentry/clientreport/ClientReportTest.kt
@@ -374,7 +374,8 @@ class ClientReportTest {
     verify(onDiscardMock, times(1)).execute(DiscardReason.NETWORK_ERROR, DataCategory.LogItem, 2)
 
     val clientReport = clientReportRecorder.resetCountsAndGenerateClientReport()
-    val logItem = clientReport!!.discardedEvents!!.first { it.category == DataCategory.LogItem.category }
+    val logItem =
+      clientReport!!.discardedEvents!!.first { it.category == DataCategory.LogItem.category }
     assertEquals(2, logItem.quantity)
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Report discarded log size in bytes as part of client reports.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since log count is not shown to customers in UI, we want to report log size too.
<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
