### PR TITLE
fix(spring-boot-jakarta): [Queue Instrumentation 37] Skip Kafka autoconfig for OTel agent

### DIFF
--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
@@ -5,22 +5,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.Before
 
-/**
- * System tests for Kafka queue instrumentation on the OTel Jakarta noagent sample.
- *
- * The Sentry Kafka auto-configuration (`SentryKafkaQueueConfiguration`) is intentionally suppressed
- * when `io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider` is on the classpath, so
- * the Sentry `SentryKafkaProducer` and `SentryKafkaRecordInterceptor` must not be wired.
- *
- * These tests produce a Kafka message end-to-end and assert that Sentry-style `queue.publish` /
- * `queue.process` spans/transactions are *not* emitted. Any Kafka telemetry in OTel mode must come
- * from the OTel Kafka instrumentation, not from the Sentry Kafka integration.
- *
- * Requires:
- * - The sample app running with `--spring.profiles.active=kafka`
- * - A Kafka broker at localhost:9092
- * - The mock Sentry server at localhost:8000
- */
 class KafkaOtelCoexistenceSystemTest {
   lateinit var testHelper: TestHelper
 
@@ -37,9 +21,21 @@ class KafkaOtelCoexistenceSystemTest {
     restClient.produceKafkaMessage("otel-coexistence-test")
     assertEquals(200, restClient.lastKnownStatusCode)
 
-    testHelper.ensureNoTransactionReceived { transaction, _ ->
-      transaction.contexts.trace?.operation == "queue.process" ||
-        transaction.spans.any { span -> span.op == "queue.publish" }
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      transaction.transaction == "GET /kafka/produce" &&
+        transaction.sdk?.integrationSet?.contains("SpringKafka") != true &&
+        transaction.spans.any { span ->
+          span.op == "queue.publish" &&
+            span.origin == "auto.opentelemetry" &&
+            span.data?.get("messaging.system") == "kafka"
+        }
+    }
+
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      transaction.contexts.trace?.operation == "queue.process" &&
+        transaction.contexts.trace?.origin == "auto.opentelemetry" &&
+        transaction.contexts.trace?.data?.get("messaging.system") == "kafka" &&
+        transaction.sdk?.integrationSet?.contains("SpringKafka") != true
     }
   }
 }

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/src/test/kotlin/io/sentry/systemtest/KafkaOtelCoexistenceSystemTest.kt
@@ -5,22 +5,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.Before
 
-/**
- * System tests for Kafka queue instrumentation on the OTel Jakarta sample.
- *
- * The Sentry Kafka auto-configuration (`SentryKafkaQueueConfiguration`) is intentionally suppressed
- * when `io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider` is on the classpath, so
- * the Sentry `SentryKafkaProducer` and `SentryKafkaRecordInterceptor` must not be wired.
- *
- * These tests produce a Kafka message end-to-end and assert that Sentry-style `queue.publish` /
- * `queue.process` spans/transactions are *not* emitted. Any Kafka telemetry in OTel mode must come
- * from the OTel Kafka instrumentation, not from the Sentry Kafka integration.
- *
- * Requires:
- * - The sample app running with `--spring.profiles.active=kafka`
- * - A Kafka broker at localhost:9092
- * - The mock Sentry server at localhost:8000
- */
 class KafkaOtelCoexistenceSystemTest {
   lateinit var testHelper: TestHelper
 
@@ -37,9 +21,21 @@ class KafkaOtelCoexistenceSystemTest {
     restClient.produceKafkaMessage("otel-coexistence-test")
     assertEquals(200, restClient.lastKnownStatusCode)
 
-    testHelper.ensureNoTransactionReceived { transaction, _ ->
-      transaction.contexts.trace?.operation == "queue.process" ||
-        transaction.spans.any { span -> span.op == "queue.publish" }
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      transaction.transaction == "GET /kafka/produce" &&
+        transaction.sdk?.integrationSet?.contains("SpringKafka") != true &&
+        transaction.spans.any { span ->
+          span.op == "queue.publish" &&
+            span.origin == "auto.opentelemetry" &&
+            span.data?.get("messaging.system") == "kafka"
+        }
+    }
+
+    testHelper.ensureTransactionReceived { transaction, _ ->
+      transaction.contexts.trace?.operation == "queue.process" &&
+        transaction.contexts.trace?.origin == "auto.opentelemetry" &&
+        transaction.contexts.trace?.data?.get("messaging.system") == "kafka" &&
+        transaction.sdk?.integrationSet?.contains("SpringKafka") != true
     }
   }
 }

