### PR TITLE
test(replay): Fix flaky ComposeMaskingOptionsTest

### DIFF
--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
@@ -65,6 +65,11 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [30])
 class ComposeMaskingOptionsTest {
+  companion object {
+    // Number of idle + measure/layout passes used to let Compose settle under Robolectric.
+    private const val SETTLE_PASSES = 10
+  }
+
   @Before
   fun setup() {
     System.setProperty("robolectric.areWindowsMarkedVisible", "true")
@@ -280,6 +285,7 @@ class ComposeMaskingOptionsTest {
 
   private inline fun <reified T> Activity.collectNodesOfType(options: SentryOptions): List<T> {
     val root = window.decorView
+    forceComposeLayout(root)
     val viewHierarchy = ViewHierarchyNode.fromView(root, null, 0, options.sessionReplay)
     root.traverse(viewHierarchy, options.sessionReplay, NoOpLogger.getInstance())
 
@@ -291,6 +297,26 @@ class ComposeMaskingOptionsTest {
       return@traverse true
     }
     return nodes
+  }
+
+  // Under Robolectric a single idle does not reliably complete Compose recomposition and layout,
+  // so the AndroidComposeView subtree intermittently keeps zero-size bounds. Nodes with empty
+  // bounds count as invisible and are skipped by masking, which flakes the masking assertions.
+  // Drive several idle + measure/layout passes (requestLayout invalidates the previous one) so the
+  // content reliably settles with non-empty bounds before the hierarchy is collected.
+  private fun Activity.forceComposeLayout(root: View) {
+    val composeView = root.lookupComposeView() ?: return
+    val metrics = resources.displayMetrics
+    val width = root.width.takeIf { it > 0 } ?: metrics.widthPixels
+    val height = root.height.takeIf { it > 0 } ?: metrics.heightPixels
+    val widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY)
+    val heightSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+    repeat(SETTLE_PASSES) {
+      shadowOf(Looper.getMainLooper()).idle()
+      composeView.requestLayout()
+      composeView.measure(widthSpec, heightSpec)
+      composeView.layout(0, 0, composeView.measuredWidth, composeView.measuredHeight)
+    }
   }
 
   private fun View.lookupComposeView(): View? {


### PR DESCRIPTION
Fixes #5585

#no-changelog

(Replaces #5615, which got a stuck head ref after a force-push and could not be reopened.)

## Root cause

`ComposeMaskingOptionsTest` intermittently failed (~10% of full-class runs) with:

```
java.lang.AssertionError: Node with text null should be masked
    at ComposeMaskingOptionsTest.kt:238
```

I reproduced it locally and instrumented the collected nodes. The flaky node is **not** the activity-title `TextView` (that node uses `AndroidTextLayout` and is always laid out and visible). The flaky nodes are the **Compose** nodes (`Text`, `TextField`, `Button`): under Robolectric, a single `Looper.idle()` does not reliably complete a Compose recomposition + layout pass, so the entire `AndroidComposeView` subtree occasionally keeps zero-size bounds. Zero-bounds nodes are reported as not visible, so masking skips them and `assertTrue(shouldMask)` fails on the first one (whose `ComposeTextLayout` is null → "text null").

Production behavior is correct (we shouldn't mask zero-size, invisible views), so this is a test-only timing issue.

## Fix

Before collecting the view hierarchy, drive several `idle` + `requestLayout` + `measure`/`layout` passes on the `AndroidComposeView` so its content reliably settles with non-empty bounds.

## Verification

- Before: reproduced the failure repeatedly (~10% of full-class runs).
- After: **97 consecutive full-class runs** passed (`--rerun-tasks`), the full `:sentry-android-replay:testReleaseUnitTest` suite is green, and spotless is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)