### PR TITLE
ref(cache): [Cache Tracing 20] Remove _KEY suffix from cache SpanDataConvention constants

### DIFF
--- a/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
+++ b/sentry-jcache/src/main/java/io/sentry/jcache/SentryJCacheWrapper.java
@@ -57,7 +57,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final V result = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, result != null);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -77,7 +77,7 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
     }
     try {
       final Map<K, V> result = delegate.getAll(keys);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, !result.isEmpty());
+      span.setData(SpanDataConvention.CACHE_HIT, !result.isEmpty());
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -497,9 +497,9 @@ public final class SentryJCacheWrapper<K, V> implements Cache<K, V> {
       return null;
     }
     if (cacheKeys != null) {
-      span.setData(SpanDataConvention.CACHE_KEY_KEY, cacheKeys);
+      span.setData(SpanDataConvention.CACHE_KEY, cacheKeys);
     }
-    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION, operationName);
     return span;
   }
 }

--- a/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
+++ b/sentry-jcache/src/test/kotlin/io/sentry/jcache/SentryJCacheWrapperTest.kt
@@ -61,11 +61,11 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.get", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
     assertEquals("auto.cache.jcache", span.spanContext.origin)
-    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -78,7 +78,7 @@ class SentryJCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   // -- getAll --
@@ -98,10 +98,10 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.getAll", span.operation)
     assertTrue(span.description!!.contains("k1"))
     assertTrue(span.description!!.contains("k2"))
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
-    val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
+    val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
-    assertEquals("getAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("getAll", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -113,7 +113,7 @@ class SentryJCacheWrapperTest {
 
     wrapper.getAll(keys)
 
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   // -- put --
@@ -131,8 +131,8 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- getAndPut --
@@ -149,7 +149,7 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndPut", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("getAndPut", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("getAndPut", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- putAll --
@@ -169,9 +169,9 @@ class SentryJCacheWrapperTest {
     assertTrue(span.description!!.contains("k1"))
     assertTrue(span.description!!.contains("k2"))
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY_KEY) as List<*>
+    val cacheKeys = span.getData(SpanDataConvention.CACHE_KEY) as List<*>
     assertTrue(cacheKeys.containsAll(listOf("k1", "k2")))
-    assertEquals("putAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("putAll", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- putIfAbsent --
@@ -191,8 +191,8 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- replace --
@@ -212,7 +212,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -230,7 +230,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.replace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("replace", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- getAndReplace --
@@ -250,7 +250,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.getAndReplace", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("getAndReplace", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("getAndReplace", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- remove(K) --
@@ -269,7 +269,7 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.remove", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("remove", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("remove", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- remove(K, V) --
@@ -286,7 +286,7 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.remove", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("remove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("remove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- getAndRemove --
@@ -303,7 +303,7 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.getAndRemove", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("getAndRemove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("getAndRemove", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- removeAll(Set) --
@@ -323,7 +323,7 @@ class SentryJCacheWrapperTest {
     assertTrue(span.description!!.contains("k1"))
     assertTrue(span.description!!.contains("k2"))
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("removeAll", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("removeAll", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- removeAll() --
@@ -339,7 +339,7 @@ class SentryJCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.removeAll", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("removeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("removeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- clear --
@@ -357,8 +357,8 @@ class SentryJCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- invoke --
@@ -375,7 +375,7 @@ class SentryJCacheWrapperTest {
     assertEquals("result", result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invoke", tx.spans.first().operation)
-    assertEquals("invoke", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("invoke", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- invokeAll --
@@ -394,7 +394,7 @@ class SentryJCacheWrapperTest {
     assertEquals(resultMap, result)
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invokeAll", tx.spans.first().operation)
-    assertEquals("invokeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("invokeAll", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- passthrough operations --

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -47,7 +47,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, result != null);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -67,7 +67,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, wrapper != null);
+      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
       span.setStatus(SpanStatus.OK);
       return result;
@@ -95,7 +95,7 @@ public final class SentryCacheWrapper implements Cache {
                 loaderInvoked.set(true);
                 return valueLoader.call();
               });
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_HIT, !loaderInvoked.get());
       span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
@@ -124,7 +124,7 @@ public final class SentryCacheWrapper implements Cache {
       throw e;
     }
     if (result == null) {
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, false);
+      span.setData(SpanDataConvention.CACHE_HIT, false);
       span.setStatus(SpanStatus.OK);
       span.finish();
       return null;
@@ -135,7 +135,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setStatus(SpanStatus.INTERNAL_ERROR);
             span.setThrowable(throwable);
           } else {
-            span.setData(SpanDataConvention.CACHE_HIT_KEY, value != null);
+            span.setData(SpanDataConvention.CACHE_HIT, value != null);
             span.setStatus(SpanStatus.OK);
           }
           span.finish();
@@ -171,7 +171,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setStatus(SpanStatus.INTERNAL_ERROR);
             span.setThrowable(throwable);
           } else {
-            span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+            span.setData(SpanDataConvention.CACHE_HIT, !loaderInvoked.get());
             span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
             span.setStatus(SpanStatus.OK);
           }
@@ -319,9 +319,9 @@ public final class SentryCacheWrapper implements Cache {
       return null;
     }
     if (keyString != null) {
-      span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
+      span.setData(SpanDataConvention.CACHE_KEY, Arrays.asList(keyString));
     }
-    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION, operationName);
     return span;
   }
 }

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -60,11 +60,11 @@ class SentryCacheWrapperTest {
     assertEquals("cache.get", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -77,7 +77,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   // -- get(Object key, Class<T>) --
@@ -94,7 +94,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("value", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -109,7 +109,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -123,7 +123,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -155,7 +155,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -173,7 +173,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -193,9 +193,9 @@ class SentryCacheWrapperTest {
     assertEquals("cache.retrieve", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION))
     assertTrue(span.isFinished)
   }
 
@@ -209,7 +209,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result!!.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -224,7 +224,7 @@ class SentryCacheWrapperTest {
     assertNull(result)
     assertEquals(1, tx.spans.size)
     val span = tx.spans.first()
-    assertEquals(false, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, span.getData(SpanDataConvention.CACHE_HIT))
     assertEquals(SpanStatus.OK, span.status)
     assertTrue(span.isFinished)
   }
@@ -290,7 +290,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("cached", result.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
@@ -310,7 +310,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("loaded", result.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
@@ -362,8 +362,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- putIfAbsent --
@@ -383,8 +383,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evict --
@@ -402,7 +402,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evictIfPresent --
@@ -419,7 +419,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- clear --
@@ -437,8 +437,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- invalidate --
@@ -455,7 +455,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- no span when no active transaction --

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -47,7 +47,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, result != null);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -67,7 +67,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, wrapper != null);
+      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
       span.setStatus(SpanStatus.OK);
       return result;
@@ -95,7 +95,7 @@ public final class SentryCacheWrapper implements Cache {
                 loaderInvoked.set(true);
                 return valueLoader.call();
               });
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_HIT, !loaderInvoked.get());
       span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
@@ -124,7 +124,7 @@ public final class SentryCacheWrapper implements Cache {
       throw e;
     }
     if (result == null) {
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, false);
+      span.setData(SpanDataConvention.CACHE_HIT, false);
       span.setStatus(SpanStatus.OK);
       span.finish();
       return null;
@@ -135,7 +135,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setStatus(SpanStatus.INTERNAL_ERROR);
             span.setThrowable(throwable);
           } else {
-            span.setData(SpanDataConvention.CACHE_HIT_KEY, value != null);
+            span.setData(SpanDataConvention.CACHE_HIT, value != null);
             span.setStatus(SpanStatus.OK);
           }
           span.finish();
@@ -171,7 +171,7 @@ public final class SentryCacheWrapper implements Cache {
             span.setStatus(SpanStatus.INTERNAL_ERROR);
             span.setThrowable(throwable);
           } else {
-            span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+            span.setData(SpanDataConvention.CACHE_HIT, !loaderInvoked.get());
             span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
             span.setStatus(SpanStatus.OK);
           }
@@ -319,9 +319,9 @@ public final class SentryCacheWrapper implements Cache {
       return null;
     }
     if (keyString != null) {
-      span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
+      span.setData(SpanDataConvention.CACHE_KEY, Arrays.asList(keyString));
     }
-    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION, operationName);
     return span;
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -60,11 +60,11 @@ class SentryCacheWrapperTest {
     assertEquals("cache.get", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -77,7 +77,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   // -- get(Object key, Class<T>) --
@@ -94,7 +94,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("value", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -109,7 +109,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -123,7 +123,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -155,7 +155,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -173,7 +173,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -193,9 +193,9 @@ class SentryCacheWrapperTest {
     assertEquals("cache.retrieve", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("retrieve", span.getData(SpanDataConvention.CACHE_OPERATION))
     assertTrue(span.isFinished)
   }
 
@@ -209,7 +209,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result!!.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertTrue(tx.spans.first().isFinished)
   }
 
@@ -224,7 +224,7 @@ class SentryCacheWrapperTest {
     assertNull(result)
     assertEquals(1, tx.spans.size)
     val span = tx.spans.first()
-    assertEquals(false, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, span.getData(SpanDataConvention.CACHE_HIT))
     assertEquals(SpanStatus.OK, span.status)
     assertTrue(span.isFinished)
   }
@@ -290,7 +290,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("cached", result.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
@@ -310,7 +310,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("loaded", result.get())
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertTrue(tx.spans.first().isFinished)
   }
@@ -362,8 +362,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- putIfAbsent --
@@ -383,8 +383,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evict --
@@ -402,7 +402,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evictIfPresent --
@@ -419,7 +419,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- clear --
@@ -437,8 +437,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- invalidate --
@@ -455,7 +455,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- no span when no active transaction --

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -45,7 +45,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper result = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, result != null);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {
@@ -65,7 +65,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, wrapper != null);
+      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
       span.setStatus(SpanStatus.OK);
       return result;
@@ -93,7 +93,7 @@ public final class SentryCacheWrapper implements Cache {
                 loaderInvoked.set(true);
                 return valueLoader.call();
               });
-      span.setData(SpanDataConvention.CACHE_HIT_KEY, !loaderInvoked.get());
+      span.setData(SpanDataConvention.CACHE_HIT, !loaderInvoked.get());
       span.setData(SpanDataConvention.CACHE_WRITE, loaderInvoked.get());
       span.setStatus(SpanStatus.OK);
       return result;
@@ -246,9 +246,9 @@ public final class SentryCacheWrapper implements Cache {
       return null;
     }
     if (keyString != null) {
-      span.setData(SpanDataConvention.CACHE_KEY_KEY, Arrays.asList(keyString));
+      span.setData(SpanDataConvention.CACHE_KEY, Arrays.asList(keyString));
     }
-    span.setData(SpanDataConvention.CACHE_OPERATION_KEY, operationName);
+    span.setData(SpanDataConvention.CACHE_OPERATION, operationName);
     return span;
   }
 }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -58,11 +58,11 @@ class SentryCacheWrapperTest {
     assertEquals("cache.get", span.operation)
     assertEquals("myKey", span.description)
     assertEquals(SpanStatus.OK, span.status)
-    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, span.getData(SpanDataConvention.CACHE_HIT))
     assertNull(span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
     assertEquals("auto.cache.spring", span.spanContext.origin)
-    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("get", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   @Test
@@ -75,7 +75,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   // -- get(Object key, Class<T>) --
@@ -92,7 +92,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("value", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -107,7 +107,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -121,7 +121,7 @@ class SentryCacheWrapperTest {
 
     assertNull(result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
   }
 
   @Test
@@ -153,7 +153,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("cached", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -171,7 +171,7 @@ class SentryCacheWrapperTest {
 
     assertEquals("loaded", result)
     assertEquals(1, tx.spans.size)
-    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT_KEY))
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
   }
 
@@ -190,8 +190,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.put", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("put", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- putIfAbsent --
@@ -211,8 +211,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.putIfAbsent", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals(listOf("myKey"), span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("putIfAbsent", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evict --
@@ -230,7 +230,7 @@ class SentryCacheWrapperTest {
     assertEquals("cache.evict", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evict", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- evictIfPresent --
@@ -247,7 +247,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.evictIfPresent", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("evictIfPresent", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- clear --
@@ -265,8 +265,8 @@ class SentryCacheWrapperTest {
     assertEquals("cache.clear", span.operation)
     assertEquals(SpanStatus.OK, span.status)
     assertEquals(true, span.getData(SpanDataConvention.CACHE_WRITE))
-    assertNull(span.getData(SpanDataConvention.CACHE_KEY_KEY))
-    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertNull(span.getData(SpanDataConvention.CACHE_KEY))
+    assertEquals("clear", span.getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- invalidate --
@@ -283,7 +283,7 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
-    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION_KEY))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 
   // -- no span when no active transaction --

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4342,9 +4342,9 @@ public final class io/sentry/SpanContext$JsonKeys {
 
 public abstract interface class io/sentry/SpanDataConvention {
 	public static final field BLOCKED_MAIN_THREAD_KEY Ljava/lang/String;
-	public static final field CACHE_HIT_KEY Ljava/lang/String;
-	public static final field CACHE_KEY_KEY Ljava/lang/String;
-	public static final field CACHE_OPERATION_KEY Ljava/lang/String;
+	public static final field CACHE_HIT Ljava/lang/String;
+	public static final field CACHE_KEY Ljava/lang/String;
+	public static final field CACHE_OPERATION Ljava/lang/String;
 	public static final field CACHE_WRITE Ljava/lang/String;
 	public static final field CALL_STACK_KEY Ljava/lang/String;
 	public static final field CONTRIBUTES_TTFD Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -26,8 +26,8 @@ public interface SpanDataConvention {
   String HTTP_START_TIMESTAMP = "http.start_timestamp";
   String HTTP_END_TIMESTAMP = "http.end_timestamp";
   String PROFILER_ID = "profiler_id";
-  String CACHE_HIT_KEY = "cache.hit";
-  String CACHE_KEY_KEY = "cache.key";
-  String CACHE_OPERATION_KEY = "cache.operation";
+  String CACHE_HIT = "cache.hit";
+  String CACHE_KEY = "cache.key";
+  String CACHE_OPERATION = "cache.operation";
   String CACHE_WRITE = "cache.write";
 }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---

## :scroll: Description

Renames `CACHE_HIT_KEY`, `CACHE_KEY_KEY`, and `CACHE_OPERATION_KEY` to `CACHE_HIT`, `CACHE_KEY`, and `CACHE_OPERATION` in `SpanDataConvention` to match the newer naming convention used by `CACHE_WRITE`, `THREAD_ID`, `FRAMES_TOTAL`, etc.

## :bulb: Motivation and Context

The older constants in `SpanDataConvention` use a `_KEY` suffix (e.g. `DB_SYSTEM_KEY`), but newer additions dropped this pattern. The three cache constants added in earlier stack PRs followed the old convention; this aligns them with the current style alongside `CACHE_WRITE` which was already correct.

## :green_heart: How did you test it?

Rename-only change verified by successful `apiDump` and `spotlessApply`. No logic change.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

#skip-changelog


