### PR TITLE
ref(samples): [Queue Instrumentation 19] Drop Kafka auto-config exclude from Spring Boot samples

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application-kafka.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application-kafka.properties
@@ -1,7 +1,6 @@
 # Kafka — activate with: --spring.profiles.active=kafka
 sentry.enable-queue-tracing=true
 
-spring.autoconfigure.exclude=
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=sentry-sample-group
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/main/resources/application.properties
@@ -35,9 +35,6 @@ spring.graphql.graphiql.enabled=true
 spring.graphql.websocket.path=/graphql
 spring.quartz.job-store-type=memory
 
-# Kafka is only active with the 'kafka' profile (--spring.profiles.active=kafka)
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
-
 # Cache tracing
 sentry.enable-cache-tracing=true
 spring.cache.cache-names=todos

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application-kafka.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application-kafka.properties
@@ -1,7 +1,6 @@
 # Kafka — activate with: --spring.profiles.active=kafka
 sentry.enable-queue-tracing=true
 
-spring.autoconfigure.exclude=
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=sentry-sample-group
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/main/resources/application.properties
@@ -35,9 +35,6 @@ spring.graphql.graphiql.enabled=true
 spring.graphql.websocket.path=/graphql
 spring.quartz.job-store-type=memory
 
-# Kafka is only active with the 'kafka' profile (--spring.profiles.active=kafka)
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
-
 # Cache tracing
 sentry.enable-cache-tracing=true
 spring.cache.cache-names=todos

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application-kafka.properties
@@ -1,7 +1,6 @@
 # Kafka — activate with: --spring.profiles.active=kafka
 sentry.enable-queue-tracing=true
 
-spring.autoconfigure.exclude=
 spring.kafka.bootstrap-servers=localhost:9092
 spring.kafka.consumer.group-id=sentry-sample-group
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/src/main/resources/application.properties
@@ -38,9 +38,6 @@ spring.quartz.job-store-type=memory
 # Cache tracing
 sentry.enable-cache-tracing=true
 
-# Kafka is only active with the 'kafka' profile (--spring.profiles.active=kafka)
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
-
 spring.cache.cache-names=todos
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=600s
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Remove `spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration` from the default `application.properties` and the corresponding empty override from `application-kafka.properties` in all three Spring Boot Jakarta samples (`sentry-samples-spring-boot-jakarta`, `sentry-samples-spring-boot-jakarta-opentelemetry`, `sentry-samples-spring-boot-jakarta-opentelemetry-noagent`).

No behavior change in default or `kafka`-profile runs.

## :bulb: Motivation and Context

`spring.autoconfigure.exclude` is a single list property — profile-specific files **replace** it rather than merge. The existing setup worked for one queue profile but does not compose with additional transport profiles we plan to add next (e.g. `rabbitmq`):

```
# application.properties
spring.autoconfigure.exclude=KafkaAutoConfiguration,RabbitAutoConfiguration

# application-kafka.properties
spring.autoconfigure.exclude=       # clears everything → also re-enables Rabbit

# application-rabbitmq.properties
spring.autoconfigure.exclude=       # clears everything → also re-enables Kafka
```

Activating the `kafka` profile would unsilence `RabbitAutoConfiguration` and vice versa; `--spring.profiles.active=kafka,rabbitmq` becomes order-dependent rather than additive.

We can drop the exclude entirely because:

- `KafkaConsumer` and `KafkaController` already carry `@Profile("kafka")`, so no `@KafkaListener` container starts and no broker connection is attempted when the profile is inactive.
- `KafkaAutoConfiguration` still creates an unused `KafkaTemplate` bean in non-Kafka runs, which is harmless.
- Sentry's Kafka auto-config (`SentryKafkaQueueConfiguration` in `SentryAutoConfiguration`) is independently gated on `@ConditionalOnProperty(name = "sentry.enable-queue-tracing", havingValue = "true")`. That property is only set in `application-kafka.properties`, so Sentry instrumentation behavior is unchanged.

This makes the samples compose cleanly with future queue-transport profiles.

## :green_heart: How did you test it?

- `./gradlew :sentry-samples:sentry-samples-spring-boot-jakarta:compileJava :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:compileJava :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:compileJava` — clean build.
- `./gradlew spotlessApply apiDump` — clean.
- The existing `KafkaQueueSystemTest` already covers the `kafka` profile end-to-end.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add a `rabbitmq` profile to the Spring Boot Jakarta samples so Kafka and Rabbit can coexist without auto-config exclusion conflicts.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

