### PR TITLE
fix(kafka): [Queue Instrumentation 25] Finish producer spans on failures

### DIFF
--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
@@ -59,11 +59,11 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
       return record;
     }
 
+    @Nullable ISpan span = null;
     try {
       final @NotNull SpanOptions spanOptions = new SpanOptions();
       spanOptions.setOrigin(traceOrigin);
-      final @NotNull ISpan span =
-          activeSpan.startChild("queue.publish", record.topic(), spanOptions);
+      span = activeSpan.startChild("queue.publish", record.topic(), spanOptions);
       if (span.isNoOp()) {
         return record;
       }
@@ -72,14 +72,20 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
       span.setData(SpanDataConvention.MESSAGING_DESTINATION_NAME, record.topic());
 
       injectHeaders(record.headers(), span);
-
       span.setStatus(SpanStatus.OK);
-      span.finish();
     } catch (Throwable t) {
+      if (span != null) {
+        span.setThrowable(t);
+        span.setStatus(SpanStatus.INTERNAL_ERROR);
+      }
       scopes
           .getOptions()
           .getLogger()
           .log(SentryLevel.ERROR, "Failed to instrument Kafka producer record.", t);
+    } finally {
+      if (span != null && !span.isFinished()) {
+        span.finish();
+      }
     }
 
     return record;

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
@@ -3,10 +3,13 @@ package io.sentry.kafka
 import io.sentry.BaggageHeader
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
+import io.sentry.ISpan
 import io.sentry.Sentry
 import io.sentry.SentryOptions
 import io.sentry.SentryTraceHeader
 import io.sentry.SentryTracer
+import io.sentry.SpanOptions
+import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.test.initForTest
 import java.nio.charset.StandardCharsets
@@ -18,7 +21,12 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.Headers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class SentryKafkaProducerInterceptorTest {
@@ -109,6 +117,35 @@ class SentryKafkaProducerInterceptorTest {
       baggageValue.contains("sentry-"),
       "expected Sentry baggage entries appended, got: $baggageValue",
     )
+  }
+
+  @Test
+  fun `finishes span with error when header injection fails`() {
+    val activeSpan = mock<ISpan>()
+    val span = mock<ISpan>()
+    val headers = mock<Headers>()
+    val record = mock<ProducerRecord<String, String>>()
+    val exception = RuntimeException("boom")
+    whenever(scopes.span).thenReturn(activeSpan)
+    whenever(activeSpan.startChild(eq("queue.publish"), eq("my-topic"), any<SpanOptions>()))
+      .thenReturn(span)
+    whenever(span.isNoOp).thenReturn(false)
+    whenever(span.isFinished).thenReturn(false)
+    whenever(span.toSentryTrace())
+      .thenReturn(SentryTraceHeader("2722d9f6ec019ade60c776169d9a8904-cedf5b7571cb4972-1"))
+    whenever(span.toBaggageHeader(null)).thenReturn(null)
+    whenever(record.topic()).thenReturn("my-topic")
+    whenever(record.headers()).thenReturn(headers)
+    whenever(headers.headers(BaggageHeader.BAGGAGE_HEADER)).thenReturn(emptyList<Header>())
+    whenever(headers.remove(SentryTraceHeader.SENTRY_TRACE_HEADER)).thenThrow(exception)
+
+    val interceptor = SentryKafkaProducerInterceptor<String, String>(scopes)
+
+    interceptor.onSend(record)
+
+    verify(span).setStatus(SpanStatus.INTERNAL_ERROR)
+    verify(span).setThrowable(exception)
+    verify(span).finish()
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

This closes the `queue.publish` producer span even when Kafka header injection fails.

The producer interceptor now keeps a local span reference, marks the span as `INTERNAL_ERROR` when instrumentation throws after span creation, and finishes it in `finally`.

It also adds a regression test covering header injection failures.

## :bulb: Motivation and Context

The current producer path logs and fails open when instrumentation throws, but a failure after `startChild(...)` can leave the created child span unfinished.

Finishing that span in `finally` preserves the fail-open send behavior while keeping the span lifecycle consistent.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump :sentry-kafka:test --tests='io.sentry.kafka.SentryKafkaProducerInterceptorTest'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

