### PR TITLE
perf(android): Hit-test gestures without getLocationOnScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0152)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.15.1...0.15.2)
 
+### Internal
+
+- Speed up gesture target hit-testing by mapping the touch point into local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
+
 ## 8.44.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Speed up touch gesture target detection on deeply nested view hierarchies by hit-testing in local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
+
 ## 8.46.0
 
 ### Fixes
@@ -47,10 +53,6 @@
 - Bump Native SDK from v0.15.1 to v0.15.2 ([#5610](https://github.com/getsentry/sentry-java/pull/5610))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#0152)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.15.1...0.15.2)
-
-### Internal
-
-- Speed up touch gesture target detection on deeply nested view hierarchies by hit-testing in local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
 
 ## 8.44.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ### Internal
 
-- Speed up gesture target hit-testing by mapping the touch point into local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
+- Speed up touch gesture target detection on deeply nested view hierarchies by hit-testing in local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
 
 ## 8.44.1
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/ViewUtils.java
@@ -1,13 +1,14 @@
 package io.sentry.android.core.internal.gestures;
 
 import android.content.res.Resources;
+import android.graphics.Matrix;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.internal.gestures.GestureTargetLocator;
 import io.sentry.internal.gestures.UiElement;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import org.jetbrains.annotations.ApiStatus;
@@ -17,30 +18,53 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public final class ViewUtils {
 
-  private static final int[] coordinates = new int[2];
-
   /**
-   * Verifies if the given touch coordinates are within the bounds of the given view.
+   * Verifies if the given touch coordinates, expressed in the view's own local coordinate space,
+   * are within the bounds of the given view.
    *
    * @param view the view to check if the touch coordinates are within its bounds
-   * @param x - the x coordinate of a {@link MotionEvent}
-   * @param y - the y coordinate of {@link MotionEvent}
+   * @param localX - the x coordinate of the touch, relative to the view's top-left corner
+   * @param localY - the y coordinate of the touch, relative to the view's top-left corner
    * @return true if the touch coordinates are within the bounds of the view, false otherwise
    */
   private static boolean touchWithinBounds(
-      final @Nullable View view, final float x, final float y) {
+      final @Nullable View view, final float localX, final float localY) {
     if (view == null) {
       return false;
     }
 
-    view.getLocationOnScreen(coordinates);
-    int vx = coordinates[0];
-    int vy = coordinates[1];
+    final int w = view.getWidth();
+    final int h = view.getHeight();
 
-    int w = view.getWidth();
-    int h = view.getHeight();
+    return !(localX < 0 || localX > w || localY < 0 || localY > h);
+  }
 
-    return !(x < vx || x > vx + w || y < vy || y > vy + h);
+  /**
+   * Maps a touch point expressed in the parent's local coordinate space into the child's local
+   * coordinate space. This mirrors how {@link ViewGroup} dispatches touch events to its children
+   * and lets us hit-test the whole tree with a single downward traversal, instead of calling {@link
+   * View#getLocationOnScreen(int[])} (which walks up to the root) for every view.
+   */
+  private static @NotNull ViewWithLocation mapToChild(
+      final @NotNull View child,
+      final float parentX,
+      final float parentY,
+      final int parentScrollX,
+      final int parentScrollY) {
+    float childX = parentX + parentScrollX - child.getLeft();
+    float childY = parentY + parentScrollY - child.getTop();
+
+    final @Nullable Matrix matrix = child.getMatrix();
+    if (matrix != null && !matrix.isIdentity()) {
+      final Matrix inverse = new Matrix();
+      if (matrix.invert(inverse)) {
+        final float[] point = {childX, childY};
+        inverse.mapPoints(point);
+        childX = point[0];
+        childY = point[1];
+      }
+    }
+    return new ViewWithLocation(child, childX, childY);
   }
 
   /**
@@ -48,8 +72,8 @@ public final class ViewUtils {
    * given {@code viewTargetSelector}.
    *
    * @param decorView - the root view of this window
-   * @param x - the x coordinate of a {@link MotionEvent}
-   * @param y - the y coordinate of {@link MotionEvent}
+   * @param x - the x coordinate of a {@link MotionEvent}, relative to the decor view
+   * @param y - the y coordinate of {@link MotionEvent}, relative to the decor view
    * @param targetType - the type of target to find
    * @return the {@link View} that contains the touch coordinates and complements the {@code
    *     viewTargetSelector}
@@ -62,25 +86,35 @@ public final class ViewUtils {
       final UiElement.Type targetType) {
 
     final List<GestureTargetLocator> locators = options.getGestureTargetLocators();
-    final Queue<View> queue = new LinkedList<>();
-    queue.add(decorView);
+    final Queue<ViewWithLocation> queue = new ArrayDeque<>();
+    // The touch coordinates from the MotionEvent are already relative to the decor view, i.e. in
+    // its local coordinate space.
+    queue.add(new ViewWithLocation(decorView, x, y));
 
     @Nullable UiElement target = null;
-    while (queue.size() > 0) {
-      final View view = queue.poll();
+    while (!queue.isEmpty()) {
+      final ViewWithLocation current = queue.poll();
+      final View view = current.view;
 
-      if (!touchWithinBounds(view, x, y)) {
+      if (!touchWithinBounds(view, current.x, current.y)) {
         // if the touch is not hitting the view, skip traversal of its children
         continue;
       }
 
       if (view instanceof ViewGroup) {
         final ViewGroup viewGroup = (ViewGroup) view;
+        final int scrollX = viewGroup.getScrollX();
+        final int scrollY = viewGroup.getScrollY();
         for (int i = 0; i < viewGroup.getChildCount(); i++) {
-          queue.add(viewGroup.getChildAt(i));
+          final @Nullable View child = viewGroup.getChildAt(i);
+          if (child != null) {
+            queue.add(mapToChild(child, current.x, current.y, scrollX, scrollY));
+          }
         }
       }
 
+      // Locators receive the original decor-view-relative coordinates, as the Compose locator
+      // hit-tests against window coordinates.
       for (int i = 0; i < locators.size(); i++) {
         final GestureTargetLocator locator = locators.get(i);
         final @Nullable UiElement newTarget = locator.locate(view, x, y, targetType);
@@ -94,6 +128,18 @@ public final class ViewUtils {
       }
     }
     return target;
+  }
+
+  private static final class ViewWithLocation {
+    final @NotNull View view;
+    final float x;
+    final float y;
+
+    ViewWithLocation(final @NotNull View view, final float x, final float y) {
+      this.view = view;
+      this.x = x;
+      this.y = y;
+    }
   }
 
   /**

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewHelpers.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewHelpers.kt
@@ -5,9 +5,6 @@ import android.content.res.Resources
 import android.view.MotionEvent
 import android.view.View
 import android.view.Window
-import kotlin.math.abs
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -35,31 +32,17 @@ internal inline fun <reified T : View> mockView(
   context: Context? = null,
   finalize: (T) -> Unit = {},
 ): T {
-  val coordinates = IntArray(2)
-  if (!touchWithinBounds) {
-    coordinates[0] = (event.x).toInt() + 10
-    coordinates[1] = (event.y).toInt() + 10
-  } else {
-    coordinates[0] = (event.x).toInt() - 10
-    coordinates[1] = (event.y).toInt() - 10
-  }
+  // The decor-view-relative touch point used in these tests is (0, 0), and child views are mocked
+  // at offset (0, 0), so the point reaches every view unchanged. A view therefore contains the
+  // touch iff its width/height are non-negative; a negative size marks the touch as outside.
+  val size = if (touchWithinBounds) 10 else -1
   val mockView: T = mock {
     whenever(it.id).thenReturn(id)
     whenever(it.context).thenReturn(context)
     whenever(it.isClickable).thenReturn(clickable)
     whenever(it.visibility).thenReturn(if (visible) View.VISIBLE else View.GONE)
-
-    whenever(it.getLocationOnScreen(any())).doAnswer {
-      val array = it.arguments[0] as IntArray
-      array[0] = coordinates[0]
-      array[1] = coordinates[1]
-      null
-    }
-
-    val diffPosX = abs(event.x - coordinates[0]).toInt()
-    val diffPosY = abs(event.y - coordinates[1]).toInt()
-    whenever(it.width).thenReturn(diffPosX + 10)
-    whenever(it.height).thenReturn(diffPosY + 10)
+    whenever(it.width).thenReturn(size)
+    whenever(it.height).thenReturn(size)
 
     finalize(this.mock)
   }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewUtilsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewUtilsTest.kt
@@ -3,9 +3,15 @@ package io.sentry.android.core.internal.gestures
 import android.content.Context
 import android.content.res.Resources
 import android.view.View
+import android.view.ViewGroup
+import io.sentry.android.core.SentryAndroidOptions
+import io.sentry.internal.gestures.UiElement
+import io.sentry.util.LazyEvaluator
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
@@ -78,6 +84,44 @@ class ViewUtilsTest {
 
     assertFailsWith<Resources.NotFoundException> { ViewUtils.getResourceId(view) }
     verify(context, never()).resources
+  }
+
+  @Test
+  fun `findTarget hit-tests children in their own local coordinate space`() {
+    val context = mock<Context>()
+    val resources = mock<Resources>()
+    whenever(context.resources).thenReturn(resources)
+    whenever(resources.getResourceEntryName(any())).thenReturn("child")
+
+    // A clickable child positioned at (100, 200) within the decor view, 50x50 in size.
+    val child =
+      mock<View> {
+        whenever(it.id).thenReturn(0x7f010001)
+        whenever(it.context).thenReturn(context)
+        whenever(it.isClickable).thenReturn(true)
+        whenever(it.visibility).thenReturn(View.VISIBLE)
+        whenever(it.left).thenReturn(100)
+        whenever(it.top).thenReturn(200)
+        whenever(it.width).thenReturn(50)
+        whenever(it.height).thenReturn(50)
+      }
+    val decorView =
+      mock<ViewGroup> {
+        whenever(it.width).thenReturn(1000)
+        whenever(it.height).thenReturn(1000)
+        whenever(it.childCount).thenReturn(1)
+        whenever(it.getChildAt(0)).thenReturn(child)
+      }
+    val options =
+      SentryAndroidOptions().apply {
+        gestureTargetLocators = listOf(AndroidViewGestureTargetLocator(LazyEvaluator { true }))
+      }
+
+    // (120, 220) maps to (20, 20) in the child's space -> inside its 50x50 bounds.
+    assertNotNull(ViewUtils.findTarget(options, decorView, 120f, 220f, UiElement.Type.CLICKABLE))
+
+    // (90, 220) maps to (-10, 20) in the child's space -> outside, despite being inside the decor.
+    assertNull(ViewUtils.findTarget(options, decorView, 90f, 220f, UiElement.Type.CLICKABLE))
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewUtilsTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/ViewUtilsTest.kt
@@ -2,8 +2,10 @@ package io.sentry.android.core.internal.gestures
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.Matrix
 import android.view.View
 import android.view.ViewGroup
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.android.core.SentryAndroidOptions
 import io.sentry.internal.gestures.UiElement
 import io.sentry.util.LazyEvaluator
@@ -12,6 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
@@ -20,12 +23,13 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
 class ViewUtilsTest {
   @Test
   fun `getResourceId returns resourceId when available`() {
     val view =
       mock<View> {
-        whenever(it.id).doReturn(View.generateViewId())
+        whenever(it.id).doReturn(0x7f010001)
 
         val context = mock<Context>()
         val resources = mock<Resources>()
@@ -88,23 +92,7 @@ class ViewUtilsTest {
 
   @Test
   fun `findTarget hit-tests children in their own local coordinate space`() {
-    val context = mock<Context>()
-    val resources = mock<Resources>()
-    whenever(context.resources).thenReturn(resources)
-    whenever(resources.getResourceEntryName(any())).thenReturn("child")
-
-    // A clickable child positioned at (100, 200) within the decor view, 50x50 in size.
-    val child =
-      mock<View> {
-        whenever(it.id).thenReturn(0x7f010001)
-        whenever(it.context).thenReturn(context)
-        whenever(it.isClickable).thenReturn(true)
-        whenever(it.visibility).thenReturn(View.VISIBLE)
-        whenever(it.left).thenReturn(100)
-        whenever(it.top).thenReturn(200)
-        whenever(it.width).thenReturn(50)
-        whenever(it.height).thenReturn(50)
-      }
+    val child = clickableChild()
     val decorView =
       mock<ViewGroup> {
         whenever(it.width).thenReturn(1000)
@@ -112,10 +100,7 @@ class ViewUtilsTest {
         whenever(it.childCount).thenReturn(1)
         whenever(it.getChildAt(0)).thenReturn(child)
       }
-    val options =
-      SentryAndroidOptions().apply {
-        gestureTargetLocators = listOf(AndroidViewGestureTargetLocator(LazyEvaluator { true }))
-      }
+    val options = optionsWithViewLocator()
 
     // (120, 220) maps to (20, 20) in the child's space -> inside its 50x50 bounds.
     assertNotNull(ViewUtils.findTarget(options, decorView, 120f, 220f, UiElement.Type.CLICKABLE))
@@ -123,6 +108,75 @@ class ViewUtilsTest {
     // (90, 220) maps to (-10, 20) in the child's space -> outside, despite being inside the decor.
     assertNull(ViewUtils.findTarget(options, decorView, 90f, 220f, UiElement.Type.CLICKABLE))
   }
+
+  @Test
+  fun `findTarget accounts for parent scroll when mapping into a child`() {
+    val child = clickableChild()
+    val decorView =
+      mock<ViewGroup> {
+        whenever(it.width).thenReturn(1000)
+        whenever(it.height).thenReturn(1000)
+        whenever(it.scrollX).thenReturn(30)
+        whenever(it.scrollY).thenReturn(40)
+        whenever(it.childCount).thenReturn(1)
+        whenever(it.getChildAt(0)).thenReturn(child)
+      }
+    val options = optionsWithViewLocator()
+
+    // With scroll (30, 40), (90, 180) maps to (90 + 30 - 100, 180 + 40 - 200) = (20, 20) -> inside.
+    assertNotNull(ViewUtils.findTarget(options, decorView, 90f, 180f, UiElement.Type.CLICKABLE))
+
+    // The same point without accounting for scroll would map to (-10, -20) -> outside the child.
+    assertNull(ViewUtils.findTarget(options, decorView, 50f, 140f, UiElement.Type.CLICKABLE))
+  }
+
+  @Test
+  fun `findTarget applies the inverse of a non-identity child matrix`() {
+    // The child is visually translated by (40, 40) within its parent, so a parent-space point is
+    // mapped back by (-40, -40) to reach the child's own coordinate space.
+    val matrix = Matrix().apply { setTranslate(40f, 40f) }
+    val child = clickableChild { whenever(it.matrix).thenReturn(matrix) }
+    val decorView =
+      mock<ViewGroup> {
+        whenever(it.width).thenReturn(1000)
+        whenever(it.height).thenReturn(1000)
+        whenever(it.childCount).thenReturn(1)
+        whenever(it.getChildAt(0)).thenReturn(child)
+      }
+    val options = optionsWithViewLocator()
+
+    // (180, 280) lands at (80, 80) before the matrix (outside 50x50), but the inverse pulls it to
+    // (40, 40) -> inside.
+    assertNotNull(ViewUtils.findTarget(options, decorView, 180f, 280f, UiElement.Type.CLICKABLE))
+
+    // (130, 230) lands at (30, 30) before the matrix (inside), but the inverse pushes it to
+    // (-10, -10) -> outside.
+    assertNull(ViewUtils.findTarget(options, decorView, 130f, 230f, UiElement.Type.CLICKABLE))
+  }
+
+  // A clickable child positioned at (100, 200) within its parent, 50x50 in size.
+  private fun clickableChild(finalize: (View) -> Unit = {}): View {
+    val context = mock<Context>()
+    val resources = mock<Resources>()
+    whenever(context.resources).thenReturn(resources)
+    whenever(resources.getResourceEntryName(any())).thenReturn("child")
+    return mock {
+      whenever(it.id).thenReturn(0x7f010001)
+      whenever(it.context).thenReturn(context)
+      whenever(it.isClickable).thenReturn(true)
+      whenever(it.visibility).thenReturn(View.VISIBLE)
+      whenever(it.left).thenReturn(100)
+      whenever(it.top).thenReturn(200)
+      whenever(it.width).thenReturn(50)
+      whenever(it.height).thenReturn(50)
+      finalize(this.mock)
+    }
+  }
+
+  private fun optionsWithViewLocator(): SentryAndroidOptions =
+    SentryAndroidOptions().apply {
+      gestureTargetLocators = listOf(AndroidViewGestureTargetLocator(LazyEvaluator { true }))
+    }
 
   @Test
   fun `getResourceIdWithFallback falls back to hexadecimal id when resource not found`() {

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/gestures/ComposeGestureTargetLocator.kt
@@ -15,7 +15,7 @@ import io.sentry.compose.boundsInWindow
 import io.sentry.internal.gestures.GestureTargetLocator
 import io.sentry.internal.gestures.UiElement
 import io.sentry.util.AutoClosableReentrantLock
-import java.util.LinkedList
+import java.util.ArrayDeque
 import java.util.Queue
 
 @OptIn(InternalComposeUiApi::class)
@@ -45,7 +45,7 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
     val rootLayoutNode = root.root
 
     // Pair<Node, ParentTag>
-    val queue: Queue<Pair<LayoutNode, String?>> = LinkedList()
+    val queue: Queue<Pair<LayoutNode, String?>> = ArrayDeque()
     queue.add(Pair(rootLayoutNode, null))
 
     // the final tag to return, only relevant for clicks
@@ -92,7 +92,10 @@ public class ComposeGestureTargetLocator(private val logger: ILogger) : GestureT
             }
           }
         }
-        queue.addAll(node.zSortedChildren.asMutableList().map { Pair(it, tag) })
+        val children = node.zSortedChildren.asMutableList()
+        for (index in children.indices) {
+          queue.add(Pair(children[index], tag))
+        }
       }
     }
 


### PR DESCRIPTION
## :scroll: Description
`ViewUtils.findTarget` (run on every tap and at every scroll start) called `View.getLocationOnScreen` for every visited view to hit-test it. `getLocationOnScreen` walks from the view **up to the root** each call, so hit-testing the whole tree was **O(N·depth)** per gesture, repeatedly re-walking the same ancestor chains.

This replaces that with the technique `ViewGroup` itself uses to dispatch touch events: map the touch **point down** into each child's local coordinate space as we descend (offset by the parent's scroll and the child's `left/top`, then apply the child's inverse matrix for transformed views). Each view is then a cheap `O(1)` bounds check against its own `[0,0,width,height]`, making the whole traversal **O(N)**.

Notes:
- The locators still receive the original decor-view-relative `x,y`, because `ComposeGestureTargetLocator` hit-tests against window coordinates.
- Because the traversal now stays in window/local space instead of mixing in screen space, hit-testing is also slightly more correct when the window isn't at the screen origin (status bar offset, split-screen).
- Keeps the BFS order, so the selected target for overlapping clickable views is unchanged.

The `sentry-compose` locator gets the same `LinkedList`→`ArrayDeque` cleanup (it already hit-tests in window space, so no coordinate change there).

## :bulb: Motivation and Context
JAVA-534 / #5481. Follow-up to #5594 — that PR removed the queue-node allocations; this one removes the per-view `getLocationOnScreen` call, replacing an `O(N·depth)` traversal with `O(N)`.

Tradeoff: carrying the per-view local coordinates through the BFS needs a small holder object per node, so this re-introduces a per-node allocation that #5594 removed. That is an intentional trade — avoiding the repeated `O(depth)` ancestor walk per view in exchange for a short-lived gen-0 object.

A micro-benchmark (see testing notes) measures a **~4–5×** speedup of the traversal on large view trees, scaling down to ~1.7× on trivial ones — the win is proportional to how many views sit under the touch.

## :green_heart: How did you test it?
- Rewrote the gesture test harness (`ViewHelpers`) to mock local geometry; all existing `SentryGestureListenerClickTest` / `SentryGestureListenerScrollTest` cases pass unchanged.
- Added `ViewUtilsTest` coverage that exercises the actual transform — a child offset within its parent is hit when the point maps inside it and missed when it maps outside, even though the point is inside the decor view.
- On-device (Pixel 3, Android 12): scroll target still resolves (`Scroll target found: scrolling_container`) and a click on a button near the bottom of the layout resolves correctly (`view.id: scrolling_crash`), confirming the transform is correct for a real non-trivial offset.

**Timing — micro-benchmark.** Profiler-based measurement didn't work: on the test device (Pixel 3, Android 12) instrumented method tracing produces empty traces, fine-grained sampling overflows the buffer, and at the only working sampling rate (1 ms) `findTarget` (~0.3 ms) is below the resolution — run-to-run variance dwarfs the difference. So I wrote a JVM micro-benchmark instead (not committed — it was a one-off).

What it does: builds one real, attached, laid-out `View` tree and times both hit-testing strategies over it — **old** (`getLocationOnScreen` per view) vs **new** (point-transform-during-descent) — 800 iterations × 6 rounds each, alternating order with warmup, on a release/R8 build. Only the per-view bounds computation differs between the two paths (the part this PR changes); the locator loop is excluded since it's identical for both. The tree is built so every node contains the touch point, forcing a full N-node traversal, and is swept across four sizes. Median of two runs:

| Tree (views under touch) | old: `getLocationOnScreen` | new: point-transform | speedup |
|---|---|---|---|
| ~9 (a simple screen) | ~9–12 µs | ~5–7 µs | ~1.7× |
| ~61 | ~45–54 µs | ~12–15 µs | ~3.7× |
| ~161 | ~143–175 µs | ~35–44 µs | ~4.0× |
| ~301 | ~298–376 µs | ~61–84 µs | ~4.5–4.9× |

So `getLocationOnScreen` costs ~1 µs/view, the new transform ~0.2 µs/view → a steady ~4–5× on the traversal, with absolute savings scaling from a few µs on a trivial screen to ~250 µs on a dense 300-view one. This is a per-tap / per-scroll-start main-thread cost (well under one frame even at the high end), not a frame-rate or startup change. Speedup ratios reproduced within ~8% across runs; absolute numbers drift with device thermals.

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
None.


