### PR TITLE
fix(replay): Allow STARTED -> RESUMED state transition in ReplayLifecycle

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayLifecycle.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayLifecycle.kt
@@ -46,7 +46,8 @@ internal class ReplayLifecycle {
     when (currentState) {
       ReplayState.INITIAL -> newState == ReplayState.STARTED || newState == ReplayState.CLOSED
       ReplayState.STARTED ->
-        newState == ReplayState.PAUSED ||
+        newState == ReplayState.RESUMED ||
+          newState == ReplayState.PAUSED ||
           newState == ReplayState.STOPPED ||
           newState == ReplayState.CLOSED
       ReplayState.RESUMED ->

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -421,6 +421,33 @@ class ReplayIntegrationTest {
   }
 
   @Test
+  fun `after stop, start and resume restarts replay`() {
+    val captureStrategy = mock<CaptureStrategy>()
+    val recorder = mock<Recorder>()
+    val replay =
+      fixture.getSut(
+        context,
+        recorderProvider = { recorder },
+        replayCaptureStrategyProvider = { captureStrategy },
+      )
+
+    replay.register(fixture.scopes, fixture.options)
+    replay.start()
+    replay.pause()
+    replay.stop()
+
+    assertFalse(replay.isRecording)
+
+    replay.start()
+    replay.resume()
+
+    assertTrue(replay.isRecording)
+    verify(captureStrategy, times(2)).start(any(), any(), anyOrNull())
+    verify(captureStrategy).resume()
+    verify(recorder).resume()
+  }
+
+  @Test
   fun `close cleans up resources`() {
     val recorder = mock<Recorder>()
     val captureStrategy = mock<CaptureStrategy>()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayLifecycleTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayLifecycleTest.kt
@@ -29,11 +29,11 @@ class ReplayLifecycleTest {
     val lifecycle = ReplayLifecycle()
     lifecycle.currentState = ReplayState.STARTED
 
+    assertTrue(lifecycle.isAllowed(ReplayState.RESUMED))
     assertTrue(lifecycle.isAllowed(ReplayState.PAUSED))
     assertTrue(lifecycle.isAllowed(ReplayState.STOPPED))
     assertTrue(lifecycle.isAllowed(ReplayState.CLOSED))
 
-    assertFalse(lifecycle.isAllowed(ReplayState.RESUMED))
     assertFalse(lifecycle.isAllowed(ReplayState.INITIAL))
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## :scroll: Description

Fix a bug in the `ReplayLifecycle` state machine where the `STARTED -> RESUMED` transition was not allowed. This caused the replay to not properly resume after the app returned to foreground following a session timeout in the background.

## :bulb: Motivation and Context

When the app goes to background for longer than `sessionIntervalMillis`:
1. The timer fires and calls `replayController.stop()` → state becomes `STOPPED`
2. When the app returns to foreground, `LifecycleWatcher.startSession()` calls `replayController.start()` → state becomes `STARTED`
3. Immediately after, it calls `replayController.resume()` → this **failed** because the state machine did not allow `STARTED → RESUMED`

The recording still partially worked through the root view listener path (which triggers `onConfigurationChanged`), but the lifecycle state was incorrect (stuck at `STARTED` instead of `RESUMED`), and `captureStrategy.resume()` / `recorder.resume()` were never called.

The fix adds `RESUMED` as a valid transition from the `STARTED` state in `ReplayLifecycle`.

## :green_heart: How did you test it?

- Updated `ReplayLifecycleTest` to verify `STARTED -> RESUMED` is now allowed
- Added a new test `after stop, start and resume restarts replay` in `ReplayIntegrationTest` that verifies the full stop → start → resume flow works correctly
- Ran existing `LifecycleWatcherTest`, `ReplayLifecycleTest`, and `ReplayIntegrationTest` — all pass

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f76dff3-3878-45ae-9dc8-938fb6882d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f76dff3-3878-45ae-9dc8-938fb6882d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

