### PR TITLE
fix(ci): Remove flaky Android 14 configuration from CI workflow

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -67,10 +67,6 @@ jobs:
             target: google_apis
             channel: canary # Necessary for ATDs
             arch: x86_64
-          - api-level: 34 # Android 14
-            target: google_apis
-            channel: canary # Necessary for ATDs
-            arch: x86_64
           - api-level: 35 # Android 15
             target: google_apis
             channel: canary # Necessary for ATDs


### PR DESCRIPTION
## :scroll: Description

The Android 14 emulator seems to often silently drop the notification, causing the tests to fail. Let's remove it for now.


## :bulb: Motivation and Context
 
stable ci

#skip-changelog
