### PR TITLE
feat(samples): [Queue Instrumentation 2] Add Kafka to Spring Boot 3 sample app

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -183,6 +183,7 @@ springboot3-starter-security = { module = "org.springframework.boot:spring-boot-
 springboot3-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc", version.ref = "springboot3" }
 springboot3-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "springboot3" }
 springboot3-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache", version.ref = "springboot3" }
+spring-kafka3 = { module = "org.springframework.kafka:spring-kafka", version = "3.3.5" }
 springboot4-otel = { module = "io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter", version.ref = "otelInstrumentation" }
 springboot4-resttestclient = { module = "org.springframework.boot:spring-boot-resttestclient", version.ref = "springboot4" }
 springboot4-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot4" }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
   implementation(libs.springboot3.starter.cache)
   implementation(libs.caffeine)
 
+  // kafka
+  implementation(libs.spring.kafka3)
+
   // OpenFeature SDK
   implementation(libs.openfeature)
 

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/KafkaConsumer.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/KafkaConsumer.java
@@ -1,0 +1,19 @@
+package io.sentry.samples.spring.boot.jakarta;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("kafka")
+public class KafkaConsumer {
+
+  private static final Logger logger = LoggerFactory.getLogger(KafkaConsumer.class);
+
+  @KafkaListener(topics = "sentry-topic", groupId = "sentry-sample-group")
+  public void listen(String message) {
+    logger.info("Received message: {}", message);
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/KafkaController.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/KafkaController.java
@@ -1,0 +1,26 @@
+package io.sentry.samples.spring.boot.jakarta;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("kafka")
+@RequestMapping("/kafka")
+public class KafkaController {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  public KafkaController(KafkaTemplate<String, String> kafkaTemplate) {
+    this.kafkaTemplate = kafkaTemplate;
+  }
+
+  @GetMapping("/produce")
+  String produce(@RequestParam(defaultValue = "hello from sentry!") String message) {
+    kafkaTemplate.send("sentry-topic", message);
+    return "Message sent: " + message;
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
@@ -1,0 +1,9 @@
+# Kafka — activate with: --spring.profiles.active=kafka
+spring.autoconfigure.exclude=
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=sentry-sample-group
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -37,6 +37,10 @@ spring.quartz.job-store-type=memory
 
 # Cache tracing
 sentry.enable-cache-tracing=true
+
+# Kafka is only active with the 'kafka' profile (--spring.profiles.active=kafka)
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+
 spring.cache.cache-names=todos
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=600s
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Add Kafka producer and consumer to the Spring Boot 3 (Jakarta) sample app behind a `kafka` Spring profile. This provides a manual test harness for upcoming Kafka queue instrumentation.

- `spring-kafka` dependency added to `libs.versions.toml`
- `KafkaController` — REST endpoint (`/kafka/produce`) that sends messages
- `KafkaConsumer` — `@KafkaListener` that receives and logs messages
- `application-kafka.properties` — Kafka config activated via `--spring.profiles.active=kafka`
- Kafka auto-configuration excluded by default to avoid startup errors when no broker is available

## :bulb: Motivation and Context

Need a working Kafka setup in the sample app to manually test queue instrumentation end-to-end.

## :green_heart: How did you test it?

Ran the sample app locally with `--spring.profiles.active=kafka` against a local Kafka broker.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

