### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 12] Add Kafka retry count attribute

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -11,6 +11,7 @@ import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
 import io.sentry.TransactionOptions;
 import io.sentry.util.SpanUtils;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.kafka.listener.RecordInterceptor;
+import org.springframework.kafka.support.KafkaHeaders;
 
 /**
  * A {@link RecordInterceptor} that creates {@code queue.process} transactions for incoming Kafka
@@ -161,6 +163,11 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
       transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_ID, messageId);
     }
 
+    final @Nullable Integer retryCount = retryCount(record);
+    if (retryCount != null) {
+      transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_RETRY_COUNT, retryCount);
+    }
+
     final @Nullable String enqueuedTimeStr =
         headerValue(record, SentryProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER);
     if (enqueuedTimeStr != null) {
@@ -176,6 +183,25 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     }
 
     return transaction;
+  }
+
+  private @Nullable Integer retryCount(final @NotNull ConsumerRecord<K, V> record) {
+    final @Nullable Header header = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
+    if (header == null) {
+      return null;
+    }
+
+    final byte[] value = header.value();
+    if (value == null || value.length != Integer.BYTES) {
+      return null;
+    }
+
+    final int attempt = ByteBuffer.wrap(value).getInt();
+    if (attempt <= 0) {
+      return null;
+    }
+
+    return attempt - 1;
   }
 
   private void finishStaleContext() {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -7,13 +7,16 @@ import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanDataConvention
 import io.sentry.TransactionContext
 import io.sentry.test.initForTest
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.internals.RecordHeaders
@@ -24,6 +27,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.kafka.listener.RecordInterceptor
+import org.springframework.kafka.support.KafkaHeaders
 
 class SentryKafkaRecordInterceptorTest {
 
@@ -32,6 +36,7 @@ class SentryKafkaRecordInterceptorTest {
   private lateinit var options: SentryOptions
   private lateinit var consumer: Consumer<String, String>
   private lateinit var lifecycleToken: ISentryLifecycleToken
+  private lateinit var transaction: SentryTracer
 
   @BeforeTest
   fun setup() {
@@ -52,8 +57,9 @@ class SentryKafkaRecordInterceptorTest {
     whenever(forkedScopes.options).thenReturn(options)
     whenever(forkedScopes.makeCurrent()).thenReturn(lifecycleToken)
 
-    val tx = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes)
-    whenever(forkedScopes.startTransaction(any<TransactionContext>(), any())).thenReturn(tx)
+    transaction = SentryTracer(TransactionContext("queue.process", "queue.process"), forkedScopes)
+    whenever(forkedScopes.startTransaction(any<TransactionContext>(), any()))
+      .thenReturn(transaction)
   }
 
   @AfterTest
@@ -81,6 +87,7 @@ class SentryKafkaRecordInterceptorTest {
     sentryTrace: String? = null,
     baggage: String? = null,
     enqueuedTime: Long? = null,
+    deliveryAttempt: Int? = null,
   ): ConsumerRecord<String, String> {
     val headers = RecordHeaders()
     sentryTrace?.let {
@@ -93,6 +100,12 @@ class SentryKafkaRecordInterceptorTest {
       headers.add(
         SentryProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER,
         it.toString().toByteArray(StandardCharsets.UTF_8),
+      )
+    }
+    deliveryAttempt?.let {
+      headers.add(
+        KafkaHeaders.DELIVERY_ATTEMPT,
+        ByteBuffer.allocate(Int.SIZE_BYTES).putInt(it).array(),
       )
     }
     val record = ConsumerRecord<String, String>("my-topic", 0, 0L, "key", "value")
@@ -130,6 +143,26 @@ class SentryKafkaRecordInterceptorTest {
     withMockSentry { interceptor.intercept(record, consumer) }
 
     verify(forkedScopes).continueTrace(org.mockito.kotlin.isNull(), org.mockito.kotlin.isNull())
+  }
+
+  @Test
+  fun `sets retry count from delivery attempt header`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecordWithHeaders(deliveryAttempt = 3)
+
+    withMockSentry { interceptor.intercept(record, consumer) }
+
+    assertEquals(2, transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_RETRY_COUNT))
+  }
+
+  @Test
+  fun `does not set retry count when delivery attempt header is missing`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord()
+
+    withMockSentry { interceptor.intercept(record, consumer) }
+
+    assertNull(transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_RETRY_COUNT))
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Set `messaging.message.retry.count` on `queue.process` transactions when Spring Kafka provides the delivery attempt header. The retry count is derived as `deliveryAttempt - 1` (attempt 1 → retry count 0).

If the header is missing, malformed, or non-positive, no retry count attribute is added.

## :bulb: Motivation and Context

Kafka retries currently create multiple `queue.process` transactions for the same record. Adding retry-count metadata makes attempts distinguishable in traces and aligns with Sentry conventions.

## :green_heart: How did you test it?

- Ran `./gradlew :sentry-spring-jakarta:test --tests='*SentryKafkaRecordInterceptorTest*'`
- Added tests:
  - `sets retry count from delivery attempt header`
  - `does not set retry count when delivery attempt header is missing`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

