### PR TITLE
fix(replay): Fix VerifyError in Compose masking under DexGuard/R8 obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session Replay: Fix `VerifyError` in Compose masking under DexGuard/R8 obfuscation ([#5507](https://github.com/getsentry/sentry-java/pull/5507))
+
 ## 8.43.1
 
 ### Fixes

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
@@ -2,8 +2,8 @@
 
 package io.sentry.android.replay.util
 
-import android.graphics.Rect
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorProducer
 import androidx.compose.ui.graphics.painter.Painter
@@ -176,7 +176,7 @@ internal fun LayoutCoordinates.boundsInWindow(rootCoordinates: LayoutCoordinates
   val boundsBottom = bounds.bottom.fastCoerceIn(0f, rootHeight)
 
   if (boundsLeft == boundsRight || boundsTop == boundsBottom) {
-    return Rect()
+    return Rect(0.0f, 0.0f, 0.0f, 0.0f)
   }
 
   val topLeft = root.localToWindow(Offset(boundsLeft, boundsTop))
@@ -200,5 +200,9 @@ internal fun LayoutCoordinates.boundsInWindow(rootCoordinates: LayoutCoordinates
   val top = fastMinOf(topLeftY, topRightY, bottomLeftY, bottomRightY)
   val bottom = fastMaxOf(topLeftY, topRightY, bottomLeftY, bottomRightY)
 
-  return Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
+  return Rect(left, top, right, bottom)
+}
+
+internal fun Rect.toRect(): android.graphics.Rect {
+  return android.graphics.Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.text.TextLayoutResult
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.roundToInt
 
 internal class ComposeTextLayout(internal val layout: TextLayoutResult) : TextLayout {
@@ -204,5 +206,14 @@ internal fun LayoutCoordinates.boundsInWindow(rootCoordinates: LayoutCoordinates
 }
 
 internal fun Rect.toRect(): android.graphics.Rect {
-  return android.graphics.Rect(left.toInt(), top.toInt(), right.toInt(), bottom.toInt())
+  // Round outward (floor min edges, ceil max edges) so that a sub-pixel but non-empty Rect doesn't
+  // collapse to a zero-width/height android.graphics.Rect. Otherwise a node could be marked visible
+  // and maskable based on the float bounds, while the integer rect the MaskRenderer draws has zero
+  // area, leaving sensitive content unmasked. Rounding outward also biases toward over-masking.
+  return android.graphics.Rect(
+    floor(left).toInt(),
+    floor(top).toInt(),
+    ceil(right).toInt(),
+    ceil(bottom).toInt(),
+  )
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ComposeViewHierarchyNode.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/ComposeViewHierarchyNode.kt
@@ -27,6 +27,7 @@ import io.sentry.android.replay.util.findPainter
 import io.sentry.android.replay.util.findTextColor
 import io.sentry.android.replay.util.isMaskable
 import io.sentry.android.replay.util.toOpaque
+import io.sentry.android.replay.util.toRect
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.GenericViewHierarchyNode
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.ImageViewHierarchyNode
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.TextViewHierarchyNode
@@ -150,8 +151,8 @@ internal object ComposeViewHierarchyNode {
       // If we're unable to retrieve the semantics configuration
       // we should play safe and mask the whole node.
       return GenericViewHierarchyNode(
-        x = visibleRect.left.toFloat(),
-        y = visibleRect.top.toFloat(),
+        x = visibleRect.left,
+        y = visibleRect.top,
         width = node.width,
         height = node.height,
         elevation = (parent?.elevation ?: 0f),
@@ -161,17 +162,17 @@ internal object ComposeViewHierarchyNode {
         isImportantForContentCapture = false, // will be set by children
         isVisible =
           !SentryLayoutNodeHelper.isTransparent(node) &&
-            visibleRect.height() > 0 &&
-            visibleRect.width() > 0,
-        visibleRect = visibleRect,
+            visibleRect.height > 0 &&
+            visibleRect.width > 0,
+        visibleRect = visibleRect.toRect(),
       )
     }
 
     val isVisible =
       !SentryLayoutNodeHelper.isTransparent(node) &&
         (semantics == null || !semantics.contains(SemanticsProperties.InvisibleToUser)) &&
-        visibleRect.height() > 0 &&
-        visibleRect.width() > 0
+        visibleRect.height > 0 &&
+        visibleRect.width > 0
     val isEditable =
       semantics?.contains(SemanticsActions.SetText) == true ||
         semantics?.contains(SemanticsProperties.EditableText) == true
@@ -206,8 +207,8 @@ internal object ComposeViewHierarchyNode {
               null
             },
           dominantColor = textColor?.toArgb()?.toOpaque(),
-          x = visibleRect.left.toFloat(),
-          y = visibleRect.top.toFloat(),
+          x = visibleRect.left,
+          y = visibleRect.top,
           width = node.width,
           height = node.height,
           elevation = (parent?.elevation ?: 0f),
@@ -216,7 +217,7 @@ internal object ComposeViewHierarchyNode {
           shouldMask = shouldMask,
           isImportantForContentCapture = true,
           isVisible = isVisible,
-          visibleRect = visibleRect,
+          visibleRect = visibleRect.toRect(),
         )
       }
       else -> {
@@ -226,8 +227,8 @@ internal object ComposeViewHierarchyNode {
 
           parent?.setImportantForCaptureToAncestors(true)
           ImageViewHierarchyNode(
-            x = visibleRect.left.toFloat(),
-            y = visibleRect.top.toFloat(),
+            x = visibleRect.left,
+            y = visibleRect.top,
             width = node.width,
             height = node.height,
             elevation = (parent?.elevation ?: 0f),
@@ -236,7 +237,7 @@ internal object ComposeViewHierarchyNode {
             isVisible = isVisible,
             isImportantForContentCapture = true,
             shouldMask = shouldMask && painter.isMaskable(),
-            visibleRect = visibleRect,
+            visibleRect = visibleRect.toRect(),
           )
         } else {
           val shouldMask = isVisible && semantics.shouldMask(isImage = false, options)
@@ -245,8 +246,8 @@ internal object ComposeViewHierarchyNode {
           // TODO: traverse the ViewHierarchyNode here again. For now we can recommend
           // TODO: using custom modifiers to obscure the entire node if it's sensitive
           GenericViewHierarchyNode(
-            x = visibleRect.left.toFloat(),
-            y = visibleRect.top.toFloat(),
+            x = visibleRect.left,
+            y = visibleRect.top,
             width = node.width,
             height = node.height,
             elevation = (parent?.elevation ?: 0f),
@@ -255,7 +256,7 @@ internal object ComposeViewHierarchyNode {
             shouldMask = shouldMask,
             isImportantForContentCapture = false, // will be set by children
             isVisible = isVisible,
-            visibleRect = visibleRect,
+            visibleRect = visibleRect.toRect(),
           )
         }
       }


### PR DESCRIPTION
## 📜 Description

`ComposeViewHierarchyNode` traversal computed node bounds via `LayoutCoordinates.boundsInWindow(...)`, which returned an `android.graphics.Rect` while the surrounding code treated the value as `androidx.compose.ui.geometry.Rect` — mixing the two `Rect` types within `fromComposeNode(...)`.

Under aggressive obfuscation/optimization (DexGuard 9.13.2 / R8 full mode) this could be rejected at class verification time with a `VerifyError` (`'Unresolved Reference: androidx.compose.ui.geometry.Rect' not instance of ...`), crashing Session Replay the moment it traversed the first Compose screen.

Fix:
- `boundsInWindow(...)` now consistently returns `androidx.compose.ui.geometry.Rect` (float-based), so a single `Rect` type flows through the method.
- Added an `internal fun Rect.toRect(): android.graphics.Rect` extension to convert only at the boundary where the view-hierarchy node actually needs `android.graphics.Rect`.

## 💡 Motivation and Context

Fixes #5497 — Session Replay `VerifyError` in `ComposeViewHierarchyNode` under DexGuard/R8 obfuscation.

## 💚 How did you test it?

Existing Session Replay Compose unit tests; built the replay module in release. The crash itself only reproduces under aggressive obfuscation (DexGuard / R8 full mode), where the mixed `Rect` types tripped the verifier; collapsing to a single `Rect` type removes the ambiguity.

Example replay: https://sentry-sdks.sentry.io/explore/replays/6783b073aef442a8b4ad8731bf6901fa

## 📝 Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps
