### PR TITLE
test(spring-jakarta): [Queue Instrumentation 30] Cover Kafka record interceptor lifecycle edge cases

### DIFF
--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.apache.kafka.clients.consumer.Consumer
@@ -27,6 +28,7 @@ import org.apache.kafka.common.record.TimestampType
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.kafka.listener.RecordInterceptor
@@ -374,6 +376,64 @@ class SentryKafkaRecordInterceptorTest {
       // expected
     }
 
+    verify(delegate).clearThreadState(consumer)
+  }
+
+  @Test
+  fun `full lifecycle intercept success clearThreadState closes token exactly once`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    val record = createRecord()
+    whenever(delegate.intercept(record, consumer)).thenReturn(record)
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+
+    interceptor.setupThreadState(consumer)
+    interceptor.intercept(record, consumer)
+    interceptor.success(record, consumer)
+    interceptor.clearThreadState(consumer)
+
+    // token closed once by success(); clearThreadState must not re-close it
+    verify(lifecycleToken, times(1)).close()
+    assertTrue(transaction.isFinished)
+    // delegate hooks still delegated across the full lifecycle
+    verify(delegate).setupThreadState(consumer)
+    verify(delegate).success(record, consumer)
+    verify(delegate).clearThreadState(consumer)
+  }
+
+  @Test
+  fun `when delegate intercept returns null clearThreadState still finishes transaction and closes token`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    val record = createRecord()
+    // delegate filters the record — per Spring Kafka contract, success/failure will not be invoked
+    whenever(delegate.intercept(record, consumer)).thenReturn(null)
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+
+    interceptor.setupThreadState(consumer)
+    val result = interceptor.intercept(record, consumer)
+    interceptor.clearThreadState(consumer)
+
+    assertNull(result)
+    verify(lifecycleToken, times(1)).close()
+    assertTrue(transaction.isFinished)
+    verify(delegate).clearThreadState(consumer)
+  }
+
+  @Test
+  fun `when delegate intercept throws clearThreadState still finishes transaction and closes token`() {
+    val delegate = mock<RecordInterceptor<String, String>>()
+    val record = createRecord()
+    val boom = RuntimeException("delegate boom")
+    whenever(delegate.intercept(record, consumer)).thenThrow(boom)
+    val interceptor = SentryKafkaRecordInterceptor(scopes, delegate)
+
+    interceptor.setupThreadState(consumer)
+    val thrown = assertFailsWith<RuntimeException> { interceptor.intercept(record, consumer) }
+    assertEquals(boom, thrown)
+
+    interceptor.clearThreadState(consumer)
+
+    verify(lifecycleToken, times(1)).close()
+    assertTrue(transaction.isFinished)
     verify(delegate).clearThreadState(consumer)
   }
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Add three regression tests for `SentryKafkaRecordInterceptor` that pin down the lifecycle contract around `clearThreadState` cleanup.

Scenarios covered:

- **Full happy-path lifecycle** — `setupThreadState → intercept → success → clearThreadState` closes the forked scope's lifecycle token exactly once and does not double-finish the transaction. Also verifies all three delegate hooks are invoked.
- **Delegate `intercept` returns `null`** — per Spring Kafka's contract, `success`/`failure` are not invoked when the record is filtered. The safety net in `clearThreadState` → `finishStaleContext` still finishes the transaction (with `UNKNOWN` status) and closes the lifecycle token, and the delegating interceptor's `clearThreadState` is still called.
- **Delegate `intercept` throws** — the exception propagates out of `SentryKafkaRecordInterceptor.intercept`. A subsequent `clearThreadState` call still finishes the transaction and closes the lifecycle token via the same safety net. (Note: in the real Spring Kafka container, `KafkaMessageListenerContainer.doInvokeRecordListener` also catches this and invokes `failure` — this test focuses on the interceptor's own fallback path.)

No source changes. The existing `clearThreadState` safety net already guarantees cleanup on all three paths; these tests lock the guarantee in place against future refactors.

## :bulb: Motivation and Context

Addresses review finding **R6-F001**: prior tests verified `setupThreadState` and `clearThreadState` delegation in isolation, but nothing exercised the full Spring Kafka listener lifecycle end to end. A future refactor of `finishSpan` or `finishStaleContext` could silently introduce a double-finish (or break the safety-net cleanup when `success`/`failure` are not invoked) without any test failing.

These tests make the "intercept-exits-abnormally still gets cleaned up exactly once" contract explicit.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-jakarta:test --tests "*SentryKafkaRecordInterceptorTest*"` — all 26 tests pass (23 prior + 3 new).
- `./gradlew spotlessApply apiDump` — clean, no API changes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Remaining open review findings from review6.md:

- **R6-F002** — `KafkaOtelCoexistenceSystemTest` negative assertion not anchored to observable activity
- **R6-F003** — Exception suppression in `clearThreadState` when both Sentry cleanup and delegate cleanup throw (P3)

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

