### PR TITLE
chore(deps): bump camerax to 1.4.0 for Android 16KB page size compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ compileSdk = "36"
 minSdk = "21"
 spotless = "7.0.4"
 gummyBears = "0.12.0"
-camerax = "1.3.0"
+camerax = "1.4.0"
 openfeature = "1.18.2"
 
 [plugins]


### PR DESCRIPTION
## Summary

Bumps CameraX from 1.3.0 to 1.4.0 to be compatible with Android 16KB page size requirements.

1.5+ already has minSdk=23, so sticking to `1.4.0` for now.

#skip-changelog