### PR TITLE
fix(replay): Release MediaMuxer when no frames are encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Release `MediaMuxer` when a replay segment has no encodable frames to avoid a resource leak ([#5583](https://github.com/getsentry/sentry-java/pull/5583))
+
 ## 8.44.1
 
 ### Fixes

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -199,6 +199,10 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
 
     if (frameCount == 0) {
       options.logger.log(DEBUG, "Generated a video with no frames, not capturing a replay segment")
+      encoderLock.acquire().use {
+        encoder?.release()
+        encoder = null
+      }
       deleteFile(videoFile)
       return null
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
@@ -67,7 +67,11 @@ internal class SimpleMp4FrameMuxer(path: String, fps: Float) : SimpleFrameMuxer 
   }
 
   override fun release() {
-    muxer.stop()
+    // stop() throws if the muxer was never started (e.g. no frame was ever muxed), so we guard it
+    // to ensure release() is always reached and the underlying resources are freed
+    if (started) {
+      muxer.stop()
+    }
     muxer.release()
   }
 


### PR DESCRIPTION
Fixes JAVA-580

## :scroll: Description

The `MediaMuxer` inside `SimpleMp4FrameMuxer` is constructed eagerly when the video encoder is created (`CloseGuard.open` registers a guard expecting `release()`), but `release()` was only reachable on the happy path. Two cases leaked it:

- `ReplayCache.createVideoOf` returned early when `frameCount == 0` (frames exist but none could be encoded) without calling `encoder?.release()`.
- `SimpleMp4FrameMuxer.release()` called `muxer.stop()` before `muxer.release()`. `MediaMuxer.stop()` throws `IllegalStateException` if the muxer was never started (i.e. no frame was ever muxed, so `INFO_OUTPUT_FORMAT_CHANGED` never fired), so `muxer.release()` was skipped. The exception was then swallowed by `SimpleVideoEncoder.release()`'s catch block.

The fix guards `stop()` behind the `started` flag so `release()` is always reached, and releases the encoder on the no-frames return path.

## :bulb: Motivation and Context

Surfaces as a CloseGuard warning: `A resource was acquired at attached stack trace but never released ... Explicit termination method 'release' not called`, pointing at the `MediaMuxer` constructor in `SimpleMp4FrameMuxer`. It is a latent resource leak in production whenever a segment ends up with zero encodable frames, and it shows up consistently in Robolectric tests where the encode pipeline doesn't start the muxer.

## :green_heart: How did you test it?

The existing `ReplayCacheTest."when screenshot is corrupted, deletes it immediately"` exercises the frames-present-but-none-encoded path (`frameCount == 0` after the encoder is created), which previously triggered the leak.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
