### PR TITLE
[DNM] ci(spring-boot): Parallelize Spring Boot matrix builds (JAVA-510)

### DIFF
--- a/.github/workflows/spring-boot-2-matrix.yml
+++ b/.github/workflows/spring-boot-2-matrix.yml
@@ -5,23 +5,248 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  spring-boot-2-matrix:
-    timeout-minutes: 45
+  spring-boot-2-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: echo 'matrix=["2.1.0","2.2.5","2.4.13","2.5.15","2.6.15","2.7.0","2.7.18"]' >> $GITHUB_OUTPUT
+
+  # One Gradle build per matrix cell → artifact sdk-build-sb2-{version} (sentry-*/build/libs,
+  # retention-days: 1, same workflow only). continue-on-error: without it, one failed version
+  # skips the entire spring-boot-2-matrix job (needs is job-level). Triage: spring-boot-2-matrix.
+  spring-boot-2-build:
+    needs: [spring-boot-2-versions]
+    continue-on-error: true
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '2.1.0', '2.2.5', '2.4.13', '2.5.15', '2.6.15', '2.7.0', '2.7.18' ]
+        springboot-version: ${{ fromJSON(needs.spring-boot-2-versions.outputs.matrix) }}
 
-    name: Spring Boot ${{ matrix.springboot-version }}
+    name: Build Spring Boot ${{ matrix.springboot-version }}
+    env:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Workaround for https://github.com/gradle/actions/issues/21 to use config cache
+      - name: Cache buildSrc
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: buildSrc/build
+          key: build-logic-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts','buildSrc/settings.gradle.kts') }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 2.x version
+        run: |
+          sed -i 's/^springboot2=.*/springboot2=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+          echo "Updated Spring Boot 2.x version to ${{ matrix.springboot-version }}"
+
+      - name: Exclude android modules from build
+        run: |
+          sed -i \
+            -e '/.*"sentry-android-ndk",/d' \
+            -e '/.*"sentry-android",/d' \
+            -e '/.*"sentry-compose",/d' \
+            -e '/.*"sentry-android-core",/d' \
+            -e '/.*"sentry-android-fragment",/d' \
+            -e '/.*"sentry-android-navigation",/d' \
+            -e '/.*"sentry-android-sqlite",/d' \
+            -e '/.*"sentry-android-timber",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
+            -e '/.*"sentry-samples:sentry-samples-android",/d' \
+            -e '/.*"sentry-android-replay",/d' \
+            settings.gradle.kts
+
+      - name: Exclude android modules from ignore list
+        run: |
+          sed -i \
+            -e '/.*"sentry-uitest-android",/d' \
+            -e '/.*"sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-uitest-android-critical",/d' \
+            -e '/.*"test-app-sentry",/d' \
+            -e '/.*"test-app-size",/d' \
+            -e '/.*"sentry-samples-android",/d' \
+            build.gradle.kts
+
+      - name: Build SDK and samples
+        run: |
+          ./gradlew assemble \
+            :sentry-samples:sentry-samples-spring-boot:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry:shadowJar \
+            :sentry-samples:sentry-samples-spring-boot-opentelemetry-noagent:shadowJar \
+            --parallel
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sdk-build-sb2-${{ matrix.springboot-version }}
+          path: |
+            sentry-*/**/build/libs/*.jar
+          retention-days: 1
+
+  # System tests per (springboot-version × sample config). Uses sdk-build-sb2-{version} at
+  # workspace root (download path: .) and test/system-test-runner.py with --build false.
+  # Failure triage: (1) spring-boot-2-build cell for that version, (2) Download build artifact,
+  # (3) Run system test / spring-server.txt / test-results. Build job may be green while
+  # version cells are red (continue-on-error); failed builds fail here, not as skipped jobs.
+  spring-boot-2-matrix:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: [spring-boot-2-build, spring-boot-2-versions]
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-2-versions.outputs.matrix) }}
+        config:
+          - { sample: "sentry-samples-spring-boot", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-webflux", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-opentelemetry", agent: "true", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-opentelemetry", agent: "true", auto_init: "false" }
+          - { sample: "sentry-samples-spring-boot-opentelemetry-noagent", agent: "false", auto_init: "true" }
+
+    name: Spring Boot ${{ matrix.springboot-version }} - ${{ matrix.config.sample }} (agent=${{ matrix.config.agent }}, auto-init=${{ matrix.config.auto_init }})
+    env:
+      SENTRY_URL: http://127.0.0.1:8000
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.10.5'
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 2.x version
+        run: |
+          sed -i 's/^springboot2=.*/springboot2=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: sdk-build-sb2-${{ matrix.springboot-version }}
+          path: .
+
+      # Guard against a confusing silent failure: if the agent JAR is absent,
+      # ensure_agent_jar() in the test runner falls back to building it via Gradle
+      # without the Spring Boot version pin or android exclusions applied — a slow,
+      # misconfigured build that will likely time out. Fail fast and clearly instead.
+      - name: Verify agent JAR present in artifact
+        if: matrix.config.agent == 'true'
+        run: |
+          jar=$(find sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/ \
+                -name "*agent*.jar" \
+                ! -name "*dontuse*" ! -name "*sources*" ! -name "*javadoc*" \
+                -print -quit 2>/dev/null)
+          if [ -z "$jar" ]; then
+            echo "ERROR: agent JAR not found in downloaded artifact."
+            echo "Expected: sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/*agent*.jar"
+            echo "Check that the build job's artifact upload completed successfully."
+            exit 1
+          fi
+          echo "Agent JAR found: $jar"
+
+      - name: Run system test
+        run: |
+          python3 test/system-test-runner.py test \
+            --module "${{ matrix.config.sample }}" \
+            --agent "${{ matrix.config.agent }}" \
+            --auto-init "${{ matrix.config.auto_init }}" \
+            --build "false"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-results-springboot-2-${{ matrix.springboot-version }}-${{ matrix.config.sample }}-agent${{ matrix.config.agent }}-init${{ matrix.config.auto_init }}
+          path: |
+            **/build/reports/*
+            **/build/test-results/**/*.xml
+            sentry-mock-server.txt
+            spring-server.txt
+
+      - name: Test Report
+        uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
+        if: always()
+        with:
+          name: JUnit Spring Boot 2.x ${{ matrix.springboot-version }} ${{ matrix.config.sample }}
+          path: |
+            **/build/test-results/**/*.xml
+          reporter: java-junit
+          output-to: step-summary
+          fail-on-error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: '**/build/test-results/**/*.xml'
+
+  spring-boot-2-war:
+    needs: [spring-boot-2-versions]
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-2-versions.outputs.matrix) }}
+
+    name: Spring Boot ${{ matrix.springboot-version }} - sentry-samples-spring (agent=false, auto-init=true)
     env:
       SENTRY_URL: http://127.0.0.1:8000
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -100,51 +325,11 @@ jobs:
         run: |
           ./gradlew assemble --parallel
 
