### PR TITLE
feat(metrics): [Trace Metrics 27] Automatically use SentryOptions.Metrics.BeforeSendMetricCallback Spring beans

### DIFF
--- a/sentry-samples/sentry-samples-spring-7/src/main/java/io/sentry/samples/spring7/web/MetricController.java
+++ b/sentry-samples/sentry-samples-spring-7/src/main/java/io/sentry/samples/spring7/web/MetricController.java
@@ -20,13 +20,13 @@ public class MetricController {
   }
 
   @GetMapping("gauge/{count}")
-  String gauge(@PathVariable Long count) {
+  String gauge(@PathVariable("count") Long count) {
     Sentry.metrics().gauge("memory.free", count.doubleValue(), "byte");
     return "gauge metric tracked";
   }
 
   @GetMapping("distribution/{count}")
-  String distribution(@PathVariable Long count) {
+  String distribution(@PathVariable("count") Long count) {
     Sentry.metrics().distribution("distributionMetric", count.doubleValue(), "child");
     return "distribution metric tracked";
   }

--- a/sentry-samples/sentry-samples-spring-7/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-7/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
@@ -10,7 +10,7 @@ class MetricsSystemTest {
 
   @Before
   fun setup() {
-    testHelper = TestHelper("http://localhost:8080")
+    testHelper = TestHelper("http://localhost:8080/sentry-samples-spring-7-0.0.1-SNAPSHOT")
     testHelper.reset()
   }
 

--- a/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/web/MetricController.java
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/main/java/io/sentry/samples/spring/jakarta/web/MetricController.java
@@ -20,13 +20,13 @@ public class MetricController {
   }
 
   @GetMapping("gauge/{count}")
-  String gauge(@PathVariable Long count) {
+  String gauge(@PathVariable("count") Long count) {
     Sentry.metrics().gauge("memory.free", count.doubleValue(), "byte");
     return "gauge metric tracked";
   }
 
   @GetMapping("distribution/{count}")
-  String distribution(@PathVariable Long count) {
+  String distribution(@PathVariable("count") Long count) {
     Sentry.metrics().distribution("distributionMetric", count.doubleValue(), "child");
     return "distribution metric tracked";
   }

--- a/sentry-samples/sentry-samples-spring-jakarta/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-jakarta/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
@@ -10,7 +10,7 @@ class MetricsSystemTest {
 
   @Before
   fun setup() {
-    testHelper = TestHelper("http://localhost:8080")
+    testHelper = TestHelper("http://localhost:8080/sentry-samples-spring-jakarta-0.0.1-SNAPSHOT")
     testHelper.reset()
   }
 

--- a/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/web/MetricController.java
+++ b/sentry-samples/sentry-samples-spring/src/main/java/io/sentry/samples/spring/web/MetricController.java
@@ -20,13 +20,13 @@ public class MetricController {
   }
 
   @GetMapping("gauge/{count}")
-  String gauge(@PathVariable Long count) {
+  String gauge(@PathVariable("count") Long count) {
     Sentry.metrics().gauge("memory.free", count.doubleValue(), "byte");
     return "gauge metric tracked";
   }
 
   @GetMapping("distribution/{count}")
-  String distribution(@PathVariable Long count) {
+  String distribution(@PathVariable("count") Long count) {
     Sentry.metrics().distribution("distributionMetric", count.doubleValue(), "child");
     return "distribution metric tracked";
   }

--- a/sentry-samples/sentry-samples-spring/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring/src/test/kotlin/io/sentry/systemtest/MetricsSystemTest.kt
@@ -10,7 +10,7 @@ class MetricsSystemTest {
 
   @Before
   fun setup() {
-    testHelper = TestHelper("http://localhost:8080")
+    testHelper = TestHelper("http://localhost:8080/sentry-samples-spring-0.0.1-SNAPSHOT")
     testHelper.reset()
   }
 

--- a/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-4/src/main/java/io/sentry/spring/boot4/SentryAutoConfiguration.java
@@ -105,6 +105,8 @@ public class SentryAutoConfiguration {
                 beforeSendTransactionCallback,
         final @NotNull ObjectProvider<SentryOptions.Logs.BeforeSendLogCallback>
                 beforeSendLogsCallback,
+        final @NotNull ObjectProvider<SentryOptions.Metrics.BeforeSendMetricCallback>
+                beforeSendMetricCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
         final @NotNull ObjectProvider<SentryOptions.TracesSamplerCallback> tracesSamplerCallback,
@@ -117,6 +119,8 @@ public class SentryAutoConfiguration {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
         beforeSendTransactionCallback.ifAvailable(options::setBeforeSendTransaction);
         beforeSendLogsCallback.ifAvailable(callback -> options.getLogs().setBeforeSend(callback));
+        beforeSendMetricCallback.ifAvailable(
+            callback -> options.getMetrics().setBeforeSend(callback));
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);
         eventProcessors.forEach(options::addEventProcessor);

--- a/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot-4/src/test/kotlin/io/sentry/spring/boot4/SentryAutoConfigurationTest.kt
@@ -21,6 +21,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
 import io.sentry.SentryLogEvent
+import io.sentry.SentryMetricsEvent
 import io.sentry.SentryOptions
 import io.sentry.asyncprofiler.profiling.JavaContinuousProfiler
 import io.sentry.asyncprofiler.provider.AsyncProfilerProfileConverterProvider
@@ -367,6 +368,17 @@ class SentryAutoConfigurationTest {
       .run {
         assertThat(it.getBean(SentryOptions::class.java).logs.beforeSend)
           .isInstanceOf(CustomBeforeSendLogsCallback::class.java)
+      }
+  }
+
+  @Test
+  fun `registers metrics beforeSendCallback on SentryOptions`() {
+    contextRunner
+      .withPropertyValues("sentry.dsn=http://key@localhost/proj")
+      .withUserConfiguration(CustomBeforeSendMetricCallbackConfiguration::class.java)
+      .run {
+        assertThat(it.getBean(SentryOptions::class.java).metrics.beforeSend)
+          .isInstanceOf(CustomBeforeSendMetricCallback::class.java)
       }
   }
 
@@ -1238,6 +1250,16 @@ class SentryAutoConfigurationTest {
 
   class CustomBeforeSendLogsCallback : SentryOptions.Logs.BeforeSendLogCallback {
     override fun execute(event: SentryLogEvent): SentryLogEvent? = null
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  open class CustomBeforeSendMetricCallbackConfiguration {
+
+    @Bean open fun beforeSendCallback() = CustomBeforeSendMetricCallback()
+  }
+
+  class CustomBeforeSendMetricCallback : SentryOptions.Metrics.BeforeSendMetricCallback {
+    override fun execute(metric: SentryMetricsEvent, hint: Hint): SentryMetricsEvent? = null
   }
 
   @Configuration(proxyBeanMethods = false)

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -105,6 +105,8 @@ public class SentryAutoConfiguration {
                 beforeSendTransactionCallback,
         final @NotNull ObjectProvider<SentryOptions.Logs.BeforeSendLogCallback>
                 beforeSendLogsCallback,
+        final @NotNull ObjectProvider<SentryOptions.Metrics.BeforeSendMetricCallback>
+                beforeSendMetricCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
         final @NotNull ObjectProvider<SentryOptions.OnDiscardCallback> onDiscardCallback,
@@ -118,6 +120,8 @@ public class SentryAutoConfiguration {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
         beforeSendTransactionCallback.ifAvailable(options::setBeforeSendTransaction);
         beforeSendLogsCallback.ifAvailable(callback -> options.getLogs().setBeforeSend(callback));
+        beforeSendMetricCallback.ifAvailable(
+            callback -> options.getMetrics().setBeforeSend(callback));
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
         onDiscardCallback.ifAvailable(options::setOnDiscard);
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);

--- a/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
+++ b/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java
@@ -103,6 +103,8 @@ public class SentryAutoConfiguration {
                 beforeSendTransactionCallback,
         final @NotNull ObjectProvider<SentryOptions.Logs.BeforeSendLogCallback>
                 beforeSendLogsCallback,
+        final @NotNull ObjectProvider<SentryOptions.Metrics.BeforeSendMetricCallback>
+                beforeSendMetricCallback,
         final @NotNull ObjectProvider<SentryOptions.BeforeBreadcrumbCallback>
                 beforeBreadcrumbCallback,
         final @NotNull ObjectProvider<SentryOptions.OnDiscardCallback> onDiscardCallback,
@@ -116,6 +118,8 @@ public class SentryAutoConfiguration {
         beforeSendCallback.ifAvailable(options::setBeforeSend);
         beforeSendTransactionCallback.ifAvailable(options::setBeforeSendTransaction);
         beforeSendLogsCallback.ifAvailable(callback -> options.getLogs().setBeforeSend(callback));
+        beforeSendMetricCallback.ifAvailable(
+            callback -> options.getMetrics().setBeforeSend(callback));
         beforeBreadcrumbCallback.ifAvailable(options::setBeforeBreadcrumb);
         onDiscardCallback.ifAvailable(options::setOnDiscard);
         tracesSamplerCallback.ifAvailable(options::setTracesSampler);

--- a/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
+++ b/sentry-spring-boot/src/test/kotlin/io/sentry/spring/boot/SentryAutoConfigurationTest.kt
@@ -23,6 +23,7 @@ import io.sentry.SentryEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
 import io.sentry.SentryLogEvent
+import io.sentry.SentryMetricsEvent
 import io.sentry.SentryOptions
 import io.sentry.asyncprofiler.profiling.JavaContinuousProfiler
 import io.sentry.asyncprofiler.provider.AsyncProfilerProfileConverterProvider
@@ -366,6 +367,17 @@ class SentryAutoConfigurationTest {
       .run {
         assertThat(it.getBean(SentryOptions::class.java).logs.beforeSend)
           .isInstanceOf(CustomBeforeSendLogsCallback::class.java)
+      }
+  }
+
+  @Test
+  fun `registers metrics beforeSendCallback on SentryOptions`() {
+    contextRunner
+      .withPropertyValues("sentry.dsn=http://key@localhost/proj")
+      .withUserConfiguration(CustomBeforeSendMetricCallbackConfiguration::class.java)
+      .run {
+        assertThat(it.getBean(SentryOptions::class.java).metrics.beforeSend)
+          .isInstanceOf(CustomBeforeSendMetricCallback::class.java)
       }
   }
 
@@ -1186,6 +1198,16 @@ class SentryAutoConfigurationTest {
 
   class CustomBeforeSendLogsCallback : SentryOptions.Logs.BeforeSendLogCallback {
     override fun execute(event: SentryLogEvent): SentryLogEvent? = null
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  open class CustomBeforeSendMetricCallbackConfiguration {
+
+    @Bean open fun beforeSendCallback() = CustomBeforeSendMetricCallback()
+  }
+
+  class CustomBeforeSendMetricCallback : SentryOptions.Metrics.BeforeSendMetricCallback {
+    override fun execute(metric: SentryMetricsEvent, hint: Hint): SentryMetricsEvent? = null
   }
 
   @Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
