### PR TITLE
ci(spring-matrix): Replace sed hacks with targeted Gradle builds

### DIFF
--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -72,88 +72,58 @@ jobs:
           perl -0pi -e 'BEGIN { $v = shift } s/^springboot2[[:space:]]*=[[:space:]]*"\K[^"]*/$v/m or die "::error::springboot2 version entry not found in gradle/libs.versions.toml\n"' "$springboot_version" gradle/libs.versions.toml
           echo "Updated Spring Boot 2.x version to $springboot_version"
 
-      - name: Exclude android modules from build
+      - name: Build sample artifacts
         run: |
-          sed -i \
-            -e '/.*"sentry-android-ndk",/d' \
-            -e '/.*"sentry-android",/d' \
-            -e '/.*"sentry-compose",/d' \
-            -e '/.*"sentry-android-core",/d' \
-            -e '/.*"sentry-android-fragment",/d' \
-            -e '/.*"sentry-android-navigation",/d' \
-            -e '/.*"sentry-android-sqlite",/d' \
-            -e '/.*"sentry-android-timber",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
-            -e '/.*"sentry-samples:sentry-samples-android",/d' \
-            -e '/.*"sentry-android-replay",/d' \
-            settings.gradle.kts
-
-      - name: Exclude android modules from ignore list
-        run: |
-          sed -i \
-            -e '/.*"sentry-uitest-android",/d' \
-            -e '/.*"sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-uitest-android-critical",/d' \
-            -e '/.*"test-app-sentry",/d' \
-            -e '/.*"test-app-size",/d' \
-            -e '/.*"sentry-samples-android",/d' \
-            build.gradle.kts
-
-      - name: Build SDK
-        run: |
-          ./gradlew assemble --parallel
+          ./gradlew \
+            :sentry-samples:sentry-samples-spring-boot:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry-noagent:shadowJar \
+            :sentry-samples:sentry-samples-spring:war \
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
+            --parallel
 
       - name: Test sentry-samples-spring-boot
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-webflux
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-webflux" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-opentelemetry agent init true
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-opentelemetry" \
             --agent true \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-opentelemetry agent init false
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-opentelemetry" \
             --agent true \
-            --auto-init "false" \
-            --build "true"
+            --auto-init "false"
 
       - name: Test sentry-samples-spring-boot-opentelemetry-noagent
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-opentelemetry-noagent" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -85,8 +85,7 @@ jobs:
             :sentry-samples:sentry-samples-spring-boot-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring:war \
             :sentry-samples:sentry-samples-spring:testClasses \
-            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
-            --parallel
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble
 
       - name: Test sentry-samples-spring-boot
         run: |

--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -76,10 +76,15 @@ jobs:
         run: |
           ./gradlew \
             :sentry-samples:sentry-samples-spring-boot:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot:testClasses \
             :sentry-samples:sentry-samples-spring-boot-webflux:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux:testClasses \
             :sentry-samples:sentry-samples-spring-boot-opentelemetry:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry:testClasses \
             :sentry-samples:sentry-samples-spring-boot-opentelemetry-noagent:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring:war \
+            :sentry-samples:sentry-samples-spring:testClasses \
             :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
             --parallel
 

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -81,8 +81,7 @@ jobs:
             :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring-jakarta:war \
             :sentry-samples:sentry-samples-spring-jakarta:testClasses \
-            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
-            --parallel
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble
 
       - name: Test sentry-samples-spring-boot-jakarta
         run: |

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -72,10 +72,15 @@ jobs:
         run: |
           ./gradlew \
             :sentry-samples:sentry-samples-spring-boot-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta:testClasses \
             :sentry-samples:sentry-samples-spring-boot-webflux-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux-jakarta:testClasses \
             :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:testClasses \
             :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring-jakarta:war \
+            :sentry-samples:sentry-samples-spring-jakarta:testClasses \
             :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
             --parallel
 

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -68,88 +68,58 @@ jobs:
           perl -0pi -e 'BEGIN { $v = shift } s/^springboot3[[:space:]]*=[[:space:]]*"\K[^"]*/$v/m or die "::error::springboot3 version entry not found in gradle/libs.versions.toml\n"' "$springboot_version" gradle/libs.versions.toml
           echo "Updated Spring Boot 3.x version to $springboot_version"
 
-      - name: Exclude android modules from build
+      - name: Build sample artifacts
         run: |
