### PR TITLE
fix(feedback): Improve shake detection sensitivity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,17 @@ The repository is organized into multiple modules:
 4. New features must be **opt-in by default** - extend `SentryOptions` or similar Option classes with getters/setters
 5. Consider backwards compatibility
 
+### Third-Party Code Attribution
+When adapting code from third-party libraries:
+1. Add a license header at the top of the adapted file (before the `package` statement):
+   ```java
+   // Adapted from <Library Name>.
+   // Copyright <year> <copyright holder>.
+   // Licensed under the <License Name>.
+   // <source URL>
+   ```
+2. Add a full attribution entry to `THIRD_PARTY_NOTICES.md` following the existing format (Source, License, Copyright, Scope, full license text)
+
 ### Getting PR Information
 
 Use `gh pr view` to get PR details from the current branch. This is needed when adding changelog entries, which require the PR number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Fix soft input keyboard not being shown on the Feedback form ([#5359](https://github.com/getsentry/sentry-java/pull/5359))
 - Fix shake-to-report not triggering on some devices due to high acceleration threshold ([#5366](https://github.com/getsentry/sentry-java/pull/5366))
+- Fix feedback form retaining previous message when shown again via shake ([#5366](https://github.com/getsentry/sentry-java/pull/5366))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixes
 
 - Fix soft input keyboard not being shown on the Feedback form ([#5359](https://github.com/getsentry/sentry-java/pull/5359))
+- Fix shake-to-report not triggering on some devices due to high acceleration threshold ([#5366](https://github.com/getsentry/sentry-java/pull/5366))
 
 ### Dependencies
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -118,6 +118,34 @@ limitations under the License.
 
 ---
 
+## Square — Seismic (Apache 2.0)
+
+**Source:** https://github.com/square/seismic<br>
+**License:** Apache License 2.0<br>
+**Copyright:** Copyright 2010 Square, Inc.
+
+### Scope
+
+The Sentry Java SDK includes an adapted version of Square's Seismic shake detection algorithm. The rolling sample window approach and `SampleQueue`/`SamplePool` data structures in `io.sentry.android.core.SentryShakeDetector` are based on Seismic's `ShakeDetector`.
+
+```
+Copyright 2010 Square, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+---
+
 ## Square — Curtains (Apache 2.0)
 
 **Source:** https://github.com/square/curtains (v1.2.5)<br>

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -94,8 +94,10 @@ public final class SentryShakeDetector implements SensorEventListener {
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
     }
-    synchronized (queue) {
-      queue.clear();
+    // Post clear to the HandlerThread so all queue access stays single-threaded
+    final @Nullable Handler h = handler;
+    if (h != null) {
+      h.post(queue::clear);
     }
   }
 
@@ -103,6 +105,7 @@ public final class SentryShakeDetector implements SensorEventListener {
   public void close() {
     stop();
     if (handlerThread != null) {
+      // quitSafely drains pending messages (including the clear posted by stop) before exiting
       handlerThread.quitSafely();
       handlerThread = null;
       handler = null;
@@ -119,18 +122,13 @@ public final class SentryShakeDetector implements SensorEventListener {
     final float az = event.values[2];
     final boolean accelerating = Math.sqrt(ax * ax + ay * ay + az * az) > ACCELERATION_THRESHOLD;
 
-    final @Nullable Listener currentListener;
-    synchronized (queue) {
-      queue.add(event.timestamp, accelerating);
-      if (queue.isShaking()) {
-        queue.clear();
-        currentListener = listener;
-      } else {
-        currentListener = null;
+    queue.add(event.timestamp, accelerating);
+    if (queue.isShaking()) {
+      queue.clear();
+      final @Nullable Listener currentListener = listener;
+      if (currentListener != null) {
+        currentListener.onShake();
       }
-    }
-    if (currentListener != null) {
-      currentListener.onShake();
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -94,8 +94,14 @@ public final class SentryShakeDetector implements SensorEventListener {
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
     }
-    // No need to clear the queue here — stale samples are purged by timestamp
-    // in add(), so they age out within 0.5s when detection resumes.
+    final @Nullable Handler h = handler;
+    if (h != null) {
+      h.post(
+          () -> {
+            //noinspection Convert2MethodRef
+            queue.clear();
+          });
+    }
   }
 
   /** Stops detection and releases the background thread. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -97,7 +97,11 @@ public final class SentryShakeDetector implements SensorEventListener {
     // Post clear to the HandlerThread so all queue access stays single-threaded
     final @Nullable Handler h = handler;
     if (h != null) {
-      h.post(queue::clear);
+      h.post(
+          () -> {
+            //noinspection Convert2MethodRef
+            queue.clear();
+          });
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -115,8 +115,7 @@ public final class SentryShakeDetector implements SensorEventListener {
     final float ax = event.values[0];
     final float ay = event.values[1];
     final float az = event.values[2];
-    final boolean accelerating =
-        Math.sqrt(ax * ax + ay * ay + az * az) > ACCELERATION_THRESHOLD;
+    final boolean accelerating = Math.sqrt(ax * ax + ay * ay + az * az) > ACCELERATION_THRESHOLD;
 
     queue.add(event.timestamp, accelerating);
     if (queue.isShaking()) {
@@ -177,9 +176,7 @@ public final class SentryShakeDetector implements SensorEventListener {
     }
 
     private void purge(final long cutoff) {
-      while (sampleCount >= MIN_QUEUE_SIZE
-          && oldest != null
-          && cutoff - oldest.timestamp > 0) {
+      while (sampleCount >= MIN_QUEUE_SIZE && oldest != null && cutoff - oldest.timestamp > 0) {
         final @NotNull Sample removed = oldest;
         if (removed.accelerating) {
           acceleratingCount--;
@@ -210,7 +207,8 @@ public final class SentryShakeDetector implements SensorEventListener {
   static class SamplePool {
     private @Nullable Sample head;
 
-    @NotNull Sample acquire() {
+    @NotNull
+    Sample acquire() {
       Sample acquired = head;
       if (acquired == null) {
         acquired = new Sample();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -1,3 +1,7 @@
+// Adapted from Square's Seismic library.
+// Copyright 2010 Square, Inc.
+// Licensed under the Apache License, Version 2.0.
+// https://github.com/square/seismic
 package io.sentry.android.core;
 
 import android.content.Context;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -7,10 +7,8 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.SystemClock;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
-import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -21,8 +19,8 @@ import org.jetbrains.annotations.Nullable;
  * <p>The accelerometer sensor (TYPE_ACCELEROMETER) does NOT require any special permissions on
  * Android. The BODY_SENSORS permission is only needed for heart rate and similar body sensors.
  *
- * <p>Requires at least {@link #SHAKE_COUNT_THRESHOLD} accelerometer readings above {@link
- * #SHAKE_THRESHOLD_GRAVITY} within {@link #SHAKE_WINDOW_MS} to trigger a shake event.
+ * <p>Uses a rolling sample window: if more than 75% of accelerometer readings in the past 0.5s
+ * exceed {@link #ACCELERATION_THRESHOLD}, a shake is detected. Based on Square's Seismic library.
  *
  * <p>Sensor events are delivered on a background {@link HandlerThread} to avoid polluting the main
  * thread.
@@ -30,21 +28,16 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class SentryShakeDetector implements SensorEventListener {
 
-  private static final float SHAKE_THRESHOLD_GRAVITY = 2.7f;
-  private static final int SHAKE_WINDOW_MS = 1500;
-  private static final int SHAKE_COUNT_THRESHOLD = 2;
-  private static final int SHAKE_COOLDOWN_MS = 1000;
+  static final int ACCELERATION_THRESHOLD = 13;
 
   private @Nullable SensorManager sensorManager;
   private @Nullable Sensor accelerometer;
   private @Nullable HandlerThread handlerThread;
   private @Nullable Handler handler;
-  private final @NotNull AtomicLong lastShakeTimestamp = new AtomicLong(0);
   private volatile @Nullable Listener listener;
   private @NotNull ILogger logger;
 
-  private int shakeCount = 0;
-  private long firstShakeTimestamp = 0;
+  private final @NotNull SampleQueue queue = new SampleQueue();
 
   public interface Listener {
     void onShake();
@@ -94,8 +87,7 @@ public final class SentryShakeDetector implements SensorEventListener {
 
   public void stop() {
     listener = null;
-    shakeCount = 0;
-    firstShakeTimestamp = 0;
+    queue.clear();
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
     }
@@ -116,32 +108,18 @@ public final class SentryShakeDetector implements SensorEventListener {
     if (event.sensor.getType() != Sensor.TYPE_ACCELEROMETER) {
       return;
     }
-    float gX = event.values[0] / SensorManager.GRAVITY_EARTH;
-    float gY = event.values[1] / SensorManager.GRAVITY_EARTH;
-    float gZ = event.values[2] / SensorManager.GRAVITY_EARTH;
-    double gForceSquared = gX * gX + gY * gY + gZ * gZ;
-    if (gForceSquared > SHAKE_THRESHOLD_GRAVITY * SHAKE_THRESHOLD_GRAVITY) {
-      long now = SystemClock.elapsedRealtime();
+    final float ax = event.values[0];
+    final float ay = event.values[1];
+    final float az = event.values[2];
+    final boolean accelerating =
+        Math.sqrt(ax * ax + ay * ay + az * az) > ACCELERATION_THRESHOLD;
 
-      // Reset counter if outside the detection window
-      if (now - firstShakeTimestamp > SHAKE_WINDOW_MS) {
-        shakeCount = 0;
-        firstShakeTimestamp = now;
-      }
-
-      shakeCount++;
-
-      if (shakeCount >= SHAKE_COUNT_THRESHOLD) {
-        // Enforce cooldown so we don't fire repeatedly
-        long lastShake = lastShakeTimestamp.get();
-        if (now - lastShake > SHAKE_COOLDOWN_MS) {
-          lastShakeTimestamp.set(now);
-          shakeCount = 0;
-          final @Nullable Listener currentListener = listener;
-          if (currentListener != null) {
-            currentListener.onShake();
-          }
-        }
+    queue.add(event.timestamp, accelerating);
+    if (queue.isShaking()) {
+      queue.clear();
+      final @Nullable Listener currentListener = listener;
+      if (currentListener != null) {
+        currentListener.onShake();
       }
     }
   }
@@ -149,5 +127,98 @@ public final class SentryShakeDetector implements SensorEventListener {
   @Override
   public void onAccuracyChanged(final @NotNull Sensor sensor, final int accuracy) {
     // Not needed for shake detection.
+  }
+
+  static class SampleQueue {
+    private static final long MAX_WINDOW_SIZE_NS = 500_000_000L; // 0.5s
+    private static final long MIN_WINDOW_SIZE_NS = MAX_WINDOW_SIZE_NS >> 1; // 0.25s
+    private static final int MIN_QUEUE_SIZE = 4;
+
+    private final @NotNull SamplePool pool = new SamplePool();
+    private @Nullable Sample oldest;
+    private @Nullable Sample newest;
+    private int sampleCount;
+    private int acceleratingCount;
+
+    void add(final long timestamp, final boolean accelerating) {
+      purge(timestamp - MAX_WINDOW_SIZE_NS);
+
+      final @NotNull Sample added = pool.acquire();
+      added.timestamp = timestamp;
+      added.accelerating = accelerating;
+      added.next = null;
+      if (newest != null) {
+        newest.next = added;
+      }
+      newest = added;
+      if (oldest == null) {
+        oldest = added;
+      }
+
+      sampleCount++;
+      if (accelerating) {
+        acceleratingCount++;
+      }
+    }
+
+    void clear() {
+      while (oldest != null) {
+        final @NotNull Sample removed = oldest;
+        oldest = removed.next;
+        pool.release(removed);
+      }
+      newest = null;
+      sampleCount = 0;
+      acceleratingCount = 0;
+    }
+
+    private void purge(final long cutoff) {
+      while (sampleCount >= MIN_QUEUE_SIZE
+          && oldest != null
+          && cutoff - oldest.timestamp > 0) {
+        final @NotNull Sample removed = oldest;
+        if (removed.accelerating) {
+          acceleratingCount--;
+        }
+        sampleCount--;
+        oldest = removed.next;
+        if (oldest == null) {
+          newest = null;
+        }
+        pool.release(removed);
+      }
+    }
+
+    boolean isShaking() {
+      return newest != null
+          && oldest != null
+          && newest.timestamp - oldest.timestamp >= MIN_WINDOW_SIZE_NS
+          && acceleratingCount >= (sampleCount >> 1) + (sampleCount >> 2);
+    }
+  }
+
+  static class Sample {
+    long timestamp;
+    boolean accelerating;
+    @Nullable Sample next;
+  }
+
+  static class SamplePool {
+    private @Nullable Sample head;
+
+    @NotNull Sample acquire() {
+      Sample acquired = head;
+      if (acquired == null) {
+        acquired = new Sample();
+      } else {
+        head = acquired.next;
+      }
+      return acquired;
+    }
+
+    void release(final @NotNull Sample sample) {
+      sample.next = head;
+      head = sample;
+    }
   }
 }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -201,6 +201,7 @@ public final class SentryShakeDetector implements SensorEventListener {
     boolean isShaking() {
       return newest != null
           && oldest != null
+          && sampleCount >= MIN_QUEUE_SIZE
           && newest.timestamp - oldest.timestamp >= MIN_WINDOW_SIZE_NS
           && acceleratingCount >= (sampleCount >> 1) + (sampleCount >> 2);
     }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -94,15 +94,8 @@ public final class SentryShakeDetector implements SensorEventListener {
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
     }
-    // Post clear to the HandlerThread so all queue access stays single-threaded
-    final @Nullable Handler h = handler;
-    if (h != null) {
-      h.post(
-          () -> {
-            //noinspection Convert2MethodRef
-            queue.clear();
-          });
-    }
+    // No need to clear the queue here — stale samples are purged by timestamp
+    // in add(), so they age out within 0.5s when detection resumes.
   }
 
   /** Stops detection and releases the background thread. */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -91,9 +91,11 @@ public final class SentryShakeDetector implements SensorEventListener {
 
   public void stop() {
     listener = null;
-    queue.clear();
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
+    }
+    synchronized (queue) {
+      queue.clear();
     }
   }
 
@@ -117,13 +119,18 @@ public final class SentryShakeDetector implements SensorEventListener {
     final float az = event.values[2];
     final boolean accelerating = Math.sqrt(ax * ax + ay * ay + az * az) > ACCELERATION_THRESHOLD;
 
-    queue.add(event.timestamp, accelerating);
-    if (queue.isShaking()) {
-      queue.clear();
-      final @Nullable Listener currentListener = listener;
-      if (currentListener != null) {
-        currentListener.onShake();
+    final @Nullable Listener currentListener;
+    synchronized (queue) {
+      queue.add(event.timestamp, accelerating);
+      if (queue.isShaking()) {
+        queue.clear();
+        currentListener = listener;
+      } else {
+        currentListener = null;
       }
+    }
+    if (currentListener != null) {
+      currentListener.onShake();
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryUserFeedbackForm.java
@@ -324,6 +324,12 @@ public class SentryUserFeedbackForm extends AlertDialog {
   @Override
   protected void onStart() {
     super.onStart();
+    // Clear the message field so subsequent show() calls start with a fresh form
+    final @NotNull EditText edtMessage =
+        findViewById(R.id.sentry_dialog_user_feedback_edt_description);
+    edtMessage.getText().clear();
+    edtMessage.setError(null);
+
     final @NotNull SentryOptions options = Sentry.getCurrentScopes().getOptions();
     final @NotNull SentryFeedbackOptions feedbackOptions = options.getFeedbackOptions();
     final @Nullable Runnable onFormOpen = feedbackOptions.getOnFormOpen();

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryShakeDetectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryShakeDetectorTest.kt
@@ -123,10 +123,11 @@ class SentryShakeDetectorTest {
     val baseTimestamp = 1_000_000_000L
     val intervalNs = 20_000_000L
     for (i in 0 until 20) {
-      val event = createSensorEvent(
-        floatArrayOf(0f, 0f, SensorManager.GRAVITY_EARTH),
-        baseTimestamp + i * intervalNs,
-      )
+      val event =
+        createSensorEvent(
+          floatArrayOf(0f, 0f, SensorManager.GRAVITY_EARTH),
+          baseTimestamp + i * intervalNs,
+        )
       sut.onSensorChanged(event)
     }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryShakeDetectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryShakeDetectorTest.kt
@@ -5,10 +5,11 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorManager
 import android.os.Handler
-import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.ILogger
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -88,29 +89,27 @@ class SentryShakeDetectorTest {
   }
 
   @Test
-  fun `triggers listener when shake is detected`() {
-    // Advance clock so cooldown check (now - 0 > 1000) passes
-    SystemClock.setCurrentTimeMillis(2000)
-
+  fun `triggers listener when sustained shake is detected`() {
     val sut = fixture.getSut()
     sut.start(fixture.context, fixture.listener)
 
-    // Needs at least SHAKE_COUNT_THRESHOLD (2) readings above threshold
-    val event1 = createSensorEvent(floatArrayOf(30f, 0f, 0f))
-    sut.onSensorChanged(event1)
-    val event2 = createSensorEvent(floatArrayOf(30f, 0f, 0f))
-    sut.onSensorChanged(event2)
+    // Send enough accelerating samples over 0.25s+ to trigger (>75% accelerating)
+    val baseTimestamp = 1_000_000_000L // 1s in nanos
+    val intervalNs = 20_000_000L // 20ms between samples (~50Hz)
+    for (i in 0 until 20) {
+      val event = createSensorEvent(floatArrayOf(20f, 0f, 0f), baseTimestamp + i * intervalNs)
+      sut.onSensorChanged(event)
+    }
 
     verify(fixture.listener).onShake()
   }
 
   @Test
-  fun `does not trigger listener on single shake`() {
+  fun `does not trigger listener on single spike`() {
     val sut = fixture.getSut()
     sut.start(fixture.context, fixture.listener)
 
-    // A single threshold crossing should not trigger
-    val event = createSensorEvent(floatArrayOf(30f, 0f, 0f))
+    val event = createSensorEvent(floatArrayOf(30f, 0f, 0f), 1_000_000_000L)
     sut.onSensorChanged(event)
 
     verify(fixture.listener, never()).onShake()
@@ -121,9 +120,15 @@ class SentryShakeDetectorTest {
     val sut = fixture.getSut()
     sut.start(fixture.context, fixture.listener)
 
-    // Gravity only (1G) - no shake
-    val event = createSensorEvent(floatArrayOf(0f, 0f, SensorManager.GRAVITY_EARTH))
-    sut.onSensorChanged(event)
+    val baseTimestamp = 1_000_000_000L
+    val intervalNs = 20_000_000L
+    for (i in 0 until 20) {
+      val event = createSensorEvent(
+        floatArrayOf(0f, 0f, SensorManager.GRAVITY_EARTH),
+        baseTimestamp + i * intervalNs,
+      )
+      sut.onSensorChanged(event)
+    }
 
     verify(fixture.listener, never()).onShake()
   }
@@ -133,7 +138,7 @@ class SentryShakeDetectorTest {
     val sut = fixture.getSut()
     sut.start(fixture.context, fixture.listener)
 
-    val event = createSensorEvent(floatArrayOf(30f, 0f, 0f), sensorType = Sensor.TYPE_GYROSCOPE)
+    val event = createSensorEvent(floatArrayOf(30f, 0f, 0f), 1_000_000_000L, Sensor.TYPE_GYROSCOPE)
     sut.onSensorChanged(event)
 
     verify(fixture.listener, never()).onShake()
@@ -145,8 +150,53 @@ class SentryShakeDetectorTest {
     sut.stop()
   }
 
+  @Test
+  fun `sample queue triggers when 75 percent of samples are accelerating`() {
+    val queue = SentryShakeDetector.SampleQueue()
+    val intervalNs = 20_000_000L
+
+    // 15 accelerating + 5 not = 75% in a 0.4s window (> 0.25s minimum)
+    for (i in 0 until 15) {
+      queue.add(i * intervalNs, true)
+    }
+    for (i in 15 until 20) {
+      queue.add(i * intervalNs, false)
+    }
+
+    assertTrue(queue.isShaking())
+  }
+
+  @Test
+  fun `sample queue does not trigger below 75 percent`() {
+    val queue = SentryShakeDetector.SampleQueue()
+    val intervalNs = 20_000_000L
+
+    // 10 accelerating + 10 not = 50%
+    for (i in 0 until 10) {
+      queue.add(i * intervalNs, true)
+    }
+    for (i in 10 until 20) {
+      queue.add(i * intervalNs, false)
+    }
+
+    assertFalse(queue.isShaking())
+  }
+
+  @Test
+  fun `sample queue does not trigger below minimum window`() {
+    val queue = SentryShakeDetector.SampleQueue()
+
+    // All accelerating but only 0.06s apart (below 0.25s minimum)
+    for (i in 0 until 4) {
+      queue.add(i * 20_000_000L, true)
+    }
+
+    assertFalse(queue.isShaking())
+  }
+
   private fun createSensorEvent(
     values: FloatArray,
+    timestamp: Long = 0L,
     sensorType: Int = Sensor.TYPE_ACCELEROMETER,
   ): SensorEvent {
     val sensor = mock<Sensor>()
@@ -159,6 +209,9 @@ class SentryShakeDetectorTest {
 
     val sensorField = SensorEvent::class.java.getField("sensor")
     sensorField.set(event, sensor)
+
+    val timestampField = SensorEvent::class.java.getField("timestamp")
+    timestampField.set(event, timestamp)
 
     return event
   }


### PR DESCRIPTION
Replace the threshold-counting shake detection with a rolling sample window approach adapted from [Square's Seismic library](https://github.com/square/seismic). The previous detector required 2 accelerometer spikes above 2.7g within 1.5s, which was too aggressive for many devices (e.g. HMD Global Pulse).

**Detection algorithm**

The new approach marks each accelerometer reading as "accelerating" if its magnitude exceeds 13 m/s² (~1.33g), then triggers a shake when >75% of samples in a 0.5s rolling window are accelerating. This catches moderate shakes reliably while still filtering out single bumps or drops. A `SamplePool` reuses `Sample` objects to avoid GC pressure from high-frequency sensor events.

Before, two individual high-g spikes within a time window:
```
if (gForceSquared > 2.7² && count >= 2 within 1.5s) → shake
```

After, sustained acceleration pattern over a sliding window:
```
if (>75% of samples in 0.5s exceed 13 m/s²) → shake
```

**Stale form fields on re-show**

When the per-form shake detection reuses the same `SentryUserFeedbackForm` instance, the message field now gets cleared in `onStart()` so subsequent shakes show a fresh form. Name and email are kept prefilled since they're typically the same user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)