### PR TITLE
build(samples): Remove outputs.upToDateWhen { false } from systemTest tasks

### DIFF
--- a/build-logic/src/main/kotlin/io.sentry.systemtest.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.systemtest.gradle.kts
@@ -1,8 +1,12 @@
+import io.sentry.gradle.SystemTestExtension
 import org.gradle.api.tasks.ClasspathNormalizer
 
-// The sample system tests launch the packaged app (war/shadowJar/bootJar) from
-// build/libs as a separate process, so the archive is a real input even though it
-// is not on the test classpath. See test/system-test-runner.py.
+val systemTest = extensions.create<SystemTestExtension>("sentrySystemTest")
+
+// The sample system tests launch the packaged app (war/shadowJar/bootJar) from build/libs as a
+// separate process, so the archive is a real input even though it is not on the test classpath.
+// Agent-based samples are additionally launched with -javaagent:<otel agent>, another runtime
+// input not on the classpath. See test/system-test-runner.py.
 tasks.matching { it.name == "systemTest" }.configureEach {
   val archiveTask =
     listOf("war", "shadowJar", "bootJar").firstOrNull { it in tasks.names }
@@ -15,4 +19,20 @@ tasks.matching { it.name == "systemTest" }.configureEach {
     .files(tasks.named(archiveTask))
     .withPropertyName("appArchive")
     .withNormalizer(ClasspathNormalizer::class.java)
+
+  if (systemTest.usesOpenTelemetryAgent.get()) {
+    // The runner builds the agent and launches the app with -javaagent before invoking this task,
+    // so the agent jar is tracked for content only (by path, no cross-project task dependency): a
+    // change to it makes systemTest out of date even though it runs outside the test JVM.
+    val version = providers.gradleProperty("versionName").get()
+    inputs
+      .files(
+        rootProject.layout.projectDirectory.file(
+          "sentry-opentelemetry/sentry-opentelemetry-agent/build/libs/" +
+            "sentry-opentelemetry-agent-$version.jar"
+        )
+      )
+      .withPropertyName("openTelemetryAgent")
+      .withNormalizer(ClasspathNormalizer::class.java)
+  }
 }

--- a/build-logic/src/main/kotlin/io.sentry.systemtest.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.systemtest.gradle.kts
@@ -1,0 +1,18 @@
+import org.gradle.api.tasks.ClasspathNormalizer
+
+// The sample system tests launch the packaged app (war/shadowJar/bootJar) from
+// build/libs as a separate process, so the archive is a real input even though it
+// is not on the test classpath. See test/system-test-runner.py.
+tasks.matching { it.name == "systemTest" }.configureEach {
+  val archiveTask =
+    listOf("war", "shadowJar", "bootJar").firstOrNull { it in tasks.names }
+      ?: throw GradleException(
+        "io.sentry.systemtest is applied to $path but none of war/shadowJar/bootJar " +
+          "exist to provide the launched app archive for the systemTest task"
+      )
+  // Declaring the archive as an input also wires the dependency on its producing task.
+  inputs
+    .files(tasks.named(archiveTask))
+    .withPropertyName("appArchive")
+    .withNormalizer(ClasspathNormalizer::class.java)
+}

--- a/build-logic/src/main/kotlin/io/sentry/gradle/SystemTestExtension.kt
+++ b/build-logic/src/main/kotlin/io/sentry/gradle/SystemTestExtension.kt
@@ -1,0 +1,17 @@
+package io.sentry.gradle
+
+import org.gradle.api.provider.Property
+
+/** Configuration for the `io.sentry.systemtest` convention plugin. */
+abstract class SystemTestExtension {
+  /**
+   * Set to `true` for samples that the system-test runner launches with the Sentry OpenTelemetry
+   * Java agent (`-javaagent`). The agent jar is then tracked as a `systemTest` input so the task
+   * re-runs when the agent changes, even though it is started outside the test JVM.
+   */
+  abstract val usesOpenTelemetryAgent: Property<Boolean>
+
+  init {
+    usesOpenTelemetryAgent.convention(false)
+  }
+}

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.console.Main") }

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
@@ -71,8 +71,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.console.Main") }

--- a/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
@@ -74,8 +74,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-console/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.console.Main") }

--- a/sentry-samples/sentry-samples-console/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console/build.gradle.kts
@@ -75,8 +75,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-jul/build.gradle.kts
+++ b/sentry-samples/sentry-samples-jul/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.jul.Main") }

--- a/sentry-samples/sentry-samples-jul/build.gradle.kts
+++ b/sentry-samples/sentry-samples-jul/build.gradle.kts
@@ -66,8 +66,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-log4j2/build.gradle.kts
+++ b/sentry-samples/sentry-samples-log4j2/build.gradle.kts
@@ -72,8 +72,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-log4j2/build.gradle.kts
+++ b/sentry-samples/sentry-samples-log4j2/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.log4j2.Main") }

--- a/sentry-samples/sentry-samples-logback/build.gradle.kts
+++ b/sentry-samples/sentry-samples-logback/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.shadow)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.logback.Main") }

