### PR TITLE
feat(android): Add binder (IPC) tracing and logging instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add opt-in binder (IPC) tracing and logging instrumentation for Android ([#5515](https://github.com/getsentry/sentry-java/pull/5515))
+  - Enable spans via `options.isEnableBinderTracing = true` or manifest: `<meta-data android:name="io.sentry.traces.binder.enable" android:value="true" />`
+  - Enable logs via `options.isEnableBinderLogging = true` or manifest: `<meta-data android:name="io.sentry.logs.binder.enable" android:value="true" />`
+
 ## 8.43.1
 
 ### Fixes

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -386,6 +386,8 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun isEnableAppLifecycleBreadcrumbs ()Z
 	public fun isEnableAutoActivityLifecycleTracing ()Z
 	public fun isEnableAutoTraceIdGeneration ()Z
+	public fun isEnableBinderLogging ()Z
+	public fun isEnableBinderTracing ()Z
 	public fun isEnableFramesTracking ()Z
 	public fun isEnableNdk ()Z
 	public fun isEnableNetworkEventBreadcrumbs ()Z
@@ -417,6 +419,8 @@ public final class io/sentry/android/core/SentryAndroidOptions : io/sentry/Sentr
 	public fun setEnableAppLifecycleBreadcrumbs (Z)V
 	public fun setEnableAutoActivityLifecycleTracing (Z)V
 	public fun setEnableAutoTraceIdGeneration (Z)V
+	public fun setEnableBinderLogging (Z)V
+	public fun setEnableBinderTracing (Z)V
 	public fun setEnableFramesTracking (Z)V
 	public fun setEnableNdk (Z)V
 	public fun setEnableNetworkEventBreadcrumbs (Z)V

--- a/sentry-android-core/proguard-rules.pro
+++ b/sentry-android-core/proguard-rules.pro
@@ -92,3 +92,5 @@
 -dontwarn io.sentry.spotlight.SpotlightIntegration
 -keepnames class io.sentry.spotlight.SpotlightIntegration
 ##---------------End: proguard configuration for sentry-spotlight  ----------
+
+-keepnames class io.sentry.android.core.internal.binder.SentryBinderAdapter { *; }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -188,6 +188,10 @@ final class ManifestMetadataReader {
 
   static final String ENABLE_ANR_FINGERPRINTING = "io.sentry.anr.enable-fingerprinting";
 
+  static final String ENABLE_BINDER_TRACING = "io.sentry.traces.binder.enable";
+
+  static final String ENABLE_BINDER_LOGGING = "io.sentry.logs.binder.enable";
+
   /** ManifestMetadataReader ctor */
   private ManifestMetadataReader() {}
 
@@ -725,6 +729,12 @@ final class ManifestMetadataReader {
         options.setEnableAnrFingerprinting(
             readBool(
                 metadata, logger, ENABLE_ANR_FINGERPRINTING, options.isEnableAnrFingerprinting()));
+
+        options.setEnableBinderTracing(
+            readBool(metadata, logger, ENABLE_BINDER_TRACING, options.isEnableBinderTracing()));
+
+        options.setEnableBinderLogging(
+            readBool(metadata, logger, ENABLE_BINDER_LOGGING, options.isEnableBinderLogging()));
       }
       options
           .getLogger()

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroid.java
@@ -14,6 +14,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.Session;
+import io.sentry.android.core.internal.binder.SentryBinderAdapter;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.android.core.performance.TimeSpan;
 import io.sentry.android.fragment.FragmentLifecycleIntegration;
@@ -150,6 +151,9 @@ public final class SentryAndroid {
                       "Error in the 'OptionsConfiguration.configure' callback.",
                       t);
             }
+
+            SentryBinderAdapter.setEnabled(
+                options.isEnableBinderTracing(), options.isEnableBinderLogging());
 
             // if SentryPerformanceProvider was disabled or removed,
             // we set the app start / sdk init time here instead

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryAndroidOptions.java
@@ -263,6 +263,12 @@ public final class SentryAndroidOptions extends SentryOptions {
 
   private boolean enableAnrFingerprinting = true;
 
+  /** Enable or disable creating spans for binder (IPC) calls. Default is disabled. */
+  private boolean enableBinderTracing = false;
+
+  /** Enable or disable logging of binder (IPC) calls. Default is disabled. */
+  private boolean enableBinderLogging = false;
+
   public SentryAndroidOptions() {
     setSentryClientName(BuildConfig.SENTRY_ANDROID_SDK_NAME + "/" + BuildConfig.VERSION_NAME);
     setSdkVersion(createSdkVersion());
@@ -753,6 +759,42 @@ public final class SentryAndroidOptions extends SentryOptions {
    */
   public void setEnableAnrFingerprinting(final boolean enableAnrFingerprinting) {
     this.enableAnrFingerprinting = enableAnrFingerprinting;
+  }
+
+  /**
+   * Returns whether creating spans for binder (IPC) calls is enabled. Default is disabled.
+   *
+   * @return true if binder spans are enabled
+   */
+  public boolean isEnableBinderTracing() {
+    return enableBinderTracing;
+  }
+
+  /**
+   * Enables or disables creating spans for binder (IPC) calls.
+   *
+   * @param enableBinderTracing true to enable binder spans
+   */
+  public void setEnableBinderTracing(final boolean enableBinderTracing) {
+    this.enableBinderTracing = enableBinderTracing;
+  }
+
+  /**
+   * Returns whether logging of binder (IPC) calls is enabled. Default is disabled.
+   *
+   * @return true if binder logging is enabled
+   */
+  public boolean isEnableBinderLogging() {
+    return enableBinderLogging;
+  }
+
+  /**
+   * Enables or disables logging of binder (IPC) calls.
+   *
+   * @param enableBinderLogging true to enable binder logging
+   */
+  public void setEnableBinderLogging(final boolean enableBinderLogging) {
+    this.enableBinderLogging = enableBinderLogging;
   }
 
   static class AndroidUserFeedbackFormHandler implements SentryFeedbackOptions.IFormHandler {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/binder/SentryBinderAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/binder/SentryBinderAdapter.java
@@ -9,7 +9,6 @@ import io.sentry.SpanDataConvention;
 import io.sentry.logger.SentryLogParameters;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,9 +16,6 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings({"unused", "deprecation"})
 @ApiStatus.Internal
 public final class SentryBinderAdapter {
-
-  private static final AtomicInteger cookieCounter = new AtomicInteger();
-  private static final int NO_COOKIE = -1;
 
   private static volatile boolean tracingEnabled = false;
   private static volatile boolean loggingEnabled = false;
@@ -30,17 +26,19 @@ public final class SentryBinderAdapter {
     SentryBinderAdapter.loggingEnabled = loggingEnabled;
   }
 
-  private static final ThreadLocal<Map<Integer, ISpan>> spanMap =
-      new ThreadLocal<Map<Integer, ISpan>>() {
-        @Override
-        protected Map<Integer, ISpan> initialValue() {
-          return new HashMap<>();
-        }
-      };
-
-  public static int onCallStart(final @NotNull String component, final @NotNull String name) {
+  /**
+   * This method is used by the Sentry Android Gradle plugin for binder instrumentation. Called
+   * right before a binder call starts. Returns an opaque token that must be passed back to {@link
+   * #onCallEnd(Object)} once the call completes, or {@code null} if nothing was recorded.
+   *
+   * @param component the component being called, e.g. "ActivityManager"
+   * @param name the method being called, e.g. "startActivity"
+   * @return an opaque token which must be later passed to {@link #onCallEnd(Object)},
+   */
+  public static @Nullable Object onCallStart(
+      final @NotNull String component, final @NotNull String name) {
     if (!tracingEnabled && !loggingEnabled) {
-      return NO_COOKIE;
+      return null;
     }
 
     try {
@@ -57,53 +55,47 @@ public final class SentryBinderAdapter {
         recordLog(component, name, threadId, threadName);
       }
       if (tracingEnabled) {
-        final int cookie = cookieCounter.incrementAndGet();
-        recordSpan(component, name, threadId, threadName, cookie);
-        return cookie;
+        return recordSpan(component, name, threadId, threadName);
       }
     } catch (Throwable t) {
       // ignored, as instrumentation should never crash
     }
-    return NO_COOKIE;
+    return null;
   }
 
-  public static void onCallEnd(final int cookie) {
-    if (cookie == NO_COOKIE) {
+  /**
+   * This method is used by the Sentry Android Gradle plugin for binder instrumentation. Called
+   * right after a binder call ends.
+   *
+   * @param token the token returned by {@link #onCallStart(String, String)}
+   */
+  public static void onCallEnd(final @Nullable Object token) {
+    if (token == null) {
       return;
     }
     try {
-      final @Nullable Map<Integer, ISpan> map = spanMap.get();
-      if (map == null) {
-        return;
-      }
-      final @Nullable ISpan span = map.remove(cookie);
-      if (span != null) {
-        span.finish();
+      if (token instanceof ISpan) {
+        ((ISpan) token).finish();
       }
     } catch (Throwable t) {
       // ignored
     }
   }
 
-  private static void recordSpan(
+  private static @Nullable ISpan recordSpan(
       final @NotNull String component,
       final @NotNull String name,
       final long threadId,
-      final @Nullable String threadName,
-      final int cookie) {
+      final @Nullable String threadName) {
 
     final @Nullable ISpan parent = Sentry.getCurrentScopes().getTransaction();
     if (parent == null) {
-      return;
-    }
-    final @Nullable Map<Integer, ISpan> map = spanMap.get();
-    if (map == null) {
-      return;
+      return null;
     }
     final @NotNull ISpan span = parent.startChild("binder", component + "." + name);
     span.setData(SpanDataConvention.THREAD_ID, String.valueOf(threadId));
     span.setData(SpanDataConvention.THREAD_NAME, threadName);
-    map.put(cookie, span);
+    return span;
   }
 
   private static void recordLog(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/binder/SentryBinderAdapter.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/binder/SentryBinderAdapter.java
@@ -1,0 +1,126 @@
+package io.sentry.android.core.internal.binder;
+
+import android.os.Build;
+import io.sentry.ISpan;
+import io.sentry.Sentry;
+import io.sentry.SentryAttributes;
+import io.sentry.SentryLogLevel;
+import io.sentry.SpanDataConvention;
+import io.sentry.logger.SentryLogParameters;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@SuppressWarnings({"unused", "deprecation"})
+@ApiStatus.Internal
+public final class SentryBinderAdapter {
+
+  private static final AtomicInteger cookieCounter = new AtomicInteger();
+  private static final int NO_COOKIE = -1;
+
+  private static volatile boolean tracingEnabled = false;
+  private static volatile boolean loggingEnabled = false;
+
+  /** Configures which binder features are active. Expected to be called once during SDK init. */
+  public static void setEnabled(final boolean tracingEnabled, final boolean loggingEnabled) {
+    SentryBinderAdapter.tracingEnabled = tracingEnabled;
+    SentryBinderAdapter.loggingEnabled = loggingEnabled;
+  }
+
+  private static final ThreadLocal<Map<Integer, ISpan>> spanMap =
+      new ThreadLocal<Map<Integer, ISpan>>() {
+        @Override
+        protected Map<Integer, ISpan> initialValue() {
+          return new HashMap<>();
+        }
+      };
+
+  public static int onCallStart(final @NotNull String component, final @NotNull String name) {
+    if (!tracingEnabled && !loggingEnabled) {
+      return NO_COOKIE;
+    }
+
+    try {
+      final @NotNull Thread currentThread = Thread.currentThread();
+      final long threadId;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        threadId = currentThread.threadId();
+      } else {
+        threadId = currentThread.getId();
+      }
+      final @Nullable String threadName = currentThread.getName();
+
+      if (loggingEnabled) {
+        recordLog(component, name, threadId, threadName);
+      }
+      if (tracingEnabled) {
+        final int cookie = cookieCounter.incrementAndGet();
+        recordSpan(component, name, threadId, threadName, cookie);
+        return cookie;
+      }
+    } catch (Throwable t) {
+      // ignored, as instrumentation should never crash
+    }
+    return NO_COOKIE;
+  }
+
+  public static void onCallEnd(final int cookie) {
+    if (cookie == NO_COOKIE) {
+      return;
+    }
+    try {
+      final @Nullable Map<Integer, ISpan> map = spanMap.get();
+      if (map == null) {
+        return;
+      }
+      final @Nullable ISpan span = map.remove(cookie);
+      if (span != null) {
+        span.finish();
+      }
+    } catch (Throwable t) {
+      // ignored
+    }
+  }
+
+  private static void recordSpan(
+      final @NotNull String component,
+      final @NotNull String name,
+      final long threadId,
+      final @Nullable String threadName,
+      final int cookie) {
+
+    final @Nullable ISpan parent = Sentry.getCurrentScopes().getTransaction();
+    if (parent == null) {
+      return;
+    }
+    final @Nullable Map<Integer, ISpan> map = spanMap.get();
+    if (map == null) {
+      return;
+    }
+    final @NotNull ISpan span = parent.startChild("binder", component + "." + name);
+    span.setData(SpanDataConvention.THREAD_ID, String.valueOf(threadId));
+    span.setData(SpanDataConvention.THREAD_NAME, threadName);
+    map.put(cookie, span);
+  }
+
+  private static void recordLog(
+      final @NotNull String component,
+      final @NotNull String name,
+      final long threadId,
+      final @Nullable String threadName) {
+    final @NotNull Map<String, Object> logAttributes = new HashMap<>();
+    logAttributes.put(SpanDataConvention.THREAD_ID, threadId);
+    logAttributes.put(SpanDataConvention.THREAD_NAME, threadName);
+
+    Sentry.logger()
+        .log(
+            SentryLogLevel.INFO,
+            SentryLogParameters.create(SentryAttributes.fromMap(logAttributes)),
+            "binder call: %s.%s",
+            component,
+            name);
+  }
+}

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -2586,4 +2586,54 @@ class ManifestMetadataReaderTest {
     // Assert
     assertEquals("12345", fixture.options.orgId)
   }
+
+  @Test
+  fun `applyMetadata reads enableBinderTracing to options`() {
+    // Arrange
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_BINDER_TRACING to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertTrue(fixture.options.isEnableBinderTracing)
+  }
+
+  @Test
+  fun `applyMetadata keeps enableBinderTracing default when not set in manifest`() {
+    // Arrange
+    val context = fixture.getContext()
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertFalse(fixture.options.isEnableBinderTracing)
+  }
+
+  @Test
+  fun `applyMetadata reads enableBinderLogging to options`() {
+    // Arrange
+    val bundle = bundleOf(ManifestMetadataReader.ENABLE_BINDER_LOGGING to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertTrue(fixture.options.isEnableBinderLogging)
+  }
+
+  @Test
+  fun `applyMetadata keeps enableBinderLogging default when not set in manifest`() {
+    // Arrange
+    val context = fixture.getContext()
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertFalse(fixture.options.isEnableBinderLogging)
+  }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryAndroidOptionsTest.kt
@@ -115,6 +115,36 @@ class SentryAndroidOptionsTest {
   }
 
   @Test
+  fun `binder tracing is disabled by default for Android`() {
+    val sentryOptions = SentryAndroidOptions()
+
+    assertFalse(sentryOptions.isEnableBinderTracing)
+  }
+
+  @Test
+  fun `binder logging is disabled by default for Android`() {
+    val sentryOptions = SentryAndroidOptions()
+
+    assertFalse(sentryOptions.isEnableBinderLogging)
+  }
+
+  @Test
+  fun `binder tracing can be enabled`() {
+    val sentryOptions = SentryAndroidOptions()
+    sentryOptions.isEnableBinderTracing = true
+
+    assertTrue(sentryOptions.isEnableBinderTracing)
+  }
+
+  @Test
+  fun `binder logging can be enabled`() {
+    val sentryOptions = SentryAndroidOptions()
+    sentryOptions.isEnableBinderLogging = true
+
+    assertTrue(sentryOptions.isEnableBinderLogging)
+  }
+
+  @Test
   fun `native sdk name is null by default`() {
     val sentryOptions = SentryAndroidOptions()
     assertNull(sentryOptions.nativeSdkName)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/binder/SentryBinderAdapterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/binder/SentryBinderAdapterTest.kt
@@ -10,8 +10,8 @@ import io.sentry.logger.SentryLogParameters
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -51,12 +51,12 @@ class SentryBinderAdapterTest {
   }
 
   @Test
-  fun `returns no cookie and does nothing when both features disabled`() {
+  fun `returns no token and does nothing when both features disabled`() {
     SentryBinderAdapter.setEnabled(false, false)
 
-    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+    val token = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
 
-    assertEquals(-1, cookie)
+    assertNull(token)
     verify(fixture.transaction, never()).startChild(any<String>(), any<String>())
     verifyNoInteractions(fixture.logger)
   }
@@ -65,12 +65,12 @@ class SentryBinderAdapterTest {
   fun `starts and finishes a span when tracing is enabled`() {
     SentryBinderAdapter.setEnabled(true, false)
 
-    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+    val token = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
 
-    assertNotEquals(-1, cookie)
+    assertNotNull(token)
     verify(fixture.transaction).startChild(eq("binder"), eq("ActivityManager.getRunningTasks"))
 
-    SentryBinderAdapter.onCallEnd(cookie)
+    SentryBinderAdapter.onCallEnd(token)
     verify(fixture.span).finish()
   }
 
@@ -88,9 +88,9 @@ class SentryBinderAdapterTest {
   fun `records a log when logging is enabled`() {
     SentryBinderAdapter.setEnabled(false, true)
 
-    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+    val token = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
 
-    assertEquals(-1, cookie)
+    assertNull(token)
     verify(fixture.logger)
       .log(
         eq(SentryLogLevel.INFO),
@@ -102,10 +102,10 @@ class SentryBinderAdapterTest {
   }
 
   @Test
-  fun `onCallEnd with no cookie is a no-op`() {
+  fun `onCallEnd with null token is a no-op`() {
     SentryBinderAdapter.setEnabled(true, false)
 
-    SentryBinderAdapter.onCallEnd(-1)
+    SentryBinderAdapter.onCallEnd(null)
 
     verify(fixture.span, never()).finish()
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/binder/SentryBinderAdapterTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/binder/SentryBinderAdapterTest.kt
@@ -1,0 +1,112 @@
+package io.sentry.android.core.internal.binder
+
+import io.sentry.IScopes
+import io.sentry.ISpan
+import io.sentry.ITransaction
+import io.sentry.Sentry
+import io.sentry.SentryLogLevel
+import io.sentry.logger.ILoggerApi
+import io.sentry.logger.SentryLogParameters
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class SentryBinderAdapterTest {
+  class Fixture {
+    val mockedSentry = mockStatic(Sentry::class.java)
+    val scopes = mock<IScopes>()
+    val transaction = mock<ITransaction>()
+    val span = mock<ISpan>()
+    val logger = mock<ILoggerApi>()
+
+    fun setUp(hasTransaction: Boolean = true) {
+      mockedSentry.`when`<Any> { Sentry.getCurrentScopes() }.thenReturn(scopes)
+      mockedSentry.`when`<Any> { Sentry.logger() }.thenReturn(logger)
+      whenever(scopes.transaction).thenReturn(if (hasTransaction) transaction else null)
+      whenever(transaction.startChild(any<String>(), any<String>())).thenReturn(span)
+    }
+  }
+
+  private val fixture = Fixture()
+
+  @BeforeTest
+  fun setUp() {
+    fixture.setUp()
+  }
+
+  @AfterTest
+  fun cleanup() {
+    SentryBinderAdapter.setEnabled(false, false)
+    fixture.mockedSentry.close()
+  }
+
+  @Test
+  fun `returns no cookie and does nothing when both features disabled`() {
+    SentryBinderAdapter.setEnabled(false, false)
+
+    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+
+    assertEquals(-1, cookie)
+    verify(fixture.transaction, never()).startChild(any<String>(), any<String>())
+    verifyNoInteractions(fixture.logger)
+  }
+
+  @Test
+  fun `starts and finishes a span when tracing is enabled`() {
+    SentryBinderAdapter.setEnabled(true, false)
+
+    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+
+    assertNotEquals(-1, cookie)
+    verify(fixture.transaction).startChild(eq("binder"), eq("ActivityManager.getRunningTasks"))
+
+    SentryBinderAdapter.onCallEnd(cookie)
+    verify(fixture.span).finish()
+  }
+
+  @Test
+  fun `does not start a span when there is no active transaction`() {
+    fixture.setUp(hasTransaction = false)
+    SentryBinderAdapter.setEnabled(true, false)
+
+    SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+
+    verify(fixture.transaction, never()).startChild(any<String>(), any<String>())
+  }
+
+  @Test
+  fun `records a log when logging is enabled`() {
+    SentryBinderAdapter.setEnabled(false, true)
+
+    val cookie = SentryBinderAdapter.onCallStart("ActivityManager", "getRunningTasks")
+
+    assertEquals(-1, cookie)
+    verify(fixture.logger)
+      .log(
+        eq(SentryLogLevel.INFO),
+        any<SentryLogParameters>(),
+        eq("binder call: %s.%s"),
+        eq("ActivityManager"),
+        eq("getRunningTasks"),
+      )
+  }
+
+  @Test
+  fun `onCallEnd with no cookie is a no-op`() {
+    SentryBinderAdapter.setEnabled(true, false)
+
+    SentryBinderAdapter.onCallEnd(-1)
+
+    verify(fixture.span, never()).finish()
+  }
+}

--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -279,5 +279,11 @@
     <meta-data
       android:name="io.sentry.feedback.use-shake-gesture"
       android:value="true" />
+    <meta-data
+      android:name="io.sentry.traces.binder.enable"
+      android:value="true" />
+    <meta-data
+      android:name="io.sentry.logs.binder.enable"
+      android:value="true" />
   </application>
 </manifest>


### PR DESCRIPTION
## :scroll: Description

Adds an internal `SentryBinderAdapter` that hooks into Android binder (IPC) calls, together with two new opt-in `SentryAndroidOptions`:

- `enableBinderTracing` (`io.sentry.traces.binder.enable`) — creates child spans on the active transaction for binder calls, annotated with thread id/name.
- `enableBinderLogging` (`io.sentry.logs.binder.enable`) — emits a Sentry log entry for each binder call.

Both options default to `false` and can also be configured via `AndroidManifest.xml` metadata. The adapter is wired up during `SentryAndroid.init` and is designed to never crash the host app (all instrumentation is wrapped in defensive try/catch).

## :bulb: Motivation and Context

Binder (IPC) calls can be a significant and hard-to-diagnose source of latency on Android. Surfacing them as spans and/or logs gives developers visibility into IPC activity happening on their threads.

## :green_heart: How did you test it?

Added unit tests for `SentryBinderAdapter`, the new `SentryAndroidOptions` getters/setters, and `ManifestMetadataReader` parsing of the new manifest attributes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