-      - name: Test sentry-samples-spring-boot
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-webflux
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-webflux" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-opentelemetry agent init true
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-opentelemetry" \
-            --agent true \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-opentelemetry agent init false
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-opentelemetry" \
-            --agent true \
-            --auto-init "false" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-opentelemetry-noagent
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-opentelemetry-noagent" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring
+      - name: Run system test
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring" \
-            --agent false \
+            --agent "false" \
             --auto-init "true" \
             --build "true"
 
@@ -152,7 +337,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-results-springboot-2-${{ matrix.springboot-version }}
+          name: test-results-springboot-2-${{ matrix.springboot-version }}-sentry-samples-spring-agentfalse-inittrue
           path: |
             **/build/reports/*
             **/build/test-results/**/*.xml
@@ -163,7 +348,7 @@ jobs:
         uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
         if: always()
         with:
-          name: JUnit Spring Boot 2.x ${{ matrix.springboot-version }}
+          name: JUnit Spring Boot 2.x ${{ matrix.springboot-version }} sentry-samples-spring
           path: |
             **/build/test-results/**/*.xml
           reporter: java-junit

--- a/.github/workflows/spring-boot-3-matrix.yml
+++ b/.github/workflows/spring-boot-3-matrix.yml
@@ -5,23 +5,248 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  spring-boot-3-matrix:
-    timeout-minutes: 45
+  spring-boot-3-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: echo 'matrix=["3.0.0","3.2.12","3.3.13","3.4.13","3.5.13"]' >> $GITHUB_OUTPUT
+
+  # One Gradle build per matrix cell → artifact sdk-build-sb3-{version} (sentry-*/build/libs,
+  # retention-days: 1, same workflow only). continue-on-error: without it, one failed version
+  # skips the entire spring-boot-3-matrix job (needs is job-level). Triage: spring-boot-3-matrix.
+  spring-boot-3-build:
+    needs: [spring-boot-3-versions]
+    continue-on-error: true
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '3.0.0', '3.2.12', '3.3.13', '3.4.13', '3.5.13' ]
+        springboot-version: ${{ fromJSON(needs.spring-boot-3-versions.outputs.matrix) }}
 
