### PR TITLE
ref(core): Reduce unnecessary boxing and redundant null checks (JAVA-554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve SDK init performance by replacing `java.net.URI` with custom string parsing for DSN ([#5448](https://github.com/getsentry/sentry-java/pull/5448))
+- Remove unnecessary boxing to improve performance ([#5520](https://github.com/getsentry/sentry-java/pull/5520))
 
 ### Fixes
 

--- a/sentry/src/main/java/io/sentry/CircularFifoQueue.java
+++ b/sentry/src/main/java/io/sentry/CircularFifoQueue.java
@@ -258,8 +258,7 @@ final class CircularFifoQueue<E> extends AbstractCollection<E> implements Queue<
     if (index < 0 || index >= sz) {
       throw new NoSuchElementException(
           String.format(
-              "The specified index (%1$d) is outside the available range [0, %2$d)",
-              Integer.valueOf(index), Integer.valueOf(sz)));
+              "The specified index (%1$d) is outside the available range [0, %2$d)", index, sz));
     }
 
     final int idx = (start + index) % maxElements;

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -115,7 +115,7 @@ public final class DateUtils {
    * @return date rounded down to milliseconds
    */
   public static Date nanosToDate(final long nanos) {
-    final Double millis = nanosToMillis(Double.valueOf(nanos));
+    final Double millis = nanosToMillis((double) nanos);
     return getDateTime(millis.longValue());
   }
 
@@ -137,7 +137,7 @@ public final class DateUtils {
    * @return seconds
    */
   public static double nanosToSeconds(final long nanos) {
-    return Double.valueOf(nanos) / (1000.0 * 1000.0 * 1000.0);
+    return (double) nanos / (1000.0 * 1000.0 * 1000.0);
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/ScopesStorageFactory.java
+++ b/sentry/src/main/java/io/sentry/ScopesStorageFactory.java
@@ -29,7 +29,7 @@ public final class ScopesStorageFactory {
           try {
             final @Nullable Object otelScopesStorage =
                 otelScopesStorageClazz.getDeclaredConstructor().newInstance();
-            if (otelScopesStorage != null && otelScopesStorage instanceof IScopesStorage) {
+            if (otelScopesStorage instanceof IScopesStorage) {
               return (IScopesStorage) otelScopesStorage;
             }
           } catch (InstantiationException e) {

--- a/sentry/src/main/java/io/sentry/SentryDate.java
+++ b/sentry/src/main/java/io/sentry/SentryDate.java
@@ -47,6 +47,6 @@ public abstract class SentryDate implements Comparable<SentryDate> {
 
   @Override
   public int compareTo(@NotNull SentryDate otherDate) {
-    return Long.valueOf(nanoTimestamp()).compareTo(otherDate.nanoTimestamp());
+    return Long.compare(nanoTimestamp(), otherDate.nanoTimestamp());
   }
 }

--- a/sentry/src/main/java/io/sentry/SentryNanotimeDate.java
+++ b/sentry/src/main/java/io/sentry/SentryNanotimeDate.java
@@ -46,7 +46,7 @@ public final class SentryNanotimeDate extends SentryDate {
 
   @Override
   public long laterDateNanosTimestampByDiff(final @Nullable SentryDate otherDate) {
-    if (otherDate != null && otherDate instanceof SentryNanotimeDate) {
+    if (otherDate instanceof SentryNanotimeDate) {
       final @NotNull SentryNanotimeDate otherNanoDate = (SentryNanotimeDate) otherDate;
       if (compareTo(otherDate) < 0) {
         return nanotimeDiff(this, otherNanoDate);
@@ -66,9 +66,9 @@ public final class SentryNanotimeDate extends SentryDate {
       final long thisDateMillis = date.getTime();
       final long otherDateMillis = otherNanoDate.date.getTime();
       if (thisDateMillis == otherDateMillis) {
-        return Long.valueOf(nanos).compareTo(otherNanoDate.nanos);
+        return Long.compare(nanos, otherNanoDate.nanos);
       } else {
-        return Long.valueOf(thisDateMillis).compareTo(otherDateMillis);
+        return Long.compare(thisDateMillis, otherDateMillis);
       }
     } else {
       return super.compareTo(otherDate);

--- a/sentry/src/main/java/io/sentry/SpanFactoryFactory.java
+++ b/sentry/src/main/java/io/sentry/SpanFactoryFactory.java
@@ -21,7 +21,7 @@ public final class SpanFactoryFactory {
           try {
             final @Nullable Object otelSpanFactory =
                 otelSpanFactoryClazz.getDeclaredConstructor().newInstance();
-            if (otelSpanFactory != null && otelSpanFactory instanceof ISpanFactory) {
+            if (otelSpanFactory instanceof ISpanFactory) {
               return (ISpanFactory) otelSpanFactory;
             }
           } catch (InstantiationException e) {

--- a/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
+++ b/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
@@ -29,6 +29,6 @@ public final class EventProcessorAndOrder implements Comparable<EventProcessorAn
 
   @Override
   public int compareTo(@NotNull EventProcessorAndOrder o) {
-    return order.compareTo(o.order);
+    return Long.compare(order, o.order);
   }
 }

--- a/sentry/src/main/java/io/sentry/protocol/Contexts.java
+++ b/sentry/src/main/java/io/sentry/protocol/Contexts.java
@@ -282,7 +282,7 @@ public class Contexts implements JsonSerializable {
 
   @Override
   public boolean equals(final @Nullable Object obj) {
-    if (obj != null && obj instanceof Contexts) {
+    if (obj instanceof Contexts) {
       final @NotNull Contexts otherContexts = (Contexts) obj;
       return internalStorage.equals(otherContexts.internalStorage);
     }

--- a/sentry/src/main/java/io/sentry/util/LifecycleHelper.java
+++ b/sentry/src/main/java/io/sentry/util/LifecycleHelper.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 public final class LifecycleHelper {
 
   public static void close(final @Nullable Object tokenObject) {
-    if (tokenObject != null && tokenObject instanceof ISentryLifecycleToken) {
+    if (tokenObject instanceof ISentryLifecycleToken) {
       final @NotNull ISentryLifecycleToken token = (ISentryLifecycleToken) tokenObject;
       token.close();
     }

--- a/sentry/src/main/java/io/sentry/util/Platform.java
+++ b/sentry/src/main/java/io/sentry/util/Platform.java
@@ -23,7 +23,7 @@ public final class Platform {
     try {
       final @Nullable String javaStringVersion = System.getProperty("java.specification.version");
       if (javaStringVersion != null) {
-        final @NotNull double javaVersion = Double.valueOf(javaStringVersion);
+        final @NotNull double javaVersion = Double.parseDouble(javaStringVersion);
         isJavaNinePlus = javaVersion >= 9.0;
       } else {
         isJavaNinePlus = false;

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -143,10 +143,9 @@ public final class StringUtils {
       final BigInteger no = new BigInteger(1, messageDigest);
 
       // Convert message digest into hex value
-      final StringBuilder stringBuilder = new StringBuilder(no.toString(16));
 
       // return the HashText
-      return stringBuilder.toString();
+      return no.toString(16);
     }
 
     // For specifying wrong message digest algorithms

--- a/sentry/src/main/java/io/sentry/util/StringUtils.java
+++ b/sentry/src/main/java/io/sentry/util/StringUtils.java
@@ -4,6 +4,7 @@ import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.CharacterIterator;
@@ -18,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class StringUtils {
 
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
 
   public static final String PROPER_NIL_UUID = "00000000-0000-0000-0000-000000000000";
   private static final String CORRUPTED_NIL_UUID = "0000-0000";
@@ -142,9 +143,7 @@ public final class StringUtils {
       // Convert byte array into signum representation
       final BigInteger no = new BigInteger(1, messageDigest);
 
-      // Convert message digest into hex value
-
-      // return the HashText
+      // Convert message digest into hex value and return the HashText
       return no.toString(16);
     }
 


### PR DESCRIPTION
## :scroll: Description

Small, behavior-preserving cleanups applied consistently across the core `sentry` module:

- Replace boxed `Long.valueOf(a).compareTo(b)` with `Long.compare(a, b)` (and `order.compareTo(...)` on a boxed `Long` field), avoiding unnecessary boxing.
- Drop the redundant `x != null && x instanceof Type` guards, since `instanceof` already returns `false` for `null`.
- Remove other unnecessary boxing flagged by inspection: pass primitives to `String.format`, cast `long`→`double` instead of `Double.valueOf`, and use `Double.parseDouble` for the Java version check.

Files touched:
- `SentryDate.java`, `SentryNanotimeDate.java` — `Long.compare`
- `internal/eventprocessor/EventProcessorAndOrder.java` — `Long.compare`
- `SpanFactoryFactory.java`, `ScopesStorageFactory.java`, `util/LifecycleHelper.java`, `protocol/Contexts.java` — redundant null check removal
- `CircularFifoQueue.java`, `DateUtils.java`, `util/Platform.java` — unnecessary boxing removal

## :bulb: Motivation and Context

Started as a small refactor in `SentryDate`/`SentryNanotimeDate` and applied the same patterns everywhere else they appeared in the core module. Pure readability/cleanup, no behavior change.

Resolves JAVA-554.


## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
