### PR TITLE
test(spring-boot-jakarta): [Queue Instrumentation 32] Filter OTel in Kafka auto-config negative tests

### DIFF
--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
@@ -33,9 +33,16 @@ class SentryKafkaAutoConfigurationTest {
     FilteredClassLoader(SentryAutoConfigurationCustomizerProvider::class.java)
 
   private val noSentryKafkaClassLoader =
-    FilteredClassLoader(SentryKafkaProducerInterceptor::class.java)
+    FilteredClassLoader(
+      SentryKafkaProducerInterceptor::class.java,
+      SentryAutoConfigurationCustomizerProvider::class.java,
+    )
 
-  private val noSpringKafkaClassLoader = FilteredClassLoader(KafkaTemplate::class.java)
+  private val noSpringKafkaClassLoader =
+    FilteredClassLoader(
+      KafkaTemplate::class.java,
+      SentryAutoConfigurationCustomizerProvider::class.java,
+    )
 
   @Test
   fun `registers Kafka BPPs when queue tracing is enabled`() {


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Fix the Kafka auto-config negative regression tests so they validate the `@ConditionalOnClass` gate they claim to guard.

`SentryKafkaQueueConfiguration` is gated by three annotations:

1. `@ConditionalOnClass({KafkaTemplate, SentryKafkaProducerInterceptor})`
2. `@ConditionalOnProperty("sentry.enable-queue-tracing" = "true")`
3. `@ConditionalOnMissingClass("io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider")`

The regression tests `does not register Kafka BPPs when sentry-kafka is not present` and `...when spring-kafka is not present` used `FilteredClassLoader` to hide `SentryKafkaProducerInterceptor` / `KafkaTemplate` respectively, asserting the BPPs are absent. But `sentry-opentelemetry-agentless-spring` is on `testImplementation`, so `SentryAutoConfigurationCustomizerProvider` is always on the test classpath — gate #3 was already blocking the config independent of gate #1. The tests passed for the wrong reason: if someone removed a class from `@ConditionalOnClass`, they would still pass.

Extend both `FilteredClassLoader`s to additionally filter `SentryAutoConfigurationCustomizerProvider`, so gate #3 is satisfied and only the gate under test can be the blocker. With this change, temporarily removing `"io.sentry.kafka.SentryKafkaProducerInterceptor"` from `@ConditionalOnClass` causes the `sentry-kafka not present` test to correctly fail — confirmed locally before restoring the gate.

Addresses [review8.md](https://github.com/getsentry/sentry-java/pull/5291#discussion_r3129873509) finding **R8-F005**.

## :bulb: Motivation and Context

PR #5291 introduced these negative regression tests to guard against the `NoClassDefFoundError` scenario from review finding R8-F003 (`sentry-kafka` absent but `spring-kafka` present with queue tracing enabled → `@ConditionalOnClass` must skip the configuration). The tests passed, so the gate was presumed covered. The audit in review8 showed the tests could not detect a regression because an unrelated gate was doing the work. Fixing this ensures the regression test is load-bearing, not decorative.

## :green_heart: How did you test it?

- `./gradlew :sentry-spring-boot-jakarta:test --tests SentryKafkaAutoConfigurationTest` — all 6 tests pass.
- Chaos check: temporarily removed `"io.sentry.kafka.SentryKafkaProducerInterceptor"` from `@ConditionalOnClass` → `does not register Kafka BPPs when sentry-kafka is not present` now fails (as it should). Gate restored.
- `./gradlew spotlessApply apiDump` — clean.

## :pencil: Checklist

- [x] I added tests to verify the changes. (This PR *is* a test-quality fix; no production code changes.)
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Remaining open items on the Queue Instrumentation stack after this PR:

- **R8-F004** — `test/system-test-runner.py` `stop_kafka_broker()` guard prevents pre-start stale-container cleanup from running.
- **R7-F004 / R8-C002** — `SentryKafkaProducerBeanPostProcessor` does not detect a `SentryKafkaProducerInterceptor` nested inside a `CompositeProducerInterceptor` (double-wrapping risk).

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

