### PR TITLE
chore: Remove dependabot grouping for gradle deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,21 +16,6 @@ updates:
       - dependency-name: "org.springframework.boot*"
     commit-message:
       prefix: "chore(deps)"
-    groups:
-      compose:
-        patterns:
-          - "androidx.compose*"
-          - "org.jetbrains.compose*"
-      androidx:
-        patterns:
-          - "androidx.*"
-      kotlin:
-        patterns:
-          - "org.jetbrains.kotlin*"
-          - "org.jetbrains.kotlinx*"
-      jackson:
-        patterns:
-          - "com.fasterxml.jackson*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Remove all dependabot dependency grouping for gradle packages (compose, androidx, kotlin, jackson)
- Keep the github-actions grouping intact
- Individual PRs for gradle dependencies make it easier to review and merge them independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)