### PR TITLE
chore(build): Enable configuration cache parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 


### PR DESCRIPTION
## :scroll: Description

Enable `org.gradle.configuration-cache.parallel=true` in `gradle.properties`.


#skip-changelog
