### PR TITLE
ref(feedback): Rename Dialog to Form across feedback APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Features
 
-- Add `Sentry.feedback()` API for `showForm()` and `capture()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
-  - `Sentry.showUserFeedbackDialog()` is deprecated in favor of `Sentry.feedback().showForm()`
+- Add `Sentry.feedback()` API for `show()` and `capture()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
+  - `Sentry.showUserFeedbackDialog()` is deprecated in favor of `Sentry.feedback().show()`
   - `Sentry.captureFeedback()` is deprecated in favor of `Sentry.feedback().capture()`
   - `Sentry.captureUserFeedback()` is deprecated in favor of `Sentry.feedback().capture()` with the new `Feedback` type
   - `SentryUserFeedbackDialog` is deprecated in favor of `SentryUserFeedbackForm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Deprecations
 
 - Rename `SentryUserFeedbackDialog` to `SentryUserFeedbackForm` and `Sentry.showUserFeedbackDialog()` to `Sentry.showUserFeedbackForm()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
-  - The old `SentryUserFeedbackDialog` class and `Sentry.showUserFeedbackDialog()` methods are deprecated but still work
+  - The old `SentryUserFeedbackDialog` class and `Sentry.showUserFeedbackDialog()` methods are deprecated but still work and will be removed in the next major version
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-### Deprecations
+### Features
 
 - Add `Sentry.feedback()` API for `showForm()` and `capture()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
-  - `Sentry.showUserFeedbackDialog()` / `Sentry.showUserFeedbackForm()` are deprecated in favor of `Sentry.feedback().showForm()`
+  - `Sentry.showUserFeedbackDialog()` is deprecated in favor of `Sentry.feedback().showForm()`
   - `Sentry.captureFeedback()` is deprecated in favor of `Sentry.feedback().capture()`
   - `Sentry.captureUserFeedback()` is deprecated in favor of `Sentry.feedback().capture()` with the new `Feedback` type
   - `SentryUserFeedbackDialog` is deprecated in favor of `SentryUserFeedbackForm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `Sentry.feedback()` API for `show()` and `capture()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
   - `Sentry.showUserFeedbackDialog()` is deprecated in favor of `Sentry.feedback().show()`
   - `Sentry.captureFeedback()` is deprecated in favor of `Sentry.feedback().capture()`
-  - `Sentry.captureUserFeedback()` is deprecated in favor of `Sentry.feedback().capture()` with the new `Feedback` type
+  - `Sentry.captureUserFeedback()` and `UserFeedback` are deprecated in favor of `Sentry.feedback().capture()` with the new `Feedback` type
   - `SentryUserFeedbackDialog` is deprecated in favor of `SentryUserFeedbackForm`
   - All deprecated APIs will be removed in the next major version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Deprecations
 
-- Rename `SentryUserFeedbackDialog` to `SentryUserFeedbackForm` and `Sentry.showUserFeedbackDialog()` to `Sentry.showUserFeedbackForm()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
-  - The old `SentryUserFeedbackDialog` class and `Sentry.showUserFeedbackDialog()` methods are deprecated but still work and will be removed in the next major version
+- Add `Sentry.feedback()` API for `showForm()` and `capture()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
+  - `Sentry.showUserFeedbackDialog()` / `Sentry.showUserFeedbackForm()` are deprecated in favor of `Sentry.feedback().showForm()`
+  - `Sentry.captureFeedback()` is deprecated in favor of `Sentry.feedback().capture()`
+  - `Sentry.captureUserFeedback()` is deprecated in favor of `Sentry.feedback().capture()` with the new `Feedback` type
+  - `SentryUserFeedbackDialog` is deprecated in favor of `SentryUserFeedbackForm`
+  - All deprecated APIs will be removed in the next major version
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Deprecations
+
+- Rename `SentryUserFeedbackDialog` to `SentryUserFeedbackForm` and `Sentry.showUserFeedbackDialog()` to `Sentry.showUserFeedbackForm()` ([#5349](https://github.com/getsentry/sentry-java/pull/5349))
+  - The old `SentryUserFeedbackDialog` class and `Sentry.showUserFeedbackDialog()` methods are deprecated but still work
+
 ### Dependencies
 
 - Bump Native SDK from v0.13.7 to v0.13.8 ([#5334](https://github.com/getsentry/sentry-java/pull/5334))

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -496,23 +496,44 @@ public class io/sentry/android/core/SentryUserFeedbackButton : android/widget/Bu
 	public fun setOnClickListener (Landroid/view/View$OnClickListener;)V
 }
 
-public final class io/sentry/android/core/SentryUserFeedbackDialog : android/app/AlertDialog {
+public final class io/sentry/android/core/SentryUserFeedbackDialog : io/sentry/android/core/SentryUserFeedbackForm {
+}
+
+public class io/sentry/android/core/SentryUserFeedbackDialog$Builder : io/sentry/android/core/SentryUserFeedbackForm$Builder {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;I)V
+	public fun <init> (Landroid/content/Context;ILio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
+	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
+	public fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;
+	public synthetic fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackForm$Builder;
+	public fun configurator (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;
+	public synthetic fun configurator (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)Lio/sentry/android/core/SentryUserFeedbackForm$Builder;
+	public fun create ()Lio/sentry/android/core/SentryUserFeedbackDialog;
+	public synthetic fun create ()Lio/sentry/android/core/SentryUserFeedbackForm;
+}
+
+public abstract interface class io/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration : io/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration {
+}
+
+public class io/sentry/android/core/SentryUserFeedbackForm : android/app/AlertDialog {
+	protected fun onCreate (Landroid/os/Bundle;)V
+	protected fun onStart ()V
 	public fun setCancelable (Z)V
 	public fun setOnDismissListener (Landroid/content/DialogInterface$OnDismissListener;)V
 	public fun show ()V
 }
 
-public class io/sentry/android/core/SentryUserFeedbackDialog$Builder {
+public class io/sentry/android/core/SentryUserFeedbackForm$Builder {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;I)V
-	public fun <init> (Landroid/content/Context;ILio/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration;)V
-	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration;)V
-	public fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;
-	public fun configurator (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;
-	public fun create ()Lio/sentry/android/core/SentryUserFeedbackDialog;
+	public fun <init> (Landroid/content/Context;ILio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
+	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
+	public fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackForm$Builder;
+	public fun configurator (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)Lio/sentry/android/core/SentryUserFeedbackForm$Builder;
+	public fun create ()Lio/sentry/android/core/SentryUserFeedbackForm;
 }
 
-public abstract interface class io/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration {
+public abstract interface class io/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration {
 	public abstract fun configure (Landroid/content/Context;Lio/sentry/SentryFeedbackOptions;)V
 }
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -502,8 +502,8 @@ public final class io/sentry/android/core/SentryUserFeedbackDialog : io/sentry/a
 public class io/sentry/android/core/SentryUserFeedbackDialog$Builder : io/sentry/android/core/SentryUserFeedbackForm$Builder {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;I)V
-	public fun <init> (Landroid/content/Context;ILio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
-	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryUserFeedbackForm$OptionsConfiguration;)V
+	public fun <init> (Landroid/content/Context;ILio/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration;)V
+	public fun <init> (Landroid/content/Context;Lio/sentry/android/core/SentryUserFeedbackDialog$OptionsConfiguration;)V
 	public fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;
 	public synthetic fun associatedEventId (Lio/sentry/protocol/SentryId;)Lio/sentry/android/core/SentryUserFeedbackForm$Builder;
 	public fun configurator (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)Lio/sentry/android/core/SentryUserFeedbackDialog$Builder;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -441,7 +441,7 @@ final class AndroidOptionsInitializer {
     }
     options
         .getFeedbackOptions()
-        .setDialogHandler(new SentryAndroidOptions.AndroidUserFeedbackIDialogHandler());
+        .setFormHandler(new SentryAndroidOptions.AndroidUserFeedbackFormHandler());
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
@@ -178,7 +178,7 @@ public final class FeedbackShakeIntegration
                               }
                               previousOnFormClose = null;
                             });
-                    new SentryUserFeedbackDialog.Builder(active).create().show();
+                    new SentryUserFeedbackForm.Builder(active).create().show();
                   } catch (Throwable e) {
                     isDialogShowing = false;
                     options.getFeedbackOptions().setOnFormClose(previousOnFormClose);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -758,7 +758,7 @@ public final class SentryAndroidOptions extends SentryOptions {
         return;
       }
 
-      new SentryUserFeedbackDialog.Builder(activity)
+      new SentryUserFeedbackForm.Builder(activity)
           .associatedEventId(associatedEventId)
           .configurator(configurator)
           .create()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -758,7 +758,7 @@ public final class SentryAndroidOptions extends SentryOptions {
         return;
       }
 
-      new SentryUserFeedbackForm.Builder(activity)
+      new SentryUserFeedbackDialog.Builder(activity)
           .associatedEventId(associatedEventId)
           .configurator(configurator)
           .create()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -741,9 +741,9 @@ public final class SentryAndroidOptions extends SentryOptions {
     this.enableAnrFingerprinting = enableAnrFingerprinting;
   }
 
-  static class AndroidUserFeedbackIDialogHandler implements SentryFeedbackOptions.IDialogHandler {
+  static class AndroidUserFeedbackFormHandler implements SentryFeedbackOptions.IFormHandler {
     @Override
-    public void showDialog(
+    public void showForm(
         final @Nullable SentryId associatedEventId,
         final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
       final @Nullable Activity activity = CurrentActivityHolder.getInstance().getActivity();
@@ -758,7 +758,7 @@ public final class SentryAndroidOptions extends SentryOptions {
         return;
       }
 
-      new SentryUserFeedbackDialog.Builder(activity)
+      new SentryUserFeedbackForm.Builder(activity)
           .associatedEventId(associatedEventId)
           .configurator(configurator)
           .create()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackButton.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackButton.java
@@ -104,7 +104,7 @@ public class SentryUserFeedbackButton extends Button {
       }
     }
 
-    // Set the default ClickListener to open the SentryUserFeedbackDialog
+    // Set the default ClickListener to open the SentryUserFeedbackForm
     setOnClickListener(delegate);
   }
 
@@ -113,7 +113,7 @@ public class SentryUserFeedbackButton extends Button {
     delegate = listener;
     super.setOnClickListener(
         v -> {
-          new SentryUserFeedbackDialog.Builder(getContext()).create().show();
+          new SentryUserFeedbackForm.Builder(getContext()).create().show();
           if (delegate != null) {
             delegate.onClick(v);
           }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
@@ -62,8 +62,7 @@ public final class SentryUserFeedbackDialog extends SentryUserFeedbackForm {
      */
     @Deprecated
     public Builder(
-        final @NotNull Context context,
-        final @Nullable SentryUserFeedbackForm.OptionsConfiguration configuration) {
+        final @NotNull Context context, final @Nullable OptionsConfiguration configuration) {
       super(context, configuration);
     }
 
@@ -80,7 +79,7 @@ public final class SentryUserFeedbackDialog extends SentryUserFeedbackForm {
     public Builder(
         final @NotNull Context context,
         final int themeResId,
-        final @Nullable SentryUserFeedbackForm.OptionsConfiguration configuration) {
+        final @Nullable OptionsConfiguration configuration) {
       super(context, themeResId, configuration);
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
@@ -1,380 +1,114 @@
 package io.sentry.android.core;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.os.Bundle;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ImageView;
-import android.widget.TextView;
-import android.widget.Toast;
-import io.sentry.IScopes;
-import io.sentry.Sentry;
 import io.sentry.SentryFeedbackOptions;
-import io.sentry.SentryIntegrationPackageStorage;
-import io.sentry.SentryLevel;
-import io.sentry.SentryOptions;
-import io.sentry.protocol.Feedback;
 import io.sentry.protocol.SentryId;
-import io.sentry.protocol.User;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public final class SentryUserFeedbackDialog extends AlertDialog {
-
-  private boolean isCancelable = false;
-  private @Nullable SentryId currentReplayId;
-  private final @Nullable SentryId associatedEventId;
-  private @Nullable OnDismissListener delegate;
-
-  private final @Nullable OptionsConfiguration configuration;
-  private final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator;
+/**
+ * @deprecated Use {@link SentryUserFeedbackForm} instead.
+ */
+@Deprecated
+public final class SentryUserFeedbackDialog extends SentryUserFeedbackForm {
 
   SentryUserFeedbackDialog(
       final @NotNull Context context,
       final int themeResId,
       final @Nullable SentryId associatedEventId,
-      final @Nullable OptionsConfiguration configuration,
+      final @Nullable SentryUserFeedbackForm.OptionsConfiguration configuration,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    super(context, themeResId);
-    this.associatedEventId = associatedEventId;
-    this.configuration = configuration;
-    this.configurator = configurator;
-    SentryIntegrationPackageStorage.getInstance().addIntegration("UserFeedbackWidget");
+    super(context, themeResId, associatedEventId, configuration, configurator);
   }
 
-  @Override
-  public void setCancelable(boolean cancelable) {
-    super.setCancelable(cancelable);
-    isCancelable = cancelable;
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.sentry_dialog_user_feedback);
-    setCancelable(isCancelable);
-
-    final @NotNull SentryFeedbackOptions feedbackOptions =
-        new SentryFeedbackOptions(Sentry.getCurrentScopes().getOptions().getFeedbackOptions());
-    if (configuration != null) {
-      configuration.configure(getContext(), feedbackOptions);
-    }
-    if (configurator != null) {
-      configurator.configure(feedbackOptions);
-    }
-    final @NotNull TextView lblTitle = findViewById(R.id.sentry_dialog_user_feedback_title);
-    final @NotNull ImageView imgLogo = findViewById(R.id.sentry_dialog_user_feedback_logo);
-    final @NotNull TextView lblName = findViewById(R.id.sentry_dialog_user_feedback_txt_name);
-    final @NotNull EditText edtName = findViewById(R.id.sentry_dialog_user_feedback_edt_name);
-    final @NotNull TextView lblEmail = findViewById(R.id.sentry_dialog_user_feedback_txt_email);
-    final @NotNull EditText edtEmail = findViewById(R.id.sentry_dialog_user_feedback_edt_email);
-    final @NotNull TextView lblMessage =
-        findViewById(R.id.sentry_dialog_user_feedback_txt_description);
-    final @NotNull EditText edtMessage =
-        findViewById(R.id.sentry_dialog_user_feedback_edt_description);
-    final @NotNull Button btnSend = findViewById(R.id.sentry_dialog_user_feedback_btn_send);
-    final @NotNull Button btnCancel = findViewById(R.id.sentry_dialog_user_feedback_btn_cancel);
-
-    if (feedbackOptions.isShowBranding()) {
-      imgLogo.setVisibility(View.VISIBLE);
-    } else {
-      imgLogo.setVisibility(View.GONE);
-    }
-
-    // If name is required, ignore showName flag
-    if (!feedbackOptions.isShowName() && !feedbackOptions.isNameRequired()) {
-      lblName.setVisibility(View.GONE);
-      edtName.setVisibility(View.GONE);
-    } else {
-      lblName.setVisibility(View.VISIBLE);
-      edtName.setVisibility(View.VISIBLE);
-      lblName.setText(feedbackOptions.getNameLabel());
-      edtName.setHint(feedbackOptions.getNamePlaceholder());
-      if (feedbackOptions.isNameRequired()) {
-        lblName.append(feedbackOptions.getIsRequiredLabel());
-      }
-    }
-
-    // If email is required, ignore showEmail flag
-    if (!feedbackOptions.isShowEmail() && !feedbackOptions.isEmailRequired()) {
-      lblEmail.setVisibility(View.GONE);
-      edtEmail.setVisibility(View.GONE);
-    } else {
-      lblEmail.setVisibility(View.VISIBLE);
-      edtEmail.setVisibility(View.VISIBLE);
-      lblEmail.setText(feedbackOptions.getEmailLabel());
-      edtEmail.setHint(feedbackOptions.getEmailPlaceholder());
-      if (feedbackOptions.isEmailRequired()) {
-        lblEmail.append(feedbackOptions.getIsRequiredLabel());
-      }
-    }
-
-    // If Sentry user is set, and useSentryUser is true, populate the name and email
-    if (feedbackOptions.isUseSentryUser()) {
-      final @Nullable User user = Sentry.getCurrentScopes().getScope().getUser();
-      if (user != null) {
-        edtName.setText(user.getUsername());
-        edtEmail.setText(user.getEmail());
-      }
-    }
-
-    lblMessage.setText(feedbackOptions.getMessageLabel());
-    lblMessage.append(feedbackOptions.getIsRequiredLabel());
-    edtMessage.setHint(feedbackOptions.getMessagePlaceholder());
-    lblTitle.setText(feedbackOptions.getFormTitle());
-
-    btnSend.setText(feedbackOptions.getSubmitButtonLabel());
-    btnSend.setOnClickListener(
-        v -> {
-          // Gather fields and trim them
-          final @NotNull String name = edtName.getText().toString().trim();
-          final @NotNull String email = edtEmail.getText().toString().trim();
-          final @NotNull String message = edtMessage.getText().toString().trim();
-
-          // If a required field is missing, shows the error label
-          if (name.isEmpty() && feedbackOptions.isNameRequired()) {
-            edtName.setError(lblName.getText());
-            return;
-          }
-
-          if (email.isEmpty() && feedbackOptions.isEmailRequired()) {
-            edtEmail.setError(lblEmail.getText());
-            return;
-          }
-
-          if (message.isEmpty()) {
-            edtMessage.setError(lblMessage.getText());
-            return;
-          }
-
-          // Create the feedback object
-          final @NotNull Feedback feedback = new Feedback(message);
-          feedback.setName(name);
-          feedback.setContactEmail(email);
-          if (associatedEventId != null) {
-            feedback.setAssociatedEventId(associatedEventId);
-          }
-          if (currentReplayId != null) {
-            feedback.setReplayId(currentReplayId);
-          }
-
-          // Capture the feedback. If the ID is empty, it means that the feedback was not sent
-          final @NotNull SentryId id = Sentry.captureFeedback(feedback);
-          if (!id.equals(SentryId.EMPTY_ID)) {
-            Toast.makeText(
-                    getContext(), feedbackOptions.getSuccessMessageText(), Toast.LENGTH_SHORT)
-                .show();
-            final @Nullable SentryFeedbackOptions.SentryFeedbackCallback onSubmitSuccess =
-                feedbackOptions.getOnSubmitSuccess();
-            if (onSubmitSuccess != null) {
-              onSubmitSuccess.call(feedback);
-            }
-          } else {
-            final @Nullable SentryFeedbackOptions.SentryFeedbackCallback onSubmitError =
-                feedbackOptions.getOnSubmitError();
-            if (onSubmitError != null) {
-              onSubmitError.call(feedback);
-            }
-          }
-          cancel();
-        });
-
-    btnCancel.setText(feedbackOptions.getCancelButtonLabel());
-    btnCancel.setOnClickListener(v -> cancel());
-    setOnDismissListener(delegate);
-  }
-
-  @Override
-  public void setOnDismissListener(final @Nullable OnDismissListener listener) {
-    delegate = listener;
-    // If the user set a custom onDismissListener, we ensure it doesn't override the onFormClose
-    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
-    final @Nullable Runnable onFormClose = options.getFeedbackOptions().getOnFormClose();
-    if (onFormClose != null) {
-      super.setOnDismissListener(
-          dialog -> {
-            onFormClose.run();
-            currentReplayId = null;
-            if (delegate != null) {
-              delegate.onDismiss(dialog);
-            }
-          });
-    } else {
-      super.setOnDismissListener(delegate);
-    }
-  }
-
-  @Override
-  protected void onStart() {
-    super.onStart();
-    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
-    final @NotNull SentryFeedbackOptions feedbackOptions = options.getFeedbackOptions();
-    final @Nullable Runnable onFormOpen = feedbackOptions.getOnFormOpen();
-    if (onFormOpen != null) {
-      onFormOpen.run();
-    }
-    options.getReplayController().captureReplay(false);
-    currentReplayId = options.getReplayController().getReplayId();
-  }
-
-  @Override
-  public void show() {
-    // If Sentry is disabled, don't show the dialog, but log a warning
-    final @NotNull IScopes scopes = Sentry.getCurrentScopes();
-    final @NotNull SentryOptions options = scopes.getOptions();
-    if (!scopes.isEnabled() || !options.isEnabled()) {
-      options
-          .getLogger()
-          .log(SentryLevel.WARNING, "Sentry is disabled. Feedback dialog won't be shown.");
-      return;
-    }
-    // Otherwise, show the dialog
-    super.show();
-  }
-
-  public static class Builder {
-
-    @Nullable OptionsConfiguration configuration;
-    @Nullable SentryFeedbackOptions.OptionsConfigurator configurator;
-    @Nullable SentryId associatedEventId;
-    final @NotNull Context context;
-    final int themeResId;
+  /**
+   * @deprecated Use {@link SentryUserFeedbackForm.Builder} instead.
+   */
+  @Deprecated
+  public static class Builder extends SentryUserFeedbackForm.Builder {
 
     /**
      * Creates a builder for a {@link SentryUserFeedbackDialog} that uses the default alert dialog
      * theme.
      *
-     * <p>The default alert dialog theme is defined by {@link android.R.attr#alertDialogTheme}
-     * within the parent {@code context}'s theme.
-     *
      * @param context the parent context
+     * @deprecated Use {@link SentryUserFeedbackForm.Builder#Builder(Context)} instead.
      */
+    @Deprecated
     public Builder(final @NotNull Context context) {
-      this(context, 0);
+      super(context);
     }
 
     /**
      * Creates a builder for a {@link SentryUserFeedbackDialog} that uses an explicit theme
      * resource.
      *
-     * <p>The specified theme resource ({@code themeResId}) is applied on top of the parent {@code
-     * context}'s theme. It may be specified as a style resource containing a fully-populated theme,
-     * such as {@link android.R.style#Theme_Material_Dialog}, to replace all attributes in the
-     * parent {@code context}'s theme including primary and accent colors.
-     *
-     * <p>To preserve attributes such as primary and accent colors, the {@code themeResId} may
-     * instead be specified as an overlay theme such as {@link
-     * android.R.style#ThemeOverlay_Material_Dialog}. This will override only the window attributes
-     * necessary to style the alert window as a dialog.
-     *
-     * <p>Alternatively, the {@code themeResId} may be specified as {@code 0} to use the parent
-     * {@code context}'s resolved value for {@link android.R.attr#alertDialogTheme}.
-     *
      * @param context the parent context
-     * @param themeResId the resource ID of the theme against which to inflate this dialog, or
-     *     {@code 0} to use the parent {@code context}'s default alert dialog theme
+     * @param themeResId the resource ID of the theme
+     * @deprecated Use {@link SentryUserFeedbackForm.Builder#Builder(Context, int)} instead.
      */
+    @Deprecated
     public Builder(Context context, int themeResId) {
-      this(context, themeResId, null);
+      super(context, themeResId);
     }
 
     /**
-     * Creates a builder for a {@link SentryUserFeedbackDialog} that uses the default alert dialog
-     * theme. The {@code configuration} can be used to configure the feedback options for this
-     * specific dialog.
-     *
-     * <p>The default alert dialog theme is defined by {@link android.R.attr#alertDialogTheme}
-     * within the parent {@code context}'s theme.
+     * Creates a builder for a {@link SentryUserFeedbackDialog} with a configuration.
      *
      * @param context the parent context
-     * @param configuration the configuration for the feedback options, can be {@code null} to use
-     *     the global feedback options.
+     * @param configuration the configuration for the feedback options
+     * @deprecated Use {@link SentryUserFeedbackForm.Builder#Builder(Context,
+     *     SentryUserFeedbackForm.OptionsConfiguration)} instead.
      */
+    @Deprecated
     public Builder(
-        final @NotNull Context context, final @Nullable OptionsConfiguration configuration) {
-      this(context, 0, configuration);
+        final @NotNull Context context,
+        final @Nullable SentryUserFeedbackForm.OptionsConfiguration configuration) {
+      super(context, configuration);
     }
 
     /**
-     * Creates a builder for a {@link SentryUserFeedbackDialog} that uses an explicit theme
-     * resource. The {@code configuration} can be used to configure the feedback options for this
-     * specific dialog.
-     *
-     * <p>The specified theme resource ({@code themeResId}) is applied on top of the parent {@code
-     * context}'s theme. It may be specified as a style resource containing a fully-populated theme,
-     * such as {@link android.R.style#Theme_Material_Dialog}, to replace all attributes in the
-     * parent {@code context}'s theme including primary and accent colors.
-     *
-     * <p>To preserve attributes such as primary and accent colors, the {@code themeResId} may
-     * instead be specified as an overlay theme such as {@link
-     * android.R.style#ThemeOverlay_Material_Dialog}. This will override only the window attributes
-     * necessary to style the alert window as a dialog.
-     *
-     * <p>Alternatively, the {@code themeResId} may be specified as {@code 0} to use the parent
-     * {@code context}'s resolved value for {@link android.R.attr#alertDialogTheme}.
+     * Creates a builder for a {@link SentryUserFeedbackDialog} with a theme and configuration.
      *
      * @param context the parent context
-     * @param themeResId the resource ID of the theme against which to inflate this dialog, or
-     *     {@code 0} to use the parent {@code context}'s default alert dialog theme
-     * @param configuration the configuration for the feedback options, can be {@code null} to use
-     *     the global feedback options.
+     * @param themeResId the resource ID of the theme
+     * @param configuration the configuration for the feedback options
+     * @deprecated Use {@link SentryUserFeedbackForm.Builder#Builder(Context, int,
+     *     SentryUserFeedbackForm.OptionsConfiguration)} instead.
      */
+    @Deprecated
     public Builder(
         final @NotNull Context context,
         final int themeResId,
-        final @Nullable OptionsConfiguration configuration) {
-      this.context = context;
-      this.themeResId = themeResId;
-      this.configuration = configuration;
+        final @Nullable SentryUserFeedbackForm.OptionsConfiguration configuration) {
+      super(context, themeResId, configuration);
     }
 
-    /**
-     * Sets the configuration for the feedback options.
-     *
-     * @param configurator the configuration for the feedback options, can be {@code null} to use
-     *     the global feedback options.
-     */
+    @Deprecated
+    @Override
     public Builder configurator(
         final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-      this.configurator = configurator;
+      super.configurator(configurator);
       return this;
     }
 
-    /**
-     * Sets the associated event ID for the feedback.
-     *
-     * @param associatedEventId the associated event ID for the feedback, can be {@code null} to
-     *     avoid associating the feedback to an event.
-     */
+    @Deprecated
+    @Override
     public Builder associatedEventId(final @Nullable SentryId associatedEventId) {
-      this.associatedEventId = associatedEventId;
+      super.associatedEventId(associatedEventId);
       return this;
     }
 
-    /**
-     * Builds a new {@link SentryUserFeedbackDialog} with the specified context, theme, and
-     * configuration.
-     *
-     * @return a new instance of {@link SentryUserFeedbackDialog}
-     */
+    @Override
     public SentryUserFeedbackDialog create() {
       return new SentryUserFeedbackDialog(
           context, themeResId, associatedEventId, configuration, configurator);
     }
   }
 
-  /** Configuration callback for feedback options. */
-  public interface OptionsConfiguration {
-
-    /**
-     * configure the feedback options
-     *
-     * @param context the context of the feedback dialog
-     * @param options the feedback options
-     */
-    void configure(final @NotNull Context context, final @NotNull SentryFeedbackOptions options);
-  }
+  /**
+   * @deprecated Use {@link SentryUserFeedbackForm.OptionsConfiguration} instead.
+   */
+  @Deprecated
+  public interface OptionsConfiguration extends SentryUserFeedbackForm.OptionsConfiguration {}
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackDialog.java
@@ -98,6 +98,7 @@ public final class SentryUserFeedbackDialog extends SentryUserFeedbackForm {
       return this;
     }
 
+    @Deprecated
     @Override
     public SentryUserFeedbackDialog create() {
       return new SentryUserFeedbackDialog(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
@@ -162,7 +162,7 @@ public class SentryUserFeedbackForm extends AlertDialog {
           }
 
           // Capture the feedback. If the ID is empty, it means that the feedback was not sent
-          final @NotNull SentryId id = Sentry.captureFeedback(feedback);
+          final @NotNull SentryId id = Sentry.feedback().capture(feedback);
           if (!id.equals(SentryId.EMPTY_ID)) {
             Toast.makeText(
                     getContext(), feedbackOptions.getSuccessMessageText(), Toast.LENGTH_SHORT)

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
@@ -1,0 +1,379 @@
+package io.sentry.android.core;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+import io.sentry.IScopes;
+import io.sentry.Sentry;
+import io.sentry.SentryFeedbackOptions;
+import io.sentry.SentryIntegrationPackageStorage;
+import io.sentry.SentryLevel;
+import io.sentry.SentryOptions;
+import io.sentry.protocol.Feedback;
+import io.sentry.protocol.SentryId;
+import io.sentry.protocol.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SentryUserFeedbackForm extends AlertDialog {
+
+  private boolean isCancelable = false;
+  private @Nullable SentryId currentReplayId;
+  private final @Nullable SentryId associatedEventId;
+  private @Nullable OnDismissListener delegate;
+
+  private final @Nullable OptionsConfiguration configuration;
+  private final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator;
+
+  SentryUserFeedbackForm(
+      final @NotNull Context context,
+      final int themeResId,
+      final @Nullable SentryId associatedEventId,
+      final @Nullable OptionsConfiguration configuration,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    super(context, themeResId);
+    this.associatedEventId = associatedEventId;
+    this.configuration = configuration;
+    this.configurator = configurator;
+    SentryIntegrationPackageStorage.getInstance().addIntegration("UserFeedbackWidget");
+  }
+
+  @Override
+  public void setCancelable(boolean cancelable) {
+    super.setCancelable(cancelable);
+    isCancelable = cancelable;
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.sentry_dialog_user_feedback);
+    setCancelable(isCancelable);
+
+    final @NotNull SentryFeedbackOptions feedbackOptions =
+        new SentryFeedbackOptions(Sentry.getCurrentScopes().getOptions().getFeedbackOptions());
+    if (configuration != null) {
+      configuration.configure(getContext(), feedbackOptions);
+    }
+    if (configurator != null) {
+      configurator.configure(feedbackOptions);
+    }
+    final @NotNull TextView lblTitle = findViewById(R.id.sentry_dialog_user_feedback_title);
+    final @NotNull ImageView imgLogo = findViewById(R.id.sentry_dialog_user_feedback_logo);
+    final @NotNull TextView lblName = findViewById(R.id.sentry_dialog_user_feedback_txt_name);
+    final @NotNull EditText edtName = findViewById(R.id.sentry_dialog_user_feedback_edt_name);
+    final @NotNull TextView lblEmail = findViewById(R.id.sentry_dialog_user_feedback_txt_email);
+    final @NotNull EditText edtEmail = findViewById(R.id.sentry_dialog_user_feedback_edt_email);
+    final @NotNull TextView lblMessage =
+        findViewById(R.id.sentry_dialog_user_feedback_txt_description);
+    final @NotNull EditText edtMessage =
+        findViewById(R.id.sentry_dialog_user_feedback_edt_description);
+    final @NotNull Button btnSend = findViewById(R.id.sentry_dialog_user_feedback_btn_send);
+    final @NotNull Button btnCancel = findViewById(R.id.sentry_dialog_user_feedback_btn_cancel);
+
+    if (feedbackOptions.isShowBranding()) {
+      imgLogo.setVisibility(View.VISIBLE);
+    } else {
+      imgLogo.setVisibility(View.GONE);
+    }
+
+    // If name is required, ignore showName flag
+    if (!feedbackOptions.isShowName() && !feedbackOptions.isNameRequired()) {
+      lblName.setVisibility(View.GONE);
+      edtName.setVisibility(View.GONE);
+    } else {
+      lblName.setVisibility(View.VISIBLE);
+      edtName.setVisibility(View.VISIBLE);
+      lblName.setText(feedbackOptions.getNameLabel());
+      edtName.setHint(feedbackOptions.getNamePlaceholder());
+      if (feedbackOptions.isNameRequired()) {
+        lblName.append(feedbackOptions.getIsRequiredLabel());
+      }
+    }
+
+    // If email is required, ignore showEmail flag
+    if (!feedbackOptions.isShowEmail() && !feedbackOptions.isEmailRequired()) {
+      lblEmail.setVisibility(View.GONE);
+      edtEmail.setVisibility(View.GONE);
+    } else {
+      lblEmail.setVisibility(View.VISIBLE);
+      edtEmail.setVisibility(View.VISIBLE);
+      lblEmail.setText(feedbackOptions.getEmailLabel());
+      edtEmail.setHint(feedbackOptions.getEmailPlaceholder());
+      if (feedbackOptions.isEmailRequired()) {
+        lblEmail.append(feedbackOptions.getIsRequiredLabel());
+      }
+    }
+
+    // If Sentry user is set, and useSentryUser is true, populate the name and email
+    if (feedbackOptions.isUseSentryUser()) {
+      final @Nullable User user = Sentry.getCurrentScopes().getScope().getUser();
+      if (user != null) {
+        edtName.setText(user.getUsername());
+        edtEmail.setText(user.getEmail());
+      }
+    }
+
+    lblMessage.setText(feedbackOptions.getMessageLabel());
+    lblMessage.append(feedbackOptions.getIsRequiredLabel());
+    edtMessage.setHint(feedbackOptions.getMessagePlaceholder());
+    lblTitle.setText(feedbackOptions.getFormTitle());
+
+    btnSend.setText(feedbackOptions.getSubmitButtonLabel());
+    btnSend.setOnClickListener(
+        v -> {
+          // Gather fields and trim them
+          final @NotNull String name = edtName.getText().toString().trim();
+          final @NotNull String email = edtEmail.getText().toString().trim();
+          final @NotNull String message = edtMessage.getText().toString().trim();
+
+          // If a required field is missing, shows the error label
+          if (name.isEmpty() && feedbackOptions.isNameRequired()) {
+            edtName.setError(lblName.getText());
+            return;
+          }
+
+          if (email.isEmpty() && feedbackOptions.isEmailRequired()) {
+            edtEmail.setError(lblEmail.getText());
+            return;
+          }
+
+          if (message.isEmpty()) {
+            edtMessage.setError(lblMessage.getText());
+            return;
+          }
+
+          // Create the feedback object
+          final @NotNull Feedback feedback = new Feedback(message);
+          feedback.setName(name);
+          feedback.setContactEmail(email);
+          if (associatedEventId != null) {
+            feedback.setAssociatedEventId(associatedEventId);
+          }
+          if (currentReplayId != null) {
+            feedback.setReplayId(currentReplayId);
+          }
+
+          // Capture the feedback. If the ID is empty, it means that the feedback was not sent
+          final @NotNull SentryId id = Sentry.captureFeedback(feedback);
+          if (!id.equals(SentryId.EMPTY_ID)) {
+            Toast.makeText(
+                    getContext(), feedbackOptions.getSuccessMessageText(), Toast.LENGTH_SHORT)
+                .show();
+            final @Nullable SentryFeedbackOptions.SentryFeedbackCallback onSubmitSuccess =
+                feedbackOptions.getOnSubmitSuccess();
+            if (onSubmitSuccess != null) {
+              onSubmitSuccess.call(feedback);
+            }
+          } else {
+            final @Nullable SentryFeedbackOptions.SentryFeedbackCallback onSubmitError =
+                feedbackOptions.getOnSubmitError();
+            if (onSubmitError != null) {
+              onSubmitError.call(feedback);
+            }
+          }
+          cancel();
+        });
+
+    btnCancel.setText(feedbackOptions.getCancelButtonLabel());
+    btnCancel.setOnClickListener(v -> cancel());
+    setOnDismissListener(delegate);
+  }
+
+  @Override
+  public void setOnDismissListener(final @Nullable OnDismissListener listener) {
+    delegate = listener;
+    // If the user set a custom onDismissListener, we ensure it doesn't override the onFormClose
+    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
+    final @Nullable Runnable onFormClose = options.getFeedbackOptions().getOnFormClose();
+    if (onFormClose != null) {
+      super.setOnDismissListener(
+          dialog -> {
+            onFormClose.run();
+            currentReplayId = null;
+            if (delegate != null) {
+              delegate.onDismiss(dialog);
+            }
+          });
+    } else {
+      super.setOnDismissListener(delegate);
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
+    final @NotNull SentryFeedbackOptions feedbackOptions = options.getFeedbackOptions();
+    final @Nullable Runnable onFormOpen = feedbackOptions.getOnFormOpen();
+    if (onFormOpen != null) {
+      onFormOpen.run();
+    }
+    options.getReplayController().captureReplay(false);
+    currentReplayId = options.getReplayController().getReplayId();
+  }
+
+  @Override
+  public void show() {
+    // If Sentry is disabled, don't show the dialog, but log a warning
+    final @NotNull IScopes scopes = Sentry.getCurrentScopes();
+    final @NotNull SentryOptions options = scopes.getOptions();
+    if (!scopes.isEnabled() || !options.isEnabled()) {
+      options
+          .getLogger()
+          .log(SentryLevel.WARNING, "Sentry is disabled. Feedback dialog won't be shown.");
+      return;
+    }
+    // Otherwise, show the dialog
+    super.show();
+  }
+
+  public static class Builder {
+
+    @Nullable OptionsConfiguration configuration;
+    @Nullable SentryFeedbackOptions.OptionsConfigurator configurator;
+    @Nullable SentryId associatedEventId;
+    final @NotNull Context context;
+    final int themeResId;
+
+    /**
+     * Creates a builder for a {@link SentryUserFeedbackForm} that uses the default alert dialog
+     * theme.
+     *
+     * <p>The default alert dialog theme is defined by {@link android.R.attr#alertDialogTheme}
+     * within the parent {@code context}'s theme.
+     *
+     * @param context the parent context
+     */
+    public Builder(final @NotNull Context context) {
+      this(context, 0);
+    }
+
+    /**
+     * Creates a builder for a {@link SentryUserFeedbackForm} that uses an explicit theme resource.
+     *
+     * <p>The specified theme resource ({@code themeResId}) is applied on top of the parent {@code
+     * context}'s theme. It may be specified as a style resource containing a fully-populated theme,
+     * such as {@link android.R.style#Theme_Material_Dialog}, to replace all attributes in the
+     * parent {@code context}'s theme including primary and accent colors.
+     *
+     * <p>To preserve attributes such as primary and accent colors, the {@code themeResId} may
+     * instead be specified as an overlay theme such as {@link
+     * android.R.style#ThemeOverlay_Material_Dialog}. This will override only the window attributes
+     * necessary to style the alert window as a dialog.
+     *
+     * <p>Alternatively, the {@code themeResId} may be specified as {@code 0} to use the parent
+     * {@code context}'s resolved value for {@link android.R.attr#alertDialogTheme}.
+     *
+     * @param context the parent context
+     * @param themeResId the resource ID of the theme against which to inflate this dialog, or
+     *     {@code 0} to use the parent {@code context}'s default alert dialog theme
+     */
+    public Builder(Context context, int themeResId) {
+      this(context, themeResId, null);
+    }
+
+    /**
+     * Creates a builder for a {@link SentryUserFeedbackForm} that uses the default alert dialog
+     * theme. The {@code configuration} can be used to configure the feedback options for this
+     * specific dialog.
+     *
+     * <p>The default alert dialog theme is defined by {@link android.R.attr#alertDialogTheme}
+     * within the parent {@code context}'s theme.
+     *
+     * @param context the parent context
+     * @param configuration the configuration for the feedback options, can be {@code null} to use
+     *     the global feedback options.
+     */
+    public Builder(
+        final @NotNull Context context, final @Nullable OptionsConfiguration configuration) {
+      this(context, 0, configuration);
+    }
+
+    /**
+     * Creates a builder for a {@link SentryUserFeedbackForm} that uses an explicit theme resource.
+     * The {@code configuration} can be used to configure the feedback options for this specific
+     * dialog.
+     *
+     * <p>The specified theme resource ({@code themeResId}) is applied on top of the parent {@code
+     * context}'s theme. It may be specified as a style resource containing a fully-populated theme,
+     * such as {@link android.R.style#Theme_Material_Dialog}, to replace all attributes in the
+     * parent {@code context}'s theme including primary and accent colors.
+     *
+     * <p>To preserve attributes such as primary and accent colors, the {@code themeResId} may
+     * instead be specified as an overlay theme such as {@link
+     * android.R.style#ThemeOverlay_Material_Dialog}. This will override only the window attributes
+     * necessary to style the alert window as a dialog.
+     *
+     * <p>Alternatively, the {@code themeResId} may be specified as {@code 0} to use the parent
+     * {@code context}'s resolved value for {@link android.R.attr#alertDialogTheme}.
+     *
+     * @param context the parent context
+     * @param themeResId the resource ID of the theme against which to inflate this dialog, or
+     *     {@code 0} to use the parent {@code context}'s default alert dialog theme
+     * @param configuration the configuration for the feedback options, can be {@code null} to use
+     *     the global feedback options.
+     */
+    public Builder(
+        final @NotNull Context context,
+        final int themeResId,
+        final @Nullable OptionsConfiguration configuration) {
+      this.context = context;
+      this.themeResId = themeResId;
+      this.configuration = configuration;
+    }
+
+    /**
+     * Sets the configuration for the feedback options.
+     *
+     * @param configurator the configuration for the feedback options, can be {@code null} to use
+     *     the global feedback options.
+     */
+    public Builder configurator(
+        final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+      this.configurator = configurator;
+      return this;
+    }
+
+    /**
+     * Sets the associated event ID for the feedback.
+     *
+     * @param associatedEventId the associated event ID for the feedback, can be {@code null} to
+     *     avoid associating the feedback to an event.
+     */
+    public Builder associatedEventId(final @Nullable SentryId associatedEventId) {
+      this.associatedEventId = associatedEventId;
+      return this;
+    }
+
+    /**
+     * Builds a new {@link SentryUserFeedbackForm} with the specified context, theme, and
+     * configuration.
+     *
+     * @return a new instance of {@link SentryUserFeedbackForm}
+     */
+    public SentryUserFeedbackForm create() {
+      return new SentryUserFeedbackForm(
+          context, themeResId, associatedEventId, configuration, configurator);
+    }
+  }
+
+  /** Configuration callback for feedback options. */
+  public interface OptionsConfiguration {
+
+    /**
+     * configure the feedback options
+     *
+     * @param context the context of the feedback dialog
+     * @param options the feedback options
+     */
+    void configure(final @NotNull Context context, final @NotNull SentryFeedbackOptions options);
+  }
+}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -18,7 +18,7 @@ import io.sentry.MainEventProcessor
 import io.sentry.NoOpContinuousProfiler
 import io.sentry.NoOpTransactionProfiler
 import io.sentry.SentryOptions
-import io.sentry.android.core.SentryAndroidOptions.AndroidUserFeedbackIDialogHandler
+import io.sentry.android.core.SentryAndroidOptions.AndroidUserFeedbackFormHandler
 import io.sentry.android.core.cache.AndroidEnvelopeCache
 import io.sentry.android.core.internal.debugmeta.AssetsDebugMetaLoader
 import io.sentry.android.core.internal.gestures.AndroidViewGestureTargetLocator
@@ -882,9 +882,9 @@ class AndroidOptionsInitializerTest {
   }
 
   @Test
-  fun `AndroidUserFeedbackIDialogHandler is set as feedback dialog handler`() {
+  fun `AndroidUserFeedbackFormHandler is set as feedback form handler`() {
     fixture.initSut()
-    assertIs<AndroidUserFeedbackIDialogHandler>(fixture.sentryOptions.feedbackOptions.dialogHandler)
+    assertIs<AndroidUserFeedbackFormHandler>(fixture.sentryOptions.feedbackOptions.formHandler)
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
@@ -22,10 +22,10 @@ class FeedbackShakeIntegrationTest {
     val scopes = mock<Scopes>()
     val options = SentryAndroidOptions().apply { dsn = "https://key@sentry.io/proj" }
     val activity = mock<Activity>()
-    val dialogHandler = mock<SentryFeedbackOptions.IDialogHandler>()
+    val formHandler = mock<SentryFeedbackOptions.IFormHandler>()
 
     init {
-      options.feedbackOptions.setDialogHandler(dialogHandler)
+      options.feedbackOptions.setFormHandler(formHandler)
     }
 
     fun getSut(useShakeGesture: Boolean = true): FeedbackShakeIntegration {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryUserFeedbackFormTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryUserFeedbackFormTest.kt
@@ -26,7 +26,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
-class SentryUserFeedbackDialogTest {
+class SentryUserFeedbackFormTest {
   class Fixture {
     val application: Context = ApplicationProvider.getApplicationContext()
     private val mockDsn = "http://key@localhost/proj"
@@ -55,10 +55,10 @@ class SentryUserFeedbackDialogTest {
 
     fun getSut(
       associatedEventId: SentryId? = null,
-      configuration: SentryUserFeedbackDialog.OptionsConfiguration? = null,
+      configuration: SentryUserFeedbackForm.OptionsConfiguration? = null,
       configurator: SentryFeedbackOptions.OptionsConfigurator? = null,
-    ): SentryUserFeedbackDialog =
-      SentryUserFeedbackDialog(application, 0, associatedEventId, configuration, configurator)
+    ): SentryUserFeedbackForm =
+      SentryUserFeedbackForm(application, 0, associatedEventId, configuration, configurator)
   }
 
   private val fixture = Fixture()

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
@@ -56,14 +56,14 @@ class UserFeedbackUiTest : BaseUiTest() {
 
   @Test
   fun userFeedbackNotShownWhenSdkDisabledViaApi() {
-    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackForm() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().showForm() }
     onView(withId(R.id.sentry_dialog_user_feedback_layout)).check(doesNotExist())
   }
 
   @Test
   fun userFeedbackShownViaApi() {
     initSentry()
-    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackForm() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().showForm() }
 
     onView(withId(R.id.sentry_dialog_user_feedback_layout))
       .inRoot(isDialog())

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
@@ -28,7 +28,7 @@ import io.sentry.SentryOptions
 import io.sentry.android.core.AndroidLogger
 import io.sentry.android.core.R
 import io.sentry.android.core.SentryUserFeedbackButton
-import io.sentry.android.core.SentryUserFeedbackDialog
+import io.sentry.android.core.SentryUserFeedbackForm
 import io.sentry.assertEnvelopeFeedback
 import io.sentry.protocol.SentryId
 import io.sentry.protocol.User
@@ -49,21 +49,21 @@ class UserFeedbackUiTest : BaseUiTest() {
   @Test
   fun userFeedbackNotShownWhenSdkDisabled() {
     launchActivity<EmptyActivity>().onActivity {
-      SentryUserFeedbackDialog.Builder(it).create().show()
+      SentryUserFeedbackForm.Builder(it).create().show()
     }
     onView(withId(R.id.sentry_dialog_user_feedback_layout)).check(doesNotExist())
   }
 
   @Test
   fun userFeedbackNotShownWhenSdkDisabledViaApi() {
-    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackDialog() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackForm() }
     onView(withId(R.id.sentry_dialog_user_feedback_layout)).check(doesNotExist())
   }
 
   @Test
   fun userFeedbackShownViaApi() {
     initSentry()
-    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackDialog() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.showUserFeedbackForm() }
 
     onView(withId(R.id.sentry_dialog_user_feedback_layout))
       .inRoot(isDialog())
@@ -639,12 +639,12 @@ class UserFeedbackUiTest : BaseUiTest() {
 
   private fun showDialogAndCheck(
     associatedEventId: SentryId? = null,
-    checker: (dialog: SentryUserFeedbackDialog) -> Unit = {},
+    checker: (dialog: SentryUserFeedbackForm) -> Unit = {},
   ) {
-    lateinit var dialog: SentryUserFeedbackDialog
+    lateinit var dialog: SentryUserFeedbackForm
     val feedbackScenario = launchActivity<EmptyActivity>()
     feedbackScenario.onActivity {
-      dialog = SentryUserFeedbackDialog.Builder(it).associatedEventId(associatedEventId).create()
+      dialog = SentryUserFeedbackForm.Builder(it).associatedEventId(associatedEventId).create()
       dialog.show()
     }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/UserFeedbackUiTest.kt
@@ -56,14 +56,14 @@ class UserFeedbackUiTest : BaseUiTest() {
 
   @Test
   fun userFeedbackNotShownWhenSdkDisabledViaApi() {
-    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().showForm() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().show() }
     onView(withId(R.id.sentry_dialog_user_feedback_layout)).check(doesNotExist())
   }
 
   @Test
   fun userFeedbackShownViaApi() {
     initSentry()
-    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().showForm() }
+    launchActivity<EmptyActivity>().onActivity { Sentry.feedback().show() }
 
     onView(withId(R.id.sentry_dialog_user_feedback_layout))
       .inRoot(isDialog())

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
@@ -21,7 +21,7 @@ public fun SentryUserFeedbackButton(
   text: String = "Report a Bug",
   configurator: SentryFeedbackOptions.OptionsConfigurator? = null,
 ) {
-  Button(modifier = modifier, onClick = { Sentry.showUserFeedbackDialog(configurator) }) {
+  Button(modifier = modifier, onClick = { Sentry.showUserFeedbackForm(configurator) }) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.Center,

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
@@ -21,7 +21,7 @@ public fun SentryUserFeedbackButton(
   text: String = "Report a Bug",
   configurator: SentryFeedbackOptions.OptionsConfigurator? = null,
 ) {
-  Button(modifier = modifier, onClick = { Sentry.showUserFeedbackForm(configurator) }) {
+  Button(modifier = modifier, onClick = { Sentry.feedback().showForm(configurator) }) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.Center,

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryUserFeedbackButton.kt
@@ -21,7 +21,7 @@ public fun SentryUserFeedbackButton(
   text: String = "Report a Bug",
   configurator: SentryFeedbackOptions.OptionsConfigurator? = null,
 ) {
-  Button(modifier = modifier, onClick = { Sentry.feedback().showForm(configurator) }) {
+  Button(modifier = modifier, onClick = { Sentry.feedback().show(configurator) }) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.Center,

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -840,9 +840,9 @@ public abstract interface class io/sentry/IFeedbackApi {
 	public abstract fun capture (Lio/sentry/protocol/Feedback;)Lio/sentry/protocol/SentryId;
 	public abstract fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public abstract fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
-	public abstract fun showForm ()V
-	public abstract fun showForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
-	public abstract fun showForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public abstract fun show ()V
+	public abstract fun show (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public abstract fun show (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 }
 
 public abstract interface class io/sentry/IHub : io/sentry/IScopes {
@@ -1586,9 +1586,9 @@ public final class io/sentry/NoOpFeedbackApi : io/sentry/IFeedbackApi {
 	public fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
 	public fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
 	public static fun getInstance ()Lio/sentry/NoOpFeedbackApi;
-	public fun showForm ()V
-	public fun showForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
-	public fun showForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public fun show ()V
+	public fun show (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public fun show (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 }
 
 public final class io/sentry/NoOpHub : io/sentry/IHub {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2793,9 +2793,6 @@ public final class io/sentry/Sentry {
 	public static fun showUserFeedbackDialog ()V
 	public static fun showUserFeedbackDialog (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 	public static fun showUserFeedbackDialog (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
-	public static fun showUserFeedbackForm ()V
-	public static fun showUserFeedbackForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
-	public static fun showUserFeedbackForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 	public static fun startProfiler ()V
 	public static fun startSession ()V
 	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3154,7 +3154,6 @@ public final class io/sentry/SentryExecutorService : io/sentry/ISentryExecutorSe
 }
 
 public final class io/sentry/SentryFeedbackOptions {
-	public fun <init> (Lio/sentry/SentryFeedbackOptions$IFormHandler;)V
 	public fun <init> (Lio/sentry/SentryFeedbackOptions;)V
 	public fun getCancelButtonLabel ()Ljava/lang/CharSequence;
 	public fun getEmailLabel ()Ljava/lang/CharSequence;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2766,6 +2766,9 @@ public final class io/sentry/Sentry {
 	public static fun showUserFeedbackDialog ()V
 	public static fun showUserFeedbackDialog (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 	public static fun showUserFeedbackDialog (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public static fun showUserFeedbackForm ()V
+	public static fun showUserFeedbackForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public static fun showUserFeedbackForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 	public static fun startProfiler ()V
 	public static fun startSession ()V
 	public static fun startTransaction (Lio/sentry/TransactionContext;)Lio/sentry/ITransaction;
@@ -3151,12 +3154,12 @@ public final class io/sentry/SentryExecutorService : io/sentry/ISentryExecutorSe
 }
 
 public final class io/sentry/SentryFeedbackOptions {
-	public fun <init> (Lio/sentry/SentryFeedbackOptions$IDialogHandler;)V
+	public fun <init> (Lio/sentry/SentryFeedbackOptions$IFormHandler;)V
 	public fun <init> (Lio/sentry/SentryFeedbackOptions;)V
 	public fun getCancelButtonLabel ()Ljava/lang/CharSequence;
-	public fun getDialogHandler ()Lio/sentry/SentryFeedbackOptions$IDialogHandler;
 	public fun getEmailLabel ()Ljava/lang/CharSequence;
 	public fun getEmailPlaceholder ()Ljava/lang/CharSequence;
+	public fun getFormHandler ()Lio/sentry/SentryFeedbackOptions$IFormHandler;
 	public fun getFormTitle ()Ljava/lang/CharSequence;
 	public fun getIsRequiredLabel ()Ljava/lang/CharSequence;
 	public fun getMessageLabel ()Ljava/lang/CharSequence;
@@ -3177,10 +3180,10 @@ public final class io/sentry/SentryFeedbackOptions {
 	public fun isUseSentryUser ()Z
 	public fun isUseShakeGesture ()Z
 	public fun setCancelButtonLabel (Ljava/lang/CharSequence;)V
-	public fun setDialogHandler (Lio/sentry/SentryFeedbackOptions$IDialogHandler;)V
 	public fun setEmailLabel (Ljava/lang/CharSequence;)V
 	public fun setEmailPlaceholder (Ljava/lang/CharSequence;)V
 	public fun setEmailRequired (Z)V
+	public fun setFormHandler (Lio/sentry/SentryFeedbackOptions$IFormHandler;)V
 	public fun setFormTitle (Ljava/lang/CharSequence;)V
 	public fun setIsRequiredLabel (Ljava/lang/CharSequence;)V
 	public fun setMessageLabel (Ljava/lang/CharSequence;)V
@@ -3202,8 +3205,8 @@ public final class io/sentry/SentryFeedbackOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/sentry/SentryFeedbackOptions$IDialogHandler {
-	public abstract fun showDialog (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+public abstract interface class io/sentry/SentryFeedbackOptions$IFormHandler {
+	public abstract fun showForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 }
 
 public abstract interface class io/sentry/SentryFeedbackOptions$OptionsConfigurator {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -834,6 +834,15 @@ public abstract interface class io/sentry/IEnvelopeSender {
 	public abstract fun processEnvelopeFile (Ljava/lang/String;Lio/sentry/Hint;)V
 }
 
+public abstract interface class io/sentry/IFeedbackApi {
+	public abstract fun capture (Lio/sentry/protocol/Feedback;)Lio/sentry/protocol/SentryId;
+	public abstract fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public abstract fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public abstract fun showForm ()V
+	public abstract fun showForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public abstract fun showForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+}
+
 public abstract interface class io/sentry/IHub : io/sentry/IScopes {
 }
 
@@ -1567,6 +1576,16 @@ public final class io/sentry/NoOpDistributionApi : io/sentry/IDistributionApi {
 public final class io/sentry/NoOpEnvelopeReader : io/sentry/IEnvelopeReader {
 	public static fun getInstance ()Lio/sentry/NoOpEnvelopeReader;
 	public fun read (Ljava/io/InputStream;)Lio/sentry/SentryEnvelope;
+}
+
+public final class io/sentry/NoOpFeedbackApi : io/sentry/IFeedbackApi {
+	public fun capture (Lio/sentry/protocol/Feedback;)Lio/sentry/protocol/SentryId;
+	public fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;)Lio/sentry/protocol/SentryId;
+	public fun capture (Lio/sentry/protocol/Feedback;Lio/sentry/Hint;Lio/sentry/ScopeCallback;)Lio/sentry/protocol/SentryId;
+	public static fun getInstance ()Lio/sentry/NoOpFeedbackApi;
+	public fun showForm ()V
+	public fun showForm (Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
+	public fun showForm (Lio/sentry/protocol/SentryId;Lio/sentry/SentryFeedbackOptions$OptionsConfigurator;)V
 }
 
 public final class io/sentry/NoOpHub : io/sentry/IHub {
@@ -2720,6 +2739,7 @@ public final class io/sentry/Sentry {
 	public static fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public static fun distribution ()Lio/sentry/IDistributionApi;
 	public static fun endSession ()V
+	public static fun feedback ()Lio/sentry/IFeedbackApi;
 	public static fun flush (J)V
 	public static fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public static fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -664,6 +664,7 @@ public final class io/sentry/HubAdapter : io/sentry/IHub {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -740,6 +741,7 @@ public final class io/sentry/HubScopesWrapper : io/sentry/IHub {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -1021,6 +1023,7 @@ public abstract interface class io/sentry/IScopes {
 	public abstract fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public abstract fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public abstract fun endSession ()V
+	public abstract fun feedback ()Lio/sentry/IFeedbackApi;
 	public abstract fun flush (J)V
 	public abstract fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public abstract fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -1614,6 +1617,7 @@ public final class io/sentry/NoOpHub : io/sentry/IHub {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -1800,6 +1804,7 @@ public final class io/sentry/NoOpScopes : io/sentry/IScopes {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -2536,6 +2541,7 @@ public final class io/sentry/Scopes : io/sentry/IScopes {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;
@@ -2615,6 +2621,7 @@ public final class io/sentry/ScopesAdapter : io/sentry/IScopes {
 	public fun configureScope (Lio/sentry/ScopeType;Lio/sentry/ScopeCallback;)V
 	public fun continueTrace (Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;
 	public fun endSession ()V
+	public fun feedback ()Lio/sentry/IFeedbackApi;
 	public fun flush (J)V
 	public fun forkedCurrentScope (Ljava/lang/String;)Lio/sentry/IScopes;
 	public fun forkedRootScopes (Ljava/lang/String;)Lio/sentry/IScopes;

--- a/sentry/src/main/java/io/sentry/FeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/FeedbackApi.java
@@ -5,7 +5,13 @@ import io.sentry.protocol.SentryId;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-final class SentryFeedbackApi implements IFeedbackApi {
+final class FeedbackApi implements IFeedbackApi {
+
+  private final @NotNull IScopes scopes;
+
+  FeedbackApi(final @NotNull IScopes scopes) {
+    this.scopes = scopes;
+  }
 
   @Override
   public void showForm() {
@@ -21,18 +27,18 @@ final class SentryFeedbackApi implements IFeedbackApi {
   public void showForm(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
+    final @NotNull SentryOptions options = scopes.getOptions();
     options.getFeedbackOptions().getFormHandler().showForm(associatedEventId, configurator);
   }
 
   @Override
   public @NotNull SentryId capture(final @NotNull Feedback feedback) {
-    return Sentry.getCurrentScopes().captureFeedback(feedback);
+    return scopes.captureFeedback(feedback);
   }
 
   @Override
   public @NotNull SentryId capture(final @NotNull Feedback feedback, final @Nullable Hint hint) {
-    return Sentry.getCurrentScopes().captureFeedback(feedback, hint);
+    return scopes.captureFeedback(feedback, hint);
   }
 
   @Override
@@ -40,6 +46,6 @@ final class SentryFeedbackApi implements IFeedbackApi {
       final @NotNull Feedback feedback,
       final @Nullable Hint hint,
       final @Nullable ScopeCallback callback) {
-    return Sentry.getCurrentScopes().captureFeedback(feedback, hint, callback);
+    return scopes.captureFeedback(feedback, hint, callback);
   }
 }

--- a/sentry/src/main/java/io/sentry/FeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/FeedbackApi.java
@@ -14,17 +14,17 @@ final class FeedbackApi implements IFeedbackApi {
   }
 
   @Override
-  public void showForm() {
-    showForm(null, null);
+  public void show() {
+    show(null, null);
   }
 
   @Override
-  public void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    showForm(null, configurator);
+  public void show(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    show(null, configurator);
   }
 
   @Override
-  public void showForm(
+  public void show(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
     final @NotNull SentryOptions options = scopes.getOptions();

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -86,7 +86,6 @@ public final class HubAdapter implements IHub {
     return Sentry.captureException(throwable, hint, callback);
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -86,6 +86,8 @@ public final class HubAdapter implements IHub {
     return Sentry.captureException(throwable, hint, callback);
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     Sentry.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -396,6 +396,11 @@ public final class HubAdapter implements IHub {
   }
 
   @Override
+  public @NotNull IFeedbackApi feedback() {
+    return Sentry.getCurrentScopes().feedback();
+  }
+
+  @Override
   public void setAttribute(final @Nullable String key, final @Nullable Object value) {
     Sentry.setAttribute(key, value);
   }

--- a/sentry/src/main/java/io/sentry/HubAdapter.java
+++ b/sentry/src/main/java/io/sentry/HubAdapter.java
@@ -86,7 +86,6 @@ public final class HubAdapter implements IHub {
     return Sentry.captureException(throwable, hint, callback);
   }
 
-  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     Sentry.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -75,6 +75,8 @@ public final class HubScopesWrapper implements IHub {
     return scopes.captureException(throwable, hint, callback);
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     scopes.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -75,7 +75,6 @@ public final class HubScopesWrapper implements IHub {
     return scopes.captureException(throwable, hint, callback);
   }
 
-  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     scopes.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -75,7 +75,6 @@ public final class HubScopesWrapper implements IHub {
     return scopes.captureException(throwable, hint, callback);
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {

--- a/sentry/src/main/java/io/sentry/HubScopesWrapper.java
+++ b/sentry/src/main/java/io/sentry/HubScopesWrapper.java
@@ -381,6 +381,11 @@ public final class HubScopesWrapper implements IHub {
   }
 
   @Override
+  public @NotNull IFeedbackApi feedback() {
+    return scopes.feedback();
+  }
+
+  @Override
   public void setAttribute(final @Nullable String key, final @Nullable Object value) {
     scopes.setAttribute(key, value);
   }

--- a/sentry/src/main/java/io/sentry/IFeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/IFeedbackApi.java
@@ -7,11 +7,11 @@ import org.jetbrains.annotations.Nullable;
 
 public interface IFeedbackApi {
 
-  void showForm();
+  void show();
 
-  void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
+  void show(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
 
-  void showForm(
+  void show(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
 

--- a/sentry/src/main/java/io/sentry/IFeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/IFeedbackApi.java
@@ -1,0 +1,29 @@
+package io.sentry;
+
+import io.sentry.protocol.Feedback;
+import io.sentry.protocol.SentryId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface IFeedbackApi {
+
+  void showForm();
+
+  void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
+
+  void showForm(
+      final @Nullable SentryId associatedEventId,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
+
+  @NotNull
+  SentryId capture(final @NotNull Feedback feedback);
+
+  @NotNull
+  SentryId capture(final @NotNull Feedback feedback, final @Nullable Hint hint);
+
+  @NotNull
+  SentryId capture(
+      final @NotNull Feedback feedback,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback);
+}

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -748,6 +748,9 @@ public interface IScopes {
   @NotNull
   IMetricsApi metrics();
 
+  @NotNull
+  IFeedbackApi feedback();
+
   /**
    * Sets an attribute.
    *

--- a/sentry/src/main/java/io/sentry/IScopes.java
+++ b/sentry/src/main/java/io/sentry/IScopes.java
@@ -217,7 +217,10 @@ public interface IScopes {
    * Captures a manually created user feedback and sends it to Sentry.
    *
    * @param userFeedback The user feedback to send to Sentry.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#capture(io.sentry.protocol.Feedback)
+   *     capture(feedback)} with the new {@link io.sentry.protocol.Feedback} type instead.
    */
+  @Deprecated
   void captureUserFeedback(@NotNull UserFeedback userFeedback);
 
   /** Starts a new session. If there's a running session, it ends it before starting the new one. */

--- a/sentry/src/main/java/io/sentry/ISentryClient.java
+++ b/sentry/src/main/java/io/sentry/ISentryClient.java
@@ -174,7 +174,10 @@ public interface ISentryClient {
    * Captures a manually created user feedback and sends it to Sentry.
    *
    * @param userFeedback The user feedback to send to Sentry.
+   * @deprecated Use {@link IFeedbackApi#capture(io.sentry.protocol.Feedback)} with the new {@link
+   *     io.sentry.protocol.Feedback} type instead.
    */
+  @Deprecated
   void captureUserFeedback(@NotNull UserFeedback userFeedback);
 
   /**

--- a/sentry/src/main/java/io/sentry/JsonSerializer.java
+++ b/sentry/src/main/java/io/sentry/JsonSerializer.java
@@ -72,6 +72,7 @@ public final class JsonSerializer implements ISerializer {
   /**
    * All our custom deserializers need to be registered to be used with the deserializer instance. *
    */
+  @SuppressWarnings("deprecation")
   public JsonSerializer(@NotNull SentryOptions options) {
     this.options = options;
 

--- a/sentry/src/main/java/io/sentry/NoOpFeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/NoOpFeedbackApi.java
@@ -1,0 +1,46 @@
+package io.sentry;
+
+import io.sentry.protocol.Feedback;
+import io.sentry.protocol.SentryId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class NoOpFeedbackApi implements IFeedbackApi {
+
+  private static final NoOpFeedbackApi instance = new NoOpFeedbackApi();
+
+  private NoOpFeedbackApi() {}
+
+  public static NoOpFeedbackApi getInstance() {
+    return instance;
+  }
+
+  @Override
+  public void showForm() {}
+
+  @Override
+  public void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {}
+
+  @Override
+  public void showForm(
+      final @Nullable SentryId associatedEventId,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {}
+
+  @Override
+  public @NotNull SentryId capture(final @NotNull Feedback feedback) {
+    return SentryId.EMPTY_ID;
+  }
+
+  @Override
+  public @NotNull SentryId capture(final @NotNull Feedback feedback, final @Nullable Hint hint) {
+    return SentryId.EMPTY_ID;
+  }
+
+  @Override
+  public @NotNull SentryId capture(
+      final @NotNull Feedback feedback,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
+    return SentryId.EMPTY_ID;
+  }
+}

--- a/sentry/src/main/java/io/sentry/NoOpFeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/NoOpFeedbackApi.java
@@ -16,13 +16,13 @@ public final class NoOpFeedbackApi implements IFeedbackApi {
   }
 
   @Override
-  public void showForm() {}
+  public void show() {}
 
   @Override
-  public void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {}
+  public void show(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {}
 
   @Override
-  public void showForm(
+  public void show(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {}
 

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -339,6 +339,11 @@ public final class NoOpHub implements IHub {
   }
 
   @Override
+  public @NotNull IFeedbackApi feedback() {
+    return NoOpFeedbackApi.getInstance();
+  }
+
+  @Override
   public void setAttribute(final @Nullable String key, final @Nullable Object value) {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -80,7 +80,6 @@ public final class NoOpHub implements IHub {
     return SentryId.EMPTY_ID;
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}

--- a/sentry/src/main/java/io/sentry/NoOpHub.java
+++ b/sentry/src/main/java/io/sentry/NoOpHub.java
@@ -80,6 +80,8 @@ public final class NoOpHub implements IHub {
     return SentryId.EMPTY_ID;
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}
 

--- a/sentry/src/main/java/io/sentry/NoOpScopes.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopes.java
@@ -77,6 +77,8 @@ public final class NoOpScopes implements IScopes {
     return SentryId.EMPTY_ID;
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}
 

--- a/sentry/src/main/java/io/sentry/NoOpScopes.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopes.java
@@ -337,6 +337,11 @@ public final class NoOpScopes implements IScopes {
   }
 
   @Override
+  public @NotNull IFeedbackApi feedback() {
+    return NoOpFeedbackApi.getInstance();
+  }
+
+  @Override
   public void setAttribute(final @Nullable String key, final @Nullable Object value) {}
 
   @Override

--- a/sentry/src/main/java/io/sentry/NoOpScopes.java
+++ b/sentry/src/main/java/io/sentry/NoOpScopes.java
@@ -77,7 +77,6 @@ public final class NoOpScopes implements IScopes {
     return SentryId.EMPTY_ID;
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -44,7 +44,6 @@ final class NoOpSentryClient implements ISentryClient {
     return SentryId.EMPTY_ID;
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}

--- a/sentry/src/main/java/io/sentry/NoOpSentryClient.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryClient.java
@@ -44,6 +44,8 @@ final class NoOpSentryClient implements ISentryClient {
     return SentryId.EMPTY_ID;
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {}
 

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -346,6 +346,8 @@ public final class Scopes implements IScopes {
     return sentryId;
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(final @NotNull UserFeedback userFeedback) {
     if (!isEnabled()) {

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -346,7 +346,6 @@ public final class Scopes implements IScopes {
     return sentryId;
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(final @NotNull UserFeedback userFeedback) {

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -34,6 +34,7 @@ public final class Scopes implements IScopes {
   private final @NotNull CombinedScopeView combinedScope;
   private final @NotNull ILoggerApi logger;
   private final @NotNull IMetricsApi metrics;
+  private final @NotNull IFeedbackApi feedbackApi;
 
   public Scopes(
       final @NotNull IScope scope,
@@ -61,6 +62,7 @@ public final class Scopes implements IScopes {
     this.compositePerformanceCollector = options.getCompositePerformanceCollector();
     this.logger = new LoggerApi(this);
     this.metrics = new MetricsApi(this);
+    this.feedbackApi = new FeedbackApi(this);
   }
 
   public @NotNull String getCreator() {
@@ -1243,6 +1245,11 @@ public final class Scopes implements IScopes {
   @Override
   public @NotNull IMetricsApi metrics() {
     return metrics;
+  }
+
+  @Override
+  public @NotNull IFeedbackApi feedback() {
+    return feedbackApi;
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -82,7 +82,6 @@ public final class ScopesAdapter implements IScopes {
     return Sentry.captureException(throwable, hint, callback);
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -51,18 +51,18 @@ public final class ScopesAdapter implements IScopes {
 
   @Override
   public @NotNull SentryId captureFeedback(@NotNull Feedback feedback) {
-    return Sentry.captureFeedback(feedback);
+    return Sentry.feedback().capture(feedback);
   }
 
   @Override
   public @NotNull SentryId captureFeedback(@NotNull Feedback feedback, @Nullable Hint hint) {
-    return Sentry.captureFeedback(feedback, hint);
+    return Sentry.feedback().capture(feedback, hint);
   }
 
   @Override
   public @NotNull SentryId captureFeedback(
       @NotNull Feedback feedback, @Nullable Hint hint, @Nullable ScopeCallback callback) {
-    return Sentry.captureFeedback(feedback, hint, callback);
+    return Sentry.feedback().capture(feedback, hint, callback);
   }
 
   @ApiStatus.Internal
@@ -82,6 +82,7 @@ public final class ScopesAdapter implements IScopes {
     return Sentry.captureException(throwable, hint, callback);
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     Sentry.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -83,6 +83,7 @@ public final class ScopesAdapter implements IScopes {
   }
 
   @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(@NotNull UserFeedback userFeedback) {
     Sentry.captureUserFeedback(userFeedback);

--- a/sentry/src/main/java/io/sentry/ScopesAdapter.java
+++ b/sentry/src/main/java/io/sentry/ScopesAdapter.java
@@ -394,6 +394,11 @@ public final class ScopesAdapter implements IScopes {
   }
 
   @Override
+  public @NotNull IFeedbackApi feedback() {
+    return Sentry.getCurrentScopes().feedback();
+  }
+
+  @Override
   public void setAttribute(final @Nullable String key, final @Nullable Object value) {
     Sentry.setAttribute(key, value);
   }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -827,40 +827,37 @@ public final class Sentry {
   }
 
   /**
-   * Captures the feedback.
-   *
-   * @param feedback The feedback to send.
-   * @return The Id (SentryId object) of the event
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#capture(Feedback) capture(feedback)}
+   *     instead.
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static @NotNull SentryId captureFeedback(final @NotNull Feedback feedback) {
-    return getCurrentScopes().captureFeedback(feedback);
+    return feedback().capture(feedback);
   }
 
   /**
-   * Captures the feedback.
-   *
-   * @param feedback The feedback to send.
-   * @param hint An optional hint to be applied to the event.
-   * @return The Id (SentryId object) of the event
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#capture(Feedback, Hint)
+   *     capture(feedback, hint)} instead.
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static @NotNull SentryId captureFeedback(
       final @NotNull Feedback feedback, final @Nullable Hint hint) {
-    return getCurrentScopes().captureFeedback(feedback, hint);
+    return feedback().capture(feedback, hint);
   }
 
   /**
-   * Captures the feedback.
-   *
-   * @param feedback The feedback to send.
-   * @param hint An optional hint to be applied to the event.
-   * @param callback The callback to configure the scope for a single invocation.
-   * @return The Id (SentryId object) of the event
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#capture(Feedback, Hint, ScopeCallback)
+   *     capture(feedback, hint, callback)} instead.
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static @NotNull SentryId captureFeedback(
       final @NotNull Feedback feedback,
       final @Nullable Hint hint,
       final @Nullable ScopeCallback callback) {
-    return getCurrentScopes().captureFeedback(feedback, hint, callback);
+    return feedback().capture(feedback, hint, callback);
   }
 
   /**
@@ -916,7 +913,11 @@ public final class Sentry {
    * Captures a manually created user feedback and sends it to Sentry.
    *
    * @param userFeedback The user feedback to send to Sentry.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#capture(Feedback) capture(feedback)}
+   *     with the new {@link Feedback} type instead.
    */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   public static void captureUserFeedback(final @NotNull UserFeedback userFeedback) {
     getCurrentScopes().captureUserFeedback(userFeedback);
   }
@@ -1355,52 +1356,79 @@ public final class Sentry {
     return getCurrentScopes().metrics();
   }
 
-  public static void showUserFeedbackForm() {
-    showUserFeedbackForm(null);
-  }
+  private static final @NotNull IFeedbackApi feedbackApi = new SentryFeedbackApi();
 
-  public static void showUserFeedbackForm(
-      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    showUserFeedbackForm(null, configurator);
-  }
-
-  public static void showUserFeedbackForm(
-      final @Nullable SentryId associatedEventId,
-      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    final @NotNull SentryOptions options = getCurrentScopes().getOptions();
-    options.getFeedbackOptions().getFormHandler().showForm(associatedEventId, configurator);
+  @NotNull
+  public static IFeedbackApi feedback() {
+    return feedbackApi;
   }
 
   /**
-   * @deprecated Use {@link #showUserFeedbackForm()} instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm() showForm()} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackForm() {
+    feedback().showForm();
+  }
+
+  /**
+   * @deprecated Use {@link #feedback()}.{@link
+   *     IFeedbackApi#showForm(SentryFeedbackOptions.OptionsConfigurator) showForm(configurator)}
+   *     instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackForm(
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    feedback().showForm(configurator);
+  }
+
+  /**
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm(SentryId,
+   *     SentryFeedbackOptions.OptionsConfigurator) showForm(associatedEventId, configurator)}
+   *     instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackForm(
+      final @Nullable SentryId associatedEventId,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    feedback().showForm(associatedEventId, configurator);
+  }
+
+  /**
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm() showForm()} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog() {
-    showUserFeedbackForm();
+    feedback().showForm();
   }
 
   /**
-   * @deprecated Use {@link #showUserFeedbackForm(SentryFeedbackOptions.OptionsConfigurator)}
+   * @deprecated Use {@link #feedback()}.{@link
+   *     IFeedbackApi#showForm(SentryFeedbackOptions.OptionsConfigurator) showForm(configurator)}
    *     instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog(
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    showUserFeedbackForm(configurator);
+    feedback().showForm(configurator);
   }
 
   /**
-   * @deprecated Use {@link #showUserFeedbackForm(SentryId,
-   *     SentryFeedbackOptions.OptionsConfigurator)} instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm(SentryId,
+   *     SentryFeedbackOptions.OptionsConfigurator) showForm(associatedEventId, configurator)}
+   *     instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    showUserFeedbackForm(associatedEventId, configurator);
+    feedback().showForm(associatedEventId, configurator);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1366,38 +1366,6 @@ public final class Sentry {
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
-  public static void showUserFeedbackForm() {
-    feedback().show();
-  }
-
-  /**
-   * @deprecated Use {@link #feedback()}.{@link
-   *     IFeedbackApi#show(SentryFeedbackOptions.OptionsConfigurator) show(configurator)} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public static void showUserFeedbackForm(
-      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().show(configurator);
-  }
-
-  /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show(SentryId,
-   *     SentryFeedbackOptions.OptionsConfigurator) show(associatedEventId, configurator)} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public static void showUserFeedbackForm(
-      final @Nullable SentryId associatedEventId,
-      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().show(associatedEventId, configurator);
-  }
-
-  /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show() show()} instead.
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog() {
     feedback().show();
   }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1356,11 +1356,9 @@ public final class Sentry {
     return getCurrentScopes().metrics();
   }
 
-  private static final @NotNull IFeedbackApi feedbackApi = new SentryFeedbackApi();
-
   @NotNull
   public static IFeedbackApi feedback() {
-    return feedbackApi;
+    return getCurrentScopes().feedback();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1355,20 +1355,52 @@ public final class Sentry {
     return getCurrentScopes().metrics();
   }
 
-  public static void showUserFeedbackDialog() {
-    showUserFeedbackDialog(null);
+  public static void showUserFeedbackForm() {
+    showUserFeedbackForm(null);
   }
 
-  public static void showUserFeedbackDialog(
+  public static void showUserFeedbackForm(
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    showUserFeedbackDialog(null, configurator);
+    showUserFeedbackForm(null, configurator);
   }
 
-  public static void showUserFeedbackDialog(
+  public static void showUserFeedbackForm(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
     final @NotNull SentryOptions options = getCurrentScopes().getOptions();
-    options.getFeedbackOptions().getDialogHandler().showDialog(associatedEventId, configurator);
+    options.getFeedbackOptions().getFormHandler().showForm(associatedEventId, configurator);
+  }
+
+  /**
+   * @deprecated Use {@link #showUserFeedbackForm()} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackDialog() {
+    showUserFeedbackForm();
+  }
+
+  /**
+   * @deprecated Use {@link #showUserFeedbackForm(SentryFeedbackOptions.OptionsConfigurator)}
+   *     instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackDialog(
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    showUserFeedbackForm(configurator);
+  }
+
+  /**
+   * @deprecated Use {@link #showUserFeedbackForm(SentryId,
+   *     SentryFeedbackOptions.OptionsConfigurator)} instead.
+   */
+  @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
+  public static void showUserFeedbackDialog(
+      final @Nullable SentryId associatedEventId,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    showUserFeedbackForm(associatedEventId, configurator);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -1362,71 +1362,67 @@ public final class Sentry {
   }
 
   /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm() showForm()} instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show() show()} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackForm() {
-    feedback().showForm();
+    feedback().show();
   }
 
   /**
    * @deprecated Use {@link #feedback()}.{@link
-   *     IFeedbackApi#showForm(SentryFeedbackOptions.OptionsConfigurator) showForm(configurator)}
-   *     instead.
+   *     IFeedbackApi#show(SentryFeedbackOptions.OptionsConfigurator) show(configurator)} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackForm(
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().showForm(configurator);
+    feedback().show(configurator);
   }
 
   /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm(SentryId,
-   *     SentryFeedbackOptions.OptionsConfigurator) showForm(associatedEventId, configurator)}
-   *     instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show(SentryId,
+   *     SentryFeedbackOptions.OptionsConfigurator) show(associatedEventId, configurator)} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackForm(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().showForm(associatedEventId, configurator);
+    feedback().show(associatedEventId, configurator);
   }
 
   /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm() showForm()} instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show() show()} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog() {
-    feedback().showForm();
+    feedback().show();
   }
 
   /**
    * @deprecated Use {@link #feedback()}.{@link
-   *     IFeedbackApi#showForm(SentryFeedbackOptions.OptionsConfigurator) showForm(configurator)}
-   *     instead.
+   *     IFeedbackApi#show(SentryFeedbackOptions.OptionsConfigurator) show(configurator)} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog(
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().showForm(configurator);
+    feedback().show(configurator);
   }
 
   /**
-   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#showForm(SentryId,
-   *     SentryFeedbackOptions.OptionsConfigurator) showForm(associatedEventId, configurator)}
-   *     instead.
+   * @deprecated Use {@link #feedback()}.{@link IFeedbackApi#show(SentryId,
+   *     SentryFeedbackOptions.OptionsConfigurator) show(associatedEventId, configurator)} instead.
    */
   @Deprecated
   @SuppressWarnings("InlineMeSuggester")
   public static void showUserFeedbackDialog(
       final @Nullable SentryId associatedEventId,
       final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
-    feedback().showForm(associatedEventId, configurator);
+    feedback().show(associatedEventId, configurator);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -717,6 +717,7 @@ public final class SentryClient implements ISentryClient {
   }
 
   @SuppressWarnings("deprecation")
+  @Deprecated
   private @NotNull SentryEnvelope buildEnvelope(final @NotNull UserFeedback userFeedback) {
     final List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -688,7 +688,6 @@ public final class SentryClient implements ISentryClient {
     return feedbackEvent;
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   @Override
   public void captureUserFeedback(final @NotNull UserFeedback userFeedback) {
@@ -716,7 +715,6 @@ public final class SentryClient implements ISentryClient {
     }
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   private @NotNull SentryEnvelope buildEnvelope(final @NotNull UserFeedback userFeedback) {
     final List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -688,6 +688,8 @@ public final class SentryClient implements ISentryClient {
     return feedbackEvent;
   }
 
+  @SuppressWarnings("deprecation")
+  @Deprecated
   @Override
   public void captureUserFeedback(final @NotNull UserFeedback userFeedback) {
     Objects.requireNonNull(userFeedback, "SentryEvent is required.");
@@ -714,6 +716,7 @@ public final class SentryClient implements ISentryClient {
     }
   }
 
+  @SuppressWarnings("deprecation")
   private @NotNull SentryEnvelope buildEnvelope(final @NotNull UserFeedback userFeedback) {
     final List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -169,6 +169,7 @@ public final class SentryEnvelopeItem {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public static SentryEnvelopeItem fromUserFeedback(
       final @NotNull ISerializer serializer, final @NotNull UserFeedback userFeedback) {
     Objects.requireNonNull(serializer, "ISerializer is required.");

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -169,7 +169,6 @@ public final class SentryEnvelopeItem {
     }
   }
 
-  @SuppressWarnings("deprecation")
   @Deprecated
   public static SentryEnvelopeItem fromUserFeedback(
       final @NotNull ISerializer serializer, final @NotNull UserFeedback userFeedback) {

--- a/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
+++ b/sentry/src/main/java/io/sentry/SentryEnvelopeItem.java
@@ -170,6 +170,7 @@ public final class SentryEnvelopeItem {
   }
 
   @SuppressWarnings("deprecation")
+  @Deprecated
   public static SentryEnvelopeItem fromUserFeedback(
       final @NotNull ISerializer serializer, final @NotNull UserFeedback userFeedback) {
     Objects.requireNonNull(serializer, "ISerializer is required.");

--- a/sentry/src/main/java/io/sentry/SentryFeedbackApi.java
+++ b/sentry/src/main/java/io/sentry/SentryFeedbackApi.java
@@ -1,0 +1,45 @@
+package io.sentry;
+
+import io.sentry.protocol.Feedback;
+import io.sentry.protocol.SentryId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+final class SentryFeedbackApi implements IFeedbackApi {
+
+  @Override
+  public void showForm() {
+    showForm(null, null);
+  }
+
+  @Override
+  public void showForm(final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    showForm(null, configurator);
+  }
+
+  @Override
+  public void showForm(
+      final @Nullable SentryId associatedEventId,
+      final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator) {
+    final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
+    options.getFeedbackOptions().getFormHandler().showForm(associatedEventId, configurator);
+  }
+
+  @Override
+  public @NotNull SentryId capture(final @NotNull Feedback feedback) {
+    return Sentry.getCurrentScopes().captureFeedback(feedback);
+  }
+
+  @Override
+  public @NotNull SentryId capture(final @NotNull Feedback feedback, final @Nullable Hint hint) {
+    return Sentry.getCurrentScopes().captureFeedback(feedback, hint);
+  }
+
+  @Override
+  public @NotNull SentryId capture(
+      final @NotNull Feedback feedback,
+      final @Nullable Hint hint,
+      final @Nullable ScopeCallback callback) {
+    return Sentry.getCurrentScopes().captureFeedback(feedback, hint, callback);
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryFeedbackOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryFeedbackOptions.java
@@ -91,10 +91,10 @@ public final class SentryFeedbackOptions {
   /** Callback called when there is an error submitting feedback via the prepared form. */
   private @Nullable SentryFeedbackCallback onSubmitError;
 
-  private @NotNull IDialogHandler iDialogHandler;
+  private @NotNull IFormHandler iFormHandler;
 
-  public SentryFeedbackOptions(@NotNull IDialogHandler iDialogHandler) {
-    this.iDialogHandler = iDialogHandler;
+  public SentryFeedbackOptions(@NotNull IFormHandler iFormHandler) {
+    this.iFormHandler = iFormHandler;
   }
 
   /** Creates a copy of the passed {@link SentryFeedbackOptions}. */
@@ -121,7 +121,7 @@ public final class SentryFeedbackOptions {
     this.onFormClose = other.onFormClose;
     this.onSubmitSuccess = other.onSubmitSuccess;
     this.onSubmitError = other.onSubmitError;
-    this.iDialogHandler = other.iDialogHandler;
+    this.iFormHandler = other.iFormHandler;
   }
 
   /**
@@ -535,23 +535,23 @@ public final class SentryFeedbackOptions {
   }
 
   /**
-   * Sets the dialog handler to be used to show the feedback form.
+   * Sets the form handler to be used to show the feedback form.
    *
-   * @param iDialogHandler the dialog handler to be used to show the feedback form
+   * @param iFormHandler the form handler to be used to show the feedback form
    */
   @ApiStatus.Internal
-  public void setDialogHandler(final @NotNull IDialogHandler iDialogHandler) {
-    this.iDialogHandler = iDialogHandler;
+  public void setFormHandler(final @NotNull IFormHandler iFormHandler) {
+    this.iFormHandler = iFormHandler;
   }
 
   /**
-   * Gets the dialog handler to be used to show the feedback form.
+   * Gets the form handler to be used to show the feedback form.
    *
-   * @return the dialog handler to be used to show the feedback form
+   * @return the form handler to be used to show the feedback form
    */
   @ApiStatus.Internal
-  public @NotNull IDialogHandler getDialogHandler() {
-    return iDialogHandler;
+  public @NotNull IFormHandler getFormHandler() {
+    return iFormHandler;
   }
 
   @Override
@@ -609,8 +609,8 @@ public final class SentryFeedbackOptions {
   }
 
   @ApiStatus.Internal
-  public interface IDialogHandler {
-    void showDialog(
+  public interface IFormHandler {
+    void showForm(
         final @Nullable SentryId associatedEventId,
         final @Nullable SentryFeedbackOptions.OptionsConfigurator configurator);
   }

--- a/sentry/src/main/java/io/sentry/SentryFeedbackOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryFeedbackOptions.java
@@ -93,7 +93,7 @@ public final class SentryFeedbackOptions {
 
   private @NotNull IFormHandler iFormHandler;
 
-  public SentryFeedbackOptions(@NotNull IFormHandler iFormHandler) {
+  SentryFeedbackOptions(@NotNull IFormHandler iFormHandler) {
     this.iFormHandler = iFormHandler;
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3397,7 +3397,7 @@ public class SentryOptions {
     feedbackOptions =
         new SentryFeedbackOptions(
             (associatedEventId, configurator) ->
-                logger.log(SentryLevel.WARNING, "showDialog() can only be called in Android."));
+                logger.log(SentryLevel.WARNING, "showForm() can only be called in Android."));
 
     if (!empty) {
       setSpanFactory(SpanFactoryFactory.create(new LoadClass(), NoOpLogger.getInstance()));

--- a/sentry/src/main/java/io/sentry/UserFeedback.java
+++ b/sentry/src/main/java/io/sentry/UserFeedback.java
@@ -8,7 +8,13 @@ import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/** Adds additional information about what happened to an event. */
+/**
+ * Adds additional information about what happened to an event.
+ *
+ * @deprecated Use {@link io.sentry.protocol.Feedback} with {@link Sentry#feedback()}.{@link
+ *     IFeedbackApi#capture(io.sentry.protocol.Feedback) capture(feedback)} instead.
+ */
+@Deprecated
 public final class UserFeedback implements JsonUnknown, JsonSerializable {
 
   private final SentryId eventId;

--- a/sentry/src/test/java/io/sentry/HubAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/HubAdapterTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class HubAdapterTest {
   val scopes: IScopes = mock()
@@ -63,6 +64,7 @@ class HubAdapterTest {
     val hint = Hint()
     val scopeCallback = mock<ScopeCallback>()
     val feedback = Feedback("message")
+    whenever(scopes.feedback()).thenReturn(FeedbackApi(scopes))
     HubAdapter.getInstance().captureFeedback(feedback)
     verify(scopes).captureFeedback(eq(feedback))
 

--- a/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesAdapterTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class ScopesAdapterTest {
   val scopes: IScopes = mock()
@@ -63,6 +64,7 @@ class ScopesAdapterTest {
     val scopeCallback = mock<ScopeCallback>()
     val hint = mock<Hint>()
     val feedback = Feedback("message")
+    whenever(scopes.feedback()).thenReturn(FeedbackApi(scopes))
     ScopesAdapter.getInstance().captureFeedback(feedback)
     verify(scopes).captureFeedback(eq(feedback))
 

--- a/sentry/src/test/java/io/sentry/SentryFeedbackOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryFeedbackOptionsTest.kt
@@ -1,6 +1,6 @@
 package io.sentry
 
-import io.sentry.SentryFeedbackOptions.IDialogHandler
+import io.sentry.SentryFeedbackOptions.IFormHandler
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.mockito.kotlin.mock
@@ -8,7 +8,7 @@ import org.mockito.kotlin.mock
 class SentryFeedbackOptionsTest {
   @Test
   fun `feedback options is initialized with default values`() {
-    val options = SentryFeedbackOptions(mock<IDialogHandler>())
+    val options = SentryFeedbackOptions(mock<IFormHandler>())
     assertEquals(false, options.isNameRequired)
     assertEquals(true, options.isShowName)
     assertEquals(false, options.isEmailRequired)
@@ -35,7 +35,7 @@ class SentryFeedbackOptionsTest {
   @Test
   fun `feedback options copy constructor`() {
     val options =
-      SentryFeedbackOptions(mock<IDialogHandler>()).apply {
+      SentryFeedbackOptions(mock<IFormHandler>()).apply {
         isNameRequired = true
         isShowName = false
         isEmailRequired = true
@@ -80,6 +80,6 @@ class SentryFeedbackOptionsTest {
     assertEquals(options.onFormClose, optionsCopy.onFormClose)
     assertEquals(options.onSubmitSuccess, optionsCopy.onSubmitSuccess)
     assertEquals(options.onSubmitError, optionsCopy.onSubmitError)
-    assertEquals(options.dialogHandler, optionsCopy.dialogHandler)
+    assertEquals(options.formHandler, optionsCopy.formHandler)
   }
 }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -907,8 +907,8 @@ class SentryOptionsTest {
         setLogger(logger)
         isDebug = true
       }
-    options.feedbackOptions.dialogHandler.showDialog(mock(), mock())
-    verify(logger).log(eq(SentryLevel.WARNING), eq("showDialog() can only be called in Android."))
+    options.feedbackOptions.formHandler.showForm(mock(), mock())
+    verify(logger).log(eq(SentryLevel.WARNING), eq("showForm() can only be called in Android."))
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1504,30 +1504,30 @@ class SentryTest {
   }
 
   @Test
-  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler`() {
+  fun `feedback showForm forwards to feedbackOptions_formHandler`() {
     val mockFormHandler = mock<IFormHandler>()
     initForTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackForm()
+    Sentry.feedback().showForm()
     verify(mockFormHandler).showForm(eq(null), eq(null))
   }
 
   @Test
-  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler with configurator`() {
+  fun `feedback showForm forwards to feedbackOptions_formHandler with configurator`() {
     val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     initForTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackForm(configurator)
+    Sentry.feedback().showForm(configurator)
     verify(mockFormHandler).showForm(eq(null), eq(configurator))
   }
 
   @Test
-  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler with associatedEventId and configurator`() {
+  fun `feedback showForm forwards to feedbackOptions_formHandler with associatedEventId and configurator`() {
     val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     val associatedEventId = SentryId()
@@ -1535,7 +1535,7 @@ class SentryTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackForm(associatedEventId, configurator)
+    Sentry.feedback().showForm(associatedEventId, configurator)
     verify(mockFormHandler).showForm(eq(associatedEventId), eq(configurator))
   }
 

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1,6 +1,6 @@
 package io.sentry
 
-import io.sentry.SentryFeedbackOptions.IDialogHandler
+import io.sentry.SentryFeedbackOptions.IFormHandler
 import io.sentry.SentryOptions.ProfilesSamplerCallback
 import io.sentry.SentryOptions.TracesSamplerCallback
 import io.sentry.backpressure.BackpressureMonitor
@@ -1504,39 +1504,39 @@ class SentryTest {
   }
 
   @Test
-  fun `showUserFeedbackDialog forwards to feedbackOptions_dialogHandler`() {
-    val mockDialogHandler = mock<IDialogHandler>()
+  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler`() {
+    val mockFormHandler = mock<IFormHandler>()
     initForTest {
       it.dsn = dsn
-      it.feedbackOptions.dialogHandler = mockDialogHandler
+      it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackDialog()
-    verify(mockDialogHandler).showDialog(eq(null), eq(null))
+    Sentry.showUserFeedbackForm()
+    verify(mockFormHandler).showForm(eq(null), eq(null))
   }
 
   @Test
-  fun `showUserFeedbackDialog forwards to feedbackOptions_dialogHandler with configurator`() {
-    val mockDialogHandler = mock<IDialogHandler>()
+  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler with configurator`() {
+    val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     initForTest {
       it.dsn = dsn
-      it.feedbackOptions.dialogHandler = mockDialogHandler
+      it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackDialog(configurator)
-    verify(mockDialogHandler).showDialog(eq(null), eq(configurator))
+    Sentry.showUserFeedbackForm(configurator)
+    verify(mockFormHandler).showForm(eq(null), eq(configurator))
   }
 
   @Test
-  fun `showUserFeedbackDialog forwards to feedbackOptions_dialogHandler with associatedEventId and configurator`() {
-    val mockDialogHandler = mock<IDialogHandler>()
+  fun `showUserFeedbackForm forwards to feedbackOptions_formHandler with associatedEventId and configurator`() {
+    val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     val associatedEventId = SentryId()
     initForTest {
       it.dsn = dsn
-      it.feedbackOptions.dialogHandler = mockDialogHandler
+      it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.showUserFeedbackDialog(associatedEventId, configurator)
-    verify(mockDialogHandler).showDialog(eq(associatedEventId), eq(configurator))
+    Sentry.showUserFeedbackForm(associatedEventId, configurator)
+    verify(mockFormHandler).showForm(eq(associatedEventId), eq(configurator))
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1504,30 +1504,30 @@ class SentryTest {
   }
 
   @Test
-  fun `feedback showForm forwards to feedbackOptions_formHandler`() {
+  fun `feedback show forwards to feedbackOptions_formHandler`() {
     val mockFormHandler = mock<IFormHandler>()
     initForTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.feedback().showForm()
+    Sentry.feedback().show()
     verify(mockFormHandler).showForm(eq(null), eq(null))
   }
 
   @Test
-  fun `feedback showForm forwards to feedbackOptions_formHandler with configurator`() {
+  fun `feedback show forwards to feedbackOptions_formHandler with configurator`() {
     val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     initForTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.feedback().showForm(configurator)
+    Sentry.feedback().show(configurator)
     verify(mockFormHandler).showForm(eq(null), eq(configurator))
   }
 
   @Test
-  fun `feedback showForm forwards to feedbackOptions_formHandler with associatedEventId and configurator`() {
+  fun `feedback show forwards to feedbackOptions_formHandler with associatedEventId and configurator`() {
     val mockFormHandler = mock<IFormHandler>()
     val configurator = mock<SentryFeedbackOptions.OptionsConfigurator>()
     val associatedEventId = SentryId()
@@ -1535,7 +1535,7 @@ class SentryTest {
       it.dsn = dsn
       it.feedbackOptions.setFormHandler(mockFormHandler)
     }
-    Sentry.feedback().showForm(associatedEventId, configurator)
+    Sentry.feedback().show(associatedEventId, configurator)
     verify(mockFormHandler).showForm(eq(associatedEventId), eq(configurator))
   }
 


### PR DESCRIPTION
Rename `SentryUserFeedbackDialog` to `SentryUserFeedbackForm` as the primary feedback UI class. The old `SentryUserFeedbackDialog` is kept as a deprecated subclass for backward compatibility — existing user code continues to compile and work unchanged.

**Public API: `Sentry.showUserFeedbackForm()`**

New `Sentry.showUserFeedbackForm()` methods replace the deprecated `Sentry.showUserFeedbackDialog()` overloads, which now delegate to the new ones.

**Internal API renames**

Internal-only types and methods are renamed directly (no deprecation shim needed): `IDialogHandler` → `IFormHandler`, `showDialog()` → `showForm()`, `setDialogHandler()`/`getDialogHandler()` → `setFormHandler()`/`getFormHandler()`, `AndroidUserFeedbackIDialogHandler` → `AndroidUserFeedbackFormHandler`.

Closes #5304 