### PR TITLE
docs: Add collection branch safety warnings to PR workflow

### DIFF
--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -35,6 +35,8 @@ Derive the branch name from the changes being made. Use `feat/`, `fix/`, `ref/`,
 
 **For stacked PRs:** For the first PR in a new stack, first create and push the collection branch (see `.cursor/rules/pr.mdc` § "Creating the Collection Branch"), then branch the PR off it. For subsequent PRs, branch off the previous stack branch. Use the naming conventions from `.cursor/rules/pr.mdc` § "Branch Naming".
 
+**CRITICAL: Never merge, fast-forward, or push commits into the collection branch.** It stays at its initial position until the user merges stack PRs through GitHub. Updating it will auto-merge and destroy the entire PR stack.
+
 ## Step 2: Format Code and Regenerate API Files
 
 ```bash

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -185,6 +185,8 @@ git push -u origin HEAD
 gh pr create --base main --draft --title "<type>(<scope>): <Topic>" --body "Collection PR for the <Topic> stack. Squash-merge this once all stack PRs are merged."
 ```
 
+**CRITICAL: Do NOT manually update the collection branch.** Never merge, fast-forward, or push stack branch commits into the collection branch. The collection branch stays at its initial position (the empty commit on `main`) until the user merges individual stack PRs into it one by one through GitHub. If you fast-forward the collection branch to include stack commits, GitHub will auto-merge and delete all stack PR branches, destroying the entire stack.
+
 ### Creating a New Stacked PR
 
 1. Start from the tip of the previous stack branch (or the collection branch for the first PR).
@@ -237,12 +239,12 @@ Once all stack PRs are merged into the collection branch, the collection PR is *
 
 ### Syncing the Stack
 
-When a base PR changes (e.g. after addressing review feedback on PR 1), merge the changes forward through the stack:
+When a base PR changes (e.g. after addressing review feedback on PR 1), merge the changes forward through the stack **between adjacent stack PR branches only**:
 
 ```bash
 # On the branch for PR 2
 git checkout feat/scope-attributes-logger
-git merge feat/scope-attributes
+git merge feat/scope-attributes-api
 git push
 
 # On the branch for PR 3
@@ -250,5 +252,7 @@ git checkout feat/scope-attributes-sample
 git merge feat/scope-attributes-logger
 git push
 ```
+
+**Never merge into the collection branch.** Syncing only happens between stack PR branches. The collection branch is untouched until the user merges PRs through GitHub.
 
 Prefer merge over rebase — it preserves commit history, doesn't invalidate existing review comments, and avoids the need for force-pushing. Only rebase if explicitly requested.


### PR DESCRIPTION
## :scroll: Description

Adds explicit warnings to `pr.mdc` and `create-java-pr` skill that the collection branch in a stacked PR workflow must **never** be manually merged, fast-forwarded, or pushed to.

Changes:
- **`.cursor/rules/pr.mdc`**: Added CRITICAL warning in "Creating the Collection Branch" section; added "Never merge into the collection branch" note in "Syncing the Stack" section; fixed example branch name to use `feat/scope-attributes-api` instead of `feat/scope-attributes` (which is the collection branch)
- **`.claude/skills/create-java-pr/SKILL.md`**: Added CRITICAL warning in Step 1's stacked PR guidance

## :bulb: Motivation and Context

During cache tracing PR stack work, the collection branch was accidentally fast-forwarded to include all stack commits. GitHub interpreted this as all stack PRs being merged, auto-closed them, and deleted their head branches. The entire stack had to be recreated with new PR numbers.

This adds guardrails to prevent the same mistake in future sessions.

## :green_heart: How did you test it?

Documentation-only change. Reviewed the wording for clarity and completeness.

## :pencil: Checklist
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

None.

#skip-changelog