### PR TITLE
fix(test): Fix flaky tests caused by SentryOptions.activate

### DIFF
--- a/sentry-test-support/api/sentry-test-support.api
+++ b/sentry-test-support/api/sentry-test-support.api
@@ -55,6 +55,16 @@ public final class io/sentry/test/MocksKt {
 	public static synthetic fun createTestScopes$default (Lio/sentry/SentryOptions;ZLio/sentry/IScope;Lio/sentry/IScope;Lio/sentry/IScope;ILjava/lang/Object;)Lio/sentry/Scopes;
 }
 
+public final class io/sentry/test/NonOverridableNoOpSentryExecutorService : io/sentry/ISentryExecutorService {
+	public fun <init> ()V
+	public fun close (J)V
+	public fun isClosed ()Z
+	public fun prewarm ()V
+	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
+	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
+	public fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
+}
+
 public final class io/sentry/test/ReflectionKt {
 	public static final fun collectInterfaceHierarchy (Ljava/lang/Class;)Ljava/util/List;
 	public static final fun containsMethod (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Z

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -79,6 +79,21 @@ class DeferredExecutorService : ISentryExecutorService {
   fun hasScheduledRunnables(): Boolean = scheduledRunnables.isNotEmpty()
 }
 
+class NonOverridableNoOpSentryExecutorService : ISentryExecutorService {
+  override fun submit(runnable: Runnable): Future<*> = FutureTask<Void> { null }
+
+  override fun <T> submit(callable: Callable<T>): Future<T> = FutureTask<T> { null }
+
+  override fun schedule(runnable: Runnable, delayMillis: Long): Future<*> =
+    FutureTask<Void> { null }
+
+  override fun close(timeoutMillis: Long) {}
+
+  override fun isClosed(): Boolean = false
+
+  override fun prewarm() = Unit
+}
+
 fun createSentryClientMock(enabled: Boolean = true) =
   mock<ISentryClient>().also {
     val isEnabled = AtomicBoolean(enabled)

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -17,6 +17,7 @@ import io.sentry.protocol.SdkVersion
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.SentryThread
 import io.sentry.test.ImmediateExecutorService
+import io.sentry.test.NonOverridableNoOpSentryExecutorService
 import io.sentry.test.createSentryClientMock
 import io.sentry.test.initForTest
 import io.sentry.test.injectForField
@@ -1217,7 +1218,7 @@ class SentryTest {
       it.profilesSampleRate = 1.0
       it.tracesSampler = mockSampleTracer
       it.profilesSampler = mockProfilesSampler
-      it.executorService = NoOpSentryExecutorService.getInstance()
+      it.executorService = NonOverridableNoOpSentryExecutorService()
       it.cacheDirPath = getTempPath()
     }
     // Samplers are called with isForNextAppStart flag set to true
@@ -1236,7 +1237,7 @@ class SentryTest {
       it.profilesSampleRate = 1.0
       it.tracesSampler = mockSampleTracer
       it.profilesSampler = mockProfilesSampler
-      it.executorService = NoOpSentryExecutorService.getInstance()
+      it.executorService = NonOverridableNoOpSentryExecutorService()
       it.cacheDirPath = null
     }
     // Samplers are called with isForNextAppStart flag set to true


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

Introduces `NonOverridableNoOpSentryExecutorService` in test support and uses it in `SentryTest` instead of `NoOpSentryExecutorService.getInstance()`.

`NoOpSentryExecutorService.getInstance()` is a sentinel value that `SentryOptions.activate()` detects and replaces with a real executor service, which causes flaky test behavior when tests expect the executor to remain a no-op.

## :bulb: Motivation and Context

Tests in `SentryTest` that set the executor service to `NoOpSentryExecutorService.getInstance()` became flaky after the introduction of `SentryOptions.activate`, which overrides sentinel no-op values. The new `NonOverridableNoOpSentryExecutorService` is a plain no-op implementation that is not recognized as a sentinel and therefore not replaced.

## :green_heart: How did you test it?

Verified the previously flaky tests now pass consistently.

## :pencil: Checklist

- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.