### PR TITLE
ci: Bump Spring Boot versions in CI matrix

### DIFF
--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '3.0.0', '3.2.10', '3.3.5', '3.4.5', '3.5.6' ]
+        springboot-version: [ '3.0.0', '3.2.12', '3.3.13', '3.4.13', '3.5.13' ]
 
     name: Spring Boot ${{ matrix.springboot-version }}
     env:

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '4.0.0' ]
+        springboot-version: [ '4.0.0', '4.0.5' ]
 
     name: Spring Boot ${{ matrix.springboot-version }}
     env:


### PR DESCRIPTION
## :scroll: Description

Bump Spring Boot patch versions in CI matrix to latest available releases.

**Spring Boot 3.x:**
- 3.2.10 → 3.2.12
- 3.3.5 → 3.3.13
- 3.4.5 → 3.4.13
- 3.5.6 → 3.5.13

**Spring Boot 4.x:**
- Add 4.0.5 (alongside existing 4.0.0)

Spring Boot 2.x matrix unchanged — all versions are already at their final patch releases.

## :bulb: Motivation and Context

Keep CI testing against the latest patch releases of each Spring Boot minor version.

## :green_heart: How did you test it?

CI will validate.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
