### PR TITLE
chore(samples-android): Adapt SQLite demo screen to SAGP build mode

### DIFF
--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -52,6 +52,12 @@ android {
     versionCode = 2
     versionName = project.version.toString()
 
+    buildConfigField(
+      "boolean",
+      "USE_SAGP",
+      providers.gradleProperty("useSagp").isPresent.toString(),
+    )
+
     externalNativeBuild {
       cmake {
         // Android 15: As we're using an older version of AGP / NDK, the STL is not 16kb page

--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.BuildConfigField
 import com.android.build.api.variant.impl.VariantImpl
 import io.sentry.android.gradle.extensions.InstrumentationFeature
 import io.sentry.android.gradle.extensions.SentryPluginExtension
@@ -51,12 +52,6 @@ android {
     targetSdk = libs.versions.targetSdk.get().toInt()
     versionCode = 2
     versionName = project.version.toString()
-
-    buildConfigField(
-      "boolean",
-      "USE_SAGP",
-      providers.gradleProperty("useSagp").isPresent.toString(),
-    )
 
     externalNativeBuild {
       cmake {
@@ -141,6 +136,17 @@ android {
   }
 
   androidComponents.onVariants { variant ->
+    variant.buildConfigFields?.put(
+      "USE_SAGP",
+      providers.provider {
+        BuildConfigField(
+          type = "boolean",
+          value = providers.gradleProperty("useSagp").isPresent.toString(),
+          comment = "Whether the Sentry Android Gradle Plugin was applied",
+        )
+      },
+    )
+
     val taskName = "toggle${variant.name.capitalized()}NativeLogging"
     val toggleNativeLoggingTask =
       project.tasks.register<ToggleNativeLoggingTask>(taskName) {

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/sqlite/SQLiteActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/sqlite/SQLiteActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.HelpOutline
@@ -45,6 +46,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -70,6 +72,7 @@ import io.sentry.SpanStatus
 import io.sentry.TransactionContext
 import io.sentry.TransactionOptions
 import io.sentry.protocol.SentryId
+import io.sentry.samples.android.BuildConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -93,33 +96,45 @@ private val CONTROL_SECTION_GAP = TOGGLE_SECTION_GAP * 2
 
 private val SECTION_HEADER_HEIGHT = 28.dp
 
+private const val SAGP_DIRECT_DRIVER_MESSAGE =
+  "SAGP doesn't auto-instrument SQLiteDriver for direct use"
+
 /** Which sentry-android-sqlite integration the demo currently targets. */
 private enum class IntegrationMode(
   val color: Color,
   val segmentLabel: String,
   val apiName: String,
-  val subtitle: String,
 ) {
-  DRIVER(
-    SentryPurple,
-    "SQLiteDriver",
-    "SQLiteDriver",
-    "SentrySQLiteDriver.create(BundledSQLiteDriver)",
-  ),
-  OPEN_HELPER(
-    SentryPink,
-    "OpenHelper",
-    "SupportSQLiteOpenHelper",
-    "SentrySupportSQLiteOpenHelper.create(...)",
-  ),
+
+  DRIVER(SentryPurple, "SQLiteDriver", "SQLiteDriver"),
+  OPEN_HELPER(SentryPink, "OpenHelper", "SupportSQLiteOpenHelper"),
   // Not directly-supported, but lets us verify behavior when both the DRIVER and OPEN_HELPER
   // integrations are used together via the SupportSQLiteDriver bridge.
-  BRIDGE(
-    SentryOrange,
-    "Bridge",
-    "SupportSQLiteDriver bridge",
-    "SentrySQLiteDriver.create(SupportSQLiteDriver(Sentry helper))",
-  ),
+  BRIDGE(SentryOrange, "Bridge", "SupportSQLiteDriver bridge");
+
+  fun subtitle(): String =
+    when (this) {
+      DRIVER ->
+        if (BuildConfig.USE_SAGP) {
+          "BundledSQLiteDriver (SAGP auto-wrap)"
+        } else {
+          "SentrySQLiteDriver.create(BundledSQLiteDriver)"
+        }
+
+      OPEN_HELPER ->
+        if (BuildConfig.USE_SAGP) {
+          "FrameworkSQLiteOpenHelperFactory (SAGP auto-wrap)"
+        } else {
+          "SentrySupportSQLiteOpenHelper.create(...)"
+        }
+
+      BRIDGE ->
+        if (BuildConfig.USE_SAGP) {
+          "SupportSQLiteDriver(open helper) (SAGP auto-wrap)"
+        } else {
+          "SentrySQLiteDriver.create(SupportSQLiteDriver(Sentry helper))"
+        }
+    }
 }
 
 /**
@@ -318,6 +333,7 @@ class SQLiteActivity : ComponentActivity() {
               lerp(MaterialTheme.colorScheme.outline, integration.color, shimmer.value)
 
             Text(text = "SQLite Instrumentation", style = MaterialTheme.typography.headlineSmall)
+            SagpBuildPill()
 
             Spacer(Modifier.height(titleGap))
 
@@ -364,6 +380,7 @@ class SQLiteActivity : ComponentActivity() {
                 label = row.label,
                 color = integration.color,
                 variant = variant,
+                sagpDisabledReason = sagpDisabledReason(integration, row),
                 disabledReason = "${row.label} doesn't support the ${integration.apiName} stack",
               )
             }
@@ -447,7 +464,7 @@ class SQLiteActivity : ComponentActivity() {
   }
 
   @OptIn(ExperimentalMaterial3Api::class)
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun IntegrationModeSelector(
     selected: IntegrationMode,
     onSelected: (IntegrationMode) -> Unit,
@@ -471,18 +488,36 @@ class SQLiteActivity : ComponentActivity() {
     }
 
     Text(
-      text = selected.subtitle,
+      text = selected.subtitle(),
       style = MaterialTheme.typography.bodySmall,
       color = Color.Gray,
       modifier = Modifier.padding(top = 6.dp),
     )
   }
 
+  @Composable
+  private fun SagpBuildPill() {
+    val useSagp = BuildConfig.USE_SAGP
+
+    Surface(
+      shape = RoundedCornerShape(percent = 50),
+      color = if (useSagp) SentryPurple.copy(alpha = 0.15f) else Color.Gray.copy(alpha = 0.2f),
+      modifier = Modifier.padding(top = 6.dp),
+    ) {
+      Text(
+        text = if (useSagp) "Built with SAGP" else "Built without SAGP",
+        style = MaterialTheme.typography.labelSmall,
+        color = if (useSagp) SentryPurple else Color.DarkGray,
+        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+      )
+    }
+  }
+
   /**
    * A compact, left-justified labeled switch. [labelColor] defaults to [Color.Unspecified] so the
    * label inherits the default text color.
    */
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun ToggleRow(
     label: String,
     checked: Boolean,
@@ -509,11 +544,11 @@ class SQLiteActivity : ComponentActivity() {
     }
   }
 
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun SectionHeader(
     title: String,
     topPadding: Dp = 8.dp,
-    trailing: (@androidx.compose.runtime.Composable () -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
   ) {
     Column(modifier = Modifier.fillMaxWidth().padding(top = topPadding)) {
       Row(verticalAlignment = Alignment.CenterVertically) {
@@ -529,7 +564,7 @@ class SQLiteActivity : ComponentActivity() {
    * tooltip that auto-dismisses after a few seconds.
    */
   @OptIn(ExperimentalMaterial3Api::class)
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun HelpTooltip() {
     val tooltipState = rememberTooltipState(isPersistent = true)
     val scope = rememberCoroutineScope()
@@ -565,16 +600,19 @@ class SQLiteActivity : ComponentActivity() {
    * dimmed and, when clicked, explains why via a toast ([disabledReason]) instead of running.
    */
   @OptIn(ExperimentalFoundationApi::class)
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun DemoRowButton(
     label: String,
     color: Color,
     variant: DemoVariant?,
+    sagpDisabledReason: String?,
     disabledReason: String,
   ) {
     val context = LocalContext.current
-    val enabled = variant != null
-    val explain = { Toast.makeText(context, disabledReason, Toast.LENGTH_SHORT).show() }
+    val enabled = variant != null && sagpDisabledReason == null
+    val explain = {
+      Toast.makeText(context, sagpDisabledReason ?: disabledReason, Toast.LENGTH_SHORT).show()
+    }
 
     Surface(
       modifier = Modifier.fillMaxWidth(),
@@ -585,8 +623,8 @@ class SQLiteActivity : ComponentActivity() {
       Box(
         modifier =
           Modifier.combinedClickable(
-              onClick = { if (variant != null) onTap(variant) else explain() },
-              onLongClick = { if (variant != null) onLongPress(variant) else explain() },
+              onClick = { if (enabled) onTap(variant) else explain() },
+              onLongClick = { if (enabled) onLongPress(variant) else explain() },
             )
             .fillMaxWidth()
             .heightIn(min = 44.dp)
@@ -598,7 +636,7 @@ class SQLiteActivity : ComponentActivity() {
     }
   }
 
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun ResetButton(dbOperationInFlight: Boolean, resetInProgress: Boolean) {
     // Debounce demo-driven disablement so fast taps don't flicker the button; reset disables
     // immediately via [resetInProgress]. [dbOperationInFlight] still guards [onClick] either way.
@@ -642,7 +680,7 @@ class SQLiteActivity : ComponentActivity() {
     }
   }
 
-  @androidx.compose.runtime.Composable
+  @Composable
   private fun DetailField(label: String, value: String, borderColor: Color) {
     OutlinedTextField(
       value = value,
@@ -696,6 +734,15 @@ class SQLiteActivity : ComponentActivity() {
       "$transactionName failed: ${t.message ?: t.javaClass.simpleName}"
     } finally {
       transaction.finish()
+    }
+  }
+
+  private fun sagpDisabledReason(mode: IntegrationMode, row: DemoRow): String? {
+    if (!BuildConfig.USE_SAGP) return null
+    val demo = row.variantFor(mode)?.demo ?: return null
+    return when (demo) {
+      SqlDemo.DRIVER_DIRECT -> SAGP_DIRECT_DRIVER_MESSAGE
+      else -> null
     }
   }
 

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/sqlite/SampleDatabases.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/sqlite/SampleDatabases.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.room.Room
 import androidx.room3.Room as Room3
 import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
@@ -13,6 +14,7 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.execSQL
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import io.sentry.android.sqlite.SentrySupportSQLiteOpenHelper
+import io.sentry.samples.android.BuildConfig
 import io.sentry.samples.android.sqlite.SampleDatabases.driverDirectLock
 import io.sentry.samples.android.sqlite.SampleDatabases.openHelperDirectLock
 import io.sentry.samples.android.sqlite.SampleDatabases.reset
@@ -85,12 +87,10 @@ object SampleDatabases {
   fun driverConnection(context: Context): SQLiteConnection =
     synchronized(driverDirectLock) {
       driverConnection
-        ?: SentrySQLiteDriver.create(BundledSQLiteDriver())
-          .open(databaseFile(context, "driver_direct.db"))
-          .also {
-            it.execSQL(SqlStatements.CREATE_SONG) // one-time table setup, at open
-            driverConnection = it
-          }
+        ?: wrapDriver(BundledSQLiteDriver()).open(databaseFile(context, "driver_direct.db")).also {
+          it.execSQL(SqlStatements.CREATE_SONG) // one-time table setup, at open
+          driverConnection = it
+        }
     }
 
   /**
@@ -104,7 +104,7 @@ object SampleDatabases {
           // SupportSQLiteDriver.open() requires fileName to match the helper's databaseName();
           // use the absolute path Room and the direct driver path both pass to open().
           val dbPath = databaseFile(context, "bridge_direct.db")
-          SentrySQLiteDriver.create(SupportSQLiteDriver(buildBridgeDirectHelper(context, dbPath)))
+          wrapDriver(SupportSQLiteDriver(buildBridgeDirectHelper(context, dbPath)))
             .open(dbPath)
             .also {
               it.execSQL(SqlStatements.CREATE_SONG)
@@ -122,9 +122,7 @@ object SampleDatabases {
             "bridge_room2.db",
           )
           .setDriver(
-            SentrySQLiteDriver.create(
-              SupportSQLiteDriver(buildBridgeRoom2Helper(context.applicationContext))
-            )
+            wrapDriver(SupportSQLiteDriver(buildBridgeRoom2Helper(context.applicationContext)))
           )
           .setQueryCoroutineContext(Dispatchers.IO)
           .fallbackToDestructiveMigration(true)
@@ -140,7 +138,7 @@ object SampleDatabases {
             SampleRoom2Database::class.java,
             "driver_room2.db",
           )
-          .setDriver(SentrySQLiteDriver.create(BundledSQLiteDriver()))
+          .setDriver(wrapDriver(BundledSQLiteDriver()))
           .setQueryCoroutineContext(Dispatchers.IO)
           .fallbackToDestructiveMigration(true)
           .build()
@@ -151,7 +149,7 @@ object SampleDatabases {
     synchronized(this) {
       driverRoom3Db
         ?: Room3.databaseBuilder<SampleRoom3Database>(context.applicationContext, "driver_room3.db")
-          .setDriver(SentrySQLiteDriver.create(BundledSQLiteDriver()))
+          .setDriver(wrapDriver(BundledSQLiteDriver()))
           .setQueryCoroutineContext(Dispatchers.IO)
           .build()
           .also { driverRoom3Db = it }
@@ -171,9 +169,7 @@ object SampleDatabases {
             "openhelper_room.db",
           )
           .openHelperFactory { configuration ->
-            SentrySupportSQLiteOpenHelper.create(
-              FrameworkSQLiteOpenHelperFactory().create(configuration)
-            )
+            wrapOpenHelper(FrameworkSQLiteOpenHelperFactory().create(configuration))
           }
           .fallbackToDestructiveMigration(true)
           .build()
@@ -189,9 +185,7 @@ object SampleDatabases {
             name = "openhelper_sqldelight.db",
             factory =
               SupportSQLiteOpenHelper.Factory { configuration ->
-                SentrySupportSQLiteOpenHelper.create(
-                  FrameworkSQLiteOpenHelperFactory().create(configuration)
-                )
+                wrapOpenHelper(FrameworkSQLiteOpenHelperFactory().create(configuration))
               },
           )
           .also { sqlDelightDriver = it }
@@ -232,9 +226,7 @@ object SampleDatabases {
           }
         )
         .build()
-    return SentrySupportSQLiteOpenHelper.create(
-      FrameworkSQLiteOpenHelperFactory().create(configuration)
-    )
+    return wrapOpenHelper(FrameworkSQLiteOpenHelperFactory().create(configuration))
   }
 
   private fun buildSentryHelper(context: Context, dbName: String): SupportSQLiteOpenHelper {
@@ -252,10 +244,14 @@ object SampleDatabases {
           }
         )
         .build()
-    return SentrySupportSQLiteOpenHelper.create(
-      FrameworkSQLiteOpenHelperFactory().create(configuration)
-    )
+    return wrapOpenHelper(FrameworkSQLiteOpenHelperFactory().create(configuration))
   }
+
+  private fun wrapDriver(driver: SQLiteDriver): SQLiteDriver =
+    if (BuildConfig.USE_SAGP) driver else SentrySQLiteDriver.create(driver)
+
+  private fun wrapOpenHelper(delegate: SupportSQLiteOpenHelper): SupportSQLiteOpenHelper =
+    if (BuildConfig.USE_SAGP) delegate else SentrySupportSQLiteOpenHelper.create(delegate)
 
   /** Opens every database on a background thread, forcing the one-time open + bootstrap to run. */
   fun warmUp(context: Context) {
@@ -263,6 +259,7 @@ object SampleDatabases {
     val generation = ++warmUpGeneration
     warmUpComplete = false
     warmUpErrors = ""
+    Log.i(TAG, "Warm-up starting (USE_SAGP=${BuildConfig.USE_SAGP})")
     // Fire-and-forget: the warm-up outlives no particular screen, so a bare scope is fine here.
     warmUpJob =
       CoroutineScope(Dispatchers.IO).launch {


### PR DESCRIPTION
## :scroll: Description

Exposes a `BuildConfig.USE_SAGP` property from the recently introduced -PuseSagp flag ([#5538](https://github.com/getsentry/sentry-java/pull/5538)).

Also updates the SQLite screen in the Android sample app so that it swizzles between auto-instrumenting vs manually wrapping `SQLiteDriver`, depending on the whether SAGP was applied to the build. 


## :bulb: Motivation and Context

Lets us test end-to-end our `SentrySQLiteDriver` and its auto-wiring via the SAGP.

JAVA-275, GRADLE-107

## Screenshots

<img width="348" height="727" alt="screenshot" src="https://github.com/user-attachments/assets/5ae51c14-cb1f-4a61-9324-c8b114b2337e" />

_Note the new pill that tells us whether or not the sample app was built via the SAGP. The SAGP auto-instruments `SQLiteDriver` when used with Room 2 and Room 3, but not when used directly – hence the buttons' enabled vs disabled states. (SQLDelight doesn't support `SQLiteDriver` whatsoever.)_

## :green_heart: How did you test it?

Manually via the samples app:

```
./gradlew :sentry-samples:sentry-samples-android:installDebug -PuseSagp
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
