### PR TITLE
ref(core): Avoid boxing in DateUtils.nanosToDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Reduce unboxing in `DateUtils.nanosToDate` ([#5523](https://github.com/getsentry/sentry-java/pull/5523))
+
 ## 8.43.2
 
 ### Improvements

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -115,8 +115,8 @@ public final class DateUtils {
    * @return date rounded down to milliseconds
    */
   public static Date nanosToDate(final long nanos) {
-    final Double millis = nanosToMillis((double) nanos);
-    return getDateTime(millis.longValue());
+    final double millis = nanosToMillis((double) nanos);
+    return getDateTime((long) millis);
   }
 
   public static @Nullable Date toUtilDate(final @Nullable SentryDate sentryDate) {


### PR DESCRIPTION
## :scroll: Description

Implementing @0xadam-brown 's suggestion here: https://github.com/getsentry/sentry-java/pull/5520/changes#r3387804225

`DateUtils.nanosToDate` stored the result of `nanosToMillis(...)` — which already returns a primitive `double` — in a boxed `Double`, then unboxed it again via `millis.longValue()`. This change keeps the value primitive and replaces the unbox with a plain `(long)` cast.

```java
// before
final Double millis = nanosToMillis((double) nanos); // box
return getDateTime(millis.longValue());              // unbox

// after
final double millis = nanosToMillis((double) nanos);
return getDateTime((long) millis);
```

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
