### PR TITLE
chore(deps): Bump SAGP from 6.0.0-alpha.6 to 6.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Bump Native SDK from v0.14.0 to v0.14.1 ([#5433](https://github.com/getsentry/sentry-java/pull/5433))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0141)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.14.0...0.14.1)
-- Bump SAGP (Sentry Android Gradle Plugin) from v6.0.0-alpha.6 to v6.6.0 ([#0000](https://github.com/getsentry/sentry-java/pull/0000))
+- Bump SAGP (Sentry Android Gradle Plugin) from v6.0.0-alpha.6 to v6.6.0 ([#5427](https://github.com/getsentry/sentry-java/pull/5427))
   - [changelog](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-android-gradle-plugin/compare/6.0.0-alpha.6...6.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Bump Native SDK from v0.14.0 to v0.14.1 ([#5433](https://github.com/getsentry/sentry-java/pull/5433))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0141)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.14.0...0.14.1)
+- Bump SAGP (Sentry Android Gradle Plugin) from v6.0.0-alpha.6 to v6.6.0 ([#0000](https://github.com/getsentry/sentry-java/pull/0000))
+  - [changelog](https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-android-gradle-plugin/compare/6.0.0-alpha.6...6.6.0)
 
 ## 8.41.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ springboot4 = { id = "org.springframework.boot", version.ref = "springboot4" }
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7" }
 gretty = { id = "org.gretty", version = "4.0.0" }
 animalsniffer = { id = "ru.vyarus.animalsniffer", version = "2.0.1" }
-sentry = { id = "io.sentry.android.gradle", version = "6.0.0-alpha.6"}
+sentry = { id = "io.sentry.android.gradle", version = "6.6.0"}
 shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
 
 [libraries]


### PR DESCRIPTION
## :scroll: Description

Bump the Sentry Android Gradle Plugin from `6.0.0-alpha.6` to `6.6.0`.

## :bulb: Motivation and Context

Upgrade to the latest stable SAGP release.

## :green_heart: How did you test it?

CI

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps