### PR TITLE
chore(skills): Add .agents symlink for Claude skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## :scroll: Description
Add a project-local `.agents/skills` symlink to `.claude/skills`.

This allows pi to discover repo skills using its built-in `.agents/skills` project discovery path without requiring a per-repo `.pi/settings.json`.

## :bulb: Motivation and Context
We want repository-scoped skill discovery without globally loading skills from unrelated repositories and without editing settings in each repo.

Using `.agents/skills` keeps discovery local to the current repository while continuing to author skills under `.claude/skills`.

## :green_heart: How did you test it?
- Ran `./gradlew spotlessApply apiDump` successfully.
- Verified symlink target: `.agents/skills -> ../.claude/skills`.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- If desired, replicate this symlink pattern in other repos that keep skills under `.claude/skills`.

#skip-changelog
