### PR TITLE
fix(android): merge tombstone and Native SDK event message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `installGroupsOverride` parameter to Build Distribution SDK for programmatic filtering, with support for configuration via properties file using `io.sentry.distribution.install-groups-override` ([#5066](https://github.com/getsentry/sentry-java/pull/5066))
 
+### Fixes
+
+- When merging tombstones with Native SDK, use the tombstone message if the Native SDK didn't explicitly provide one. ([#5095](https://github.com/getsentry/sentry-java/pull/5095))
+
 ### Dependencies
 
 - Bump Native SDK from v0.12.4 to v0.12.6 ([#5071](https://github.com/getsentry/sentry-java/pull/5071))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -291,6 +291,14 @@ public class TombstoneIntegration implements Integration, Closeable {
         if (mechanism != null) {
           mechanism.setType(NativeExceptionMechanism.TOMBSTONE_MERGED.getValue());
         }
+
+        // Don't overwrite existing messages in the native event
+        if (nativeEvent.getMessage() == null
+            || nativeEvent.getMessage().getMessage() == null
+            || nativeEvent.getMessage().getMessage().isEmpty()) {
+          nativeEvent.setMessage(tombstoneEvent.getMessage());
+        }
+
         nativeEvent.setExceptions(tombstoneExceptions);
         nativeEvent.setDebugMeta(tombstoneDebugMeta);
         nativeEvent.setThreads(tombstoneThreads);


### PR DESCRIPTION
## :scroll: Description
When merging tombstone and Native SDK events, we assume the message from the Native SDK. However, in most cases, this property will be empty from the Native SDK, whereas we explicitly construct a message from the tombstone that closely matches what debuggerd would print in logcat. This PR uses the tombstone message if the native envelope doesn't provide one.


## :bulb: Motivation and Context
Better crash information.

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

