### PR TITLE
chore(build): Remove commons-compress from buildscript classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ buildscript {
         // add classpath of sentry android gradle plugin
         // classpath("io.sentry:sentry-android-gradle-plugin:{version}")
 
-        classpath(libs.commons.compress)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath(Config.BuildPlugins.androidGradle)
+        classpath(Config.BuildPlugins.androidGradle) {
+            exclude(group = "org.apache.commons", module = "commons-compress")
+        }
 
         // add classpath of sentry android gradle plugin
         // classpath("io.sentry:sentry-android-gradle-plugin:{version}")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,6 @@ async-profiler-jfr-converter = { module = "tools.profiler:jfr-converter", versio
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
 caffeine-jcache = { module = "com.github.ben-manes.caffeine:jcache", version = "3.2.0" }
 coil-compose = { module = "io.coil-kt:coil-compose", version = "2.6.0" }
-commons-compress = {module = "org.apache.commons:commons-compress", version = "1.25.0"}
 context-propagation = { module = "io.micrometer:context-propagation", version = "1.1.0" }
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version = "2.11.0" }
 feign-core = { module = "io.github.openfeign:feign-core", version.ref = "feign" }


### PR DESCRIPTION
## :scroll: Description

Remove `org.apache.commons:commons-compress` from the buildscript classpath and version catalog. This dependency was added to the buildscript but it's unclear what actually needs it at build time. Creating this PR to let CI tell us if anything breaks.

## :bulb: Motivation and Context

Investigating whether this buildscript dependency is actually required. If CI passes, we can drop it and reduce the build classpath.

## :green_heart: How did you test it?

CI will tell us.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

If CI passes, mark ready for review and merge. If it fails, we know what depends on it.

#skip-changelog