### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 9] Clean up stale ThreadLocal context in Kafka consumer interceptor

### DIFF
--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -260,6 +260,7 @@ public final class io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor :
 	public fun <init> (Lio/sentry/IScopes;)V
 	public fun <init> (Lio/sentry/IScopes;Lorg/springframework/kafka/listener/RecordInterceptor;)V
 	public fun afterRecord (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Lorg/apache/kafka/clients/consumer/Consumer;)V
+	public fun clearThreadState (Lorg/apache/kafka/clients/consumer/Consumer;)V
 	public fun failure (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Ljava/lang/Exception;Lorg/apache/kafka/clients/consumer/Consumer;)V
 	public fun intercept (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Lorg/apache/kafka/clients/consumer/Consumer;)Lorg/apache/kafka/clients/consumer/ConsumerRecord;
 	public fun success (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Lorg/apache/kafka/clients/consumer/Consumer;)V

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -52,6 +52,8 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
       return delegateIntercept(record, consumer);
     }
 
+    finishStaleContext();
+
     final @NotNull IScopes forkedScopes = scopes.forkedScopes("SentryKafkaRecordInterceptor");
     final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
 
@@ -96,6 +98,11 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     if (delegate != null) {
       delegate.afterRecord(record, consumer);
     }
+  }
+
+  @Override
+  public void clearThreadState(final @NotNull Consumer<?, ?> consumer) {
+    finishStaleContext();
   }
 
   private @Nullable ConsumerRecord<K, V> delegateIntercept(
@@ -163,6 +170,12 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     }
 
     return transaction;
+  }
+
+  private void finishStaleContext() {
+    if (currentContext.get() != null) {
+      finishSpan(SpanStatus.UNKNOWN, null);
+    }
   }
 
   private void finishSpan(final @NotNull SpanStatus status, final @Nullable Throwable throwable) {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -208,4 +208,64 @@ class SentryKafkaRecordInterceptorTest {
       SentryKafkaRecordInterceptor.TRACE_ORIGIN,
     )
   }
+
+  @Test
+  fun `clearThreadState cleans up stale context`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord()
+
+    // intercept sets up context in ThreadLocal
+    interceptor.intercept(record, consumer)
+
+    // clearThreadState should clean up without success/failure being called
+    interceptor.clearThreadState(consumer)
+
+    // lifecycle token should have been closed
+    verify(lifecycleToken).close()
+  }
+
+  @Test
+  fun `clearThreadState is no-op when no context exists`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+
+    // should not throw
+    interceptor.clearThreadState(consumer)
+  }
+
+  @Test
+  fun `intercept cleans up stale context from previous record`() {
+    val lifecycleToken2 = mock<ISentryLifecycleToken>()
+    val forkedScopes2 = mock<IScopes>()
+    whenever(forkedScopes2.options).thenReturn(options)
+    whenever(forkedScopes2.makeCurrent()).thenReturn(lifecycleToken2)
+    val tx2 = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes2)
+    whenever(forkedScopes2.startTransaction(any<TransactionContext>(), any())).thenReturn(tx2)
+
+    var callCount = 0
+    whenever(scopes.forkedScopes(any())).thenAnswer {
+      callCount++
+      if (callCount == 1) {
+        val forkedScopes1 = mock<IScopes>()
+        whenever(forkedScopes1.options).thenReturn(options)
+        whenever(forkedScopes1.makeCurrent()).thenReturn(lifecycleToken)
+        val tx1 = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes1)
+        whenever(forkedScopes1.startTransaction(any<TransactionContext>(), any())).thenReturn(tx1)
+        forkedScopes1
+      } else {
+        forkedScopes2
+      }
+    }
+
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord()
+
+    // First intercept sets up context
+    interceptor.intercept(record, consumer)
+
+    // Second intercept without success/failure — should clean up stale context first
+    interceptor.intercept(record, consumer)
+
+    // First lifecycle token should have been closed by the defensive cleanup
+    verify(lifecycleToken).close()
+  }
 }


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Implement `clearThreadState()` and defensive cleanup in `intercept()` on `SentryKafkaRecordInterceptor` to prevent ThreadLocal leaks of `SentryRecordContext` (lifecycle token + transaction).

Spring Kafka's `RecordInterceptor` extends `ThreadStateProcessor`, which provides `clearThreadState()` — called in the poll loop's `finally` block, making it the most reliable cleanup hook. This catches edge cases where `success()`/`failure()` callbacks are skipped (e.g. `Error` thrown by listener).

Also adds defensive cleanup at the start of `intercept()` to handle any stale context from a previous record that was not properly cleaned up.

## :bulb: Motivation and Context

Review finding F-001 identified that `SentryRecordContext` stored in ThreadLocal is only cleaned in `success()`/`failure()`. While the realistic leak surface is narrow for synchronous listeners (Spring Kafka reliably calls these callbacks in most scenarios), implementing `clearThreadState()` is a trivially cheap safety net that Spring already calls on our instance.

## :green_heart: How did you test it?

- Added unit test: `clearThreadState cleans up stale context`
- Added unit test: `clearThreadState is no-op when no context exists`
- Added unit test: `intercept cleans up stale context from previous record`
- All existing tests continue to pass

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Nothing — this is a standalone defensive fix.


#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

