### PR TITLE
ci(replay): Skip snapshot upload on PRs from forks

### DIFF
--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -78,7 +78,8 @@ jobs:
         run: curl -sL https://sentry.io/get-cli/ | bash
 
       - name: Upload Replay Snapshots to Sentry
-        if: ${{ !cancelled() && env.SAUCE_USERNAME != null }}
+        # Skip on PRs from forks, which don't have access to the upload secret
+        if: ${{ !cancelled() && env.SAUCE_USERNAME != null && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           shopt -s globstar nullglob
           pngs=(artifacts/**/*.png)


### PR DESCRIPTION
## :scroll: Description
Guards the "Upload Replay Snapshots to Sentry" step (which runs `sentry-cli build snapshots`) so it only runs on pushes and same-repo PRs, skipping PRs opened from forks.

## :bulb: Motivation and Context
PRs from forks don't have access to repository secrets (e.g. `SENTRY_AUTH_TOKEN`), so the `sentry-cli` snapshot upload can't succeed on them. Adding an explicit fork guard makes the intent clear and avoids a confusing failed/no-op step on fork PRs.

The condition allows non-PR events (pushes to `main`) and same-repo PRs through, while excluding fork PRs by comparing `github.event.pull_request.head.repo.full_name` against `github.repository`.

## :green_heart: How did you test it?
CI-only change. Verified the conditional logic covers the three cases: push to `main` (runs), same-repo PR (runs), fork PR (skipped).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
