### PR TITLE
perf(android): [SDK Overhead Reduction 2] Replace reflective OptionsContainer with direct subclass

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -9,7 +9,6 @@ import io.sentry.ILogger;
 import io.sentry.IScopes;
 import io.sentry.ISentryLifecycleToken;
 import io.sentry.Integration;
-import io.sentry.OptionsContainer;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
@@ -98,7 +97,7 @@ public final class SentryAndroid {
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration) {
     try (final @NotNull ISentryLifecycleToken ignored = staticLock.acquire()) {
       Sentry.init(
-          OptionsContainer.create(SentryAndroidOptions.class),
+          new SentryAndroidOptionsContainer(),
           options -> {
             final io.sentry.util.LoadClass classLoader = new io.sentry.util.LoadClass();
             final boolean isTimberUpstreamAvailable =

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptionsContainer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptionsContainer.java
@@ -1,0 +1,16 @@
+package io.sentry.android.core;
+
+import io.sentry.OptionsContainer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Direct OptionsContainer for SentryAndroidOptions that avoids reflective
+ * getDeclaredConstructor().newInstance() on the Android startup path.
+ */
+final class SentryAndroidOptionsContainer extends OptionsContainer<SentryAndroidOptions> {
+
+  @Override
+  public @NotNull SentryAndroidOptions createInstance() {
+    return new SentryAndroidOptions();
+  }
+}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2068,7 +2068,8 @@ public abstract interface class io/sentry/ObjectWriter {
 	public abstract fun value (Z)Lio/sentry/ObjectWriter;
 }
 
-public final class io/sentry/OptionsContainer {
+public class io/sentry/OptionsContainer {
+	protected fun <init> ()V
 	public static fun create (Ljava/lang/Class;)Lio/sentry/OptionsContainer;
 	public fun createInstance ()Ljava/lang/Object;
 }

--- a/sentry/src/main/java/io/sentry/OptionsContainer.java
+++ b/sentry/src/main/java/io/sentry/OptionsContainer.java
@@ -1,21 +1,31 @@
 package io.sentry;
 
+import com.jakewharton.nopen.annotation.Open;
+import io.sentry.util.Objects;
 import java.lang.reflect.InvocationTargetException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
-public final class OptionsContainer<T> {
+@Open
+public class OptionsContainer<T> {
 
   public @NotNull static <T> OptionsContainer<T> create(final @NotNull Class<T> clazz) {
     return new OptionsContainer<>(clazz);
   }
 
-  private final @NotNull Class<T> clazz;
+  private final @Nullable Class<T> clazz;
 
   private OptionsContainer(final @NotNull Class<T> clazz) {
     super();
     this.clazz = clazz;
+  }
+
+  /** Constructor for subclasses that create the instance directly without reflection. */
+  protected OptionsContainer() {
+    super();
+    this.clazz = null;
   }
 
   public @NotNull T createInstance()
@@ -23,6 +33,8 @@ public final class OptionsContainer<T> {
           IllegalAccessException,
           NoSuchMethodException,
           InvocationTargetException {
-    return clazz.getDeclaredConstructor().newInstance();
+    return Objects.requireNonNull(clazz, "OptionsContainer clazz is required")
+        .getDeclaredConstructor()
+        .newInstance();
   }
 }


### PR DESCRIPTION
## PR Stack (SDK Overhead Reduction)

- #5499
- #5500
- #5501
- #5502
- #5587
- #5589
- #5591
- #5598
- #5599
- #5600
- #5601
- #5602
- #5603
- #5609

---

## :scroll: Description

Replace `OptionsContainer.create(SentryAndroidOptions.class)` — which uses `getDeclaredConstructor().newInstance()` — with a direct `SentryAndroidOptionsContainer` subclass that returns `new SentryAndroidOptions()` without reflection.

To enable subclassing, `OptionsContainer` is made non-final (`@Open`) with a `protected` no-arg constructor. The `clazz` field becomes `@Nullable` with a null check in `createInstance()` for the reflective path (used by non-Android callers).

## :bulb: Motivation and Context

Part of the SDK Overhead Reduction stack. Avoids reflective constructor invocation on the Android cold-start path. While the improvement is below the noise floor in isolation (AR-71 in autoresearch report), it removes unnecessary reflection and is a clean, risk-free change.

## :green_heart: How did you test it?

- `./gradlew :sentry:test` — all tests pass
- `./gradlew :sentry-android-core:testDebugUnitTest` — all tests pass
- `./gradlew spotlessApply apiDump` — API change is only the expected non-final + protected ctor

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

More SDK overhead reduction PRs in this stack.


#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.





