### PR TITLE
chore: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       - gradle-plugin-portal
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "org.springframework.boot*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,18 @@
 version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
 updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    registries:
+      - gradle-plugin-portal
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,11 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "org.springframework.boot*"
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,19 +11,19 @@ updates:
     registries:
       - gradle-plugin-portal
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       - dependency-name: "org.springframework.boot*"
     commit-message:
       prefix: "chore(deps)"
     groups:
-      androidx:
-        patterns:
-          - "androidx.*"
       compose:
         patterns:
           - "androidx.compose*"
           - "org.jetbrains.compose*"
+      androidx:
+        patterns:
+          - "androidx.*"
       kotlin:
         patterns:
           - "org.jetbrains.kotlin*"
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,21 @@ updates:
       - dependency-name: "org.springframework.boot*"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+      compose:
+        patterns:
+          - "androidx.compose*"
+          - "org.jetbrains.compose*"
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,32 +16,6 @@ updates:
       - dependency-name: "org.springframework.boot*"
     commit-message:
       prefix: "chore(deps)"
-    groups:
-      androidx:
-        patterns:
-          - "androidx.*"
-      compose:
-        patterns:
-          - "androidx.compose*"
-          - "org.jetbrains.compose*"
-      kotlin:
-        patterns:
-          - "org.jetbrains.kotlin*"
-          - "org.jetbrains.kotlinx*"
-      spring:
-        patterns:
-          - "org.springframework*"
-          - "io.spring*"
-      opentelemetry:
-        patterns:
-          - "io.opentelemetry*"
-      graphql:
-        patterns:
-          - "com.graphql-java*"
-          - "com.apollographql*"
-      jackson:
-        patterns:
-          - "com.fasterxml.jackson*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,44 @@ updates:
     registries:
       - gradle-plugin-portal
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "org.springframework.boot*"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+      compose:
+        patterns:
+          - "androidx.compose*"
+          - "org.jetbrains.compose*"
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+      spring:
+        patterns:
+          - "org.springframework*"
+          - "io.spring*"
+      opentelemetry:
+        patterns:
+          - "io.opentelemetry*"
+      graphql:
+        patterns:
+          - "com.graphql-java*"
+          - "com.apollographql*"
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `gradle` package ecosystem to Dependabot config with the Gradle Plugin Portal registry so plugin/dependency updates are tracked automatically.
- Updates both `gradle` and `github-actions` ecosystems to run daily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)