### PR TITLE
ref(cache): [Cache Tracing 17] Move operation attribute to centralized CACHE_OPERATION_KEY

### DIFF
--- a/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
+++ b/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.Nullable;
 public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
 
   private static final String TRACE_ORIGIN = "auto.cache.jcache";
-  private static final String OPERATION_ATTRIBUTE = "db.operation.name";
 
   private final @NotNull Cache<K, V> delegate;
   private final @NotNull IScopes scopes;
@@ -489,7 +488,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     if (cacheKeys != null) {
       span.setData(SpanDataConvention.CACHE_KEY_KEY, cacheKeys);
     }
-    span.setData(OPERATION_ATTRIBUTE, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
     return span;
   }
 }

--- a/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
+++ b/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
@@ -64,7 +64,7 @@ class SentryJCacheWrapperTest {
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.jcache", span.spanContext.origin)
-    assertEquals("get", span.getData("db.operation.name"))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -99,7 +99,7 @@ class SentryJCacheWrapperTest {
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
-    assertEquals("getAll", span.getData("db.operation.name"))
+    assertEquals("getAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -129,7 +129,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData("db.operation.name"))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- getAndPut --
@@ -145,7 +145,7 @@ class SentryJCacheWrapperTest {
     assertEquals("oldValue", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndPut", tx.spans.first().operation)
-    assertEquals("getAndPut", tx.spans.first().getData("db.operation.name"))
+    assertEquals("getAndPut", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- putAll --
@@ -165,7 +165,7 @@ class SentryJCacheWrapperTest {
     assertEquals("testCache", span.description)
     val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
-    assertEquals("putAll", span.getData("db.operation.name"))
+    assertEquals("putAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- putIfAbsent --
@@ -185,7 +185,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData("db.operation.name"))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- replace --
@@ -204,7 +204,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("replace", span.getData("db.operation.name"))
+    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -221,7 +221,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("replace", span.getData("db.operation.name"))
+    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- getAndReplace --
@@ -240,7 +240,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.getAndReplace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("getAndReplace", span.getData("db.operation.name"))
+    assertEquals("getAndReplace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- remove(K) --
@@ -258,7 +258,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.remove", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("remove", span.getData("db.operation.name"))
+    assertEquals("remove", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- remove(K, V) --
@@ -274,7 +274,7 @@ class SentryJCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.remove", tx.spans.first().operation)
-    assertEquals("remove", tx.spans.first().getData("db.operation.name"))
+    assertEquals("remove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- getAndRemove --
@@ -290,7 +290,7 @@ class SentryJCacheWrapperTest {
     assertEquals("value", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndRemove", tx.spans.first().operation)
-    assertEquals("getAndRemove", tx.spans.first().getData("db.operation.name"))
+    assertEquals("getAndRemove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- removeAll(Set) --
@@ -308,7 +308,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.removeAll", span.operation)
     assertEquals("testCache", span.description)
-    assertEquals("removeAll", span.getData("db.operation.name"))
+    assertEquals("removeAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- removeAll() --
@@ -323,7 +323,7 @@ class SentryJCacheWrapperTest {
     verify(delegate).removeAll()
     assertEquals(1, tx.spans.size)
     assertEquals("cache.removeAll", tx.spans.first().operation)
-    assertEquals("removeAll", tx.spans.first().getData("db.operation.name"))
+    assertEquals("removeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- clear --
@@ -341,7 +341,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData("db.operation.name"))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- invoke --
@@ -358,7 +358,7 @@ class SentryJCacheWrapperTest {
     assertEquals("result", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invoke", tx.spans.first().operation)
-    assertEquals("invoke", tx.spans.first().getData("db.operation.name"))
+    assertEquals("invoke", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- invokeAll --
@@ -377,7 +377,7 @@ class SentryJCacheWrapperTest {
     assertEquals(resultMap, result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invokeAll", tx.spans.first().operation)
-    assertEquals("invokeAll", tx.spans.first().getData("db.operation.name"))
+    assertEquals("invokeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- passthrough operations --

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -20,7 +20,6 @@ import org.springframework.cache.Cache;
 public final class SentryCacheWrapper implements Cache {
 
   private static final String TRACE_ORIGIN = "auto.cache.spring";
-  private static final String OPERATION_ATTRIBUTE = "db.operation.name";
 
   private final @NotNull Cache delegate;
   private final @NotNull IScopes scopes;
@@ -314,7 +313,7 @@ public final class SentryCacheWrapper implements Cache {
     if (keyString != null) {
       span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
     }
-    span.setData(OPERATION_ATTRIBUTE, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
     return span;
   }
 }

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -63,7 +63,7 @@ class SentryCacheWrapperTest {
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData("db.operation.name"))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -191,7 +191,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
-    assertEquals("retrieve", span.getData("db.operation.name"))
+    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
     assertTrue(span.isFinished)
   }
 
@@ -356,7 +356,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData("db.operation.name"))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- putIfAbsent --
@@ -376,7 +376,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData("db.operation.name"))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evict --
@@ -393,7 +393,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("evict", span.getData("db.operation.name"))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evictIfPresent --
@@ -409,7 +409,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
-    assertEquals("evictIfPresent", tx.spans.first().getData("db.operation.name"))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- clear --
@@ -427,7 +427,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData("db.operation.name"))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- invalidate --
@@ -443,7 +443,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
-    assertEquals("invalidate", tx.spans.first().getData("db.operation.name"))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- no span when no active transaction --

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -20,7 +20,6 @@ import org.springframework.cache.Cache;
 public final class SentryCacheWrapper implements Cache {
 
   private static final String TRACE_ORIGIN = "auto.cache.spring";
-  private static final String OPERATION_ATTRIBUTE = "db.operation.name";
 
   private final @NotNull Cache delegate;
   private final @NotNull IScopes scopes;
@@ -314,7 +313,7 @@ public final class SentryCacheWrapper implements Cache {
     if (keyString != null) {
       span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
     }
-    span.setData(OPERATION_ATTRIBUTE, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
     return span;
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -63,7 +63,7 @@ class SentryCacheWrapperTest {
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData("db.operation.name"))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -191,7 +191,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
-    assertEquals("retrieve", span.getData("db.operation.name"))
+    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
     assertTrue(span.isFinished)
   }
 
@@ -356,7 +356,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData("db.operation.name"))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- putIfAbsent --
@@ -376,7 +376,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData("db.operation.name"))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evict --
@@ -393,7 +393,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("evict", span.getData("db.operation.name"))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evictIfPresent --
@@ -409,7 +409,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
-    assertEquals("evictIfPresent", tx.spans.first().getData("db.operation.name"))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- clear --
@@ -427,7 +427,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData("db.operation.name"))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- invalidate --
@@ -443,7 +443,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
-    assertEquals("invalidate", tx.spans.first().getData("db.operation.name"))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- no span when no active transaction --

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -18,7 +18,6 @@ import org.springframework.cache.Cache;
 public final class SentryCacheWrapper implements Cache {
 
   private static final String TRACE_ORIGIN = "auto.cache.spring";
-  private static final String OPERATION_ATTRIBUTE = "db.operation.name";
 
   private final @NotNull Cache delegate;
   private final @NotNull IScopes scopes;
@@ -242,7 +241,7 @@ public final class SentryCacheWrapper implements Cache {
     if (keyString != null) {
       span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
     }
-    span.setData(OPERATION_ATTRIBUTE, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
     return span;
   }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -61,7 +61,7 @@ class SentryCacheWrapperTest {
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData("db.operation.name"))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   @Test
@@ -187,7 +187,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData("db.operation.name"))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- putIfAbsent --
@@ -207,7 +207,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData("db.operation.name"))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evict --
@@ -224,7 +224,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals("evict", span.getData("db.operation.name"))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- evictIfPresent --
@@ -240,7 +240,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
-    assertEquals("evictIfPresent", tx.spans.first().getData("db.operation.name"))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- clear --
@@ -258,7 +258,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData("db.operation.name"))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- invalidate --
@@ -274,7 +274,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
-    assertEquals("invalidate", tx.spans.first().getData("db.operation.name"))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
   // -- no span when no active transaction --

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4344,6 +4344,7 @@ public abstract interface class io/sentry/SpanDataConvention {
 	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
 	public static final field CACHE_HIT_KEY Ljava/lang/String;
 	public static final field CACHE_KEY_KEY Ljava/lang/String;
+	public static final field CACHE_OPERATION_KEY Ljava/lang/String;
 	public static final field CALL_STACK_KEY Ljava/lang/String;
 	public static final field CONTRIBUTES_TTFD Ljava/lang/String;
 	public static final field CONTRIBUTES_TTID Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -28,4 +28,5 @@ public interface SpanDataConvention {
   String PROFILER_ID = "profiler_id";
   String CACHE_HIT_KEY = "cache.hit";
   String CACHE_KEY_KEY = "cache.key";
+  String CACHE_OPERATION_KEY = "cache.operation";
 }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---


## :scroll: Description

Replaces the local `OPERATION_ATTRIBUTE = "db.operation.name"` constants in all four cache wrapper classes with a shared `CACHE_OPERATION_KEY = "cache.operation"` constant in `SpanDataConvention`. Tests now also reference the constant instead of hardcoding the string.

## :bulb: Motivation and Context

The attribute key was duplicated across `SentryCacheWrapper` (spring, spring-7, spring-jakarta) and `SentryJCacheWrapper` (jcache). Moving it to `SpanDataConvention` follows the same pattern as `CACHE_HIT_KEY` and `CACHE_KEY_KEY`. Also renames from `db.operation.name` to `cache.operation` since this is a cache attribute, not a database one.

## :green_heart: How did you test it?

- All cache wrapper tests updated and pass

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


#skip-changelog




