### PR TITLE
fix(core): [Session based Traces for Mobile 4] No longer unfreeze Baggage

### DIFF
--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -221,21 +221,23 @@ public final class Baggage {
 
   @ApiStatus.Internal
   static @NotNull Baggage copyWithOverrides(
-      final @NotNull Baggage baggage,
+      final @Nullable Baggage baggage,
       final @NotNull SentryId traceId,
       final @Nullable Double sampleRand) {
+    final @NotNull Baggage source =
+        baggage == null ? new Baggage(NoOpLogger.getInstance()) : baggage;
     final @NotNull ConcurrentHashMap<String, String> keyValues =
-        new ConcurrentHashMap<>(baggage.keyValues);
+        new ConcurrentHashMap<>(source.keyValues);
     keyValues.put(DSCKeys.TRACE_ID, traceId.toString());
 
     return new Baggage(
         keyValues,
-        baggage.sampleRate,
+        source.sampleRate,
         sampleRand,
-        baggage.thirdPartyHeader,
-        true,
-        false,
-        baggage.logger);
+        source.thirdPartyHeader,
+        source.mutable,
+        source.shouldFreeze,
+        source.logger);
   }
 
   @ApiStatus.Internal

--- a/sentry/src/main/java/io/sentry/TransactionContext.java
+++ b/sentry/src/main/java/io/sentry/TransactionContext.java
@@ -44,7 +44,7 @@ public final class TransactionContext extends SpanContext {
       final @NotNull TransactionContext transactionContext) {
     final @NotNull Baggage baggage =
         Baggage.copyWithOverrides(
-            propagationContext.getBaggage(),
+            transactionContext.getBaggage(),
             propagationContext.getTraceId(),
             propagationContext.getSampleRand());
 

--- a/sentry/src/test/java/io/sentry/BaggageTest.kt
+++ b/sentry/src/test/java/io/sentry/BaggageTest.kt
@@ -440,7 +440,7 @@ class BaggageTest {
   }
 
   @Test
-  fun `copy with overrides creates mutable baggage`() {
+  fun `copy with overrides preserves frozen state`() {
     val baggage =
       Baggage.fromHeader(
         "sentry-sample_rand=0.1,sentry-trace_id=75302ac48a024bde9a3b3734a82e36c8",
@@ -450,12 +450,22 @@ class BaggageTest {
 
     val copy = Baggage.copyWithOverrides(baggage, SentryId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 0.2)
 
-    assertTrue(copy.isMutable)
-    assertFalse(copy.isShouldFreeze)
+    assertFalse(copy.isMutable)
+    assertTrue(copy.isShouldFreeze)
     assertEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", copy.traceId)
     assertEquals(0.2, copy.sampleRand!!, 0.0001)
     assertEquals("75302ac48a024bde9a3b3734a82e36c8", baggage.traceId)
     assertEquals(0.1, baggage.sampleRand!!, 0.0001)
+  }
+
+  @Test
+  fun `copy with overrides creates baggage when source is null`() {
+    val copy = Baggage.copyWithOverrides(null, SentryId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 0.2)
+
+    assertTrue(copy.isMutable)
+    assertFalse(copy.isShouldFreeze)
+    assertEquals("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", copy.traceId)
+    assertEquals(0.2, copy.sampleRand!!, 0.0001)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/TransactionContextTest.kt
+++ b/sentry/src/test/java/io/sentry/TransactionContextTest.kt
@@ -99,6 +99,7 @@ class TransactionContextTest {
   fun `fromPropagationContextAsRoot copies non trace state`() {
     val propagationBaggage = Baggage(NoOpLogger.getInstance())
     propagationBaggage.sampleRand = 0.42
+    propagationBaggage.publicKey = "propagation-public-key"
     val propagationContext =
       PropagationContext(
         SentryId("75302ac48a024bde9a3b3734a82e36c8"),
@@ -109,6 +110,7 @@ class TransactionContextTest {
       )
     val samplingDecision = TracesSamplingDecision(true, 0.3, true, 0.4)
     val transactionContext = TransactionContext("name", "op", samplingDecision)
+    transactionContext.baggage!!.publicKey = "transaction-public-key"
     transactionContext.transactionNameSource = TransactionNameSource.ROUTE
     transactionContext.description = "description"
     transactionContext.status = SpanStatus.OK
@@ -145,6 +147,7 @@ class TransactionContextTest {
     assertEquals(0.4, context.samplingDecision!!.profileSampleRate)
     assertEquals(0.42, context.baggage!!.sampleRand)
     assertEquals(propagationContext.traceId.toString(), context.baggage!!.traceId)
+    assertEquals("transaction-public-key", context.baggage!!.publicKey)
     assertNull(context.featureFlagBuffer.featureFlags)
   }
 


### PR DESCRIPTION
## PR Stack (Session based Traces for Mobile)

- #5383
- #5398
- #5402
- #5417
- #5429
- #5430

---

## :scroll: Description
Avoids reusing the session propagation context's frozen baggage when remapping root transactions onto the session trace. The remapped transaction now keeps its own transaction baggage as the source and only overrides the session `traceId` and `sampleRand`.

This preserves the session trace linkage without creating a mutable copy from already-frozen propagation baggage.

## :bulb: Motivation and Context
Session trace lifecycle needs root transactions to share the session trace ID and sampling random value. The previous approach did that by copying the scope propagation baggage as mutable transaction baggage, effectively unfreezing baggage that had already been frozen during header propagation.

Keeping the transaction baggage as the source avoids that unfreeze behavior while still reusing the session trace identifiers required for session-based traces.

## :green_heart: How did you test it?
- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test --tests='io.sentry.BaggageTest' --tests='io.sentry.TransactionContextTest'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
Continue the Session based Traces for Mobile stack.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.

