### PR TITLE
feat(metrics): [Trace Metrics 22] Close and flush `MetricsBatchProcessor` from `SentryClient`

### DIFF
--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -1657,6 +1657,7 @@ public final class SentryClient implements ISentryClient {
     try {
       flush(isRestarting ? 0 : options.getShutdownTimeoutMillis());
       loggerBatchProcessor.close(isRestarting);
+      metricsBatchProcessor.close(isRestarting);
       transport.close(isRestarting);
     } catch (IOException e) {
       options
@@ -1684,6 +1685,7 @@ public final class SentryClient implements ISentryClient {
   @Override
   public void flush(final long timeoutMillis) {
     loggerBatchProcessor.flush(timeoutMillis);
+    metricsBatchProcessor.flush(timeoutMillis);
     transport.flush(timeoutMillis);
   }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -14,7 +14,9 @@ import io.sentry.hints.Cached
 import io.sentry.hints.DiskFlushNotification
 import io.sentry.hints.TransactionEnd
 import io.sentry.logger.ILoggerBatchProcessor
+import io.sentry.logger.ILoggerBatchProcessorFactory
 import io.sentry.metrics.IMetricsBatchProcessor
+import io.sentry.metrics.IMetricsBatchProcessorFactory
 import io.sentry.protocol.Contexts
 import io.sentry.protocol.Feedback
 import io.sentry.protocol.Mechanism
@@ -78,6 +80,10 @@ class SentryClientTest {
   class Fixture {
     var transport = mock<ITransport>()
     var factory = mock<ITransportFactory>()
+    var loggerBatchProcessor = mock<ILoggerBatchProcessor>()
+    var loggerBatchProcessorFactory = mock<ILoggerBatchProcessorFactory>()
+    var metricsBatchProcessor = mock<IMetricsBatchProcessor>()
+    var metricsBatchProcessorFactory = mock<IMetricsBatchProcessorFactory>()
     val maxAttachmentSize: Long = (5 * 1024 * 1024).toLong()
     val scopes = mock<IScopes>()
     val sentryTracer: SentryTracer
@@ -94,12 +100,16 @@ class SentryClientTest {
         setLogger(mock())
         maxAttachmentSize = this@Fixture.maxAttachmentSize
         setTransportFactory(factory)
+        logs.setLoggerBatchProcessorFactory(loggerBatchProcessorFactory)
+        metrics.setMetricsBatchProcessorFactory(metricsBatchProcessorFactory)
         release = "0.0.1"
         isTraceSampling = true
       }
 
     init {
       whenever(factory.create(any(), any())).thenReturn(transport)
+      whenever(loggerBatchProcessorFactory.create(any(), any())).thenReturn(loggerBatchProcessor)
+      whenever(metricsBatchProcessorFactory.create(any(), any())).thenReturn(metricsBatchProcessor)
       whenever(scopes.options).thenReturn(sentryOptions)
       sentryTracer =
         SentryTracer(
@@ -168,21 +178,29 @@ class SentryClientTest {
 
   @Test
   fun `when client is closed with isRestarting false, transport waits`() {
-    val sut = fixture.getSut()
+    val sut = fixture.getSut { options -> options.logs.isEnabled = true }
     assertTrue(sut.isEnabled)
     sut.close(false)
     assertNotEquals(0, fixture.sentryOptions.shutdownTimeoutMillis)
     verify(fixture.transport).flush(eq(fixture.sentryOptions.shutdownTimeoutMillis))
+    verify(fixture.loggerBatchProcessor).flush(eq(fixture.sentryOptions.shutdownTimeoutMillis))
+    verify(fixture.metricsBatchProcessor).flush(eq(fixture.sentryOptions.shutdownTimeoutMillis))
     verify(fixture.transport).close(eq(false))
+    verify(fixture.loggerBatchProcessor).close(eq(false))
+    verify(fixture.metricsBatchProcessor).close(eq(false))
   }
 
   @Test
   fun `when client is closed with isRestarting true, transport does not wait`() {
-    val sut = fixture.getSut()
+    val sut = fixture.getSut { options -> options.logs.isEnabled = true }
     assertTrue(sut.isEnabled)
     sut.close(true)
     verify(fixture.transport).flush(eq(0))
+    verify(fixture.loggerBatchProcessor).flush(eq(0))
+    verify(fixture.metricsBatchProcessor).flush(eq(0))
     verify(fixture.transport).close(eq(true))
+    verify(fixture.loggerBatchProcessor).close(eq(true))
+    verify(fixture.metricsBatchProcessor).close(eq(true))
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
