### PR TITLE
feat(feedback): Add runtime toggle for shake-to-report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Features
 
+- Add `Sentry.enableFeedbackOnShake()` and `Sentry.disableFeedbackOnShake()` for runtime control of shake-to-report ([#5232](https://github.com/getsentry/sentry-java/pull/5232))
 - Add configurable `IScopesStorageFactory` to `SentryOptions` for providing a custom `IScopesStorage`, e.g. when the default `ThreadLocal`-backed storage is incompatible with non-pinning thread models ([#5199](https://github.com/getsentry/sentry-java/pull/5199))
 - Android: Add `beforeErrorSampling` callback to Session Replay ([#5214](https://github.com/getsentry/sentry-java/pull/5214))
   - Allows filtering which errors trigger replay capture before the `onErrorSampleRate` is checked

--- a/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
@@ -44,21 +44,17 @@ public final class FeedbackShakeIntegration
                 : null,
             "SentryAndroidOptions is required");
 
-    if (!this.options.getFeedbackOptions().isUseShakeGesture()) {
-      return;
-    }
-
-    shakeDetector.init(application, options.getLogger());
-
     addIntegrationToSdkVersion("FeedbackShake");
     application.registerActivityLifecycleCallbacks(this);
     options.getLogger().log(SentryLevel.DEBUG, "FeedbackShakeIntegration installed.");
 
-    // In case of a deferred init, hook into any already-resumed activity
-    final @Nullable Activity activity = CurrentActivityHolder.getInstance().getActivity();
-    if (activity != null) {
-      currentActivityRef = new WeakReference<>(activity);
-      startShakeDetection(activity);
+    if (this.options.getFeedbackOptions().isUseShakeGesture()) {
+      // In case of a deferred init, hook into any already-resumed activity
+      final @Nullable Activity activity = CurrentActivityHolder.getInstance().getActivity();
+      if (activity != null) {
+        currentActivityRef = new WeakReference<>(activity);
+        startShakeDetection(activity);
+      }
     }
   }
 
@@ -92,7 +88,12 @@ public final class FeedbackShakeIntegration
       previousOnFormClose = null;
     }
     currentActivityRef = new WeakReference<>(activity);
-    startShakeDetection(activity);
+    // Check dynamically so the flag can be toggled at runtime
+    if (options != null && options.getFeedbackOptions().isUseShakeGesture()) {
+      startShakeDetection(activity);
+    } else {
+      stopShakeDetection();
+    }
   }
 
   @Override
@@ -146,6 +147,8 @@ public final class FeedbackShakeIntegration
     if (options == null) {
       return;
     }
+    // Initialize sensor and thread if not already done (idempotent)
+    shakeDetector.init(application, options.getLogger());
     // Stop any existing detection (e.g. when transitioning between activities)
     stopShakeDetection();
     shakeDetector.start(
@@ -156,6 +159,7 @@ public final class FeedbackShakeIntegration
           final Boolean inBackground = AppState.getInstance().isInBackground();
           if (active != null
               && options != null
+              && options.getFeedbackOptions().isUseShakeGesture()
               && !isDialogShowing
               && !Boolean.TRUE.equals(inBackground)) {
             active.runOnUiThread(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -50,11 +49,11 @@ class FeedbackShakeIntegrationTest {
   }
 
   @Test
-  fun `when useShakeGesture is disabled does not register activity lifecycle callbacks`() {
+  fun `when useShakeGesture is disabled still registers activity lifecycle callbacks for runtime toggle`() {
     val sut = fixture.getSut(useShakeGesture = false)
     sut.register(fixture.scopes, fixture.options)
 
-    verify(fixture.application, never()).registerActivityLifecycleCallbacks(any())
+    verify(fixture.application).registerActivityLifecycleCallbacks(any())
   }
 
   @Test
@@ -102,5 +101,35 @@ class FeedbackShakeIntegrationTest {
   fun `close without register does not crash`() {
     val sut = fixture.getSut()
     sut.close()
+  }
+
+  @Test
+  fun `enabling shake at runtime starts detection on next activity resume`() {
+    val sut = fixture.getSut(useShakeGesture = false)
+    sut.register(fixture.scopes, fixture.options)
+
+    whenever(fixture.activity.getSystemService(any())).thenReturn(null)
+
+    // Shake is disabled, onActivityResumed should not crash
+    sut.onActivityResumed(fixture.activity)
+
+    // Now enable at runtime and resume a new activity
+    fixture.options.feedbackOptions.isUseShakeGesture = true
+    sut.onActivityResumed(fixture.activity)
+    // Should not throw — shake detection attempted (fails gracefully with null SensorManager)
+  }
+
+  @Test
+  fun `disabling shake at runtime stops detection on next activity resume`() {
+    val sut = fixture.getSut(useShakeGesture = true)
+    sut.register(fixture.scopes, fixture.options)
+
+    whenever(fixture.activity.getSystemService(any())).thenReturn(null)
+    sut.onActivityResumed(fixture.activity)
+
+    // Disable at runtime and resume
+    fixture.options.feedbackOptions.isUseShakeGesture = false
+    sut.onActivityResumed(fixture.activity)
+    // Should not throw — detection stopped gracefully
   }
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2705,7 +2705,9 @@ public final class io/sentry/Sentry {
 	public static fun configureScope (Lio/sentry/ScopeCallback;)V
 	public static fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public static fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
+	public static fun disableFeedbackOnShake ()V
 	public static fun distribution ()Lio/sentry/IDistributionApi;
+	public static fun enableFeedbackOnShake ()V
 	public static fun endSession ()V
 	public static fun flush (J)V
 	public static fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1372,6 +1372,24 @@ public final class Sentry {
   }
 
   /**
+   * Enables shake-to-report for user feedback. When enabled, shaking the device will show the
+   * feedback dialog. Takes effect on the next activity transition. This can be toggled at runtime.
+   */
+  @ApiStatus.Experimental
+  public static void enableFeedbackOnShake() {
+    getCurrentScopes().getOptions().getFeedbackOptions().setUseShakeGesture(true);
+  }
+
+  /**
+   * Disables shake-to-report for user feedback. Takes effect on the next activity transition. If a
+   * shake occurs before the transition, the dialog will not be shown.
+   */
+  @ApiStatus.Experimental
+  public static void disableFeedbackOnShake() {
+    getCurrentScopes().getOptions().getFeedbackOptions().setUseShakeGesture(false);
+  }
+
+  /**
    * Sets an attribute on the scope.
    *
    * @param key the key


### PR DESCRIPTION
## :scroll: Description

Add `Sentry.enableFeedbackOnShake()` and `Sentry.disableFeedbackOnShake()` static methods for runtime control of shake gesture detection, matching the [React Native API](https://docs.sentry.io/platforms/react-native/user-feedback/#shake-to-report).

The integration now always registers lifecycle callbacks and checks the `useShakeGesture` flag dynamically on each activity transition. When disabled, there is zero overhead — no sensor registration, no thread allocation.

**Changes:**
- `FeedbackShakeIntegration`: always registers lifecycle callbacks, checks `isUseShakeGesture()` dynamically in `onActivityResumed` and in the shake callback
- `SentryShakeDetector.init()`: deferred to first `startShakeDetection()` call (lazy initialization)
- `Sentry.java`: added `enableFeedbackOnShake()` / `disableFeedbackOnShake()` convenience methods
- Updated test to reflect always-register behavior

## :bulb: Motivation and Context

Users want to enable/disable shake-to-report at runtime (e.g., only in certain screens or for specific user roles) without restarting the app. This mirrors the existing React Native API.

Stacked on #5150.

## :green_heart: How did you test it?

- All unit tests pass (`FeedbackShakeIntegrationTest`, `SentryShakeDetectorTest`, `SentryAndroidTest`, `ManifestMetadataReaderTest`)
- Lint and API checks pass
- Tested on physical device (Pixel 8 Pro) via sample app with shake gesture enabled via manifest

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- Update docs to document the new `enableFeedbackOnShake()` / `disableFeedbackOnShake()` API
- Add changelog entry once approved