### PR TITLE
chore(ci): Skip backend system tests when updating Android modules

### DIFF
--- a/.github/workflows/system-tests-backend.yml
+++ b/.github/workflows/system-tests-backend.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*android*/**'
-      - 'sentry-compose/**'
-      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
     paths-ignore:
       - '*android*/**'

--- a/.github/workflows/system-tests-backend.yml
+++ b/.github/workflows/system-tests-backend.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## :scroll: Description

Android-only PRs were silently triggering 24 unrelated backend system test jobs (up to 10 min each). This update lets us skip those jobs when we don't need them.

Every push to main still runs the full matrix (in line with @runningcode's review).

## Quantifying the win

[
<img width="625" height="118" alt="Per PR savings" src="https://github.com/user-attachments/assets/42e5473a-39bd-4f39-90dd-4538fab3d6f4" />
](url)

## :bulb: Motivation and Context

Follow-up to #5453, which fixed the same issue for the Spring Boot matrix workflows.

addresses: JAVA-519

## :green_heart: How did you test it?

CI configuration only — no code behaviour changed. Verified glob semantics: `*android*/**` is anchored to the repo root and matches any top-level directory whose name contains "android".

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog