### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 13] Align enqueue time with Python

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -1,6 +1,7 @@
 package io.sentry.spring.jakarta.kafka;
 
 import io.sentry.BaggageHeader;
+import io.sentry.DateUtils;
 import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransaction;
@@ -172,8 +173,9 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
         headerValue(record, SentryProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER);
     if (enqueuedTimeStr != null) {
       try {
-        final long enqueuedTime = Long.parseLong(enqueuedTimeStr);
-        final long latencyMs = System.currentTimeMillis() - enqueuedTime;
+        final double enqueuedTimeSeconds = Double.parseDouble(enqueuedTimeStr);
+        final double nowSeconds = DateUtils.millisToSeconds(System.currentTimeMillis());
+        final long latencyMs = (long) ((nowSeconds - enqueuedTimeSeconds) * 1000);
         if (latencyMs >= 0) {
           transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_RECEIVE_LATENCY, latencyMs);
         }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryProducerInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryProducerInterceptor.java
@@ -1,6 +1,7 @@
 package io.sentry.spring.jakarta.kafka;
 
 import io.sentry.BaggageHeader;
+import io.sentry.DateUtils;
 import io.sentry.IScopes;
 import io.sentry.ISpan;
 import io.sentry.SentryTraceHeader;
@@ -107,6 +108,7 @@ public final class SentryProducerInterceptor<K, V> implements ProducerIntercepto
     headers.remove(SENTRY_ENQUEUED_TIME_HEADER);
     headers.add(
         SENTRY_ENQUEUED_TIME_HEADER,
-        String.valueOf(System.currentTimeMillis()).getBytes(StandardCharsets.UTF_8));
+        String.valueOf(DateUtils.millisToSeconds(System.currentTimeMillis()))
+            .getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.internals.RecordHeaders
@@ -86,7 +87,7 @@ class SentryKafkaRecordInterceptorTest {
   private fun createRecordWithHeaders(
     sentryTrace: String? = null,
     baggage: String? = null,
-    enqueuedTime: Long? = null,
+    enqueuedTime: String? = null,
     deliveryAttempt: Int? = null,
   ): ConsumerRecord<String, String> {
     val headers = RecordHeaders()
@@ -99,7 +100,7 @@ class SentryKafkaRecordInterceptorTest {
     enqueuedTime?.let {
       headers.add(
         SentryProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER,
-        it.toString().toByteArray(StandardCharsets.UTF_8),
+        it.toByteArray(StandardCharsets.UTF_8),
       )
     }
     deliveryAttempt?.let {
@@ -163,6 +164,18 @@ class SentryKafkaRecordInterceptorTest {
     withMockSentry { interceptor.intercept(record, consumer) }
 
     assertNull(transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_RETRY_COUNT))
+  }
+
+  @Test
+  fun `sets receive latency from enqueued time in epoch seconds`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val enqueuedTime = (System.currentTimeMillis() / 1000.0 - 1.0).toString()
+    val record = createRecordWithHeaders(enqueuedTime = enqueuedTime)
+
+    withMockSentry { interceptor.intercept(record, consumer) }
+
+    val latency = transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_RECEIVE_LATENCY)
+    assertTrue(latency is Long && latency >= 0)
   }
 
   @Test

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryProducerInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryProducerInterceptorTest.kt
@@ -104,8 +104,8 @@ class SentryProducerInterceptorTest {
     val enqueuedTimeHeader =
       resultHeaders.lastHeader(SentryProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER)
     assertNotNull(enqueuedTimeHeader, "sentry-task-enqueued-time header should be injected")
-    val enqueuedTime = String(enqueuedTimeHeader.value(), StandardCharsets.UTF_8).toLong()
-    assertTrue(enqueuedTime > 0, "enqueued time should be a positive epoch millis value")
+    val enqueuedTime = String(enqueuedTimeHeader.value(), StandardCharsets.UTF_8).toDouble()
+    assertTrue(enqueuedTime > 0, "enqueued time should be a positive epoch seconds value")
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Align `sentry-task-enqueued-time` format with sentry-python by storing epoch seconds in the producer interceptor and computing `messaging.message.receive.latency` from seconds in the consumer interceptor.

This keeps the header semantics consistent across SDKs and avoids cross-SDK parsing mismatches.

## :bulb: Motivation and Context

F-009 identified a cross-SDK format mismatch: Java wrote epoch millis while sentry-python writes epoch seconds. Mixed-language queue pipelines could produce wrong or missing receive latency.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `./gradlew :sentry-spring-jakarta:test --tests='*SentryProducerInterceptorTest*' --tests='*SentryKafkaRecordInterceptorTest*'`
- Updated tests to validate epoch-seconds handling and latency calculation path

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

