### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 10] Fork root scopes and skip when OTel is active in Kafka consumer

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -4,11 +4,13 @@ import io.sentry.BaggageHeader;
 import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransaction;
+import io.sentry.Sentry;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
+import io.sentry.util.SpanUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -48,13 +50,13 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
   @Override
   public @Nullable ConsumerRecord<K, V> intercept(
       final @NotNull ConsumerRecord<K, V> record, final @NotNull Consumer<K, V> consumer) {
-    if (!scopes.getOptions().isEnableQueueTracing()) {
+    if (!scopes.getOptions().isEnableQueueTracing() || isIgnored()) {
       return delegateIntercept(record, consumer);
     }
 
     finishStaleContext();
 
-    final @NotNull IScopes forkedScopes = scopes.forkedScopes("SentryKafkaRecordInterceptor");
+    final @NotNull IScopes forkedScopes = Sentry.forkedRootScopes("SentryKafkaRecordInterceptor");
     final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
 
     final @Nullable TransactionContext transactionContext = continueTrace(forkedScopes, record);
@@ -103,6 +105,10 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
   @Override
   public void clearThreadState(final @NotNull Consumer<?, ?> consumer) {
     finishStaleContext();
+  }
+
+  private boolean isIgnored() {
+    return SpanUtils.isIgnored(scopes.getOptions().getIgnoredSpanOrigins(), TRACE_ORIGIN);
   }
 
   private @Nullable ConsumerRecord<K, V> delegateIntercept(

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.assertEquals
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.internals.RecordHeaders
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -27,6 +28,7 @@ import org.springframework.kafka.listener.RecordInterceptor
 class SentryKafkaRecordInterceptorTest {
 
   private lateinit var scopes: IScopes
+  private lateinit var forkedScopes: IScopes
   private lateinit var options: SentryOptions
   private lateinit var consumer: Consumer<String, String>
   private lateinit var lifecycleToken: ISentryLifecycleToken
@@ -46,10 +48,9 @@ class SentryKafkaRecordInterceptorTest {
     whenever(scopes.options).thenReturn(options)
     whenever(scopes.isEnabled).thenReturn(true)
 
-    val forkedScopes = mock<IScopes>()
+    forkedScopes = mock()
     whenever(forkedScopes.options).thenReturn(options)
     whenever(forkedScopes.makeCurrent()).thenReturn(lifecycleToken)
-    whenever(scopes.forkedScopes(any())).thenReturn(forkedScopes)
 
     val tx = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes)
     whenever(forkedScopes.startTransaction(any<TransactionContext>(), any())).thenReturn(tx)
@@ -59,6 +60,13 @@ class SentryKafkaRecordInterceptorTest {
   fun teardown() {
     Sentry.close()
   }
+
+  private fun <T> withMockSentry(closure: () -> T): T =
+    Mockito.mockStatic(Sentry::class.java).use {
+      it.`when`<Any> { Sentry.forkedRootScopes(any()) }.thenReturn(forkedScopes)
+      it.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
+      closure.invoke()
+    }
 
   private fun createRecord(
     topic: String = "my-topic",
@@ -93,30 +101,22 @@ class SentryKafkaRecordInterceptorTest {
   }
 
   @Test
-  fun `intercept creates forked scopes`() {
+  fun `intercept forks root scopes`() {
     val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
     val record = createRecord()
 
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
 
-    verify(scopes).forkedScopes("SentryKafkaRecordInterceptor")
+    verify(forkedScopes).makeCurrent()
   }
 
   @Test
   fun `intercept continues trace from headers`() {
-    val forkedScopes = mock<IScopes>()
-    whenever(forkedScopes.options).thenReturn(options)
-    whenever(forkedScopes.makeCurrent()).thenReturn(lifecycleToken)
-    whenever(scopes.forkedScopes(any())).thenReturn(forkedScopes)
-
-    val tx = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes)
-    whenever(forkedScopes.startTransaction(any<TransactionContext>(), any())).thenReturn(tx)
-
     val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
     val sentryTraceValue = "2722d9f6ec019ade60c776169d9a8904-cedf5b7571cb4972-1"
     val record = createRecordWithHeaders(sentryTrace = sentryTraceValue)
 
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
 
     verify(forkedScopes)
       .continueTrace(org.mockito.kotlin.eq(sentryTraceValue), org.mockito.kotlin.isNull())
@@ -124,18 +124,10 @@ class SentryKafkaRecordInterceptorTest {
 
   @Test
   fun `intercept calls continueTrace with null when no headers`() {
-    val forkedScopes = mock<IScopes>()
-    whenever(forkedScopes.options).thenReturn(options)
-    whenever(forkedScopes.makeCurrent()).thenReturn(lifecycleToken)
-    whenever(scopes.forkedScopes(any())).thenReturn(forkedScopes)
-
-    val tx = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes)
-    whenever(forkedScopes.startTransaction(any<TransactionContext>(), any())).thenReturn(tx)
-
     val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
     val record = createRecord()
 
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
 
     verify(forkedScopes).continueTrace(org.mockito.kotlin.isNull(), org.mockito.kotlin.isNull())
   }
@@ -148,7 +140,19 @@ class SentryKafkaRecordInterceptorTest {
 
     val result = interceptor.intercept(record, consumer)
 
-    verify(scopes, never()).forkedScopes(any())
+    verify(forkedScopes, never()).makeCurrent()
+    assertEquals(record, result)
+  }
+
+  @Test
+  fun `does not create span when origin is ignored`() {
+    options.setIgnoredSpanOrigins(listOf(SentryKafkaRecordInterceptor.TRACE_ORIGIN))
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord()
+
+    val result = interceptor.intercept(record, consumer)
+
+    verify(forkedScopes, never()).makeCurrent()
     assertEquals(record, result)
   }
 
@@ -159,7 +163,7 @@ class SentryKafkaRecordInterceptorTest {
     whenever(delegate.intercept(record, consumer)).thenReturn(record)
 
     val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
 
     verify(delegate).intercept(record, consumer)
   }
@@ -170,8 +174,7 @@ class SentryKafkaRecordInterceptorTest {
     val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
     val record = createRecord()
 
-    // intercept first to set up context
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
     interceptor.success(record, consumer)
 
     verify(delegate).success(record, consumer)
@@ -184,7 +187,7 @@ class SentryKafkaRecordInterceptorTest {
     val record = createRecord()
     val exception = RuntimeException("processing failed")
 
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
     interceptor.failure(record, exception, consumer)
 
     verify(delegate).failure(record, exception, consumer)
@@ -214,13 +217,10 @@ class SentryKafkaRecordInterceptorTest {
     val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
     val record = createRecord()
 
-    // intercept sets up context in ThreadLocal
-    interceptor.intercept(record, consumer)
+    withMockSentry { interceptor.intercept(record, consumer) }
 
-    // clearThreadState should clean up without success/failure being called
     interceptor.clearThreadState(consumer)
 
-    // lifecycle token should have been closed
     verify(lifecycleToken).close()
   }
 
@@ -242,28 +242,25 @@ class SentryKafkaRecordInterceptorTest {
     whenever(forkedScopes2.startTransaction(any<TransactionContext>(), any())).thenReturn(tx2)
 
     var callCount = 0
-    whenever(scopes.forkedScopes(any())).thenAnswer {
-      callCount++
-      if (callCount == 1) {
-        val forkedScopes1 = mock<IScopes>()
-        whenever(forkedScopes1.options).thenReturn(options)
-        whenever(forkedScopes1.makeCurrent()).thenReturn(lifecycleToken)
-        val tx1 = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes1)
-        whenever(forkedScopes1.startTransaction(any<TransactionContext>(), any())).thenReturn(tx1)
-        forkedScopes1
-      } else {
-        forkedScopes2
-      }
-    }
 
     val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
     val record = createRecord()
 
-    // First intercept sets up context
-    interceptor.intercept(record, consumer)
+    Mockito.mockStatic(Sentry::class.java).use { mockSentry ->
+      mockSentry.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
+      mockSentry
+        .`when`<Any> { Sentry.forkedRootScopes(any()) }
+        .thenAnswer {
+          callCount++
+          if (callCount == 1) forkedScopes else forkedScopes2
+        }
 
-    // Second intercept without success/failure — should clean up stale context first
-    interceptor.intercept(record, consumer)
+      // First intercept sets up context
+      interceptor.intercept(record, consumer)
+
+      // Second intercept without success/failure — should clean up stale context first
+      interceptor.intercept(record, consumer)
+    }
 
     // First lifecycle token should have been closed by the defensive cleanup
     verify(lifecycleToken).close()


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Two changes to `SentryKafkaRecordInterceptor`:

1. **Fork root scopes** — Use `Sentry.forkedRootScopes()` instead of `scopes.forkedScopes()`. Each Kafka message is an independent request boundary, so it should start with a clean scope from root rather than inheriting whatever scope happens to be on the consumer thread. This matches the pattern used by `SentryWebFilter` for reactive request boundaries.

2. **Skip when OTel is active** — Add `isIgnored()` check using `SpanUtils.isIgnored()` on the trace origin. When OTel is active and the origin is in the ignored span origins list, the interceptor skips instrumentation entirely (no fork, no transaction, no ThreadLocal). This is consistent with how `SentryTracingFilter` handles OTel coexistence.

## :bulb: Motivation and Context

- Forking from current scopes on a Kafka consumer thread could inherit stale scope state from a previous message or unrelated context. Root scopes provide proper isolation per message.
- The OTel dedup via ignored origins ensures Sentry's Kafka instrumentation doesn't create duplicate spans when OTel is also instrumenting Kafka consumers.

## :green_heart: How did you test it?

- Updated existing tests to use `Mockito.mockStatic(Sentry::class.java)` for `forkedRootScopes`
- Added test: `does not create span when origin is ignored`
- All 13 tests pass

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Nothing — this completes the root scopes + OTel dedup fix for the consumer interceptor.


#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

