### PR TITLE
[DON'T REVIEW] perf(replay): Defer ReplayIntegration.start() off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   ```
 - Parse ART memory and garbage collector info from ANR tombstones into ART context ([#5428](https://github.com/getsentry/sentry-java/pull/5428))
 
+### Improvements
+
+- Improve SDK init performance by deferring `ReplayIntegration.start()` off the main thread ([#XXXX](https://github.com/getsentry/sentry-java/pull/XXXX))
+
 ## 8.42.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Improvements
 
-- Improve SDK init performance by deferring `ReplayIntegration.start()` off the main thread ([#XXXX](https://github.com/getsentry/sentry-java/pull/XXXX))
+- Improve SDK init performance by deferring `ReplayIntegration.start()` off the main thread ([#5474](https://github.com/getsentry/sentry-java/pull/5474))
 
 ## 8.42.0
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -161,6 +161,7 @@ public class ReplayIntegration(
     lifecycle.currentState >= STARTED && lifecycle.currentState < STOPPED
 
   override fun start() {
+    val isFullSession: Boolean
     lifecycleLock.acquire().use {
       if (!isEnabled.get()) {
         return
@@ -174,7 +175,7 @@ public class ReplayIntegration(
         return
       }
 
-      val isFullSession = random.sample(options.sessionReplay.sessionSampleRate)
+      isFullSession = random.sample(options.sessionReplay.sessionSampleRate)
       if (!isFullSession && !options.sessionReplay.isSessionReplayForErrorsEnabled) {
         options.logger.log(
           INFO,
@@ -184,30 +185,39 @@ public class ReplayIntegration(
       }
 
       lifecycle.currentState = STARTED
-      captureStrategy =
-        replayCaptureStrategyProvider?.invoke(isFullSession)
-          ?: if (isFullSession) {
-            SessionCaptureStrategy(
-              options,
-              scopes,
-              dateProvider,
-              replayExecutor,
-              replayCacheProvider,
-            )
-          } else {
-            BufferCaptureStrategy(
-              options,
-              scopes,
-              dateProvider,
-              random,
-              replayExecutor,
-              replayCacheProvider,
-            )
-          }
-      recorder?.start()
-      captureStrategy?.start()
+    }
 
-      registerRootViewListeners()
+    // Defer the expensive work (strategy creation, recorder start, listener registration)
+    // off the calling thread to avoid blocking SentryAndroid.init() on the main thread.
+    options.executorService.submitSafely(options, "ReplayIntegration.start") {
+      lifecycleLock.acquire().use {
+        captureStrategy =
+          replayCaptureStrategyProvider?.invoke(isFullSession)
+            ?: if (isFullSession) {
+              SessionCaptureStrategy(
+                options,
+                scopes,
+                dateProvider,
+                replayExecutor,
+                replayCacheProvider,
+              )
+            } else {
+              BufferCaptureStrategy(
+                options,
+                scopes,
+                dateProvider,
+                random,
+                replayExecutor,
+                replayCacheProvider,
+              )
+            }
+        recorder?.start()
+        captureStrategy?.start()
+      }
+
+      // Post to main thread since registerRootViewListeners triggers View operations
+      // (e.g. addOnLayoutChangeListener) via the OnRootViewsChangedListener callback
+      mainLooperHandler.post { registerRootViewListeners() }
     }
   }
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationWithRecorderTest.kt
@@ -18,6 +18,7 @@ import io.sentry.android.replay.ReplayIntegrationWithRecorderTest.LifecycleState
 import io.sentry.android.replay.util.ReplayShadowMediaCodec
 import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
 import io.sentry.util.thread.NoOpThreadChecker
@@ -44,7 +45,11 @@ class ReplayIntegrationWithRecorderTest {
   @get:Rule val tmpDir = TemporaryFolder()
 
   internal class Fixture {
-    val options = SentryOptions().apply { threadChecker = NoOpThreadChecker.getInstance() }
+    val options =
+      SentryOptions().apply {
+        threadChecker = NoOpThreadChecker.getInstance()
+        executorService = ImmediateExecutorService()
+      }
     val scopes = mock<IScopes>()
 
     fun getSut(

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplaySmokeTest.kt
@@ -21,6 +21,7 @@ import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.util.ReplayShadowMediaCodec
 import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebVideoEvent
+import io.sentry.test.ImmediateExecutorService
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
 import java.time.Duration
@@ -59,7 +60,7 @@ class ReplaySmokeTest {
   @get:Rule val tmpDir = TemporaryFolder()
 
   internal class Fixture {
-    val options = SentryOptions()
+    val options = SentryOptions().apply { executorService = ImmediateExecutorService() }
     val scope = Scope(options)
     val scopes =
       mock<IScopes> {


### PR DESCRIPTION
## :scroll: Description

Move the expensive work in `ReplayIntegration.start()` (capture strategy creation, recorder start, root view listener registration) to the executor service background thread. The lightweight state checks and lifecycle transition (`lifecycle.currentState = STARTED`) remain synchronous so that `isRecording()` returns the correct value immediately.

`registerRootViewListeners()` is posted to the main looper handler since it triggers View operations (e.g. `addOnLayoutChangeListener`) via `OnRootViewsChangedListener`.

## :bulb: Motivation and Context

Perfetto traces on a Pixel 3 show `ReplayIntegration.start()` taking ~16ms on the main thread during `SentryAndroid.init()`. Since `start()` is called after init is complete and doesn't need to block the caller, the heavy work can be deferred to a background thread.

## :green_heart: How did you test it?

- Ran `:sentry-android-core:testDebugUnitTest` — all 22 tests pass
- Ran `:sentry-android-replay:testDebugUnitTest` — all 209 tests pass (including `ReplayIntegrationTest`, `ReplayIntegrationWithRecorderTest`, `ReplaySmokeTest`)

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps