### PR TITLE
fix(kafka): [Queue Instrumentation 26] Mark producer interceptor experimental

### DIFF
--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInterceptor<K, V> {
 
   public static final @NotNull String TRACE_ORIGIN = "auto.queue.kafka.producer";


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

This changes `SentryKafkaProducerInterceptor` from `@ApiStatus.Internal` to `@ApiStatus.Experimental`.

It also audits the remaining Kafka classes still marked internal and leaves the Spring Kafka bean post processors and Spring record interceptor unchanged.

## :bulb: Motivation and Context

Raw Kafka customers configure `SentryKafkaProducerInterceptor` directly by canonical class name through Kafka producer properties.

Marking that class internal is contradictory and makes the only supported raw producer setup path look unsupported in IDEs and static analysis. `Experimental` matches the current maturity of the queue tracing API without hiding it behind an internal annotation.

The other Kafka classes still marked internal are Spring wiring details used by Sentry auto-configuration rather than direct customer entry points, so they should remain internal for now.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump :sentry-kafka:test --tests='io.sentry.kafka.SentryKafkaProducerInterceptorTest' :sentry-spring-boot-jakarta:test --tests='io.sentry.spring.boot.jakarta.SentryKafkaAutoConfigurationTest'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

