### PR TITLE
fix(core): [Session based Traces for Mobile 2] Keep transaction baggage mutable

### DIFF
--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -233,8 +233,8 @@ public final class Baggage {
         baggage.sampleRate,
         sampleRand,
         baggage.thirdPartyHeader,
-        baggage.mutable,
-        baggage.shouldFreeze,
+        true,
+        false,
         baggage.logger);
   }
 

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -1024,11 +1024,10 @@ public final class Scopes implements IScopes {
 
   private @NotNull TransactionContext maybeApplySessionTraceLifecycle(
       final @NotNull TransactionContext transactionContext) {
+    final @NotNull PropagationContext propagationContext =
+        getCombinedScopeView().getPropagationContext();
     if (getOptions().isEnableSessionTraceLifecycle()
-        && transactionContext.getParentSpanId() == null
-        && getCombinedScopeView().getSession() != null) {
-      final @NotNull PropagationContext propagationContext =
-          getCombinedScopeView().getPropagationContext();
+        && transactionContext.getParentSpanId() == null) {
       return TransactionContext.fromPropagationContextAsRoot(
           propagationContext, transactionContext);
     }

--- a/sentry/src/main/java/io/sentry/Scopes.java
+++ b/sentry/src/main/java/io/sentry/Scopes.java
@@ -1024,10 +1024,11 @@ public final class Scopes implements IScopes {
 
   private @NotNull TransactionContext maybeApplySessionTraceLifecycle(
       final @NotNull TransactionContext transactionContext) {
-    final @NotNull PropagationContext propagationContext =
-        getCombinedScopeView().getPropagationContext();
     if (getOptions().isEnableSessionTraceLifecycle()
-        && transactionContext.getParentSpanId() == null) {
+        && transactionContext.getParentSpanId() == null
+        && getCombinedScopeView().getSession() != null) {
+      final @NotNull PropagationContext propagationContext =
+          getCombinedScopeView().getPropagationContext();
       return TransactionContext.fromPropagationContextAsRoot(
           propagationContext, transactionContext);
     }

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -440,7 +440,7 @@ class BaggageTest {
   }
 
   @Test
-  fun `copy with overrides preserves frozen state`() {
+  fun `copy with overrides creates mutable baggage`() {
     val baggage =
       Baggage.fromHeader(
         "sentry-sample_rand=0.1,sentry-trace_id=75302ac48a024bde9a3b3734a82e36c8",
@@ -450,7 +450,8 @@ class BaggageTest {
 
     val copy = Baggage.copyWithOverrides(baggage, SentryId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 0.2)
 
-    assertFalse(copy.isMutable)
+    assertTrue(copy.isMutable)
+    assertFalse(copy.isShouldFreeze)
     assertEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", copy.traceId)
     assertEquals(0.2, copy.sampleRand!!, 0.0001)
     assertEquals("75302ac48a024bde9a3b3734a82e36c8", baggage.traceId)

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -21,6 +21,7 @@ import io.sentry.test.createTestScopes
 import io.sentry.test.initForTest
 import io.sentry.util.HintUtils
 import io.sentry.util.StringUtils
+import io.sentry.util.TracingUtils
 import java.io.File
 import java.nio.file.Files
 import java.util.Queue
@@ -1863,6 +1864,47 @@ class ScopesTest {
     assertEquals(SentryId(traceId), transaction.root.spanContext.traceId)
     assertNotEquals(SpanId(parentSpanId), transaction.root.spanContext.spanId)
     assertNull(transaction.root.spanContext.parentSpanId)
+  }
+
+  @Test
+  fun `session trace transaction baggage is populated after scope baggage is frozen`() {
+    val scopes = generateScopes {
+      it.isEnableSessionTraceLifecycle = true
+      it.release = "1.0.0"
+      it.environment = "production"
+    }
+
+    scopes.startSession()
+
+    val sessionTraceId = AtomicReference<SentryId>()
+    val sessionSampleRand = AtomicReference<Double>()
+    val headersWithoutTransaction =
+      TracingUtils.traceIfAllowed(scopes, "https://sentry.io/hello", emptyList(), null)
+    assertNotNull(headersWithoutTransaction)
+    scopes.configureScope { scope ->
+      sessionTraceId.set(scope.propagationContext.traceId)
+      sessionSampleRand.set(scope.propagationContext.sampleRand)
+      assertFalse(scope.propagationContext.baggage!!.isMutable)
+    }
+
+    val firstTransaction =
+      scopes.startTransaction(TransactionContext("first transaction", "ui.load"))
+    assertSessionTraceBaggage(
+      firstTransaction,
+      scopes,
+      sessionTraceId.get(),
+      sessionSampleRand.get(),
+    )
+    firstTransaction.finish()
+
+    val secondTransaction =
+      scopes.startTransaction(TransactionContext("second transaction", "ui.action"))
+    assertSessionTraceBaggage(
+      secondTransaction,
+      scopes,
+      sessionTraceId.get(),
+      sessionSampleRand.get(),
+    )
   }
 
   @Test
@@ -4406,6 +4448,30 @@ class ScopesTest {
       }
     optionsConfiguration?.configure(options)
     return createScopes(options)
+  }
+
+  private fun assertSessionTraceBaggage(
+    transaction: ITransaction,
+    scopes: IScopes,
+    sessionTraceId: SentryId,
+    sessionSampleRand: Double,
+  ) {
+    assertTrue(transaction is SentryTracer)
+    assertEquals(sessionTraceId, transaction.root.spanContext.traceId)
+
+    val tracingHeaders =
+      TracingUtils.traceIfAllowed(scopes, "https://sentry.io/hello", emptyList(), transaction)
+    val baggage =
+      Baggage.fromHeader(tracingHeaders!!.baggageHeader!!.value, NoOpLogger.getInstance())
+
+    assertEquals(sessionTraceId.toString(), baggage.traceId)
+    assertEquals(transaction.name, baggage.transaction)
+    assertEquals("true", baggage.sampled)
+    assertEquals(1.0, baggage.sampleRate!!, 0.0001)
+    assertEquals(sessionSampleRand, baggage.sampleRand!!, 0.0001)
+    assertEquals("key", baggage.publicKey)
+    assertEquals("1.0.0", baggage.release)
+    assertEquals("production", baggage.environment)
   }
 
   private fun getEnabledScopes(

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -1823,8 +1823,26 @@ class ScopesTest {
   }
 
   @Test
-  fun `when session trace lifecycle is enabled, startTransaction uses session propagation context`() {
+  fun `when session trace lifecycle is enabled without active session, root transaction does not use scope propagation context`() {
     val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
+    var propagationContext: PropagationContext? = null
+    scopes.configureScope { propagationContext = it.propagationContext }
+    val context = TransactionContext("name", "op")
+
+    val transaction = scopes.startTransaction(context)
+
+    assertTrue(transaction is SentryTracer)
+    assertEquals(context.traceId, transaction.root.spanContext.traceId)
+    assertNotEquals(propagationContext!!.traceId, transaction.root.spanContext.traceId)
+  }
+
+  @Test
+  fun `when session trace lifecycle is enabled, startTransaction uses session propagation context`() {
+    val scopes = generateScopes {
+      it.isEnableSessionTraceLifecycle = true
+      it.release = "1.0.0"
+    }
+    scopes.startSession()
     var propagationContext: PropagationContext? = null
     scopes.configureScope { propagationContext = it.propagationContext }
 
@@ -1839,7 +1857,11 @@ class ScopesTest {
 
   @Test
   fun `continued trace with parent span is not remapped to session trace`() {
-    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
+    val scopes = generateScopes {
+      it.isEnableSessionTraceLifecycle = true
+      it.release = "1.0.0"
+    }
+    scopes.startSession()
     val traceId = "75302ac48a024bde9a3b3734a82e36c8"
     val parentSpanId = "1000000000000000"
     val context = scopes.continueTrace("$traceId-$parentSpanId-1", emptyList())!!
@@ -1853,7 +1875,11 @@ class ScopesTest {
 
   @Test
   fun `when session trace lifecycle is enabled, root transaction uses current propagation context`() {
-    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
+    val scopes = generateScopes {
+      it.isEnableSessionTraceLifecycle = true
+      it.release = "1.0.0"
+    }
+    scopes.startSession()
     val traceId = "75302ac48a024bde9a3b3734a82e36c8"
     val parentSpanId = "1000000000000000"
     scopes.continueTrace("$traceId-$parentSpanId-1", emptyList())

--- a/sentry/src/test/java/io/sentry/ScopesTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopesTest.kt
@@ -1823,26 +1823,8 @@ class ScopesTest {
   }
 
   @Test
-  fun `when session trace lifecycle is enabled without active session, root transaction does not use scope propagation context`() {
-    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
-    var propagationContext: PropagationContext? = null
-    scopes.configureScope { propagationContext = it.propagationContext }
-    val context = TransactionContext("name", "op")
-
-    val transaction = scopes.startTransaction(context)
-
-    assertTrue(transaction is SentryTracer)
-    assertEquals(context.traceId, transaction.root.spanContext.traceId)
-    assertNotEquals(propagationContext!!.traceId, transaction.root.spanContext.traceId)
-  }
-
-  @Test
   fun `when session trace lifecycle is enabled, startTransaction uses session propagation context`() {
-    val scopes = generateScopes {
-      it.isEnableSessionTraceLifecycle = true
-      it.release = "1.0.0"
-    }
-    scopes.startSession()
+    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
     var propagationContext: PropagationContext? = null
     scopes.configureScope { propagationContext = it.propagationContext }
 
@@ -1857,11 +1839,7 @@ class ScopesTest {
 
   @Test
   fun `continued trace with parent span is not remapped to session trace`() {
-    val scopes = generateScopes {
-      it.isEnableSessionTraceLifecycle = true
-      it.release = "1.0.0"
-    }
-    scopes.startSession()
+    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
     val traceId = "75302ac48a024bde9a3b3734a82e36c8"
     val parentSpanId = "1000000000000000"
     val context = scopes.continueTrace("$traceId-$parentSpanId-1", emptyList())!!
@@ -1875,11 +1853,7 @@ class ScopesTest {
 
   @Test
   fun `when session trace lifecycle is enabled, root transaction uses current propagation context`() {
-    val scopes = generateScopes {
-      it.isEnableSessionTraceLifecycle = true
-      it.release = "1.0.0"
-    }
-    scopes.startSession()
+    val scopes = generateScopes { it.isEnableSessionTraceLifecycle = true }
     val traceId = "75302ac48a024bde9a3b3734a82e36c8"
     val parentSpanId = "1000000000000000"
     scopes.continueTrace("$traceId-$parentSpanId-1", emptyList())


### PR DESCRIPTION
## PR Stack (Session based Traces for Mobile)

- #5383
- #5398
- #5402
- #5417
- #5429
- #5430

---

## :scroll: Description
Keeps transaction baggage mutable when remapping a root transaction onto the current session trace. This lets each transaction populate its own DSC fields even if the ambient session propagation baggage was already frozen by an earlier outgoing request without an active transaction.

Adds regression coverage for:
- starting a new session
- producing outgoing headers without an active transaction, freezing the session baggage
- starting a transaction in the session trace and verifying outgoing transaction baggage
- finishing that transaction, then starting a second transaction and verifying its baggage too

## :bulb: Motivation and Context
Session trace lifecycle can freeze ambient scope baggage before any transaction starts. If a later transaction reuses that frozen baggage directly, outgoing transaction propagation can miss transaction-specific DSC such as `sentry-transaction`, `sentry-sampled`, `sentry-sample_rate`, and `sentry-sample_rand`.

This keeps the session trace id and sample rand while allowing each remapped transaction to complete its own outgoing baggage.

## :green_heart: How did you test it?
- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test --tests 'io.sentry.BaggageTest' --tests 'io.sentry.ScopesTest.session trace transaction baggage is populated after scope baggage is frozen'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
Continue the Session based Traces for Mobile stack.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