-    name: Spring Boot ${{ matrix.springboot-version }}
+    name: Build Spring Boot ${{ matrix.springboot-version }}
+    env:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Workaround for https://github.com/gradle/actions/issues/21 to use config cache
+      - name: Cache buildSrc
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: buildSrc/build
+          key: build-logic-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts','buildSrc/settings.gradle.kts') }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 3.x version
+        run: |
+          sed -i 's/^springboot3=.*/springboot3=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+          echo "Updated Spring Boot 3.x version to ${{ matrix.springboot-version }}"
+
+      - name: Exclude android modules from build
+        run: |
+          sed -i \
+            -e '/.*"sentry-android-ndk",/d' \
+            -e '/.*"sentry-android",/d' \
+            -e '/.*"sentry-compose",/d' \
+            -e '/.*"sentry-android-core",/d' \
+            -e '/.*"sentry-android-fragment",/d' \
+            -e '/.*"sentry-android-navigation",/d' \
+            -e '/.*"sentry-android-sqlite",/d' \
+            -e '/.*"sentry-android-timber",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
+            -e '/.*"sentry-samples:sentry-samples-android",/d' \
+            -e '/.*"sentry-android-replay",/d' \
+            settings.gradle.kts
+
+      - name: Exclude android modules from ignore list
+        run: |
+          sed -i \
+            -e '/.*"sentry-uitest-android",/d' \
+            -e '/.*"sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-uitest-android-critical",/d' \
+            -e '/.*"test-app-sentry",/d' \
+            -e '/.*"test-app-size",/d' \
+            -e '/.*"sentry-samples-android",/d' \
+            build.gradle.kts
+
+      - name: Build SDK and samples
+        run: |
+          ./gradlew assemble \
+            :sentry-samples:sentry-samples-spring-boot-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-webflux-jakarta:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-jakarta-opentelemetry-noagent:bootJar \
+            --parallel
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sdk-build-sb3-${{ matrix.springboot-version }}
+          path: |
+            sentry-*/**/build/libs/*.jar
+          retention-days: 1
+
+  # System tests per (springboot-version × sample config). Uses sdk-build-sb3-{version} at
+  # workspace root (download path: .) and test/system-test-runner.py with --build false.
+  # Failure triage: (1) spring-boot-3-build cell for that version, (2) Download build artifact,
+  # (3) Run system test / spring-server.txt / test-results. Build job may be green while
+  # version cells are red (continue-on-error); failed builds fail here, not as skipped jobs.
+  spring-boot-3-matrix:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: [spring-boot-3-build, spring-boot-3-versions]
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-3-versions.outputs.matrix) }}
+        config:
+          - { sample: "sentry-samples-spring-boot-jakarta", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-webflux-jakarta", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-jakarta-opentelemetry", agent: "true", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-jakarta-opentelemetry", agent: "true", auto_init: "false" }
+          - { sample: "sentry-samples-spring-boot-jakarta-opentelemetry-noagent", agent: "false", auto_init: "true" }
+
+    name: Spring Boot ${{ matrix.springboot-version }} - ${{ matrix.config.sample }} (agent=${{ matrix.config.agent }}, auto-init=${{ matrix.config.auto_init }})
+    env:
+      SENTRY_URL: http://127.0.0.1:8000
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.10.5'
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 3.x version
+        run: |
+          sed -i 's/^springboot3=.*/springboot3=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: sdk-build-sb3-${{ matrix.springboot-version }}
+          path: .
+
+      # Guard against a confusing silent failure: if the agent JAR is absent,
+      # ensure_agent_jar() in the test runner falls back to building it via Gradle
+      # without the Spring Boot version pin or android exclusions applied — a slow,
+      # misconfigured build that will likely time out. Fail fast and clearly instead.
+      - name: Verify agent JAR present in artifact
+        if: matrix.config.agent == 'true'
+        run: |
+          jar=$(find sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/ \
+                -name "*agent*.jar" \
+                ! -name "*dontuse*" ! -name "*sources*" ! -name "*javadoc*" \
+                -print -quit 2>/dev/null)
+          if [ -z "$jar" ]; then
+            echo "ERROR: agent JAR not found in downloaded artifact."
+            echo "Expected: sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/*agent*.jar"
+            echo "Check that the build job's artifact upload completed successfully."
+            exit 1
+          fi
+          echo "Agent JAR found: $jar"
+
+      - name: Run system test
+        run: |
+          python3 test/system-test-runner.py test \
+            --module "${{ matrix.config.sample }}" \
+            --agent "${{ matrix.config.agent }}" \
+            --auto-init "${{ matrix.config.auto_init }}" \
+            --build "false"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-results-springboot-3-${{ matrix.springboot-version }}-${{ matrix.config.sample }}-agent${{ matrix.config.agent }}-init${{ matrix.config.auto_init }}
+          path: |
+            **/build/reports/*
+            **/build/test-results/**/*.xml
+            sentry-mock-server.txt
+            spring-server.txt
+
+      - name: Test Report
+        uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
+        if: always()
+        with:
+          name: JUnit Spring Boot 3.x ${{ matrix.springboot-version }} ${{ matrix.config.sample }}
+          path: |
+            **/build/test-results/**/*.xml
+          reporter: java-junit
+          output-to: step-summary
+          fail-on-error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: '**/build/test-results/**/*.xml'
+
+  spring-boot-3-war:
+    needs: [spring-boot-3-versions]
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-3-versions.outputs.matrix) }}
+
+    name: Spring Boot ${{ matrix.springboot-version }} - sentry-samples-spring-jakarta (agent=false, auto-init=true)
     env:
       SENTRY_URL: http://127.0.0.1:8000
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -100,51 +325,11 @@ jobs:
         run: |
           ./gradlew assemble --parallel
 
