### PR TITLE
feat(metrics): [Trace Metrics 26] SentryMetricsParameters create shortcut for attributes map

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -5283,6 +5283,7 @@ public final class io/sentry/metrics/SentryMetricsParameters {
 	public fun <init> ()V
 	public static fun create (Lio/sentry/SentryAttributes;)Lio/sentry/metrics/SentryMetricsParameters;
 	public static fun create (Lio/sentry/SentryDate;Lio/sentry/SentryAttributes;)Lio/sentry/metrics/SentryMetricsParameters;
+	public static fun create (Ljava/util/Map;)Lio/sentry/metrics/SentryMetricsParameters;
 	public fun getAttributes ()Lio/sentry/SentryAttributes;
 	public fun getHint ()Lio/sentry/Hint;
 	public fun getOrigin ()Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/metrics/SentryMetricsParameters.java
+++ b/sentry/src/main/java/io/sentry/metrics/SentryMetricsParameters.java
@@ -3,6 +3,7 @@ package io.sentry.metrics;
 import io.sentry.Hint;
 import io.sentry.SentryAttributes;
 import io.sentry.SentryDate;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,5 +60,16 @@ public final class SentryMetricsParameters {
   public static @NotNull SentryMetricsParameters create(
       final @Nullable SentryAttributes attributes) {
     return create(null, attributes);
+  }
+
+  /**
+   * A shortcut for SentryMetricsParameters.create(SentryAttributes.fromMap())
+   *
+   * @param attributes a map of attributes
+   * @return parameters
+   */
+  public static @NotNull SentryMetricsParameters create(
+      final @Nullable Map<String, Object> attributes) {
+    return create(null, SentryAttributes.fromMap(attributes));
   }
 }

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -3325,6 +3325,36 @@ class ScopesTest {
   }
 
   @Test
+  fun `creating count metric with attributes from map and shortcut factory method works`() {
+    val (sut, mockClient) = getEnabledScopes()
+
+    sut
+      .metrics()
+      .count(
+        "metric name",
+        1.0,
+        "visit",
+        SentryMetricsParameters.create(mapOf("attrname1" to "attrval1")),
+      )
+
+    verify(mockClient)
+      .captureMetric(
+        check {
+          assertEquals("metric name", it.name)
+          assertEquals(1.0, it.value)
+          assertEquals("visit", it.unit)
+          assertEquals("counter", it.type)
+
+          val attr1 = it.attributes?.get("attrname1")!!
+          assertEquals("attrval1", attr1.value)
+          assertEquals("string", attr1.type)
+        },
+        anyOrNull(),
+        anyOrNull(),
+      )
+  }
+
+  @Test
   fun `creating count metric with attributes works`() {
     val (sut, mockClient) = getEnabledScopes()
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
