### PR TITLE
chore(build): Apply Develocity build scans plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,6 @@ develocity {
     buildScan {
         termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
         termsOfUseAgree.set("yes")
-        publishing.onlyIf { true }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,18 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("com.gradle.develocity") version "4.4.2"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+        publishing.onlyIf { true }
+    }
+}
+
 dependencyResolutionManagement {
     repositories {
         google()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.develocity") version "4.4.2"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.6.0"
 }
 
 develocity {


### PR DESCRIPTION
## :scroll: Description

Applies the [Develocity](https://gradle.com/) `com.gradle.develocity` plugin (v4.4.2) to `settings.gradle.kts` so that every Gradle invocation publishes a build scan to scans.gradle.com.

## :bulb: Motivation and Context

Build scans provide detailed performance and debugging insights for Gradle builds. Publishing on every build makes it easy to share scan links when investigating build issues or slow tasks.

## :green_heart: How did you test it?

Ran `./gradlew help` locally and verified it published a scan link at the end of the output.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog