### PR TITLE
ci: Add Spring Boot 4.1.0-M4 milestone to CI matrix

### DIFF
--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '4.0.0' ]
+        springboot-version: [ '4.0.0', '4.1.0-M4' ]
 
     name: Spring Boot ${{ matrix.springboot-version }}
     env:


### PR DESCRIPTION
## :scroll: Description

Add Spring Boot 4.1.0-M4 (latest milestone) to the 4.x CI matrix to catch compatibility issues early before GA.

## :bulb: Motivation and Context

Spring Boot 4.1 is in milestone phase. Testing against it now surfaces breaking changes early so we can prepare ahead of the GA release.

## :green_heart: How did you test it?

CI will validate.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
