### PR TITLE
fix(replay): Fix network detail response body size being unknown for gzip-compressed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix replay network detail response body size being unknown for gzip-compressed responses ([#5592](https://github.com/getsentry/sentry-java/pull/5592))
+- Session Replay: Fix network detail response body size being unknown for gzip-compressed responses ([#5592](https://github.com/getsentry/sentry-java/pull/5592))
 
 ## 8.44.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix replay network detail response body size being unknown for gzip-compressed responses ([#5592](https://github.com/getsentry/sentry-java/pull/5592))
+
 ## 8.44.1
 
 ### Fixes

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7976,7 +7976,6 @@ public final class io/sentry/util/network/NetworkBody {
 	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
 	public fun getBody ()Ljava/lang/Object;
-	public fun getOriginalByteCount ()J
 	public fun getWarnings ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7975,7 +7975,9 @@ public final class io/sentry/util/UrlUtils$UrlDetails {
 public final class io/sentry/util/network/NetworkBody {
 	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;J)V
 	public fun getBody ()Ljava/lang/Object;
+	public fun getOriginalByteCount ()J
 	public fun getWarnings ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7975,7 +7975,6 @@ public final class io/sentry/util/UrlUtils$UrlDetails {
 public final class io/sentry/util/network/NetworkBody {
 	public fun <init> (Ljava/lang/Object;)V
 	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
-	public fun <init> (Ljava/lang/Object;Ljava/util/List;J)V
 	public fun getBody ()Ljava/lang/Object;
 	public fun getOriginalByteCount ()J
 	public fun getWarnings ()Ljava/util/List;

--- a/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
+++ b/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
@@ -16,15 +16,24 @@ public final class NetworkBody {
 
   private final @Nullable Object body;
   private final @Nullable List<NetworkBodyWarning> warnings;
+  private final long originalByteCount;
 
   public NetworkBody(final @Nullable Object body) {
-    this(body, null);
+    this(body, null, -1);
   }
 
   public NetworkBody(
       final @Nullable Object body, final @Nullable List<NetworkBodyWarning> warnings) {
+    this(body, warnings, -1);
+  }
+
+  public NetworkBody(
+      final @Nullable Object body,
+      final @Nullable List<NetworkBodyWarning> warnings,
+      final long originalByteCount) {
     this.body = body;
     this.warnings = warnings;
+    this.originalByteCount = originalByteCount;
   }
 
   public @Nullable Object getBody() {
@@ -33,6 +42,10 @@ public final class NetworkBody {
 
   public @Nullable List<NetworkBodyWarning> getWarnings() {
     return warnings;
+  }
+
+  public long getOriginalByteCount() {
+    return originalByteCount;
   }
 
   // Based on

--- a/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
+++ b/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
@@ -27,7 +27,7 @@ public final class NetworkBody {
     this(body, warnings, -1);
   }
 
-  public NetworkBody(
+  NetworkBody(
       final @Nullable Object body,
       final @Nullable List<NetworkBodyWarning> warnings,
       final long originalByteCount) {

--- a/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
+++ b/sentry/src/main/java/io/sentry/util/network/NetworkBody.java
@@ -44,7 +44,7 @@ public final class NetworkBody {
     return warnings;
   }
 
-  public long getOriginalByteCount() {
+  long getOriginalByteCount() {
     return originalByteCount;
   }
 

--- a/sentry/src/main/java/io/sentry/util/network/NetworkBodyParser.java
+++ b/sentry/src/main/java/io/sentry/util/network/NetworkBodyParser.java
@@ -45,24 +45,33 @@ public final class NetworkBodyParser {
       return null;
     }
 
+    final boolean isTruncated = bytes.length > maxSizeBytes;
+    final long originalByteCount = bytes.length;
+
     if (contentType != null && isBinaryContentType(contentType)) {
       // For binary content, return a description instead of the actual content
       return new NetworkBody(
-          "[Binary data, " + bytes.length + " bytes, type: " + contentType + "]");
+          "[Binary data, " + bytes.length + " bytes, type: " + contentType + "]",
+          null,
+          originalByteCount);
     }
 
     // Convert to string and parse
     try {
       final String effectiveCharset = charset != null ? charset : "UTF-8";
       final int size = Math.min(bytes.length, maxSizeBytes);
-      final boolean isPartial = bytes.length > maxSizeBytes;
       final String content = new String(bytes, 0, size, effectiveCharset);
-      return parse(content, contentType, isPartial, logger);
+      final NetworkBody parsed = parse(content, contentType, isTruncated, logger);
+      if (parsed == null) {
+        return null;
+      }
+      return new NetworkBody(parsed.getBody(), parsed.getWarnings(), originalByteCount);
     } catch (UnsupportedEncodingException e) {
       logger.log(SentryLevel.WARNING, "Failed to decode bytes: " + e.getMessage());
       return new NetworkBody(
           "[Failed to decode bytes, " + bytes.length + " bytes]",
-          Collections.singletonList(NetworkBody.NetworkBodyWarning.BODY_PARSE_ERROR));
+          Collections.singletonList(NetworkBody.NetworkBodyWarning.BODY_PARSE_ERROR),
+          originalByteCount);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/network/NetworkDetailCaptureUtils.java
+++ b/sentry/src/main/java/io/sentry/util/network/NetworkDetailCaptureUtils.java
@@ -160,9 +160,15 @@ public final class NetworkDetailCaptureUtils {
       body = bodyExtractor.extract(httpObject);
     }
 
+    // When contentLength is unknown (-1), use the actual byte count from body extraction
+    Long effectiveBodySize = bodySize;
+    if ((bodySize == null || bodySize == -1L) && body != null && body.getOriginalByteCount() >= 0) {
+      effectiveBodySize = body.getOriginalByteCount();
+    }
+
     Map<String, String> headers =
         getCaptureHeaders(headerExtractor.extract(httpObject), allowedHeaders);
 
-    return new ReplayNetworkRequestOrResponse(bodySize, body, headers);
+    return new ReplayNetworkRequestOrResponse(effectiveBodySize, body, headers);
   }
 }

--- a/sentry/src/test/java/io/sentry/util/network/NetworkBodyParserTest.kt
+++ b/sentry/src/test/java/io/sentry/util/network/NetworkBodyParserTest.kt
@@ -341,6 +341,27 @@ class NetworkBodyParserTest {
     val body = NetworkBodyParser.fromBytes(bytes, "image/png", null, bytes.size, logger)
     assertNotNull(body)
     assertEquals("[Binary data, 100 bytes, type: image/png]", body.body)
+    assertEquals(100, body.originalByteCount)
+  }
+
+  @Test
+  fun `originalByteCount is set when body fits within limit`() {
+    val logger = mock<ILogger>()
+    val bytes = """{"key":"value"}""".toByteArray()
+
+    val body = NetworkBodyParser.fromBytes(bytes, "application/json", null, bytes.size, logger)
+    assertNotNull(body)
+    assertEquals(bytes.size.toLong(), body.originalByteCount)
+  }
+
+  @Test
+  fun `originalByteCount is set to capped size when body is truncated`() {
+    val logger = mock<ILogger>()
+    val bytes = """{"key":"value"}""".toByteArray()
+
+    val body = NetworkBodyParser.fromBytes(bytes, "application/json", null, bytes.size - 1, logger)
+    assertNotNull(body)
+    assertEquals(bytes.size.toLong(), body.originalByteCount)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/util/network/NetworkDetailCaptureUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/network/NetworkDetailCaptureUtilsTest.kt
@@ -1,11 +1,69 @@
 package io.sentry.util.network
 
+import io.sentry.ILogger
 import java.util.LinkedHashMap
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class NetworkDetailCaptureUtilsTest {
+
+  @Test
+  fun `createResponse uses originalByteCount when bodySize is unknown`() {
+    val logger = mock<ILogger>()
+    val jsonBytes = """{"key":"value"}""".toByteArray()
+
+    val result =
+      NetworkDetailCaptureUtils.createResponse(
+        jsonBytes,
+        -1L,
+        true,
+        { bytes ->
+          NetworkBodyParser.fromBytes(bytes, "application/json", null, bytes.size, logger)
+        },
+        emptyList(),
+        { emptyMap() },
+      )
+
+    assertEquals(jsonBytes.size.toLong(), result.size)
+  }
+
+  @Test
+  fun `createResponse keeps explicit bodySize when available`() {
+    val logger = mock<ILogger>()
+    val jsonBytes = """{"key":"value"}""".toByteArray()
+
+    val result =
+      NetworkDetailCaptureUtils.createResponse(
+        jsonBytes,
+        42L,
+        true,
+        { bytes ->
+          NetworkBodyParser.fromBytes(bytes, "application/json", null, bytes.size, logger)
+        },
+        emptyList(),
+        { emptyMap() },
+      )
+
+    assertEquals(42L, result.size)
+  }
+
+  @Test
+  fun `createResponse keeps null bodySize when body capture is off`() {
+    val result =
+      NetworkDetailCaptureUtils.createResponse(
+        "unused",
+        null,
+        false,
+        { null },
+        emptyList(),
+        { emptyMap() },
+      )
+
+    assertNull(result.size)
+  }
 
   @Test
   fun `getCaptureHeaders should match headers case-insensitively`() {


### PR DESCRIPTION
## :scroll: Description

For gzip-compressed responses, OkHttp strips the `Content-Length` header during transparent decompression, so `response.body.contentLength()` returns `-1`. This caused `NetworkRequestData.responseBodySize` to always be unknown for replay network details on such responses.

This PR adds `originalByteCount` to `NetworkBody`, populated from the actual byte array length in `NetworkBodyParser.fromBytes`. `NetworkDetailCaptureUtils.createRequestOrResponseInternal` now uses this as a fallback when the passed `bodySize` is `null` or `-1`.

The fix piggybacks on the existing `peekBody` call — no additional network I/O. For responses larger than the peek limit (`MAX_NETWORK_BODY_SIZE`), the capped byte count is reported (lower bound) instead of unknown.

Example replay: https://sentry-sdks.sentry.io/explore/replays/95bf32448ef94fafb41b5164ccde5d19

<img width="1416" height="394" alt="Screenshot 2026-06-22 17 04 56" src="https://github.com/user-attachments/assets/75bfb4da-3c92-4c1b-baaf-4d24634a8d4b" />

## :bulb: Motivation and Context

Session replay network details show response body size. For gzip-compressed HTTP responses (common for JSON APIs), OkHttp's transparent decompression strips `Content-Length`, making the size always unknown (`-1`). The Sentry UI shows "It is possible the network transfer size is smaller due to compression", so reporting the decompressed size is the correct behavior.

Fixes SDK-1006

## :green_heart: How did you test it?

- Added unit tests for `NetworkBodyParser` covering `originalByteCount` for both truncated and non-truncated bodies
- Added unit tests for `NetworkDetailCaptureUtils` covering the bodySize fallback logic (unknown → uses byte count, explicit → preserved, body capture off → unchanged)
- Verified existing tests pass

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps