### PR TITLE
ref(kafka): [Queue Instrumentation 20] Log Kafka instrumentation failures

### DIFF
--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
@@ -6,6 +6,7 @@ import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransaction;
 import io.sentry.ScopesAdapter;
+import io.sentry.SentryLevel;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
@@ -83,7 +84,11 @@ public final class SentryKafkaConsumerTracing {
     try {
       forkedScopes = scopes.forkedRootScopes(CREATOR);
       lifecycleToken = forkedScopes.makeCurrent();
-    } catch (Throwable ignored) {
+    } catch (Throwable t) {
+      scopes
+          .getOptions()
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to fork scopes for Kafka consumer tracing.", t);
       return callable.call();
     }
 
@@ -175,7 +180,11 @@ public final class SentryKafkaConsumerTracing {
       }
 
       return transaction;
-    } catch (Throwable ignored) {
+    } catch (Throwable t) {
+      scopes
+          .getOptions()
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to start Kafka consumer tracing transaction.", t);
       return null;
     }
   }
@@ -194,8 +203,12 @@ public final class SentryKafkaConsumerTracing {
         transaction.setThrowable(throwable);
       }
       transaction.finish();
-    } catch (Throwable ignored) {
+    } catch (Throwable t) {
       // Instrumentation must never break customer processing.
+      scopes
+          .getOptions()
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to finish Kafka consumer tracing transaction.", t);
     }
   }
 

--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
@@ -5,6 +5,7 @@ import io.sentry.DateUtils;
 import io.sentry.IScopes;
 import io.sentry.ISpan;
 import io.sentry.ScopesAdapter;
+import io.sentry.SentryLevel;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanOptions;
@@ -71,8 +72,11 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
 
       span.setStatus(SpanStatus.OK);
       span.finish();
-    } catch (Throwable ignored) {
-      // Instrumentation must never break the customer's Kafka send.
+    } catch (Throwable t) {
+      scopes
+          .getOptions()
+          .getLogger()
+          .log(SentryLevel.ERROR, "Failed to instrument Kafka producer record.", t);
     }
 
     return record;


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Log `Throwable`s caught inside Kafka instrumentation instead of silently swallowing them.

Affected catch sites:

- `SentryKafkaProducerInterceptor.onSend(...)` — wrapping span creation and header injection.
- `SentryKafkaConsumerTracing.withTracingImpl(...)` — forking scopes + `makeCurrent()`.
- `SentryKafkaConsumerTracing.startTransaction(...)` — transaction creation.
- `SentryKafkaConsumerTracing.finishTransaction(...)` — transaction finish.

All catches still swallow the throwable so instrumentation failures never break the customer's Kafka send or record processing. The only change is that the failure is now reported to the SDK's own logger at `SentryLevel.ERROR` (same pattern already used in `RequestPayloadExtractor`).

`SentryKafkaRecordInterceptor` (Spring Jakarta) was audited alongside — it does not wrap instrumentation in `catch (Throwable)` blocks, so there is nothing silent to log. The existing `NumberFormatException` branches on malformed `sentry-task-enqueued-time` headers are expected input, not instrumentation faults, and remain silent both in the Spring interceptor and in `SentryKafkaConsumerTracing.receiveLatency(...)`.

## :bulb: Motivation and Context

The raw Kafka instrumentation in `sentry-kafka` deliberately fails open: if anything throws while Sentry tries to start/finish a span or inject tracing headers, the customer's Kafka operation still succeeds. That behavior is correct and is preserved here.

What was missing was any trace of such a failure. With `catch (Throwable ignored)`, an instrumentation bug would be invisible in production — neither the customer nor us would know the SDK was quietly failing. Surfacing it through the SDK logger matches how other integrations report unexpected internal failures (e.g. `RequestPayloadExtractor` in Spring Jakarta) and makes these paths debuggable without changing fail-open semantics.

## :green_heart: How did you test it?

- `./gradlew :sentry-kafka:compileJava` — clean.
- `./gradlew :sentry-kafka:test` — all tests pass, including the existing `SentryKafkaConsumerTracingTest` and `SentryKafkaProducerInterceptorTest` suites.
- `./gradlew spotlessApply apiDump` — clean.

Behavior verified by reading: catches still swallow the throwable and fall back exactly as before; only additional effect is a single `logger.log(ERROR, msg, t)` call per caught throwable.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

If the `NumberFormatException` header-parse branches ever prove useful to debug, they could be downgraded to `DEBUG` logs. Leaving silent for now since a malformed `sentry-task-enqueued-time` header is a data-shape issue, not an SDK fault.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

