### PR TITLE
feat(android-sqlite): Make SentrySQLiteDriver experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add experimental `SentrySQLiteDriver` to `sentry-android-sqlite` for instrumenting `androidx.sqlite.SQLiteDriver` ([#5563](https://github.com/getsentry/sentry-java/pull/5563))
+  - To use it, pass `SQLiteDriver` to `SentrySQLiteDriver.create(...)`
+  - Requires `androidx.sqlite:sqlite` (2.5.0+) on runtime classpath (typically provided by Room or SQLDelight)
+
 ## 8.44.0
 
 ### Features

--- a/sentry-android-sqlite/api/sentry-android-sqlite.api
+++ b/sentry-android-sqlite/api/sentry-android-sqlite.api
@@ -21,3 +21,15 @@ public final class io/sentry/android/sqlite/SentrySupportSQLiteOpenHelper$Compan
 	public final fun create (Landroidx/sqlite/db/SupportSQLiteOpenHelper;)Landroidx/sqlite/db/SupportSQLiteOpenHelper;
 }
 
+public final class io/sentry/sqlite/SentrySQLiteDriver : androidx/sqlite/SQLiteDriver {
+	public static final field Companion Lio/sentry/sqlite/SentrySQLiteDriver$Companion;
+	public synthetic fun <init> (Landroidx/sqlite/SQLiteDriver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Landroidx/sqlite/SQLiteDriver;)Landroidx/sqlite/SQLiteDriver;
+	public fun hasConnectionPool ()Z
+	public fun open (Ljava/lang/String;)Landroidx/sqlite/SQLiteConnection;
+}
+
+public final class io/sentry/sqlite/SentrySQLiteDriver$Companion {
+	public final fun create (Landroidx/sqlite/SQLiteDriver;)Landroidx/sqlite/SQLiteDriver;
+}
+

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -47,6 +47,10 @@ android {
 
   buildFeatures { buildConfig = true }
 
+  // Needed b/c Kotlin 1.4.x would otherwise pull in an older version without the annotations we
+  // want.
+  configurations.all { resolutionStrategy.force(libs.jetbrains.annotations.get()) }
+
   androidComponents.beforeVariants {
     it.enable = !Config.Android.shouldSkipDebugVariant(it.buildType)
   }
@@ -65,6 +69,7 @@ dependencies {
   api(projects.sentry)
 
   compileOnly(libs.androidx.sqlite)
+  compileOnly(libs.jetbrains.annotations)
 
   implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
 

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -5,6 +5,7 @@ import androidx.sqlite.SQLiteDriver
 import io.sentry.ScopesAdapter
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
+import org.jetbrains.annotations.ApiStatus
 
 /**
  * Wraps a [SQLiteDriver] and automatically adds spans for each SQL statement it executes.
@@ -28,13 +29,16 @@ import io.sentry.SentryLevel
  *
  * @param delegate The [SQLiteDriver] instance to delegate calls to.
  */
-internal class SentrySQLiteDriver private constructor(private val delegate: SQLiteDriver) :
+@ApiStatus.Experimental
+public class SentrySQLiteDriver private constructor(private val delegate: SQLiteDriver) :
   SQLiteDriver {
 
   init {
     SentryIntegrationPackageStorage.getInstance().addIntegration("SQLiteDriver")
   }
 
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("hasConnectionPool")
   override val hasConnectionPool: Boolean
     get() =
       try {
@@ -66,14 +70,14 @@ internal class SentrySQLiteDriver private constructor(private val delegate: SQLi
     }
   }
 
-  companion object {
+  public companion object {
 
     /**
      * Wraps the provided delegate in a [SentrySQLiteDriver]. Returns the delegate as-is if already
      * wrapped.
      */
     @JvmStatic
-    fun create(delegate: SQLiteDriver): SQLiteDriver =
+    public fun create(delegate: SQLiteDriver): SQLiteDriver =
       delegate as? SentrySQLiteDriver ?: SentrySQLiteDriver(delegate)
   }
 }


### PR DESCRIPTION
## :scroll: Description

Makes SentrySQLiteDriver public + experimental during development. (Plan is to remove experimental status prior to inclusion in next week's release.)

## :bulb: Motivation and Context

Lets us access `SentrySQLiteDriver` from the Android sample app.

[JAVA-275](https://linear.app/getsentry/issue/JAVA-275/support-for-androidxsqlites-sqlitedriver)

## :green_heart: How did you test it?


## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps