### PR TITLE
fix(queue): [Queue Instrumentation 42] Review Changes

### DIFF
--- a/sentry-kafka/README.md
+++ b/sentry-kafka/README.md
@@ -2,4 +2,4 @@
 
 This module provides Kafka-native queue instrumentation for applications using `kafka-clients` directly.
 
-Spring users should use `sentry-spring-boot-jakarta` / `sentry-spring-jakarta`, which provide higher-fidelity consumer instrumentation via Spring Kafka hooks.
+Spring users should use the Sentry Spring (Boot) SDKs, which provide higher-fidelity consumer instrumentation via Spring Kafka hooks.

--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaConsumerTracing.java
@@ -143,8 +143,8 @@ public final class SentryKafkaConsumerTracing {
       }
 
       final @NotNull TransactionContext txContext =
-          continued != null ? continued : new TransactionContext("queue.process", "queue.process");
-      txContext.setName("queue.process");
+          continued != null ? continued : new TransactionContext(record.topic(), "queue.process");
+      txContext.setName(record.topic());
       txContext.setOperation("queue.process");
 
       final @NotNull TransactionOptions txOptions = new TransactionOptions();
@@ -204,7 +204,6 @@ public final class SentryKafkaConsumerTracing {
       }
       transaction.finish();
     } catch (Throwable t) {
-      // Instrumentation must never break customer processing.
       scopes
           .getOptions()
           .getLogger()

--- a/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducer.java
+++ b/sentry-kafka/src/main/java/io/sentry/kafka/SentryKafkaProducer.java
@@ -29,13 +29,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Wraps a Kafka {@link Producer} via {@link Proxy} to record a {@code queue.publish} span around
- * each {@code send} and to inject Sentry trace propagation headers into the produced record.
- *
- * <p>Only the two {@code send} overloads are intercepted; every other {@link Producer} method is
- * forwarded directly to the delegate. Because the wrapper is a dynamic proxy, it is compatible with
- * any Kafka client version — new methods added to the {@link Producer} interface in future Kafka
- * releases are forwarded automatically without recompilation.
+ * Wraps a Kafka {@link Producer} to record a {@code queue.publish} span around each {@code send}
+ * and to inject Sentry trace propagation headers into the produced record.
  *
  * <p>For raw Kafka usage:
  *
@@ -44,9 +39,8 @@ import org.jetbrains.annotations.Nullable;
  *     SentryKafkaProducer.wrap(new KafkaProducer<>(props));
  * }</pre>
  *
