### PR TITLE
chore(pi): Add pi settings for local skills

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,6 @@
+{
+  "skills": [
+    "../.claude/skills"
+  ],
+  "enableSkillCommands": true
+}


### PR DESCRIPTION
## :scroll: Description
Add `.pi/settings.json` to register local skill discovery for this repository and enable skill commands in pi sessions.

## :bulb: Motivation and Context
Keeps the repo-local pi configuration checked in so sessions in this repository consistently load `../.claude/skills` and support skill commands without per-machine setup.

## :green_heart: How did you test it?
- Ran `./gradlew spotlessApply apiDump` successfully (using Java 17)

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
