### PR TITLE
docs(ai): Refresh AGENTS.md module list and fix coding.mdc command

### DIFF
--- a/.cursor/rules/coding.mdc
+++ b/.cursor/rules/coding.mdc
@@ -24,13 +24,13 @@ sentry-java is the Java and Android SDK for Sentry. This repository contains the
 ./gradlew check
 
 # Run unit tests for a specific file
-./gradle ':<module>:testDebugUnitTest' --tests="*<file name>*" --info
+./gradlew ':<module>:testDebugUnitTest' --tests="*<file name>*" --info
 ```
 
 ## Contributing Guidelines
 
 1. Follow existing code style and language
-2. Do not modify the API files (e.g. sentry.api) manually, instead run `./gradlew  apiDump` to regenerate them
+2. Do not modify the API files (e.g. sentry.api) manually, instead run `./gradlew apiDump` to regenerate them
 3. Write comprehensive tests
 4. New features should always be opt-in by default, extend `SentryOptions` or similar Option classes with getters and setters to enable/disable a new feature
 5. Consider backwards compatibility

--- a/.cursor/rules/pr.mdc
+++ b/.cursor/rules/pr.mdc
@@ -93,6 +93,8 @@ Entry format:
 - <Short description> ([#<PR_NUMBER>](https://github.com/getsentry/sentry-java/pull/<PR_NUMBER>))
 ```
 
+**When rebasing:** A rebase onto `main` can land your branch after a release was cut, where the `## Unreleased` heading your entry lived under has since been renamed to that version number. If that happens, move your new entry into an `## Unreleased` section at the top of `CHANGELOG.md` (create the section if it no longer exists) so it is not left under an already-released version.
+
 Commit changelog separately:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,14 @@ make systemTest
 6. **Format and regenerate**: Once done, format code and regenerate .api files: `./gradlew spotlessApply apiDump`
 7. **Propose commit**: As final step, git stage relevant files and propose (but not execute) a single git commit command
 
+## Repository Skills
+
+This repo ships task-specific skills (declared in `agents.toml`, sources under `.agents/skills`). Prefer them over performing the steps manually:
+- **`create-java-pr`**: Branch, format, `apiDump`, commit, push, open PR, and add the changelog entry (automates the PR workflow above)
+- **`test`**: Run unit or system tests for a module or a specific class
+- **`check-code-attribution`**: Verify third-party code attribution on the current branch (see Third-Party Code Attribution below)
+- **`btrace-perfetto`**: Capture and compare Perfetto traces for Android performance work
+
 ## Module Architecture
 
 The repository is organized into multiple modules:
@@ -100,15 +108,22 @@ The repository is organized into multiple modules:
 - **`sentry`** - Core Java SDK implementation
 - **`sentry-android-core`** - Core Android SDK implementation
 - **`sentry-android`** - High-level Android SDK
+- **`sentry-android-ndk`** - Native (NDK) crash handling
 
 ### Integration Modules
 - **Spring Framework**: `sentry-spring*`, `sentry-spring-boot*`
-- **Logging**: `sentry-logback`, `sentry-log4j2`, `sentry-jul`
-- **Web**: `sentry-servlet*`, `sentry-okhttp`, `sentry-apache-http-client-5`
+- **Logging**: `sentry-logback`, `sentry-log4j2`, `sentry-jul`, `sentry-android-timber`
+- **Web**: `sentry-servlet*`, `sentry-okhttp`, `sentry-openfeign`, `sentry-apache-http-client-5`
 - **GraphQL**: `sentry-graphql*`, `sentry-apollo*`
 - **Android UI**: `sentry-android-fragment`, `sentry-android-navigation`, `sentry-compose`
+- **Session Replay**: `sentry-android-replay`
+- **Database**: `sentry-jdbc`, `sentry-android-sqlite`, `sentry-jcache`
 - **Reactive**: `sentry-reactor`, `sentry-ktor-client`
+- **Feature Flags**: `sentry-launchdarkly-android`, `sentry-launchdarkly-server`, `sentry-openfeature`
+- **Queues**: `sentry-kafka`
+- **Profiling**: `sentry-async-profiler` (JVM continuous profiling)
 - **Monitoring**: `sentry-opentelemetry*`, `sentry-quartz`
+- **Other**: `sentry-spotlight`, `sentry-kotlin-extensions`, `sentry-android-distribution`
 
 ### Utility Modules
 - **`sentry-test-support`** - Shared test utilities

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,10 @@ gh pr view <branch-name> --json number -q '.number'
 gh pr view --json url -q '.url'
 ```
 
+### Changelog
+
+User-facing changes get an entry under the `## Unreleased` section of `CHANGELOG.md`. When rebasing onto `main`, a release may have renamed the `## Unreleased` heading your entry was under to a version number — if so, move your entry back into an `## Unreleased` section at the top of the file (create it if it no longer exists). See `.cursor/rules/pr.mdc` for the full changelog and PR workflow.
+
 ## Useful Resources
 
 - Main SDK documentation: https://develop.sentry.dev/sdk/overview/


### PR DESCRIPTION
## :scroll: Description

Brings the agent-instruction docs back in line with the repo:

- **`AGENTS.md` Module Architecture** — the list had drifted and omitted whole product areas that now exist as modules and already have dedicated `.cursor/rules`. Added Session Replay (`sentry-android-replay`), Feature Flags (`sentry-launchdarkly-*`, `sentry-openfeature`), Queues (`sentry-kafka`), and JVM continuous profiling (`sentry-async-profiler`), plus the other previously-unlisted modules (NDK, SQLite, Timber, JDBC, JCache, OpenFeign, Spotlight, etc.), grouped under clear categories.
- **`AGENTS.md` Repository Skills** — added a short pointer to the repo's committed skills (`create-java-pr`, `test`, `check-code-attribution`, `btrace-perfetto`) so agents prefer them over the manual workflow steps.
- **`.cursor/rules/coding.mdc`** — fixed a typo where the per-file test command used `./gradle` instead of `./gradlew`, and removed a stray double space in `./gradlew apiDump`.

## :bulb: Motivation and Context

`AGENTS.md` is the required-reading entrypoint for AI coding agents in this repo, but its module list predated several modules/product areas, and the `coding.mdc` test command was broken. Both lead agents astray.

## :green_heart: How did you test it?

Docs-only change. Verified the module list against `settings.gradle.kts` and the corrected command against the `Makefile` / Gradle task names.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog
