### PR TITLE
fix(test): [Queue Instrumentation 39] Remove stale Kafka container before startup

### DIFF
--- a/test/system-test-runner.py
+++ b/test/system-test-runner.py
@@ -442,6 +442,7 @@ class SystemTestRunner:
 
         if self.module_requires_kafka_profile(sample_module):
             env["SPRING_PROFILES_ACTIVE"] = "kafka"
+            env["SENTRY_ENABLE_QUEUE_TRACING"] = "true"
             print("Enabling Spring profile: kafka")
         else:
             env.pop("SPRING_PROFILES_ACTIVE", None)

--- a/test/system-test-runner.py
+++ b/test/system-test-runner.py
@@ -227,13 +227,21 @@ class SystemTestRunner:
                 time.sleep(1)
         return False
 
+    def remove_kafka_broker_container(self) -> None:
+        subprocess.run(
+            ["docker", "rm", "-f", KAFKA_CONTAINER_NAME],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
     def start_kafka_broker(self) -> None:
         if self.wait_for_port("localhost", 9092, max_attempts=1):
             print("Kafka broker already running on localhost:9092, reusing it.")
             self.kafka_started_by_runner = False
             return
 
-        self.stop_kafka_broker()
+        self.remove_kafka_broker_container()
 
         print("Starting Kafka broker (Redpanda) for system tests...")
         run_result = subprocess.run(
@@ -280,12 +288,7 @@ class SystemTestRunner:
         if not self.kafka_started_by_runner:
             return
 
-        subprocess.run(
-            ["docker", "rm", "-f", KAFKA_CONTAINER_NAME],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        self.remove_kafka_broker_container()
         self.kafka_started_by_runner = False
 
     def start_sentry_mock_server(self) -> None:


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Clean up stale Kafka system-test containers before starting the local broker.

`SystemTestRunner.start_kafka_broker()` now force-removes the named container up front, even when the current runner instance did not start the previous broker. `stop_kafka_broker()` stays ownership-aware and still only tears down brokers started by the current run.

## :bulb: Motivation and Context

A review comment on the original Kafka console sample PR pointed out that interrupted runs could leave behind a stopped container named `sentry-java-system-test-kafka`. The runner tried to clean that up before startup, but the cleanup path returned early whenever `kafka_started_by_runner` was false, so the next `docker run --name ...` failed with a container-name conflict.

This change fixes the stale-container path without changing the reuse behavior for an already running broker on `localhost:9092`.

I also looked into replacing Redpanda with the official Apache Kafka image. That is possible, but it is not a drop-in swap because the current startup command is Redpanda-specific, so I left that as a separate follow-up.

## :green_heart: How did you test it?

- Ran `./gradlew spotlessApply apiDump`
- Ran `python3 -m py_compile test/system-test-runner.py`
- Ran a mocked Python verification that `start_kafka_broker()` now issues `docker rm -f sentry-java-system-test-kafka` before `docker run`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

If we want the most official broker image for these tests, switch the runner to `apache/kafka` in a separate PR.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

