### PR TITLE
fix(android): Stop duplicating attachments on native events (JAVA-559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+- Fix attachments being duplicated on native events that carry scope attachments ([#5548](https://github.com/getsentry/sentry-java/pull/5548))
 - Fix performance collector scheduling many tasks in a row ([#5524](https://github.com/getsentry/sentry-java/pull/5524))
 
 ## 8.43.2

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -112,7 +112,9 @@ public final class SentryClient implements ISentryClient {
       hint = new Hint();
     }
 
-    if (shouldApplyScopeData(event, hint)) {
+    // Cached envelopes (e.g. native crashes from the outbox) already carry their attachments as
+    // envelope items. Re-applying scope attachments here would duplicate them.
+    if (shouldApplyScopeData(event, hint) && !HintUtils.hasType(hint, Cached.class)) {
       addScopeAttachmentsToHint(scope, hint);
     }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -871,6 +871,25 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when hint is Cached, scope attachments are not added to avoid duplication`() {
+    val sut = fixture.getSut()
+
+    val event = createEvent()
+    val scope = createScopeWithAttachments()
+
+    val hints = HintUtils.createWithTypeCheckHint(CustomCachedApplyScopeDataHint())
+    sut.captureEvent(event, scope, hints)
+
+    verify(fixture.transport)
+      .send(
+        check { actual ->
+          assertEquals(0, actual.items.count { it.header.type == SentryItemType.Attachment })
+        },
+        anyOrNull(),
+      )
+  }
+
+  @Test
   fun `when transport factory is NoOp, it should initialize it`() {
     fixture.sentryOptions.setTransportFactory(NoOpTransportFactory.getInstance())
     fixture.getSut()


### PR DESCRIPTION
## :scroll: Description

Native (NDK) events no longer duplicate scope attachments.

When an attachment is added to the scope on the Java side, it is synced down to the native SDK via `NdkScopeObserver`. A native event captured through `sentry_capture_event` is then written to the outbox **already carrying that attachment as its own envelope item**. When `OutboxSender` re-ingests the cached envelope, it calls `captureEvent` with a hint that is both `Cached` and `ApplyScopeData`, so `SentryClient` re-applied the Java scope's attachments on top — sending each attachment twice.

The fix skips re-applying scope attachments when the event comes from a cached envelope (`!HintUtils.hasType(hint, Cached.class)`). The guard is intentionally narrow: it only gates `addScopeAttachmentsToHint`, leaving the rest of scope-data enrichment (contexts, tags, breadcrumbs, level, user) applied as before, which native crashes rely on.

## :bulb: Motivation and Context

Fixes attachment duplication on native/NDK events.

- GH: #5542
- Linear: JAVA-559

## :green_heart: How did you test it?

- Added a unit test in `SentryClientTest` asserting that a `Cached` + `ApplyScopeData` hint does not add scope attachments to the envelope.
- Reproduced manually in `sentry-samples-android`: tapping "Native Capture" with a scope attachment configured showed `sentry.png` twice before the fix and once after.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
