### PR TITLE
chore(ci): Skip Spring Boot tests when updating Android modules

### DIFF
--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*android*/**'
-      - 'sentry-compose/**'
-      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
     paths-ignore:
       - '*android*/**'

--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*android*/**'
-      - 'sentry-compose/**'
-      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
     paths-ignore:
       - '*android*/**'

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*android*/**'
-      - 'sentry-compose/**'
-      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
     paths-ignore:
       - '*android*/**'

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## :scroll: Description

Android-only PRs were silently triggering 14 unrelated Spring Boot matrix jobs (up to 45 min each) on every push and PR. The `pull_request `trigger had no path filter at all, and the `push` filter only matched one of the ~10 Android modules. 

This PR adds a pull_request paths-ignore for all Android directories (and related paths). Spring Boot CI is skipped on Android-only PRs; every push to main still runs the full matrix (in line with @runningcode's review).


## Quantifying the win

<img width="632" height="266" alt="Per PR savings" src="https://github.com/user-attachments/assets/21b2c02c-0462-448d-b5f7-96d63624b905" />


## :bulb: Motivation and Context

@runningcode rightly pointed out that our CI times were obnoxiously long and got us to look for easy wins to shorten them. This is one. (Thanks @runningcode 💯)

addresses: JAVA-510

## :green_heart: How did you test it?

CI configuration only — no code behaviour changed. Verified glob semantics: `sentry-android*/**` is anchored to the repo root and correctly covers all `sentry-android-*` top-level directories.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog