### PR TITLE
fix(test): Fix flaky background-foreground replay test

### DIFF
--- a/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/LifecycleWatcherTest.kt
@@ -282,7 +282,8 @@ class LifecycleWatcherTest {
   @Test
   fun `background-foreground replay`() {
     whenever(fixture.dateProvider.currentTimeMillis).thenReturn(1L)
-    val watcher = fixture.getSUT(sessionIntervalMillis = 2L, enableAppLifecycleBreadcrumbs = false)
+    val watcher =
+      fixture.getSUT(sessionIntervalMillis = 500L, enableAppLifecycleBreadcrumbs = false)
     watcher.onForeground()
     verify(fixture.replayController).start()
 


### PR DESCRIPTION
Fix flaky `background-foreground replay` test in `LifecycleWatcherTest`.

The test uses `sessionIntervalMillis = 2L` (2ms), meaning the `TimerTask` scheduled by the first `onBackground()` can fire before `cancelTask()` in the second `onForeground()` cancels it. When this happens, `replayController.stop()` gets called from both the first and second timer tasks, causing the `Wanted 1 time but was 2 times` verification failure.

Increase `sessionIntervalMillis` to 500ms so the first timer can't race ahead of `cancelTask()`. The session interval check on the second `onForeground()` still works correctly since `(1 + 500) <= 1` is false.

#skip-changelog