### PR TITLE
chore(ci): Kill BinarySizeTest in favour of Size Analysis status check

### DIFF
--- a/sentry-android-integration-tests/metrics-test.yml
+++ b/sentry-android-integration-tests/metrics-test.yml
@@ -10,7 +10,3 @@ startupTimeTest:
   runs: 50
   diffMin: 0
   diffMax: 150
-
-binarySizeTest:
-  diffMin: 600 KiB
-  diffMax: 850 KiB


### PR DESCRIPTION
_#skip-changelog_

Size Analysis is currently configured to fail the build when the SDK exceeds 1MB in download size, so we should be covered