### PR TITLE
fix(spring): [Cache Tracing 24] Track invalidate cache.write accurately

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/cache/SentryCacheWrapper.java
@@ -287,7 +287,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
-      span.setData(SpanDataConvention.CACHE_WRITE, true);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/cache/SentryCacheWrapperTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.mockito.kotlin.any
@@ -447,6 +448,21 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
+  }
+
+  @Test
+  fun `invalidate sets cache write false when cache had no mappings`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.invalidate()).thenReturn(false)
+
+    val result = wrapper.invalidate()
+
+    assertFalse(result)
+    assertEquals(1, tx.spans.size)
+    assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/cache/SentryCacheWrapper.java
@@ -287,7 +287,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
-      span.setData(SpanDataConvention.CACHE_WRITE, true);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/cache/SentryCacheWrapperTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.mockito.kotlin.any
@@ -447,6 +448,21 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
+  }
+
+  @Test
+  fun `invalidate sets cache write false when cache had no mappings`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.invalidate()).thenReturn(false)
+
+    val result = wrapper.invalidate()
+
+    assertFalse(result)
+    assertEquals(1, tx.spans.size)
+    assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 

--- a/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/cache/SentryCacheWrapper.java
@@ -214,7 +214,7 @@ public final class SentryCacheWrapper implements Cache {
     }
     try {
       final boolean result = delegate.invalidate();
-      span.setData(SpanDataConvention.CACHE_WRITE, true);
+      span.setData(SpanDataConvention.CACHE_WRITE, result);
       span.setStatus(SpanStatus.OK);
       return result;
     } catch (Throwable e) {

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/cache/SentryCacheWrapperTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.mockito.kotlin.any
@@ -271,6 +272,21 @@ class SentryCacheWrapperTest {
     assertEquals(1, tx.spans.size)
     assertEquals("cache.invalidate", tx.spans.first().operation)
     assertEquals(true, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
+    assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
+  }
+
+  @Test
+  fun `invalidate sets cache write false when cache had no mappings`() {
+    val tx = createTransaction()
+    val wrapper = SentryCacheWrapper(delegate, scopes)
+    whenever(delegate.invalidate()).thenReturn(false)
+
+    val result = wrapper.invalidate()
+
+    assertFalse(result)
+    assertEquals(1, tx.spans.size)
+    assertEquals("cache.invalidate", tx.spans.first().operation)
+    assertEquals(false, tx.spans.first().getData(SpanDataConvention.CACHE_WRITE))
     assertEquals("invalidate", tx.spans.first().getData(SpanDataConvention.CACHE_OPERATION))
   }
 


### PR DESCRIPTION
## PR Stack (Cache Tracing)

- [#5165](https://github.com/getsentry/sentry-java/pull/5165) — Collection PR
- (this PR) [Cache Tracing 24] Track invalidate cache.write accurately

> Note: All previous Cache Tracing stack PRs (#5172–#5228) have already been merged into the collection branch.

---

## :scroll: Description
This fixes cache span data correctness for `invalidate()` across Spring cache wrappers (`sentry-spring`, `sentry-spring-jakarta`, and `sentry-spring-7`).

Previously, `cache.write` was always set to `true` after `delegate.invalidate()`, even when `invalidate()` returned `false` (no mappings were present or presence could not be determined). This PR sets `cache.write` to the actual returned boolean.

It also adds regression tests in all three wrapper test suites to verify the `false` path.

## :bulb: Motivation and Context
During PR review, we found that span data could over-report writes for cache flush operations. This makes span attributes less trustworthy for downstream analysis.

This change aligns span data with Spring's documented `Cache.invalidate()` semantics.

## :green_heart: How did you test it?
- `./gradlew :sentry-spring:test --tests="*SentryCacheWrapperTest*" :sentry-spring-jakarta:test --tests="*SentryCacheWrapperTest*" :sentry-spring-7:test --tests="*SentryCacheWrapperTest*"`
- Added new test case in each module: `invalidate sets cache write false when cache had no mappings`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- Merge into the collection branch and include this fix in the final squash merge of `feat/cache-tracing` to `main`.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
