### PR TITLE
fix(test): [Queue Instrumentation 16] Enable Kafka profile in system runner

### DIFF
--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -77,7 +77,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.client.RestClient;
@@ -250,7 +249,11 @@ public class SentryAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(KafkaTemplate.class)
+    @ConditionalOnClass(
+        name = {
+          "org.springframework.kafka.core.KafkaTemplate",
+          "io.sentry.kafka.SentryKafkaProducerInterceptor"
+        })
     @ConditionalOnProperty(name = "sentry.enable-queue-tracing", havingValue = "true")
     @ConditionalOnMissingClass("io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider")
     @Open

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.spring.boot.jakarta
 
+import io.sentry.kafka.SentryKafkaProducerInterceptor
 import io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider
 import io.sentry.spring.jakarta.kafka.SentryKafkaConsumerBeanPostProcessor
 import io.sentry.spring.jakarta.kafka.SentryKafkaProducerBeanPostProcessor
@@ -30,6 +31,9 @@ class SentryKafkaAutoConfigurationTest {
   private val noOtelClassLoader =
     FilteredClassLoader(SentryAutoConfigurationCustomizerProvider::class.java)
 
+  private val noSentryKafkaClassLoader =
+    FilteredClassLoader(SentryKafkaProducerInterceptor::class.java)
+
   @Test
   fun `registers Kafka BPPs when queue tracing is enabled`() {
     contextRunner
@@ -47,6 +51,17 @@ class SentryKafkaAutoConfigurationTest {
       assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)
       assertThat(context).doesNotHaveBean(SentryKafkaConsumerBeanPostProcessor::class.java)
     }
+  }
+
+  @Test
+  fun `does not register Kafka BPPs when sentry-kafka is not present`() {
+    contextRunner
+      .withClassLoader(noSentryKafkaClassLoader)
+      .withPropertyValues("sentry.enable-queue-tracing=true")
+      .run { context ->
+        assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)
+        assertThat(context).doesNotHaveBean(SentryKafkaConsumerBeanPostProcessor::class.java)
+      }
   }
 
   @Test

--- a/test/system-test-runner.py
+++ b/test/system-test-runner.py
@@ -68,6 +68,13 @@ SENTRY_ENVIRONMENT_VARIABLES = {
 
 KAFKA_CONTAINER_NAME = "sentry-java-system-test-kafka"
 KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
+KAFKA_BROKER_REQUIRED_MODULES = {
+    "sentry-samples-console",
+    "sentry-samples-spring-boot-jakarta",
+}
+KAFKA_PROFILE_REQUIRED_MODULES = {
+    "sentry-samples-spring-boot-jakarta",
+}
 
 class ServerType(Enum):
     TOMCAT = 0
@@ -202,7 +209,10 @@ class SystemTestRunner:
             print(f"Process {pid} was already dead")
 
     def module_requires_kafka(self, sample_module: str) -> bool:
-        return sample_module == "sentry-samples-console"
+        return sample_module in KAFKA_BROKER_REQUIRED_MODULES
+
+    def module_requires_kafka_profile(self, sample_module: str) -> bool:
+        return sample_module in KAFKA_PROFILE_REQUIRED_MODULES
 
     def wait_for_port(self, host: str, port: int, max_attempts: int = 20) -> bool:
         for _ in range(max_attempts):
@@ -422,6 +432,12 @@ class SystemTestRunner:
         env = os.environ.copy()
         env.update(SENTRY_ENVIRONMENT_VARIABLES)
         env["SENTRY_AUTO_INIT"] = java_agent_auto_init
+
+        if self.module_requires_kafka_profile(sample_module):
+            env["SPRING_PROFILES_ACTIVE"] = "kafka"
+            print("Enabling Spring profile: kafka")
+        else:
+            env.pop("SPRING_PROFILES_ACTIVE", None)
 
         # Build command
         jar_path = f"sentry-samples/{sample_module}/build/libs/{sample_module}-0.0.1-SNAPSHOT.jar"


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Finalize the top Kafka stack PR with the Spring Boot Jakarta review fix.

Changes:
- define module lists for Kafka broker requirements and Kafka Spring profile requirements
- start Kafka for modules that require it
- set `SPRING_PROFILES_ACTIVE=kafka` for modules that need Kafka endpoints enabled
- require `io.sentry.kafka.SentryKafkaProducerInterceptor` before activating Spring Boot Jakarta Kafka queue auto-configuration
- add a regression test proving Kafka bean post-processors are skipped when `sentry-kafka` is absent from the classpath

## :bulb: Motivation and Context

Kafka queue system tests for `sentry-samples-spring-boot-jakarta` were running without the
`kafka` profile, so `/kafka` endpoints were not active and tests failed with 404s.

This PR also fixes the late stack regression where Spring Boot Jakarta queue auto-configuration
could activate without the optional `sentry-kafka` module being present.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `./gradlew :sentry-spring-boot-jakarta:test --tests='*SentryKafkaAutoConfigurationTest'`
- Verified the system runner script changes and Spring Boot Jakarta Kafka auto-config regression test

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

