### PR TITLE
refactor(android-sqlite): Rename classes instrumenting SQLite spans for consistency

### DIFF
--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/OpenHelperSpans.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/OpenHelperSpans.kt
@@ -13,7 +13,8 @@ import io.sentry.SpanStatus
 
 private const val TRACE_ORIGIN = "auto.db.sqlite"
 
-internal class SQLiteSpanManager(
+/** Span instrumentation for [SentrySupportSQLiteOpenHelper]. */
+internal class OpenHelperSpans(
   private val scopes: IScopes = ScopesAdapter.getInstance(),
   private val databaseName: String? = null,
 ) {

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentryCrossProcessCursor.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentryCrossProcessCursor.kt
@@ -13,7 +13,7 @@ import android.database.CursorWindow
  */
 internal class SentryCrossProcessCursor(
   private val delegate: CrossProcessCursor,
-  private val spanManager: SQLiteSpanManager,
+  private val spans: OpenHelperSpans,
   private val sql: String,
 ) : CrossProcessCursor by delegate {
   // We have to start the span only the first time, regardless of how many times its methods get
@@ -25,7 +25,7 @@ internal class SentryCrossProcessCursor(
       return delegate.count
     }
     isSpanStarted = true
-    return spanManager.performSql(sql) { delegate.count }
+    return spans.performSql(sql) { delegate.count }
   }
 
   override fun onMove(oldPosition: Int, newPosition: Int): Boolean {
@@ -33,7 +33,7 @@ internal class SentryCrossProcessCursor(
       return delegate.onMove(oldPosition, newPosition)
     }
     isSpanStarted = true
-    return spanManager.performSql(sql) { delegate.onMove(oldPosition, newPosition) }
+    return spans.performSql(sql) { delegate.onMove(oldPosition, newPosition) }
   }
 
   override fun fillWindow(position: Int, window: CursorWindow?) {
@@ -41,6 +41,6 @@ internal class SentryCrossProcessCursor(
       return delegate.fillWindow(position, window)
     }
     isSpanStarted = true
-    return spanManager.performSql(sql) { delegate.fillWindow(position, window) }
+    return spans.performSql(sql) { delegate.fillWindow(position, window) }
   }
 }

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteDatabase.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteDatabase.kt
@@ -14,11 +14,11 @@ import androidx.sqlite.db.SupportSQLiteStatement
  * and it's created automatically by the [SentrySupportSQLiteOpenHelper].
  *
  * @param delegate The [SupportSQLiteDatabase] instance to delegate calls to.
- * @param sqLiteSpanManager The [SQLiteSpanManager] responsible for the creation of the spans.
+ * @param spans The [OpenHelperSpans] manager responsible for the creation of the spans.
  */
 internal class SentrySupportSQLiteDatabase(
   private val delegate: SupportSQLiteDatabase,
-  private val sqLiteSpanManager: SQLiteSpanManager,
+  private val spans: OpenHelperSpans,
 ) : SupportSQLiteDatabase by delegate {
   /**
    * Compiles the given SQL statement. It will return Sentry's wrapper around
@@ -28,35 +28,34 @@ internal class SentrySupportSQLiteDatabase(
    * @return Compiled statement.
    */
   override fun compileStatement(sql: String): SupportSQLiteStatement =
-    SentrySupportSQLiteStatement(delegate.compileStatement(sql), sqLiteSpanManager, sql)
+    SentrySupportSQLiteStatement(delegate.compileStatement(sql), spans, sql)
 
   @Suppress("AcronymName") // To keep consistency with framework method name.
   override fun execPerConnectionSQL(
     sql: String,
     @SuppressLint("ArrayReturn") bindArgs: Array<out Any?>?,
   ) {
-    sqLiteSpanManager.performSql(sql) { delegate.execPerConnectionSQL(sql, bindArgs) }
+    spans.performSql(sql) { delegate.execPerConnectionSQL(sql, bindArgs) }
   }
 
-  override fun query(query: String): Cursor =
-    sqLiteSpanManager.performSql(query) { delegate.query(query) }
+  override fun query(query: String): Cursor = spans.performSql(query) { delegate.query(query) }
 
   override fun query(query: String, bindArgs: Array<out Any?>): Cursor =
-    sqLiteSpanManager.performSql(query) { delegate.query(query, bindArgs) }
+    spans.performSql(query) { delegate.query(query, bindArgs) }
 
   override fun query(query: SupportSQLiteQuery): Cursor =
-    sqLiteSpanManager.performSql(query.sql) { delegate.query(query) }
+    spans.performSql(query.sql) { delegate.query(query) }
 
   override fun query(query: SupportSQLiteQuery, cancellationSignal: CancellationSignal?): Cursor =
-    sqLiteSpanManager.performSql(query.sql) { delegate.query(query, cancellationSignal) }
+    spans.performSql(query.sql) { delegate.query(query, cancellationSignal) }
 
   @Throws(SQLException::class)
   override fun execSQL(sql: String) {
-    sqLiteSpanManager.performSql(sql) { delegate.execSQL(sql) }
+    spans.performSql(sql) { delegate.execSQL(sql) }
   }
 
   @Throws(SQLException::class)
   override fun execSQL(sql: String, bindArgs: Array<out Any?>) {
-    sqLiteSpanManager.performSql(sql) { delegate.execSQL(sql, bindArgs) }
+    spans.performSql(sql) { delegate.execSQL(sql, bindArgs) }
   }
 }

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelper.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteOpenHelper.kt
@@ -33,14 +33,14 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper
 public class SentrySupportSQLiteOpenHelper
 private constructor(private val delegate: SupportSQLiteOpenHelper) :
   SupportSQLiteOpenHelper by delegate {
-  private val sqLiteSpanManager = SQLiteSpanManager(databaseName = delegate.databaseName)
+  private val spans = OpenHelperSpans(databaseName = delegate.databaseName)
 
   private val sentryWritableDatabase: SupportSQLiteDatabase by lazy {
-    SentrySupportSQLiteDatabase(delegate.writableDatabase, sqLiteSpanManager)
+    SentrySupportSQLiteDatabase(delegate.writableDatabase, spans)
   }
 
   private val sentryReadableDatabase: SupportSQLiteDatabase by lazy {
-    SentrySupportSQLiteDatabase(delegate.readableDatabase, sqLiteSpanManager)
+    SentrySupportSQLiteDatabase(delegate.readableDatabase, spans)
   }
 
   override val writableDatabase: SupportSQLiteDatabase

--- a/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteStatement.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/android/sqlite/SentrySupportSQLiteStatement.kt
@@ -9,25 +9,22 @@ import androidx.sqlite.db.SupportSQLiteStatement
  * [SentrySupportSQLiteDatabase.compileStatement].
  *
  * @param delegate The [SupportSQLiteStatement] instance to delegate calls to.
- * @param sqLiteSpanManager The [SQLiteSpanManager] responsible for the creation of the spans.
+ * @param spans The [OpenHelperSpans] manager responsible for the creation of the spans.
  * @param sql The query string.
  */
 internal class SentrySupportSQLiteStatement(
   private val delegate: SupportSQLiteStatement,
-  private val sqLiteSpanManager: SQLiteSpanManager,
+  private val spans: OpenHelperSpans,
   private val sql: String,
 ) : SupportSQLiteStatement by delegate {
-  override fun execute() = sqLiteSpanManager.performSql(sql) { delegate.execute() }
+  override fun execute() = spans.performSql(sql) { delegate.execute() }
 
-  override fun executeUpdateDelete(): Int =
-    sqLiteSpanManager.performSql(sql) { delegate.executeUpdateDelete() }
+  override fun executeUpdateDelete(): Int = spans.performSql(sql) { delegate.executeUpdateDelete() }
 
-  override fun executeInsert(): Long =
-    sqLiteSpanManager.performSql(sql) { delegate.executeInsert() }
+  override fun executeInsert(): Long = spans.performSql(sql) { delegate.executeInsert() }
 
-  override fun simpleQueryForLong(): Long =
-    sqLiteSpanManager.performSql(sql) { delegate.simpleQueryForLong() }
+  override fun simpleQueryForLong(): Long = spans.performSql(sql) { delegate.simpleQueryForLong() }
 
   override fun simpleQueryForString(): String? =
-    sqLiteSpanManager.performSql(sql) { delegate.simpleQueryForString() }
+    spans.performSql(sql) { delegate.simpleQueryForString() }
 }

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/DriverSpans.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/DriverSpans.kt
@@ -20,20 +20,17 @@ private const val SQLITE_TRACE_ORIGIN = "auto.db.sqlite"
 private val EMPTY_NANO_TIME = SentryNanotimeDate(0, 0L)
 
 /** Span instrumentation for [SentrySQLiteDriver]. */
-internal class SQLiteSpanInstrumentation(
-  private val scopes: IScopes,
-  private val dbMetadata: DbMetadata,
-) {
+internal class DriverSpans(private val scopes: IScopes, private val dbMetadata: DbMetadata) {
 
   private val stackTraceFactory = SentryStackTraceFactory(scopes.options)
 
   /**
-   * Returns a timestamp in nanoseconds for use with [recordSpan]. Timestamp is ns-precise if the
-   * active parent span uses a [SentryNanotimeDate] (the ordinary case); otherwise it's ms-precise.
+   * Returns a timestamp in nanoseconds for use with [record]. Timestamp is ns-precise if the active
+   * parent span uses a [SentryNanotimeDate] (the ordinary case); otherwise it's ms-precise.
    *
-   * Note: Internalizing the start time in [recordSpan] would shift spans to end-of-work on the
-   * trace timeline, which is less desirable; callers capture the start before doing database work
-   * and pass it back to [recordSpan].
+   * Note: Internalizing the start time in [record] would shift spans to end-of-work on the trace
+   * timeline, which is less desirable; callers capture the start before doing database work and
+   * pass it back to [record].
    */
   fun startTimestamp(): Long =
     // Try to retain nanosecond precision + avoid SentryDate allocation...
@@ -42,7 +39,7 @@ internal class SQLiteSpanInstrumentation(
       ?: scopes.options.dateProvider.now().nanoTimestamp()
 
   /** Records a `db.sql.query` span. */
-  fun recordSpan(
+  fun record(
     sql: String,
     startTimestampNanos: Long,
     durationNanos: Long,
@@ -73,14 +70,11 @@ internal class SQLiteSpanInstrumentation(
   companion object {
 
     /**
-     * Returns [SQLiteSpanInstrumentation] based on the [fileName] argument passed to
+     * Returns [DriverSpans] based on the [fileName] argument passed to
      * [SQLiteDriver.open][androidx.sqlite.SQLiteDriver.open].
      */
-    fun fromFileName(
-      fileName: String,
-      scopes: IScopes = ScopesAdapter.getInstance(),
-    ): SQLiteSpanInstrumentation =
-      SQLiteSpanInstrumentation(scopes, dbMetadataFromFileName(fileName))
+    fun fromFileName(fileName: String, scopes: IScopes = ScopesAdapter.getInstance()): DriverSpans =
+      DriverSpans(scopes, dbMetadataFromFileName(fileName))
   }
 }
 

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteConnection.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteConnection.kt
@@ -5,7 +5,7 @@ import androidx.sqlite.SQLiteStatement
 
 internal class SentrySQLiteConnection(
   private val delegate: SQLiteConnection,
-  private val spans: SQLiteSpanInstrumentation,
+  private val spans: DriverSpans,
 ) : SQLiteConnection by delegate {
 
   override fun prepare(sql: String): SQLiteStatement {

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -48,7 +48,7 @@ public class SentrySQLiteDriver private constructor(private val delegate: SQLite
     val connection = delegate.open(fileName)
 
     return try {
-      val spans = SQLiteSpanInstrumentation.fromFileName(fileName)
+      val spans = DriverSpans.fromFileName(fileName)
       // create() ensures delegate is unwrapped, so we don't need to protect against double-wrapping
       // the connection.
       SentrySQLiteConnection(connection, spans)

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteStatement.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteStatement.kt
@@ -16,7 +16,7 @@ import io.sentry.SpanStatus
  */
 internal class SentrySQLiteStatement(
   private val delegate: SQLiteStatement,
-  private val spans: SQLiteSpanInstrumentation,
+  private val spans: DriverSpans,
   private val sql: String,
   private val nanoTimeProvider: () -> Long = { System.nanoTime() },
 ) : SQLiteStatement by delegate {
@@ -74,6 +74,6 @@ internal class SentrySQLiteStatement(
     val duration = accumulatedDbNanos
     firstStepTimestampNanos = null
     accumulatedDbNanos = 0L
-    spans.recordSpan(sql, startNanos, duration, status, throwable)
+    spans.record(sql, startNanos, duration, status, throwable)
   }
 }

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/OpenHelperSpansTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/OpenHelperSpansTest.kt
@@ -21,13 +21,13 @@ import org.junit.Before
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-class SQLiteSpanManagerTest {
+class OpenHelperSpansTest {
   private class Fixture {
     private val scopes = mock<IScopes>()
     lateinit var sentryTracer: SentryTracer
     lateinit var options: SentryOptions
 
-    fun getSut(isSpanActive: Boolean = true, databaseName: String? = null): SQLiteSpanManager {
+    fun getSut(isSpanActive: Boolean = true, databaseName: String? = null): OpenHelperSpans {
       options = SentryOptions().apply { dsn = "https://key@sentry.io/proj" }
       whenever(scopes.options).thenReturn(options)
       sentryTracer = SentryTracer(TransactionContext("name", "op"), scopes)
@@ -35,7 +35,7 @@ class SQLiteSpanManagerTest {
       if (isSpanActive) {
         whenever(scopes.span).thenReturn(sentryTracer)
       }
-      return SQLiteSpanManager(scopes, databaseName)
+      return OpenHelperSpans(scopes, databaseName)
     }
   }
 

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentryCrossProcessCursorTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentryCrossProcessCursorTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.whenever
 class SentryCrossProcessCursorTest {
   private class Fixture {
     private val scopes = mock<IScopes>()
-    private val spanManager = SQLiteSpanManager(scopes)
+    private val spans = OpenHelperSpans(scopes)
     val mockCursor = mock<CrossProcessCursor>()
     lateinit var options: SentryOptions
     lateinit var sentryTracer: SentryTracer
@@ -33,7 +33,7 @@ class SentryCrossProcessCursorTest {
       if (isSpanActive) {
         whenever(scopes.span).thenReturn(sentryTracer)
       }
-      return SentryCrossProcessCursor(mockCursor, spanManager, sql)
+      return SentryCrossProcessCursor(mockCursor, spans, sql)
     }
   }
 

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteDatabaseTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteDatabaseTest.kt
@@ -23,7 +23,7 @@ import org.mockito.kotlin.whenever
 class SentrySupportSQLiteDatabaseTest {
   private class Fixture {
     private val scopes = mock<IScopes>()
-    private val spanManager = SQLiteSpanManager(scopes)
+    private val spans = OpenHelperSpans(scopes)
     val mockDatabase = mock<SupportSQLiteDatabase>()
     lateinit var sentryTracer: SentryTracer
     lateinit var options: SentryOptions
@@ -41,7 +41,7 @@ class SentrySupportSQLiteDatabaseTest {
         whenever(scopes.span).thenReturn(sentryTracer)
       }
 
-      return SentrySupportSQLiteDatabase(mockDatabase, spanManager)
+      return SentrySupportSQLiteDatabase(mockDatabase, spans)
     }
   }
 

--- a/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteStatementTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/android/sqlite/SentrySupportSQLiteStatementTest.kt
@@ -18,7 +18,7 @@ import org.mockito.kotlin.whenever
 class SentrySupportSQLiteStatementTest {
   private class Fixture {
     private val scopes = mock<IScopes>()
-    private val spanManager = SQLiteSpanManager(scopes)
+    private val spans = OpenHelperSpans(scopes)
     val mockStatement = mock<SupportSQLiteStatement>()
     lateinit var sentryTracer: SentryTracer
     lateinit var options: SentryOptions
@@ -31,7 +31,7 @@ class SentrySupportSQLiteStatementTest {
       if (isSpanActive) {
         whenever(scopes.span).thenReturn(sentryTracer)
       }
-      return SentrySupportSQLiteStatement(mockStatement, spanManager, sql)
+      return SentrySupportSQLiteStatement(mockStatement, spans, sql)
     }
   }
 

--- a/sentry-android-sqlite/src/test/java/io/sentry/sqlite/DriverSpansTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/sqlite/DriverSpansTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-class SQLiteSpanInstrumentationTest {
+class DriverSpansTest {
 
   private class Fixture {
 
@@ -29,17 +29,14 @@ class SQLiteSpanInstrumentationTest {
     lateinit var sentryTracer: SentryTracer
     lateinit var options: SentryOptions
 
-    fun getSut(
-      isTransactionActive: Boolean = true,
-      fileName: String = ":memory:",
-    ): SQLiteSpanInstrumentation {
+    fun getSut(isTransactionActive: Boolean = true, fileName: String = ":memory:"): DriverSpans {
       options = SentryOptions().apply { dsn = "https://key@sentry.io/proj" }
       whenever(scopes.options).thenReturn(options)
       sentryTracer = SentryTracer(TransactionContext("name", "op"), scopes)
       if (isTransactionActive) {
         whenever(scopes.span).thenReturn(sentryTracer)
       }
-      return SQLiteSpanInstrumentation.fromFileName(fileName, scopes)
+      return DriverSpans.fromFileName(fileName, scopes)
     }
   }
 
@@ -56,7 +53,7 @@ class SQLiteSpanInstrumentationTest {
     val start = sut.startTimestamp()
 
     val durationNanos = 42_000_000L
-    sut.recordSpan("SELECT 1", start, durationNanos, SpanStatus.OK)
+    sut.record("SELECT 1", start, durationNanos, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
 
@@ -81,7 +78,7 @@ class SQLiteSpanInstrumentationTest {
     whenever(fixture.scopes.options).thenReturn(options)
     whenever(fixture.scopes.span).thenReturn(parentSpan)
 
-    val sut = SQLiteSpanInstrumentation.fromFileName(":memory:", fixture.scopes)
+    val sut = DriverSpans.fromFileName(":memory:", fixture.scopes)
 
     assertEquals(providerDate.nanoTimestamp(), sut.startTimestamp())
   }
@@ -97,31 +94,31 @@ class SQLiteSpanInstrumentationTest {
     whenever(fixture.scopes.options).thenReturn(options)
     whenever(fixture.scopes.span).thenReturn(null)
 
-    val sut = SQLiteSpanInstrumentation.fromFileName(":memory:", fixture.scopes)
+    val sut = DriverSpans.fromFileName(":memory:", fixture.scopes)
 
     assertEquals(providerDate.nanoTimestamp(), sut.startTimestamp())
   }
 
   @Test
-  fun `recordSpan records a span if a transaction is active`() {
+  fun `record method records a span if a transaction is active`() {
     val sut = fixture.getSut(isTransactionActive = true)
-    sut.recordSpan("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
     assertEquals(1, fixture.sentryTracer.children.size)
   }
 
   @Test
-  fun `recordSpan does not record a span if no transaction is active`() {
+  fun `record method does not record a span if no transaction is active`() {
     val sut = fixture.getSut(isTransactionActive = false)
     val start = sut.startTimestamp()
-    sut.recordSpan("SELECT 1", start, 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", start, 1_000_000, SpanStatus.OK)
     assertEquals(0, fixture.sentryTracer.children.size)
   }
 
   @Test
-  fun `recordSpan creates a span with correct properties`() {
+  fun `record method creates a span with correct properties`() {
     val sut = fixture.getSut()
     val start = sut.startTimestamp()
-    sut.recordSpan("SELECT * FROM users", start, 1_000_000, SpanStatus.OK)
+    sut.record("SELECT * FROM users", start, 1_000_000, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.firstOrNull()
     assertNotNull(span)
@@ -133,24 +130,24 @@ class SQLiteSpanInstrumentationTest {
   }
 
   @Test
-  fun `recordSpan sets finishDate equal to startDate + durationNanos`() {
+  fun `record method sets finishDate equal to startDate + durationNanos`() {
     val sut = fixture.getSut()
     val start = sut.startTimestamp()
     val durationNanos = 42_000_000L
 
-    sut.recordSpan("SELECT 1", start, durationNanos, SpanStatus.OK)
+    sut.record("SELECT 1", start, durationNanos, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
     assertEquals(span.startDate.nanoTimestamp() + durationNanos, span.finishDate!!.nanoTimestamp())
   }
 
   @Test
-  fun `recordSpan attaches throwable when provided`() {
+  fun `record method attaches throwable when provided`() {
     val sut = fixture.getSut()
     val start = sut.startTimestamp()
     val exception = RuntimeException("disk I/O error")
 
-    sut.recordSpan("INSERT INTO t VALUES(1)", start, 500_000, SpanStatus.INTERNAL_ERROR, exception)
+    sut.record("INSERT INTO t VALUES(1)", start, 500_000, SpanStatus.INTERNAL_ERROR, exception)
 
     val span = fixture.sentryTracer.children.first()
     assertEquals(SpanStatus.INTERNAL_ERROR, span.status)
@@ -158,10 +155,10 @@ class SQLiteSpanInstrumentationTest {
   }
 
   @Test
-  fun `recordSpan sets db system and db name when fileName is not the in-memory sentinel`() {
+  fun `record method sets db system and db name when fileName is not the in-memory sentinel`() {
     val sut = fixture.getSut(fileName = "/data/data/com.example/databases/tracks.db")
     val start = sut.startTimestamp()
-    sut.recordSpan("SELECT 1", start, 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", start, 1_000_000, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
     assertEquals("sqlite", span.data[SpanDataConvention.DB_SYSTEM_KEY])
@@ -169,10 +166,10 @@ class SQLiteSpanInstrumentationTest {
   }
 
   @Test
-  fun `recordSpan sets db system only when fileName is the in-memory sentinel`() {
+  fun `record method sets db system only when fileName is the in-memory sentinel`() {
     val sut = fixture.getSut(fileName = ":memory:")
     val start = sut.startTimestamp()
-    sut.recordSpan("SELECT 1", start, 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", start, 1_000_000, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
     assertEquals("in-memory", span.data[SpanDataConvention.DB_SYSTEM_KEY])
@@ -180,13 +177,13 @@ class SQLiteSpanInstrumentationTest {
   }
 
   @Test
-  fun `recordSpan sets blocked_main_thread to true and attaches call stack on main thread`() {
+  fun `record method sets blocked_main_thread to true and attaches call stack on main thread`() {
     val sut = fixture.getSut()
     fixture.options.threadChecker = mock<IThreadChecker>()
     whenever(fixture.options.threadChecker.isMainThread).thenReturn(true)
     whenever(fixture.options.threadChecker.currentThreadName).thenReturn("main")
 
-    sut.recordSpan("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
     assertTrue(span.getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
@@ -194,20 +191,20 @@ class SQLiteSpanInstrumentationTest {
   }
 
   @Test
-  fun `recordSpan sets blocked_main_thread to false and does not attach a call stack on background thread`() {
+  fun `record method sets blocked_main_thread to false and does not attach a call stack on background thread`() {
     val sut = fixture.getSut()
     fixture.options.threadChecker = mock<IThreadChecker>()
     whenever(fixture.options.threadChecker.isMainThread).thenReturn(false)
     whenever(fixture.options.threadChecker.currentThreadName).thenReturn("worker")
 
-    sut.recordSpan("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
+    sut.record("SELECT 1", sut.startTimestamp(), 1_000_000, SpanStatus.OK)
 
     val span = fixture.sentryTracer.children.first()
     assertFalse(span.getData(SpanDataConvention.BLOCKED_MAIN_THREAD_KEY) as Boolean)
     assertNull(span.getData(SpanDataConvention.CALL_STACK_KEY))
   }
 
-  private fun setUpWithNanotimeDates(vararg dates: SentryNanotimeDate): SQLiteSpanInstrumentation {
+  private fun setUpWithNanotimeDates(vararg dates: SentryNanotimeDate): DriverSpans {
     val dateQueue = ArrayDeque(dates.toList())
     val options =
       SentryOptions().apply {
@@ -217,6 +214,6 @@ class SQLiteSpanInstrumentationTest {
     whenever(fixture.scopes.options).thenReturn(options)
     fixture.sentryTracer = SentryTracer(TransactionContext("name", "op"), fixture.scopes)
     whenever(fixture.scopes.span).thenReturn(fixture.sentryTracer)
-    return SQLiteSpanInstrumentation.fromFileName(":memory:", fixture.scopes)
+    return DriverSpans.fromFileName(":memory:", fixture.scopes)
   }
 }

--- a/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SentrySQLiteConnectionTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SentrySQLiteConnectionTest.kt
@@ -24,7 +24,7 @@ class SentrySQLiteConnectionTest {
       options = SentryOptions().apply { dsn = "https://key@sentry.io/proj" }
       whenever(scopes.options).thenReturn(options)
       whenever(mockConnection.prepare("SELECT 1")).thenReturn(mockStatement)
-      val spans = SQLiteSpanInstrumentation.fromFileName("test.db", scopes)
+      val spans = DriverSpans.fromFileName("test.db", scopes)
       return SentrySQLiteConnection(mockConnection, spans)
     }
   }
@@ -41,7 +41,7 @@ class SentrySQLiteConnectionTest {
   @Test
   fun `prepare with already-wrapped statement returns same instance without re-wrapping`() {
     val sut = fixture.getSut()
-    val spans = SQLiteSpanInstrumentation.fromFileName("test.db", fixture.scopes)
+    val spans = DriverSpans.fromFileName("test.db", fixture.scopes)
     val alreadyInstrumented = SentrySQLiteStatement(fixture.mockStatement, spans, "SELECT 1")
     whenever(fixture.mockConnection.prepare("SELECT 1")).thenReturn(alreadyInstrumented)
 

--- a/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SentrySQLiteStatementTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SentrySQLiteStatementTest.kt
@@ -19,7 +19,7 @@ class SentrySQLiteStatementTest {
 
   private class Fixture {
     val mockStatement = mock<SQLiteStatement>()
-    val mockSpans = mock<SQLiteSpanInstrumentation>()
+    val mockSpans = mock<DriverSpans>()
     val startTimestampNanos = 1_000_000_000_000L
     val fakeClock = AtomicLong(0L)
 
@@ -40,7 +40,7 @@ class SentrySQLiteStatementTest {
     verifyNeverCalledRecordSpan()
     sut.step()
     verify(fixture.mockSpans)
-      .recordSpan(
+      .record(
         eq("SELECT * FROM users"),
         eq(fixture.startTimestampNanos),
         any(),
@@ -58,7 +58,7 @@ class SentrySQLiteStatementTest {
     assertFailsWith<RuntimeException> { sut.step() }
 
     verify(fixture.mockSpans)
-      .recordSpan(
+      .record(
         eq("BAD SQL"),
         eq(fixture.startTimestampNanos),
         any(),
@@ -224,7 +224,7 @@ class SentrySQLiteStatementTest {
     sut.step()
 
     val durationCaptor = argumentCaptor<Long>()
-    verify(fixture.mockSpans).recordSpan(any(), any(), durationCaptor.capture(), any(), anyOrNull())
+    verify(fixture.mockSpans).record(any(), any(), durationCaptor.capture(), any(), anyOrNull())
     // Each step contributes its internal time (10 + 20 + 30) plus one unit from
     // fakeClock::getAndIncrement between before/after reads, so total is 63.
     assertEquals(63L, durationCaptor.firstValue)
@@ -285,6 +285,6 @@ class SentrySQLiteStatementTest {
   }
 
   private fun verifyCalledRecordSpan(times: Int = 1) {
-    verify(fixture.mockSpans, times(times)).recordSpan(any(), any(), any(), any(), anyOrNull())
+    verify(fixture.mockSpans, times(times)).record(any(), any(), any(), any(), anyOrNull())
   }
 }


### PR DESCRIPTION
## :scroll: Description

Follow up to [#5543](https://github.com/getsentry/sentry-java/pull/5543). 

Now that `SQLiteSpanInstrumentation` solely services the `SentrySQLiteDriver` path, we can give it a name specific to the driver (and therefore less confusing). Doing so also gives us a chance to bring its name in line with the analogous `SQLiteSpanManager`. 

PR renames as follows:

- `SQLiteSpanManager` -> `OpenHelperSpans`
- `SQLiteSpanInstrumentation` -> `DriverSpans`

That^^ also lets us avoid the '-er' syndrom Roman mentioned [here](https://github.com/getsentry/sentry-java/pull/5466#discussion_r3341644401). 

## :bulb: Motivation and Context

Keeping things neat and tidy.

## :green_heart: How did you test it?

N/a

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
