### PR TITLE
chore: bump action-app-sdk-overhead-metrics SHA

### DIFF
--- a/.github/workflows/integration-tests-benchmarks.yml
+++ b/.github/workflows/integration-tests-benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
         run: ./gradlew :sentry-android-integration-tests:test-app-sentry:assembleRelease
 
       - name: Collect app metrics
-        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
+        uses: getsentry/action-app-sdk-overhead-metrics@44fb5489ac4ac252c87d84811972dc93a1e490b8
         with:
           config: sentry-android-integration-tests/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
## Description

Bump `getsentry/action-app-sdk-overhead-metrics` to `44fb5489ac4ac252c87d84811972dc93a1e490b8`.

This improves the workflow iteration to filter on the backend instead of locally, which should reduce flakiness when downloading previous data.

See: https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/30

#skip-changelog