### PR TITLE
test(samples): [Queue Instrumentation 6] Add Kafka queue system tests

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
@@ -1,4 +1,6 @@
 # Kafka — activate with: --spring.profiles.active=kafka
+sentry.enable-queue-tracing=true
+
 spring.autoconfigure.exclude=
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=sentry-sample-group

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/test/kotlin/io/sentry/systemtest/KafkaQueueSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/test/kotlin/io/sentry/systemtest/KafkaQueueSystemTest.kt
@@ -1,0 +1,117 @@
+package io.sentry.systemtest
+
+import io.sentry.systemtest.util.TestHelper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.Before
+
+/**
+ * System tests for Kafka queue instrumentation.
+ *
+ * Requires:
+ * - The sample app running with `--spring.profiles.active=kafka`
+ * - A Kafka broker at localhost:9092
+ * - The mock Sentry server at localhost:8000
+ */
+class KafkaQueueSystemTest {
+  lateinit var testHelper: TestHelper
+
+  @Before
+  fun setup() {
+    testHelper = TestHelper("http://localhost:8080")
+    testHelper.reset()
+  }
+
+  @Test
+  fun `producer endpoint creates queue publish span`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("test-message")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      testHelper.doesTransactionContainSpanWithOp(transaction, "queue.publish")
+    }
+  }
+
+  @Test
+  fun `consumer creates queue process transaction`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("test-consumer-message")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    // The consumer runs asynchronously, so wait for the queue.process transaction
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      testHelper.doesTransactionHaveOp(transaction, "queue.process")
+    }
+  }
+
+  @Test
+  fun `producer and consumer share same trace`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("trace-test-message")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    // Capture the trace ID from the producer transaction (has queue.publish span)
+    var producerTraceId: String? = null
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      if (testHelper.doesTransactionContainSpanWithOp(transaction, "queue.publish")) {
+        producerTraceId = transaction.contexts.trace?.traceId?.toString()
+        true
+      } else {
+        false
+      }
+    }
+
+    // Verify the consumer transaction has the same trace ID
+    // Use retryCount=3 since the consumer may take a moment to process
+    testHelper.ensureEnvelopeReceived(retryCount = 3) { envelopeString ->
+      val envelope =
+        testHelper.jsonSerializer.deserializeEnvelope(envelopeString.byteInputStream())
+          ?: return@ensureEnvelopeReceived false
+      val txItem =
+        envelope.items.firstOrNull { it.header.type == io.sentry.SentryItemType.Transaction }
+          ?: return@ensureEnvelopeReceived false
+      val tx =
+        txItem.getTransaction(testHelper.jsonSerializer) ?: return@ensureEnvelopeReceived false
+
+      tx.contexts.trace?.operation == "queue.process" &&
+        tx.contexts.trace?.traceId?.toString() == producerTraceId
+    }
+  }
+
+  @Test
+  fun `queue publish span has messaging attributes`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("attrs-test")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      val span = transaction.spans.firstOrNull { it.op == "queue.publish" }
+      if (span == null) return@ensureTransactionReceived false
+
+      val data = span.data ?: return@ensureTransactionReceived false
+      data["messaging.system"] == "kafka" && data["messaging.destination.name"] == "sentry-topic"
+    }
+  }
+
+  @Test
+  fun `queue process transaction has messaging attributes`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("process-attrs-test")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      if (!testHelper.doesTransactionHaveOp(transaction, "queue.process")) {
+        return@ensureTransactionReceived false
+      }
+
+      val data = transaction.contexts.trace?.data ?: return@ensureTransactionReceived false
+      data["messaging.system"] == "kafka" && data["messaging.destination.name"] == "sentry-topic"
+    }
+  }
+}

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -55,9 +55,10 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     final @NotNull IScopes forkedScopes = scopes.forkedScopes("SentryKafkaRecordInterceptor");
     final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
 
-    continueTrace(forkedScopes, record);
+    final @Nullable TransactionContext transactionContext = continueTrace(forkedScopes, record);
 
-    final @Nullable ITransaction transaction = startTransaction(forkedScopes, record);
+    final @Nullable ITransaction transaction =
+        startTransaction(forkedScopes, record, transactionContext);
     currentContext.set(new SentryRecordContext(lifecycleToken, transaction));
 
     return delegateIntercept(record, consumer);
@@ -105,28 +106,35 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     return record;
   }
 
