### PR TITLE
feat(distribution): Add install_groups support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `installGroupsOverride` parameter and `installGroups` property to Build Distribution SDK ([#5062](https://github.com/getsentry/sentry-java/pull/5062))
 - Update Android targetSdk to API 36 (Android 16) ([#5016](https://github.com/getsentry/sentry-java/pull/5016))
 
 ### Internal

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/DistributionHttpClient.kt
@@ -27,6 +27,7 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
     val versionCode: Long,
     val versionName: String,
     val buildConfiguration: String,
+    val installGroupsOverride: List<String>? = null,
   )
 
   /**
@@ -58,6 +59,9 @@ internal class DistributionHttpClient(private val options: SentryOptions) {
       append("&build_number=${URLEncoder.encode(params.versionCode.toString(), "UTF-8")}")
       append("&build_version=${URLEncoder.encode(params.versionName, "UTF-8")}")
       append("&build_configuration=${URLEncoder.encode(params.buildConfiguration, "UTF-8")}")
+      params.installGroupsOverride?.forEach { group ->
+        append("&install_groups=${URLEncoder.encode(group, "UTF-8")}")
+      }
     }
     val url = URL(urlString)
 

--- a/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
+++ b/sentry-android-distribution/src/main/java/io/sentry/android/distribution/UpdateResponseParser.kt
@@ -57,6 +57,7 @@ internal class UpdateResponseParser(private val options: SentryOptions) {
     val downloadUrl = json.optString("download_url", "")
     val appName = json.optString("app_name", "")
     val createdDate = json.optString("created_date", "")
+    val installGroups = parseInstallGroups(json)
 
     // Validate required fields (optString returns "null" for null values)
     val missingFields = mutableListOf<String>()
@@ -77,6 +78,26 @@ internal class UpdateResponseParser(private val options: SentryOptions) {
       )
     }
 
-    return UpdateInfo(id, buildVersion, buildNumber, downloadUrl, appName, createdDate)
+    return UpdateInfo(
+      id,
+      buildVersion,
+      buildNumber,
+      downloadUrl,
+      appName,
+      createdDate,
+      installGroups,
+    )
+  }
+
+  private fun parseInstallGroups(json: JSONObject): List<String>? {
+    val installGroupsArray = json.optJSONArray("install_groups") ?: return null
+    val installGroups = mutableListOf<String>()
+    for (i in 0 until installGroupsArray.length()) {
+      val group = installGroupsArray.optString(i)
+      if (group.isNotEmpty() && group != "null") {
+        installGroups.add(group)
+      }
+    }
+    return if (installGroups.isEmpty()) null else installGroups
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4521,13 +4521,14 @@ public class io/sentry/UncaughtExceptionHandlerIntegration$UncaughtExceptionHint
 }
 
 public final class io/sentry/UpdateInfo {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public fun getAppName ()Ljava/lang/String;
 	public fun getBuildNumber ()I
 	public fun getBuildVersion ()Ljava/lang/String;
 	public fun getCreatedDate ()Ljava/lang/String;
 	public fun getDownloadUrl ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
+	public fun getInstallGroups ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/sentry/src/main/java/io/sentry/UpdateInfo.java
+++ b/sentry/src/main/java/io/sentry/UpdateInfo.java
@@ -1,5 +1,6 @@
 package io.sentry;
 
+import java.util.List;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,6 +14,7 @@ public final class UpdateInfo {
   private final @NotNull String downloadUrl;
   private final @NotNull String appName;
   private final @Nullable String createdDate;
+  private final @Nullable List<String> installGroups;
 
   public UpdateInfo(
       final @NotNull String id,
@@ -20,13 +22,15 @@ public final class UpdateInfo {
       final int buildNumber,
       final @NotNull String downloadUrl,
       final @NotNull String appName,
-      final @Nullable String createdDate) {
+      final @Nullable String createdDate,
+      final @Nullable List<String> installGroups) {
     this.id = id;
     this.buildVersion = buildVersion;
     this.buildNumber = buildNumber;
     this.downloadUrl = downloadUrl;
     this.appName = appName;
     this.createdDate = createdDate;
+    this.installGroups = installGroups;
   }
 
   public @NotNull String getId() {
@@ -53,6 +57,10 @@ public final class UpdateInfo {
     return createdDate;
   }
 
+  public @Nullable List<String> getInstallGroups() {
+    return installGroups;
+  }
+
   @Override
   public String toString() {
     return "UpdateInfo{"
@@ -73,6 +81,8 @@ public final class UpdateInfo {
         + ", createdDate='"
         + createdDate
         + '\''
+        + ", installGroups="
+        + installGroups
         + '}';
   }
 }


### PR DESCRIPTION
## Summary

- Add `installGroupsOverride` parameter to `UpdateCheckParams` for specifying install groups when checking for updates
- Add `installGroups` property to `UpdateInfo` to receive install groups from the API response
- Parse `install_groups` from the distribution API response

This matches the iOS implementation: https://github.com/getsentry/sentry-cocoa/pull/7278

🤖 Generated with [Claude Code](https://claude.com/claude-code)