### PR TITLE
test(spring-boot-jakarta): [Queue Instrumentation 22] Cover spring-kafka class-absence gate

### DIFF
--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
@@ -9,6 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.kafka.core.KafkaTemplate
 
 class SentryKafkaAutoConfigurationTest {
 
@@ -34,6 +35,8 @@ class SentryKafkaAutoConfigurationTest {
   private val noSentryKafkaClassLoader =
     FilteredClassLoader(SentryKafkaProducerInterceptor::class.java)
 
+  private val noSpringKafkaClassLoader = FilteredClassLoader(KafkaTemplate::class.java)
+
   @Test
   fun `registers Kafka BPPs when queue tracing is enabled`() {
     contextRunner
@@ -57,6 +60,17 @@ class SentryKafkaAutoConfigurationTest {
   fun `does not register Kafka BPPs when sentry-kafka is not present`() {
     contextRunner
       .withClassLoader(noSentryKafkaClassLoader)
+      .withPropertyValues("sentry.enable-queue-tracing=true")
+      .run { context ->
+        assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)
+        assertThat(context).doesNotHaveBean(SentryKafkaConsumerBeanPostProcessor::class.java)
+      }
+  }
+
+  @Test
+  fun `does not register Kafka BPPs when spring-kafka is not present`() {
+    contextRunner
+      .withClassLoader(noSpringKafkaClassLoader)
       .withPropertyValues("sentry.enable-queue-tracing=true")
       .run { context ->
         assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

`SentryKafkaQueueConfiguration` in `SentryAutoConfiguration` is gated on two classes being present on the classpath:

```java
@ConditionalOnClass(name = {
  "org.springframework.kafka.core.KafkaTemplate",
  "io.sentry.kafka.SentryKafkaProducerInterceptor"
})
```

Only the `SentryKafkaProducerInterceptor`-missing half of that gate had test coverage. This PR adds a `FilteredClassLoader(KafkaTemplate::class.java)` test that asserts neither `SentryKafkaProducerBeanPostProcessor` nor `SentryKafkaConsumerBeanPostProcessor` is registered when spring-kafka is missing, even with `sentry.enable-queue-tracing=true`.

## :bulb: Motivation and Context

Round out the class-absence gate coverage in `SentryKafkaAutoConfigurationTest` so the autoconfig contract for spring-kafka being absent is explicitly pinned by a test.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-boot-jakarta:test --tests='io.sentry.spring.boot.jakarta.SentryKafkaAutoConfigurationTest'` — 6/6 pass (incl. new `does not register Kafka BPPs when spring-kafka is not present`).
- `./gradlew spotlessApply apiDump` — clean.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

