### PR TITLE
Add support for Android API level 36 in CI workflow

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -75,6 +75,10 @@ jobs:
             target: aosp_atd
             channel: canary # Necessary for ATDs
             arch: x86_64
+          - api-level: 36 # Android 16
+            target: aosp_atd
+            channel: canary # Necessary for ATDs
+            arch: x86_64
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## :scroll: Description
Adds Android 16 (API level 36) config to test matrix.

## :bulb: Motivation and Context

Better test coverage.

#skip-changelog
