### PR TITLE
fix(test): Fix flaky previous session finalization test

### DIFF
--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -964,7 +964,9 @@ class SentryTest {
     }
 
     await.untilTrue(triggered)
-    assertFalse(previousSessionFile.exists())
+    // The PreviousSessionFinalizer runs as a separate task after the test's task in the
+    // single-threaded executor, so we need to wait for it to delete the file too.
+    await.until { !previousSessionFile.exists() }
   }
 
   @Test


### PR DESCRIPTION
Fix flaky test `if there is work enqueued, init finalizes previous session after that work is done` in `SentryTest`.

The test submits work to the single-threaded executor that reads the previous session file and sets a `triggered` flag. `Sentry.init` then enqueues the `PreviousSessionFinalizer` (which deletes the file) as a separate task after the test's task. The test was waiting for `triggered` to become true and then immediately asserting the file was deleted — but since the finalizer is a separate queued task, there's a race where the assertion runs before the finalizer has executed.

Replace the immediate `assertFalse(previousSessionFile.exists())` with `await.until { !previousSessionFile.exists() }` to poll until the finalizer completes.

#skip-changelog