--- a/sentry-samples/sentry-samples-logback/build.gradle.kts
+++ b/sentry-samples/sentry-samples-logback/build.gradle.kts
@@ -66,8 +66,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-7/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-7/build.gradle.kts
@@ -77,8 +77,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-7/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-7/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
   alias(libs.plugins.kotlin.spring)
   id("war")
   alias(libs.plugins.gretty)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring7.Main") }

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
@@ -90,8 +90,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-4"

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
@@ -111,6 +111,9 @@ tasks.register<BootRun>("bootRunWithAgent").configure {
   jvmArgs = listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
+// The runner launches this sample with -javaagent, so track the agent jar as a systemTest input.
+sentrySystemTest { usesOpenTelemetryAgent = true }
+
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-4"

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
@@ -118,8 +118,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-4-otlp"

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
@@ -91,8 +91,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-4-webflux"

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
@@ -70,8 +70,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
@@ -92,8 +92,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-4"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -95,8 +95,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -128,8 +128,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -121,6 +121,9 @@ tasks.register<BootRun>("bootRunWithAgent").configure {
   jvmArgs = listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
+// The runner launches this sample with -javaagent, so track the agent jar as a systemTest input.
+sentrySystemTest { usesOpenTelemetryAgent = true }
+
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
@@ -98,8 +98,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-jakarta"

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -140,8 +140,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.shadow)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.boot.SentryDemoApplication") }

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -155,6 +155,9 @@ tasks.register<JavaExec>("bootRunWithAgent").configure {
   jvmArgs = listOf("-Dotel.javaagent.debug=true", "-javaagent:$agentJarPath")
 }
 
+// The runner launches this sample with -javaagent, so track the agent jar as a systemTest input.
+sentrySystemTest { usesOpenTelemetryAgent = true }
+
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.shadow)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.boot.SentryDemoApplication") }

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -162,8 +162,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -72,8 +72,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.spring.dependency.management)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 group = "io.sentry.sample.spring-boot-webflux-jakarta"

--- a/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
@@ -107,8 +107,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.shadow)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.boot.SentryDemoApplication") }

--- a/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
@@ -141,8 +141,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.shadow)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.spring)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.boot.SentryDemoApplication") }

--- a/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
@@ -77,8 +77,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test

--- a/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.kotlin.spring)
   id("war")
   alias(libs.plugins.gretty)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.jakarta.Main") }

--- a/sentry-samples/sentry-samples-spring/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.kotlin.spring)
   id("war")
   alias(libs.plugins.gretty)
+  id("io.sentry.systemtest")
 }
 
 application { mainClass.set("io.sentry.samples.spring.Main") }

--- a/sentry-samples/sentry-samples-spring/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring/build.gradle.kts
@@ -78,8 +78,6 @@ tasks.register<Test>("systemTest").configure {
   testClassesDirs = test.output.classesDirs
   classpath = test.runtimeClasspath
 
-  outputs.upToDateWhen { false }
-
   maxParallelForks = 1
 
   // Cap JVM args per test


### PR DESCRIPTION
## :scroll: Description
Removes `outputs.upToDateWhen { false }` from the `systemTest` tasks in the `sentry-samples/*` modules and replaces it with proper Gradle input tracking via a new `io.sentry.systemtest` convention plugin.

The system tests launch the packaged sample app (`shadowJar`/`bootJar`/`war`) from `build/libs` as a **separate process** — it is not on the test classpath. With only `outputs.upToDateWhen { false }` removed, Gradle would compute up-to-date purely from the test classes and runtime classpath, so a separate jar build could refresh the artifact while `systemTest` was skipped, meaning the assertions never ran against the rebuilt sample.

Rather than repeat the wiring in all 22 sample build files, it lives in one `build-logic` convention plugin (`build-logic/src/main/kotlin/io.sentry.systemtest.gradle.kts`), following the existing `io.sentry.spotless` / `io.sentry.javadoc` pattern. Each sample applies `id("io.sentry.systemtest")`. The plugin auto-detects the packaging task with precedence **war → shadowJar → bootJar** (mirroring `test/system-test-runner.py`) and declares its archive as a `systemTest` input:

```kotlin
tasks.matching { it.name == "systemTest" }.configureEach {
  val archiveTask =
    listOf("war", "shadowJar", "bootJar").firstOrNull { it in tasks.names }
      ?: throw GradleException("…none of war/shadowJar/bootJar exist…")
  // Declaring the archive as an input also wires the dependency on its producing task.
  inputs.files(tasks.named(archiveTask))
    .withPropertyName("appArchive")
    .withNormalizer(ClasspathNormalizer::class.java)
  …
}
```

**OpenTelemetry agent.** The agent-based OTel samples are also launched with `-javaagent:<sentry-opentelemetry-agent>`, started outside the test JVM and likewise untracked. The plugin exposes a `usesOpenTelemetryAgent` opt-in (`sentrySystemTest { usesOpenTelemetryAgent = true }`); the three agent samples enable it and the agent jar is tracked as a content input. The runner already builds and launches the agent before invoking the task, so it is tracked by path (no cross-project task dependency), which keeps it configuration-on-demand and configuration-cache compatible.

Notes on Gradle best practices:
- `tasks.matching { … }.configureEach` + `it in tasks.names` + `tasks.named(…)` are all lazy — no eager task realization (configuration avoidance preserved).
- No `afterEvaluate`.
- Misconfiguration fails loudly (`GradleException`) rather than silently skipping the input.
- Configuration cache verified: entry **stored** then **reused** across runs with no problems.

## :bulb: Motivation and Context
`outputs.upToDateWhen { false }` disabled up-to-date checks and build-cache reuse for the `systemTest` tasks because the launched JAR/WAR (and OTel agent) were not modeled as task inputs. This models those inputs properly — in one place — instead of disabling incremental builds wholesale.

## :green_heart: How did you test it?
- `./gradlew spotlessApply` / `spotlessCheck` pass; the convention plugin compiles and applies.
- `./gradlew --dry-run --configuration-cache :sentry-samples:<module>:systemTest` for a console (`shadowJar`), Spring Boot 2 (`shadowJar`), Spring Boot 4 (`bootJar`), and Tomcat (`war`) module confirms the packaging task is wired ahead of `systemTest`; agent modules additionally track the agent jar. Configuration cache stores and reuses cleanly.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
