### PR TITLE
fix(android): Declare test-snapshots as task output for cache compatibility

### DIFF
--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -70,6 +70,13 @@ tasks.withType<JavaCompile>().configureEach {
   }
 }
 
+// Snapshot PNGs are written by ScreenshotEventProcessorTest at runtime but must be declared as
+// outputs so Gradle's build cache restores them on cache hits (otherwise the CLI upload step
+// finds an empty directory).
+tasks.matching { it.name == "testDebugUnitTest" || it.name == "testReleaseUnitTest" }.configureEach {
+  outputs.dir(layout.buildDirectory.dir("test-snapshots"))
+}
+
 dependencies {
   api(projects.sentry)
   compileOnly(libs.jetbrains.annotations)

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -73,9 +73,9 @@ tasks.withType<JavaCompile>().configureEach {
 // Snapshot PNGs are written by ScreenshotEventProcessorTest at runtime but must be declared as
 // outputs so Gradle's build cache restores them on cache hits (otherwise the CLI upload step
 // finds an empty directory).
-tasks.matching { it.name == "testDebugUnitTest" || it.name == "testReleaseUnitTest" }.configureEach {
-  outputs.dir(layout.buildDirectory.dir("test-snapshots"))
-}
+tasks
+  .matching { it.name == "testDebugUnitTest" || it.name == "testReleaseUnitTest" }
+  .configureEach { outputs.dir(layout.buildDirectory.dir("test-snapshots")) }
 
 dependencies {
   api(projects.sentry)


### PR DESCRIPTION
[Some PRs](https://github.com/getsentry/sentry-java/actions/runs/25556938011/job/75018216252?pr=5394) are failing when the gradle task that generates the snapshots comes from the cache because the snapshots are not pulled from the cache. This adjust it so that the snapshots are stored in the cache so they are successfully retrieved and then uploaded to sentry.

## Summary
- The screenshot snapshot PNGs written by `ScreenshotEventProcessorTest` are not declared as outputs of `testDebugUnitTest`. When the task result comes from the Gradle remote cache, the test code never runs and the `build/test-snapshots/` directory is never created, so `sentry-cli` finds an empty folder and uploads nothing.
- Declares `build/test-snapshots/` as a task output so Gradle caches and restores the snapshots on cache hits.

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)