### PR TITLE
fix(spring): [Cache Tracing 21] Fix get(key, type) double-call in SentryCacheWrapper

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -66,9 +66,8 @@ public final class SentryCacheWrapper implements Cache {
       return delegate.get(key, type);
     }
     try {
-      final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -86,8 +86,6 @@ class SentryCacheWrapperTest {
   fun `get with type creates span with cache hit true on hit`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
     whenever(delegate.get("myKey", String::class.java)).thenReturn("value")
 
     val result = wrapper.get("myKey", String::class.java)
@@ -98,25 +96,9 @@ class SentryCacheWrapperTest {
   }
 
   @Test
-  fun `get with type creates span with cache hit true when cached value is null`() {
-    val tx = createTransaction()
-    val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
-    whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
-
-    val result = wrapper.get("myKey", String::class.java)
-
-    assertNull(result)
-    assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
-  }
-
-  @Test
   fun `get with type creates span with cache hit false on miss`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    whenever(delegate.get("myKey")).thenReturn(null)
     whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
 
     val result = wrapper.get("myKey", String::class.java)
@@ -131,7 +113,6 @@ class SentryCacheWrapperTest {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     val exception = RuntimeException("cache error")
-    whenever(delegate.get("myKey")).thenReturn(mock<Cache.ValueWrapper>())
     whenever(delegate.get("myKey", String::class.java)).thenThrow(exception)
 
     assertFailsWith<RuntimeException> { wrapper.get("myKey", String::class.java) }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -66,9 +66,8 @@ public final class SentryCacheWrapper implements Cache {
       return delegate.get(key, type);
     }
     try {
-      final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -86,8 +86,6 @@ class SentryCacheWrapperTest {
   fun `get with type creates span with cache hit true on hit`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
     whenever(delegate.get("myKey", String::class.java)).thenReturn("value")
 
     val result = wrapper.get("myKey", String::class.java)
@@ -98,25 +96,9 @@ class SentryCacheWrapperTest {
   }
 
   @Test
-  fun `get with type creates span with cache hit true when cached value is null`() {
-    val tx = createTransaction()
-    val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
-    whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
-
-    val result = wrapper.get("myKey", String::class.java)
-
-    assertNull(result)
-    assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
-  }
-
-  @Test
   fun `get with type creates span with cache hit false on miss`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    whenever(delegate.get("myKey")).thenReturn(null)
     whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
 
     val result = wrapper.get("myKey", String::class.java)
@@ -131,7 +113,6 @@ class SentryCacheWrapperTest {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     val exception = RuntimeException("cache error")
-    whenever(delegate.get("myKey")).thenReturn(mock<Cache.ValueWrapper>())
     whenever(delegate.get("myKey", String::class.java)).thenThrow(exception)
 
     assertFailsWith<RuntimeException> { wrapper.get("myKey", String::class.java) }

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -64,9 +64,8 @@ public final class SentryCacheWrapper implements Cache {
       return delegate.get(key, type);
     }
     try {
-      final ValueWrapper wrapper = delegate.get(key);
-      span.setData(SpanDataConvention.CACHE_HIT, wrapper != null);
       final T result = delegate.get(key, type);
+      span.setData(SpanDataConvention.CACHE_HIT, result != null);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -84,8 +84,6 @@ class SentryCacheWrapperTest {
   fun `get with type creates span with cache hit true on hit`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
     whenever(delegate.get("myKey", String::class.java)).thenReturn("value")
 
     val result = wrapper.get("myKey", String::class.java)
@@ -96,25 +94,9 @@ class SentryCacheWrapperTest {
   }
 
   @Test
-  fun `get with type creates span with cache hit true when cached value is null`() {
-    val tx = createTransaction()
-    val wrapper = SentryCacheWrapper(delegate, scopes)
-    val valueWrapper = mock<Cache.ValueWrapper>()
-    whenever(delegate.get("myKey")).thenReturn(valueWrapper)
-    whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
-
-    val result = wrapper.get("myKey", String::class.java)
-
-    assertNull(result)
-    assertEquals(1, tx.spans.size)
-    assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_HIT))
-  }
-
-  @Test
   fun `get with type creates span with cache hit false on miss`() {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
-    whenever(delegate.get("myKey")).thenReturn(null)
     whenever(delegate.get("myKey", String::class.java)).thenReturn(null)
 
     val result = wrapper.get("myKey", String::class.java)
@@ -129,7 +111,6 @@ class SentryCacheWrapperTest {
     val tx = createTransaction()
     val wrapper = SentryCacheWrapper(delegate, scopes)
     val exception = RuntimeException("cache error")
-    whenever(delegate.get("myKey")).thenReturn(mock<Cache.ValueWrapper>())
     whenever(delegate.get("myKey", String::class.java)).thenThrow(exception)
 
     assertFailsWith<RuntimeException> { wrapper.get("myKey", String::class.java) }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- [#5212](https://github.com/getsentry/sentry-java/pull/5212) — Fix cache evict system test to match actual span op

---
