### PR TITLE
perf(android): Speed up ViewUtils.findTarget by reducing allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Release `MediaMuxer` when a replay segment has no encodable frames to avoid a resource leak ([#5583](https://github.com/getsentry/sentry-java/pull/5583))
 
+### Internal
+
+- Reduce allocations in gesture target traversal by using `ArrayDeque` instead of `LinkedList` ([#5594](https://github.com/getsentry/sentry-java/pull/5594))
+
 ## 8.44.1
 
 ### Fixes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
@@ -7,7 +7,7 @@ import android.view.ViewGroup;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.gestures.UiElement;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import org.jetbrains.annotations.ApiStatus;
@@ -62,11 +62,11 @@ public final class ViewUtils {
       final UiElement.Type targetType) {
 
     final List<GestureTargetLocator> locators = options.getGestureTargetLocators();
-    final Queue<View> queue = new LinkedList<>();
+    final Queue<View> queue = new ArrayDeque<>();
     queue.add(decorView);
 
     @Nullable UiElement target = null;
-    while (queue.size() > 0) {
+    while (!queue.isEmpty()) {
       final View view = queue.poll();
 
       if (!touchWithinBounds(view, x, y)) {

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
@@ -15,7 +15,7 @@ import io.sentry.compose.boundsInWindow
 import io.sentry.internal.gestures.GestureTargetLocator
 import io.sentry.internal.gestures.UiElement
 import io.sentry.util.AutoClosableReentrantLock
-import java.util.LinkedList
+import java.util.ArrayDeque
 import java.util.Queue
 
 @OptIn(InternalComposeUiApi::class)
@@ -45,7 +45,7 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
     val rootLayoutNode = root.root
 
     // Pair<Node, ParentTag>
-    val queue: Queue<Pair<LayoutNode, String?>> = LinkedList()
+    val queue: Queue<Pair<LayoutNode, String?>> = ArrayDeque()
     queue.add(Pair(rootLayoutNode, null))
 
     // the final tag to return, only relevant for clicks
@@ -92,7 +92,10 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
             }
           }
         }
-        queue.addAll(node.zSortedChildren.asMutableList().map { Pair(it, tag) })
+        val children = node.zSortedChildren.asMutableList()
+        for (index in children.indices) {
+          queue.add(Pair(children[index], tag))
+        }
       }
     }
 


### PR DESCRIPTION
## :scroll: Description
Replace the per-gesture `LinkedList` BFS queue with an `ArrayDeque` in `ViewUtils.findTarget` and `ComposeGestureTargetLocator`, and drop the intermediate list allocated when enqueuing Compose children.

`ViewUtils.findTarget` runs on every tap (`onSingleTapUp`) and at the start of every scroll (`onScroll`), traversing the view tree to locate the gesture target. The traversal used a `LinkedList` as its queue, which allocates a node object for every `add`/`poll` — i.e. one allocation per visited view, on the main thread, on every gesture. `ArrayDeque` is array-backed and allocates almost nothing per element. The Compose locator had the same `LinkedList` pattern plus an extra intermediate `List` allocated per node via `.asMutableList().map { }`.

Traversal order and target-selection logic are unchanged — this is an allocation/GC-pressure reduction only, not a behavior change.

## :bulb: Motivation and Context
JAVA-534 / #5481. Reduce avoidable main-thread allocations in the gesture target traversal hot path.

Note on scope: profiling on a Pixel 3 (Android 12) shows the dominant CPU cost in `findTarget` is `getLocationOnScreen` (called per visited view), not the queue allocation. This PR is the low-risk allocation cleanup; the `getLocationOnScreen` cost is tracked as a separate follow-up.

## :green_heart: How did you test it?
Existing `ViewUtilsTest` and `SentryGestureListener` unit tests pass. Verified on-device (Pixel 3, Android 12) that gesture target resolution is unchanged — scroll target still resolves correctly (`Scroll target found: scrolling_container`).

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
Separate PR: replace the per-view `getLocationOnScreen` (O(N·depth)) with point-transform-during-descent (O(N)), the actual CPU hotspot in this path.
