### PR TITLE
perf(android): [SDK Overhead Reduction 3] Reuse SentryExecutorService for DeviceInfoUtil pre-caching

### DIFF
--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import org.jetbrains.annotations.NotNull;
@@ -56,16 +54,16 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     // noinspection Convert2MethodRef
     // some device info performs disk I/O, but it's result is cached, let's pre-cache it
     @Nullable Future<DeviceInfoUtil> deviceInfoUtil;
-    final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
       deviceInfoUtil =
-          executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
+          options
+              .getExecutorService()
+              .submit(() -> DeviceInfoUtil.getInstance(this.context, options));
     } catch (RejectedExecutionException e) {
       deviceInfoUtil = null;
       options.getLogger().log(SentryLevel.WARNING, "Device info caching task rejected.", e);
     }
     this.deviceInfoUtil = deviceInfoUtil;
-    executorService.shutdown();
   }
 
   @Override


### PR DESCRIPTION
## PR Stack (SDK Overhead Reduction)

- #5499
- #5500
- #5501
- #5502
- #5587
- #5589
- #5591
- #5598
- #5599
- #5600
- #5601
- #5602
- #5603
- #5609

---

## :scroll: Description

Replace `Executors.newSingleThreadExecutor()` with `options.getExecutorService()` in `DefaultAndroidEventProcessor` for the `DeviceInfoUtil` pre-caching task. This avoids creating a dedicated thread + executor during SDK init when the SDK already has an executor service available. Also removes the `executorService.shutdown()` call since we don't own the shared executor.

## :bulb: Motivation and Context

Part of the SDK Overhead Reduction stack. During Android SDK init, `DefaultAndroidEventProcessor` was creating its own `SingleThreadExecutor` just to submit one task for pre-caching device info. The SDK's executor service (`SentryExecutorService`) is already available at this point and can handle this work without the overhead of spinning up an additional thread pool.

## :green_heart: How did you test it?

- `./gradlew :sentry-android-core:compileDebugUnitTestJavaWithJavac` — compiles successfully
- `./gradlew spotlessApply apiDump` — no API surface changes

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

More SDK overhead reduction PRs in this stack.


#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.





