### PR TITLE
fix(size-analysis): Use local sentry-android module

### DIFF
--- a/sentry-android-integration-tests/test-app-size/build.gradle.kts
+++ b/sentry-android-integration-tests/test-app-size/build.gradle.kts
@@ -41,6 +41,7 @@ configurations.configureEach {
 }
 
 dependencies {
+  implementation(projects.sentryAndroid)
   implementation(projects.sentryAndroidTimber)
   implementation(projects.sentryAndroidSqlite)
   implementation(projects.sentryOkhttp)
@@ -56,5 +57,6 @@ sentry {
   tracingInstrumentation.enabled.set(false)
   includeDependenciesReport.set(false)
   telemetry.set(false)
+  autoInstallation.enabled.set(false)
   sizeAnalysis.enabled.set(providers.environmentVariable("SENTRY_AUTH_TOKEN").isPresent)
 }


### PR DESCRIPTION
_#skip-changelog_

we were getting the sentry-android module installed from maven central, therefore the PR changes made in its submodules were not reflected in the size analysis breakdown