### PR TITLE
feat(core): [Queue Instrumentation 1] Add enableQueueTracing option and messaging span data conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `enableQueueTracing` option and messaging span data conventions ([#5250](https://github.com/getsentry/sentry-java/pull/5250))
 - Prevent cross-organization trace continuation ([#5136](https://github.com/getsentry/sentry-java/pull/5136))
   - By default, the SDK now extracts the organization ID from the DSN (e.g. `o123.ingest.sentry.io`) and compares it with the `sentry-org_id` value in incoming baggage headers. When the two differ, the SDK starts a fresh trace instead of continuing the foreign one. This guards against accidentally linking traces across organizations.
   - New option `enableStrictTraceContinuation` (default `false`): when enabled, both the SDK's org ID **and** the incoming baggage org ID must be present and match for a trace to be continued. Traces with a missing org ID on either side are rejected. Configurable via code (`setStrictTraceContinuation(true)`), `sentry.properties` (`enable-strict-trace-continuation=true`), Android manifest (`io.sentry.strict-trace-continuation.enabled`), or Spring Boot (`sentry.strict-trace-continuation=true`).

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -529,6 +529,7 @@ public final class io/sentry/ExternalOptions {
 	public fun isEnableLogs ()Ljava/lang/Boolean;
 	public fun isEnableMetrics ()Ljava/lang/Boolean;
 	public fun isEnablePrettySerializationOutput ()Ljava/lang/Boolean;
+	public fun isEnableQueueTracing ()Ljava/lang/Boolean;
 	public fun isEnableSpotlight ()Ljava/lang/Boolean;
 	public fun isEnabled ()Ljava/lang/Boolean;
 	public fun isForceInit ()Ljava/lang/Boolean;
@@ -548,6 +549,7 @@ public final class io/sentry/ExternalOptions {
 	public fun setEnableLogs (Ljava/lang/Boolean;)V
 	public fun setEnableMetrics (Ljava/lang/Boolean;)V
 	public fun setEnablePrettySerializationOutput (Ljava/lang/Boolean;)V
+	public fun setEnableQueueTracing (Ljava/lang/Boolean;)V
 	public fun setEnableSpotlight (Ljava/lang/Boolean;)V
 	public fun setEnableUncaughtExceptionHandler (Ljava/lang/Boolean;)V
 	public fun setEnabled (Ljava/lang/Boolean;)V
@@ -3688,6 +3690,7 @@ public class io/sentry/SentryOptions {
 	public fun isEnableEventSizeLimiting ()Z
 	public fun isEnableExternalConfiguration ()Z
 	public fun isEnablePrettySerializationOutput ()Z
+	public fun isEnableQueueTracing ()Z
 	public fun isEnableScopePersistence ()Z
 	public fun isEnableScreenTracking ()Z
 	public fun isEnableShutdownHook ()Z
@@ -3748,6 +3751,7 @@ public class io/sentry/SentryOptions {
 	public fun setEnableEventSizeLimiting (Z)V
 	public fun setEnableExternalConfiguration (Z)V
 	public fun setEnablePrettySerializationOutput (Z)V
+	public fun setEnableQueueTracing (Z)V
 	public fun setEnableScopePersistence (Z)V
 	public fun setEnableScreenTracking (Z)V
 	public fun setEnableShutdownHook (Z)V
@@ -4392,6 +4396,12 @@ public abstract interface class io/sentry/SpanDataConvention {
 	public static final field HTTP_RESPONSE_CONTENT_LENGTH_KEY Ljava/lang/String;
 	public static final field HTTP_START_TIMESTAMP Ljava/lang/String;
 	public static final field HTTP_STATUS_CODE_KEY Ljava/lang/String;
+	public static final field MESSAGING_DESTINATION_NAME Ljava/lang/String;
+	public static final field MESSAGING_MESSAGE_BODY_SIZE Ljava/lang/String;
+	public static final field MESSAGING_MESSAGE_ID Ljava/lang/String;
+	public static final field MESSAGING_MESSAGE_RECEIVE_LATENCY Ljava/lang/String;
+	public static final field MESSAGING_MESSAGE_RETRY_COUNT Ljava/lang/String;
+	public static final field MESSAGING_SYSTEM Ljava/lang/String;
 	public static final field PROFILER_ID Ljava/lang/String;
 	public static final field THREAD_ID Ljava/lang/String;
 	public static final field THREAD_NAME Ljava/lang/String;

--- a/sentry/src/main/java/io/sentry/ExternalOptions.java
+++ b/sentry/src/main/java/io/sentry/ExternalOptions.java
@@ -58,6 +58,7 @@ public final class ExternalOptions {
   private @Nullable Boolean enableBackpressureHandling;
   private @Nullable Boolean enableDatabaseTransactionTracing;
   private @Nullable Boolean enableCacheTracing;
+  private @Nullable Boolean enableQueueTracing;
   private @Nullable Boolean globalHubMode;
   private @Nullable Boolean forceInit;
   private @Nullable Boolean captureOpenTelemetryEvents;
@@ -167,6 +168,8 @@ public final class ExternalOptions {
         propertiesProvider.getBooleanProperty("enable-database-transaction-tracing"));
 
     options.setEnableCacheTracing(propertiesProvider.getBooleanProperty("enable-cache-tracing"));
+
+    options.setEnableQueueTracing(propertiesProvider.getBooleanProperty("enable-queue-tracing"));
 
     options.setGlobalHubMode(propertiesProvider.getBooleanProperty("global-hub-mode"));
 
@@ -539,6 +542,14 @@ public final class ExternalOptions {
 
   public @Nullable Boolean isEnableCacheTracing() {
     return enableCacheTracing;
+  }
+
+  public void setEnableQueueTracing(final @Nullable Boolean enableQueueTracing) {
+    this.enableQueueTracing = enableQueueTracing;
+  }
+
+  public @Nullable Boolean isEnableQueueTracing() {
+    return enableQueueTracing;
   }
 
   public void setGlobalHubMode(final @Nullable Boolean globalHubMode) {

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -508,6 +508,9 @@ public class SentryOptions {
   /** Whether cache operations (get, put, remove, flush) should be traced. */
   private boolean enableCacheTracing = false;
 
+  /** Whether queue operations (publish, process) should be traced. */
+  private boolean enableQueueTracing = false;
+
   /** Date provider to retrieve the current date from. */
   @ApiStatus.Internal
   private final @NotNull LazyEvaluator<SentryDateProvider> dateProvider =
@@ -2705,6 +2708,24 @@ public class SentryOptions {
   }
 
   /**
+   * Whether queue operations (publish, process) should be traced.
+   *
+   * @return true if queue operations should be traced
+   */
+  public boolean isEnableQueueTracing() {
+    return enableQueueTracing;
+  }
+
+  /**
+   * Whether queue operations (publish, process) should be traced.
+   *
+   * @param enableQueueTracing true if queue operations should be traced
+   */
+  public void setEnableQueueTracing(boolean enableQueueTracing) {
+    this.enableQueueTracing = enableQueueTracing;
+  }
+
+  /**
    * Whether Sentry is enabled.
    *
    * @return true if Sentry should be enabled
@@ -3544,6 +3565,9 @@ public class SentryOptions {
     }
     if (options.isEnableCacheTracing() != null) {
       setEnableCacheTracing(options.isEnableCacheTracing());
+    }
+    if (options.isEnableQueueTracing() != null) {
+      setEnableQueueTracing(options.isEnableQueueTracing());
     }
     if (options.getMaxRequestBodySize() != null) {
       setMaxRequestBodySize(options.getMaxRequestBodySize());

--- a/sentry/src/main/java/io/sentry/SpanDataConvention.java
+++ b/sentry/src/main/java/io/sentry/SpanDataConvention.java
@@ -30,4 +30,10 @@ public interface SpanDataConvention {
   String CACHE_KEY = "cache.key";
   String CACHE_OPERATION = "cache.operation";
   String CACHE_WRITE = "cache.write";
+  String MESSAGING_SYSTEM = "messaging.system";
+  String MESSAGING_DESTINATION_NAME = "messaging.destination.name";
+  String MESSAGING_MESSAGE_ID = "messaging.message.id";
+  String MESSAGING_MESSAGE_RETRY_COUNT = "messaging.message.retry.count";
+  String MESSAGING_MESSAGE_BODY_SIZE = "messaging.message.body.size";
+  String MESSAGING_MESSAGE_RECEIVE_LATENCY = "messaging.message.receive.latency";
 }

--- a/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/ExternalOptionsTest.kt
@@ -346,6 +346,20 @@ class ExternalOptionsTest {
   }
 
   @Test
+  fun `creates options with enableQueueTracing set to true`() {
+    withPropertiesFile("enable-queue-tracing=true") { options ->
+      assertTrue(options.isEnableQueueTracing == true)
+    }
+  }
+
+  @Test
+  fun `creates options with enableQueueTracing set to false`() {
+    withPropertiesFile("enable-queue-tracing=false") { options ->
+      assertTrue(options.isEnableQueueTracing == false)
+    }
+  }
+
+  @Test
   fun `creates options with cron defaults`() {
     withPropertiesFile(
       listOf(

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -709,6 +709,11 @@ class SentryOptionsTest {
   }
 
   @Test
+  fun `when options are initialized, enableQueueTracing is set to false by default`() {
+    assertFalse(SentryOptions().isEnableQueueTracing)
+  }
+
+  @Test
   fun `when options are initialized, metrics is enabled by default`() {
     assertTrue(SentryOptions().metrics.isEnabled)
   }
@@ -1016,6 +1021,23 @@ class SentryOptionsTest {
     options.orgId = "original"
     options.merge(externalOptions)
     assertEquals("original", options.orgId)
+  }
+
+  @Test
+  fun `merging options applies enableQueueTracing`() {
+    val externalOptions = ExternalOptions()
+    externalOptions.setEnableQueueTracing(true)
+    val options = SentryOptions()
+    options.merge(externalOptions)
+    assertTrue(options.isEnableQueueTracing)
+  }
+
+  @Test
+  fun `merging options preserves enableQueueTracing default when not set`() {
+    val externalOptions = ExternalOptions()
+    val options = SentryOptions()
+    options.merge(externalOptions)
+    assertFalse(options.isEnableQueueTracing)
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Add core plumbing for queue instrumentation:

- `enableQueueTracing` boolean to `SentryOptions` (default `false`) and `ExternalOptions` (nullable `Boolean`) with merge support
- Messaging span data keys (`messaging.*`) to `SpanDataConvention` for queue instrumentation span data

## :bulb: Motivation and Context

Provides the foundational option and span data conventions needed by the queue instrumentation feature.

## :green_heart: How did you test it?

Unit tests for `SentryOptions` and `ExternalOptions`.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