-  private void continueTrace(
+  private @Nullable TransactionContext continueTrace(
       final @NotNull IScopes forkedScopes, final @NotNull ConsumerRecord<K, V> record) {
     final @Nullable String sentryTrace = headerValue(record, SentryTraceHeader.SENTRY_TRACE_HEADER);
     final @Nullable String baggage = headerValue(record, BaggageHeader.BAGGAGE_HEADER);
     final @Nullable List<String> baggageHeaders =
         baggage != null ? Collections.singletonList(baggage) : null;
-    forkedScopes.continueTrace(sentryTrace, baggageHeaders);
+    return forkedScopes.continueTrace(sentryTrace, baggageHeaders);
   }
 
   private @Nullable ITransaction startTransaction(
-      final @NotNull IScopes forkedScopes, final @NotNull ConsumerRecord<K, V> record) {
+      final @NotNull IScopes forkedScopes,
+      final @NotNull ConsumerRecord<K, V> record,
+      final @Nullable TransactionContext transactionContext) {
     if (!forkedScopes.getOptions().isTracingEnabled()) {
       return null;
     }
+
+    final @NotNull TransactionContext txContext =
+        transactionContext != null
+            ? transactionContext
+            : new TransactionContext("queue.process", "queue.process");
+    txContext.setName("queue.process");
+    txContext.setOperation("queue.process");
 
     final @NotNull TransactionOptions txOptions = new TransactionOptions();
     txOptions.setOrigin(TRACE_ORIGIN);
     txOptions.setBindToScope(true);
 
-    final @NotNull ITransaction transaction =
-        forkedScopes.startTransaction(
-            new TransactionContext("queue.process", "queue.process"), txOptions);
+    final @NotNull ITransaction transaction = forkedScopes.startTransaction(txContext, txOptions);
 
     if (transaction.isNoOp()) {
       return null;

--- a/sentry-system-test-support/api/sentry-system-test-support.api
+++ b/sentry-system-test-support/api/sentry-system-test-support.api
@@ -560,6 +560,8 @@ public final class io/sentry/systemtest/util/RestTestClient : io/sentry/systemte
 	public final fun getTodo (J)Lio/sentry/systemtest/Todo;
 	public final fun getTodoRestClient (J)Lio/sentry/systemtest/Todo;
 	public final fun getTodoWebclient (J)Lio/sentry/systemtest/Todo;
+	public final fun produceKafkaMessage (Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun produceKafkaMessage$default (Lio/sentry/systemtest/util/RestTestClient;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun saveCachedTodo (Lio/sentry/systemtest/Todo;)Lio/sentry/systemtest/Todo;
 }
 

--- a/sentry-system-test-support/src/main/kotlin/io/sentry/systemtest/util/RestTestClient.kt
+++ b/sentry-system-test-support/src/main/kotlin/io/sentry/systemtest/util/RestTestClient.kt
@@ -81,6 +81,12 @@ class RestTestClient(private val backendBaseUrl: String) : LoggingInsecureRestCl
     return response?.body?.string()
   }
 
+  fun produceKafkaMessage(message: String = "hello from sentry!"): String? {
+    val request = Request.Builder().url("$backendBaseUrl/kafka/produce?message=$message")
+
+    return callTyped(request, true)
+  }
+
   fun getCountMetric(): String? {
     val request = Request.Builder().url("$backendBaseUrl/metric/count")
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5250
- #5253
- #5254
- #5255
- #5256
- **→ #5258**

---

## :scroll: Description

Add end-to-end system tests for Kafka queue instrumentation in the Spring Boot 3 sample app:

- **`KafkaQueueSystemTest`** — 5 tests covering:
  - Producer endpoint creates `queue.publish` span
  - Consumer creates `queue.process` transaction
  - Distributed tracing: producer and consumer share the same trace ID
  - `queue.publish` span has `messaging.system=kafka` and `messaging.destination.name=sentry-topic`
  - `queue.process` transaction has matching messaging attributes

- **`RestTestClient.produceKafkaMessage`** — new helper method for hitting the `/kafka/produce` endpoint

- **`application-kafka.properties`** — adds `sentry.enable-queue-tracing=true` to the kafka profile

## :bulb: Motivation and Context

PR 6 in the Queue Instrumentation stack. Validates the full stack (producer → consumer → auto-config) works end-to-end before moving to OTel and ports. Follows the existing `CacheSystemTest` pattern.

**Infrastructure note:** These tests require a running Kafka broker at `localhost:9092` and the sample app started with `--spring.profiles.active=kafka`. They won't run in the standard CI flow until Kafka infrastructure is added to the system test pipeline.

## :green_heart: How did you test it?

- Compilation verified: `./gradlew :sentry-samples:sentry-samples-spring-boot-jakarta:compileTestKotlin`
- Full e2e validation requires running Kafka + sample app (not automated yet)

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- PR 7: Add Kafka to Spring Boot 3 OTel sample apps
- PR 8: OTel coexistence

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

#skip-changelog
