### PR TITLE
chore(android-sqlite): Remove calls to deprecated SentryNanotimeDate constructor

### DIFF
--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SQLiteSpanInstrumentation.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SQLiteSpanInstrumentation.kt
@@ -10,7 +10,6 @@ import io.sentry.SentryNanotimeDate
 import io.sentry.SentryStackTraceFactory
 import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
-import java.util.Date
 
 private const val SQLITE_TRACE_ORIGIN = "auto.db.sqlite"
 
@@ -18,7 +17,7 @@ private const val SQLITE_TRACE_ORIGIN = "auto.db.sqlite"
  * Sentinel for extracting a [SentryNanotimeDate]'s underlying [System.nanoTime] value via
  * [SentryDate.diff].
  */
-private val EMPTY_NANO_TIME = SentryNanotimeDate(Date(0), 0L)
+private val EMPTY_NANO_TIME = SentryNanotimeDate(0, 0L)
 
 /** Span instrumentation for [SentrySQLiteDriver]. */
 internal class SQLiteSpanInstrumentation(

--- a/sentry-android-sqlite/src/test/java/io/sentry/sqlite/ComputeNanoStartTimestampForChildTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/sqlite/ComputeNanoStartTimestampForChildTest.kt
@@ -4,7 +4,6 @@ import io.sentry.DateUtils
 import io.sentry.ISpan
 import io.sentry.SentryLongDate
 import io.sentry.SentryNanotimeDate
-import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -86,7 +85,7 @@ class ComputeNanoStartTimestampForChildTest {
   }
 
   private fun spanWithNanotimeStart(wallClockMillis: Long, parentMonotonicNanos: Long): ISpan {
-    val startDate = SentryNanotimeDate(Date(wallClockMillis), parentMonotonicNanos)
+    val startDate = SentryNanotimeDate(wallClockMillis, parentMonotonicNanos)
     val span = mock<ISpan>()
     whenever(span.startDate).thenReturn(startDate)
     return span

--- a/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SQLiteSpanInstrumentationTest.kt
+++ b/sentry-android-sqlite/src/test/java/io/sentry/sqlite/SQLiteSpanInstrumentationTest.kt
@@ -11,7 +11,6 @@ import io.sentry.SpanDataConvention
 import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.util.thread.IThreadChecker
-import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -51,7 +50,7 @@ class SQLiteSpanInstrumentationTest {
     // Only the parent date is queued. If startTimestamp() were to call dateProvider.now(),
     // the queue would underflow and the test would fail loudly — this is what verifies the
     // optimization is in effect.
-    val parentDate = SentryNanotimeDate(Date(1_000_000L), 100_000_000L)
+    val parentDate = SentryNanotimeDate(1_000_000L, 100_000_000L)
     val sut = setUpWithNanotimeDates(parentDate)
 
     val start = sut.startTimestamp()
@@ -71,7 +70,7 @@ class SQLiteSpanInstrumentationTest {
 
   @Test
   fun `startTimestamp falls back to date provider when parent does not use SentryNanotimeDate`() {
-    val providerDate = SentryNanotimeDate(Date(2_000_000L), 200_000_000L)
+    val providerDate = SentryNanotimeDate(2_000_000L, 200_000_000L)
     val parentSpan = mock<ISpan>()
     whenever(parentSpan.startDate).thenReturn(SentryLongDate(1_000_000_000_000_000L))
     val options =
@@ -89,7 +88,7 @@ class SQLiteSpanInstrumentationTest {
 
   @Test
   fun `startTimestamp falls back to date provider when no transaction is active`() {
-    val providerDate = SentryNanotimeDate(Date(2_000_000L), 200_000_000L)
+    val providerDate = SentryNanotimeDate(2_000_000L, 200_000_000L)
     val options =
       SentryOptions().apply {
         dsn = "https://key@sentry.io/proj"


### PR DESCRIPTION
## :scroll: Description

A few snuck in when I merged #5555 just before @runningcode deprecated the constructor in #5550. Zapped.


## :bulb: Motivation and Context

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
