### PR TITLE
test(samples): [Queue Instrumentation 28] Cover OTel Jakarta Kafka coexistence in CI

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
@@ -1,0 +1,45 @@
+package io.sentry.systemtest
+
+import io.sentry.systemtest.util.TestHelper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.Before
+
+/**
+ * System tests for Kafka queue instrumentation on the OTel Jakarta noagent sample.
+ *
+ * The Sentry Kafka auto-configuration (`SentryKafkaQueueConfiguration`) is intentionally suppressed
+ * when `io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider` is on the classpath, so
+ * the Sentry `SentryKafkaProducerInterceptor` and `SentryKafkaRecordInterceptor` must not be wired.
+ *
+ * These tests produce a Kafka message end-to-end and assert that Sentry-style `queue.publish` /
+ * `queue.process` spans/transactions are *not* emitted. Any Kafka telemetry in OTel mode must come
+ * from the OTel Kafka instrumentation, not from the Sentry Kafka integration.
+ *
+ * Requires:
+ * - The sample app running with `--spring.profiles.active=kafka`
+ * - A Kafka broker at localhost:9092
+ * - The mock Sentry server at localhost:8000
+ */
+class KafkaOtelCoexistenceSystemTest {
+  lateinit var testHelper: TestHelper
+
+  @Before
+  fun setup() {
+    testHelper = TestHelper("http://localhost:8080")
+    testHelper.reset()
+  }
+
+  @Test
+  fun `Sentry Kafka integration is suppressed when OTel is active`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("otel-coexistence-test")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    testHelper.ensureNoTransactionReceived { transaction, _ ->
+      transaction.contexts.trace?.operation == "queue.process" ||
+        transaction.spans.any { span -> span.op == "queue.publish" }
+    }
+  }
+}

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
@@ -1,0 +1,45 @@
+package io.sentry.systemtest
+
+import io.sentry.systemtest.util.TestHelper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.Before
+
+/**
+ * System tests for Kafka queue instrumentation on the OTel Jakarta sample.
+ *
+ * The Sentry Kafka auto-configuration (`SentryKafkaQueueConfiguration`) is intentionally suppressed
+ * when `io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider` is on the classpath, so
+ * the Sentry `SentryKafkaProducerInterceptor` and `SentryKafkaRecordInterceptor` must not be wired.
+ *
+ * These tests produce a Kafka message end-to-end and assert that Sentry-style `queue.publish` /
+ * `queue.process` spans/transactions are *not* emitted. Any Kafka telemetry in OTel mode must come
+ * from the OTel Kafka instrumentation, not from the Sentry Kafka integration.
+ *
+ * Requires:
+ * - The sample app running with `--spring.profiles.active=kafka`
+ * - A Kafka broker at localhost:9092
+ * - The mock Sentry server at localhost:8000
+ */
+class KafkaOtelCoexistenceSystemTest {
+  lateinit var testHelper: TestHelper
+
+  @Before
+  fun setup() {
+    testHelper = TestHelper("http://localhost:8080")
+    testHelper.reset()
+  }
+
+  @Test
+  fun `Sentry Kafka integration is suppressed when OTel is active`() {
+    val restClient = testHelper.restClient
+
+    restClient.produceKafkaMessage("otel-coexistence-test")
+    assertEquals(200, restClient.lastKnownStatusCode)
+
+    testHelper.ensureNoTransactionReceived { transaction, _ ->
+      transaction.contexts.trace?.operation == "queue.process" ||
+        transaction.spans.any { span -> span.op == "queue.publish" }
+    }
+  }
+}

--- a/test/system-test-runner.py
+++ b/test/system-test-runner.py
@@ -71,9 +71,13 @@ KAFKA_BOOTSTRAP_SERVERS = "localhost:9092"
 KAFKA_BROKER_REQUIRED_MODULES = {
     "sentry-samples-console",
     "sentry-samples-spring-boot-jakarta",
+    "sentry-samples-spring-boot-jakarta-opentelemetry",
+    "sentry-samples-spring-boot-jakarta-opentelemetry-noagent",
 }
 KAFKA_PROFILE_REQUIRED_MODULES = {
     "sentry-samples-spring-boot-jakarta",
+    "sentry-samples-spring-boot-jakarta-opentelemetry",
+    "sentry-samples-spring-boot-jakarta-opentelemetry-noagent",
 }
 
 class ServerType(Enum):


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Enable Kafka-profile CI coverage for the OTel Spring Boot 3 Jakarta sample variants and assert the intended OTel coexistence behavior end-to-end.

- Add `sentry-samples-spring-boot-jakarta-opentelemetry` and `sentry-samples-spring-boot-jakarta-opentelemetry-noagent` to both `KAFKA_BROKER_REQUIRED_MODULES` and `KAFKA_PROFILE_REQUIRED_MODULES` in `test/system-test-runner.py` so they start with `--spring.profiles.active=kafka` and a Kafka broker in CI.
- Add `KafkaOtelCoexistenceSystemTest` in each OTel Jakarta sample that produces a Kafka message end-to-end and asserts no Sentry-style `queue.publish` span or `queue.process` transaction is emitted.

## :bulb: Motivation and Context

`SentryKafkaQueueConfiguration` is guarded by `@ConditionalOnMissingClass("io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider")`, so the Sentry Kafka bean post-processors are intentionally not wired when the Sentry OTel integration is present. Previously the OTel Jakarta samples were part of the backend system-test matrix but never ran with the Kafka profile active, so the shipped OTel + Kafka coexistence contract had no end-to-end guardrail in CI. Regressions that re-enabled Sentry's Kafka interceptors in OTel mode (or otherwise broke the suppression) could ship unnoticed.

Addresses review finding F-011.

## :green_heart: How did you test it?

- `./gradlew :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:compileTestKotlin :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:compileTestKotlin` — new system tests compile cleanly.
- `./gradlew spotlessApply apiDump` — formatting applied, no API changes.
- `python3 -c "import ast; ast.parse(open('test/system-test-runner.py').read())"` — runner still parses.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

