### PR TITLE
fix(skill): Detect stacked PR context from branch

### DIFF
--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -40,7 +40,8 @@ git branch --show-current
     ```bash
     gh pr list --base "$(git branch --show-current)" --json number,headRefName,title
     ```
-    If there are downstream PRs, treat this as **next PR in an existing stack** with the current branch as the stack base (collection branch).
+    - If there are downstream PRs, treat this as **next PR in an existing stack** with the current branch as the stack base (collection branch).
+    - If there are no downstream PRs either, treat it as **standalone PR context** (fresh feature branch).
 
 3. If signals are mixed or ambiguous, ask one focused question to confirm.
 

--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -34,20 +34,20 @@ git branch --show-current
     ```bash
     gh pr list --base "$(git branch --show-current)" --json number,headRefName,title
     ```
-    - If there are downstream PRs, treat this as a **stack base context** (collection branch).
+    - If there are downstream PRs, treat this as **next PR in an existing stack** with the current branch as the stack base (collection branch).
     - If there are no downstream PRs, treat it as **standalone PR context**.
   - If no PR exists for the current branch, check whether other PRs target it:
     ```bash
     gh pr list --base "$(git branch --show-current)" --json number,headRefName,title
     ```
-    If there are downstream PRs, treat this as a stack base context.
+    If there are downstream PRs, treat this as **next PR in an existing stack** with the current branch as the stack base (collection branch).
 
 3. If signals are mixed or ambiguous, ask one focused question to confirm.
 
 PR types:
 - **Standalone PR** — regular PR targeting `main`.
 - **First PR of a new stack** — create collection branch from `main`, then first PR off it.
-- **Next PR in an existing stack** — target previous stack branch.
+- **Next PR in an existing stack** — target the current stack base branch (usually the previous stack PR branch, or the collection branch if creating the first follow-up PR from the collection branch).
 
 If the user explicitly says "stack", "stacked PR", or provides numbered stack titles (e.g. `[Topic 2]`), honor that even if branch heuristics are inconclusive.
 

--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -9,15 +9,42 @@ Prepare local changes and create a pull request for the sentry-java repo.
 
 **Required reading:** Before proceeding, read `.cursor/rules/pr.mdc` for the full PR and stacked PR workflow details. That file is the source of truth for PR conventions, stack comment format, branch naming, and merge strategy.
 
-## Step 0: Determine PR Type
+## Step 0: Determine PR Type From Git Branch Context
 
-Ask the user (or infer from context) whether this is:
+Infer PR type from the current branch before asking the user.
 
-- **Standalone PR** — a regular PR targeting `main`. Follow Steps 1–6 as written.
-- **First PR of a new stack** — ask for a topic name (e.g. "Global Attributes"). Create a collection branch from `main`, then branch the first PR off it. The first PR targets the collection branch.
-- **Next PR in an existing stack** — identify the previous stack branch and topic. This PR targets the previous stack branch.
+1. Get current branch:
 
-If the user mentions "stack", "stacked PR", or provides a topic name with a number (e.g. `[Topic 2]`), treat it as a stacked PR. See `.cursor/rules/pr.mdc` § "Stacked PRs" for full details.
+```bash
+git branch --show-current
+```
+
+2. Apply these rules:
+
+- **If branch is `main` or `master`**: default to a **standalone PR**.
+  - Do **not** assume stack mode from `main`.
+  - Only use stack mode if the user explicitly asks for a stacked PR.
+- **If branch is not `main`/`master`**:
+  - Check whether that branch already has a PR and what its base is:
+    ```bash
+    gh pr list --head "$(git branch --show-current)" --json number,baseRefName,title --jq '.[0]'
+    ```
+  - If that branch PR exists and `baseRefName` is **not** `main`/`master`, treat the work as a **stacked PR context**.
+  - If that branch PR exists and `baseRefName` **is** `main`/`master`, treat it as **standalone PR context**.
+  - If no PR exists for the current branch, check whether other PRs target it:
+    ```bash
+    gh pr list --base "$(git branch --show-current)" --json number,headRefName,title
+    ```
+    If there are downstream PRs, treat this as a stack base context.
+
+3. If signals are mixed or ambiguous, ask one focused question to confirm.
+
+PR types:
+- **Standalone PR** — regular PR targeting `main`.
+- **First PR of a new stack** — create collection branch from `main`, then first PR off it.
+- **Next PR in an existing stack** — target previous stack branch.
+
+If the user explicitly says "stack", "stacked PR", or provides numbered stack titles (e.g. `[Topic 2]`), honor that even if branch heuristics are inconclusive.
 
 ## Step 1: Ensure Feature Branch
 

--- a/.claude/skills/create-java-pr/SKILL.md
+++ b/.claude/skills/create-java-pr/SKILL.md
@@ -30,7 +30,12 @@ git branch --show-current
     gh pr list --head "$(git branch --show-current)" --json number,baseRefName,title --jq '.[0]'
     ```
   - If that branch PR exists and `baseRefName` is **not** `main`/`master`, treat the work as a **stacked PR context**.
-  - If that branch PR exists and `baseRefName` **is** `main`/`master`, treat it as **standalone PR context**.
+  - If that branch PR exists and `baseRefName` **is** `main`/`master`, also check whether other PRs target the current branch:
+    ```bash
+    gh pr list --base "$(git branch --show-current)" --json number,headRefName,title
+    ```
+    - If there are downstream PRs, treat this as a **stack base context** (collection branch).
+    - If there are no downstream PRs, treat it as **standalone PR context**.
   - If no PR exists for the current branch, check whether other PRs target it:
     ```bash
     gh pr list --base "$(git branch --show-current)" --json number,headRefName,title


### PR DESCRIPTION
## :scroll: Description
Improve the local `create-java-pr` skill so it determines whether to run in standalone or stacked PR mode from git context.

The skill now checks the current branch and existing PR relationships to infer stack context, instead of relying on manual prompting.


## :bulb: Motivation and Context
When the workflow starts on `main`, it should default to a normal PR against `main` and not accidentally assume stacked PR behavior.

This change makes that default explicit and still allows stacked mode when the user asks for it.


## :green_heart: How did you test it?
- Ran `./gradlew spotlessApply apiDump` successfully (using JDK 17 locally)
- Verified the updated skill content and git diff


## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
- Use the updated skill in future PR prep flows and refine heuristics if new branch patterns appear.

#skip-changelog
