### PR TITLE
fix(replay): Release MediaMuxer when the encoder fails to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Pin the published Sentry Android SDK's AAR metadata `minCompileSdk` to our `minSdk` (`21`) instead of AGP 9's new default of the SDK's own `compileSdk` (`37`), so apps that depend on the SDK aren't forced to raise their `compileSdk` ([#5823](https://github.com/getsentry/sentry-java/pull/5823))
+- Release `MediaMuxer` when the replay video encoder fails to start to avoid a resource leak ([#5607](https://github.com/getsentry/sentry-java/pull/5607))
 
 ### Performance
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -162,7 +162,16 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
               bitRate = bitRate,
             ),
           )
-          .also { it.start() }
+          .apply {
+            // the constructor already opened the MediaMuxer, so release it if start() fails,
+            // otherwise the encoder is never assigned and its resources leak (CloseGuard warning)
+            try {
+              start()
+            } catch (t: Throwable) {
+              release()
+              throw t
+            }
+          }
       }
 
     val step = 1000 / frameRate.toLong()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
@@ -67,7 +67,8 @@ internal class SimpleMp4FrameMuxer(path: String, fps: Float) : SimpleFrameMuxer 
   }
 
   override fun release() {
-    // stop() throws unless the muxer was started AND at least one sample was written, so we guard it
+    // stop() throws unless the muxer was started AND at least one sample was written, so we guard
+    // it
     // to ensure muxer.release() is always reached and the underlying resources are freed
     if (started && videoFrames > 0) {
       muxer.stop()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleMp4FrameMuxer.kt
@@ -67,9 +67,9 @@ internal class SimpleMp4FrameMuxer(path: String, fps: Float) : SimpleFrameMuxer 
   }
 
   override fun release() {
-    // stop() throws if the muxer was never started (e.g. no frame was ever muxed), so we guard it
-    // to ensure release() is always reached and the underlying resources are freed
-    if (started) {
+    // stop() throws unless the muxer was started AND at least one sample was written, so we guard it
+    // to ensure muxer.release() is always reached and the underlying resources are freed
+    if (started && videoFrames > 0) {
       muxer.stop()
     }
     muxer.release()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -287,12 +287,14 @@ internal class SimpleVideoEncoder(
       onClose?.invoke()
       drainCodec(true)
       mediaCodec.stop()
+    } catch (e: RuntimeException) {
+      options.logger.log(DEBUG, "Failed to properly release video encoder", e)
+    } finally {
+      // always release the native resources, even if draining/stopping the codec above threw (e.g.
+      // when the encoder failed to fully start), otherwise they leak (CloseGuard warning)
       mediaCodec.release()
       surface?.release()
-
       frameMuxer.release()
-    } catch (e: Throwable) {
-      options.logger.log(DEBUG, "Failed to properly release video encoder", e)
     }
   }
 }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -291,10 +291,21 @@ internal class SimpleVideoEncoder(
       options.logger.log(DEBUG, "Failed to properly release video encoder", e)
     } finally {
       // always release the native resources, even if draining/stopping the codec above threw (e.g.
-      // when the encoder failed to fully start), otherwise they leak (CloseGuard warning)
-      mediaCodec.release()
-      surface?.release()
-      frameMuxer.release()
+      // when the encoder failed to fully start), otherwise they leak (CloseGuard warning). guard
+      // each
+      // call so failing to release one resource neither skips the others nor propagates to callers,
+      // which treat release() as safe cleanup
+      releaseQuietly("MediaCodec") { mediaCodec.release() }
+      releaseQuietly("Surface") { surface?.release() }
+      releaseQuietly("MediaMuxer") { frameMuxer.release() }
+    }
+  }
+
+  private inline fun releaseQuietly(name: String, block: () -> Unit) {
+    try {
+      block()
+    } catch (e: RuntimeException) {
+      options.logger.log(DEBUG, "Failed to release $name", e)
     }
   }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -36,6 +37,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowBitmapFactory
+import org.robolectric.shadows.ShadowCloseGuard
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [26], shadows = [ReplayShadowMediaCodec::class])
@@ -56,6 +58,7 @@ class ReplayCacheTest {
   @BeforeTest
   fun `set up`() {
     ReplayShadowMediaCodec.framesToEncode = 5
+    ReplayShadowMediaCodec.throwOnStart = false
     ShadowBitmapFactory.setAllowInvalidImageData(true)
   }
 
@@ -91,6 +94,26 @@ class ReplayCacheTest {
     val video = replayCache.createVideoOf(5000L, 0, 0, 100, 200, 1, 20_000)
 
     assertNull(video)
+  }
+
+  @Test
+  fun `releases the muxer when the encoder fails to start`() {
+    ReplayShadowMediaCodec.throwOnStart = true
+    val replayCache = fixture.getSut(tmpDir)
+
+    val bitmap = Bitmap.createBitmap(1, 1, ARGB_8888)
+    replayCache.addFrame(bitmap, 1)
+
+    ShadowCloseGuard.reset()
+    assertFailsWith<IllegalStateException> {
+      replayCache.createVideoOf(5000L, 0, 0, 100, 200, 1, 20_000)
+    }
+
+    val muxerLeaks =
+      ShadowCloseGuard.getErrors().filter { error ->
+        error.stackTrace.any { it.className.contains("MediaMuxer") }
+      }
+    assertTrue(muxerLeaks.isEmpty(), "MediaMuxer was not released: $muxerLeaks")
   }
 
   @Test

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ReplayShadowMediaCodec.kt
@@ -15,12 +15,16 @@ class ReplayShadowMediaCodec : ShadowMediaCodec() {
   companion object {
     var frameRate = 1
     var framesToEncode = 5
+    var throwOnStart = false
   }
 
   private val encoded = AtomicBoolean(false)
 
   @Implementation
   fun start() {
+    if (throwOnStart) {
+      throw IllegalStateException("Simulated codec start failure")
+    }
     super.native_start()
   }
 


### PR DESCRIPTION
## :scroll: Description
The `MediaMuxer` is opened eagerly in `SimpleVideoEncoder`'s constructor, but its `release()` was only reachable on paths that assume `start()` succeeded. Two cases leaked it when the encoder failed to start:

- `ReplayCache.createVideoOf` constructed the encoder and called `start()` in a single expression (`SimpleVideoEncoder(...).also { it.start() }`). If `start()` threw, the assignment to the `encoder` field never happened, so the only caller of `release()` could never run.
- `SimpleVideoEncoder.release()` released the muxer as the last statement of the `try` block, after draining and stopping the codec. Draining a codec that never started throws, which jumped to the `catch` and skipped the muxer release.

The fix releases the encoder if `start()` throws (then rethrows), and always releases the muxer from a `finally` block so it is freed even when draining/stopping the codec fails.

## :bulb: Motivation and Context
This surfaced as a `CloseGuard` "A resource was acquired at attached stack trace but never released" warning pointing at the `MediaMuxer` allocation in `SimpleMp4FrameMuxer`. It is a real resource leak on devices where the encoder fails to start, not just a test artifact. Complements #5583, which closed the no-frames and never-started paths.

## :green_heart: How did you test it?
Added a regression test (`ReplayCacheTest.releases the muxer when the encoder fails to start`) that forces `start()` to fail via the test `MediaCodec` shadow and asserts, through `ShadowCloseGuard.getErrors()`, that no `MediaMuxer` leak is reported. Verified the test fails without the fix (with the exact `Explicit termination method 'release' not called` error) and passes with it. The full `ReplayCacheTest` suite is green.

## :pencil: Checklist
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
None.
