### PR TITLE
fix(core): [Session based Traces for Mobile 1] Keep spanless baggage mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixes
 
+- Fix transaction-specific dynamic sampling context fields missing after earlier spanless outgoing requests ([#5384](https://github.com/getsentry/sentry-java/pull/5384))
 - Fix soft input keyboard not being shown on the Feedback form ([#5359](https://github.com/getsentry/sentry-java/pull/5359))
 - Fix shake-to-report not triggering on some devices due to high acceleration threshold ([#5366](https://github.com/getsentry/sentry-java/pull/5366))
 - Fix feedback form retaining previous message when shown again via shake ([#5366](https://github.com/getsentry/sentry-java/pull/5366))

--- a/sentry/src/main/java/io/sentry/util/TracingUtils.java
+++ b/sentry/src/main/java/io/sentry/util/TracingUtils.java
@@ -115,7 +115,9 @@ public final class TracingUtils {
           @NotNull Baggage baggage = propagationContext.getBaggage();
           if (baggage.isMutable()) {
             baggage.setValuesFromScope(scope, sentryOptions);
-            baggage.freeze();
+            if (baggage.isShouldFreeze()) {
+              baggage.freeze();
+            }
           }
         });
   }

--- a/sentry/src/test/java/io/sentry/util/TracingUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/TracingUtilsTest.kt
@@ -16,6 +16,7 @@ import io.sentry.TracesSamplingDecision
 import io.sentry.TransactionContext
 import io.sentry.W3CTraceparentHeader
 import io.sentry.protocol.SentryId
+import io.sentry.protocol.TransactionNameSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
@@ -77,7 +78,7 @@ class TracingUtilsTest {
         .value
         .contains("sentry-trace_id=${fixture.scope.propagationContext.traceId}")
     )
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
   }
 
   @Test
@@ -98,7 +99,7 @@ class TracingUtilsTest {
     assertEquals(fixture.scope.propagationContext.traceId, headers.sentryTraceHeader.traceId)
     assertEquals(fixture.scope.propagationContext.isSampled, headers.sentryTraceHeader.isSampled)
     assertTrue(headers.baggageHeader!!.value.contains("some-baggage-key=some-baggage-value"))
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
   }
 
   @Test
@@ -120,7 +121,7 @@ class TracingUtilsTest {
     assertEquals(fixture.scope.propagationContext.traceId, headers.sentryTraceHeader.traceId)
     assertEquals(fixture.scope.propagationContext.isSampled, headers.sentryTraceHeader.isSampled)
     assertTrue(headers.baggageHeader!!.value.contains("some-baggage-key=some-baggage-value"))
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
   }
 
   @Test
@@ -142,7 +143,7 @@ class TracingUtilsTest {
     assertEquals(fixture.scope.propagationContext.traceId, headers.sentryTraceHeader.traceId)
     assertEquals(fixture.scope.propagationContext.isSampled, headers.sentryTraceHeader.isSampled)
     assertTrue(headers.baggageHeader!!.value.contains("some-baggage-key=some-baggage-value"))
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
   }
 
   @Test
@@ -164,7 +165,7 @@ class TracingUtilsTest {
     assertEquals(fixture.scope.propagationContext.traceId, headers.sentryTraceHeader.traceId)
     assertEquals(fixture.scope.propagationContext.isSampled, headers.sentryTraceHeader.isSampled)
     assertTrue(headers.baggageHeader!!.value.contains("some-baggage-key=some-baggage-value"))
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
   }
 
   @Test
@@ -301,7 +302,7 @@ class TracingUtilsTest {
   }
 
   @Test
-  fun `updates mutable baggage`() {
+  fun `updates mutable baggage without freezing local baggage`() {
     fixture.setup()
     // not frozen because it doesn't contain sentry-* keys
     fixture.scope.propagationContext =
@@ -319,7 +320,35 @@ class TracingUtilsTest {
       fixture.scope.propagationContext.traceId.toString(),
       fixture.scope.propagationContext.baggage!!.traceId,
     )
-    assertFalse(fixture.scope.propagationContext.baggage!!.isMutable)
+    assertTrue(fixture.scope.propagationContext.baggage!!.isMutable)
+  }
+
+  @Test
+  fun `spanless propagation leaves baggage mutable for later transaction DSC`() {
+    fixture.setup()
+    val propagationContext = fixture.scope.propagationContext
+
+    TracingUtils.maybeUpdateBaggage(fixture.scope, fixture.options)
+
+    assertTrue(propagationContext.baggage.isMutable)
+    assertNull(propagationContext.baggage.transaction)
+    assertNull(propagationContext.baggage.sampleRate)
+    assertNull(propagationContext.baggage.sampled)
+
+    val transactionContext = TransactionContext.fromPropagationContext(propagationContext)
+    transactionContext.name = "GET /session"
+    transactionContext.transactionNameSource = TransactionNameSource.CUSTOM
+    transactionContext.setSamplingDecision(
+      TracesSamplingDecision(true, 0.5, propagationContext.sampleRand)
+    )
+    val tracer = SentryTracer(transactionContext, fixture.scopes)
+
+    val baggageHeader = tracer.toBaggageHeader(null)
+
+    assertNotNull(baggageHeader)
+    assertTrue(baggageHeader.value.contains("sentry-transaction=GET%20%2Fsession"))
+    assertTrue(baggageHeader.value.contains("sentry-sampled=true"))
+    assertTrue(baggageHeader.value.contains("sentry-sample_rate=0.5"))
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Session based Traces for Mobile)

- #5383
- #5384

---

## :scroll: Description
Keeps local scope baggage mutable after spanless trace propagation. `TracingUtils.maybeUpdateBaggage` now freezes baggage only when it was marked as `shouldFreeze`, which protects incoming Sentry DSC without finalizing local propagation baggage.

Adds regression coverage for the spanless-before-transaction sequence to ensure a later transaction can still write `sentry-transaction`, `sentry-sampled`, and `sentry-sample_rate` into outgoing DSC.

## :bulb: Motivation and Context
For session-based traces on mobile, an outgoing request can happen before an Activity or navigation transaction starts. Previously, that spanless request froze local scope baggage, and a later transaction could inherit frozen baggage and miss transaction-specific DSC fields.

This keeps incoming/fixed DSC protected while allowing local session trace baggage to be completed by the eventual transaction.

## :green_heart: How did you test it?
- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test --tests io.sentry.util.TracingUtilsTest`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
Continue the Session based Traces for Mobile stack.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
