### PR TITLE
fix(jcache): [Cache Tracing 19] Use comma-joined keys as span description for bulk operations

### DIFF
--- a/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
+++ b/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
@@ -473,10 +473,8 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
 
   private @Nullable ISpan startSpanForKeys(
       final @NotNull Set<?> keys, final @NotNull String operationName) {
-    return startSpan(
-        operationName,
-        delegate.getName(),
-        keys.stream().map(String::valueOf).collect(Collectors.toList()));
+    final List<String> keyStrings = keys.stream().map(String::valueOf).collect(Collectors.toList());
+    return startSpan(operationName, String.join(", ", keyStrings), keyStrings);
   }
 
   private @Nullable ISpan startSpan(

--- a/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
+++ b/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
@@ -96,7 +96,8 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     val span = tx.spans.first()
     assertEquals("cache.getAll", span.operation)
-    assertEquals("testCache", span.description)
+    assertTrue(span.description!!.contains("k1"))
+    assertTrue(span.description!!.contains("k2"))
     assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
     val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
@@ -165,7 +166,8 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     val span = tx.spans.first()
     assertEquals("cache.putAll", span.operation)
-    assertEquals("testCache", span.description)
+    assertTrue(span.description!!.contains("k1"))
+    assertTrue(span.description!!.contains("k2"))
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
@@ -318,7 +320,8 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     val span = tx.spans.first()
     assertEquals("cache.removeAll", span.operation)
-    assertEquals("testCache", span.description)
+    assertTrue(span.description!!.contains("k1"))
+    assertTrue(span.description!!.contains("k2"))
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("removeAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
   }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---


## :scroll: Description

Fixes span description for JCache bulk operations (`getAll`, `putAll`, `removeAll`, `invokeAll`) to use comma-joined cache keys instead of the cache name.

The [Caches Module spec](https://develop.sentry.dev/sdk/telemetry/traces/modules/caches/) says the span description should be "the cache key(s), separated by commas", e.g. `article1, article2`. The single-key operations already did this correctly, but `startSpanForKeys` was using `delegate.getName()` (the cache name) instead.

## :bulb: Motivation and Context

Align with the Sentry SDK span specification for cache modules. The incorrect description would show the cache name (e.g. "testCache") instead of the actual keys involved in the operation.

## :green_heart: How did you test it?

Updated unit tests for `getAll`, `putAll`, and `removeAll` to verify keys appear in the span description.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue aligning span operations with spec (mapping to canonical 4 ops).

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


#skip-changelog



