### PR TITLE
fix(kafka): [Queue Instrumentation 21] Preserve third-party baggage on Kafka producer records

### DIFF
--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
@@ -13,10 +13,13 @@ import io.sentry.SpanStatus;
 import io.sentry.util.SpanUtils;
 import io.sentry.util.TracingUtils;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -97,8 +100,10 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
   public void configure(final @Nullable Map<String, ?> configs) {}
 
   private void injectHeaders(final @NotNull Headers headers, final @NotNull ISpan span) {
+    final @Nullable List<String> existingBaggageHeaders =
+        readHeaderValues(headers, BaggageHeader.BAGGAGE_HEADER);
     final @Nullable TracingUtils.TracingHeaders tracingHeaders =
-        TracingUtils.trace(scopes, null, span);
+        TracingUtils.trace(scopes, existingBaggageHeaders, span);
     if (tracingHeaders != null) {
       final @NotNull SentryTraceHeader sentryTraceHeader = tracingHeaders.getSentryTraceHeader();
       headers.remove(sentryTraceHeader.getName());
@@ -119,5 +124,20 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
         SENTRY_ENQUEUED_TIME_HEADER,
         String.valueOf(DateUtils.millisToSeconds(System.currentTimeMillis()))
             .getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static @Nullable List<String> readHeaderValues(
+      final @NotNull Headers headers, final @NotNull String name) {
+    @Nullable List<String> values = null;
+    for (final @NotNull Header header : headers.headers(name)) {
+      final byte @Nullable [] value = header.value();
+      if (value != null) {
+        if (values == null) {
+          values = new ArrayList<>();
+        }
+        values.add(new String(value, StandardCharsets.UTF_8));
+      }
+    }
+    return values;
   }
 }

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.kafka
 
+import io.sentry.BaggageHeader
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
 import io.sentry.Sentry
@@ -77,6 +78,37 @@ class SentryKafkaProducerInterceptorTest {
     assertNotNull(enqueuedTimeHeader)
     val enqueuedTime = String(enqueuedTimeHeader.value(), StandardCharsets.UTF_8).toDouble()
     assertTrue(enqueuedTime > 0)
+  }
+
+  @Test
+  fun `preserves pre-existing third-party baggage header entries`() {
+    val tx = createTransaction()
+    val interceptor = SentryKafkaProducerInterceptor<String, String>(scopes)
+    val record = ProducerRecord<String, String>("my-topic", "key", "value")
+    record
+      .headers()
+      .add(
+        BaggageHeader.BAGGAGE_HEADER,
+        "othervendor=someValue,another=thing".toByteArray(StandardCharsets.UTF_8),
+      )
+
+    interceptor.onSend(record)
+
+    val baggageHeaders = record.headers().headers(BaggageHeader.BAGGAGE_HEADER).toList()
+    assertEquals(1, baggageHeaders.size)
+    val baggageValue = String(baggageHeaders.first().value(), StandardCharsets.UTF_8)
+    assertTrue(
+      baggageValue.contains("othervendor=someValue"),
+      "expected third-party baggage entry preserved, got: $baggageValue",
+    )
+    assertTrue(
+      baggageValue.contains("another=thing"),
+      "expected third-party baggage entry preserved, got: $baggageValue",
+    )
+    assertTrue(
+      baggageValue.contains("sentry-"),
+      "expected Sentry baggage entries appended, got: $baggageValue",
+    )
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

`SentryKafkaProducerInterceptor.injectHeaders(...)` previously removed and overwrote the outgoing `baggage` header on every record, discarding any third-party baggage entries already present on the `ProducerRecord` (e.g. set by another vendor's instrumentation or by the application itself).

`injectHeaders(...)` now reads the existing `baggage` header values off the record and passes them to `TracingUtils.trace(scopes, existingBaggageHeaders, span)`. The downstream `BaggageHeader.fromBaggageAndOutgoingHeader(...)` parses those values, keeps the non-`sentry-*` entries, and appends them to Sentry's outgoing baggage — so upstream third-party baggage survives while Sentry still owns its own keys.

## :bulb: Motivation and Context

Consistent with how `sentry-okhttp`, `sentry-ktor-client`, and the Spring HTTP interceptors already preserve third-party baggage by forwarding existing `baggage` header values into `TracingUtils.traceIfAllowed(...)`. The raw Kafka producer integration should behave the same so customers don't lose vendor- or app-authored baggage entries when the Sentry producer interceptor writes its header.

## :green_heart: How did you test it?

- Added regression test `preserves pre-existing third-party baggage header entries` in `SentryKafkaProducerInterceptorTest` that pre-sets `baggage: othervendor=someValue,another=thing` on the record, runs `onSend`, and verifies the resulting outgoing `baggage` header contains both third-party entries and Sentry entries.
- `./gradlew :sentry-kafka:test --tests='io.sentry.kafka.SentryKafkaProducerInterceptorTest'` — all 6 tests pass.
- `./gradlew spotlessApply apiDump` — clean.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

