### PR TITLE
fix(samples): [Cache Tracing 22] Fix cache evict system test to match actual span op

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-4/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-4/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot/src/test/kotlin/io/sentry/systemtest/CacheSystemTest.kt
@@ -45,7 +45,7 @@ class CacheSystemTest {
     restClient.deleteCachedTodo(1L)
 
     testHelper.ensureTransactionReceived { transaction, _ ->
-      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.remove")
+      testHelper.doesTransactionContainSpanWithOp(transaction, "cache.evict")
     }
   }
 }


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5172](https://github.com/getsentry/sentry-java/pull/5172) — Add SentryCacheWrapper and SentryCacheManagerWrapper
- [#5173](https://github.com/getsentry/sentry-java/pull/5173) — Add enableCacheTracing option
- [#5174](https://github.com/getsentry/sentry-java/pull/5174) — Add BeanPostProcessor and auto-configuration
- [#5175](https://github.com/getsentry/sentry-java/pull/5175) — Add cache tracing e2e sample
- [#5179](https://github.com/getsentry/sentry-java/pull/5179) — Add SentryJCacheWrapper for JCache (JSR-107)
- [#5182](https://github.com/getsentry/sentry-java/pull/5182) — Add JCache console sample
- [#5183](https://github.com/getsentry/sentry-java/pull/5183) — Add cache tracing to all Spring Boot 4 samples
- [#5184](https://github.com/getsentry/sentry-java/pull/5184) — Add retrieve() overrides for reactive/async cache support
- [#5190](https://github.com/getsentry/sentry-java/pull/5190) — Port cache tracing to Spring Boot 3 Jakarta + samples
- [#5191](https://github.com/getsentry/sentry-java/pull/5191) — Port cache tracing to Spring Boot 2 + samples
- [#5192](https://github.com/getsentry/sentry-java/pull/5192) — Skip cache span data when child span is NoOp
- [#5201](https://github.com/getsentry/sentry-java/pull/5201) — Add db.operation.name attribute to cache spans
- [#5202](https://github.com/getsentry/sentry-java/pull/5202) — Instrument putIfAbsent, replace, and getAndReplace
- [#5203](https://github.com/getsentry/sentry-java/pull/5203) — Fix cache hit detection for typed get and fix jcache docs link
- [#5204](https://github.com/getsentry/sentry-java/pull/5204) — Use method-specific span operations for cache spans
- [#5205](https://github.com/getsentry/sentry-java/pull/5205) — Merge startSpan helpers into shared core method
- [#5206](https://github.com/getsentry/sentry-java/pull/5206) — Move operation attribute to centralized CACHE_OPERATION_KEY constant
- [#5207](https://github.com/getsentry/sentry-java/pull/5207) — Add cache.write boolean span attribute
- [#5208](https://github.com/getsentry/sentry-java/pull/5208) — Use comma-joined keys as span description for bulk JCache operations
- [#5209](https://github.com/getsentry/sentry-java/pull/5209) — Remove _KEY suffix from cache SpanDataConvention constants
- [#5210](https://github.com/getsentry/sentry-java/pull/5210) — Fix get(key, type) double-call in SentryCacheWrapper
- **This PR** — Fix cache evict system test to match actual span op

---

## :scroll: Description

Updates `CacheSystemTest.cache evict produces span` across all 9 Spring Boot sample modules to check for `cache.evict` instead of `cache.remove`. The test was written expecting the spec op name, but the implementation uses the Spring method name as the span operation.

## :bulb: Motivation and Context

The `cache evict produces span` system test was failing across the entire Spring Boot CI matrix because it asserted `cache.remove` while the code emits `cache.evict`. This is a test/code alignment fix — the non-standard op names are a known issue tracked separately.

## :green_heart: How did you test it?

Test-only change. Updated the assertion in all 9 copies of `CacheSystemTest.kt`.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.


#skip-changelog

