### PR TITLE
meta(craft): Register missing SDK modules

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -42,16 +42,20 @@ targets:
       maven:io.sentry:sentry-bom:
       maven:io.sentry:sentry-openfeign:
       maven:io.sentry:sentry-openfeature:
+      maven:io.sentry:sentry-launchdarkly-android:
+      maven:io.sentry:sentry-launchdarkly-server:
       maven:io.sentry:sentry-opentelemetry-agent:
       maven:io.sentry:sentry-opentelemetry-agentcustomization:
       maven:io.sentry:sentry-opentelemetry-agentless:
       maven:io.sentry:sentry-opentelemetry-agentless-spring:
       maven:io.sentry:sentry-opentelemetry-bootstrap:
       maven:io.sentry:sentry-opentelemetry-core:
-#      maven:io.sentry:sentry-opentelemetry-otlp:
-#      maven:io.sentry:sentry-opentelemetry-otlp-spring:
+      maven:io.sentry:sentry-opentelemetry-otlp:
+      maven:io.sentry:sentry-opentelemetry-otlp-spring:
+      maven:io.sentry:sentry-kafka:
       maven:io.sentry:sentry-apollo:
       maven:io.sentry:sentry-jdbc:
+      maven:io.sentry:sentry-jcache:
       maven:io.sentry:sentry-graphql:
       maven:io.sentry:sentry-graphql-22:
       maven:io.sentry:sentry-graphql-core:


### PR DESCRIPTION
## :scroll: Description
Register SDK artifacts that are present in this repository but missing from the Craft release registry SDK list:

- `sentry-launchdarkly-android`
- `sentry-launchdarkly-server`
- `sentry-opentelemetry-otlp`
- `sentry-opentelemetry-otlp-spring`
- `sentry-kafka`
- `sentry-jcache`

## :bulb: Motivation and Context
The `.craft.yml` registry target should stay aligned with the published SDK modules in this repo so releases update the release registry for all SDK artifacts.

## :green_heart: How did you test it?
- Ran `./gradlew spotlessApply apiDump`
- Parsed `.craft.yml` as YAML
- Compared the active `.craft.yml` registry entries against the README package table and confirmed no README package entries are missing

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
