### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 27] Delegate Kafka record thread-state hooks

### DIFF
--- a/sentry-spring-jakarta/api/sentry-spring-jakarta.api
+++ b/sentry-spring-jakarta/api/sentry-spring-jakarta.api
@@ -263,6 +263,7 @@ public final class io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor :
 	public fun clearThreadState (Lorg/apache/kafka/clients/consumer/Consumer;)V
 	public fun failure (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Ljava/lang/Exception;Lorg/apache/kafka/clients/consumer/Consumer;)V
 	public fun intercept (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Lorg/apache/kafka/clients/consumer/Consumer;)Lorg/apache/kafka/clients/consumer/ConsumerRecord;
+	public fun setupThreadState (Lorg/apache/kafka/clients/consumer/Consumer;)V
 	public fun success (Lorg/apache/kafka/clients/consumer/ConsumerRecord;Lorg/apache/kafka/clients/consumer/Consumer;)V
 }
 

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -107,8 +107,21 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
   }
 
   @Override
+  public void setupThreadState(final @NotNull Consumer<?, ?> consumer) {
+    if (delegate != null) {
+      delegate.setupThreadState(consumer);
+    }
+  }
+
+  @Override
   public void clearThreadState(final @NotNull Consumer<?, ?> consumer) {
-    finishStaleContext();
+    try {
+      finishStaleContext();
+    } finally {
+      if (delegate != null) {
+        delegate.clearThreadState(consumer);
+      }
+    }
   }
 
   private boolean isIgnored() {

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -299,6 +299,52 @@ class SentryKafkaRecordInterceptorTest {
   }
 
   @Test
+  fun `setupThreadState delegates to existing interceptor`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+
+    interceptor.setupThreadState(consumer)
+
+    verify(delegate).setupThreadState(consumer)
+  }
+
+  @Test
+  fun `setupThreadState is no-op without delegate`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+
+    // should not throw
+    interceptor.setupThreadState(consumer)
+  }
+
+  @Test
+  fun `clearThreadState delegates to existing interceptor`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+
+    interceptor.clearThreadState(consumer)
+
+    verify(delegate).clearThreadState(consumer)
+  }
+
+  @Test
+  fun `clearThreadState delegates to existing interceptor even when sentry cleanup throws`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    whenever(lifecycleToken.close()).thenThrow(RuntimeException("boom"))
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+    val record = createRecord()
+
+    interceptor.intercept(record, consumer)
+
+    try {
+      interceptor.clearThreadState(consumer)
+    } catch (ignored: RuntimeException) {
+      // expected
+    }
+
+    verify(delegate).clearThreadState(consumer)
+  }
+
+  @Test
   fun `intercept cleans up stale context from previous record`() {
     val lifecycleToken2 = mock<ISentryLifecycleToken>()
     val forkedScopes2 = mock<IScopes>()


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Delegate Spring Kafka `ThreadStateProcessor` hooks (`setupThreadState` / `clearThreadState`) from `SentryKafkaRecordInterceptor` to the wrapped customer `RecordInterceptor`, if any.

- Override `setupThreadState(Consumer<?, ?>)` and forward to the delegate.
- In `clearThreadState(Consumer<?, ?>)`, run Sentry cleanup in `try` and forward to the delegate in `finally` so the delegate's cleanup still runs if Sentry's cleanup throws.
- Added unit tests covering: delegation of both lifecycle hooks, no-op behavior when no delegate is present, and delegate cleanup running even when Sentry cleanup throws.

## :bulb: Motivation and Context

`SentryKafkaConsumerBeanPostProcessor` automatically wraps any existing `RecordInterceptor` on the listener container factory. `RecordInterceptor` extends `ThreadStateProcessor`, which exposes `setupThreadState` and `clearThreadState` — commonly used for MDC, security-context, or other thread-local propagation/cleanup on Kafka listener threads.

Previously `SentryKafkaRecordInterceptor` did not override `setupThreadState` (so the default no-op from `ThreadStateProcessor` shadowed the delegate's implementation) and its `clearThreadState` did Sentry cleanup without ever forwarding to the delegate. Customers with a pre-existing `RecordInterceptor` using these hooks would silently lose thread-state setup/cleanup after Sentry wrapped their interceptor — potentially surfacing as missing MDC, stale security context, or leaked thread-local state on listener threads.

Addresses review finding F-010.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-jakarta:test --tests "io.sentry.spring.jakarta.kafka.SentryKafkaRecordInterceptorTest"` — all 21 tests pass, including four new regression tests for thread-state delegation.
- `./gradlew spotlessApply apiDump` — no formatting changes; API dump updated to expose the new `setupThreadState` override.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

