### PR TITLE
feat(spring): [Cache Tracing 13] Instrument putIfAbsent, replace, and getAndReplace

### DIFF
--- a/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
+++ b/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
@@ -153,29 +153,80 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
   }
 
-  // putIfAbsent is not instrumented — we cannot know ahead of time whether the put
-  // will actually happen, and emitting a cache.put span for a no-op would be misleading.
   @Override
   public boolean putIfAbsent(final K key, final V value) {
-    return delegate.putIfAbsent(key, value);
+    final ISpan span = startSpan("cache.put", key, "putIfAbsent");
+    if (span == null) {
+      return delegate.putIfAbsent(key, value);
+    }
+    try {
+      final boolean result = delegate.putIfAbsent(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
-  // replace and getAndReplace are not instrumented — like putIfAbsent, they are conditional
-  // writes (only happen if the key exists / value matches). Emitting a cache.put span for a
-  // potential no-op would be misleading.
   @Override
   public boolean replace(final K key, final V oldValue, final V newValue) {
-    return delegate.replace(key, oldValue, newValue);
+    final ISpan span = startSpan("cache.put", key, "replace");
+    if (span == null) {
+      return delegate.replace(key, oldValue, newValue);
+    }
+    try {
+      final boolean result = delegate.replace(key, oldValue, newValue);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   @Override
   public boolean replace(final K key, final V value) {
-    return delegate.replace(key, value);
+    final ISpan span = startSpan("cache.put", key, "replace");
+    if (span == null) {
+      return delegate.replace(key, value);
+    }
+    try {
+      final boolean result = delegate.replace(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   @Override
   public V getAndReplace(final K key, final V value) {
-    return delegate.getAndReplace(key, value);
+    final ISpan span = startSpan("cache.put", key, "getAndReplace");
+    if (span == null) {
+      return delegate.getAndReplace(key, value);
+    }
+    try {
+      final V result = delegate.getAndReplace(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   // -- remove operations --

--- a/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
+++ b/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
@@ -171,7 +171,7 @@ class SentryJCacheWrapperTest {
   // -- putIfAbsent --
 
   @Test
-  fun `putIfAbsent delegates without creating span`() {
+  fun `putIfAbsent creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryJCacheWrapper(delegate, scopes)
     whenever(delegate.putIfAbsent("myKey", "myValue")).thenReturn(true)
@@ -180,13 +180,18 @@ class SentryJCacheWrapperTest {
 
     assertTrue(result)
     verify(delegate).putIfAbsent("myKey", "myValue")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals("putIfAbsent", span.getData("db.operation.name"))
   }
 
-  // -- replace (passthrough, no span — conditional write) --
+  // -- replace --
 
   @Test
-  fun `replace with old value delegates without creating span`() {
+  fun `replace with old value creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryJCacheWrapper(delegate, scopes)
     whenever(delegate.replace("myKey", "old", "new")).thenReturn(true)
@@ -195,11 +200,15 @@ class SentryJCacheWrapperTest {
 
     assertTrue(result)
     verify(delegate).replace("myKey", "old", "new")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals("replace", span.getData("db.operation.name"))
   }
 
   @Test
-  fun `replace delegates without creating span`() {
+  fun `replace creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryJCacheWrapper(delegate, scopes)
     whenever(delegate.replace("myKey", "value")).thenReturn(true)
@@ -208,13 +217,17 @@ class SentryJCacheWrapperTest {
 
     assertTrue(result)
     verify(delegate).replace("myKey", "value")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals("replace", span.getData("db.operation.name"))
   }
 
-  // -- getAndReplace (passthrough, no span — conditional write) --
+  // -- getAndReplace --
 
   @Test
-  fun `getAndReplace delegates without creating span`() {
+  fun `getAndReplace creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryJCacheWrapper(delegate, scopes)
     whenever(delegate.getAndReplace("myKey", "newValue")).thenReturn("oldValue")
@@ -223,7 +236,11 @@ class SentryJCacheWrapperTest {
 
     assertEquals("oldValue", result)
     verify(delegate).getAndReplace("myKey", "newValue")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals("getAndReplace", span.getData("db.operation.name"))
   }
 
   // -- remove(K) --

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -196,14 +196,24 @@ public final class SentryCacheWrapper implements Cache {
     }
   }
 
-  // putIfAbsent is not instrumented — we cannot know ahead of time whether the put
-  // will actually happen, and emitting a cache.put span for a no-op would be misleading.
-  // This matches sentry-python and sentry-javascript which also skip conditional puts.
-  // We must override to bypass the default implementation which calls this.get() + this.put().
   @Override
   public @Nullable ValueWrapper putIfAbsent(
       final @NotNull Object key, final @Nullable Object value) {
-    return delegate.putIfAbsent(key, value);
+    final ISpan span = startSpan("cache.put", key, "putIfAbsent");
+    if (span == null) {
+      return delegate.putIfAbsent(key, value);
+    }
+    try {
+      final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   @Override

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -328,15 +328,21 @@ class SentryCacheWrapperTest {
   // -- putIfAbsent --
 
   @Test
-  fun `putIfAbsent delegates without creating span`() {
+  fun `putIfAbsent creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     whenever(delegate.putIfAbsent("myKey", "myValue")).thenReturn(null)
 
-    wrapper.putIfAbsent("myKey", "myValue")
+    val result = wrapper.putIfAbsent("myKey", "myValue")
 
+    assertNull(result)
     verify(delegate).putIfAbsent("myKey", "myValue")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals("putIfAbsent", span.getData("db.operation.name"))
   }
 
   // -- evict --

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -196,14 +196,24 @@ public final class SentryCacheWrapper implements Cache {
     }
   }
 
-  // putIfAbsent is not instrumented — we cannot know ahead of time whether the put
-  // will actually happen, and emitting a cache.put span for a no-op would be misleading.
-  // This matches sentry-python and sentry-javascript which also skip conditional puts.
-  // We must override to bypass the default implementation which calls this.get() + this.put().
   @Override
   public @Nullable ValueWrapper putIfAbsent(
       final @NotNull Object key, final @Nullable Object value) {
-    return delegate.putIfAbsent(key, value);
+    final ISpan span = startSpan("cache.put", key, "putIfAbsent");
+    if (span == null) {
+      return delegate.putIfAbsent(key, value);
+    }
+    try {
+      final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   @Override

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -328,15 +328,21 @@ class SentryCacheWrapperTest {
   // -- putIfAbsent --
 
   @Test
-  fun `putIfAbsent delegates without creating span`() {
+  fun `putIfAbsent creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     whenever(delegate.putIfAbsent("myKey", "myValue")).thenReturn(null)
 
-    wrapper.putIfAbsent("myKey", "myValue")
+    val result = wrapper.putIfAbsent("myKey", "myValue")
 
+    assertNull(result)
     verify(delegate).putIfAbsent("myKey", "myValue")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals("putIfAbsent", span.getData("db.operation.name"))
   }
 
   // -- evict --

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -124,14 +124,24 @@ public final class SentryCacheWrapper implements Cache {
     }
   }
 
-  // putIfAbsent is not instrumented — we cannot know ahead of time whether the put
-  // will actually happen, and emitting a cache.put span for a no-op would be misleading.
-  // This matches sentry-python and sentry-javascript which also skip conditional puts.
-  // We must override to bypass the default implementation which calls this.get() + this.put().
   @Override
   public @Nullable ValueWrapper putIfAbsent(
       final @NotNull Object key, final @Nullable Object value) {
-    return delegate.putIfAbsent(key, value);
+    final ISpan span = startSpan("cache.put", key, "putIfAbsent");
+    if (span == null) {
+      return delegate.putIfAbsent(key, value);
+    }
+    try {
+      final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setStatus(SpanStatus.OK);
+      return result;
+    } catch (Throwable e) {
+      span.setStatus(SpanStatus.INTERNAL_ERROR);
+      span.setThrowable(e);
+      throw e;
+    } finally {
+      span.finish();
+    }
   }
 
   @Override

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -159,15 +159,21 @@ class SentryCacheWrapperTest {
   // -- putIfAbsent --
 
   @Test
-  fun `putIfAbsent delegates without creating span`() {
+  fun `putIfAbsent creates cache put span`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     whenever(delegate.putIfAbsent("myKey", "myValue")).thenReturn(null)
 
-    wrapper.putIfAbsent("myKey", "myValue")
+    val result = wrapper.putIfAbsent("myKey", "myValue")
 
+    assertNull(result)
     verify(delegate).putIfAbsent("myKey", "myValue")
-    assertEquals(0, tx.spans.size)
+    assertEquals(1, tx.spans.size)
+    val span = tx.spans.first()
+    assertEquals("cache.put", span.operation)
+    assertEquals(SpanStatus.OK, span.status)
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals("putIfAbsent", span.getData("db.operation.name"))
   }
 
   // -- evict --


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---


## :scroll: Description

Add span instrumentation to previously-passthrough conditional cache operations:

**Spring Cache (all 3 modules):**
- `putIfAbsent(key, value)` — now creates a `cache.put` span

**JCache:**
- `putIfAbsent(key, value)` — `cache.put` span
- `replace(key, oldValue, newValue)` — `cache.put` span (conditional CAS)
- `replace(key, value)` — `cache.put` span (replace if present)
- `getAndReplace(key, value)` — `cache.put` span (atomic get-and-replace)

All follow the same error-handling pattern as existing instrumented methods (try/catch/finally with `SpanStatus.INTERNAL_ERROR` + `setThrowable` on exception). Each sets `db.operation.name` to the method name via the `startSpan` helper.

## :bulb: Motivation and Context

These operations were previously skipped because they are conditional writes that may be no-ops. However, they still represent meaningful cache interactions that should be visible in the Sentry Caches UI for observability. The `db.operation.name` attribute (added in the previous PR) allows distinguishing them from unconditional `put` operations.

## :green_heart: How did you test it?

Updated existing passthrough tests to verify span creation, operation, status, `cache.key`, and `db.operation.name` attributes. All tests pass across all 4 modules.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None — completes coverage of all data operations in Spring Cache and JCache wrappers.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

#skip-changelog








