### PR TITLE
ref(android): Remove kotlinStdLibVersionAndroid pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Release `MediaMuxer` when a replay segment has no encodable frames to avoid a resource leak ([#5583](https://github.com/getsentry/sentry-java/pull/5583))
 
+### Dependencies
+
+- Align the Kotlin stdlib version in Android modules with the Kotlin Gradle plugin instead of pinning it to 1.9.24 ([#5590](https://github.com/getsentry/sentry-java/pull/5590))
+
 ## 8.44.1
 
 ### Fixes

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -2,7 +2,6 @@
 object Config {
     val AGP = System.getenv("VERSION_AGP") ?: "8.13.1"
     val kotlinStdLib = "stdlib-jdk8"
-    val kotlinStdLibVersionAndroid = "1.9.24"
     val kotlinTestJunit = "test-junit"
 
     object BuildPlugins {

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   implementation(
     libs.jetbrains.annotations
   ) // Use implementation instead of compileOnly to override kotlin stdlib's version
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
   testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.roboelectric)
   testImplementation(libs.kotlin.test.junit)

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
   api(projects.sentry)
 
   compileOnly(libs.androidx.compose.ui.replay)
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
   // tests
   testImplementation(projects.sentryTestSupport)
   testImplementation(projects.sentryAndroidCore)

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
   compileOnly(libs.androidx.sqlite)
   compileOnly(libs.jetbrains.annotations)
 
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
 
   // tests
   testImplementation(libs.androidx.sqlite)

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
   compileOnly(libs.timber)
 
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
 
   // tests
   testImplementation(libs.timber)

--- a/sentry-ktor-client/build.gradle.kts
+++ b/sentry-ktor-client/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin { explicitApi() }
 dependencies {
   api(projects.sentry)
 
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
   api(projects.sentryKotlinExtensions)
 
   compileOnly(libs.jetbrains.annotations)

--- a/sentry-launchdarkly-android/build.gradle.kts
+++ b/sentry-launchdarkly-android/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
   // tests
   testImplementation(projects.sentry)
   testImplementation(projects.sentryTestSupport)
-  testImplementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  testImplementation(kotlin(Config.kotlinStdLib))
   testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.mockito.kotlin)

--- a/sentry-okhttp/build.gradle.kts
+++ b/sentry-okhttp/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin { explicitApi() }
 dependencies {
   api(projects.sentry)
 
-  implementation(kotlin(Config.kotlinStdLib, Config.kotlinStdLibVersionAndroid))
+  implementation(kotlin(Config.kotlinStdLib))
 
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.nopen.annotations)


### PR DESCRIPTION
## :scroll: Description

Removes the `Config.kotlinStdLibVersionAndroid` constant (`1.9.24`) and the explicit version argument from the `kotlin(Config.kotlinStdLib, ...)` dependency declarations in the Android modules. The stdlib version now aligns with the Kotlin Gradle plugin (2.2.0) automatically.

Affected modules: `sentry-okhttp`, `sentry-ktor-client`, `sentry-android-sqlite`, `sentry-android-timber`, `sentry-android-distribution`, `sentry-android-replay`, `sentry-launchdarkly-android`.

## :bulb: Motivation and Context

The pin overrode the stdlib version managed by the Kotlin Gradle plugin, which is discouraged. Letting the plugin manage the stdlib version keeps it consistent with the compiler and removes a stale constant.

## :green_heart: How did you test it?

`./gradlew spotlessApply apiDump` builds successfully; no API changes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
