### PR TITLE
ref(core): Use primitive long for EventProcessorAndOrder.order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Reduce unboxing in `DateUtils.nanosToDate` ([#5523](https://github.com/getsentry/sentry-java/pull/5523))
+- Avoid boxing by using a primitive `long` for `EventProcessorAndOrder.order` ([#5527](https://github.com/getsentry/sentry-java/pull/5527))
 
 ## 8.43.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Improvements
 
-- Reduce unboxing in `DateUtils.nanosToDate` ([#5523](https://github.com/getsentry/sentry-java/pull/5523))
-- Avoid boxing by using a primitive `long` for `EventProcessorAndOrder.order` ([#5527](https://github.com/getsentry/sentry-java/pull/5527))
+- Reduce boxing to improve performance ([#5523](https://github.com/getsentry/sentry-java/pull/5523), [#5527](https://github.com/getsentry/sentry-java/pull/5527))
 
 ## 8.43.2
 

--- a/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
+++ b/sentry/src/main/java/io/sentry/internal/eventprocessor/EventProcessorAndOrder.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 public final class EventProcessorAndOrder implements Comparable<EventProcessorAndOrder> {
 
   private final @NotNull EventProcessor eventProcessor;
-  private final @NotNull Long order;
+  private final long order;
 
   public EventProcessorAndOrder(
       final @NotNull EventProcessor eventProcessor, final @Nullable Long order) {


### PR DESCRIPTION
## :scroll: Description

Store `EventProcessorAndOrder.order` as a primitive `long` instead of a boxed `@NotNull Long`.

## :bulb: Motivation and Context

The constructor already normalizes a `null` order to `System.nanoTime()`, so the field never needs to represent `null`. Using a primitive avoids unnecessary boxing, in line with the recent boxing-reduction refactors in core.

## :green_heart: How did you test it?

Existing unit tests; `./gradlew spotlessApply apiDump` runs clean with no public API change.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
