### PR TITLE
feat(metrics): [Trace Metrics 1] Metrics Options

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3420,6 +3420,7 @@ public class io/sentry/SentryOptions {
 	public fun getMaxRequestBodySize ()Lio/sentry/SentryOptions$RequestSize;
 	public fun getMaxSpans ()I
 	public fun getMaxTraceFileSize ()J
+	public fun getMetrics ()Lio/sentry/SentryOptions$Metrics;
 	public fun getModulesLoader ()Lio/sentry/internal/modules/IModulesLoader;
 	public fun getOnDiscard ()Lio/sentry/SentryOptions$OnDiscardCallback;
 	public fun getOnOversizedEvent ()Lio/sentry/SentryOptions$OnOversizedEventCallback;
@@ -3572,6 +3573,7 @@ public class io/sentry/SentryOptions {
 	public fun setMaxRequestBodySize (Lio/sentry/SentryOptions$RequestSize;)V
 	public fun setMaxSpans (I)V
 	public fun setMaxTraceFileSize (J)V
+	public fun setMetrics (Lio/sentry/SentryOptions$Metrics;)V
 	public fun setModulesLoader (Lio/sentry/internal/modules/IModulesLoader;)V
 	public fun setOnDiscard (Lio/sentry/SentryOptions$OnDiscardCallback;)V
 	public fun setOnOversizedEvent (Lio/sentry/SentryOptions$OnOversizedEventCallback;)V
@@ -3626,10 +3628,6 @@ public abstract interface class io/sentry/SentryOptions$BeforeBreadcrumbCallback
 	public abstract fun execute (Lio/sentry/Breadcrumb;Lio/sentry/Hint;)Lio/sentry/Breadcrumb;
 }
 
-public abstract interface class io/sentry/SentryOptions$BeforeEmitMetricCallback {
-	public abstract fun execute (Ljava/lang/String;Ljava/util/Map;)Z
-}
-
 public abstract interface class io/sentry/SentryOptions$BeforeEnvelopeCallback {
 	public abstract fun execute (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 }
@@ -3681,6 +3679,18 @@ public final class io/sentry/SentryOptions$Logs {
 
 public abstract interface class io/sentry/SentryOptions$Logs$BeforeSendLogCallback {
 	public abstract fun execute (Lio/sentry/SentryLogEvent;)Lio/sentry/SentryLogEvent;
+}
+
+public final class io/sentry/SentryOptions$Metrics {
+	public fun <init> ()V
+	public fun getBeforeSend ()Lio/sentry/SentryOptions$Metrics$BeforeSendMetricCallback;
+	public fun isEnabled ()Z
+	public fun setBeforeSend (Lio/sentry/SentryOptions$Metrics$BeforeSendMetricCallback;)V
+	public fun setEnabled (Z)V
+}
+
+public abstract interface class io/sentry/SentryOptions$Metrics$BeforeSendMetricCallback {
+	public abstract fun execute (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class io/sentry/SentryOptions$OnDiscardCallback {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -624,6 +624,8 @@ public class SentryOptions {
 
   private @NotNull SentryOptions.Logs logs = new SentryOptions.Logs();
 
+  private @NotNull SentryOptions.Metrics metrics = new SentryOptions.Metrics();
+
   private @NotNull ISocketTagger socketTagger = NoOpSocketTagger.getInstance();
 
   /** Runtime manager to manage runtime policies, like StrictMode on Android. */
@@ -3261,20 +3263,6 @@ public class SentryOptions {
     void execute(@NotNull SentryEnvelope envelope, @Nullable Hint hint);
   }
 
-  /** The BeforeEmitMetric callback */
-  @ApiStatus.Experimental
-  public interface BeforeEmitMetricCallback {
-
-    /**
-     * A callback which gets called right before a metric is about to be emitted.
-     *
-     * @param key the metric key
-     * @param tags the metric tags
-     * @return true if the metric should be emitted, false otherwise
-     */
-    boolean execute(@NotNull String key, @Nullable Map<String, String> tags);
-  }
-
   /**
    * Creates SentryOptions instance without initializing any of the internal parts.
    *
@@ -3537,6 +3525,16 @@ public class SentryOptions {
     this.logs = logs;
   }
 
+  @ApiStatus.Experimental
+  public @NotNull SentryOptions.Metrics getMetrics() {
+    return metrics;
+  }
+
+  @ApiStatus.Experimental
+  public void setMetrics(@NotNull SentryOptions.Metrics metrics) {
+    this.metrics = metrics;
+  }
+
   public static final class Proxy {
     private @Nullable String host;
     private @Nullable String port;
@@ -3738,6 +3736,67 @@ public class SentryOptions {
        */
       @Nullable
       SentryLogEvent execute(@NotNull SentryLogEvent event);
+    }
+  }
+
+  public static final class Metrics {
+
+    /** Whether Sentry Metrics feature is enabled and metrics are sent to Sentry. */
+    private boolean enable = false;
+
+    /**
+     * This function is called with a metric key and tags and can return false to skip sending the
+     * metric
+     */
+    private @Nullable BeforeSendMetricCallback beforeSend;
+
+    /**
+     * Whether Sentry Metrics feature is enabled and metrics are sent to Sentry.
+     *
+     * @return true if Sentry Metrics should be enabled
+     */
+    public boolean isEnabled() {
+      return enable;
+    }
+
+    /**
+     * Whether Sentry Metrics feature is enabled and metrics are sent to Sentry.
+     *
+     * @param enableMetrics true if Sentry Metrics should be enabled
+     */
+    public void setEnabled(boolean enableMetrics) {
+      this.enable = enableMetrics;
+    }
+
+    /**
+     * Returns the BeforeSendMetric callback
+     *
+     * @return the beforeSend callback or null if not set
+     */
+    public @Nullable BeforeSendMetricCallback getBeforeSend() {
+      return beforeSend;
+    }
+
+    /**
+     * Sets the beforeSend callback for metrics
+     *
+     * @param beforeSend the beforeSend callback for metrics
+     */
+    public void setBeforeSend(@Nullable BeforeSendMetricCallback beforeSend) {
+      this.beforeSend = beforeSend;
+    }
+
+    public interface BeforeSendMetricCallback {
+
+      /**
+       * A callback which gets called right before a metric is about to be sent.
+       *
+       * @param metric the metric
+       * @return the original metric, mutated metric or null if metric was dropped
+       */
+      // TODO replace with SentryMetric
+      @Nullable
+      Object execute(@NotNull Object metric);
     }
   }
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add options for Metrics to `SentryOptions`:
- `SentryOptions.getMetrics().setEnabled(true)`
- `SentryOptions.getMetrics().setBeforeSend(...)`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
