### PR TITLE
perf(core): [SDK Overhead reduction for JVM 2] Short-circuit combined scope breadcrumbs

### DIFF
--- a/sentry/src/main/java/io/sentry/CombinedScopeView.java
+++ b/sentry/src/main/java/io/sentry/CombinedScopeView.java
@@ -171,10 +171,31 @@ public final class CombinedScopeView implements IScope {
 
   @Override
   public @NotNull Queue<Breadcrumb> getBreadcrumbs() {
+    final @NotNull Queue<Breadcrumb> globalBreadcrumbs = globalScope.getBreadcrumbs();
+    final @NotNull Queue<Breadcrumb> isolationBreadcrumbs = isolationScope.getBreadcrumbs();
+    final @NotNull Queue<Breadcrumb> currentBreadcrumbs = scope.getBreadcrumbs();
+
+    final boolean hasGlobalBreadcrumbs = !globalBreadcrumbs.isEmpty();
+    final boolean hasIsolationBreadcrumbs = !isolationBreadcrumbs.isEmpty();
+    final boolean hasCurrentBreadcrumbs = !currentBreadcrumbs.isEmpty();
+
+    if (!hasGlobalBreadcrumbs && !hasIsolationBreadcrumbs && !hasCurrentBreadcrumbs) {
+      return getDefaultWriteScope().getBreadcrumbs();
+    }
+    if (!hasIsolationBreadcrumbs && !hasCurrentBreadcrumbs) {
+      return globalBreadcrumbs;
+    }
+    if (!hasGlobalBreadcrumbs && !hasCurrentBreadcrumbs) {
+      return isolationBreadcrumbs;
+    }
+    if (!hasGlobalBreadcrumbs && !hasIsolationBreadcrumbs) {
+      return currentBreadcrumbs;
+    }
+
     final @NotNull List<Breadcrumb> allBreadcrumbs = new ArrayList<>();
-    allBreadcrumbs.addAll(globalScope.getBreadcrumbs());
-    allBreadcrumbs.addAll(isolationScope.getBreadcrumbs());
-    allBreadcrumbs.addAll(scope.getBreadcrumbs());
+    allBreadcrumbs.addAll(globalBreadcrumbs);
+    allBreadcrumbs.addAll(isolationBreadcrumbs);
+    allBreadcrumbs.addAll(currentBreadcrumbs);
     Collections.sort(allBreadcrumbs);
 
     final @NotNull Queue<Breadcrumb> breadcrumbs =

--- a/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
+++ b/sentry/src/test/java/io/sentry/CombinedScopeViewTest.kt
@@ -11,6 +11,7 @@ import junit.framework.TestCase.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import org.junit.Assert.assertNotEquals
@@ -70,6 +71,42 @@ class CombinedScopeViewTest {
     assertEquals("global 2", breadcrumbs.poll().message)
     assertEquals("isolation 2", breadcrumbs.poll().message)
     assertEquals("current 2", breadcrumbs.poll().message)
+  }
+
+  @Test
+  fun `returns single non-empty breadcrumb queue directly`() {
+    var combined = fixture.getSut()
+    fixture.globalScope.addBreadcrumb(Breadcrumb.info("global"))
+    assertSame(fixture.globalScope.breadcrumbs, combined.breadcrumbs)
+
+    combined = fixture.getSut()
+    fixture.isolationScope.addBreadcrumb(Breadcrumb.info("isolation"))
+    assertSame(fixture.isolationScope.breadcrumbs, combined.breadcrumbs)
+
+    combined = fixture.getSut()
+    fixture.scope.addBreadcrumb(Breadcrumb.info("current"))
+    assertSame(fixture.scope.breadcrumbs, combined.breadcrumbs)
+  }
+
+  @Test
+  fun `returns default write scope breadcrumbs when all scopes are empty`() {
+    val combined = fixture.getSut(SentryOptions().also { it.defaultScopeType = ScopeType.CURRENT })
+
+    assertSame(fixture.scope.breadcrumbs, combined.breadcrumbs)
+  }
+
+  @Test
+  fun `returns merged breadcrumb copy when multiple scopes have breadcrumbs`() {
+    val combined = fixture.getSut()
+
+    fixture.globalScope.addBreadcrumb(Breadcrumb.info("global"))
+    fixture.isolationScope.addBreadcrumb(Breadcrumb.info("isolation"))
+
+    val breadcrumbs = combined.breadcrumbs
+
+    assertNotSame(fixture.globalScope.breadcrumbs, breadcrumbs)
+    assertNotSame(fixture.isolationScope.breadcrumbs, breadcrumbs)
+    assertEquals(2, breadcrumbs.size)
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (SDK Overhead reduction for JVM)

- #5535
- #5536
- #5540

---

## :scroll: Description

Short-circuit `CombinedScopeView.getBreadcrumbs()` when only one component scope contains breadcrumbs.

The method now returns the single non-empty scope queue directly, keeps the existing merged/sorted bounded queue path when multiple scopes have breadcrumbs, and uses the configured default write scope when all queues are empty.

## :bulb: Motivation and Context

This implements the breadcrumb portion of AR-08 from the SDK overhead reduction research. The previous code always allocated a temporary list, copied breadcrumbs from all three scopes, sorted them, allocated a bounded queue, and copied them again, even when only one scope had breadcrumbs.

Avoiding that merge path reduces per-event allocation overhead on the common single-scope breadcrumb path.

## :green_heart: How did you test it?

- `./gradlew :sentry:test --tests io.sentry.CombinedScopeViewTest`
- `./gradlew spotlessApply apiDump :sentry:test --tests io.sentry.CombinedScopeViewTest`

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
