### PR TITLE
fix(spring-jakarta): [Queue Instrumentation 38] Close leaked Kafka interceptor scope

### DIFF
--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -5,6 +5,7 @@ import io.sentry.DateUtils;
 import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.ITransaction;
+import io.sentry.SentryLevel;
 import io.sentry.SentryTraceHeader;
 import io.sentry.SpanDataConvention;
 import io.sentry.SpanStatus;
@@ -57,18 +58,21 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
       return delegateIntercept(record, consumer);
     }
 
-    finishStaleContext();
+    try {
+      finishStaleContext();
 
-    final @NotNull IScopes forkedScopes = scopes.forkedRootScopes("SentryKafkaRecordInterceptor");
-    final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
-    currentContext.set(new SentryRecordContext(lifecycleToken, null));
+      final @NotNull IScopes forkedScopes = scopes.forkedRootScopes("SentryKafkaRecordInterceptor");
+      final @NotNull ISentryLifecycleToken lifecycleToken = forkedScopes.makeCurrent();
+      currentContext.set(new SentryRecordContext(lifecycleToken, null));
 
-    final @Nullable TransactionContext transactionContext = continueTrace(forkedScopes, record);
+      final @Nullable TransactionContext transactionContext = continueTrace(forkedScopes, record);
 
-    final @Nullable ITransaction transaction =
-        startTransaction(forkedScopes, record, transactionContext);
-    currentContext.set(new SentryRecordContext(lifecycleToken, transaction));
-
+      final @Nullable ITransaction transaction =
+          startTransaction(forkedScopes, record, transactionContext);
+      currentContext.set(new SentryRecordContext(lifecycleToken, transaction));
+    } catch (Throwable t) {
+      scopes.getOptions().getLogger().log(SentryLevel.ERROR, "Unable to wrap Kafka consumer.", t);
+    }
     return delegateIntercept(record, consumer);
   }
 


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Ensure `SentryKafkaRecordInterceptor` does not leak its forked scopes when interceptor setup throws.

The interceptor now stores the lifecycle token in `currentContext` immediately after `makeCurrent()`, before `continueTrace()` or `startTransaction()` can fail. If setup fails, the existing cleanup path can still close the token instead of leaving the forked scopes current on the consumer thread.

## :bulb: Motivation and Context

A review comment pointed out that `continueTrace()` or `startTransaction()` could throw after `makeCurrent()` succeeded but before the lifecycle token was saved into the thread-local. In that case `failure()` and `clearThreadState()` would see no context to finish, and the lifecycle token would never be closed.

This change keeps the cleanup path intact and logs setup failures without breaking Kafka consumer processing.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `./gradlew :sentry-spring-jakarta:test --tests='*SentryKafkaRecordInterceptorTest*'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Continue tightening the remaining Queue Instrumentation error paths.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

