### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 23] Install Kafka context before trace setup

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -61,6 +61,7 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
 
     final @NotNull IScopes forkedScopes = scopes.forkedRootScopes("SentryKafkaRecordInterceptor");
     final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
+    currentContext.set(new SentryRecordContext(lifecycleToken, null));
 
     final @Nullable TransactionContext transactionContext = continueTrace(forkedScopes, record);
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

`SentryKafkaRecordInterceptor.intercept()` installs the forked scopes with `makeCurrent()` before it continues the trace or starts the consumer transaction.

This change stores the lifecycle token in `currentContext` immediately after `makeCurrent()`, before `continueTrace()` and `startTransaction()` run.

## :bulb: Motivation and Context

Spring Kafka invokes `RecordInterceptor.failure(...)` and `clearThreadState(...)` when interceptor work fails, but those callbacks can only clean up the forked scopes if the lifecycle token has already been published into `currentContext`.

Previously, exceptions during trace continuation or transaction setup could happen before that handoff. Publishing the context earlier makes the normal interceptor cleanup path available for those failures too.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry-spring-jakarta:test --tests='io.sentry.spring.jakarta.kafka.SentryKafkaRecordInterceptorTest'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

