### PR TITLE
fix(replay): Fix Compose masking on obfuscated/minified builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: Fix Compose view masking not working on obfuscated/minified builds ([#5503](https://github.com/getsentry/sentry-java/pull/5503))
+
 ## 8.43.1
 
 ### Fixes

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
@@ -8,11 +8,23 @@ import kotlin.test.Test
 import leakcanary.LeakAssertions
 import leakcanary.LeakCanary
 import org.awaitility.kotlin.await
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assume.assumeThat
+import org.junit.Before
 import shark.AndroidReferenceMatchers
 import shark.IgnoredReferenceMatcher
 import shark.ReferencePattern
 
 class ReplayTest : BaseUiTest() {
+  @Before
+  fun setup() {
+    // we can't run on GH actions emulator, because they don't allow capturing screenshots properly
+    @Suppress("KotlinConstantConditions")
+    assumeThat(BuildConfig.ENVIRONMENT != "github", `is`(true))
+    // crash on swallowed Compose masking errors (e.g. broken obfuscated internals) so regressions
+    // fail this on-device test instead of silently under-masking (see SentryReplayDebug)
+    System.setProperty("io.sentry.replay.compose.fail-fast", "true")
+  }
 
   @Test
   fun composeReplayDoesNotLeak() {

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
@@ -8,9 +8,6 @@ import kotlin.test.Test
 import leakcanary.LeakAssertions
 import leakcanary.LeakCanary
 import org.awaitility.kotlin.await
-import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assume.assumeThat
-import org.junit.Before
 import shark.AndroidReferenceMatchers
 import shark.IgnoredReferenceMatcher
 import shark.ReferencePattern

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/ReplayTest.kt
@@ -16,12 +16,6 @@ import shark.IgnoredReferenceMatcher
 import shark.ReferencePattern
 
 class ReplayTest : BaseUiTest() {
-  @Before
-  fun setup() {
-    // we can't run on GH actions emulator, because they don't allow capturing screenshots properly
-    @Suppress("KotlinConstantConditions")
-    assumeThat(BuildConfig.ENVIRONMENT != "github", `is`(true))
-  }
 
   @Test
   fun composeReplayDoesNotLeak() {

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTestReplay/java/io/sentry/uitest/android/ReplaySnapshotTest.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTestReplay/java/io/sentry/uitest/android/ReplaySnapshotTest.kt
@@ -23,6 +23,9 @@ class ReplaySnapshotTest : BaseUiTest() {
     // GH Actions emulators don't support capturing screenshots for replay
     @Suppress("KotlinConstantConditions")
     assumeThat(BuildConfig.ENVIRONMENT != "github", `is`(true))
+    // crash on swallowed Compose masking errors (e.g. broken obfuscated internals) so regressions
+    // fail this on-device test instead of silently under-masking (see SentryReplayDebug)
+    System.setProperty("io.sentry.replay.compose.fail-fast", "true")
   }
 
   @Test

--- a/sentry-android-replay/proguard-rules.pro
+++ b/sentry-android-replay/proguard-rules.pro
@@ -29,3 +29,9 @@
 # Rules to detect a PreviewView view to later mask it
 -dontwarn androidx.camera.view.PreviewView
 -keepnames class androidx.camera.view.PreviewView
+# Rules to walk the Compose Node tree.
+-keep class androidx.compose.ui.node.LayoutNode {
+    *** getChildren*(...);
+    *** getOuterCoordinator*(...);
+    *** getCollapsedSemantics*(...);
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/SentryReplayDebug.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/SentryReplayDebug.kt
@@ -1,0 +1,26 @@
+package io.sentry.android.replay.util
+
+/**
+ * Internal, undocumented escape hatch used to make Session Replay fail fast instead of silently
+ * degrading masking when an exception is swallowed (e.g. unsupported/obfuscated Compose internals).
+ *
+ * It is intended to be enabled only in our own sample/UI-test apps that run on real devices in CI
+ * (which are release/obfuscated builds, so [io.sentry.android.replay.BuildConfig.DEBUG] can't be
+ * used), so that regressions surface as crashes rather than under-masked replays. Customers should
+ * never set this.
+ *
+ * Enable via:
+ * ```
+ * System.setProperty("io.sentry.replay.compose.fail-fast", "true")
+ * ```
+ */
+internal object SentryReplayDebug {
+  private const val FAIL_FAST_PROPERTY = "io.sentry.replay.compose.fail-fast"
+
+  /**
+   * Read live (not cached) so it's only evaluated on the error path and unit tests can toggle it
+   * between cases.
+   */
+  val failFast: Boolean
+    get() = "true".equals(System.getProperty(FAIL_FAST_PROPERTY), ignoreCase = true)
+}

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ComposeViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ComposeViewHierarchyNode.kt
@@ -22,6 +22,7 @@ import io.sentry.SentryLevel
 import io.sentry.SentryMaskingOptions
 import io.sentry.android.replay.SentryReplayModifiers
 import io.sentry.android.replay.util.ComposeTextLayout
+import io.sentry.android.replay.util.SentryReplayDebug
 import io.sentry.android.replay.util.boundsInWindow
 import io.sentry.android.replay.util.findPainter
 import io.sentry.android.replay.util.findTextColor
@@ -145,6 +146,12 @@ internal object ComposeViewHierarchyNode {
           """
             .trimIndent(),
         )
+      }
+
+      // fail fast in our own sample/UI-test apps (see SentryReplayDebug), so regressions surface
+      // as crashes instead of silently degrading masking
+      if (SentryReplayDebug.failFast) {
+        throw t
       }
 
       // If we're unable to retrieve the semantics configuration
@@ -291,6 +298,11 @@ internal object ComposeViewHierarchyNode {
         """
           .trimIndent(),
       )
+      // fail fast in our own sample/UI-test apps (see SentryReplayDebug), so regressions surface
+      // as crashes instead of silently skipping the whole Compose subtree (i.e. not masking it)
+      if (SentryReplayDebug.failFast) {
+        throw e
+      }
       return false
     }
 

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MyApplication.java
@@ -9,6 +9,11 @@ public class MyApplication extends Application {
 
   @Override
   public void onCreate() {
+    // Make Session Replay fail fast instead of silently degrading masking when an exception is
+    // swallowed (e.g. unsupported/obfuscated Compose internals). This way regressions surface as
+    // crashes in our release/obfuscated builds that run on real devices in CI. Only meant for our
+    // own sample/UI-test apps, customers should never set this.
+    System.setProperty("io.sentry.replay.compose.fail-fast", "true");
     Sentry.startProfiler();
     strictMode();
     super.onCreate();


### PR DESCRIPTION
## 📜 Description

Fixes Compose view masking on obfuscated/minified (R8) builds, plus adds a CI mechanism to catch such regressions early.

- **Masking fix**: the SDK accesses internal Compose `LayoutNode` members to walk the node tree. On Compose < 1.10 these are looked up via reflection by their mangled names (`getChildren$ui_release`, `getOuterCoordinator$ui_release`, `getCollapsedSemantics$ui_release`). Since they aren't referenced directly, R8 could strip or rename them, silently breaking masking on minified builds. Added consumer proguard keep rules for them.
- **Fail-fast in CI**: added an internal `SentryReplayDebug.failFast` switch (gated on the `io.sentry.replay.compose.fail-fast` system property) that re-throws the exceptions `ComposeViewHierarchyNode` normally swallows. It's enabled in the sample app and the on-device `ReplayTest`/`ReplaySnapshotTest`, so our release/obfuscated builds running on real devices in Sauce Labs crash instead of silently under-masking. Defaults off, so customers are unaffected.
- Guard the on-device replay tests against GitHub-hosted emulators, which can't capture screenshots reliably.

## 💡 Motivation and Context

On obfuscated/minified builds, R8 could rename/strip the reflected Compose internals, which silently degraded or disabled Compose masking. Because the SDK swallows these errors to avoid crashing customer apps, the regression was invisible in our CI until now.

## 💚 How did you test it?

Unit tests + on-device `ReplayTest`/`ReplaySnapshotTest` running on release/obfuscated builds on real devices (Sauce Labs), which now fail fast if masking breaks.

Example replay: https://sentry-sdks.sentry.io/explore/replays/6783b073aef442a8b4ad8731bf6901fa

## 📝 Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
