### PR TITLE
ci(build): Skip snapshot upload on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
         run: curl -sL https://sentry.io/get-cli/ | bash
 
       - name: Upload Snapshots to Sentry
+        # Skip on PRs from forks, which don't have access to the upload secret
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           sentry-cli build snapshots ./sentry-android-core/build/test-snapshots \
             --app-id sentry-android-core


### PR DESCRIPTION
## :scroll: Description
Add a guard to the "Upload Snapshots to Sentry" step in `build.yml` so it is skipped on pull requests from forks:

```yaml
if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

This matches the guard already present on the replay snapshot upload in `integration-tests-ui.yml` (added in #5621).

## :bulb: Motivation and Context
Fork PRs don't have access to `secrets.SENTRY_AUTH_TOKEN`, so the upload step would attempt to run `sentry-cli build snapshots` without credentials and fail. With this guard, fork PRs cleanly skip the upload instead of failing, making both snapshot-uploading pipelines (`build.yml` and `integration-tests-ui.yml`) consistent.

## :green_heart: How did you test it?
CI-only change. The condition mirrors the existing, working guard in `integration-tests-ui.yml`.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
