### PR TITLE
fix(size-analysis): Do not upload bundles on forks

### DIFF
--- a/sentry-android-integration-tests/test-app-size/build.gradle.kts
+++ b/sentry-android-integration-tests/test-app-size/build.gradle.kts
@@ -58,5 +58,6 @@ sentry {
   includeDependenciesReport.set(false)
   telemetry.set(false)
   autoInstallation.enabled.set(false)
+  distribution.enabled.set(providers.environmentVariable("SENTRY_AUTH_TOKEN").isPresent)
   sizeAnalysis.enabled.set(providers.environmentVariable("SENTRY_AUTH_TOKEN").isPresent)
 }


### PR DESCRIPTION
_#skip-changelog_

Bundles were still being uploaded because distribution is not dependant on auth token presence, hence triggering the upload task 