### PR TITLE
feat(metrics): [Trace Metrics 11] Metrics Envelope item deserialization

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2955,6 +2955,7 @@ public final class io/sentry/SentryEnvelopeItem {
 	public fun getEvent (Lio/sentry/ISerializer;)Lio/sentry/SentryEvent;
 	public fun getHeader ()Lio/sentry/SentryEnvelopeItemHeader;
 	public fun getLogs (Lio/sentry/ISerializer;)Lio/sentry/SentryLogEvents;
+	public fun getMetrics (Lio/sentry/ISerializer;)Lio/sentry/SentryMetricsEvents;
 	public fun getTransaction (Lio/sentry/ISerializer;)Lio/sentry/protocol/SentryTransaction;
 }
 

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -123,6 +123,7 @@ public final class JsonSerializer implements ISerializer {
     deserializersByClass.put(SentryLevel.class, new SentryLevel.Deserializer());
     deserializersByClass.put(SentryLockReason.class, new SentryLockReason.Deserializer());
     deserializersByClass.put(SentryLogEvents.class, new SentryLogEvents.Deserializer());
+    deserializersByClass.put(SentryMetricsEvents.class, new SentryMetricsEvents.Deserializer());
     deserializersByClass.put(SentryPackage.class, new SentryPackage.Deserializer());
     deserializersByClass.put(SentryRuntime.class, new SentryRuntime.Deserializer());
     deserializersByClass.put(SentryReplayEvent.class, new SentryReplayEvent.Deserializer());

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -158,6 +158,17 @@ public final class SentryEnvelopeItem {
     }
   }
 
+  public @Nullable SentryMetricsEvents getMetrics(final @NotNull ISerializer serializer)
+      throws Exception {
+    if (header == null || header.getType() != SentryItemType.TraceMetric) {
+      return null;
+    }
+    try (final Reader eventReader =
+        new BufferedReader(new InputStreamReader(new ByteArrayInputStream(getData()), UTF_8))) {
+      return serializer.deserialize(eventReader, SentryMetricsEvents.class);
+    }
+  }
+
   public static SentryEnvelopeItem fromUserFeedback(
       final @NotNull ISerializer serializer, final @NotNull UserFeedback userFeedback) {
     Objects.requireNonNull(serializer, "ISerializer is required.");


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Register `SentryMetricsEvents.Deserializer` as known deserializer and implement `SentryEnvelopeItem.getMetrics`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
