### PR TITLE
fix(profiling): Reset shouldStop flag on startProfiler

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidContinuousProfiler.java
@@ -146,6 +146,7 @@ public class AndroidContinuousProfiler
           break;
       }
       if (!isRunning()) {
+        shouldStop = false;
         logger.log(SentryLevel.DEBUG, "Started Profiler.");
         start();
       }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidContinuousProfilerTest.kt
@@ -556,6 +556,24 @@ class AndroidContinuousProfilerTest {
       .log(eq(SentryLevel.WARNING), eq("Device is offline. Stopping profiler."))
   }
 
+  @Test
+  fun `manual profiler can be started again after a full start-stop cycle`() {
+    val profiler = fixture.getSut()
+
+    profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+    assertTrue(profiler.isRunning)
+    profiler.stopProfiler(ProfileLifecycle.MANUAL)
+    // Triggers the scheduled executor task that collects perf metrics and finalizes the chunk
+    fixture.executor.runAll()
+    assertFalse(profiler.isRunning)
+
+    profiler.startProfiler(ProfileLifecycle.MANUAL, fixture.mockTracesSampler)
+    assertTrue(profiler.isRunning)
+    // Triggers the scheduled executor task that collects perf metrics and finalizes the chunk
+    fixture.executor.runAll()
+    assertTrue(profiler.isRunning, "shouldStop must be reset on start")
+  }
+
   fun withMockScopes(closure: () -> Unit) =
     Mockito.mockStatic(Sentry::class.java).use {
       it.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(fixture.scopes)


### PR DESCRIPTION
## :scroll: Description

`shouldStop` is never reset to `false` after `stopProfiler()`, so a stop/start cycle leaves `shouldStop=true`. When the next 60-second chunk timer fires, `stop(restartProfiler=true)` checks `!shouldStop` and does not restart — the profiler silently stops after one chunk instead of continuing indefinitely.

This affects both lifecycle modes:
- **MANUAL**: `Sentry.startProfiler()` → `Sentry.stopProfiler()` → `Sentry.startProfiler()` — second session stops after one chunk
- **TRACE**: all transactions finish (rootSpanCounter reaches 0, sets `shouldStop=true`) → new transaction starts → profiler starts but stops after one chunk

Fix: reset `shouldStop = false` at the top of `startProfiler()`, since it represents a new intent to profile.

## :bulb: Motivation and Context

Discovered while working on the Perfetto ProfilingManager integration (#5251). The same bug existed in both `AndroidContinuousProfiler` and `PerfettoContinuousProfiler`.

## :green_heart: How did you test it?

Unit test added: `manual profiler can be started again after a full start-stop cycle` — starts profiling, stops it, starts again, verifies the profiler continues running after the first chunk restart.

```
JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :sentry-android-core:testDebugUnitTest --tests "io.sentry.android.core.AndroidContinuousProfilerTest.manual profiler can be started again after a full start-stop cycle"
```

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None — standalone bugfix.
