### PR TITLE
chore: Add stacked PR support to create-java-pr skill and PR rules

### DIFF
--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -171,7 +171,7 @@ git push
 If no changelog entry is needed, add `#skip-changelog` to the PR description to disable the changelog CI check:
 
 ```bash
-gh pr edit <PR_NUMBER> --body "$(gh pr view <PR_NUMBER> --json body --jq '.body')
-
-#skip-changelog"
+gh pr view <PR_NUMBER> --json body --jq '.body' > /tmp/pr-body.md
+printf '\n#skip-changelog\n' >> /tmp/pr-body.md
+gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md
 ```

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -213,17 +213,19 @@ Format:
 
 No status column — GitHub already shows that. The `---` separates the stack list from the rest of the PR description.
 
-To update the PR description:
+To update the PR description, use `--body-file` to avoid shell quoting issues with special characters in the body:
 
 ```bash
-# Get current PR description
-gh pr view <PR_NUMBER> --json body --jq '.body'
+# Get current PR description into a temp file
+gh pr view <PR_NUMBER> --json body --jq '.body' > /tmp/pr-body.md
 
-# Update the description (prepend or replace the stack list section)
-gh pr edit <PR_NUMBER> --body "<updated body>"
+# Edit /tmp/pr-body.md to prepend or replace the stack list section
+# (replace everything from "## PR Stack" up to and including the "---" separator,
+#  or prepend before the existing description if no stack list exists yet)
+
+# Update the description
+gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md
 ```
-
-When updating, replace everything from `## PR Stack` up to and including the `---` separator. If no stack list exists yet, prepend it before the existing description.
 
 ### Merging Stacked PRs (done by the user, not the agent)
 


### PR DESCRIPTION
## :scroll: Description

Updates the `create-java-pr` skill and `.cursor/rules/pr.mdc` to support stacked PRs:

- **Skill file** (`.claude/skills/create-java-pr/SKILL.md`):
  - Added Step 0 to determine PR type (standalone, first in stack, next in stack)
  - Extended Steps 1 and 5 with stacked PR instructions (collection branch, `--base`, `[Topic N]` title format)
  - Added Step 5.5 for updating stack lists on all PRs
  - Made Step 6 (changelog) conditional — skips for non-user-facing changes, adds `#skip-changelog` to PR description
  - Added required reading directive pointing to `pr.mdc` as source of truth

- **Rule file** (`.cursor/rules/pr.mdc`):
  - Added collection branch workflow (empty commit for immediate PR creation)
  - Stack list goes in PR description (top of body) instead of a separate comment
  - Merge strategy: merge commits for stack PRs, squash-merge for collection branch into main
  - Explicit "do not merge PRs" guardrail for agents
  - Syncing and finding PRs in a stack

## :bulb: Motivation and Context

The skill previously only handled standalone PRs. The PR rule file had stacked PR docs but the skill didn't reference or use them. This change connects the two so the agent can handle the full stacked PR workflow.

The collection branch pattern with merge commits avoids repeated merge conflict resolution that squash merging causes when syncing stacks.

## :green_heart: How did you test it?

Manual review of both files for consistency and completeness.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Test the skill end-to-end by invoking it to create a stacked PR.

#skip-changelog