### PR TITLE
fix(replay): Associate trace IDs with replay segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: Populate `trace_ids` in replay events to enable searching replays by trace ID ([#5473](https://github.com/getsentry/sentry-java/pull/5473))
+
 ## 8.43.0
 
 ### Features

--- a/sentry-android-replay/api/sentry-android-replay.api
+++ b/sentry-android-replay/api/sentry-android-replay.api
@@ -76,6 +76,7 @@ public final class io/sentry/android/replay/ReplayIntegration : io/sentry/IConne
 	public fun onWindowSizeChanged (II)V
 	public fun pause ()V
 	public fun register (Lio/sentry/IScopes;Lio/sentry/SentryOptions;)V
+	public fun registerTraceId (Lio/sentry/protocol/SentryId;)V
 	public fun resume ()V
 	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -280,6 +280,13 @@ public class ReplayIntegration(
 
   override fun isDebugMaskingOverlayEnabled(): Boolean = debugMaskingEnabled
 
+  override fun registerTraceId(traceId: SentryId) {
+    if (!isEnabled.get() || !isRecording()) {
+      return
+    }
+    captureStrategy?.registerTraceId(traceId)
+  }
+
   private fun pauseInternal() {
     lifecycleLock.acquire().use {
       if (!isEnabled.get() || !lifecycle.isAllowed(PAUSED)) {

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -33,6 +33,7 @@ import io.sentry.transport.ICurrentDateProvider
 import java.io.File
 import java.util.Date
 import java.util.Deque
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -96,6 +97,7 @@ internal abstract class BaseCaptureStrategy(
   override var replayType by persistableAtomic<ReplayType>(propertyName = SEGMENT_KEY_REPLAY_TYPE)
 
   protected val currentEvents: Deque<RRWebEvent> = ConcurrentLinkedDeque()
+  protected val currentTraceIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
   override fun start(segmentId: Int, replayId: SentryId, replayType: ReplayType?) {
     cache = replayCacheProvider?.invoke(replayId) ?: ReplayCache(options, replayId)
@@ -135,8 +137,10 @@ internal abstract class BaseCaptureStrategy(
     screenAtStart: String? = this.screenAtStart,
     breadcrumbs: List<Breadcrumb>? = null,
     events: Deque<RRWebEvent> = this.currentEvents,
-  ): ReplaySegment =
-    createSegment(
+  ): ReplaySegment {
+    val traceIds = currentTraceIds.toList().ifEmpty { null }
+    currentTraceIds.clear()
+    return createSegment(
       scopes,
       options,
       duration,
@@ -152,7 +156,9 @@ internal abstract class BaseCaptureStrategy(
       screenAtStart,
       breadcrumbs,
       events,
+      traceIds,
     )
+  }
 
   override fun onConfigurationChanged(recorderConfig: ScreenshotRecorderConfig) {
     this.recorderConfig = recorderConfig
@@ -164,6 +170,12 @@ internal abstract class BaseCaptureStrategy(
       if (rrwebEvents != null) {
         currentEvents += rrwebEvents
       }
+    }
+  }
+
+  override fun registerTraceId(traceId: SentryId) {
+    if (traceId != SentryId.EMPTY_ID) {
+      currentTraceIds.add(traceId.toString())
     }
   }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -140,11 +140,12 @@ internal abstract class BaseCaptureStrategy(
     breadcrumbs: List<Breadcrumb>? = null,
     events: Deque<RRWebEvent> = this.currentEvents,
   ): ReplaySegment {
-    val traceIds = synchronized(traceIdsLock) {
-      val ids = currentTraceIds.toList()
-      currentTraceIds.clear()
-      ids
-    }
+    val traceIds =
+      synchronized(traceIdsLock) {
+        val ids = currentTraceIds.toList()
+        currentTraceIds.clear()
+        ids
+      }
     return createSegment(
       scopes,
       options,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -33,7 +33,6 @@ import io.sentry.transport.ICurrentDateProvider
 import java.io.File
 import java.util.Date
 import java.util.Deque
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -55,6 +54,8 @@ internal abstract class BaseCaptureStrategy(
 ) : CaptureStrategy {
   internal companion object {
     private const val TAG = "CaptureStrategy"
+    // https://github.com/getsentry/sentry-javascript/blob/30eb68fff5077211c30c61ba74625e66ab514870/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts#L41
+    private const val MAX_TRACE_IDS = 100
   }
 
   private val persistingExecutor: ScheduledExecutorService by lazy {
@@ -97,7 +98,8 @@ internal abstract class BaseCaptureStrategy(
   override var replayType by persistableAtomic<ReplayType>(propertyName = SEGMENT_KEY_REPLAY_TYPE)
 
   protected val currentEvents: Deque<RRWebEvent> = ConcurrentLinkedDeque()
-  protected val currentTraceIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+  private val traceIdsLock = Any()
+  private val currentTraceIds: MutableList<String> = mutableListOf()
 
   override fun start(segmentId: Int, replayId: SentryId, replayType: ReplayType?) {
     cache = replayCacheProvider?.invoke(replayId) ?: ReplayCache(options, replayId)
@@ -138,8 +140,11 @@ internal abstract class BaseCaptureStrategy(
     breadcrumbs: List<Breadcrumb>? = null,
     events: Deque<RRWebEvent> = this.currentEvents,
   ): ReplaySegment {
-    val traceIds = currentTraceIds.toList().ifEmpty { null }
-    currentTraceIds.clear()
+    val traceIds = synchronized(traceIdsLock) {
+      val ids = currentTraceIds.toList()
+      currentTraceIds.clear()
+      ids
+    }
     return createSegment(
       scopes,
       options,
@@ -175,7 +180,14 @@ internal abstract class BaseCaptureStrategy(
 
   override fun registerTraceId(traceId: SentryId) {
     if (traceId != SentryId.EMPTY_ID) {
-      currentTraceIds.add(traceId.toString())
+      synchronized(traceIdsLock) {
+        if (currentTraceIds.size < MAX_TRACE_IDS) {
+          val id = traceId.toString()
+          if (!currentTraceIds.contains(id)) {
+            currentTraceIds.add(id)
+          }
+        }
+      }
     }
   }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -86,7 +86,7 @@ internal interface CaptureStrategy {
       screenAtStart: String?,
       breadcrumbs: List<Breadcrumb>?,
       events: Deque<RRWebEvent>,
-      traceIds: List<String>? = null,
+      traceIds: List<String> = emptyList(),
     ): ReplaySegment {
       val generatedVideo =
         cache?.createVideoOf(
@@ -145,7 +145,7 @@ internal interface CaptureStrategy {
       screenAtStart: String?,
       breadcrumbs: List<Breadcrumb>,
       events: Deque<RRWebEvent>,
-      traceIds: List<String>?,
+      traceIds: List<String>,
     ): ReplaySegment {
       val endTimestamp = DateUtils.getDateTime(segmentTimestamp.time + videoDuration)
       val replay =

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -53,6 +53,8 @@ internal interface CaptureStrategy {
 
   fun convert(): CaptureStrategy
 
+  fun registerTraceId(traceId: SentryId)
+
   companion object {
     private fun Breadcrumb?.isNetworkAvailable(): Boolean =
       this != null &&
@@ -84,6 +86,7 @@ internal interface CaptureStrategy {
       screenAtStart: String?,
       breadcrumbs: List<Breadcrumb>?,
       events: Deque<RRWebEvent>,
+      traceIds: List<String>? = null,
     ): ReplaySegment {
       val generatedVideo =
         cache?.createVideoOf(
@@ -122,6 +125,7 @@ internal interface CaptureStrategy {
         screenAtStart,
         replayBreadcrumbs,
         events,
+        traceIds,
       )
     }
 
@@ -141,6 +145,7 @@ internal interface CaptureStrategy {
       screenAtStart: String?,
       breadcrumbs: List<Breadcrumb>,
       events: Deque<RRWebEvent>,
+      traceIds: List<String>?,
     ): ReplaySegment {
       val endTimestamp = DateUtils.getDateTime(segmentTimestamp.time + videoDuration)
       val replay =
@@ -152,6 +157,7 @@ internal interface CaptureStrategy {
           this.replayStartTimestamp = segmentTimestamp
           this.replayType = replayType
           this.videoFile = video
+          this.traceIds = traceIds
         }
 
       val recordingPayload = mutableListOf<RRWebEvent>()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -1072,6 +1072,38 @@ class ReplayIntegrationTest {
     verify(fixture.replayCache).addFrame(any<Bitmap>(), any(), anyOrNull())
   }
 
+  @Test
+  fun `registerTraceId does nothing when replay is not started`() {
+    val replay = fixture.getSut(context)
+
+    replay.register(fixture.scopes, fixture.options)
+    // Don't call start()
+
+    // Should not throw
+    replay.registerTraceId(SentryId())
+  }
+
+  @Test
+  fun `registerTraceId forwards to capture strategy when recording`() {
+    var traceIdRegistered: SentryId? = null
+    val captureStrategy =
+      mock<CaptureStrategy> {
+        on { currentReplayId }.thenReturn(SentryId())
+        doAnswer { traceIdRegistered = it.arguments[0] as SentryId }
+          .whenever(mock)
+          .registerTraceId(any())
+      }
+    val replay = fixture.getSut(context, replayCaptureStrategyProvider = { captureStrategy })
+
+    replay.register(fixture.scopes, fixture.options)
+    replay.start()
+
+    val traceId = SentryId()
+    replay.registerTraceId(traceId)
+
+    assertEquals(traceId, traceIdRegistered)
+  }
+
   private fun getSessionCaptureStrategy(options: SentryOptions): SessionCaptureStrategy =
     SessionCaptureStrategy(
       options,

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -475,4 +475,81 @@ class SessionCaptureStrategyTest {
         },
       )
   }
+
+  @Test
+  fun `registerTraceId includes trace IDs in next segment`() {
+    val now =
+      System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
+    val strategy = fixture.getSut(dateProvider = { now })
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+
+    val traceId1 = SentryId()
+    val traceId2 = SentryId()
+    strategy.registerTraceId(traceId1)
+    strategy.registerTraceId(traceId2)
+
+    strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    verify(fixture.scopes)
+      .captureReplay(
+        argThat { event ->
+          event is SentryReplayEvent &&
+            event.traceIds?.size == 2 &&
+            event.traceIds!!.contains(traceId1.toString()) &&
+            event.traceIds!!.contains(traceId2.toString())
+        },
+        any(),
+      )
+  }
+
+  @Test
+  fun `registerTraceId clears trace IDs after segment is created`() {
+    val now =
+      System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
+    val strategy = fixture.getSut(dateProvider = { now })
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+
+    val traceId = SentryId()
+    strategy.registerTraceId(traceId)
+
+    strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    verify(fixture.scopes)
+      .captureReplay(
+        argThat { event ->
+          event is SentryReplayEvent && event.traceIds?.contains(traceId.toString()) == true
+        },
+        any(),
+      )
+
+    // trigger another segment, trace IDs should be cleared
+    strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    verify(fixture.scopes)
+      .captureReplay(
+        argThat { event -> event is SentryReplayEvent && event.segmentId == 1 && event.traceIds.isNullOrEmpty() },
+        any(),
+      )
+  }
+
+  @Test
+  fun `registerTraceId ignores empty trace ID`() {
+    val now =
+      System.currentTimeMillis() + (fixture.options.sessionReplay.sessionSegmentDuration * 5)
+    val strategy = fixture.getSut(dateProvider = { now })
+    strategy.start()
+    strategy.onConfigurationChanged(fixture.recorderConfig)
+
+    strategy.registerTraceId(SentryId.EMPTY_ID)
+
+    strategy.onScreenshotRecorded(mock<Bitmap>()) {}
+
+    verify(fixture.scopes)
+      .captureReplay(
+        argThat { event -> event is SentryReplayEvent && event.traceIds.isNullOrEmpty() },
+        any(),
+      )
+  }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -529,7 +529,9 @@ class SessionCaptureStrategyTest {
 
     verify(fixture.scopes)
       .captureReplay(
-        argThat { event -> event is SentryReplayEvent && event.segmentId == 1 && event.traceIds.isNullOrEmpty() },
+        argThat { event ->
+          event is SentryReplayEvent && event.segmentId == 1 && event.traceIds.isNullOrEmpty()
+        },
         any(),
       )
   }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1703,6 +1703,7 @@ public final class io/sentry/NoOpReplayController : io/sentry/ReplayController {
 	public fun isDebugMaskingOverlayEnabled ()Z
 	public fun isRecording ()Z
 	public fun pause ()V
+	public fun registerTraceId (Lio/sentry/protocol/SentryId;)V
 	public fun resume ()V
 	public fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public fun start ()V
@@ -2344,6 +2345,7 @@ public abstract interface class io/sentry/ReplayController : io/sentry/IReplayAp
 	public abstract fun isDebugMaskingOverlayEnabled ()Z
 	public abstract fun isRecording ()Z
 	public abstract fun pause ()V
+	public abstract fun registerTraceId (Lio/sentry/protocol/SentryId;)V
 	public abstract fun resume ()V
 	public abstract fun setBreadcrumbConverter (Lio/sentry/ReplayBreadcrumbConverter;)V
 	public abstract fun start ()V

--- a/sentry/src/main/java/io/sentry/NoOpReplayController.java
+++ b/sentry/src/main/java/io/sentry/NoOpReplayController.java
@@ -57,4 +57,7 @@ public final class NoOpReplayController implements ReplayController {
 
   @Override
   public void disableDebugMaskingOverlay() {}
+
+  @Override
+  public void registerTraceId(@NotNull SentryId traceId) {}
 }

--- a/sentry/src/main/java/io/sentry/ReplayController.java
+++ b/sentry/src/main/java/io/sentry/ReplayController.java
@@ -28,4 +28,12 @@ public interface ReplayController extends IReplayApi {
   ReplayBreadcrumbConverter getBreadcrumbConverter();
 
   boolean isDebugMaskingOverlayEnabled();
+
+  /**
+   * Registers a trace ID to be associated with the current replay. This is called when a
+   * transaction is captured while replay is recording, to enable searching for replays by trace ID.
+   *
+   * @param traceId the trace ID to associate with the current replay
+   */
+  void registerTraceId(@NotNull SentryId traceId);
 }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -1043,6 +1043,13 @@ public final class SentryClient implements ISentryClient {
       sentryId = SentryId.EMPTY_ID;
     }
 
+    if (!sentryId.equals(SentryId.EMPTY_ID)) {
+      final @Nullable SpanContext trace = transaction.getContexts().getTrace();
+      if (trace != null) {
+        options.getReplayController().registerTraceId(trace.getTraceId());
+      }
+    }
+
     return sentryId;
   }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -1959,6 +1959,23 @@ class SentryClientTest {
   }
 
   @Test
+  fun `captureTransaction registers trace ID with replay controller`() {
+    var registeredTraceId: SentryId? = null
+    fixture.sentryOptions.setReplayController(
+      object : ReplayController by NoOpReplayController.getInstance() {
+        override fun registerTraceId(traceId: SentryId) {
+          registeredTraceId = traceId
+        }
+      }
+    )
+    val sut = fixture.getSut()
+    val sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.scopes)
+    val transaction = SentryTransaction(sentryTracer)
+    sut.captureTransaction(transaction, sentryTracer.traceContext())
+    assertEquals(sentryTracer.spanContext.traceId, registeredTraceId)
+  }
+
+  @Test
   fun `when exception type is ignored, capturing event does not send it`() {
     fixture.sentryOptions.addIgnoredExceptionForType(IllegalStateException::class.java)
     val sut = fixture.getSut()


### PR DESCRIPTION
## :scroll: Description

This change enables associating trace IDs with replay segments, allowing replays to be searched and filtered by the trace IDs of transactions that occurred during recording.

### Key Changes:
- Added `registerTraceId()` method to `ReplayController` interface and implementations
- Modified `BaseCaptureStrategy` to collect trace IDs in a `ConcurrentHashMap` and include them in generated replay segments
- Updated `SentryClient.captureTransaction()` to register the transaction's trace ID with the replay controller when a transaction is captured
- Modified `ReplayIntegration` to forward trace ID registration to the active capture strategy
- Updated `ReplaySegment` to include trace IDs in the replay payload
- Added validation to ignore empty trace IDs

### Implementation Details:
- Trace IDs are collected in `currentTraceIds` set during a segment's lifetime
- After a segment is created, the trace IDs are cleared for the next segment
- Empty trace IDs (`SentryId.EMPTY_ID`) are filtered out
- The feature gracefully handles cases where replay is not recording

## :bulb: Motivation and Context

This enables better correlation between replays and transactions. When a transaction occurs while replay is recording, its trace ID is now associated with the replay segment, making it possible to:
- Search for replays by trace ID
- Link replays to specific transactions in the UI
- Improve debugging workflows by connecting performance data with visual recordings

Example replay: https://sentry-sdks.sentry.io/explore/replays/?project=5428559&statsPeriod=24h&query=trace:f2b899ed30f0476ebea8a7678998cc8b

I'm able to search by trace id:

<img width="1237" height="307" alt="Google Chrome 2026-05-28 21 31 21" src="https://github.com/user-attachments/assets/8b41adb2-9933-480d-8aeb-05bb96b74c35" />


Closes #5346

## :green_heart: How did you test it?

Added comprehensive unit tests covering:
- `registerTraceId` includes trace IDs in the next segment
- `registerTraceId` clears trace IDs after segment creation
- `registerTraceId` ignores empty trace IDs
- `registerTraceId` does nothing when replay is not started
- `registerTraceId` forwards to capture strategy when recording
- `captureTransaction` registers trace ID with replay controller

All tests pass and verify the trace ID registration flow end-to-end.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

https://claude.ai/code/session_012wjHQtsEPzcrxSMCufxrDY