-          sed -i \
-            -e '/.*"sentry-android-ndk",/d' \
-            -e '/.*"sentry-android",/d' \
-            -e '/.*"sentry-compose",/d' \
-            -e '/.*"sentry-android-core",/d' \
-            -e '/.*"sentry-android-fragment",/d' \
-            -e '/.*"sentry-android-navigation",/d' \
-            -e '/.*"sentry-android-sqlite",/d' \
-            -e '/.*"sentry-android-timber",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
-            -e '/.*"sentry-samples:sentry-samples-android",/d' \
-            -e '/.*"sentry-android-replay",/d' \
-            settings.gradle.kts
-
-      - name: Exclude android modules from ignore list
-        run: |
-          sed -i \
-            -e '/.*"sentry-uitest-android",/d' \
-            -e '/.*"sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-uitest-android-critical",/d' \
-            -e '/.*"test-app-sentry",/d' \
-            -e '/.*"test-app-size",/d' \
-            -e '/.*"sentry-samples-android",/d' \
-            build.gradle.kts
-
-      - name: Build SDK
-        run: |
-          ./gradlew assemble --parallel
+          ./gradlew \
+            :sentry-samples:sentry-samples-spring-boot-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:bootJar \
+            :sentry-samples:sentry-samples-spring-jakarta:war \
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
+            --parallel
 
       - name: Test sentry-samples-spring-boot-jakarta
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-jakarta" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-webflux-jakarta
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-webflux-jakarta" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-jakarta-opentelemetry agent init true
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-jakarta-opentelemetry" \
             --agent true \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-boot-jakarta-opentelemetry agent init false
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-jakarta-opentelemetry" \
             --agent true \
-            --auto-init "false" \
-            --build "true"
+            --auto-init "false"
 
       - name: Test sentry-samples-spring-boot-jakarta-opentelemetry-noagent
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-jakarta-opentelemetry-noagent" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Test sentry-samples-spring-jakarta
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-jakarta" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -81,8 +81,7 @@ jobs:
             :sentry-samples:sentry-samples-spring-boot-4-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring-7:war \
             :sentry-samples:sentry-samples-spring-7:testClasses \
-            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
-            --parallel
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble
 
       - name: Run sentry-samples-spring-boot-4
         run: |

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -72,10 +72,15 @@ jobs:
         run: |
           ./gradlew \
             :sentry-samples:sentry-samples-spring-boot-4:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4:testClasses \
             :sentry-samples:sentry-samples-spring-boot-4-webflux:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-webflux:testClasses \
             :sentry-samples:sentry-samples-spring-boot-4-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry:testClasses \
             :sentry-samples:sentry-samples-spring-boot-4-opentelemetry-noagent:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry-noagent:testClasses \
             :sentry-samples:sentry-samples-spring-7:war \
+            :sentry-samples:sentry-samples-spring-7:testClasses \
             :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
             --parallel
 

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -68,88 +68,58 @@ jobs:
           perl -0pi -e 'BEGIN { $v = shift } s/^springboot4[[:space:]]*=[[:space:]]*"\K[^"]*/$v/m or die "::error::springboot4 version entry not found in gradle/libs.versions.toml\n"' "$springboot_version" gradle/libs.versions.toml
           echo "Updated Spring Boot 4.x version to $springboot_version"
 
-      - name: Exclude android modules from build
+      - name: Build sample artifacts
         run: |
-          sed -i \
-            -e '/.*"sentry-android-ndk",/d' \
-            -e '/.*"sentry-android",/d' \
-            -e '/.*"sentry-compose",/d' \
-            -e '/.*"sentry-android-core",/d' \
-            -e '/.*"sentry-android-fragment",/d' \
-            -e '/.*"sentry-android-navigation",/d' \
-            -e '/.*"sentry-android-sqlite",/d' \
-            -e '/.*"sentry-android-timber",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
-            -e '/.*"sentry-samples:sentry-samples-android",/d' \
-            -e '/.*"sentry-android-replay",/d' \
-            settings.gradle.kts
-
-      - name: Exclude android modules from ignore list
-        run: |
-          sed -i \
-            -e '/.*"sentry-uitest-android",/d' \
-            -e '/.*"sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-uitest-android-critical",/d' \
-            -e '/.*"test-app-sentry",/d' \
-            -e '/.*"test-app-size",/d' \
-            -e '/.*"sentry-samples-android",/d' \
-            build.gradle.kts
-
-      - name: Build SDK
-        run: |
-          ./gradlew assemble --parallel
+          ./gradlew \
+            :sentry-samples:sentry-samples-spring-boot-4:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-webflux:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry-noagent:bootJar \
+            :sentry-samples:sentry-samples-spring-7:war \
+            :sentry-opentelemetry:sentry-opentelemetry-agent:assemble \
+            --parallel
 
       - name: Run sentry-samples-spring-boot-4
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-4" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Run sentry-samples-spring-boot-4-webflux
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-4-webflux" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Run sentry-samples-spring-boot-4-opentelemetry agent init true
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-4-opentelemetry" \
             --agent true \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Run sentry-samples-spring-boot-4-opentelemetry agent init false
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-4-opentelemetry" \
             --agent true \
-            --auto-init "false" \
-            --build "true"
+            --auto-init "false"
 
       - name: Run sentry-samples-spring-boot-4-opentelemetry-noagent
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-boot-4-opentelemetry-noagent" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Run sentry-samples-spring-7
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-7" \
             --agent false \
-            --auto-init "true" \
-            --build "true"
+            --auto-init "true"
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- Remove `sed`-based Android module exclusion from `settings.gradle.kts` and `build.gradle.kts` in the three Spring Boot matrix workflows — unnecessary because `org.gradle.configureondemand=true` ensures Gradle only configures projects needed for the requested tasks
- Replace the broad `./gradlew assemble --parallel` (which built the entire non-Android project) with a single targeted Gradle invocation that builds only the specific artifacts needed (`shadowJar`/`bootJar`/`war` + OTel agent)
- Remove redundant `--build "true"` from test runner invocations since artifacts are already pre-built

🤖 Generated with [Claude Code](https://claude.com/claude-code)