### PR TITLE
chore(android-sqlite): Update SQLite instrumentation documentation after 8.45.0 release

### DIFF
--- a/sentry-android-sqlite/README.md
+++ b/sentry-android-sqlite/README.md
@@ -4,10 +4,12 @@ SQLite instrumentation for AndroidX APIs.
 
 Two instrumentation paths are supported:
 
-- **`androidx.sqlite.SQLiteDriver`**: Used by Room 2.7+ and 3.0+.
+- **`androidx.sqlite.SQLiteDriver`**: Used by Room 2.7+ and 3.0+. Applied automatically by the Sentry Android Gradle Plugin.
 - **`androidx.sqlite.db.SupportSQLiteOpenHelper`**: Used by SQLDelight and legacy (pre-2.7) Room. Applied automatically by the Sentry Android Gradle Plugin.
 
 To avoid duplicate spans, only one path should be used per database file. Most Room and SQLDelight APIs enforce that division. The exception is Room's `SupportSQLiteDriver`: either the `SupportSQLiteOpenHelper` it consumes should be wrapped or the support driver itself, but never both.
+
+See the [SQLite integration docs](https://docs.sentry.io/platforms/android/integrations/room-and-sqlite/) for more details.
 
 ## Package layout
 

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -22,7 +22,8 @@ import org.jetbrains.annotations.ApiStatus
  *     .build()
  * ```
  *
- * If you're using the Sentry Android Gradle plugin, wrapping will be performed automatically.
+ * If you're using the Sentry Android Gradle Plugin (SAGP), wrapping will be performed
+ * automatically.
  *
  * @param delegate The [SQLiteDriver] instance to delegate calls to.
  */
@@ -94,12 +95,11 @@ public class SentrySQLiteDriver private constructor(private val delegate: SQLite
      * wraps or subclasses one. In that case, ensure the open helper passed to the support driver
      * constructor is *not* wrapped.
      */
-    // The Sentry Android Gradle Plugin depends on this method's ABI. Don't change it without
-    // updating the SAGP.
+    // Warning! The SAGP depends on this method's ABI.
     @JvmStatic
     public fun create(delegate: SQLiteDriver): SQLiteDriver =
-      // The SAGP relies on the FQN check for correctness (it lets it naively instrument all
-      // Room.DatabaseBuilder.setDriver() call sites).
+      // FQN check simplifies our SAGP implementation, allowing it to naively instrument all
+      // Room.DatabaseBuilder.setDriver() call sites.
       if (delegate is SentrySQLiteDriver || delegate.javaClass.name == SUPPORT_SQLITE_DRIVER_FQN) {
         delegate
       } else {

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -99,7 +99,7 @@ public class SentrySQLiteDriver private constructor(private val delegate: SQLite
     @JvmStatic
     public fun create(delegate: SQLiteDriver): SQLiteDriver =
       // FQN check simplifies our SAGP implementation, allowing it to naively instrument all
-      // Room.DatabaseBuilder.setDriver() call sites.
+      // RoomDatabase.Builder.setDriver() call sites.
       if (delegate is SentrySQLiteDriver || delegate.javaClass.name == SUPPORT_SQLITE_DRIVER_FQN) {
         delegate
       } else {

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -22,6 +22,8 @@ import org.jetbrains.annotations.ApiStatus
  *     .build()
  * ```
  *
+ * If you're using the Sentry Android Gradle plugin, wrapping will be performed automatically.
+ *
  * @param delegate The [SQLiteDriver] instance to delegate calls to.
  */
 @ApiStatus.Experimental
@@ -87,9 +89,17 @@ public class SentrySQLiteDriver private constructor(private val delegate: SQLite
      *
      * In the case of (2), wrap the open helper passed to the `SupportSQLiteDriver` constructor via
      * `SentrySupportSQLiteOpenHelper` instead.
+     *
+     * Note that wrapping will be performed if the delegate isn't a `SupportSQLiteDriver` itself
+     * but wraps or subclasses one. In that case, ensure the open helper passed to the support
+     * driver constructor is *not* wrapped.
      */
+    // The Sentry Android Gradle Plugin depends on this method's ABI. Don't change it without
+    // updating the SAGP.
     @JvmStatic
     public fun create(delegate: SQLiteDriver): SQLiteDriver =
+      // The SAGP relies on the FQN check for correctness (it lets it naively instrument all
+      // Room.DatabaseBuilder.setDriver() call sites).
       if (delegate is SentrySQLiteDriver || delegate.javaClass.name == SUPPORT_SQLITE_DRIVER_FQN) {
         delegate
       } else {

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -90,9 +90,9 @@ public class SentrySQLiteDriver private constructor(private val delegate: SQLite
      * In the case of (2), wrap the open helper passed to the `SupportSQLiteDriver` constructor via
      * `SentrySupportSQLiteOpenHelper` instead.
      *
-     * Note that wrapping will be performed if the delegate isn't a `SupportSQLiteDriver` itself
-     * but wraps or subclasses one. In that case, ensure the open helper passed to the support
-     * driver constructor is *not* wrapped.
+     * Note that wrapping will be performed if the delegate isn't a `SupportSQLiteDriver` itself but
+     * wraps or subclasses one. In that case, ensure the open helper passed to the support driver
+     * constructor is *not* wrapped.
      */
     // The Sentry Android Gradle Plugin depends on this method's ABI. Don't change it without
     // updating the SAGP.

--- a/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
+++ b/sentry-android-sqlite/src/main/java/io/sentry/sqlite/SentrySQLiteDriver.kt
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus
  *     .build()
  * ```
  *
- * If you're using the Sentry Android Gradle Plugin (SAGP), wrapping will be performed
+ * If you're using the Sentry Android Gradle Plugin (SAGP) 6.13.0+, wrapping will be performed
  * automatically.
  *
  * @param delegate The [SQLiteDriver] instance to delegate calls to.


### PR DESCRIPTION
## :scroll: Description

We'll be coordinating the 8.45.0 release with the introduction of SAGP auto-instrumentation for the `SentrySQLiteDriver`. PR contains related documentation updates.


## :bulb: Motivation and Context

Addresses JAVA-275 / GRADLE-107


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
