### PR TITLE
fix(kafka): [Queue Instrumentation 24] Read all baggage headers on consumers

### DIFF
--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
@@ -15,7 +15,7 @@ import io.sentry.TransactionOptions;
 import io.sentry.util.SpanUtils;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -215,9 +215,8 @@ public final class SentryKafkaConsumerTracing {
   private <K, V> @Nullable TransactionContext continueTrace(
       final @NotNull IScopes forkedScopes, final @NotNull ConsumerRecord<K, V> record) {
     final @Nullable String sentryTrace = headerValue(record, SentryTraceHeader.SENTRY_TRACE_HEADER);
-    final @Nullable String baggage = headerValue(record, BaggageHeader.BAGGAGE_HEADER);
     final @Nullable List<String> baggageHeaders =
-        baggage != null ? Collections.singletonList(baggage) : null;
+        headerValues(record, BaggageHeader.BAGGAGE_HEADER);
     return forkedScopes.continueTrace(sentryTrace, baggageHeaders);
   }
 
@@ -264,5 +263,19 @@ public final class SentryKafkaConsumerTracing {
       return null;
     }
     return new String(header.value(), StandardCharsets.UTF_8);
+  }
+
+  private <K, V> @Nullable List<String> headerValues(
+      final @NotNull ConsumerRecord<K, V> record, final @NotNull String headerName) {
+    @Nullable List<String> values = null;
+    for (final @NotNull Header header : record.headers().headers(headerName)) {
+      if (header.value() != null) {
+        if (values == null) {
+          values = new ArrayList<>();
+        }
+        values.add(new String(header.value(), StandardCharsets.UTF_8));
+      }
+    }
+    return values;
   }
 }

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaConsumerTracingTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaConsumerTracingTest.kt
@@ -112,6 +112,21 @@ class SentryKafkaConsumerTracingTest {
   }
 
   @Test
+  fun `withTracing passes all baggage headers to continueTrace`() {
+    val sentryTraceValue = "2722d9f6ec019ade60c776169d9a8904-cedf5b7571cb4972-1"
+    val record =
+      createRecord(
+        sentryTrace = sentryTraceValue,
+        baggageHeaders = listOf("third=party", "sentry-sample_rate=1"),
+      )
+
+    tracing.withTracingImpl(record, Callable { "done" })
+
+    verify(forkedScopes)
+      .continueTrace(eq(sentryTraceValue), eq(listOf("third=party", "sentry-sample_rate=1")))
+  }
+
+  @Test
   fun `withTracing skips scope forking when queue tracing is disabled`() {
     options.isEnableQueueTracing = false
     val record = createRecord()
@@ -193,6 +208,7 @@ class SentryKafkaConsumerTracingTest {
     topic: String = "my-topic",
     sentryTrace: String? = null,
     baggage: String? = null,
+    baggageHeaders: List<String>? = null,
     messageId: String? = null,
     deliveryAttempt: Int? = null,
     enqueuedTime: String? = null,
@@ -203,6 +219,9 @@ class SentryKafkaConsumerTracingTest {
       headers.add(SentryTraceHeader.SENTRY_TRACE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
     }
     baggage?.let {
+      headers.add(BaggageHeader.BAGGAGE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
+    }
+    baggageHeaders?.forEach {
       headers.add(BaggageHeader.BAGGAGE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
     }
     messageId?.let {

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -14,7 +14,7 @@ import io.sentry.kafka.SentryKafkaProducerInterceptor;
 import io.sentry.util.SpanUtils;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -126,9 +126,8 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
   private @Nullable TransactionContext continueTrace(
       final @NotNull IScopes forkedScopes, final @NotNull ConsumerRecord<K, V> record) {
     final @Nullable String sentryTrace = headerValue(record, SentryTraceHeader.SENTRY_TRACE_HEADER);
-    final @Nullable String baggage = headerValue(record, BaggageHeader.BAGGAGE_HEADER);
     final @Nullable List<String> baggageHeaders =
-        baggage != null ? Collections.singletonList(baggage) : null;
+        headerValues(record, BaggageHeader.BAGGAGE_HEADER);
     return forkedScopes.continueTrace(sentryTrace, baggageHeaders);
   }
 
@@ -241,6 +240,20 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
       return null;
     }
     return new String(header.value(), StandardCharsets.UTF_8);
+  }
+
+  private @Nullable List<String> headerValues(
+      final @NotNull ConsumerRecord<K, V> record, final @NotNull String headerName) {
+    @Nullable List<String> values = null;
+    for (final @NotNull Header header : record.headers().headers(headerName)) {
+      if (header.value() != null) {
+        if (values == null) {
+          values = new ArrayList<>();
+        }
+        values.add(new String(header.value(), StandardCharsets.UTF_8));
+      }
+    }
+    return values;
   }
 
   private static final class SentryRecordContext {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -81,6 +81,7 @@ class SentryKafkaRecordInterceptorTest {
   private fun createRecordWithHeaders(
     sentryTrace: String? = null,
     baggage: String? = null,
+    baggageHeaders: List<String>? = null,
     enqueuedTime: String? = null,
     deliveryAttempt: Int? = null,
   ): ConsumerRecord<String, String> {
@@ -89,6 +90,9 @@ class SentryKafkaRecordInterceptorTest {
       headers.add(SentryTraceHeader.SENTRY_TRACE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
     }
     baggage?.let {
+      headers.add(BaggageHeader.BAGGAGE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
+    }
+    baggageHeaders?.forEach {
       headers.add(BaggageHeader.BAGGAGE_HEADER, it.toByteArray(StandardCharsets.UTF_8))
     }
     enqueuedTime?.let {
@@ -139,6 +143,25 @@ class SentryKafkaRecordInterceptorTest {
     interceptor.intercept(record, consumer)
 
     verify(forkedScopes).continueTrace(org.mockito.kotlin.isNull(), org.mockito.kotlin.isNull())
+  }
+
+  @Test
+  fun `intercept passes all baggage headers to continueTrace`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val sentryTraceValue = "2722d9f6ec019ade60c776169d9a8904-cedf5b7571cb4972-1"
+    val record =
+      createRecordWithHeaders(
+        sentryTrace = sentryTraceValue,
+        baggageHeaders = listOf("third=party", "sentry-sample_rate=1"),
+      )
+
+    interceptor.intercept(record, consumer)
+
+    verify(forkedScopes)
+      .continueTrace(
+        org.mockito.kotlin.eq(sentryTraceValue),
+        org.mockito.kotlin.eq(listOf("third=party", "sentry-sample_rate=1")),
+      )
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Both Kafka consumer tracing paths only forwarded `lastHeader("baggage")` into `continueTrace(...)`.

This change reads every `baggage` header from the record and passes the full list into trace continuation in:

- `SentryKafkaConsumerTracing`
- `SentryKafkaRecordInterceptor`

It also adds tests covering multiple baggage headers for both implementations.

## :bulb: Motivation and Context

Kafka records can legitimately carry multiple `baggage` headers. Reading only the last one drops earlier entries and can break distributed tracing interop with upstream OpenTelemetry or other W3C baggage producers.

Passing the full header list preserves the existing baggage context during queue trace continuation.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump :sentry-kafka:test --tests='io.sentry.kafka.SentryKafkaConsumerTracingTest' :sentry-spring-jakarta:test --tests='io.sentry.spring.jakarta.kafka.SentryKafkaRecordInterceptorTest'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

