### PR TITLE
fix: Avoid stack overflow when deserializing large flat JSON objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Fixes
 
-- Avoid stack overflow when deserializing large flat JSON objects([#5361](https://github.com/getsentry/sentry-java/pull/#5361))
+- Avoid stack overflow when deserializing large flat JSON objects([#5361](https://github.com/getsentry/sentry-java/pull/5361))
 
 ## 8.40.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0138)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.13.7...0.13.8)
 
+### Fixes
+
+- Avoid stack overflow when deserializing large flat JSON objects([#5361](https://github.com/getsentry/sentry-java/pull/#5361))
+
 ## 8.40.0
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Fixes
 
-- Avoid stack overflow when deserializing large flat JSON objects([#5361](https://github.com/getsentry/sentry-java/pull/5361))
+- Avoid stack overflow when deserializing large flat JSON objects ([#5361](https://github.com/getsentry/sentry-java/pull/5361))
 
 ## 8.40.0
 

--- a/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
@@ -82,49 +82,48 @@ public final class JsonObjectDeserializer {
 
   private void parse(@NotNull JsonObjectReader reader) throws IOException {
     boolean done = false;
-    switch (reader.peek()) {
-      case BEGIN_ARRAY:
-        reader.beginArray();
-        pushCurrentToken(new TokenArray());
-        break;
-      case END_ARRAY:
-        reader.endArray();
-        done = handleArrayOrMapEnd();
-        break;
-      case BEGIN_OBJECT:
-        reader.beginObject();
-        pushCurrentToken(new TokenMap());
-        break;
-      case END_OBJECT:
-        reader.endObject();
-        done = handleArrayOrMapEnd();
-        break;
-      case NAME:
-        pushCurrentToken(new TokenName(reader.nextName()));
-        break;
-      case STRING:
-        // avoid method refs on Android due to some issues with older AGP setups
-        // noinspection Convert2MethodRef
-        done = handlePrimitive(() -> reader.nextString());
-        break;
-      case NUMBER:
-        done = handlePrimitive(() -> nextNumber(reader));
-        break;
-      case BOOLEAN:
-        // avoid method refs on Android due to some issues with older AGP setups
-        // noinspection Convert2MethodRef
-        done = handlePrimitive(() -> reader.nextBoolean());
-        break;
-      case NULL:
-        reader.nextNull();
-        done = handlePrimitive(() -> null);
-        break;
-      case END_DOCUMENT:
-        done = true;
-        break;
-    }
-    if (!done) {
-      parse(reader);
+    while (!done) {
+      switch (reader.peek()) {
+        case BEGIN_ARRAY:
+          reader.beginArray();
+          pushCurrentToken(new TokenArray());
+          break;
+        case END_ARRAY:
+          reader.endArray();
+          done = handleArrayOrMapEnd();
+          break;
+        case BEGIN_OBJECT:
+          reader.beginObject();
+          pushCurrentToken(new TokenMap());
+          break;
+        case END_OBJECT:
+          reader.endObject();
+          done = handleArrayOrMapEnd();
+          break;
+        case NAME:
+          pushCurrentToken(new TokenName(reader.nextName()));
+          break;
+        case STRING:
+          // avoid method refs on Android due to some issues with older AGP setups
+          // noinspection Convert2MethodRef
+          done = handlePrimitive(() -> reader.nextString());
+          break;
+        case NUMBER:
+          done = handlePrimitive(() -> nextNumber(reader));
+          break;
+        case BOOLEAN:
+          // avoid method refs on Android due to some issues with older AGP setups
+          // noinspection Convert2MethodRef
+          done = handlePrimitive(() -> reader.nextBoolean());
+          break;
+        case NULL:
+          reader.nextNull();
+          done = handlePrimitive(() -> null);
+          break;
+        case END_DOCUMENT:
+          done = true;
+          break;
+      }
     }
   }
 

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -3,9 +3,11 @@ package io.sentry
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.Mechanism
 import io.sentry.protocol.SentryId
+import java.io.StringReader
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Collections
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -172,6 +174,48 @@ class SentryEventTest {
     assertNotNull(event.modules) {
       assertEquals(mapOf("key1" to "value1", "key2" to "value2", "key3" to "value3"), it)
     }
+  }
+
+  @Test
+  fun `deserializes event with large flat modules map on a small stack`() {
+    val moduleCount = 8000
+    val json = buildString {
+      append("{\"event_id\":\"00000000000000000000000000000000\",\"modules\":{")
+      repeat(moduleCount) {
+        if (it > 0) {
+          append(',')
+        }
+        append("\"package_")
+        append(it)
+        append("\":\"unknown\"")
+      }
+      append("}}")
+    }
+
+    val error = AtomicReference<Throwable?>()
+    val event = AtomicReference<SentryEvent?>()
+    val thread =
+      Thread(
+        null,
+        Runnable {
+          try {
+            event.set(
+              JsonSerializer(SentryOptions())
+                .deserialize(StringReader(json), SentryEvent::class.java)
+            )
+          } catch (throwable: Throwable) {
+            error.set(throwable)
+          }
+        },
+        "large-flat-modules-repro",
+        1024L * 1024L,
+      )
+
+    thread.start()
+    thread.join()
+
+    assertNull(error.get())
+    assertEquals(moduleCount, event.get()?.modules?.size)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryEventTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryEventTest.kt
@@ -178,16 +178,16 @@ class SentryEventTest {
 
   @Test
   fun `deserializes event with large flat modules map on a small stack`() {
-    val moduleCount = 8000
+    val moduleCount = 50000
     val json = buildString {
       append("{\"event_id\":\"00000000000000000000000000000000\",\"modules\":{")
       repeat(moduleCount) {
         if (it > 0) {
           append(',')
         }
-        append("\"package_")
+        append("\"m")
         append(it)
-        append("\":\"unknown\"")
+        append("\":\"v\"")
       }
       append("}}")
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

Replace JsonObjectDeserializer's recursive token parsing with an iterative loop. The parser already tracks state explicitly, so recursion was only used to advance to the next JSON token and could overflow on large flat maps.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/getsentry/sentry-dart/issues/3668

<!--
* resolves: #1234
* resolves: LIN-1234
-->

## :green_heart: How did you test it?

Added a regression test. It fails with StackOverflow before the test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
