### PR TITLE
feat(cache): [Cache Tracing 18] Add cache.write boolean span attribute

### DIFF
--- a/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
+++ b/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
@@ -105,6 +105,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       delegate.put(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -123,6 +124,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final V result = delegate.getAndPut(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -143,6 +145,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       delegate.putAll(map);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -161,6 +164,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final boolean result = delegate.putIfAbsent(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -180,6 +184,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final boolean result = delegate.replace(key, oldValue, newValue);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -199,6 +204,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final boolean result = delegate.replace(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -218,6 +224,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final V result = delegate.getAndReplace(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -239,6 +246,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final boolean result = delegate.remove(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -258,6 +266,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final boolean result = delegate.remove(key, oldValue);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -277,6 +286,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final V result = delegate.getAndRemove(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -297,6 +307,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       delegate.removeAll(keys);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -316,6 +327,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       delegate.removeAll();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -337,6 +349,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       delegate.clear();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);

--- a/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
+++ b/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
@@ -62,6 +62,7 @@ class SentryJCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.jcache", span.spanContext.origin)
     assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
@@ -128,6 +129,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -145,6 +147,7 @@ class SentryJCacheWrapperTest {
     assertEquals("oldValue", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndPut", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("getAndPut", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -163,6 +166,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.putAll", span.operation)
     assertEquals("testCache", span.description)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
     assertEquals("putAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
@@ -184,6 +188,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -204,6 +209,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -221,6 +227,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -240,6 +247,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.getAndReplace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("getAndReplace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -258,6 +266,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.remove", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("remove", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -274,6 +283,7 @@ class SentryJCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.remove", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("remove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -290,6 +300,7 @@ class SentryJCacheWrapperTest {
     assertEquals("value", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndRemove", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("getAndRemove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -308,6 +319,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.removeAll", span.operation)
     assertEquals("testCache", span.description)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("removeAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -323,6 +335,7 @@ class SentryJCacheWrapperTest {
     verify(delegate).removeAll()
     assertEquals(1, tx.spans.size)
     assertEquals("cache.removeAll", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("removeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -340,6 +353,7 @@ class SentryJCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -96,6 +96,7 @@ public final class SentryCacheWrapper implements Cache {
                 return valueLoader.call();
               });
       span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -171,6 +172,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setThrowable(throwable);
           } else {
             span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+            span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
             span.setStatus(SpanStatus.OK);
           }
           span.finish();
@@ -186,6 +188,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.put(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -205,6 +208,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result == null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -225,6 +229,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.evict(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -243,6 +248,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.evictIfPresent(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -263,6 +269,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.clear();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -281,6 +288,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -61,6 +61,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
     assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
@@ -155,6 +156,7 @@ class SentryCacheWrapperTest {
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   @Test
@@ -172,6 +174,7 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   // -- retrieve(Object key) --
@@ -191,6 +194,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
     assertTrue(span.isFinished)
   }
@@ -287,6 +291,7 @@ class SentryCacheWrapperTest {
     assertEquals("cached", result.get())
     assertEquals(1, tx.spans.size)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -306,6 +311,7 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result.get())
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -355,6 +361,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -375,6 +382,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -393,6 +401,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -409,6 +418,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -426,6 +436,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -443,6 +454,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -96,6 +96,7 @@ public final class SentryCacheWrapper implements Cache {
                 return valueLoader.call();
               });
       span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -171,6 +172,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setThrowable(throwable);
           } else {
             span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+            span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
             span.setStatus(SpanStatus.OK);
           }
           span.finish();
@@ -186,6 +188,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.put(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -205,6 +208,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result == null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -225,6 +229,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.evict(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -243,6 +248,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.evictIfPresent(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -263,6 +269,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.clear();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -281,6 +288,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -61,6 +61,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
     assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
@@ -155,6 +156,7 @@ class SentryCacheWrapperTest {
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   @Test
@@ -172,6 +174,7 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   // -- retrieve(Object key) --
@@ -191,6 +194,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
     assertTrue(span.isFinished)
   }
@@ -287,6 +291,7 @@ class SentryCacheWrapperTest {
     assertEquals("cached", result.get())
     assertEquals(1, tx.spans.size)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -306,6 +311,7 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result.get())
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -355,6 +361,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -375,6 +382,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -393,6 +401,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -409,6 +418,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -426,6 +436,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -443,6 +454,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -94,6 +94,7 @@ public final class SentryCacheWrapper implements Cache {
                 return valueLoader.call();
               });
       span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -114,6 +115,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.put(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -133,6 +135,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.putIfAbsent(key, value);
+      span.setData(SpanDataConvention.CACHE_WRITE, result == null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -153,6 +156,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.evict(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -171,6 +175,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.evictIfPresent(key);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -191,6 +196,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       delegate.clear();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
     } catch (Throwable e) {
       span.setStatus(SpanStatus.INTERNAL_ERROR);
@@ -209,6 +215,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
+      span.setData(SpanDataConvention.CACHE_WRITE, true);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -59,6 +59,7 @@ class SentryCacheWrapperTest {
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
     assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
@@ -153,6 +154,7 @@ class SentryCacheWrapperTest {
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   @Test
@@ -170,6 +172,7 @@ class SentryCacheWrapperTest {
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
   // -- put --
@@ -186,6 +189,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -206,6 +210,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -224,6 +229,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -240,6 +246,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 
@@ -257,6 +264,7 @@ class SentryCacheWrapperTest {
     val span = tx.spans.first()
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
     assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
@@ -274,6 +282,7 @@ class SentryCacheWrapperTest {
     assertTrue(result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4345,6 +4345,7 @@ public abstract interface class io/sentry/SpanDataConvention {
 	public static final field CACHE_HIT_KEY Ljava/lang/String;
 	public static final field CACHE_KEY_KEY Ljava/lang/String;
 	public static final field CACHE_OPERATION_KEY Ljava/lang/String;
+	public static final field CACHE_WRITE Ljava/lang/String;
 	public static final field CALL_STACK_KEY Ljava/lang/String;
 	public static final field CONTRIBUTES_TTFD Ljava/lang/String;
 	public static final field CONTRIBUTES_TTID Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -29,4 +29,5 @@ public interface SpanDataConvention {
   String CACHE_HIT_KEY = "cache.hit";
   String CACHE_KEY_KEY = "cache.key";
   String CACHE_OPERATION_KEY = "cache.operation";
+  String CACHE_WRITE = "cache.write";
 }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op
- [#5228](https://github.com/getsentry/sentry-java/pull/5228) — Add missing cache key assertions and use exact equals

---


## :scroll: Description

Adds a `CACHE_WRITE = "cache.write"` constant to `SpanDataConvention` and sets it on spans across all four cache wrapper implementations (spring, spring-7, spring-jakarta, jcache).

The value reflects whether the operation actually modified the cache:
- Pure reads (`get`, `getAll`, `retrieve`): omitted
- Unconditional writes (`put`, `putAll`, `evict`, `clear`, `invalidate`, `removeAll`): `true`
- Conditional writes (`putIfAbsent`, `replace`, `remove`, `getAndReplace`, `getAndRemove`): based on return value
- Loader-based reads (`get(key, Callable)`, `retrieve(key, Supplier)`): based on whether loader was invoked
- Opaque operations (`invoke`, `invokeAll`): omitted (can't determine if EntryProcessor wrote)

## :bulb: Motivation and Context

Cache tracing spans currently track `cache.hit` for read operations, but there's no equivalent attribute indicating whether an operation actually modified the cache. Adding `cache.write` lets the Sentry UI show write counts/rates and helps users distinguish no-op conditional operations (e.g. `putIfAbsent` when key exists) from actual mutations.

## :green_heart: How did you test it?

- Added `cache.write` assertions to all existing cache wrapper test classes
- All tests pass across sentry-spring, sentry-spring-7, sentry-spring-jakarta, and sentry-jcache

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

#skip-changelog




