### PR TITLE
ci: Notify linked issues on release

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,0 +1,39 @@
+name: 'Automation: Notify issues for release'
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-24.04
+    name: 'Notify issues'
+    steps:
+      - name: Get version
+        id: get_version
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on linked issues that are mentioned in release
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
+
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,13 @@ or
 
 However, if your change did not intend to modify the public API, consider changing the method/property visibility or removing the change altogether.
 
+# Linking issues
+
+If a PR should notify a linked issue after release, use a GitHub closing keyword in the PR
+description, such as `Fixes #123`, `Closes #123`, or `Resolves #123`. Release notification
+automation only comments on issues GitHub recognizes as closed by the released PR; mentioning an
+issue without a closing keyword is not enough.
+
 # CI
 
 Build and tests are automatically run against branches and pull requests


### PR DESCRIPTION
## Summary

- Add a release workflow that comments on GitHub issues closed by PRs included in a published stable release
- Document that PR authors need to use GitHub closing keywords (`Fixes #123`, etc.) for linked issues to receive the release notification

Mirrors https://github.com/getsentry/sentry-dart/pull/3685

## Test plan

- [ ] Review workflow against this repo's release and changelog conventions
- [ ] Monitor the first stable release run to confirm the action comments on issues linked through closing keywords

#skip-changelog 
🤖 Generated with [Claude Code](https://claude.com/claude-code)