### PR TITLE
feat(metrics): [Trace Metrics 16] Only send user attributes if sendDefaultPii is true

### DIFF
--- a/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
+++ b/sentry/src/main/java/io/sentry/metrics/MetricsApi.java
@@ -231,7 +231,9 @@ public final class MetricsApi implements IMetricsApi {
       setServerName(attributes);
     }
 
-    setUser(attributes);
+    if (scopes.getOptions().isSendDefaultPii()) {
+      setUser(attributes);
+    }
 
     return attributes;
   }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
