### PR TITLE
docs(replay): Add THIRD_PARTY_NOTICES entry for SimpleMp4FrameMuxer

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -154,7 +154,7 @@ limitations under the License.
 
 ### Scope
 
-The Sentry Java SDK includes an adapted version of Square's Curtains library for null-safe `Window.Callback` handling. The code resides in `io.sentry.android.replay.util.FixedWindowCallback`.
+The Sentry Java SDK includes adapted versions of Square's Curtains library for null-safe `Window.Callback` handling and for tracking attached window roots. The code resides in `io.sentry.android.replay.util.FixedWindowCallback` and `io.sentry.android.replay.Windows`.
 
 ```
 Copyright 2021 Square Inc.
@@ -524,7 +524,7 @@ SOFTWARE.
 
 ### Scope
 
-The Sentry Android Replay SDK includes an adapted version of `SimpleMp4FrameMuxer` from the flutter_screen_recorder library, used to mux encoded video frames into an MP4 file. The code resides in `io.sentry.android.replay.video.SimpleMp4FrameMuxer`.
+The Sentry Android Replay SDK includes adapted versions of the video encoding and muxing classes from the flutter_screen_recorder library, used to encode and mux replay video frames into an MP4 file. The code resides in the `io.sentry.android.replay.video` package and includes `SimpleFrameMuxer`, `SimpleMp4FrameMuxer`, and `SimpleVideoEncoder`.
 
 ```
 Copyright (c) 2021 fzyzcjy

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -513,3 +513,40 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+---
+
+## fzyzcjy — Flutter Screen Recorder (MIT)
+
+**Source:** https://github.com/fzyzcjy/flutter_screen_recorder (Commit: dce41cec25c66baf42c6bac4198e95874ce3eb9d)<br>
+**License:** MIT License<br>
+**Copyright:** Copyright (c) 2021 fzyzcjy
+
+### Scope
+
+The Sentry Android Replay SDK includes an adapted version of `SimpleMp4FrameMuxer` from the flutter_screen_recorder library, used to mux encoded video frames into an MP4 file. The code resides in `io.sentry.android.replay.video.SimpleMp4FrameMuxer`.
+
+```
+Copyright (c) 2021 fzyzcjy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+In addition to the standard MIT license, this library requires the following: The recorder itself
+only saves data on user's phone locally, thus it does not have any privacy problem. However, if
+you are going to get the records out of the local storage (e.g. upload the records to your
+server), please explicitly ask the user for permission, and promise to only use the records to
+debug your app. This is a part of the license of this library.
+```

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -1,6 +1,6 @@
 /**
  * Adapted from
- * https://github.com/fzyzcjy/flutter_screen_recorder/blob/dce41cec25c66baf42c6bac4198e95874ce3eb9d/packages/fast_screen_recorder/android/src/main/kotlin/com/cjy/fast_screen_recorder/SimpleFrameMuxer.kt
+ * https://github.com/fzyzcjy/flutter_screen_recorder/blob/dce41cec25c66baf42c6bac4198e95874ce3eb9d/packages/fast_screen_recorder/android/src/main/kotlin/com/cjy/fast_screen_recorder/SimpleVideoEncoder.kt
  *
  * Copyright (c) 2021 fzyzcjy
  *


### PR DESCRIPTION
The `check-code-attribution` flagged that `SimpleMp4FrameMuxer.kt` is adapted from [flutter_screen_recorder](https://github.com/fzyzcjy/flutter_screen_recorder) (MIT, Copyright (c) 2021 fzyzcjy) and carries a complete attribution header, but there is no corresponding entry in `THIRD_PARTY_NOTICES.md`.

This adds the missing entry (Source, License, Copyright, Scope, and full MIT license text including the library's additional privacy clause). The file is pre-existing on `main`, so this is split out from #5583 as warden suggested.

Flagged on #5583 — `PSU-5VC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)