### PR TITLE
perf: Avoid boxing in doubleToBigDecimal timestamp serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Improvements
 
-- Reduce boxing to improve performance ([#5523](https://github.com/getsentry/sentry-java/pull/5523), [#5527](https://github.com/getsentry/sentry-java/pull/5527))
+- Reduce boxing to improve performance ([#5523](https://github.com/getsentry/sentry-java/pull/5523), [#5527](https://github.com/getsentry/sentry-java/pull/5527), [#5551](https://github.com/getsentry/sentry-java/pull/5551))
 
 ### Dependencies
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -384,7 +384,7 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 public final class io/sentry/DateUtils {
 	public static fun dateToNanos (Ljava/util/Date;)J
 	public static fun dateToSeconds (Ljava/util/Date;)D
-	public static fun doubleToBigDecimal (Ljava/lang/Double;)Ljava/math/BigDecimal;
+	public static fun doubleToBigDecimal (D)Ljava/math/BigDecimal;
 	public static fun getCurrentDateTime ()Ljava/util/Date;
 	public static fun getDateTime (J)Ljava/util/Date;
 	public static fun getDateTime (Ljava/lang/String;)Ljava/util/Date;

--- a/sentry/src/main/java/io/sentry/DateUtils.java
+++ b/sentry/src/main/java/io/sentry/DateUtils.java
@@ -166,7 +166,7 @@ public final class DateUtils {
     return seconds * (1000L * 1000L * 1000L);
   }
 
-  public static @NotNull BigDecimal doubleToBigDecimal(final @NotNull Double value) {
+  public static @NotNull BigDecimal doubleToBigDecimal(final double value) {
     return BigDecimal.valueOf(value).setScale(6, RoundingMode.DOWN);
   }
 }

--- a/sentry/src/main/java/io/sentry/ProfileChunk.java
+++ b/sentry/src/main/java/io/sentry/ProfileChunk.java
@@ -1,5 +1,7 @@
 package io.sentry;
 
+import static io.sentry.DateUtils.doubleToBigDecimal;
+
 import io.sentry.profilemeasurements.ProfileMeasurement;
 import io.sentry.protocol.DebugMeta;
 import io.sentry.protocol.SdkVersion;
@@ -8,8 +10,6 @@ import io.sentry.protocol.profiling.SentryProfile;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -262,10 +262,6 @@ public final class ProfileChunk implements JsonUnknown, JsonSerializable {
       }
     }
     writer.endObject();
-  }
-
-  private @NotNull BigDecimal doubleToBigDecimal(final @NotNull Double value) {
-    return BigDecimal.valueOf(value).setScale(6, RoundingMode.DOWN);
   }
 
   @Nullable

--- a/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
+++ b/sentry/src/main/java/io/sentry/profilemeasurements/ProfileMeasurementValue.java
@@ -1,5 +1,7 @@
 package io.sentry.profilemeasurements;
 
+import static io.sentry.DateUtils.doubleToBigDecimal;
+
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
@@ -10,8 +12,6 @@ import io.sentry.ObjectWriter;
 import io.sentry.util.Objects;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -90,10 +90,6 @@ public final class ProfileMeasurementValue implements JsonUnknown, JsonSerializa
       }
     }
     writer.endObject();
-  }
-
-  private @NotNull BigDecimal doubleToBigDecimal(final @NotNull Double value) {
-    return BigDecimal.valueOf(value).setScale(6, RoundingMode.DOWN);
   }
 
   @Nullable

--- a/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentrySpan.java
@@ -1,5 +1,7 @@
 package io.sentry.protocol;
 
+import static io.sentry.DateUtils.doubleToBigDecimal;
+
 import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
@@ -16,8 +18,6 @@ import io.sentry.util.CollectionUtils;
 import io.sentry.util.Objects;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -228,10 +228,6 @@ public final class SentrySpan implements JsonUnknown, JsonSerializable {
       }
     }
     writer.endObject();
-  }
-
-  private @NotNull BigDecimal doubleToBigDecimal(final @NotNull Double value) {
-    return BigDecimal.valueOf(value).setScale(6, RoundingMode.DOWN);
   }
 
   @Nullable

--- a/sentry/src/main/java/io/sentry/protocol/profiling/SentrySample.java
+++ b/sentry/src/main/java/io/sentry/protocol/profiling/SentrySample.java
@@ -1,5 +1,7 @@
 package io.sentry.protocol.profiling;
 
+import static io.sentry.DateUtils.doubleToBigDecimal;
+
 import io.sentry.ILogger;
 import io.sentry.JsonDeserializer;
 import io.sentry.JsonSerializable;
@@ -8,8 +10,6 @@ import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.vendor.gson.stream.JsonToken;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
@@ -76,10 +76,6 @@ public final class SentrySample implements JsonUnknown, JsonSerializable {
     }
 
     writer.endObject();
-  }
-
-  private @NotNull BigDecimal doubleToBigDecimal(final @NotNull Double value) {
-    return BigDecimal.valueOf(value).setScale(6, RoundingMode.DOWN);
   }
 
   @Nullable


### PR DESCRIPTION
## :scroll: Description

`DateUtils.doubleToBigDecimal` took a boxed `Double`, so callers holding a primitive `double` timestamp autoboxed on every serialization. This:

- Changes the parameter to a primitive `double`.
- Consolidates four byte-identical private copies of the helper (`ProfileChunk`, `ProfileMeasurementValue`, `SentrySample`, `SentrySpan`) to route through the single `DateUtils.doubleToBigDecimal`.

The classes with primitive `double` timestamp fields (`ProfileChunk`, `ProfileMeasurementValue`, `SentrySample`) no longer box on each serialize. The protocol classes whose timestamps are `Double` (`SentrySpan`, `SentryTransaction`, `SentryLogEvent`, `SentryMetricsEvent`) unbox at the call site instead — behavior is identical, since the previous code already unboxed internally via `BigDecimal.valueOf` (so null handling is unchanged).

Net `-16` lines (four duplicate helpers removed).

## :bulb: Motivation and Context

Follow-up to the "Reduce boxing to improve performance" effort. Spun out of review on #5550 (`SentryNanotimeDate`), where this adjacent boxing site was noticed but kept out of that focused PR.

## :green_heart: How did you test it?

Existing serialization round-trip tests pass unchanged (`SentryTransactionSerializationTest`, `SentryProfileSerializationTest`, and `JsonSerializerTest` cases `serializes profileChunk` / `serializes profileMeasurement` / `serializes profilingTraceData` / `serializes transaction`), confirming byte-identical JSON output.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.
