### PR TITLE
ref(samples): [Queue Instrumentation 18] Move Kafka sources into queues.kafka package

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaConsumer.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/java/io/sentry/samples/spring/boot/jakarta/queues/kafka/KafkaController.java
@@ -1,4 +1,4 @@
-package io.sentry.samples.spring.boot.jakarta;
+package io.sentry.samples.spring.boot.jakarta.queues.kafka;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Move `KafkaConsumer` and `KafkaController` in the three Spring Boot Jakarta samples (`sentry-samples-spring-boot-jakarta`, `sentry-samples-spring-boot-jakarta-opentelemetry`, `sentry-samples-spring-boot-jakarta-opentelemetry-noagent`) into a `queues.kafka` sub-package.

No behavior change. Only the `package` declaration and file location change.

## :bulb: Motivation and Context

Groups the Kafka-specific sample sources under a dedicated sub-package so future queue integrations can sit next to them under `queues`. Keeps the top-level sample package from accumulating integration-specific classes.

## :green_heart: How did you test it?

- `./gradlew :sentry-samples:sentry-samples-spring-boot-jakarta:compileJava :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:compileJava :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:compileJava` — all compile
- `./gradlew spotlessApply apiDump`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue on top of this branch for the next PR in the Queue Instrumentation stack.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

