### PR TITLE
chore(build): Remove IDEA-316081 toolchain workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,14 +262,6 @@ tasks.register("buildForCodeQL") {
         }
 }
 
-// Workaround for https://youtrack.jetbrains.com/issue/IDEA-316081/Gradle-8-toolchain-error-Toolchain-from-executable-property-does-not-match-toolchain-from-javaLauncher-property-when-different
-gradle.taskGraph.whenReady {
-    val task = this.allTasks.find { it.name.endsWith(".main()") } as? JavaExec
-    task?.let {
-        it.setExecutable(it.javaLauncher.get().executablePath.asFile.absolutePath)
-    }
-}
-
 /*
  * Adapted from https://github.com/androidx/androidx/blob/c799cba927a71f01ea6b421a8f83c181682633fb/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt#L524-L549
  *


### PR DESCRIPTION
## :scroll: Description

Remove the Gradle `taskGraph.whenReady` workaround for [IDEA-316081](https://youtrack.jetbrains.com/issue/IDEA-316081/Gradle-8-toolchain-error-Toolchain-from-executable-property-does-not-match-toolchain-from-javaLauncher-property-when-different). This workaround patched `JavaExec` tasks to manually set the executable path to work around a toolchain mismatch error in IntelliJ IDEA.

## :bulb: Motivation and Context

The JetBrains issue has been resolved, so this workaround is no longer needed. It also calls `allTasks` which eagerly resolves those tasks.

## :green_heart: How did you test it?

Build completes successfully without the workaround.

## :pencil: Checklist

- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

None.

#skip-changelog