### PR TITLE
fix(android): Make FirstDrawDoneListener cleanup OnGlobalLayoutListener after use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix `FirstDrawDoneListener` leaking an `OnGlobalLayoutListener` per registration ([#5567](https://github.com/getsentry/sentry-java/pull/5567))
+
 ### Features
 
 - Add experimental `SentrySQLiteDriver` to `sentry-android-sqlite` for instrumenting `androidx.sqlite.SQLiteDriver` ([#5563](https://github.com/getsentry/sentry-java/pull/5563))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/FirstDrawDoneListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/FirstDrawDoneListener.java
@@ -112,7 +112,14 @@ public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
     // OnDrawListeners cannot be removed within onDraw, so we remove it with a
     // GlobalLayoutListener
     view.getViewTreeObserver()
-        .addOnGlobalLayoutListener(() -> view.getViewTreeObserver().removeOnDrawListener(this));
+        .addOnGlobalLayoutListener(
+            new ViewTreeObserver.OnGlobalLayoutListener() {
+              @Override
+              public void onGlobalLayout() {
+                view.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                view.getViewTreeObserver().removeOnDrawListener(FirstDrawDoneListener.this);
+              }
+            });
     mainThreadHandler.postAtFrontOfQueue(callback);
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/FirstDrawDoneListenerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/FirstDrawDoneListenerTest.kt
@@ -129,6 +129,37 @@ class FirstDrawDoneListenerTest {
   }
 
   @Test
+  fun `OnGlobalLayoutListener is removed after cleanup`() {
+    val view = fixture.getSut()
+
+    // Initialize mOnGlobalLayoutListeners via a dummy add/remove
+    val dummyGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {}
+    view.viewTreeObserver.addOnGlobalLayoutListener(dummyGlobalListener)
+    view.viewTreeObserver.removeOnGlobalLayoutListener(dummyGlobalListener)
+
+    // CopyOnWriteArray wraps an internal ArrayList called mData
+    val copyOnWriteArray: Any = view.viewTreeObserver.getProperty("mOnGlobalLayoutListeners")
+    val mDataField = copyOnWriteArray.javaClass.getDeclaredField("mData")
+    mDataField.isAccessible = true
+
+    @Suppress("UNCHECKED_CAST")
+    fun globalLayoutListeners(): ArrayList<*> = mDataField.get(copyOnWriteArray) as ArrayList<*>
+
+    assertTrue(globalLayoutListeners().isEmpty())
+
+    FirstDrawDoneListener.registerForNextDraw(view, {}, fixture.buildInfo)
+
+    // onDraw registers a cleanup OnGlobalLayoutListener
+    view.viewTreeObserver.dispatchOnDraw()
+    assertFalse(globalLayoutListeners().isEmpty())
+
+    // onGlobalLayout fires the cleanup, which removes both the draw and layout listeners
+    view.viewTreeObserver.dispatchOnGlobalLayout()
+    assertTrue(globalLayoutListeners().isEmpty())
+    assertTrue(fixture.onDrawListeners.isEmpty())
+  }
+
+  @Test
   fun `registerForNextDraw calls the given callback on the main thread after onDraw`() {
     val view = fixture.getSut()
     val r: Runnable = mock()


### PR DESCRIPTION
## :scroll: Description

The `OnGlobalLayoutListener` registered in `onDraw()` to defer removal of the `OnDrawListener` was never itself removed from the `ViewTreeObserver`. In single-Activity apps (e.g. React Native), this caused an unbounded per-navigation leak — one listener per `registerForNextDraw` call, each pinning the dismissed screen's view tree.

The fix makes the `OnGlobalLayoutListener` remove itself after firing.

Note: this bug was inherited from Firebase's original implementation, which has the same issue.

## :bulb: Motivation and Context

* resolves: #5495
* resolves: JAVA-545

~80–100 MB of Java heap retained after ~50 navigations in the reporter's RN app, with leaked listener count tracking navigations 1:1.

## :green_heart: How did you test it?

- Added a regression test that verifies `mOnGlobalLayoutListeners` is empty after the cleanup fires
- Confirmed the test fails without the fix and passes with it

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
