### PR TITLE
release: 8.43.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.43.3
+
+### Fixes
+
+- Fix crash when `getHistoricalProcessStartReasons` is called from an isolated or wrong-userId process ([#5597](https://github.com/getsentry/sentry-java/pull/5597))
+
 ## 8.43.2
 
 ### Improvements

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ android.useAndroidX=true
 android.experimental.lint.version=8.13.1
 
 # Release information
-versionName=8.43.2
+versionName=8.43.3
 
 # Override the SDK name on native crashes on Android
 sentryAndroidSdkName=sentry.native.android

--- a/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/performance/AppStartMetrics.java
@@ -12,6 +12,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.MessageQueue;
 import android.os.SystemClock;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -342,17 +343,27 @@ public class AppStartMetrics extends ActivityLifecycleCallbacksAdapter {
       final @Nullable ActivityManager activityManager =
           (ActivityManager) application.getSystemService(Context.ACTIVITY_SERVICE);
       if (activityManager != null) {
-        final List<ApplicationStartInfo> historicalProcessStartReasons =
-            activityManager.getHistoricalProcessStartReasons(1);
-        if (!historicalProcessStartReasons.isEmpty()) {
-          final @NotNull ApplicationStartInfo info = historicalProcessStartReasons.get(0);
-          if (info.getStartupState() == ApplicationStartInfo.STARTUP_STATE_STARTED) {
-            if (info.getStartType() == ApplicationStartInfo.START_TYPE_COLD) {
-              appStartType = AppStartType.COLD;
-            } else {
-              appStartType = AppStartType.WARM;
+        try {
+          final List<ApplicationStartInfo> historicalProcessStartReasons =
+              activityManager.getHistoricalProcessStartReasons(1);
+          if (!historicalProcessStartReasons.isEmpty()) {
+            final @NotNull ApplicationStartInfo info = historicalProcessStartReasons.get(0);
+            if (info.getStartupState() == ApplicationStartInfo.STARTUP_STATE_STARTED) {
+              if (info.getStartType() == ApplicationStartInfo.START_TYPE_COLD) {
+                appStartType = AppStartType.COLD;
+              } else {
+                appStartType = AppStartType.WARM;
+              }
             }
           }
+        } catch (RuntimeException ignored) {
+          // getHistoricalProcessStartReasons may throw different kinds of exceptions, namely:
+          // - SecurityException when called from an isolated process
+          // - IllegalArgumentException when called with a wrong userId
+          // - others
+          // See impl:
+          // https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/services/core/java/com/android/server/am/ActivityManagerService.java;l=10866-10893
+          Log.w("AppStartMetrics", ignored); // no logger instance here, so we just Log
         }
       }
     }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/SentryShadowActivityManager.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/SentryShadowActivityManager.kt
@@ -10,18 +10,25 @@ import org.robolectric.annotation.Implements
 class SentryShadowActivityManager {
   companion object {
     private var historicalProcessStartReasons: List<ApplicationStartInfo> = emptyList()
+    private var historicalProcessStartReasonsException: RuntimeException? = null
 
     fun setHistoricalProcessStartReasons(startReasons: List<ApplicationStartInfo>) {
       historicalProcessStartReasons = startReasons
     }
 
+    fun setHistoricalProcessStartReasonsException(exception: RuntimeException) {
+      historicalProcessStartReasonsException = exception
+    }
+
     fun reset() {
       historicalProcessStartReasons = emptyList()
+      historicalProcessStartReasonsException = null
     }
   }
 
   @Implementation
   fun getHistoricalProcessStartReasons(maxNum: Int): List<ApplicationStartInfo> {
+    historicalProcessStartReasonsException?.let { throw it }
     return historicalProcessStartReasons.take(maxNum)
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/performance/AppStartMetricsTestApi35.kt
@@ -81,4 +81,17 @@ class AppStartMetricsTestApi35 {
 
     assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
   }
+
+  @Test
+  fun `does not crash when getHistoricalProcessStartReasons throws RuntimeException`() {
+    SentryShadowActivityManager.setHistoricalProcessStartReasonsException(
+      RuntimeException("isolated process")
+    )
+    val metrics = AppStartMetrics.getInstance()
+
+    val app = ApplicationProvider.getApplicationContext<Application>()
+    metrics.registerLifecycleCallbacks(app)
+
+    assertEquals(AppStartMetrics.AppStartType.UNKNOWN, metrics.appStartType)
+  }
 }


### PR DESCRIPTION
Backport of #5597 onto 8.43.2 for patch release 8.43.3.

## What changed

- **fix(android):** Wrap `getHistoricalProcessStartReasons` in a `try/catch (RuntimeException)` to prevent crashes when the API is called from an isolated process or with a wrong userId ([#5597](https://github.com/getsentry/sentry-java/pull/5597))

## Backport notes

Cherry-picked manually from `ec5e3a5` onto the `8.43.2` tag. The `cachedStartInfo` assignment was omitted (that field was introduced after 8.43.2). The crash-regression test was also adapted to remove `appStartReason` assertions (that property doesn't exist in this branch).

Files changed:
- `AppStartMetrics.java` — add try/catch around `getHistoricalProcessStartReasons`
- `SentryShadowActivityManager.kt` — add exception-injection helper for tests
- `AppStartMetricsTestApi35.kt` — add crash regression test
- `CHANGELOG.md` / `gradle.properties` — bump to 8.43.3

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B7S4MRH32%3A1782301477.480009%22)