--- a/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
+++ b/sentry-spring-boot-jakarta/src/main/java/io/sentry/spring/boot/jakarta/SentryAutoConfiguration.java
@@ -255,7 +255,10 @@ public class SentryAutoConfiguration {
           "io.sentry.kafka.SentryKafkaProducer"
         })
     @ConditionalOnProperty(name = "sentry.enable-queue-tracing", havingValue = "true")
-    @ConditionalOnMissingClass("io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider")
+    @ConditionalOnMissingClass({
+      "io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider",
+      "io.sentry.opentelemetry.agent.AgentMarker"
+    })
     @Open
     static class SentryKafkaQueueConfiguration {
 

--- a/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
+++ b/sentry-spring-boot-jakarta/src/test/kotlin/io/sentry/spring/boot/jakarta/SentryKafkaAutoConfigurationTest.kt
@@ -2,6 +2,7 @@ package io.sentry.spring.boot.jakarta
 
 import io.sentry.kafka.SentryKafkaProducer
 import io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider
+import io.sentry.opentelemetry.agent.AgentMarker
 import io.sentry.spring.jakarta.kafka.SentryKafkaConsumerBeanPostProcessor
 import io.sentry.spring.jakarta.kafka.SentryKafkaProducerBeanPostProcessor
 import kotlin.test.Test
@@ -28,20 +29,27 @@ class SentryKafkaAutoConfigurationTest {
         "sentry.debug=false",
       )
 
-  /** Hide the OTel customizer so conditions evaluate as "no OTel present". */
   private val noOtelClassLoader =
+    FilteredClassLoader(
+      SentryAutoConfigurationCustomizerProvider::class.java,
+      AgentMarker::class.java,
+    )
+
+  private val noOtelCustomizerClassLoader =
     FilteredClassLoader(SentryAutoConfigurationCustomizerProvider::class.java)
 
   private val noSentryKafkaClassLoader =
     FilteredClassLoader(
       SentryKafkaProducer::class.java,
       SentryAutoConfigurationCustomizerProvider::class.java,
+      AgentMarker::class.java,
     )
 
   private val noSpringKafkaClassLoader =
     FilteredClassLoader(
       KafkaTemplate::class.java,
       SentryAutoConfigurationCustomizerProvider::class.java,
+      AgentMarker::class.java,
     )
 
   @Test
@@ -90,6 +98,17 @@ class SentryKafkaAutoConfigurationTest {
     contextRunner
       .withClassLoader(noOtelClassLoader)
       .withPropertyValues("sentry.enable-queue-tracing=false")
+      .run { context ->
+        assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)
+        assertThat(context).doesNotHaveBean(SentryKafkaConsumerBeanPostProcessor::class.java)
+      }
+  }
+
+  @Test
+  fun `does not register Kafka BPPs when OpenTelemetry agent is present`() {
+    contextRunner
+      .withClassLoader(noOtelCustomizerClassLoader)
+      .withPropertyValues("sentry.enable-queue-tracing=true")
       .run { context ->
         assertThat(context).doesNotHaveBean(SentryKafkaProducerBeanPostProcessor::class.java)
         assertThat(context).doesNotHaveBean(SentryKafkaConsumerBeanPostProcessor::class.java)


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Prevent Spring Kafka auto-configuration from installing Sentry Kafka bean post-processors when the Sentry OpenTelemetry Java agent is active.

This change also updates the Jakarta OTel coexistence system tests to assert the intended behavior: OTel queue spans still reach Sentry, but the Sentry `SpringKafka` integration stays disabled.

## :bulb: Motivation and Context

The Kafka auto-config gate only checked for `SentryAutoConfigurationCustomizerProvider`, which covered the app-classpath OTel integration but missed the Java agent path. As a result, the agent sample still installed `SentryKafkaProducerBeanPostProcessor`, and the coexistence test failed for the wrong reason.

Adding `AgentMarker` to the conditional fixes the real suppression bug and aligns the tests with the current OTel messaging mapping behavior.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `./gradlew :sentry-spring-boot-jakarta:test --tests='*SentryKafkaAutoConfigurationTest' -x :sentry-spring-jakarta:compileJava -x :sentry-spring-jakarta:jar`
- Ran `./gradlew :sentry-spring-boot-jakarta:compileTestKotlin :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:compileTestKotlin :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:compileTestKotlin -x :sentry-spring-jakarta:compileJava -x :sentry-spring-jakarta:jar`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue moving the Queue Instrumentation stack toward a clean OTel coexistence story across the remaining samples.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

