### PR TITLE
Remove testBuildType mechanism from UI test modules

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -90,7 +90,7 @@ jobs:
           disable-spellchecker: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disk-size: 4096M
-          script: ./gradlew sentry-android-integration-tests:sentry-uitest-android:connectedReleaseAndroidTest -DtestBuildType=release -Denvironment=github --daemon
+          script: ./gradlew sentry-android-integration-tests:sentry-uitest-android:connectedReleaseAndroidTest -Denvironment=github --daemon
 
       - name: Upload test results
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ make systemTest
 ```bash
 # Assemble Android test APKs
 ./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease
-./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest -DtestBuildType=release
+./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest
 
 # Run critical UI tests
 ./scripts/test-ui-critical.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,7 @@ make systemTest
 ### Android-Specific Commands
 ```bash
 # Assemble Android test APKs
-./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease
-./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest
+./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest
 
 # Run critical UI tests
 ./scripts/test-ui-critical.sh

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,11 @@ api:
 
 # Assemble release and Android test apk of the uitest-android-benchmark module
 assembleBenchmarkTestRelease:
-	./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleRelease
-	./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleAndroidTest -DtestBuildType=release
+	./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleRelease :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleAndroidTest
 
 # Assemble release and Android test apk of the uitest-android module
 assembleUiTestRelease:
-	./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease
-	./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest -DtestBuildType=release
+	./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest
 
 # Assemble release of the uitest-android-critical module
 assembleUiTestCriticalRelease:

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -46,21 +46,9 @@ android {
     }
   }
 
-  testBuildType = System.getProperty("testBuildType", "debug")
+  testBuildType = "release"
 
   buildTypes {
-    getByName("debug") {
-      isMinifyEnabled = true
-      signingConfig = signingConfigs.getByName("debug")
-      proguardFiles(
-        getDefaultProguardFile("proguard-android-optimize.txt"),
-        "benchmark-proguard-rules.pro",
-      )
-      testProguardFiles(
-        getDefaultProguardFile("proguard-android-optimize.txt"),
-        "benchmark-proguard-rules.pro",
-      )
-    }
     getByName("release") {
       isMinifyEnabled = true
       isShrinkResources = true
@@ -89,7 +77,9 @@ android {
   }
 
   androidComponents.beforeVariants {
-    it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
+    if (it.buildType == "debug") {
+      it.enable = false
+    }
   }
 }
 

--- a/sentry-android-integration-tests/sentry-uitest-android/README.md
+++ b/sentry-android-integration-tests/sentry-uitest-android/README.md
@@ -14,14 +14,12 @@ You can run benchmark tests only with `./gradlew :sentry-android-integration-tes
 To run on saucelabs execute following commands (need also `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables):
 For Benchmarks:
 ```
-./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleRelease
-./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleAndroidTest -DtestBuildType=release
+./gradlew :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleRelease :sentry-android-integration-tests:sentry-uitest-android-benchmark:assembleAndroidTest
 saucectl run -c .sauce/sentry-uitest-android-benchmark.yml
 ```
 For End 2 End:
 ```
-./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease
-./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest -DtestBuildType=release
+./gradlew :sentry-android-integration-tests:sentry-uitest-android:assembleRelease :sentry-android-integration-tests:sentry-uitest-android:assembleAndroidTest
 saucectl run -c .sauce/sentry-uitest-android-end2end.yml
 ```
 

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -51,18 +51,11 @@ android {
     }
   }
 
-  testBuildType = System.getProperty("testBuildType", "debug")
+  testBuildType = "release"
 
   buildTypes {
-    getByName("debug") {
-      isMinifyEnabled = true
-      signingConfig = signingConfigs.getByName("debug")
-      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-      testProguardFiles("proguard-rules.pro")
-    }
     getByName("release") {
       isMinifyEnabled = true
-      isShrinkResources = false
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
       signingConfig = signingConfigs.getByName("debug") // to be able to run release mode
       testProguardFiles("proguard-rules.pro")
@@ -82,7 +75,9 @@ android {
   }
 
   androidComponents.beforeVariants {
-    it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
+    if (it.buildType == "debug") {
+      it.enable = false
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Disable the debug variant unconditionally in `sentry-uitest-android` and `sentry-uitest-android-benchmark` since debug and release were configured identically (same minification, proguard rules, signing)
- Hardcode `testBuildType = "release"` and remove the `-DtestBuildType=release` system property mechanism
- Combine separate Gradle invocations into single commands in the Makefile and docs

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)