### PR TITLE
chore(util): Add CompileOnlyCompat for compile-only linkage errors

### DIFF
--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/SentryLayoutNodeHelper.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/viewhierarchy/SentryLayoutNodeHelper.kt
@@ -10,6 +10,7 @@ package io.sentry.android.replay.viewhierarchy
 
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.NodeCoordinator
+import io.sentry.util.CompileOnlyCompat.CompileOnlyCall
 import java.lang.reflect.Method
 
 /**
@@ -41,17 +42,13 @@ internal object SentryLayoutNodeHelper {
   fun getChildren(node: LayoutNode): List<LayoutNode> {
     when (useFallback) {
       false -> return node.children
-      true -> {
-        return getFallback().getChildren!!.invoke(node) as List<LayoutNode>
-      }
-      null -> {
-        try {
-          return node.children.also { useFallback = false }
-        } catch (_: NoSuchMethodError) {
-          useFallback = true
-          return getFallback().getChildren!!.invoke(node) as List<LayoutNode>
-        }
-      }
+      true -> return getFallback().getChildren!!.invoke(node) as List<LayoutNode>
+      null ->
+        return CompileOnlyCall { node.children.also { useFallback = false } }
+          .ifAbsent {
+            useFallback = true
+            getFallback().getChildren!!.invoke(node) as List<LayoutNode>
+          }
     }
   }
 
@@ -63,16 +60,16 @@ internal object SentryLayoutNodeHelper {
         val coordinator = fb.getOuterCoordinator!!.invoke(node) as NodeCoordinator
         return coordinator.isTransparent()
       }
-      null -> {
-        try {
-          return node.outerCoordinator.isTransparent().also { useFallback = false }
-        } catch (_: NoSuchMethodError) {
-          useFallback = true
-          val fb = getFallback()
-          val coordinator = fb.getOuterCoordinator!!.invoke(node) as NodeCoordinator
-          return coordinator.isTransparent()
-        }
-      }
+      null ->
+        return CompileOnlyCall {
+            node.outerCoordinator.isTransparent().also { useFallback = false }
+          }
+          .ifAbsent {
+            useFallback = true
+            val fb = getFallback()
+            val coordinator = fb.getOuterCoordinator!!.invoke(node) as NodeCoordinator
+            coordinator.isTransparent()
+          }
     }
   }
 

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -5,6 +5,7 @@ import androidx.sqlite.SQLiteDriver
 import io.sentry.ScopesAdapter
 import io.sentry.SentryIntegrationPackageStorage
 import io.sentry.SentryLevel
+import io.sentry.util.CompileOnlyCompat.CompileOnlyCall
 
 /**
  * Wraps a [SQLiteDriver] and automatically adds spans for each SQL statement it executes.
@@ -36,13 +37,7 @@ internal class SentrySQLiteDriver private constructor(private val delegate: SQLi
   }
 
   override val hasConnectionPool: Boolean
-    get() =
-      try {
-        delegate.hasConnectionPool
-      } catch (_: LinkageError) {
-        // Delegates on androidx.sqlite < 2.6.0 won't have a hasConnectionPool property.
-        false
-      }
+    get() = CompileOnlyCall { delegate.hasConnectionPool }.ifAbsent(false)
 
   @Suppress("TooGenericExceptionCaught")
   override fun open(fileName: String): SQLiteConnection {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7628,6 +7628,19 @@ public abstract interface class io/sentry/util/CollectionUtils$Predicate {
 	public abstract fun test (Ljava/lang/Object;)Z
 }
 
+public final class io/sentry/util/CompileOnlyCompat {
+}
+
+public abstract interface class io/sentry/util/CompileOnlyCompat$CompileOnlyCall {
+	public abstract fun call ()Ljava/lang/Object;
+	public fun ifAbsent (Lio/sentry/util/CompileOnlyCompat$Fallback;)Ljava/lang/Object;
+	public fun ifAbsent (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/sentry/util/CompileOnlyCompat$Fallback {
+	public abstract fun call (Ljava/lang/LinkageError;)Ljava/lang/Object;
+}
+
 public final class io/sentry/util/DebugMetaPropertiesApplier {
 	public static field DEBUG_META_PROPERTIES_FILENAME Ljava/lang/String;
 	public fun <init> ()V

--- a/sentry/src/main/java/io/sentry/util/CompileOnlyCompat.java
+++ b/sentry/src/main/java/io/sentry/util/CompileOnlyCompat.java
@@ -1,0 +1,72 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Helpers for safely calling methods from {@code compileOnly} dependencies that may not exist at
+ * runtime.
+ *
+ * <p>When a dependency is {@code compileOnly}, the app supplies the actual version. That version
+ * may predate the API we compiled against, which means it may not have methods we call from our
+ * source code if the API has added methods over time. Calling a missing method throws a {@link
+ * LinkageError} (e.g., {@link NoSuchMethodError}, {@link AbstractMethodError}, etc.). This class
+ * lets us centralize the try/catch-with-fallback pattern.
+ *
+ * <p>This is not for {@code implementation} dependencies with transitive version conflicts on the
+ * classpath; use local {@code try/catch} handling for those cases instead.
+ */
+@ApiStatus.Internal
+public final class CompileOnlyCompat {
+
+  /**
+   * Functional interface for a call that returns a non-null value and may throw a {@link
+   * LinkageError}.
+   *
+   * <p>Use it when calling from Kotlin:
+   *
+   * <pre>{@code
+   * CompileOnlyCall { delegate.hasConnectionPool }.ifAbsent(false)
+   * }</pre>
+   */
+  @FunctionalInterface
+  public interface CompileOnlyCall<T> {
+
+    @NotNull
+    T call();
+
+    /**
+     * Invokes this callable and returns its result. If the call throws a {@link LinkageError},
+     * returns {@code fallback} instead.
+     */
+    default @NotNull T ifAbsent(final @NotNull T fallback) {
+      return run(this, error -> fallback);
+    }
+
+    /**
+     * Invokes this callable and returns its result. If the call throws a {@link LinkageError},
+     * invokes {@code fallback} and returns its result instead.
+     */
+    default @NotNull T ifAbsent(final @NotNull Fallback<T> fallback) {
+      return run(this, fallback);
+    }
+  }
+
+  /** Fallback that receives the caught {@link LinkageError} and returns a non-null value. */
+  @FunctionalInterface
+  public interface Fallback<T> {
+    @NotNull
+    T call(@NotNull LinkageError error);
+  }
+
+  private CompileOnlyCompat() {}
+
+  private static <T> @NotNull T run(
+      final @NotNull CompileOnlyCall<T> call, final @NotNull Fallback<T> fallback) {
+    try {
+      return call.call();
+    } catch (LinkageError e) {
+      return fallback.call(e);
+    }
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/CompileOnlyCompatTest.kt
+++ b/sentry/src/test/java/io/sentry/util/CompileOnlyCompatTest.kt
@@ -1,0 +1,79 @@
+package io.sentry.util
+
+import io.sentry.util.CompileOnlyCompat.CompileOnlyCall
+import io.sentry.util.CompileOnlyCompat.Fallback
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CompileOnlyCompatTest {
+
+  @Test
+  fun `ifAbsent returns call result when method exists`() {
+    val result = CompileOnlyCall { "hello" }.ifAbsent("fallback")
+    assertEquals("hello", result)
+  }
+
+  @Test
+  fun `ifAbsent returns constant fallback on LinkageError`() {
+    val result = CompileOnlyCall<String> { throw NoSuchMethodError() }.ifAbsent("fallback")
+    assertEquals("fallback", result)
+  }
+
+  @Test
+  fun `ifAbsent does not catch non-LinkageErrors`() {
+    assertFailsWith<IllegalStateException> {
+      CompileOnlyCall<String> { throw IllegalStateException() }.ifAbsent("fallback")
+    }
+  }
+
+  @Test
+  fun `ifAbsent with Fallback returns call result when method exists`() {
+    val result = CompileOnlyCall { "hello" }.ifAbsent(Fallback { _ -> "fallback" })
+    assertEquals("hello", result)
+  }
+
+  @Test
+  fun `ifAbsent with Fallback invokes fallback on LinkageError`() {
+    var fallbackInvoked = false
+    val result =
+      CompileOnlyCall<String> { throw NoSuchMethodError() }
+        .ifAbsent { _ ->
+          fallbackInvoked = true
+          "fallback"
+        }
+    assertEquals("fallback", result)
+    assertTrue(fallbackInvoked)
+  }
+
+  @Test
+  fun `ifAbsent with Fallback passes the LinkageError`() {
+    var captured: LinkageError? = null
+    CompileOnlyCall<String> { throw NoSuchMethodError("test") }
+      .ifAbsent { error ->
+        captured = error
+        "fallback"
+      }
+    assertTrue(captured is NoSuchMethodError)
+    assertEquals("test", captured!!.message)
+  }
+
+  @Test
+  fun `ifAbsent with Fallback does not invoke fallback on success`() {
+    var fallbackInvoked = false
+    CompileOnlyCall { "hello" }
+      .ifAbsent { _ ->
+        fallbackInvoked = true
+        "fallback"
+      }
+    assertTrue(!fallbackInvoked)
+  }
+
+  @Test
+  fun `ifAbsent with Fallback does not catch non-LinkageErrors`() {
+    assertFailsWith<IllegalStateException> {
+      CompileOnlyCall<String> { throw IllegalStateException() }.ifAbsent { _ -> "fallback" }
+    }
+  }
+}


### PR DESCRIPTION
_**I'm not convinced this PR is worthwhile: see the "Callouts" section below.**_

## :scroll: Description

Introduces an internal helper for calling compileOnly APIs that may be missing or binary-incompatible at runtime.

Adopted in SentrySQLiteDriver and SentryLayoutNodeHelper to replace ad-hoc try/catch blocks.

## :bulb: Motivation and Context

We frequently use `compileOnly` dependencies to instrument code so that users can remain free to chose their preferred version. That means the shape of the dependency we compile against may not match what shows up at runtime. In particular, if the dependency has an API that adds methods over time, users can crash if we don't use `try-catch` blocks when calling those methods. The utilities introduced here help us raise awareness about the issue and centralize our approach.

## ⚠️ Callouts

Not in love with this PR (my vote would be to close it and wait for more examples to show up, if ever), but I'm posting b/c I said I would in our sync + I wanted folks to have a chance to weigh in. IMO, it's heavyweight for what ended up being just two call sites. And there's probably no way to keep everyone happy with the approach. 

A number of reasons for that: 

**[1]** If we want these utilities to be generally available, they need to live in the core `sentry` module. That module is Java-only, and that means making Kotlin call sites look reasonably idiomatic can be tricky.

**[2]** We can't easily make them Kotlin-only as there's no "core"/"util" Kotlin module that all other Kotlin modules depend on. (The closest is `sentry-kotlin-extension`, but those are externally-facing and higher-level than the abstractions here.)

**[3]** Extracting `try-catch` logic into a method requires using lambdas / SAMs, and that means an additional object allocation relative to an inline `try-catch`. (We can't use an inline function b/c of [1]/[2].)

**[4]** Sometimes fallbacks are themselves lambdas rather than a simple default value. That means two lambda args, which further complicates call sites. (Eg, my first approach was `T withFallbackIfAbsent(T fallback, Callable<T> callable)`, but the additional Callable for the fallback case made that less-than-lovely. Plus, putting the fallback first was misleading in the case of booleans, as it looks like you're opting out of some under-the-hood functionality: `withFallbackIfAbsent(false) { delegate.doSomething() }`.)

Sigh.

## :green_heart: How did you test it?

New unit tests + existing tests still pass.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
