### PR TITLE
chore: Add missing binary types to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,10 @@
 *.jpg binary
 *.pb binary
 *.gz binary
+*.bin binary
+*.zip binary
+*.jar binary
+*.gpg binary
 
 # These are explicitly windows files and should use crlf
 *.bat           text eol=crlf


### PR DESCRIPTION
## Summary
- Add `*.bin`, `*.zip`, `*.jar`, and `*.gpg` as binary in `.gitattributes` to prevent line-ending conversions and diff noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)