### PR TITLE
chore: Use GitHub native PR references in stack list format

### DIFF
--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -204,9 +204,9 @@ Format:
 ```markdown
 ## PR Stack (<Topic>)
 
-- [#5118](https://github.com/getsentry/sentry-java/pull/5118) — Add scope-level attributes API
-- [#5120](https://github.com/getsentry/sentry-java/pull/5120) — Wire scope attributes into LoggerApi and MetricsApi
-- [#5121](https://github.com/getsentry/sentry-java/pull/5121) — Showcase scope attributes in Spring Boot 4 samples
+- #5118
+- #5120
+- #5121
 
 ---
 ```


### PR DESCRIPTION
## :scroll: Description

Simplify the PR stack list format in `.cursor/rules/pr.mdc` to use GitHub's native PR references (`#5118`) instead of the custom format (`[#5118](url) — title`). GitHub automatically renders `#NNNN` as a clickable link showing the PR title, so the manual URL and title duplication is unnecessary.

## :bulb: Motivation and Context

The previous format was verbose and required manually copying PR titles into the stack list. GitHub's native reference format is simpler to maintain and always shows the current PR title.

## :green_heart: How did you test it?

Verified that GitHub renders `#NNNN` references correctly in PR descriptions.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None — this is a self-contained change to agent rules.

#skip-changelog
