### PR TITLE
feat(core): [Cache Tracing 2] Add enableCacheTracing option

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -210,6 +210,10 @@ public final class SentryCacheWrapper implements Cache {
   }
 
   private @Nullable ISpan startSpan(final @NotNull String operation, final @Nullable Object key) {
+    if (!scopes.getOptions().isEnableCacheTracing()) {
+      return null;
+    }
+
     final ISpan activeSpan = scopes.getSpan();
     if (activeSpan == null || activeSpan.isNoOp()) {
       return null;

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -24,12 +24,14 @@ class SentryCacheWrapperTest {
 
   private lateinit var scopes: IScopes
   private lateinit var delegate: Cache
+  private lateinit var options: SentryOptions
 
   @BeforeTest
   fun setup() {
     scopes = mock()
     delegate = mock()
-    whenever(scopes.options).thenReturn(SentryOptions())
+    options = SentryOptions().apply { isEnableCacheTracing = true }
+    whenever(scopes.options).thenReturn(options)
     whenever(delegate.name).thenReturn("testCache")
   }
 
@@ -240,6 +242,21 @@ class SentryCacheWrapperTest {
     wrapper.get("myKey")
 
     verify(delegate).get("myKey")
+  }
+
+  // -- no span when option is disabled --
+
+  @Test
+  fun `does not create span when enableCacheTracing is false`() {
+    options.isEnableCacheTracing = false
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.get("myKey")).thenReturn(null)
+
+    wrapper.get("myKey")
+
+    verify(delegate).get("myKey")
+    assertEquals(0, tx.spans.size)
   }
 
   // -- error handling --

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -520,6 +520,7 @@ public final class io/sentry/ExternalOptions {
 	public fun getTracesSampleRate ()Ljava/lang/Double;
 	public fun isCaptureOpenTelemetryEvents ()Ljava/lang/Boolean;
 	public fun isEnableBackpressureHandling ()Ljava/lang/Boolean;
+	public fun isEnableCacheTracing ()Ljava/lang/Boolean;
 	public fun isEnableDatabaseTransactionTracing ()Ljava/lang/Boolean;
 	public fun isEnableLogs ()Ljava/lang/Boolean;
 	public fun isEnableMetrics ()Ljava/lang/Boolean;
@@ -536,6 +537,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setDist (Ljava/lang/String;)V
 	public fun setDsn (Ljava/lang/String;)V
 	public fun setEnableBackpressureHandling (Ljava/lang/Boolean;)V
+	public fun setEnableCacheTracing (Ljava/lang/Boolean;)V
 	public fun setEnableDatabaseTransactionTracing (Ljava/lang/Boolean;)V
 	public fun setEnableDeduplication (Ljava/lang/Boolean;)V
 	public fun setEnableLogs (Ljava/lang/Boolean;)V
@@ -3660,6 +3662,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableAppStartProfiling ()Z
 	public fun isEnableAutoSessionTracking ()Z
 	public fun isEnableBackpressureHandling ()Z
+	public fun isEnableCacheTracing ()Z
 	public fun isEnableDatabaseTransactionTracing ()Z
 	public fun isEnableDeduplication ()Z
 	public fun isEnableEventSizeLimiting ()Z
@@ -3718,6 +3721,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableAppStartProfiling (Z)V
 	public fun setEnableAutoSessionTracking (Z)V
 	public fun setEnableBackpressureHandling (Z)V
+	public fun setEnableCacheTracing (Z)V
 	public fun setEnableDatabaseTransactionTracing (Z)V
 	public fun setEnableDeduplication (Z)V
 	public fun setEnableEventSizeLimiting (Z)V

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -57,6 +57,7 @@ public final class ExternalOptions {
   private @Nullable Boolean sendDefaultPii;
   private @Nullable Boolean enableBackpressureHandling;
   private @Nullable Boolean enableDatabaseTransactionTracing;
+  private @Nullable Boolean enableCacheTracing;
   private @Nullable Boolean globalHubMode;
   private @Nullable Boolean forceInit;
   private @Nullable Boolean captureOpenTelemetryEvents;
@@ -161,6 +162,8 @@ public final class ExternalOptions {
 
     options.setEnableDatabaseTransactionTracing(
         propertiesProvider.getBooleanProperty("enable-database-transaction-tracing"));
+
+    options.setEnableCacheTracing(propertiesProvider.getBooleanProperty("enable-cache-tracing"));
 
     options.setGlobalHubMode(propertiesProvider.getBooleanProperty("global-hub-mode"));
 
@@ -521,6 +524,14 @@ public final class ExternalOptions {
 
   public @Nullable Boolean isEnableDatabaseTransactionTracing() {
     return enableDatabaseTransactionTracing;
+  }
+
+  public void setEnableCacheTracing(final @Nullable Boolean enableCacheTracing) {
+    this.enableCacheTracing = enableCacheTracing;
+  }
+
+  public @Nullable Boolean isEnableCacheTracing() {
+    return enableCacheTracing;
   }
 
   public void setGlobalHubMode(final @Nullable Boolean globalHubMode) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -490,6 +490,9 @@ public class SentryOptions {
   /** Whether database transaction spans (BEGIN, COMMIT, ROLLBACK) should be traced. */
   private boolean enableDatabaseTransactionTracing = false;
 
+  /** Whether cache operations (get, put, evict, clear) should be traced. */
+  private boolean enableCacheTracing = false;
+
   /** Date provider to retrieve the current date from. */
   @ApiStatus.Internal
   private final @NotNull LazyEvaluator<SentryDateProvider> dateProvider =
@@ -2631,6 +2634,24 @@ public class SentryOptions {
   }
 
   /**
+   * Whether cache operations (get, put, evict, clear) should be traced.
+   *
+   * @return true if cache operations should be traced
+   */
+  public boolean isEnableCacheTracing() {
+    return enableCacheTracing;
+  }
+
+  /**
+   * Whether cache operations (get, put, evict, clear) should be traced.
+   *
+   * @param enableCacheTracing true if cache operations should be traced
+   */
+  public void setEnableCacheTracing(boolean enableCacheTracing) {
+    this.enableCacheTracing = enableCacheTracing;
+  }
+
+  /**
    * Whether Sentry is enabled.
    *
    * @return true if Sentry should be enabled
@@ -3467,6 +3488,9 @@ public class SentryOptions {
     }
     if (options.isEnableDatabaseTransactionTracing() != null) {
       setEnableDatabaseTransactionTracing(options.isEnableDatabaseTransactionTracing());
+    }
+    if (options.isEnableCacheTracing() != null) {
+      setEnableCacheTracing(options.isEnableCacheTracing());
     }
     if (options.getMaxRequestBodySize() != null) {
       setMaxRequestBodySize(options.getMaxRequestBodySize());

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -332,6 +332,20 @@ class ExternalOptionsTest {
   }
 
   @Test
+  fun `creates options with enableCacheTracing set to true`() {
+    withPropertiesFile("enable-cache-tracing=true") { options ->
+      assertTrue(options.isEnableCacheTracing == true)
+    }
+  }
+
+  @Test
+  fun `creates options with enableCacheTracing set to false`() {
+    withPropertiesFile("enable-cache-tracing=false") { options ->
+      assertTrue(options.isEnableCacheTracing == false)
+    }
+  }
+
+  @Test
   fun `creates options with cron defaults`() {
     withPropertiesFile(
       listOf(

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -400,6 +400,7 @@ class SentryOptionsTest {
     externalOptions.ignoredErrors = listOf("Some error", "Another .*")
     externalOptions.isEnableBackpressureHandling = false
     externalOptions.isEnableDatabaseTransactionTracing = true
+    externalOptions.isEnableCacheTracing = true
     externalOptions.maxRequestBodySize = SentryOptions.RequestSize.MEDIUM
     externalOptions.isSendDefaultPii = true
     externalOptions.isForceInit = true
@@ -465,6 +466,7 @@ class SentryOptionsTest {
     )
     assertFalse(options.isEnableBackpressureHandling)
     assertTrue(options.isEnableDatabaseTransactionTracing)
+    assertTrue(options.isEnableCacheTracing)
     assertTrue(options.isForceInit)
     assertNotNull(options.cron)
     assertEquals(10L, options.cron?.defaultCheckinMargin)
@@ -699,6 +701,11 @@ class SentryOptionsTest {
   @Test
   fun `when options are initialized, enableDatabaseTransactionTracing is set to false by default`() {
     assertFalse(SentryOptions().isEnableDatabaseTransactionTracing)
+  }
+
+  @Test
+  fun `when options are initialized, enableCacheTracing is set to false by default`() {
+    assertFalse(SentryOptions().isEnableCacheTracing)
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5162](https://github.com/getsentry/sentry-java/pull/5162) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5163](https://github.com/getsentry/sentry-java/pull/5163) — Add enableCacheTracing option
- [#5164](https://github.com/getsentry/sentry-java/pull/5164) — Add BeanPostProcessor and auto-configuration
- [#5167](https://github.com/getsentry/sentry-java/pull/5167) — Add cache tracing e2e sample
---

## :scroll: Description

Adds `enableCacheTracing` boolean option to `SentryOptions` and `ExternalOptions`, gating the cache wrapper span creation behind an opt-in property (`sentry.enable-cache-tracing`). Default is `false`.

## :green_heart: How did you test it?

- `SentryOptionsTest` — default value, merge behavior
- `ExternalOptionsTest` — property binding (true/false)
- `SentryCacheWrapperTest` — no span created when option disabled

## :pencil: Checklist
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.




