### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 11] Guard entire span lifecycle in Kafka producer interceptor

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryProducerInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryProducerInterceptor.java
@@ -53,24 +53,25 @@ public final class SentryProducerInterceptor<K, V> implements ProducerIntercepto
       return record;
     }
 
-    final @NotNull SpanOptions spanOptions = new SpanOptions();
-    spanOptions.setOrigin(TRACE_ORIGIN);
-    final @NotNull ISpan span = activeSpan.startChild("queue.publish", record.topic(), spanOptions);
-    if (span.isNoOp()) {
-      return record;
-    }
-
-    span.setData(SpanDataConvention.MESSAGING_SYSTEM, "kafka");
-    span.setData(SpanDataConvention.MESSAGING_DESTINATION_NAME, record.topic());
-
     try {
-      injectHeaders(record.headers(), span);
-    } catch (Throwable ignored) {
-      // Header injection must not break the send
-    }
+      final @NotNull SpanOptions spanOptions = new SpanOptions();
+      spanOptions.setOrigin(TRACE_ORIGIN);
+      final @NotNull ISpan span =
+          activeSpan.startChild("queue.publish", record.topic(), spanOptions);
+      if (span.isNoOp()) {
+        return record;
+      }
 
-    span.setStatus(SpanStatus.OK);
-    span.finish();
+      span.setData(SpanDataConvention.MESSAGING_SYSTEM, "kafka");
+      span.setData(SpanDataConvention.MESSAGING_DESTINATION_NAME, record.topic());
+
+      injectHeaders(record.headers(), span);
+
+      span.setStatus(SpanStatus.OK);
+      span.finish();
+    } catch (Throwable ignored) {
+      // Instrumentation must never break the customer's Kafka send
+    }
 
     return record;
   }


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Wrap the entire span lifecycle in `SentryProducerInterceptor.onSend()` in a single try-catch so instrumentation can never break the customer's Kafka send. The `ProducerRecord` is always returned regardless of any exception in Sentry code.

Previously, only header injection was guarded. Span creation (`startChild`), `setData()`, and `finish()` were unguarded — any exception from these would propagate and fail the customer's Kafka send per the `ProducerInterceptor.onSend()` contract.

The inner try-catch around `injectHeaders` is removed since the outer catch now covers it.

## :bulb: Motivation and Context

Kafka's `ProducerInterceptor.onSend()` contract requires that interceptors not throw exceptions — any exception propagates and fails the send. Observability code must never cause customer message loss.

## :green_heart: How did you test it?

- All 8 existing `SentryProducerInterceptorTest` tests pass
- The change is purely defensive — wraps existing logic in try-catch without changing behavior

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Nothing.


#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

