### PR TITLE
feat(samples): [Cache Tracing 5] Add Caffeine cache to Spring Boot sample

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
   implementation(projects.sentryQuartz)
   implementation(projects.sentryAsyncProfiler)
 
+  // cache tracing
+  implementation("com.github.ben-manes.caffeine:caffeine")
+
   // database query tracing
   implementation(projects.sentryJdbc)
   runtimeOnly(libs.hsqldb)

--- a/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/SentryDemoApplication.java
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/java/io/sentry/samples/spring/boot/SentryDemoApplication.java
@@ -9,6 +9,7 @@ import org.quartz.SimpleTrigger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
@@ -18,6 +19,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
+@EnableCaching
 @EnableScheduling
 public class SentryDemoApplication {
   public static void main(String[] args) {

--- a/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot/src/main/resources/application.properties
@@ -20,6 +20,11 @@ sentry.profile-session-sample-rate=1.0
 sentry.profiling-traces-dir-path=tmp/sentry/profiling-traces
 sentry.profile-lifecycle=TRACE
 
+# Cache tracing
+sentry.enable-cache-tracing=true
+spring.cache.cache-names=todos
+spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=600s
+
 # Database configuration
 spring.datasource.url=jdbc:p6spy:hsqldb:mem:testdb
 spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5162](https://github.com/getsentry/sentry-java/pull/5162) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5163](https://github.com/getsentry/sentry-java/pull/5163) — Add enableCacheTracing option
- [#5164](https://github.com/getsentry/sentry-java/pull/5164) — Add BeanPostProcessor and auto-configuration
- [#5167](https://github.com/getsentry/sentry-java/pull/5167) — Add cache tracing e2e sample
- [#5171](https://github.com/getsentry/sentry-java/pull/5171) — Add Caffeine cache to Spring Boot sample

---

## :scroll: Description

Adds Caffeine-backed caching to the Spring Boot 2/3 sample app to demonstrate cache tracing without external infrastructure (no Redis/Docker needed).

- Adds `com.github.ben-manes.caffeine:caffeine` dependency (version managed by Spring Boot BOM)
- Enables `@EnableCaching` on the application
- Configures `sentry.enable-cache-tracing=true` and Caffeine cache spec in `application.properties`

## :bulb: Motivation and Context

The Spring Boot 4 sample uses `ConcurrentMapCacheManager` for cache tracing. This PR adds a more realistic cache provider (Caffeine with TTL and size limits) to the Spring Boot 2/3 sample, while keeping it zero-infrastructure.

## :green_heart: How did you test it?

- Verified the sample app starts and compiles successfully
- Cache endpoints (`/cache/`) work with Caffeine as the backing store

## :pencil: Checklist
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

#skip-changelog

