### PR TITLE
fix(samples): allow leak canary for non-debug builds

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/res/values/bools.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
+</resources>


### PR DESCRIPTION
## :scroll: Description

This way the sample app won't crash when running profiling session via the Android Studio Profiler.

#skip-changelog