### PR TITLE
perf(core): [SDK Overhead reduction for JVM 1] Remove redundant event map copies

### DIFF
--- a/sentry/src/main/java/io/sentry/MainEventProcessor.java
+++ b/sentry/src/main/java/io/sentry/MainEventProcessor.java
@@ -11,7 +11,6 @@ import io.sentry.util.HintUtils;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
@@ -191,7 +190,7 @@ public final class MainEventProcessor implements EventProcessor, Closeable {
 
   private void setTags(final @NotNull SentryBaseEvent event) {
     if (event.getTags() == null) {
-      event.setTags(new HashMap<>(options.getTags()));
+      event.setTags(options.getTags());
     } else {
       for (Map.Entry<String, String> item : options.getTags().entrySet()) {
         if (!event.getTags().containsKey(item.getKey())) {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
@@ -1423,7 +1422,7 @@ public final class SentryClient implements ISentryClient {
       event.setUser(scope.getUser());
     }
     if (event.getTags() == null) {
-      event.setTags(new HashMap<>(scope.getTags()));
+      event.setTags(scope.getTags());
     } else {
       for (Map.Entry<String, String> item : scope.getTags().entrySet()) {
         if (!event.getTags().containsKey(item.getKey())) {
@@ -1481,7 +1480,7 @@ public final class SentryClient implements ISentryClient {
         replayEvent.setUser(scope.getUser());
       }
       if (replayEvent.getTags() == null) {
-        replayEvent.setTags(new HashMap<>(scope.getTags()));
+        replayEvent.setTags(scope.getTags());
       } else {
         for (Map.Entry<String, String> item : scope.getTags().entrySet()) {
           if (!replayEvent.getTags().containsKey(item.getKey())) {
@@ -1521,7 +1520,7 @@ public final class SentryClient implements ISentryClient {
         sentryBaseEvent.setUser(scope.getUser());
       }
       if (sentryBaseEvent.getTags() == null) {
-        sentryBaseEvent.setTags(new HashMap<>(scope.getTags()));
+        sentryBaseEvent.setTags(scope.getTags());
       } else {
         for (Map.Entry<String, String> item : scope.getTags().entrySet()) {
           if (!sentryBaseEvent.getTags().containsKey(item.getKey())) {
@@ -1535,7 +1534,7 @@ public final class SentryClient implements ISentryClient {
         sortBreadcrumbsByDate(sentryBaseEvent, scope.getBreadcrumbs());
       }
       if (sentryBaseEvent.getExtras() == null) {
-        sentryBaseEvent.setExtras(new HashMap<>(scope.getExtras()));
+        sentryBaseEvent.setExtras(scope.getExtras());
       } else {
         for (Map.Entry<String, Object> item : scope.getExtras().entrySet()) {
           if (!sentryBaseEvent.getExtras().containsKey(item.getKey())) {

--- a/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
+++ b/sentry/src/test/java/io/sentry/MainEventProcessorTest.kt
@@ -359,6 +359,19 @@ class MainEventProcessorTest {
   }
 
   @Test
+  fun `options tags are copied when applied to event`() {
+    val sut = fixture.getSut(tags = mapOf("tag1" to "value1"))
+    val event = SentryEvent()
+
+    sut.process(event, Hint())
+    val eventTags = event.tags!!
+
+    fixture.sentryOptions.setTag("tag2", "value2")
+
+    assertFalse(eventTags.containsKey("tag2"))
+  }
+
+  @Test
   fun `when event has a tag set with the same name as SentryOptions tags, the tag value from the event is retained`() {
     val sut = fixture.getSut(tags = mapOf("tag1" to "value1", "tag2" to "value2"))
     val event = SentryEvent()

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -535,6 +535,24 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when captureEvent applies scope tags and extras, event map containers are copied`() {
+    val event = SentryEvent()
+    val scope = createScope()
+
+    val sut = fixture.getSut()
+
+    sut.captureEvent(event, scope)
+    val eventTags = event.tags!!
+    val eventExtras = event.extras!!
+
+    scope.setTag("newTag", "newValue")
+    scope.setExtra("newExtra", "newValue")
+
+    assertFalse(eventTags.containsKey("newTag"))
+    assertFalse(eventExtras.containsKey("newExtra"))
+  }
+
+  @Test
   fun `when breadcrumbs are not empty, sort them out by date`() {
     val b1 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.001Z"))
     val b2 = Breadcrumb(DateUtils.getDateTime("2020-03-27T08:52:58.002Z"))

--- a/sentry/src/test/java/io/sentry/protocol/SentryBaseEventSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SentryBaseEventSerializationTest.kt
@@ -9,6 +9,7 @@ import io.sentry.SentryBaseEvent
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.vendor.gson.stream.JsonToken
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -101,5 +102,27 @@ class SentryBaseEventSerializationTest {
     val actualJson = SerializationUtils.serializeToString(actual, fixture.logger)
 
     assertEquals(expectedJson, actualJson)
+  }
+
+  @Test
+  fun `setTags copies source map`() {
+    val source = mutableMapOf("a" to "1")
+    val sut = Sut()
+
+    sut.tags = source
+    source["b"] = "2"
+
+    assertFalse(sut.tags!!.containsKey("b"))
+  }
+
+  @Test
+  fun `setExtras copies source map`() {
+    val source = mutableMapOf<String, Any>("a" to "1")
+    val sut = Sut()
+
+    sut.setExtras(source)
+    source["b"] = "2"
+
+    assertFalse(sut.extras!!.containsKey("b"))
   }
 }


### PR DESCRIPTION
## PR Stack (SDK Overhead reduction for JVM)

- #5532
- #5533

---

## :scroll: Description

Remove redundant intermediate `HashMap` copies when applying scope and options tags, and scope extras, to events.

The event setters still copy the provided maps, so this keeps event map containers isolated from the source scope/options maps while avoiding one temporary allocation per application path.

## :bulb: Motivation and Context

This implements AR-04b from the SDK overhead reduction research. The previous code copied tags/extras before calling setters that already copy their input. Removing the extra copy reduces allocation overhead without exposing live scope or options maps to events.

## :green_heart: How did you test it?

- `./gradlew :sentry:test --tests io.sentry.SentryClientTest --tests io.sentry.MainEventProcessorTest --tests io.sentry.protocol.SentryBaseEventSerializationTest`
- `./gradlew spotlessApply apiDump`

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
