### PR TITLE
fix(kafka): [Queue Instrumentation 36] Avoid dropping customer interceptor

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
@@ -21,6 +21,18 @@ import org.springframework.kafka.listener.RecordInterceptor;
 public final class SentryKafkaConsumerBeanPostProcessor
     implements BeanPostProcessor, PriorityOrdered {
 
+  private static final @NotNull String RECORD_INTERCEPTOR_FIELD_NAME = "recordInterceptor";
+
+  private final @NotNull String recordInterceptorFieldName;
+
+  public SentryKafkaConsumerBeanPostProcessor() {
+    this(RECORD_INTERCEPTOR_FIELD_NAME);
+  }
+
+  SentryKafkaConsumerBeanPostProcessor(final @NotNull String recordInterceptorFieldName) {
+    this.recordInterceptorFieldName = recordInterceptorFieldName;
+  }
+
   private static final class InterceptorReadFailedException extends Exception {
     private static final long serialVersionUID = 1L;
 
@@ -71,7 +83,7 @@ public final class SentryKafkaConsumerBeanPostProcessor
       throws InterceptorReadFailedException {
     try {
       final @NotNull Field field =
-          AbstractKafkaListenerContainerFactory.class.getDeclaredField("recordInterceptor");
+          AbstractKafkaListenerContainerFactory.class.getDeclaredField(recordInterceptorFieldName);
       field.setAccessible(true);
       return (RecordInterceptor<?, ?>) field.get(factory);
     } catch (NoSuchFieldException | IllegalAccessException | RuntimeException e) {

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
@@ -46,10 +46,10 @@ public final class SentryKafkaConsumerBeanPostProcessor
             .getLogger()
             .log(
                 SentryLevel.ERROR,
+                e,
                 "Sentry Kafka consumer tracing disabled for factory '%s' \u2014 could not read "
                     + "existing recordInterceptor via reflection. Refusing to install Sentry's "
                     + "interceptor to avoid overwriting a customer-configured RecordInterceptor.",
-                e,
                 beanName);
         return bean;
       }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessor.java
@@ -21,6 +21,14 @@ import org.springframework.kafka.listener.RecordInterceptor;
 public final class SentryKafkaConsumerBeanPostProcessor
     implements BeanPostProcessor, PriorityOrdered {
 
+  private static final class InterceptorReadFailedException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    InterceptorReadFailedException(final @NotNull Throwable cause) {
+      super(cause);
+    }
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public @NotNull Object postProcessAfterInitialization(
@@ -29,7 +37,23 @@ public final class SentryKafkaConsumerBeanPostProcessor
       final @NotNull AbstractKafkaListenerContainerFactory<?, ?, ?> factory =
           (AbstractKafkaListenerContainerFactory<?, ?, ?>) bean;
 
-      final @Nullable RecordInterceptor<?, ?> existing = getExistingInterceptor(factory);
+      final @Nullable RecordInterceptor<?, ?> existing;
+      try {
+        existing = getExistingInterceptor(factory);
+      } catch (InterceptorReadFailedException e) {
+        ScopesAdapter.getInstance()
+            .getOptions()
+            .getLogger()
+            .log(
+                SentryLevel.ERROR,
+                "Sentry Kafka consumer tracing disabled for factory '%s' \u2014 could not read "
+                    + "existing recordInterceptor via reflection. Refusing to install Sentry's "
+                    + "interceptor to avoid overwriting a customer-configured RecordInterceptor.",
+                e,
+                beanName);
+        return bean;
+      }
+
       if (existing instanceof SentryKafkaRecordInterceptor) {
         return bean;
       }
@@ -42,25 +66,16 @@ public final class SentryKafkaConsumerBeanPostProcessor
     return bean;
   }
 
-  @SuppressWarnings("unchecked")
   private @Nullable RecordInterceptor<?, ?> getExistingInterceptor(
-      final @NotNull AbstractKafkaListenerContainerFactory<?, ?, ?> factory) {
+      final @NotNull AbstractKafkaListenerContainerFactory<?, ?, ?> factory)
+      throws InterceptorReadFailedException {
     try {
       final @NotNull Field field =
           AbstractKafkaListenerContainerFactory.class.getDeclaredField("recordInterceptor");
       field.setAccessible(true);
       return (RecordInterceptor<?, ?>) field.get(factory);
-    } catch (NoSuchFieldException | IllegalAccessException e) {
-      ScopesAdapter.getInstance()
-          .getOptions()
-          .getLogger()
-          .log(
-              SentryLevel.WARNING,
-              "Unable to read existing recordInterceptor from "
-                  + "AbstractKafkaListenerContainerFactory via reflection. "
-                  + "If you had a custom RecordInterceptor, it may not be chained with Sentry's interceptor.",
-              e);
-      return null;
+    } catch (NoSuchFieldException | IllegalAccessException | RuntimeException e) {
+      throw new InterceptorReadFailedException(e);
     }
   }
 

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessorTest.kt
@@ -1,11 +1,15 @@
 package io.sentry.spring.jakarta.kafka
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.mockito.kotlin.mock
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.listener.RecordInterceptor
 
 class SentryKafkaConsumerBeanPostProcessorTest {
 
@@ -54,5 +58,88 @@ class SentryKafkaConsumerBeanPostProcessorTest {
     val result = processor.postProcessAfterInitialization(someBean, "someBean")
 
     assertSame(someBean, result)
+  }
+
+  @Test
+  fun `chains existing customer RecordInterceptor as delegate`() {
+    val consumerFactory = mock<ConsumerFactory<String, String>>()
+    val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+    factory.consumerFactory = consumerFactory
+
+    val customerInterceptor =
+      object : RecordInterceptor<String, String> {
+        override fun intercept(
+          record: ConsumerRecord<String, String>,
+          consumer: Consumer<String, String>,
+        ): ConsumerRecord<String, String>? = record
+      }
+    factory.setRecordInterceptor(customerInterceptor)
+
+    val processor = SentryKafkaConsumerBeanPostProcessor()
+    processor.postProcessAfterInitialization(factory, "kafkaListenerContainerFactory")
+
+    val field = factory.javaClass.superclass.getDeclaredField("recordInterceptor")
+    field.isAccessible = true
+    val installed = field.get(factory)
+    assertTrue(
+      installed is SentryKafkaRecordInterceptor<*, *>,
+      "expected SentryKafkaRecordInterceptor, got ${installed?.javaClass}",
+    )
+
+    val delegateField = SentryKafkaRecordInterceptor::class.java.getDeclaredField("delegate")
+    delegateField.isAccessible = true
+    assertSame(
+      customerInterceptor,
+      delegateField.get(installed),
+      "customer interceptor must be preserved as delegate",
+    )
+  }
+
+  @Test
+  fun `skips installation when reflection fails and preserves customer interceptor`() {
+    // Subclass whose declared 'recordInterceptor' field does not exist on the
+    // AbstractKafkaListenerContainerFactory class lookup path — this simulates the
+    // future-spring-kafka case where the private field is renamed/removed.
+    // We can't easily corrupt JDK reflection, so we instead verify the chosen
+    // contract: when reflection succeeds and yields a non-Sentry interceptor,
+    // it is preserved as a delegate (covered above). The reflection-failure
+    // branch is logged at ERROR and returns the bean untouched; see
+    // SentryKafkaConsumerBeanPostProcessor#postProcessAfterInitialization.
+    val consumerFactory = mock<ConsumerFactory<String, String>>()
+    val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
+    factory.consumerFactory = consumerFactory
+    val customerInterceptor =
+      object : RecordInterceptor<String, String> {
+        override fun intercept(
+          record: ConsumerRecord<String, String>,
+          consumer: Consumer<String, String>,
+        ): ConsumerRecord<String, String>? = record
+      }
+    factory.setRecordInterceptor(customerInterceptor)
+
+    // Sanity check: customer interceptor is set before BPP runs.
+    val field = factory.javaClass.superclass.getDeclaredField("recordInterceptor")
+    field.isAccessible = true
+    assertSame(customerInterceptor, field.get(factory))
+
+    // After BPP runs the customer interceptor must still be reachable
+    // (either directly, or as the delegate of a SentryKafkaRecordInterceptor).
+    val processor = SentryKafkaConsumerBeanPostProcessor()
+    processor.postProcessAfterInitialization(factory, "kafkaListenerContainerFactory")
+
+    val installed = field.get(factory)
+    val effective =
+      if (installed is SentryKafkaRecordInterceptor<*, *>) {
+        val delegateField = SentryKafkaRecordInterceptor::class.java.getDeclaredField("delegate")
+        delegateField.isAccessible = true
+        delegateField.get(installed)
+      } else {
+        installed
+      }
+    assertEquals(
+      customerInterceptor,
+      effective,
+      "customer interceptor must never be silently dropped",
+    )
   }
 }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaConsumerBeanPostProcessorTest.kt
@@ -1,7 +1,6 @@
 package io.sentry.spring.jakarta.kafka
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import org.apache.kafka.clients.consumer.Consumer
@@ -97,14 +96,6 @@ class SentryKafkaConsumerBeanPostProcessorTest {
 
   @Test
   fun `skips installation when reflection fails and preserves customer interceptor`() {
-    // Subclass whose declared 'recordInterceptor' field does not exist on the
-    // AbstractKafkaListenerContainerFactory class lookup path — this simulates the
-    // future-spring-kafka case where the private field is renamed/removed.
-    // We can't easily corrupt JDK reflection, so we instead verify the chosen
-    // contract: when reflection succeeds and yields a non-Sentry interceptor,
-    // it is preserved as a delegate (covered above). The reflection-failure
-    // branch is logged at ERROR and returns the bean untouched; see
-    // SentryKafkaConsumerBeanPostProcessor#postProcessAfterInitialization.
     val consumerFactory = mock<ConsumerFactory<String, String>>()
     val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
     factory.consumerFactory = consumerFactory
@@ -117,29 +108,17 @@ class SentryKafkaConsumerBeanPostProcessorTest {
       }
     factory.setRecordInterceptor(customerInterceptor)
 
-    // Sanity check: customer interceptor is set before BPP runs.
     val field = factory.javaClass.superclass.getDeclaredField("recordInterceptor")
     field.isAccessible = true
     assertSame(customerInterceptor, field.get(factory))
 
-    // After BPP runs the customer interceptor must still be reachable
-    // (either directly, or as the delegate of a SentryKafkaRecordInterceptor).
-    val processor = SentryKafkaConsumerBeanPostProcessor()
+    val processor = SentryKafkaConsumerBeanPostProcessor("missingRecordInterceptor")
     processor.postProcessAfterInitialization(factory, "kafkaListenerContainerFactory")
 
-    val installed = field.get(factory)
-    val effective =
-      if (installed is SentryKafkaRecordInterceptor<*, *>) {
-        val delegateField = SentryKafkaRecordInterceptor::class.java.getDeclaredField("delegate")
-        delegateField.isAccessible = true
-        delegateField.get(installed)
-      } else {
-        installed
-      }
-    assertEquals(
+    assertSame(
       customerInterceptor,
-      effective,
-      "customer interceptor must never be silently dropped",
+      field.get(factory),
+      "customer interceptor must remain installed when Sentry cannot read it",
     )
   }
 }


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Avoid installing `SentryKafkaRecordInterceptor` when the bean post-processor cannot safely read the existing `recordInterceptor` field from `AbstractKafkaListenerContainerFactory`.

Before this change, reflection failures fell back to `existing = null`, and the post-processor still called `setRecordInterceptor(sentryInterceptor)`. That could silently overwrite a customer-configured interceptor.

After this change:
- `getExistingInterceptor` throws a dedicated exception when reflection fails
- `postProcessAfterInitialization` logs an error and leaves the bean untouched
- The reflection-failure log now passes the bean name as the format argument and the exception as the throwable
- Existing customer interceptors are still chained as the delegate when reflection succeeds
- Tests cover both the chaining path and the deterministic reflection-failure "do not modify the bean" invariant

## :bulb: Motivation and Context

Addresses review finding R10-F003: reflection fallback silently drops the customer's existing `RecordInterceptor`.

Customers often use `RecordInterceptor` for DLQ routing, auditing, or other message handling behavior. If Sentry cannot safely discover the existing interceptor, it must disable consumer tracing for that factory instead of overwriting customer behavior.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `./gradlew :sentry-spring-jakarta:test --tests "io.sentry.spring.jakarta.kafka.SentryKafkaConsumerBeanPostProcessorTest"`
- Added tests covering customer interceptor chaining and deterministic reflection-failure preservation

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue addressing the remaining Queue Instrumentation review findings.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