- * <p>For Spring Kafka, the {@code SentryKafkaProducerBeanPostProcessor} in {@code
- * sentry-spring-jakarta} installs this wrapper automatically via {@code
- * ProducerFactory.addPostProcessor(...)}.
+ * <p>For Spring Kafka, the {@code SentryKafkaProducerBeanPostProcessor} installs this wrapper
+ * automatically.
  */
 @ApiStatus.Experimental
 public final class SentryKafkaProducer {
@@ -57,7 +51,7 @@ public final class SentryKafkaProducer {
   private SentryKafkaProducer() {}
 
   /**
-   * Wraps the given producer with Sentry instrumentation using the global scopes.
+   * Wraps the given producer with Sentry instrumentation.
    *
    * @param delegate the Kafka producer to wrap
    * @return an instrumented producer that records {@code queue.publish} spans

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaConsumerTracingTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaConsumerTracingTest.kt
@@ -91,7 +91,7 @@ class SentryKafkaConsumerTracingTest {
     verify(forkedScopes).continueTrace(eq(sentryTraceValue), eq(listOf(baggageValue)))
     verify(forkedScopes).startTransaction(txContextCaptor.capture(), txOptionsCaptor.capture())
 
-    assertEquals("queue.process", txContextCaptor.firstValue.name)
+    assertEquals("my-topic", txContextCaptor.firstValue.name)
     assertEquals("queue.process", txContextCaptor.firstValue.operation)
     assertEquals(SentryKafkaConsumerTracing.TRACE_ORIGIN, txOptionsCaptor.firstValue.origin)
     assertTrue(txOptionsCaptor.firstValue.isBindToScope)

--- a/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerTest.kt
+++ b/sentry-kafka/src/test/kotlin/io/sentry/kafka/SentryKafkaProducerTest.kt
@@ -73,12 +73,6 @@ class SentryKafkaProducerTest {
     Sentry.close()
   }
 
-  private fun createTransaction(): SentryTracer {
-    val tx = SentryTracer(TransactionContext("tx", "op"), scopes)
-    whenever(scopes.span).thenReturn(tx)
-    return tx
-  }
-
   @Test
   fun `creates queue publish span and injects headers`() {
     val tx = createTransaction()
@@ -357,5 +351,11 @@ class SentryKafkaProducerTest {
   fun `toString includes delegate`() {
     val producer = SentryKafkaProducer.wrap(delegate, scopes)
     assertTrue(producer.toString().startsWith("SentryKafkaProducer[delegate="))
+  }
+
+  private fun createTransaction(): SentryTracer {
+    val tx = SentryTracer(TransactionContext("tx", "op"), scopes)
+    whenever(scopes.span).thenReturn(tx)
+    return tx
   }
 }

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SentrySpanExporter.java
@@ -362,10 +362,6 @@ public final class SentrySpanExporter implements SpanExporter {
     maybeTransferOtelAttribute(span, sentryTransaction, ThreadIncubatingAttributes.THREAD_ID);
     maybeTransferOtelAttribute(span, sentryTransaction, ThreadIncubatingAttributes.THREAD_NAME);
 
-    // Root transactions don't bulk-copy OTel attributes into span data (unlike child spans).
-    // The Sentry Queues product reads `trace.data.messaging.*`, so messaging attributes must
-    // be explicitly transferred for consumer root transactions to show up correctly. These are
-    // operational metadata (no payload contents) and are safe to transfer unconditionally.
     maybeTransferOtelAttribute(
         span, sentryTransaction, MessagingIncubatingAttributes.MESSAGING_SYSTEM);
     maybeTransferOtelAttribute(

--- a/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/src/main/java/io/sentry/opentelemetry/SpanDescriptionExtractor.java
@@ -116,9 +116,6 @@ public final class SpanDescriptionExtractor {
   @SuppressWarnings("deprecation")
   private @NotNull String opForMessaging(final @NotNull SpanData otelSpan) {
     final @NotNull Attributes attributes = otelSpan.getAttributes();
-    // Prefer `messaging.operation.type` (current OTel semconv), fall back to legacy
-    // `messaging.operation`. OTel's SpanKind.CONSUMER is overloaded for both `receive` and
-    // `process`, so attribute-first mapping is required. SpanKind is used only as a last resort.
     @Nullable
     String operationType = attributes.get(MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE);
     if (operationType == null) {
@@ -139,7 +136,6 @@ public final class SpanDescriptionExtractor {
         case "settle":
           return "queue.settle";
         default:
-          // fall through to SpanKind mapping
           break;
       }
     }

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/kafka/SentryKafkaRecordInterceptor.java
@@ -159,8 +159,8 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     final @NotNull TransactionContext txContext =
         transactionContext != null
             ? transactionContext
-            : new TransactionContext("queue.process", "queue.process");
-    txContext.setName("queue.process");
+            : new TransactionContext(record.topic(), "queue.process");
+    txContext.setName(record.topic());
     txContext.setOperation("queue.process");
 
     final @NotNull TransactionOptions txOptions = new TransactionOptions();

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -136,6 +136,14 @@ class SentryKafkaRecordInterceptorTest {
 
     verify(scopes).forkedRootScopes("SentryKafkaRecordInterceptor")
     verify(forkedScopes).makeCurrent()
+    verify(forkedScopes)
+      .startTransaction(
+        org.mockito.kotlin.check<TransactionContext> {
+          assertEquals("my-topic", it.name)
+          assertEquals("queue.process", it.operation)
+        },
+        any(),
+      )
   }
 
   @Test

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptor.java
@@ -159,8 +159,8 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     final @NotNull TransactionContext txContext =
         transactionContext != null
             ? transactionContext
-            : new TransactionContext("queue.process", "queue.process");
-    txContext.setName("queue.process");
+            : new TransactionContext(record.topic(), "queue.process");
+    txContext.setName(record.topic());
     txContext.setOperation("queue.process");
 
     final @NotNull TransactionOptions txOptions = new TransactionOptions();

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -136,6 +136,14 @@ class SentryKafkaRecordInterceptorTest {
 
     verify(scopes).forkedRootScopes("SentryKafkaRecordInterceptor")
     verify(forkedScopes).makeCurrent()
+    verify(forkedScopes)
+      .startTransaction(
+        org.mockito.kotlin.check<TransactionContext> {
+          assertEquals("my-topic", it.name)
+          assertEquals("queue.process", it.operation)
+        },
+        any(),
+      )
   }
 
   @Test

--- a/sentry-spring/src/main/java/io/sentry/spring/kafka/SentryKafkaRecordInterceptor.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/kafka/SentryKafkaRecordInterceptor.java
@@ -165,8 +165,8 @@ public final class SentryKafkaRecordInterceptor<K, V> implements RecordIntercept
     final @NotNull TransactionContext txContext =
         transactionContext != null
             ? transactionContext
-            : new TransactionContext("queue.process", "queue.process");
-    txContext.setName("queue.process");
+            : new TransactionContext(record.topic(), "queue.process");
+    txContext.setName(record.topic());
     txContext.setOperation("queue.process");
 
     final @NotNull TransactionOptions txOptions = new TransactionOptions();

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/exception/SentryCaptureExceptionParameterAdviceTest.kt
@@ -4,6 +4,8 @@ import io.sentry.Hint
 import io.sentry.IScopes
 import io.sentry.Sentry
 import io.sentry.exception.ExceptionMechanismException
+import io.sentry.test.initForTest
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,6 +34,13 @@ class SentryCaptureExceptionParameterAdviceTest {
   @BeforeTest
   fun setup() {
     reset(scopes)
+    initForTest { it.dsn = "https://key@sentry.io/proj" }
+    Sentry.setCurrentScopes(scopes)
+  }
+
+  @AfterTest
+  fun teardown() {
+    Sentry.close()
   }
 
   @Test

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/kafka/SentryKafkaRecordInterceptorTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/kafka/SentryKafkaRecordInterceptorTest.kt
@@ -136,6 +136,14 @@ class SentryKafkaRecordInterceptorTest {
 
     verify(scopes).forkedRootScopes("SentryKafkaRecordInterceptor")
     verify(forkedScopes).makeCurrent()
+    verify(forkedScopes)
+      .startTransaction(
+        org.mockito.kotlin.check<TransactionContext> {
+          assertEquals("my-topic", it.name)
+          assertEquals("queue.process", it.operation)
+        },
+        any(),
+      )
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Queue Instrumentation)

- #5249
- #5250
- #5253
- #5254
- #5255
- #5259
- #5260
- #5265
- #5274
- #5279
- #5280
- #5281
- #5282
- #5283
- #5288
- #5289
- #5291
- #5312
- #5313
- #5314
- #5315
- #5316
- #5318
- #5319
- #5320
- #5321
- #5322
- #5323
- #5324
- #5325
- #5327
- #5328
- #5330
- #5337
- #5338
- #5341
- #5343
- #5345
- #5347
- #5348
- #5352
- #5368

---

## :scroll: Description

Applies follow-up review changes across the queue instrumentation stack.

This updates Kafka consumer transaction names to use the record topic, applies the same behavior to Spring Kafka record interceptors, keeps tests aligned, and trims explanatory comments/docs that were too implementation-specific.

## :bulb: Motivation and Context

These are follow-up fixes for the Queue Instrumentation stack before it is merged. Keeping them as the next stacked PR makes the review adjustments easy to inspect separately from the larger Spring Boot porting PRs.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry-kafka:test --tests '*Kafka*' :sentry-spring:test --tests '*Kafka*' :sentry-spring-jakarta:test --tests '*Kafka*' :sentry-spring-7:test --tests '*Kafka*' :sentry-opentelemetry:sentry-opentelemetry-core:test --tests '*SpanDescriptionExtractor*' --tests '*SentrySpanExporter*'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

