### PR TITLE
feat(android): Report app start reason on standalone app start transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Emits a transaction named `App Start` with op `app.start`, carrying the existing app start measurements and phase spans (`process.load`, `contentprovider.load`, `application.load`, activity lifecycle spans) as direct children of the root
   - The standalone transaction shares the same `traceId` as the first `ui.load` activity transaction so they remain linked in the trace view
   - Also covers non-activity starts (broadcast receivers, services, content providers)
-  - On Android 15+ (API 35), the standalone transaction reports why the OS started the process via `app.vitals.start.reason` trace data (e.g. `launcher`, `broadcast`, `service`, `content_provider`), derived from `ApplicationStartInfo.getReason()` ([#5552](https://github.com/getsentry/sentry-java/pull/5552))
+  - On Android 15+ (API 35), the standalone `app.start` transaction reports why the OS started the process via `app.vitals.start.reason` trace data (e.g. `launcher`, `broadcast`, `service`, `content_provider`), derived from `ApplicationStartInfo.getReason()`. You can search and group by this attribute in the Trace Explorer. ([#5552](https://github.com/getsentry/sentry-java/pull/5552))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Emits a transaction named `App Start` with op `app.start`, carrying the existing app start measurements and phase spans (`process.load`, `contentprovider.load`, `application.load`, activity lifecycle spans) as direct children of the root
   - The standalone transaction shares the same `traceId` as the first `ui.load` activity transaction so they remain linked in the trace view
   - Also covers non-activity starts (broadcast receivers, services, content providers)
+  - On Android 15+ (API 35), the standalone transaction reports why the OS started the process via `app.vitals.start.reason` trace data (e.g. `launcher`, `broadcast`, `service`, `content_provider`), derived from `ApplicationStartInfo.getReason()` ([#5552](https://github.com/getsentry/sentry-java/pull/5552))
 
 ### Improvements
 

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -746,6 +746,7 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public fun getAppStartContinuousProfiler ()Lio/sentry/IContinuousProfiler;
 	public fun getAppStartEndTime ()Lio/sentry/SentryDate;
 	public fun getAppStartProfiler ()Lio/sentry/ITransactionProfiler;
+	public fun getAppStartReason ()Ljava/lang/String;
 	public fun getAppStartSamplingDecision ()Lio/sentry/TracesSamplingDecision;
 	public fun getAppStartSentryTraceHeader ()Ljava/lang/String;
 	public fun getAppStartTimeSpan ()Lio/sentry/android/core/performance/TimeSpan;
@@ -780,6 +781,7 @@ public class io/sentry/android/core/performance/AppStartMetrics : io/sentry/andr
 	public fun setAppStartSentryTraceHeader (Ljava/lang/String;)V
 	public fun setAppStartTraceId (Lio/sentry/protocol/SentryId;)V
 	public fun setAppStartType (Lio/sentry/android/core/performance/AppStartMetrics$AppStartType;)V
+	public fun setCachedStartInfo (Landroid/app/ApplicationStartInfo;)V
 	public fun setClassLoadedUptimeMs (J)V
 	public fun setHeadlessAppStartListener (Lio/sentry/android/core/performance/AppStartMetrics$HeadlessAppStartListener;)V
 	public fun shouldSendStartMeasurements ()Z

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -141,6 +141,7 @@ public final class ActivityLifecycleIntegration
 
     if (performanceEnabled && this.options.isEnableStandaloneAppStartTracing()) {
       AppStartMetrics.getInstance().setHeadlessAppStartListener(this::onHeadlessAppStart);
+      addIntegrationToSdkVersion("StandaloneAppStart");
     }
 
     this.options.getLogger().log(SentryLevel.DEBUG, "ActivityLifecycleIntegration installed.");

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java
@@ -72,6 +72,7 @@ public final class ActivityLifecycleIntegration
   static final long APP_START_TO_UI_LOAD_CONTINUATION_MAX_GAP_NANOS = TimeUnit.MINUTES.toNanos(1);
   private static final String TRACE_ORIGIN = "auto.ui.activity";
   static final String APP_START_SCREEN_DATA = "app.vitals.start.screen";
+  static final String APP_START_REASON_DATA = "app.vitals.start.reason";
   static final String APP_START_TRACE_ORIGIN = "auto.app.start";
 
   private final @NotNull Application application;
@@ -286,6 +287,10 @@ public final class ActivityLifecycleIntegration
                       appStartSamplingDecision),
                   appStartTransactionOptions);
           appStartTransaction.setData(APP_START_SCREEN_DATA, activityName);
+          final @Nullable String appStartReason = AppStartMetrics.getInstance().getAppStartReason();
+          if (appStartReason != null) {
+            appStartTransaction.setData(APP_START_REASON_DATA, appStartReason);
+          }
         }
 
         // Continue either the foreground app.start above or an earlier headless app.start.
@@ -1002,6 +1007,10 @@ public final class ActivityLifecycleIntegration
             null);
 
     final @NotNull ITransaction transaction = scopes.startTransaction(txnContext, txnOptions);
+    final @Nullable String appStartReason = metrics.getAppStartReason();
+    if (appStartReason != null) {
+      transaction.setData(APP_START_REASON_DATA, appStartReason);
+    }
     metrics.setAppStartTraceId(transaction.getSpanContext().getTraceId());
     // Persist trace headers so a later ui.load can share traceId and sampleRand.
     metrics.setAppStartSentryTraceHeader(transaction.toSentryTrace().getValue());

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -166,6 +166,45 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
     return appStartType;
   }
 
+  /**
+   * The reason the OS started the process, mapped from {@link ApplicationStartInfo#getReason()}.
+   * Only available on API 35+ (when {@link #cachedStartInfo} was resolved); returns {@code null}
+   * otherwise or for an unmapped reason.
+   */
+  public @Nullable String getAppStartReason() {
+    if (cachedStartInfo == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      return null;
+    }
+    switch (cachedStartInfo.getReason()) {
+      case ApplicationStartInfo.START_REASON_ALARM:
+        return "alarm";
+      case ApplicationStartInfo.START_REASON_BACKUP:
+        return "backup";
+      case ApplicationStartInfo.START_REASON_BOOT_COMPLETE:
+        return "boot_complete";
+      case ApplicationStartInfo.START_REASON_BROADCAST:
+        return "broadcast";
+      case ApplicationStartInfo.START_REASON_CONTENT_PROVIDER:
+        return "content_provider";
+      case ApplicationStartInfo.START_REASON_JOB:
+        return "job";
+      case ApplicationStartInfo.START_REASON_LAUNCHER:
+        return "launcher";
+      case ApplicationStartInfo.START_REASON_LAUNCHER_RECENTS:
+        return "launcher_recents";
+      case ApplicationStartInfo.START_REASON_PUSH:
+        return "push";
+      case ApplicationStartInfo.START_REASON_SERVICE:
+        return "service";
+      case ApplicationStartInfo.START_REASON_START_ACTIVITY:
+        return "start_activity";
+      case ApplicationStartInfo.START_REASON_OTHER:
+        return "other";
+      default:
+        return null;
+    }
+  }
+
   public boolean isAppLaunchedInForeground() {
     return appLaunchedInForeground.getValue();
   }
@@ -370,6 +409,12 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
   @ApiStatus.Internal
   public void setClassLoadedUptimeMs(final long classLoadedUptimeMs) {
     CLASS_LOADED_UPTIME_MS = classLoadedUptimeMs;
+  }
+
+  @TestOnly
+  @ApiStatus.Internal
+  public void setCachedStartInfo(final @Nullable ApplicationStartInfo cachedStartInfo) {
+    this.cachedStartInfo = cachedStartInfo;
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ActivityLifecycleIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.app.ActivityManager.RunningAppProcessInfo
 import android.app.Application
+import android.app.ApplicationStartInfo
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
@@ -273,6 +274,76 @@ class ActivityLifecycleIntegrationTest {
           it.operation == ActivityLifecycleIntegration.APP_START_WARM
       }
     )
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+  fun `Standalone app start transaction carries app start reason when available`() {
+    val sut =
+      fixture.getSut {
+        it.tracesSampleRate = 1.0
+        it.isEnableStandaloneAppStartTracing = true
+      }
+    sut.register(fixture.scopes, fixture.options)
+
+    setAppStartTime()
+    val startInfo =
+      mock<ApplicationStartInfo>().apply {
+        whenever(reason).thenReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
+      }
+    AppStartMetrics.getInstance().setCachedStartInfo(startInfo)
+
+    val activity = mock<Activity>()
+    sut.onActivityCreated(activity, fixture.bundle)
+
+    val appStartTransaction =
+      fixture.createdTransactions.single {
+        it.spanContext.operation == ActivityLifecycleIntegration.STANDALONE_APP_START_OP
+      }
+    assertEquals("launcher", appStartTransaction.getData("app.vitals.start.reason"))
+  }
+
+  @Test
+  fun `Standalone app start transaction has no app start reason when unavailable`() {
+    val sut =
+      fixture.getSut {
+        it.tracesSampleRate = 1.0
+        it.isEnableStandaloneAppStartTracing = true
+      }
+    sut.register(fixture.scopes, fixture.options)
+
+    setAppStartTime()
+
+    val activity = mock<Activity>()
+    sut.onActivityCreated(activity, fixture.bundle)
+
+    val appStartTransaction =
+      fixture.createdTransactions.single {
+        it.spanContext.operation == ActivityLifecycleIntegration.STANDALONE_APP_START_OP
+      }
+    assertNull(appStartTransaction.getData("app.vitals.start.reason"))
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+  fun `Headless standalone app start transaction carries app start reason when available`() {
+    val sut =
+      fixture.getSut {
+        it.tracesSampleRate = 1.0
+        it.isEnableStandaloneAppStartTracing = true
+      }
+    sut.register(fixture.scopes, fixture.options)
+    prepareHeadlessAppStart(appStartType = AppStartType.COLD)
+    val startInfo =
+      mock<ApplicationStartInfo>().apply {
+        whenever(reason).thenReturn(ApplicationStartInfo.START_REASON_BROADCAST)
+      }
+    AppStartMetrics.getInstance().setCachedStartInfo(startInfo)
+
+    driveHeadlessAppStart()
+
+    val transaction = fixture.createdTransactions.single()
+    assertEquals("broadcast", transaction.getData("app.vitals.start.reason"))
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -205,6 +206,47 @@ class AppStartMetricsTestApi35 {
     assertEquals(AppStartMetrics.AppStartType.COLD, metrics.appStartType)
     assertFalse(metrics.isAppLaunchedInForeground)
     assertEquals(1, listenerCalls.get())
+  }
+
+  @Test
+  fun `getAppStartReason maps ApplicationStartInfo reason to string on API 35`() {
+    val mockStartInfo = mock<ApplicationStartInfo>()
+    whenever(mockStartInfo.startupState).thenReturn(ApplicationStartInfo.STARTUP_STATE_STARTED)
+    whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_COLD)
+    whenever(mockStartInfo.reason).thenReturn(ApplicationStartInfo.START_REASON_BROADCAST)
+    SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
+    val metrics = AppStartMetrics.getInstance()
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    metrics.registerLifecycleCallbacks(app)
+
+    assertEquals("broadcast", metrics.appStartReason)
+  }
+
+  @Test
+  fun `getAppStartReason returns null when no ApplicationStartInfo is available`() {
+    SentryShadowActivityManager.setHistoricalProcessStartReasons(emptyList())
+    val metrics = AppStartMetrics.getInstance()
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    metrics.registerLifecycleCallbacks(app)
+
+    assertNull(metrics.appStartReason)
+  }
+
+  @Test
+  fun `getAppStartReason returns null for an unmapped reason`() {
+    val mockStartInfo = mock<ApplicationStartInfo>()
+    whenever(mockStartInfo.startupState).thenReturn(ApplicationStartInfo.STARTUP_STATE_STARTED)
+    whenever(mockStartInfo.startType).thenReturn(ApplicationStartInfo.START_TYPE_COLD)
+    whenever(mockStartInfo.reason).thenReturn(Int.MAX_VALUE)
+    SentryShadowActivityManager.setHistoricalProcessStartReasons(listOf(mockStartInfo))
+    val metrics = AppStartMetrics.getInstance()
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    metrics.registerLifecycleCallbacks(app)
+
+    assertNull(metrics.appStartReason)
   }
 
   private fun waitForMainLooperIdle() {


### PR DESCRIPTION
## :scroll: Description
Reports **why the OS started the process** on the standalone app start transaction, using `ApplicationStartInfo.getReason()` (Android 15 / API 35+).

- Adds `AppStartMetrics.getAppStartReason()`, which maps the already-cached `ApplicationStartInfo` reason to a stable lowercase string (`launcher`, `launcher_recents`, `start_activity`, `broadcast`, `service`, `content_provider`, `job`, `alarm`, `push`, `backup`, `boot_complete`, `other`). Returns `null` on API < 35, when no start info was resolved, or for an unmapped value.
- Attaches it as `app.vitals.start.reason` trace data on the standalone `app.start` transaction in both paths: foreground/activity (`onActivityCreated`) and headless/non-activity (`onHeadlessAppStart`).
- Also registers a `StandaloneAppStart` marker in the SDK metadata `integrations` when the feature is enabled (internal only, no changelog) so we can tell from events that standalone app start tracing was active.

Only standalone app start transactions are affected; this rides the existing `enableStandaloneAppStartTracing` opt-in and adds no new option.

## :bulb: Motivation and Context
Builds on standalone app start tracing (#5342). The reason is a high-value dimension for standalone starts: it distinguishes a real user launch (`launcher` / `start_activity`) from headless starts (`broadcast`, `service`, `content_provider`, `job`, …) — exactly the disambiguation the headless app start path was built for. The reason (why the process started) is orthogonal to cold/warm (`getStartType()`), so both are reported.

`ApplicationStartInfo` is already cached in `AppStartMetrics` from the standalone work, so this only reads one additional field (`getReason()`) off the same object — no extra system calls.

## :green_heart: How did you test it?
Unit tests in `sentry-android-core`:
- `AppStartMetricsTestApi35`: reason → string mapping (API 35), `null` when no start info, `null` for an unmapped reason value.
- `ActivityLifecycleIntegrationTest`: `app.vitals.start.reason` present on the foreground standalone transaction (API 35), absent when unavailable, and present on the headless standalone transaction.

Note: the headless-vs-foreground detection in `PerformanceAndroidEventProcessor` keys off the *absence* of `app.vitals.start.screen`; the new distinct `app.vitals.start.reason` key does not affect it (existing tests still pass).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- Confirm with the product/spec side whether the reason should also be exposed as a queryable **tag** (in addition to span data), and lock in the exact string values dashboards/alerts will rely on.