### PR TITLE
perf(core): Use fixed-delay scheduling for performance collector (JAVA-555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@
 
 - Reduce unboxing in `DateUtils.nanosToDate` ([#5523](https://github.com/getsentry/sentry-java/pull/5523))
 
+### Fixes
+
+- Fix performance collector scheduling many tasks in a row ([#5524](https://github.com/getsentry/sentry-java/pull/5524))
+
 ## 8.43.2
 
 ### Improvements
 
 - Improve SDK init performance by replacing `java.net.URI` with custom string parsing for DSN ([#5448](https://github.com/getsentry/sentry-java/pull/5448))
 - Remove unnecessary boxing to improve performance ([#5520](https://github.com/getsentry/sentry-java/pull/5520))
-- Use fixed-delay scheduling for the performance collector to avoid catch-up collection bursts ([#5524](https://github.com/getsentry/sentry-java/pull/5524))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Improve SDK init performance by replacing `java.net.URI` with custom string parsing for DSN ([#5448](https://github.com/getsentry/sentry-java/pull/5448))
 - Remove unnecessary boxing to improve performance ([#5520](https://github.com/getsentry/sentry-java/pull/5520))
+- Use fixed-delay scheduling for the performance collector to avoid catch-up collection bursts ([#5524](https://github.com/getsentry/sentry-java/pull/5524))
 
 ### Fixes
 

--- a/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
+++ b/sentry/src/main/java/io/sentry/DefaultCompositePerformanceCollector.java
@@ -27,7 +27,6 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
 
   private final @NotNull SentryOptions options;
   private final @NotNull AtomicBoolean isStarted = new AtomicBoolean(false);
-  private long lastCollectionTimestamp = 0;
 
   public DefaultCompositePerformanceCollector(final @NotNull SentryOptions options) {
     this.options = Objects.requireNonNull(options, "The options object is required.");
@@ -112,16 +111,8 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
             new TimerTask() {
               @Override
               public void run() {
-                long now = System.currentTimeMillis();
-                // The timer is scheduled to run every 100ms on average. In case it takes longer,
-                // subsequent tasks are executed more quickly. If two tasks are scheduled to run in
-                // less than 10ms, the measurement that we collect is not meaningful, so we skip it
-                if (now - lastCollectionTimestamp <= 10) {
-                  return;
-                }
                 timedOutTransactions.clear();
 
-                lastCollectionTimestamp = now;
                 final @NotNull PerformanceCollectionData tempData =
                     new PerformanceCollectionData(options.getDateProvider().now().nanoTimestamp());
 
@@ -147,7 +138,7 @@ public final class DefaultCompositePerformanceCollector implements CompositePerf
                 }
               }
             };
-        timer.scheduleAtFixedRate(
+        timer.schedule(
             timerTask,
             TRANSACTION_COLLECTION_INTERVAL_MILLIS,
             TRANSACTION_COLLECTION_INTERVAL_MILLIS);

--- a/sentry/src/test/java/io/sentry/DefaultCompositePerformanceCollectorTest.kt
+++ b/sentry/src/test/java/io/sentry/DefaultCompositePerformanceCollectorTest.kt
@@ -86,7 +86,7 @@ class DefaultCompositePerformanceCollectorTest {
     val collector = fixture.getSut(null, null)
     assertTrue(fixture.options.performanceCollectors.isEmpty())
     collector.start(fixture.transaction1)
-    verify(fixture.mockTimer, never())!!.scheduleAtFixedRate(any(), any<Long>(), any())
+    verify(fixture.mockTimer, never())!!.schedule(any(), any<Long>(), any())
   }
 
   @Test
@@ -104,14 +104,14 @@ class DefaultCompositePerformanceCollectorTest {
   fun `when start, timer is scheduled every 100 milliseconds`() {
     val collector = fixture.getSut()
     collector.start(fixture.transaction1)
-    verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer)!!.schedule(any(), any<Long>(), eq(100))
   }
 
   @Test
   fun `when start with a string, timer is scheduled every 100 milliseconds`() {
     val collector = fixture.getSut()
     collector.start(fixture.id1)
-    verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer)!!.schedule(any(), any<Long>(), eq(100))
   }
 
   @Test
@@ -119,7 +119,7 @@ class DefaultCompositePerformanceCollectorTest {
     val collector = fixture.getSut()
     collector.start(fixture.transaction1)
     collector.stop(fixture.transaction1)
-    verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer)!!.schedule(any(), any<Long>(), eq(100))
     verify(fixture.mockTimer)!!.cancel()
   }
 
@@ -128,7 +128,7 @@ class DefaultCompositePerformanceCollectorTest {
     val collector = fixture.getSut()
     collector.start(fixture.id1)
     collector.stop(fixture.id1)
-    verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer)!!.schedule(any(), any<Long>(), eq(100))
     verify(fixture.mockTimer)!!.cancel()
   }
 
@@ -136,7 +136,7 @@ class DefaultCompositePerformanceCollectorTest {
   fun `stopping a not collected transaction return null`() {
     val collector = fixture.getSut()
     val data = collector.stop(fixture.transaction1)
-    verify(fixture.mockTimer, never())!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer, never())!!.schedule(any(), any<Long>(), eq(100))
     verify(fixture.mockTimer, never())!!.cancel()
     assertNull(data)
   }
@@ -145,7 +145,7 @@ class DefaultCompositePerformanceCollectorTest {
   fun `stopping a not collected id return null`() {
     val collector = fixture.getSut()
     val data = collector.stop(fixture.id1)
-    verify(fixture.mockTimer, never())!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer, never())!!.schedule(any(), any<Long>(), eq(100))
     verify(fixture.mockTimer, never())!!.cancel()
     assertNull(data)
   }
@@ -316,7 +316,7 @@ class DefaultCompositePerformanceCollectorTest {
     collector.close()
 
     // Timer was canceled
-    verify(fixture.mockTimer)!!.scheduleAtFixedRate(any(), any<Long>(), eq(100))
+    verify(fixture.mockTimer)!!.schedule(any(), any<Long>(), eq(100))
     verify(fixture.mockTimer)!!.cancel()
 
     // Data was cleared


### PR DESCRIPTION
## :scroll: Description

Switch the transaction collection timer in `DefaultCompositePerformanceCollector` from `Timer.scheduleAtFixedRate` to `Timer.schedule` (fixed-delay scheduling).

Fixes JAVA-555.

## :bulb: Motivation and Context

`scheduleAtFixedRate` schedules tasks relative to the *initial* start time, so after a delay or GC pause it fires a burst of rapid catch-up executions to "make up" for missed runs. The old code defended against this with a 10ms skip check, since collections spaced closer than that are not meaningful. In addition, it is using `System.currentTimeMillis()` which isn't a monotonic clock meaning it could go forwards and then guard is broken allowing all the tasks to run.

`schedule` uses fixed-delay scheduling: each collection is scheduled 100ms after the previous one *finishes*. Catch-up bursts can no longer happen, so the guard and its supporting state are redundant. The result is more even collection spacing and simpler code.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
