### PR TITLE
feat(spring7): [Cache Tracing 8] Add retrieve() overrides for reactive/async cache support

### DIFF
--- a/sentry-spring-7/api/sentry-spring-7.api
+++ b/sentry-spring-7/api/sentry-spring-7.api
@@ -129,6 +129,8 @@ public final class io/sentry/spring7/cache/SentryCacheWrapper : org/springframew
 	public fun invalidate ()Z
 	public fun put (Ljava/lang/Object;Ljava/lang/Object;)V
 	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Lorg/springframework/cache/Cache$ValueWrapper;
+	public fun retrieve (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun retrieve (Ljava/lang/Object;Ljava/util/function/Supplier;)Ljava/util/concurrent/CompletableFuture;
 }
 
 public abstract interface annotation class io/sentry/spring7/checkin/SentryCheckIn : java/lang/annotation/Annotation {

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -7,7 +7,9 @@ import io.sentry.SpanOptions;
 import io.sentry.SpanStatus;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -102,6 +104,76 @@ public final class SentryCacheWrapper implements Cache {
     } finally {
       span.finish();
     }
+  }
+
+  @Override
+  public @Nullable CompletableFuture<?> retrieve(final @NotNull Object key) {
+    final ISpan span = startSpan("cache.get", key);
+    if (span == null) {
+      return delegate.retrieve(key);
+    }
+    final CompletableFuture<?> result;
+    try {
+      result = delegate.retrieve(key);
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      span.finish();
+      throw e;
+    }
+    if (result == null) {
+      span.setData(SpanDataConvention.CACHE_HIT_KEY, false);
+      span.setStatus(SpanStatus.OK);
+      span.finish();
+      return null;
+    }
+    return result.whenComplete(
+        (value, throwable) -> {
+          if (throwable != null) {
+            span.setStatus(SpanStatus.INTERNAL_ERROR);
+            span.setThrowable(throwable);
+          } else {
+            span.setData(SpanDataConvention.CACHE_HIT_KEY, value != null);
+            span.setStatus(SpanStatus.OK);
+          }
+          span.finish();
+        });
+  }
+
+  @Override
+  public <T> CompletableFuture<T> retrieve(
+      final @NotNull Object key, final @NotNull Supplier<CompletableFuture<T>> valueLoader) {
+    final ISpan span = startSpan("cache.get", key);
+    if (span == null) {
+      return delegate.retrieve(key, valueLoader);
+    }
+    final AtomicBoolean loaderInvoked = new AtomicBoolean(false);
+    final CompletableFuture<T> result;
+    try {
+      result =
+          delegate.retrieve(
+              key,
+              () -> {
+                loaderInvoked.set(true);
+                return valueLoader.get();
+              });
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      span.finish();
+      throw e;
+    }
+    return result.whenComplete(
+        (value, throwable) -> {
+          if (throwable != null) {
+            span.setStatus(SpanStatus.INTERNAL_ERROR);
+            span.setThrowable(throwable);
+          } else {
+            span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+            span.setStatus(SpanStatus.OK);
+          }
+          span.finish();
+        });
   }
 
   @Override

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -7,6 +7,8 @@ import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -135,6 +137,172 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+  }
+
+  // -- retrieve(Object key) --
+
+  @Test
+  fun `retrieve creates span with cache hit true when future resolves with value`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.retrieve("myKey")).thenReturn(CompletableFuture.completedFuture("value"))
+
+    val result = wrapper.retrieve("myKey")
+
+    assertEquals("value", result!!.get())
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.get", span.operation)
+    assertEquals("myKey", span.description)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertTrue(span.isFinished)
+  }
+
+  @Test
+  fun `retrieve creates span with cache hit false when future resolves with null`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.retrieve("myKey")).thenReturn(CompletableFuture.completedFuture(null))
+
+    val result = wrapper.retrieve("myKey")
+
+    assertNull(result!!.get())
+    assertEquals(1, tx.spans.size)
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertTrue(tx.spans.first().isFinished)
+  }
+
+  @Test
+  fun `retrieve creates span with cache hit false when delegate returns null`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.retrieve("myKey")).thenReturn(null)
+
+    val result = wrapper.retrieve("myKey")
+
+    assertNull(result)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals(false, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(SpanStatus.OK, span.status)
+    assertTrue(span.isFinished)
+  }
+
+  @Test
+  fun `retrieve sets error status when future completes exceptionally`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    val exception = RuntimeException("async cache error")
+    whenever(delegate.retrieve("myKey"))
+      .thenReturn(CompletableFuture<Any>().also { it.completeExceptionally(exception) })
+
+    val result = wrapper.retrieve("myKey")
+
+    assertFailsWith<Exception> { result!!.get() }
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals(SpanStatus.INTERNAL_ERROR, span.status)
+    assertEquals(exception, span.throwable)
+    assertTrue(span.isFinished)
+  }
+
+  @Test
+  fun `retrieve sets error status when delegate throws synchronously`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    val exception = RuntimeException("sync error")
+    whenever(delegate.retrieve("myKey")).thenThrow(exception)
+
+    assertFailsWith<RuntimeException> { wrapper.retrieve("myKey") }
+
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals(SpanStatus.INTERNAL_ERROR, span.status)
+    assertEquals(exception, span.throwable)
+    assertTrue(span.isFinished)
+  }
+
+  @Test
+  fun `retrieve does not create span when tracing is disabled`() {
+    options.isEnableCacheTracing = false
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.retrieve("myKey")).thenReturn(CompletableFuture.completedFuture("value"))
+
+    wrapper.retrieve("myKey")
+
+    verify(delegate).retrieve("myKey")
+    assertEquals(0, tx.spans.size)
+  }
+
+  // -- retrieve(Object key, Supplier<CompletableFuture<T>>) --
+
+  @Test
+  fun `retrieve with loader creates span with cache hit true when loader not invoked`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    // Simulate cache hit: delegate returns value without invoking the loader
+    whenever(delegate.retrieve(eq("myKey"), any<Supplier<CompletableFuture<String>>>()))
+      .thenReturn(CompletableFuture.completedFuture("cached"))
+
+    val result = wrapper.retrieve("myKey") { CompletableFuture.completedFuture("loaded") }
+
+    assertEquals("cached", result.get())
+    assertEquals(1, tx.spans.size)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertTrue(tx.spans.first().isFinished)
+  }
+
+  @Test
+  fun `retrieve with loader creates span with cache hit false when loader invoked`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    // Simulate cache miss: delegate invokes the loader supplier
+    whenever(delegate.retrieve(eq("myKey"), any<Supplier<CompletableFuture<String>>>()))
+      .thenAnswer { invocation ->
+        val loader = invocation.getArgument<Supplier<CompletableFuture<String>>>(1)
+        loader.get()
+      }
+
+    val result = wrapper.retrieve("myKey") { CompletableFuture.completedFuture("loaded") }
+
+    assertEquals("loaded", result.get())
+    assertEquals(1, tx.spans.size)
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertTrue(tx.spans.first().isFinished)
+  }
+
+  @Test
+  fun `retrieve with loader sets error status when future completes exceptionally`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    val exception = RuntimeException("async loader error")
+    whenever(delegate.retrieve(eq("myKey"), any<Supplier<CompletableFuture<String>>>()))
+      .thenReturn(CompletableFuture<String>().also { it.completeExceptionally(exception) })
+
+    val result = wrapper.retrieve("myKey") { CompletableFuture.completedFuture("loaded") }
+
+    assertFailsWith<Exception> { result.get() }
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals(SpanStatus.INTERNAL_ERROR, span.status)
+    assertEquals(exception, span.throwable)
+    assertTrue(span.isFinished)
+  }
+
+  @Test
+  fun `retrieve with loader does not create span when tracing is disabled`() {
+    options.isEnableCacheTracing = false
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.retrieve(eq("myKey"), any<Supplier<CompletableFuture<String>>>()))
+      .thenReturn(CompletableFuture.completedFuture("cached"))
+
+    wrapper.retrieve("myKey") { CompletableFuture.completedFuture("loaded") }
+
+    verify(delegate).retrieve(eq("myKey"), any<Supplier<CompletableFuture<String>>>())
+    assertEquals(0, tx.spans.size)
   }
 
   // -- put --


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---



