### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 29] Set body_size on Spring Kafka consumer transaction

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -177,6 +177,11 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
       transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_ID, messageId);
     }
 
+    final int bodySize = record.serializedValueSize();
+    if (bodySize >= 0) {
+      transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_BODY_SIZE, bodySize);
+    }
+
     final @Nullable Integer retryCount = retryCount(record);
     if (retryCount != null) {
       transaction.setData(SpanDataConvention.MESSAGING_MESSAGE_RETRY_COUNT, retryCount);

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -13,6 +13,7 @@ import io.sentry.kafka.SentryKafkaProducerInterceptor
 import io.sentry.test.initForTest
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import java.util.Optional
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -22,6 +23,7 @@ import kotlin.test.assertTrue
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.internals.RecordHeaders
+import org.apache.kafka.common.record.TimestampType
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -72,10 +74,21 @@ class SentryKafkaRecordInterceptorTest {
   private fun createRecord(
     topic: String = "my-topic",
     headers: RecordHeaders = RecordHeaders(),
+    serializedValueSize: Int = -1,
   ): ConsumerRecord<String, String> {
-    val record = ConsumerRecord<String, String>(topic, 0, 0L, "key", "value")
-    headers.forEach { record.headers().add(it) }
-    return record
+    return ConsumerRecord(
+      topic,
+      0,
+      0L,
+      System.currentTimeMillis(),
+      TimestampType.CREATE_TIME,
+      3,
+      serializedValueSize,
+      "key",
+      "value",
+      headers,
+      Optional.empty(),
+    )
   }
 
   private fun createRecordWithHeaders(
@@ -162,6 +175,26 @@ class SentryKafkaRecordInterceptorTest {
         org.mockito.kotlin.eq(sentryTraceValue),
         org.mockito.kotlin.eq(listOf("third=party", "sentry-sample_rate=1")),
       )
+  }
+
+  @Test
+  fun `sets body size from serializedValueSize`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord(serializedValueSize = 42)
+
+    interceptor.intercept(record, consumer)
+
+    assertEquals(42, transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_BODY_SIZE))
+  }
+
+  @Test
+  fun `does not set body size when serializedValueSize is negative`() {
+    val interceptor = SentryKafkaRecordInterceptor<String, String>(scopes)
+    val record = createRecord(serializedValueSize = -1)
+
+    interceptor.intercept(record, consumer)
+
+    assertNull(transaction.data?.get(SpanDataConvention.MESSAGING_MESSAGE_BODY_SIZE))
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Set `messaging.message.body_size` on the `queue.process` transaction created by the Spring Kafka consumer path (`SentryKafkaRecordInterceptor`).

- Mirror `sentry-kafka`'s `SentryKafkaConsumerTracing`: read `ConsumerRecord#serializedValueSize()` and, when non-negative, set `SpanDataConvention.MESSAGING_MESSAGE_BODY_SIZE` on the transaction.
- Add two regression tests — positive `serializedValueSize` sets the attribute; the default `-1` (unknown) omits it.

## :bulb: Motivation and Context

Two first-party Kafka consumer integrations shipped in the same stack — the raw `sentry-kafka` helper and the Spring Kafka `RecordInterceptor` — were emitting different messaging schemas for the same underlying record metadata. The raw helper already set `messaging.message.body_size` from `record.serializedValueSize()`, but the Spring path never did, so customers filtering or grouping on that attribute saw inconsistent results across Spring vs. raw Kafka setups and dashboards could not rely on it being populated.

Addresses review finding F-012.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-jakarta:test --tests "io.sentry.spring.jakarta.kafka.SentryKafkaRecordInterceptorTest"` — 23/23 tests pass, including the two new `body_size` cases.
- `./gradlew spotlessApply apiDump` — formatting applied, no API changes (class is `@ApiStatus.Internal`).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

