### PR TITLE
feat(core): Add API to clear scope feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add API to clear feature flags from scopes ([#5426](https://github.com/getsentry/sentry-java/pull/5426))
 - Add support to configure reporting historical ANRs via `AndroidManifest.xml` using the  `io.sentry.anr.report-historical` attribute ([#5387](https://github.com/getsentry/sentry-java/pull/5387))
 
 ## 8.41.0

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -273,6 +273,7 @@ public final class io/sentry/CombinedScopeView : io/sentry/IScope {
 	public fun clear ()V
 	public fun clearAttachments ()V
 	public fun clearBreadcrumbs ()V
+	public fun clearFeatureFlags ()V
 	public fun clearSession ()V
 	public fun clearTransaction ()V
 	public fun clone ()Lio/sentry/IScope;
@@ -901,6 +902,7 @@ public abstract interface class io/sentry/IScope {
 	public abstract fun clear ()V
 	public abstract fun clearAttachments ()V
 	public abstract fun clearBreadcrumbs ()V
+	public abstract fun clearFeatureFlags ()V
 	public abstract fun clearSession ()V
 	public abstract fun clearTransaction ()V
 	public abstract fun clone ()Lio/sentry/IScope;
@@ -1715,6 +1717,7 @@ public final class io/sentry/NoOpScope : io/sentry/IScope {
 	public fun clear ()V
 	public fun clearAttachments ()V
 	public fun clearBreadcrumbs ()V
+	public fun clearFeatureFlags ()V
 	public fun clearSession ()V
 	public fun clearTransaction ()V
 	public fun clone ()Lio/sentry/IScope;
@@ -2401,6 +2404,7 @@ public final class io/sentry/Scope : io/sentry/IScope {
 	public fun clear ()V
 	public fun clearAttachments ()V
 	public fun clearBreadcrumbs ()V
+	public fun clearFeatureFlags ()V
 	public fun clearSession ()V
 	public fun clearTransaction ()V
 	public fun clone ()Lio/sentry/IScope;
@@ -5039,6 +5043,7 @@ public final class io/sentry/exception/SentryHttpClientException : java/lang/Exc
 
 public final class io/sentry/featureflags/FeatureFlagBuffer : io/sentry/featureflags/IFeatureFlagBuffer {
 	public fun add (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun clear ()V
 	public fun clone ()Lio/sentry/featureflags/IFeatureFlagBuffer;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/featureflags/IFeatureFlagBuffer;
@@ -5048,6 +5053,7 @@ public final class io/sentry/featureflags/FeatureFlagBuffer : io/sentry/featuref
 
 public abstract interface class io/sentry/featureflags/IFeatureFlagBuffer {
 	public abstract fun add (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public abstract fun clear ()V
 	public abstract fun clone ()Lio/sentry/featureflags/IFeatureFlagBuffer;
 	public abstract fun getFeatureFlags ()Lio/sentry/protocol/FeatureFlags;
 }
@@ -5055,6 +5061,7 @@ public abstract interface class io/sentry/featureflags/IFeatureFlagBuffer {
 public final class io/sentry/featureflags/NoOpFeatureFlagBuffer : io/sentry/featureflags/IFeatureFlagBuffer {
 	public fun <init> ()V
 	public fun add (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun clear ()V
 	public fun clone ()Lio/sentry/featureflags/IFeatureFlagBuffer;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public fun getFeatureFlags ()Lio/sentry/protocol/FeatureFlags;
@@ -5063,6 +5070,7 @@ public final class io/sentry/featureflags/NoOpFeatureFlagBuffer : io/sentry/feat
 
 public final class io/sentry/featureflags/SpanFeatureFlagBuffer : io/sentry/featureflags/IFeatureFlagBuffer {
 	public fun add (Ljava/lang/String;Ljava/lang/Boolean;)V
+	public fun clear ()V
 	public fun clone ()Lio/sentry/featureflags/IFeatureFlagBuffer;
 	public synthetic fun clone ()Ljava/lang/Object;
 	public static fun create ()Lio/sentry/featureflags/IFeatureFlagBuffer;

--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -550,6 +550,11 @@ public final class CombinedScopeView implements IScope {
   }
 
   @Override
+  public void clearFeatureFlags() {
+    getDefaultWriteScope().clearFeatureFlags();
+  }
+
+  @Override
   public @Nullable FeatureFlags getFeatureFlags() {
     return getFeatureFlagBuffer().getFeatureFlags();
   }

--- a/sentry/src/main/java/io/sentry/IScope.java
+++ b/sentry/src/main/java/io/sentry/IScope.java
@@ -465,6 +465,8 @@ public interface IScope {
 
   void addFeatureFlag(final @Nullable String flag, final @Nullable Boolean result);
 
+  void clearFeatureFlags();
+
   @ApiStatus.Internal
   @Nullable
   FeatureFlags getFeatureFlags();

--- a/sentry/src/main/java/io/sentry/NoOpScope.java
+++ b/sentry/src/main/java/io/sentry/NoOpScope.java
@@ -322,6 +322,9 @@ public final class NoOpScope implements IScope {
   public void addFeatureFlag(final @Nullable String flag, final @Nullable Boolean result) {}
 
   @Override
+  public void clearFeatureFlags() {}
+
+  @Override
   public @Nullable FeatureFlags getFeatureFlags() {
     return null;
   }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -574,6 +574,7 @@ public final class Scope implements IScope {
     eventProcessors.clear();
     clearTransaction();
     clearAttachments();
+    clearFeatureFlags();
   }
 
   /**
@@ -1209,6 +1210,11 @@ public final class Scope implements IScope {
   @Override
   public void addFeatureFlag(final @Nullable String flag, final @Nullable Boolean result) {
     featureFlags.add(flag, result);
+  }
+
+  @Override
+  public void clearFeatureFlags() {
+    featureFlags.clear();
   }
 
   @Override

--- a/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/FeatureFlagBuffer.java
@@ -70,6 +70,13 @@ public final class FeatureFlagBuffer implements IFeatureFlagBuffer {
   }
 
   @Override
+  public void clear() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      flags.clear();
+    }
+  }
+
+  @Override
   public @Nullable FeatureFlags getFeatureFlags() {
     List<FeatureFlag> featureFlags = new ArrayList<>();
     for (FeatureFlagEntry entry : flags) {

--- a/sentry/src/main/java/io/sentry/featureflags/IFeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/IFeatureFlagBuffer.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.Nullable;
 public interface IFeatureFlagBuffer {
   void add(final @Nullable String flag, final @Nullable Boolean result);
 
+  void clear();
+
   @Nullable
   FeatureFlags getFeatureFlags();
 

--- a/sentry/src/main/java/io/sentry/featureflags/NoOpFeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/NoOpFeatureFlagBuffer.java
@@ -17,6 +17,9 @@ public final class NoOpFeatureFlagBuffer implements IFeatureFlagBuffer {
   public void add(final @Nullable String flag, final @Nullable Boolean result) {}
 
   @Override
+  public void clear() {}
+
+  @Override
   public @Nullable FeatureFlags getFeatureFlags() {
     return null;
   }

--- a/sentry/src/main/java/io/sentry/featureflags/SpanFeatureFlagBuffer.java
+++ b/sentry/src/main/java/io/sentry/featureflags/SpanFeatureFlagBuffer.java
@@ -49,6 +49,13 @@ public final class SpanFeatureFlagBuffer implements IFeatureFlagBuffer {
   }
 
   @Override
+  public void clear() {
+    try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
+      flags = null;
+    }
+  }
+
+  @Override
   public @Nullable FeatureFlags getFeatureFlags() {
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       if (flags == null || flags.isEmpty()) {

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -294,6 +294,7 @@ class ScopeTest {
     scope.setAttribute("some", "attribute")
     scope.addEventProcessor(eventProcessor())
     scope.addAttachment(Attachment("path"))
+    scope.addFeatureFlag("flag", true)
 
     scope.clear()
 
@@ -309,6 +310,7 @@ class ScopeTest {
     assertEquals(0, scope.extras.size)
     assertEquals(0, scope.eventProcessors.size)
     assertEquals(0, scope.attachments.size)
+    assertEquals(0, scope.featureFlags!!.values.size)
   }
 
   @Test
@@ -1152,6 +1154,18 @@ class ScopeTest {
     val flags = scope.featureFlags
     assertNotNull(flags)
 
+    assertEquals(0, flags.values.size)
+  }
+
+  @Test
+  fun `feature flags can be cleared`() {
+    val scope = Scope(SentryOptions.empty())
+
+    scope.addFeatureFlag("flag1", true)
+    scope.clearFeatureFlags()
+
+    val flags = scope.featureFlags
+    assertNotNull(flags)
     assertEquals(0, flags.values.size)
   }
 

--- a/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/FeatureFlagBufferTest.kt
@@ -34,6 +34,19 @@ class FeatureFlagBufferTest {
   }
 
   @Test
+  fun `clears values`() {
+    val buffer = FeatureFlagBuffer.create(SentryOptions().also { it.maxFeatureFlags = 2 })
+    buffer.add("a", true)
+    buffer.add("b", false)
+
+    buffer.clear()
+
+    val featureFlags = buffer.featureFlags
+    assertNotNull(featureFlags)
+    assertEquals(0, featureFlags.values.size)
+  }
+
+  @Test
   fun `drops oldest entry when limit is reached`() {
     val buffer = FeatureFlagBuffer.create(SentryOptions().also { it.maxFeatureFlags = 2 })
     buffer.add("a", true)

--- a/sentry/src/test/java/io/sentry/featureflags/SpanFeatureFlagBufferTest.kt
+++ b/sentry/src/test/java/io/sentry/featureflags/SpanFeatureFlagBufferTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SpanFeatureFlagBufferTest {
@@ -24,6 +25,17 @@ class SpanFeatureFlagBufferTest {
 
     assertEquals("b", featureFlagValues[1]!!.flag)
     assertFalse(featureFlagValues[1]!!.result)
+  }
+
+  @Test
+  fun `clears values`() {
+    val buffer = SpanFeatureFlagBuffer.create()
+    buffer.add("a", true)
+    buffer.add("b", false)
+
+    buffer.clear()
+
+    assertNull(buffer.featureFlags)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description
Add `IScope.clearFeatureFlags()` to clear feature flag evaluations stored on a scope.

This also makes `Scope.clear()` reset the feature flag buffer, matching the existing expectation that clearing a scope returns it to its default state.

## :bulb: Motivation and Context
Fixes #5422
Refs JAVA-512

Previously, feature flag evaluations could only be added or overwritten by name. There was no way to remove evaluations that no longer apply, which could leave stale feature flags attached to later error events after an app account switch.

## :green_heart: How did you test it?
- `./gradlew :sentry:test --tests 'io.sentry.ScopeTest' --tests 'io.sentry.featureflags.FeatureFlagBufferTest' --tests 'io.sentry.featureflags.SpanFeatureFlagBufferTest'`
- `./gradlew spotlessApply apiDump`

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
Docs can be updated separately if we want to document the new scope-level clearing API.