## :scroll: Description

Adds `retrieve(Object key)` and `retrieve(Object key, Supplier<CompletableFuture<T>>)` overrides to `SentryCacheWrapper`.

Spring 6.1+ added these two methods to the `Cache` interface for non-blocking cache operations. Spring's `CacheInterceptor` calls them when `@Cacheable` is placed on methods returning `CompletableFuture<T>` or `Mono<T>`. Without these overrides, the default `Cache.retrieve()` throws `UnsupportedOperationException`, meaning any app using reactive `@Cacheable` with cache tracing enabled would crash.

Key design decisions:
- Spans are started synchronously and finished asynchronously via `CompletableFuture.whenComplete()`
- `retrieve(key)` handles three result states: `null` return (immediate miss), CF resolving to `null` (late miss), CF resolving to value (hit)
- `retrieve(key, valueLoader)` uses the same `AtomicBoolean` loader-tracking pattern as `get(key, Callable)` for cache hit detection

## :bulb: Motivation and Context

This is a functional bug fix. The `SentryCacheWrapper` implements `Cache` but didn't override the `retrieve()` default methods, which throw `UnsupportedOperationException`. When cache tracing is enabled and the wrapper intercepts the cache, reactive `@Cacheable` methods crash instead of working.

## :green_heart: How did you test it?

- 10 new unit tests in `SentryCacheWrapperTest` covering:
  - Cache hit/miss detection for both `retrieve` variants
  - Immediate null return vs late-determined null
  - Async error handling (failed futures)
  - Synchronous delegate exceptions
  - No-span behavior when tracing disabled

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Port `retrieve()` overrides to `sentry-spring-jakarta` when cache classes are ported there.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.



#skip-changelog












