### PR TITLE
Guard continuous profiling on API < 35

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -326,6 +326,16 @@ final class AndroidOptionsInitializer {
       if (appStartTransactionProfiler != null) {
         appStartTransactionProfiler.close();
       }
+      if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        options
+            .getLogger()
+            .log(SentryLevel.INFO, "Continuous profiling is disabled on API levels below 35.");
+        if (appStartContinuousProfiler != null) {
+          appStartContinuousProfiler.close(true);
+        }
+        options.setContinuousProfiler(NoOpContinuousProfiler.getInstance());
+        return;
+      }
       if (appStartContinuousProfiler != null) {
         options.setContinuousProfiler(appStartContinuousProfiler);
         // If the profiler is running, we start the performance collector too, otherwise we'd miss

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryPerformanceProvider.java
@@ -155,6 +155,10 @@ public final class SentryPerformanceProvider extends EmptySecureContentProvider 
       final @NotNull Context context,
       final @NotNull SentryAppStartProfilingOptions profilingOptions,
       final @NotNull AppStartMetrics appStartMetrics) {
+    if (buildInfoProvider.getSdkInfoVersion() < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      logger.log(SentryLevel.INFO, "Continuous profiling is disabled on API levels below 35.");
+      return;
+    }
 
     if (!profilingOptions.isContinuousProfileSampled()) {
       logger.log(SentryLevel.DEBUG, "App start profiling was not sampled. It will not start.");

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -497,6 +497,15 @@ class AndroidOptionsInitializerTest {
     assertNull(AppStartMetrics.getInstance().appStartContinuousProfiler)
   }
 
+  @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+  @Test
+  fun `init with continuous profiling on API below 35 sets no-op continuous profiler`() {
+    fixture.initSut(useRealContext = true)
+
+    assertEquals(NoOpTransactionProfiler.getInstance(), fixture.sentryOptions.transactionProfiler)
+    assertEquals(NoOpContinuousProfiler.getInstance(), fixture.sentryOptions.continuousProfiler)
+  }
+
   @Test
   fun `NdkIntegration will load SentryNdk class and add to the integration list`() {
     fixture.initSutWithClassLoader(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryPerformanceProviderTest.kt
@@ -291,6 +291,16 @@ class SentryPerformanceProviderTest {
   }
 
   @Test
+  fun `when sdk is below api 35, continuous profiler is not started`() {
+    fixture.getSut(sdkVersion = Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { config ->
+      writeConfig(config, profilingEnabled = false, continuousProfilingEnabled = true)
+    }
+    assertNull(AppStartMetrics.getInstance().appStartContinuousProfiler)
+    verify(fixture.logger)
+      .log(eq(SentryLevel.INFO), eq("Continuous profiling is disabled on API levels below 35."))
+  }
+
+  @Test
   fun `when provider is closed, continuous profiler is stopped`() {
     val provider = fixture.getSut { config -> writeConfig(config, profilingEnabled = false) }
     provider.shutdown()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## :scroll: Description
- add an explicit API level guard in `AndroidOptionsInitializer.setupProfiler` so continuous profiling is not initialized below API 35
- add the same guard in `SentryPerformanceProvider.createAndStartContinuousProfiler` for app-start continuous profiling
- add regression tests covering API < 35 behavior in:
  - `AndroidOptionsInitializerTest`
  - `SentryPerformanceProviderTest`

## :bulb: Motivation and Context
Continuous profiling can be enabled by options, but API < 35 should not initialize the API-35-only implementation path. Without an explicit runtime guard, lazy initialization can still reach classes that depend on API 35 (`ProfilingManager` path), leading to runtime crashes on older Android versions.

## :green_heart: How did you test it?
- Added unit tests asserting continuous profiler remains `NoOpContinuousProfiler` / not started on API < 35.
- Attempted to run targeted tests:
  - `./gradlew :sentry-android-core:testDebugUnitTest --tests="*AndroidOptionsInitializerTest*" --tests="*SentryPerformanceProviderTest*"`
- In this cloud environment, test execution is blocked by missing Android SDK configuration (`ANDROID_HOME` / `sdk.dir`).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- Re-run the targeted Android unit tests in an environment with Android SDK configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b4158d6-4682-48d0-a32e-843488915932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b4158d6-4682-48d0-a32e-843488915932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