-      - name: Test sentry-samples-spring-boot-jakarta
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-jakarta" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-webflux-jakarta
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-webflux-jakarta" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-jakarta-opentelemetry agent init true
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-jakarta-opentelemetry" \
-            --agent true \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-jakarta-opentelemetry agent init false
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-jakarta-opentelemetry" \
-            --agent true \
-            --auto-init "false" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-boot-jakarta-opentelemetry-noagent
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-jakarta-opentelemetry-noagent" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Test sentry-samples-spring-jakarta
+      - name: Run system test
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-jakarta" \
-            --agent false \
+            --agent "false" \
             --auto-init "true" \
             --build "true"
 
@@ -152,7 +337,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-results-springboot-3-${{ matrix.springboot-version }}
+          name: test-results-springboot-3-${{ matrix.springboot-version }}-sentry-samples-spring-jakarta-agentfalse-inittrue
           path: |
             **/build/reports/*
             **/build/test-results/**/*.xml
@@ -163,7 +348,7 @@ jobs:
         uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
         if: always()
         with:
-          name: JUnit Spring Boot 3.x ${{ matrix.springboot-version }}
+          name: JUnit Spring Boot 3.x ${{ matrix.springboot-version }} sentry-samples-spring-jakarta
           path: |
             **/build/test-results/**/*.xml
           reporter: java-junit

--- a/.github/workflows/spring-boot-4-matrix.yml
+++ b/.github/workflows/spring-boot-4-matrix.yml
@@ -5,23 +5,248 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/sentry-android/**'
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
   pull_request:
+    paths-ignore:
+      - '*android*/**'
+      - 'sentry-compose/**'
+      - 'sentry-samples/sentry-samples-android/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  spring-boot-4-matrix:
-    timeout-minutes: 45
+  spring-boot-4-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: echo 'matrix=["4.0.0","4.0.5"]' >> $GITHUB_OUTPUT
+
+  # One Gradle build per matrix cell → artifact sdk-build-sb4-{version} (sentry-*/build/libs,
+  # retention-days: 1, same workflow only). continue-on-error: without it, one failed version
+  # skips the entire spring-boot-4-matrix job (needs is job-level). Triage: spring-boot-4-matrix.
+  spring-boot-4-build:
+    needs: [spring-boot-4-versions]
+    continue-on-error: true
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        springboot-version: [ '4.0.0', '4.0.5' ]
+        springboot-version: ${{ fromJSON(needs.spring-boot-4-versions.outputs.matrix) }}
 
