### PR TITLE
ref(build): Move apply<MavenPublishPlugin>() outside afterEvaluate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -214,9 +214,9 @@ subprojects {
             }
         }
 
-        afterEvaluate {
-            apply<MavenPublishPlugin>()
+        apply<MavenPublishPlugin>()
 
+        afterEvaluate {
             configure<MavenPublishBaseExtension> {
                 assignAarTypes()
             }


### PR DESCRIPTION
## :scroll: Description

Move `apply<MavenPublishPlugin>()` (Gradle's built-in `maven-publish` plugin) outside of the `afterEvaluate` block in the root `build.gradle.kts`.

## :bulb: Motivation and Context

Applying plugins inside `afterEvaluate` is a Gradle anti-pattern that can cause ordering issues and makes the build harder to reason about. The `maven-publish` plugin can be applied eagerly alongside the other plugins in the same block.

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump` passes
- `./gradlew projects` configures successfully

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog
