### PR TITLE
feat(metrics): [Trace Metrics 13] Metrics external options

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -513,6 +513,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isCaptureOpenTelemetryEvents ()Ljava/lang/Boolean;
 	public fun isEnableBackpressureHandling ()Ljava/lang/Boolean;
 	public fun isEnableLogs ()Ljava/lang/Boolean;
+	public fun isEnableMetrics ()Ljava/lang/Boolean;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
 	public fun isEnableSpotlight ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
@@ -528,6 +529,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setEnableBackpressureHandling (Ljava/lang/Boolean;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnableLogs (Ljava/lang/Boolean;)V
+	public fun setEnableMetrics (Ljava/lang/Boolean;)V
 	public fun setEnablePrettySerializationOutput (Ljava/lang/Boolean;)V
 	public fun setEnableSpotlight (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -44,6 +44,7 @@ public final class ExternalOptions {
   private @Nullable Boolean enablePrettySerializationOutput;
   private @Nullable Boolean enableSpotlight;
   private @Nullable Boolean enableLogs;
+  private @Nullable Boolean enableMetrics;
   private @Nullable String spotlightConnectionUrl;
 
   private @Nullable List<String> ignoredCheckIns;
@@ -156,6 +157,8 @@ public final class ExternalOptions {
         propertiesProvider.getBooleanProperty("capture-open-telemetry-events"));
 
     options.setEnableLogs(propertiesProvider.getBooleanProperty("logs.enabled"));
+
+    options.setEnableMetrics(propertiesProvider.getBooleanProperty("metrics.enabled"));
 
     for (final String ignoredExceptionType :
         propertiesProvider.getList("ignored-exceptions-for-type")) {
@@ -537,6 +540,14 @@ public final class ExternalOptions {
 
   public @Nullable Boolean isEnableLogs() {
     return enableLogs;
+  }
+
+  public void setEnableMetrics(final @Nullable Boolean enableMetrics) {
+    this.enableMetrics = enableMetrics;
+  }
+
+  public @Nullable Boolean isEnableMetrics() {
+    return enableMetrics;
   }
 
   public @Nullable Double getProfileSessionSampleRate() {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3480,6 +3480,10 @@ public class SentryOptions {
       getLogs().setEnabled(options.isEnableLogs());
     }
 
+    if (options.isEnableMetrics() != null) {
+      getMetrics().setEnabled(options.isEnableMetrics());
+    }
+
     if (options.getProfileSessionSampleRate() != null) {
       setProfileSessionSampleRate(options.getProfileSessionSampleRate());
     }

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -377,6 +377,25 @@ class ExternalOptionsTest {
   }
 
   @Test
+  fun `creates options with enableMetrics set to true`() {
+    withPropertiesFile("metrics.enabled=true") { options ->
+      assertTrue(options.isEnableMetrics == true)
+    }
+  }
+
+  @Test
+  fun `creates options with enableMetrics set to false`() {
+    withPropertiesFile("metrics.enabled=false") { options ->
+      assertTrue(options.isEnableMetrics == false)
+    }
+  }
+
+  @Test
+  fun `creates options with enableMetrics set to null when not set`() {
+    withPropertiesFile { assertNull(it.isEnableMetrics) }
+  }
+
+  @Test
   fun `creates options with profileSessionSampleRate set to 0_8`() {
     withPropertiesFile("profile-session-sample-rate=0.8") { options ->
       assertTrue(options.profileSessionSampleRate == 0.8)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -411,6 +411,7 @@ class SentryOptionsTest {
     externalOptions.spotlightConnectionUrl = "http://local.sentry.io:1234"
     externalOptions.isGlobalHubMode = true
     externalOptions.isEnableLogs = true
+    externalOptions.isEnableMetrics = false
     externalOptions.profileSessionSampleRate = 0.8
     externalOptions.profilingTracesDirPath = "/profiling-traces"
     externalOptions.profileLifecycle = ProfileLifecycle.TRACE
@@ -469,6 +470,7 @@ class SentryOptionsTest {
     assertEquals("http://local.sentry.io:1234", options.spotlightConnectionUrl)
     assertTrue(options.isGlobalHubMode!!)
     assertTrue(options.logs.isEnabled!!)
+    assertFalse(options.metrics.isEnabled)
     assertEquals(0.8, options.profileSessionSampleRate)
     assertEquals("/profiling-traces${File.separator}${hash}", options.profilingTracesDirPath)
     assertEquals(ProfileLifecycle.TRACE, options.profileLifecycle)
@@ -480,6 +482,14 @@ class SentryOptionsTest {
     val options = SentryOptions()
     options.merge(externalOptions)
     assertTrue(options.isEnableUncaughtExceptionHandler)
+  }
+
+  @Test
+  fun `merging options when enableMetrics is not set preserves the default value`() {
+    val externalOptions = ExternalOptions()
+    val options = SentryOptions()
+    options.merge(externalOptions)
+    assertTrue(options.metrics.isEnabled)
   }
 
   @Test
@@ -658,6 +668,11 @@ class SentryOptionsTest {
   @Test
   fun `when options are initialized, enableBackpressureHandling is set to true by default`() {
     assertTrue(SentryOptions().isEnableBackpressureHandling)
+  }
+
+  @Test
+  fun `when options are initialized, metrics is enabled by default`() {
+    assertTrue(SentryOptions().metrics.isEnabled)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `metrics.enabled` to `sentry.properties` and ENV vars.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
