### PR TITLE
chore(repo): Ignore .factorypath and local Claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ local.properties
 **/sentry-native-local
 target/
 .classpath
+.factorypath
 .project
 .settings/
 bin/
@@ -30,5 +31,6 @@ spy.log
 **/tomcat.8080/webapps/
 **/__pycache__
 
-# Local Claude Code settings that should not be committed
+# Local Claude Code settings/state that should not be committed
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## :scroll: Description
- Add `.factorypath` to `.gitignore`
- Add `.claude/worktrees/` to `.gitignore`
- Keep existing tracked `.claude` project files unaffected

## :bulb: Motivation and Context
Local IDE and Claude worktree state files should stay untracked and out of commits.

## :green_heart: How did you test it?
- Ran `./gradlew spotlessApply apiDump` successfully

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- Merge if this ignore-list update looks good.

#skip-changelog
