### PR TITLE
fix(kafka): [Queue Instrumentation 31] Write enqueued-time header as plain decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Android: Attachments on the scope will now be synced to native ([#5211](https://github.com/getsentry/sentry-java/pull/5211))
 - Add THIRD_PARTY_NOTICES.md for vendored third-party code, bundled as SENTRY_THIRD_PARTY_NOTICES.md in the sentry JAR under META-INF ([#5186](https://github.com/getsentry/sentry-java/pull/5186))
 
+### Fixes
+
+- Write the `sentry-task-enqueued-time` Kafka header as a plain decimal so cross-SDK consumers (e.g. sentry-python) can parse it ([#5328](https://github.com/getsentry/sentry-java/pull/5328))
+
 ## 8.37.1
 
 ### Fixes

--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducerInterceptor.java
@@ -128,7 +128,8 @@ public final class SentryKafkaProducerInterceptor<K, V> implements ProducerInter
     headers.remove(SENTRY_ENQUEUED_TIME_HEADER);
     headers.add(
         SENTRY_ENQUEUED_TIME_HEADER,
-        String.valueOf(DateUtils.millisToSeconds(System.currentTimeMillis()))
+        DateUtils.doubleToBigDecimal(DateUtils.millisToSeconds(System.currentTimeMillis()))
+            .toString()
             .getBytes(StandardCharsets.UTF_8));
   }
 

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerInterceptorTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -84,7 +85,19 @@ class SentryKafkaProducerInterceptorTest {
     val enqueuedTimeHeader =
       record.headers().lastHeader(SentryKafkaProducerInterceptor.SENTRY_ENQUEUED_TIME_HEADER)
     assertNotNull(enqueuedTimeHeader)
-    val enqueuedTime = String(enqueuedTimeHeader.value(), StandardCharsets.UTF_8).toDouble()
+    val enqueuedTimeRaw = String(enqueuedTimeHeader.value(), StandardCharsets.UTF_8)
+    // Must be written as a plain decimal so cross-SDK consumers (e.g. sentry-python) can
+    // parse it. String.valueOf(double) would emit scientific notation (e.g. 1.77E9) for
+    // epoch seconds.
+    assertFalse(
+      enqueuedTimeRaw.contains('E') || enqueuedTimeRaw.contains('e'),
+      "enqueued-time header must not use scientific notation, got: $enqueuedTimeRaw",
+    )
+    assertTrue(
+      enqueuedTimeRaw.matches(Regex("""^\d+\.\d{6}$""")),
+      "enqueued-time header must be plain epoch seconds with 6 decimals, got: $enqueuedTimeRaw",
+    )
+    val enqueuedTime = enqueuedTimeRaw.toDouble()
     assertTrue(enqueuedTime > 0)
   }
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Fix the `sentry-task-enqueued-time` Kafka header being serialized in scientific notation (e.g. `1.776933649613E9`). The producer interceptor was writing the value via `String.valueOf(double)`, which switches to scientific notation once `|d| >= 10^7` — and epoch seconds are always `~1.77 × 10^9`.

Route the value through `DateUtils.doubleToBigDecimal(...).toString()` — the same helper already used to serialize epoch-seconds timestamps in `SentryTransaction`, `SentrySpan`, `SentryLogEvent`, `SentryMetricsEvent`, `ProfileChunk`, etc. At the pinned scale of 6, `BigDecimal.toString()` produces plain decimal form (`1776938295.692000`) for every realistic epoch-seconds magnitude.

Addresses [review7.md](https://github.com/getsentry/sentry-java/pull/5283#discussion_r3122702573) finding **R7-F017** — the only remaining open review comment across the Queue Instrumentation stack (1–30).

## :bulb: Motivation and Context

PR #5283 ("Align enqueue time with Python") was meant to make the Java Kafka queue instrumentation interoperable with other Sentry SDKs by switching the header payload to epoch seconds. However, the format it actually shipped — Java's default `double` `toString` — uses scientific notation for all realistic timestamps, which:

- Python's `sentry_sdk` (and Ruby, PHP, .NET) Celery consumers parse the header with plain-decimal expectations, so they would fail to parse Java-produced headers.
- The Java consumer (`SentryKafkaConsumerTracing.receiveLatency`) uses `Double.parseDouble`, which accepts both plain and scientific forms — so internal round-trips pass and none of the existing tests caught the bug.

This PR closes the gap without a core API change by reusing the canonical `DateUtils.doubleToBigDecimal` helper.

## :green_heart: How did you test it?

- Added regression assertions in `SentryKafkaProducerInterceptorTest."creates queue publish span and injects headers"` that:
  - reject scientific notation (`'E'`/`'e'` characters),
  - pin the plain-decimal format via `^\d+\.\d{6}$`,
  - round-trip via `toDouble()`.
- `./gradlew :sentry-kafka:test` — all 7 producer-interceptor tests pass.
- `./gradlew :sentry-spring-jakarta:test --tests="*Kafka*"` — green.
- `./gradlew spotlessApply apiDump` — clean, no API surface changes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Port the same fix to the Spring Boot 4 and Spring Boot 2 Kafka interceptors once those stack PRs land.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

