### PR TITLE
fix: use System.nanoTime() for cron check-in duration measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Use `System.nanoTime()` for cron check-in duration measurement to avoid incorrect durations from wall-clock adjustments ([#5611](https://github.com/getsentry/sentry-java/pull/5611))
 - Fix crash when `getHistoricalProcessStartReasons` is called from an isolated or wrong-userId process ([#5597](https://github.com/getsentry/sentry-java/pull/5597))
 - Release `MediaMuxer` when a replay segment has no encodable frames to avoid a resource leak ([#5583](https://github.com/getsentry/sentry-java/pull/5583))
 

--- a/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java
@@ -91,7 +91,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.currentTimeMillis();
+      final long startTime = System.nanoTime();
       boolean didError = false;
 
       try {
@@ -105,7 +105,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java
@@ -91,7 +91,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.currentTimeMillis();
+      final long startTime = System.nanoTime();
       boolean didError = false;
 
       try {
@@ -105,7 +105,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java
@@ -94,7 +94,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       TracingUtils.startNewTrace(scopes);
 
       @Nullable SentryId checkInId = null;
-      final long startTime = System.currentTimeMillis();
+      final long startTime = System.nanoTime();
       boolean didError = false;
 
       try {
@@ -108,7 +108,7 @@ public class SentryCheckInAdvice implements MethodInterceptor, EmbeddedValueReso
       } finally {
         final @NotNull CheckInStatus status = didError ? CheckInStatus.ERROR : CheckInStatus.OK;
         CheckIn checkIn = new CheckIn(checkInId, monitorSlug, status);
-        checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
         scopes.captureCheckIn(checkIn);
       }
     }

--- a/sentry/src/main/java/io/sentry/util/CheckInUtils.java
+++ b/sentry/src/main/java/io/sentry/util/CheckInUtils.java
@@ -37,7 +37,7 @@ public final class CheckInUtils {
     try (final @NotNull ISentryLifecycleToken ignored =
             Sentry.forkedScopes("CheckInUtils").makeCurrent()) {
       final @NotNull IScopes scopes = Sentry.getCurrentScopes();
-      final long startTime = System.currentTimeMillis();
+      final long startTime = System.nanoTime();
       boolean didError = false;
 
       TracingUtils.startNewTrace(scopes);
@@ -61,7 +61,7 @@ public final class CheckInUtils {
         if (environment != null) {
           checkIn.setEnvironment(environment);
         }
-        checkIn.setDuration(DateUtils.millisToSeconds(System.currentTimeMillis() - startTime));
+        checkIn.setDuration(DateUtils.nanosToSeconds(System.nanoTime() - startTime));
         scopes.captureCheckIn(checkIn);
       }
     }


### PR DESCRIPTION
Fixes #5579

## Problem

Cron check-in durations were computed by subtracting two `System.currentTimeMillis()` values. The wall clock is not monotonic — it is subject to NTP steps, leap-second smearing, and DST transitions. For long-running cron jobs this gives wide exposure to clock jumps, which can produce incorrect or negative duration values in the check-in payload.

## Fix

Switch the start/end capture to `System.nanoTime()`, which is guaranteed monotonic and is the correct choice for measuring elapsed time. `DateUtils.nanosToSeconds()` (already present in the SDK) is used to convert the nanosecond delta to the seconds value expected by `setDuration()`.

Changed files:
- `sentry/src/main/java/io/sentry/util/CheckInUtils.java`
- `sentry-spring/src/main/java/io/sentry/spring/checkin/SentryCheckInAdvice.java`
- `sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/checkin/SentryCheckInAdvice.java`
- `sentry-spring-7/src/main/java/io/sentry/spring7/checkin/SentryCheckInAdvice.java`

Existing duration tests (`assertNotNull(doneCheckIn.duration)`) continue to pass unchanged; the delta of two `nanoTime()` calls is always non-negative and non-zero for any real workload