### PR TITLE
chore(deps): Bump Robolectric from 4.14 to 4.15

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -246,5 +246,5 @@ mockito-inline = { module = "org.mockito:mockito-inline", version = "4.8.0" }
 msgpack = { module = "org.msgpack:msgpack-core", version = "0.9.8" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version = "1.13.0" }
-roboelectric = { module = "org.robolectric:robolectric", version = "4.14" }
+roboelectric = { module = "org.robolectric:robolectric", version = "4.15" }
 


### PR DESCRIPTION
## What

Bump Robolectric from 4.14 to 4.15.

## Why

4.16 failed due to dropping minsdk 21 https://github.com/getsentry/sentry-java/pull/5412

#skip-changelog