### PR TITLE
feat(tombstones): Add option to attach raw tombstone as protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Add option to attach raw tombstone protobuf on native crash events ([#5446](https://github.com/getsentry/sentry-java/pull/5446))
-  - Enable via `options.isAttachTombstone = true` or manifest: `<meta-data android:name="io.sentry.tombstone.attach" android:value="true" />`
+  - Enable via `options.isAttachRawTombstone = true` or manifest: `<meta-data android:name="io.sentry.tombstone.attach-raw" android:value="true" />`
 - Add support to configure reporting historical ANRs via `AndroidManifest.xml` using the  `io.sentry.anr.report-historical` attribute ([#5387](https://github.com/getsentry/sentry-java/pull/5387))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add option to attach raw tombstone protobuf on native crash events ([#5446](https://github.com/getsentry/sentry-java/pull/5446))
+  - Enable via `options.isAttachTombstone = true` or manifest: `<meta-data android:name="io.sentry.tombstone.attach" android:value="true" />`
 - Add support to configure reporting historical ANRs via `AndroidManifest.xml` using the  `io.sentry.anr.report-historical` attribute ([#5387](https://github.com/getsentry/sentry-java/pull/5387))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add option to attach raw tombstone protobuf on native crash events ([#5446](https://github.com/getsentry/sentry-java/pull/5446))
 - Add support to configure reporting historical ANRs via `AndroidManifest.xml` using the  `io.sentry.anr.report-historical` attribute ([#5387](https://github.com/getsentry/sentry-java/pull/5387))
 
 ### Dependencies

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -375,6 +375,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isAnrReportInDebug ()Z
 	public fun isAttachAnrThreadDump ()Z
 	public fun isAttachScreenshot ()Z
+	public fun isAttachTombstone ()Z
 	public fun isAttachViewHierarchy ()Z
 	public fun isCollectAdditionalContext ()Z
 	public fun isCollectExternalStorageContext ()Z
@@ -402,6 +403,7 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setAnrTimeoutIntervalMillis (J)V
 	public fun setAttachAnrThreadDump (Z)V
 	public fun setAttachScreenshot (Z)V
+	public fun setAttachTombstone (Z)V
 	public fun setAttachViewHierarchy (Z)V
 	public fun setBeforeScreenshotCaptureCallback (Lio/sentry/android/core/SentryAndroidOptions$BeforeCaptureCallback;)V
 	public fun setBeforeViewHierarchyCaptureCallback (Lio/sentry/android/core/SentryAndroidOptions$BeforeCaptureCallback;)V

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -374,8 +374,8 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isAnrProfilingEnabled ()Z
 	public fun isAnrReportInDebug ()Z
 	public fun isAttachAnrThreadDump ()Z
+	public fun isAttachRawTombstone ()Z
 	public fun isAttachScreenshot ()Z
-	public fun isAttachTombstone ()Z
 	public fun isAttachViewHierarchy ()Z
 	public fun isCollectAdditionalContext ()Z
 	public fun isCollectExternalStorageContext ()Z
@@ -402,8 +402,8 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setAnrReportInDebug (Z)V
 	public fun setAnrTimeoutIntervalMillis (J)V
 	public fun setAttachAnrThreadDump (Z)V
+	public fun setAttachRawTombstone (Z)V
 	public fun setAttachScreenshot (Z)V
-	public fun setAttachTombstone (Z)V
 	public fun setAttachViewHierarchy (Z)V
 	public fun setBeforeScreenshotCaptureCallback (Lio/sentry/android/core/SentryAndroidOptions$BeforeCaptureCallback;)V
 	public fun setBeforeViewHierarchyCaptureCallback (Lio/sentry/android/core/SentryAndroidOptions$BeforeCaptureCallback;)V

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -18,6 +18,7 @@ import io.sentry.SentryOptions;
 import io.sentry.android.core.cache.AndroidEnvelopeCache;
 import io.sentry.android.core.internal.threaddump.Lines;
 import io.sentry.android.core.internal.threaddump.ThreadDumpParser;
+import io.sentry.android.core.internal.util.NativeEventUtils;
 import io.sentry.hints.AbnormalExit;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.BlockingFlushHint;
@@ -32,7 +33,6 @@ import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -194,7 +194,7 @@ public class AnrV2Integration implements Integration, Closeable {
         if (trace == null) {
           return new ParseResult(ParseResult.Type.NO_DUMP);
         }
-        dump = getDumpBytes(trace);
+        dump = NativeEventUtils.readBytes(trace);
       } catch (Throwable e) {
         options.getLogger().log(SentryLevel.WARNING, "Failed to read ANR thread dump", e);
         return new ParseResult(ParseResult.Type.NO_DUMP);
@@ -221,20 +221,6 @@ public class AnrV2Integration implements Integration, Closeable {
       } catch (Throwable e) {
         options.getLogger().log(SentryLevel.WARNING, "Failed to parse ANR thread dump", e);
         return new ParseResult(ParseResult.Type.ERROR, dump);
-      }
-    }
-
-    private byte[] getDumpBytes(final @NotNull InputStream trace) throws IOException {
-      try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
-
-        int nRead;
-        final byte[] data = new byte[1024];
-
-        while ((nRead = trace.read(data, 0, data.length)) != -1) {
-          buffer.write(data, 0, nRead);
-        }
-
-        return buffer.toByteArray();
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -36,7 +36,7 @@ final class ManifestMetadataReader {
   static final String ANR_REPORT_HISTORICAL = "io.sentry.anr.report-historical";
 
   static final String TOMBSTONE_ENABLE = "io.sentry.tombstone.enable";
-  static final String TOMBSTONE_ATTACH = "io.sentry.tombstone.attach";
+  static final String TOMBSTONE_ATTACH_RAW = "io.sentry.tombstone.attach-raw";
 
   static final String AUTO_INIT = "io.sentry.auto-init";
   static final String NDK_ENABLE = "io.sentry.ndk.enable";
@@ -227,8 +227,8 @@ final class ManifestMetadataReader {
         options.setAnrEnabled(readBool(metadata, logger, ANR_ENABLE, options.isAnrEnabled()));
         options.setTombstoneEnabled(
             readBool(metadata, logger, TOMBSTONE_ENABLE, options.isTombstoneEnabled()));
-        options.setAttachTombstone(
-            readBool(metadata, logger, TOMBSTONE_ATTACH, options.isAttachTombstone()));
+        options.setAttachRawTombstone(
+            readBool(metadata, logger, TOMBSTONE_ATTACH_RAW, options.isAttachRawTombstone()));
 
         // use enableAutoSessionTracking as fallback
         options.setEnableAutoSessionTracking(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -36,6 +36,7 @@ final class ManifestMetadataReader {
   static final String ANR_REPORT_HISTORICAL = "io.sentry.anr.report-historical";
 
   static final String TOMBSTONE_ENABLE = "io.sentry.tombstone.enable";
+  static final String TOMBSTONE_ATTACH = "io.sentry.tombstone.attach";
 
   static final String AUTO_INIT = "io.sentry.auto-init";
   static final String NDK_ENABLE = "io.sentry.ndk.enable";
@@ -226,6 +227,8 @@ final class ManifestMetadataReader {
         options.setAnrEnabled(readBool(metadata, logger, ANR_ENABLE, options.isAnrEnabled()));
         options.setTombstoneEnabled(
             readBool(metadata, logger, TOMBSTONE_ENABLE, options.isTombstoneEnabled()));
+        options.setAttachTombstone(
+            readBool(metadata, logger, TOMBSTONE_ATTACH, options.isAttachTombstone()));
 
         // use enableAutoSessionTracking as fallback
         options.setEnableAutoSessionTracking(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -238,6 +238,12 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   private boolean attachAnrThreadDump = false;
 
+  /**
+   * Controls whether to send raw tombstone as an attachment with plain text. The tombstone is being
+   * attached from {@link ApplicationExitInfo#getTraceInputStream()}, if available.
+   */
+  private boolean attachTombstone = false;
+
   private boolean enablePerformanceV2 = true;
 
   private @Nullable SentryFrameMetricsCollector frameMetricsCollector;
@@ -641,6 +647,14 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   public void setAttachAnrThreadDump(final boolean attachAnrThreadDump) {
     this.attachAnrThreadDump = attachAnrThreadDump;
+  }
+
+  public boolean isAttachTombstone() {
+    return attachTombstone;
+  }
+
+  public void setAttachTombstone(final boolean attachTombstone) {
+    this.attachTombstone = attachTombstone;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -242,7 +242,7 @@ public final class SentryAndroidOptions extends SentryOptions {
    * Controls whether to send raw tombstone as an attachment with plain text. The tombstone is being
    * attached from {@link ApplicationExitInfo#getTraceInputStream()}, if available.
    */
-  private boolean attachTombstone = false;
+  private boolean attachRawTombstone = false;
 
   private boolean enablePerformanceV2 = true;
 
@@ -649,12 +649,12 @@ public final class SentryAndroidOptions extends SentryOptions {
     this.attachAnrThreadDump = attachAnrThreadDump;
   }
 
-  public boolean isAttachTombstone() {
-    return attachTombstone;
+  public boolean isAttachRawTombstone() {
+    return attachRawTombstone;
   }
 
-  public void setAttachTombstone(final boolean attachTombstone) {
-    this.attachTombstone = attachTombstone;
+  public void setAttachRawTombstone(final boolean attachRawTombstone) {
+    this.attachRawTombstone = attachRawTombstone;
   }
 
   /**

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -239,7 +239,7 @@ public final class SentryAndroidOptions extends SentryOptions {
   private boolean attachAnrThreadDump = false;
 
   /**
-   * Controls whether to send raw tombstone as an attachment with plain text. The tombstone is being
+   * Controls whether to attach the raw tombstone protobuf as an attachment. The tombstone is being
    * attached from {@link ApplicationExitInfo#getTraceInputStream()}, if available.
    */
   private boolean attachRawTombstone = false;

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -195,7 +195,7 @@ public class TombstoneIntegration implements Integration, Closeable {
               options.getFlushTimeoutMillis(), options.getLogger(), tombstoneTimestamp, enrich);
       final Hint hint = HintUtils.createWithTypeCheckHint(tombstoneHint);
 
-      if (options.isAttachTombstone()) {
+      if (options.isAttachRawTombstone()) {
         hint.setTombstone(Attachment.fromTombstone(rawTombstone));
       }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -36,6 +36,8 @@ import io.sentry.transport.CurrentDateProvider;
 import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -150,6 +152,7 @@ public class TombstoneIntegration implements Integration, Closeable {
     public @Nullable ApplicationExitInfoHistoryDispatcher.Report buildReport(
         final @NotNull ApplicationExitInfo exitInfo, final boolean enrich) {
       SentryEvent event;
+      final byte[] rawTombstone;
       try {
         final InputStream tombstoneInputStream = exitInfo.getTraceInputStream();
         if (tombstoneInputStream == null) {
@@ -163,9 +166,11 @@ public class TombstoneIntegration implements Integration, Closeable {
           return null;
         }
 
+        rawTombstone = readBytes(tombstoneInputStream);
+
         try (final TombstoneParser parser =
             new TombstoneParser(
-                tombstoneInputStream,
+                new ByteArrayInputStream(rawTombstone),
                 this.options.getInAppIncludes(),
                 this.options.getInAppExcludes(),
                 this.context.getApplicationInfo().nativeLibraryDir)) {
@@ -189,6 +194,10 @@ public class TombstoneIntegration implements Integration, Closeable {
           new TombstoneHint(
               options.getFlushTimeoutMillis(), options.getLogger(), tombstoneTimestamp, enrich);
       final Hint hint = HintUtils.createWithTypeCheckHint(tombstoneHint);
+
+      if (options.isAttachTombstone()) {
+        hint.setTombstone(Attachment.fromTombstone(rawTombstone));
+      }
 
       try {
         final @Nullable SentryEvent mergedEvent =
@@ -302,6 +311,17 @@ public class TombstoneIntegration implements Integration, Closeable {
         nativeEvent.setExceptions(tombstoneExceptions);
         nativeEvent.setDebugMeta(tombstoneDebugMeta);
         nativeEvent.setThreads(tombstoneThreads);
+      }
+    }
+
+    private byte[] readBytes(final @NotNull InputStream stream) throws IOException {
+      try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+        int nRead;
+        final byte[] data = new byte[1024];
+        while ((nRead = stream.read(data, 0, data.length)) != -1) {
+          buffer.write(data, 0, nRead);
+        }
+        return buffer.toByteArray();
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -154,19 +154,20 @@ public class TombstoneIntegration implements Integration, Closeable {
       SentryEvent event;
       final byte[] rawTombstone;
       try {
-        final InputStream tombstoneInputStream = exitInfo.getTraceInputStream();
-        if (tombstoneInputStream == null) {
-          options
-              .getLogger()
-              .log(
-                  SentryLevel.WARNING,
-                  "No tombstone InputStream available for ApplicationExitInfo from %s",
-                  DateTimeFormatter.ISO_INSTANT.format(
-                      Instant.ofEpochMilli(exitInfo.getTimestamp())));
-          return null;
-        }
+        try (final InputStream tombstoneInputStream = exitInfo.getTraceInputStream()) {
+          if (tombstoneInputStream == null) {
+            options
+                .getLogger()
+                .log(
+                    SentryLevel.WARNING,
+                    "No tombstone InputStream available for ApplicationExitInfo from %s",
+                    DateTimeFormatter.ISO_INSTANT.format(
+                        Instant.ofEpochMilli(exitInfo.getTimestamp())));
+            return null;
+          }
 
-        rawTombstone = readBytes(tombstoneInputStream);
+          rawTombstone = readBytes(tombstoneInputStream);
+        }
 
         try (final TombstoneParser parser =
             new TombstoneParser(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -152,7 +152,7 @@ public class TombstoneIntegration implements Integration, Closeable {
     public @Nullable ApplicationExitInfoHistoryDispatcher.Report buildReport(
         final @NotNull ApplicationExitInfo exitInfo, final boolean enrich) {
       SentryEvent event;
-      final byte[] rawTombstone;
+      @Nullable byte[] rawTombstone = null;
       try {
         try (final InputStream tombstoneInputStream = exitInfo.getTraceInputStream()) {
           if (tombstoneInputStream == null) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -24,6 +24,7 @@ import io.sentry.android.core.NativeEventCollector.NativeEventData;
 import io.sentry.android.core.cache.AndroidEnvelopeCache;
 import io.sentry.android.core.internal.tombstone.NativeExceptionMechanism;
 import io.sentry.android.core.internal.tombstone.TombstoneParser;
+import io.sentry.android.core.internal.util.NativeEventUtils;
 import io.sentry.hints.Backfillable;
 import io.sentry.hints.BlockingFlushHint;
 import io.sentry.hints.NativeCrashExit;
@@ -37,7 +38,6 @@ import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.HintUtils;
 import io.sentry.util.Objects;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -166,7 +166,7 @@ public class TombstoneIntegration implements Integration, Closeable {
             return null;
           }
 
-          rawTombstone = readBytes(tombstoneInputStream);
+          rawTombstone = NativeEventUtils.readBytes(tombstoneInputStream);
         }
 
         try (final TombstoneParser parser =
@@ -312,17 +312,6 @@ public class TombstoneIntegration implements Integration, Closeable {
         nativeEvent.setExceptions(tombstoneExceptions);
         nativeEvent.setDebugMeta(tombstoneDebugMeta);
         nativeEvent.setThreads(tombstoneThreads);
-      }
-    }
-
-    private byte[] readBytes(final @NotNull InputStream stream) throws IOException {
-      try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
-        int nRead;
-        final byte[] data = new byte[1024];
-        while ((nRead = stream.read(data, 0, data.length)) != -1) {
-          buffer.write(data, 0, nRead);
-        }
-        return buffer.toByteArray();
       }
     }
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -154,6 +154,7 @@ public class TombstoneIntegration implements Integration, Closeable {
       SentryEvent event;
       @Nullable byte[] rawTombstone = null;
       try {
+        final boolean attachRaw = options.isAttachRawTombstone();
         try (final InputStream tombstoneInputStream = exitInfo.getTraceInputStream()) {
           if (tombstoneInputStream == null) {
             options
@@ -166,16 +167,20 @@ public class TombstoneIntegration implements Integration, Closeable {
             return null;
           }
 
-          rawTombstone = NativeEventUtils.readBytes(tombstoneInputStream);
-        }
+          if (attachRaw) {
+            rawTombstone = NativeEventUtils.readBytes(tombstoneInputStream);
+          }
 
-        try (final TombstoneParser parser =
-            new TombstoneParser(
-                new ByteArrayInputStream(rawTombstone),
-                this.options.getInAppIncludes(),
-                this.options.getInAppExcludes(),
-                this.context.getApplicationInfo().nativeLibraryDir)) {
-          event = parser.parse();
+          final InputStream parserInput =
+              attachRaw ? new ByteArrayInputStream(rawTombstone) : tombstoneInputStream;
+          try (final TombstoneParser parser =
+              new TombstoneParser(
+                  parserInput,
+                  this.options.getInAppIncludes(),
+                  this.options.getInAppExcludes(),
+                  this.context.getApplicationInfo().nativeLibraryDir)) {
+            event = parser.parse();
+          }
         }
       } catch (Throwable e) {
         options
@@ -196,7 +201,7 @@ public class TombstoneIntegration implements Integration, Closeable {
               options.getFlushTimeoutMillis(), options.getLogger(), tombstoneTimestamp, enrich);
       final Hint hint = HintUtils.createWithTypeCheckHint(tombstoneHint);
 
-      if (options.isAttachRawTombstone()) {
+      if (rawTombstone != null) {
         hint.setTombstone(Attachment.fromTombstone(rawTombstone));
       }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/NativeEventUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/NativeEventUtils.java
@@ -1,5 +1,8 @@
 package io.sentry.android.core.internal.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -8,6 +11,18 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class NativeEventUtils {
+
+  public static byte[] readBytes(final @NotNull InputStream stream) throws IOException {
+    try (final ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+      int nRead;
+      final byte[] data = new byte[1024];
+      while ((nRead = stream.read(data, 0, data.length)) != -1) {
+        buffer.write(data, 0, nRead);
+      }
+      return buffer.toByteArray();
+    }
+  }
+
   @Nullable
   public static String buildIdToDebugId(final @NotNull String buildId) {
     try {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -289,6 +289,31 @@ class ManifestMetadataReaderTest {
   }
 
   @Test
+  fun `applyMetadata reads tombstone attach raw to options`() {
+    // Arrange
+    val bundle = bundleOf(ManifestMetadataReader.TOMBSTONE_ATTACH_RAW to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(true, fixture.options.isAttachRawTombstone)
+  }
+
+  @Test
+  fun `applyMetadata reads tombstone attach raw to options and keeps default`() {
+    // Arrange
+    val context = fixture.getContext()
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(false, fixture.options.isAttachRawTombstone)
+  }
+
+  @Test
   fun `applyMetadata reads anr report historical to options`() {
     // Arrange
     val bundle = bundleOf(ManifestMetadataReader.ANR_REPORT_HISTORICAL to true)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
@@ -132,11 +132,7 @@ class TombstoneIntegrationTest : ApplicationExitIntegrationTestBase<TombstoneHin
 
     integration.register(fixture.scopes, fixture.options)
 
-    verify(fixture.scopes)
-      .captureEvent(
-        any(),
-        argThat<Hint> { this.tombstone == null },
-      )
+    verify(fixture.scopes).captureEvent(any(), argThat<Hint> { this.tombstone == null })
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
@@ -97,6 +97,49 @@ class TombstoneIntegrationTest : ApplicationExitIntegrationTestBase<TombstoneHin
   }
 
   @Test
+  fun `when attachRawTombstone is enabled, raw tombstone is attached to hint`() {
+    val integration =
+      fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp) { options ->
+        options.isAttachRawTombstone = true
+      }
+
+    fixture.addAppExitInfo(timestamp = newTimestamp)
+
+    integration.register(fixture.scopes, fixture.options)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        any(),
+        argThat<Hint> {
+          val tombstone = this.tombstone
+          tombstone != null &&
+            tombstone.filename == "tombstone.pb" &&
+            tombstone.contentType == "application/x-protobuf" &&
+            tombstone.bytes != null &&
+            tombstone.bytes!!.isNotEmpty()
+        },
+      )
+  }
+
+  @Test
+  fun `when attachRawTombstone is disabled, no tombstone is attached to hint`() {
+    val integration =
+      fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp) { options ->
+        options.isAttachRawTombstone = false
+      }
+
+    fixture.addAppExitInfo(timestamp = newTimestamp)
+
+    integration.register(fixture.scopes, fixture.options)
+
+    verify(fixture.scopes)
+      .captureEvent(
+        any(),
+        argThat<Hint> { this.tombstone == null },
+      )
+  }
+
+  @Test
   fun `when matching native event has attachments, they are added to the hint`() {
     val integration =
       fixture.getSut(tmpDir, lastReportedTimestamp = oldTimestamp) { options ->

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -19,6 +19,7 @@ public final class io/sentry/Attachment {
 	public static fun fromByteProvider (Ljava/util/concurrent/Callable;Ljava/lang/String;Ljava/lang/String;Z)Lio/sentry/Attachment;
 	public static fun fromScreenshot ([B)Lio/sentry/Attachment;
 	public static fun fromThreadDump ([B)Lio/sentry/Attachment;
+	public static fun fromTombstone ([B)Lio/sentry/Attachment;
 	public static fun fromViewHierarchy (Lio/sentry/protocol/ViewHierarchy;)Lio/sentry/Attachment;
 	public fun getAttachmentType ()Ljava/lang/String;
 	public fun getByteProvider ()Ljava/util/concurrent/Callable;
@@ -613,6 +614,7 @@ public final class io/sentry/Hint {
 	public fun getReplayRecording ()Lio/sentry/ReplayRecording;
 	public fun getScreenshot ()Lio/sentry/Attachment;
 	public fun getThreadDump ()Lio/sentry/Attachment;
+	public fun getTombstone ()Lio/sentry/Attachment;
 	public fun getViewHierarchy ()Lio/sentry/Attachment;
 	public fun remove (Ljava/lang/String;)V
 	public fun replaceAttachments (Ljava/util/List;)V
@@ -620,6 +622,7 @@ public final class io/sentry/Hint {
 	public fun setReplayRecording (Lio/sentry/ReplayRecording;)V
 	public fun setScreenshot (Lio/sentry/Attachment;)V
 	public fun setThreadDump (Lio/sentry/Attachment;)V
+	public fun setTombstone (Lio/sentry/Attachment;)V
 	public fun setViewHierarchy (Lio/sentry/Attachment;)V
 	public static fun withAttachment (Lio/sentry/Attachment;)Lio/sentry/Hint;
 	public static fun withAttachments (Ljava/util/List;)Lio/sentry/Hint;

--- a/sentry/src/main/java/io/sentry/Attachment.java
+++ b/sentry/src/main/java/io/sentry/Attachment.java
@@ -396,4 +396,14 @@ public final class Attachment {
   public static @NotNull Attachment fromThreadDump(final byte[] bytes) {
     return new Attachment(bytes, "thread-dump.txt", "text/plain", false);
   }
+
+  /**
+   * Creates a new Tombstone Attachment
+   *
+   * @param bytes the array bytes
+   * @return the Attachment
+   */
+  public static @NotNull Attachment fromTombstone(final byte[] bytes) {
+    return new Attachment(bytes, "tombstone.pb", "application/x-protobuf", false);
+  }
 }

--- a/sentry/src/main/java/io/sentry/Hint.java
+++ b/sentry/src/main/java/io/sentry/Hint.java
@@ -32,6 +32,7 @@ public final class Hint {
   private @Nullable Attachment screenshot = null;
   private @Nullable Attachment viewHierarchy = null;
   private @Nullable Attachment threadDump = null;
+  private @Nullable Attachment tombstone = null;
   private @Nullable ReplayRecording replayRecording = null;
 
   public static @NotNull Hint withAttachment(@Nullable Attachment attachment) {
@@ -145,6 +146,14 @@ public final class Hint {
 
   public @Nullable Attachment getThreadDump() {
     return threadDump;
+  }
+
+  public void setTombstone(final @Nullable Attachment tombstone) {
+    this.tombstone = tombstone;
+  }
+
+  public @Nullable Attachment getTombstone() {
+    return tombstone;
   }
 
   @Nullable

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -399,6 +399,11 @@ public final class SentryClient implements ISentryClient {
       attachments.add(threadDump);
     }
 
+    @Nullable final Attachment tombstone = hint.getTombstone();
+    if (tombstone != null) {
+      attachments.add(tombstone);
+    }
+
     return attachments;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -2136,9 +2136,7 @@ class SentryClientTest {
       .send(
         check { envelope ->
           val tombstone = envelope.items.last()
-          assertNotNull(tombstone) {
-            assertEquals(attachment.filename, tombstone.header.fileName)
-          }
+          assertNotNull(tombstone) { assertEquals(attachment.filename, tombstone.header.fileName) }
         },
         anyOrNull(),
       )

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -2125,6 +2125,39 @@ class SentryClientTest {
   }
 
   @Test
+  fun `tombstone is added to the envelope from the hint`() {
+    val sut = fixture.getSut()
+    val attachment = Attachment.fromTombstone(byteArrayOf())
+    val hint = Hint().also { it.tombstone = attachment }
+
+    sut.captureEvent(SentryEvent(), hint)
+
+    verify(fixture.transport)
+      .send(
+        check { envelope ->
+          val tombstone = envelope.items.last()
+          assertNotNull(tombstone) {
+            assertEquals(attachment.filename, tombstone.header.fileName)
+          }
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
+  fun `tombstone is dropped from hint via before send`() {
+    fixture.sentryOptions.beforeSend = CustomBeforeSendCallback()
+    val sut = fixture.getSut()
+    val attachment = Attachment.fromTombstone(byteArrayOf())
+    val hint = Hint().also { it.tombstone = attachment }
+
+    sut.captureEvent(SentryEvent(), hint)
+
+    verify(fixture.transport)
+      .send(check { envelope -> assertEquals(1, envelope.items.count()) }, anyOrNull())
+  }
+
+  @Test
   fun `capturing an error updates session and sends event + session`() {
     val sut = fixture.getSut()
     val scope = givenScopeWithStartedSession()
@@ -3647,6 +3680,7 @@ class SentryClientTest {
       hint.screenshot = null
       hint.viewHierarchy = null
       hint.threadDump = null
+      hint.tombstone = null
       return event
     }
   }

--- a/sentry/src/test/java/io/sentry/hints/HintTest.kt
+++ b/sentry/src/test/java/io/sentry/hints/HintTest.kt
@@ -210,6 +210,7 @@ class HintTest {
     hint.screenshot = newAttachment("2")
     hint.viewHierarchy = newAttachment("3")
     hint.threadDump = newAttachment("4")
+    hint.tombstone = newAttachment("5")
 
     hint.clear()
 
@@ -219,6 +220,7 @@ class HintTest {
     assertNotNull(hint.screenshot)
     assertNotNull(hint.viewHierarchy)
     assertNotNull(hint.threadDump)
+    assertNotNull(hint.tombstone)
   }
 
   @Test
@@ -246,6 +248,15 @@ class HintTest {
     hint.threadDump = attachment
 
     assertNotNull(hint.threadDump)
+  }
+
+  @Test
+  fun `can create hint with a tombstone`() {
+    val hint = Hint()
+    val attachment = newAttachment("tombstone")
+    hint.tombstone = attachment
+
+    assertNotNull(hint.tombstone)
   }
 
   companion object {


### PR DESCRIPTION
## :scroll: Description

Adds a new `attachRawTombstone` option (default `false`) that attaches the raw tombstone protobuf from `ApplicationExitInfo.getTraceInputStream()` as an attachment on native crash events.

Changes:
- `Hint.java`: Added `tombstone` field with getter/setter
- `Attachment.java`: Added `fromTombstone(byte[])` factory method (`tombstone.pb`, `application/x-protobuf`)
- `SentryClient.java`: Retrieves tombstone from hint and adds to envelope attachments
- `SentryAndroidOptions.java`: Added `attachRawTombstone` boolean option with getter/setter
- `TombstoneIntegration.java`: Buffers raw bytes from the trace InputStream before parsing, attaches when option is enabled
- `ManifestMetadataReader.java`: Added `io.sentry.tombstone.attach-raw` manifest meta-data option

### Usage

**Kotlin (programmatic):**
```kotlin
SentryAndroid.init(context) { options ->
    options.isAttachRawTombstone = true
}
```

**AndroidManifest.xml:**
```xml
<meta-data
    android:name="io.sentry.tombstone.attach-raw"
    android:value="true" />
```

## :bulb: Motivation and Context

Allows users to get the raw tombstone protobuf alongside the parsed native crash event, useful for deeper post-mortem analysis.

## :green_heart: How did you test it?

Manually tested on a physical device (HMD Pulse, Android 15) by triggering a native crash in the sample app and verifying the tombstone attachment is present.

https://sentry-sdks.sentry.io/issues/7229399848/events/1e81d1e1ed9a400b78e1be7811776a18/

Downloaded the raw tombstone file and verified it can be correctly parsed and viewed via `protoc`:

[tombstone.txt](https://github.com/user-attachments/files/27974268/tombstone.txt)

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- Update docs