-    name: Spring Boot ${{ matrix.springboot-version }}
+    name: Build Spring Boot ${{ matrix.springboot-version }}
+    env:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # Workaround for https://github.com/gradle/actions/issues/21 to use config cache
+      - name: Cache buildSrc
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: buildSrc/build
+          key: build-logic-${{ hashFiles('buildSrc/src/**', 'buildSrc/build.gradle.kts','buildSrc/settings.gradle.kts') }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 4.x version
+        run: |
+          sed -i 's/^springboot4=.*/springboot4=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+          echo "Updated Spring Boot 4.x version to ${{ matrix.springboot-version }}"
+
+      - name: Exclude android modules from build
+        run: |
+          sed -i \
+            -e '/.*"sentry-android-ndk",/d' \
+            -e '/.*"sentry-android",/d' \
+            -e '/.*"sentry-compose",/d' \
+            -e '/.*"sentry-android-core",/d' \
+            -e '/.*"sentry-android-fragment",/d' \
+            -e '/.*"sentry-android-navigation",/d' \
+            -e '/.*"sentry-android-sqlite",/d' \
+            -e '/.*"sentry-android-timber",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
+            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
+            -e '/.*"sentry-android-integration-tests:test-app-size",/d' \
+            -e '/.*"sentry-samples:sentry-samples-android",/d' \
+            -e '/.*"sentry-android-replay",/d' \
+            settings.gradle.kts
+
+      - name: Exclude android modules from ignore list
+        run: |
+          sed -i \
+            -e '/.*"sentry-uitest-android",/d' \
+            -e '/.*"sentry-uitest-android-benchmark",/d' \
+            -e '/.*"sentry-uitest-android-critical",/d' \
+            -e '/.*"test-app-sentry",/d' \
+            -e '/.*"test-app-size",/d' \
+            -e '/.*"sentry-samples-android",/d' \
+            build.gradle.kts
+
+      - name: Build SDK and samples
+        run: |
+          ./gradlew assemble \
+            :sentry-samples:sentry-samples-spring-boot-4:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-webflux:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry:bootJar \
+            :sentry-samples:sentry-samples-spring-boot-4-opentelemetry-noagent:bootJar \
+            --parallel
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sdk-build-sb4-${{ matrix.springboot-version }}
+          path: |
+            sentry-*/**/build/libs/*.jar
+          retention-days: 1
+
+  # System tests per (springboot-version × sample config). Uses sdk-build-sb4-{version} at
+  # workspace root (download path: .) and test/system-test-runner.py with --build false.
+  # Failure triage: (1) spring-boot-4-build cell for that version, (2) Download build artifact,
+  # (3) Run system test / spring-server.txt / test-results. Build job may be green while
+  # version cells are red (continue-on-error); failed builds fail here, not as skipped jobs.
+  spring-boot-4-matrix:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: [spring-boot-4-build, spring-boot-4-versions]
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-4-versions.outputs.matrix) }}
+        config:
+          - { sample: "sentry-samples-spring-boot-4", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-4-webflux", agent: "false", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-4-opentelemetry", agent: "true", auto_init: "true" }
+          - { sample: "sentry-samples-spring-boot-4-opentelemetry", agent: "true", auto_init: "false" }
+          - { sample: "sentry-samples-spring-boot-4-opentelemetry-noagent", agent: "false", auto_init: "true" }
+
+    name: Spring Boot ${{ matrix.springboot-version }} - ${{ matrix.config.sample }} (agent=${{ matrix.config.agent }}, auto-init=${{ matrix.config.auto_init }})
+    env:
+      SENTRY_URL: http://127.0.0.1:8000
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.10.5'
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Update Spring Boot 4.x version
+        run: |
+          sed -i 's/^springboot4=.*/springboot4=${{ matrix.springboot-version }}/' gradle/libs.versions.toml
+
+      - name: Download build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: sdk-build-sb4-${{ matrix.springboot-version }}
+          path: .
+
+      # Guard against a confusing silent failure: if the agent JAR is absent,
+      # ensure_agent_jar() in the test runner falls back to building it via Gradle
+      # without the Spring Boot version pin or android exclusions applied — a slow,
+      # misconfigured build that will likely time out. Fail fast and clearly instead.
+      - name: Verify agent JAR present in artifact
+        if: matrix.config.agent == 'true'
+        run: |
+          jar=$(find sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/ \
+                -name "*agent*.jar" \
+                ! -name "*dontuse*" ! -name "*sources*" ! -name "*javadoc*" \
+                -print -quit 2>/dev/null)
+          if [ -z "$jar" ]; then
+            echo "ERROR: agent JAR not found in downloaded artifact."
+            echo "Expected: sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/*agent*.jar"
+            echo "Check that the build job's artifact upload completed successfully."
+            exit 1
+          fi
+          echo "Agent JAR found: $jar"
+
+      - name: Run system test
+        run: |
+          python3 test/system-test-runner.py test \
+            --module "${{ matrix.config.sample }}" \
+            --agent "${{ matrix.config.agent }}" \
+            --auto-init "${{ matrix.config.auto_init }}" \
+            --build "false"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-results-springboot-4-${{ matrix.springboot-version }}-${{ matrix.config.sample }}-agent${{ matrix.config.agent }}-init${{ matrix.config.auto_init }}
+          path: |
+            **/build/reports/*
+            **/build/test-results/**/*.xml
+            sentry-mock-server.txt
+            spring-server.txt
+
+      - name: Test Report
+        uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
+        if: always()
+        with:
+          name: JUnit Spring Boot 4.x ${{ matrix.springboot-version }} ${{ matrix.config.sample }}
+          path: |
+            **/build/test-results/**/*.xml
+          reporter: java-junit
+          output-to: step-summary
+          fail-on-error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: '**/build/test-results/**/*.xml'
+
+  spring-boot-4-war:
+    needs: [spring-boot-4-versions]
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        springboot-version: ${{ fromJSON(needs.spring-boot-4-versions.outputs.matrix) }}
+
+    name: Spring Boot ${{ matrix.springboot-version }} - sentry-samples-spring-7 (agent=false, auto-init=true)
     env:
       SENTRY_URL: http://127.0.0.1:8000
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -100,51 +325,11 @@ jobs:
         run: |
           ./gradlew assemble --parallel
 
-      - name: Run sentry-samples-spring-boot-4
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-4" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Run sentry-samples-spring-boot-4-webflux
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-4-webflux" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Run sentry-samples-spring-boot-4-opentelemetry agent init true
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-4-opentelemetry" \
-            --agent true \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Run sentry-samples-spring-boot-4-opentelemetry agent init false
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-4-opentelemetry" \
-            --agent true \
-            --auto-init "false" \
-            --build "true"
-
-      - name: Run sentry-samples-spring-boot-4-opentelemetry-noagent
-        run: |
-          python3 test/system-test-runner.py test \
-            --module "sentry-samples-spring-boot-4-opentelemetry-noagent" \
-            --agent false \
-            --auto-init "true" \
-            --build "true"
-
-      - name: Run sentry-samples-spring-7
+      - name: Run system test
         run: |
           python3 test/system-test-runner.py test \
             --module "sentry-samples-spring-7" \
-            --agent false \
+            --agent "false" \
             --auto-init "true" \
             --build "true"
 
@@ -152,7 +337,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: test-results-springboot-4-${{ matrix.springboot-version }}
+          name: test-results-springboot-4-${{ matrix.springboot-version }}-sentry-samples-spring-7-agentfalse-inittrue
           path: |
             **/build/reports/*
             **/build/test-results/**/*.xml
@@ -163,7 +348,7 @@ jobs:
         uses: phoenix-actions/test-reporting@7317eea6e13c47348dd0bb318669485157c518d6 # pin@v16
         if: always()
         with:
-          name: JUnit Spring Boot 4.x ${{ matrix.springboot-version }}
+          name: JUnit Spring Boot 4.x ${{ matrix.springboot-version }} sentry-samples-spring-7
           path: |
             **/build/test-results/**/*.xml
           reporter: java-junit


### PR DESCRIPTION
⚠️ _**DO NOT REVIEW: For test purposes only.**_ ⚠️ 

## :scroll: Description

Test PR for parallel Spring Boot matrix CI: per-version Gradle build jobs upload `sdk-build-sb*-{version}` artifacts; matrix test jobs download them and run `system-test-runner.py` with `--build false`.

Changes only `.github/workflows/spring-boot-{2,3,4}-matrix.yml`.

## :bulb: Motivation and Context
* resolves: JAVA-510

Reduces wall-clock time by splitting build and test across matrix cells and reusing build artifacts.

## :green_heart: How did you test it?
CI only — validating via Spring Boot 2.x / 3.x / 4.x Matrix workflows on this PR.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

Made with [Cursor](https://cursor.com)