### PR TITLE
chore(ci): Fix app overhead metrics action failing because of Appium version

### DIFF
--- a/.github/workflows/integration-tests-benchmarks.yml
+++ b/.github/workflows/integration-tests-benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
         run: ./gradlew :sentry-android-integration-tests:test-app-sentry:assembleRelease
 
       - name: Collect app metrics
-        uses: getsentry/action-app-sdk-overhead-metrics@5f2d99b8e5a7b833386524924d24320501099a44
+        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
         with:
           config: sentry-android-integration-tests/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
_#skip-changelog_