### PR TITLE
fix(license): Attribute vendored AndroidX Compose UI code in Session Replay

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -315,6 +315,35 @@ limitations under the License.
 
 ---
 
+## Android Open Source Project — Jetpack Compose UI (Apache 2.0)
+
+**Source:** https://github.com/androidx/androidx/blob/fc7df0dd68466ac3bb16b1c79b7a73dd0bfdd4c1/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/LayoutCoordinates.kt#L187<br>
+**Source:** https://github.com/androidx/androidx/blob/androidx-main/compose/ui/ui-util/src/commonMain/kotlin/androidx/compose/ui/util/MathHelpers.kt<br>
+**License:** Apache License 2.0<br>
+**Copyright:** Copyright (C) 2019, 2020 The Android Open Source Project
+
+### Scope
+
+The Sentry Android Replay SDK includes code adapted from Jetpack Compose UI, used to compute Compose node bounds while traversing the view hierarchy for masking. The code resides in `io.sentry.android.replay.util.Nodes`: the `boundsInWindow` extension function (a faster copy of `LayoutCoordinates.boundsInWindow`) and the `fastMinOf`, `fastMaxOf`, `fastCoerceIn`, `fastCoerceAtLeast`, and `fastCoerceAtMost` numeric helpers (copied from `androidx.compose.ui.util.MathHelpers`).
+
+```
+Copyright (C) 2019, 2020 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+---
+
 ## OpenTelemetry (Apache 2.0)
 
 **Source:** https://github.com/open-telemetry/opentelemetry-java (Commit: 0aacc55d1e3f5cc6dbb4f8fa26bcb657b01a7bc9)<br>

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/Nodes.kt
@@ -1,3 +1,25 @@
+/*
+ * Portions of this file are adapted from AndroidX Compose UI:
+ *  - the `boundsInWindow` extension is a faster copy of `LayoutCoordinates.boundsInWindow`
+ *  - the `fastMinOf`, `fastMaxOf`, `fastCoerceIn`, `fastCoerceAtLeast` and `fastCoerceAtMost`
+ *    helpers are copied from `androidx.compose.ui.util.MathHelpers`
+ *
+ * Adapted from:
+ * https://github.com/androidx/androidx/blob/fc7df0dd68466ac3bb16b1c79b7a73dd0bfdd4c1/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/LayoutCoordinates.kt
+ * https://github.com/androidx/androidx/blob/androidx-main/compose/ui/ui-util/src/commonMain/kotlin/androidx/compose/ui/util/MathHelpers.kt
+ *
+ * Copyright (C) 2019, 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE") // to access internal vals and classes
 
 package io.sentry.android.replay.util


### PR DESCRIPTION
## 📜 Description

`sentry-android-replay`'s `Nodes.kt` vendors code from AndroidX Compose UI (Apache-2.0, The Android Open Source Project) without attribution:

- `boundsInWindow` is an adapted ("faster copy") of `LayoutCoordinates.boundsInWindow`.
- `fastMinOf` / `fastMaxOf` / `fastCoerceIn` / `fastCoerceAtLeast` / `fastCoerceAtMost` are copied from `androidx.compose.ui.util.MathHelpers`.

This PR adds:
- a source-file attribution header to `Nodes.kt` (vendoring origin, both source URLs, copyright, Apache-2.0 license);
- a `THIRD_PARTY_NOTICES.md` entry (both Source URLs, License, Copyright, Scope, full Apache-2.0 text).

This is pre-existing vendored code on `main`; the `sentry-warden[bot]` `check-code-attribution` finding surfaced it on #5507 (which modifies `boundsInWindow`). Splitting the attribution fix out so it can land independently.

## 💡 Motivation and Context

Addresses the `check-code-attribution` finding (`LL3-2QU`) reported by Warden. Apache-2.0 is permissive/compatible per https://open.sentry.io/licensing/ — this PR only adds the legally-required attribution, no behavior change.

## 💚 How did you test it?

Not applicable — attribution/licensing only (header comment + `THIRD_PARTY_NOTICES.md`). Verified the module still compiles and `spotlessApply apiDump` produced no API changes.

## 📝 Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

#skip-changelog
