### PR TITLE
build: Remove redundant build-script declarations

### DIFF
--- a/sentry-apache-http-client-5/build.gradle.kts
+++ b/sentry-apache-http-client-5/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
   testImplementation(libs.mockito.kotlin)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-apollo-3/build.gradle.kts
+++ b/sentry-apollo-3/build.gradle.kts
@@ -42,8 +42,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/sentry-apollo-4/build.gradle.kts
+++ b/sentry-apollo-4/build.gradle.kts
@@ -49,8 +49,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/sentry-apollo/build.gradle.kts
+++ b/sentry-apollo/build.gradle.kts
@@ -43,8 +43,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/sentry-async-profiler/build.gradle.kts
+++ b/sentry-async-profiler/build.gradle.kts
@@ -36,8 +36,6 @@ dependencies {
   testImplementation(libs.mockito.inline)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-graphql-22/build.gradle.kts
+++ b/sentry-graphql-22/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
   testImplementation("com.netflix.graphql.dgs:graphql-error-types:4.9.2")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-graphql-core/build.gradle.kts
+++ b/sentry-graphql-core/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
   testImplementation("com.netflix.graphql.dgs:graphql-error-types:4.9.2")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-graphql/build.gradle.kts
+++ b/sentry-graphql/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
   testImplementation("com.netflix.graphql.dgs:graphql-error-types:4.9.2")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-jcache/build.gradle.kts
+++ b/sentry-jcache/build.gradle.kts
@@ -36,8 +36,6 @@ dependencies {
   testImplementation(libs.mockito.inline)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-jdbc/build.gradle.kts
+++ b/sentry-jdbc/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
   testImplementation(libs.mockito.inline)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-jul/build.gradle.kts
+++ b/sentry-jul/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
   testImplementation(libs.slf4j.api)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks {
   test {
     // used to test io.sentry.jul.SentryHandler

--- a/sentry-kafka/build.gradle.kts
+++ b/sentry-kafka/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
   testImplementation(libs.kafka.clients)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-kotlin-extensions/build.gradle.kts
+++ b/sentry-kotlin-extensions/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 tasks.withType<Detekt>().configureEach {

--- a/sentry-ktor-client/build.gradle.kts
+++ b/sentry-ktor-client/build.gradle.kts
@@ -44,8 +44,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 buildConfig {

--- a/sentry-launchdarkly-server/build.gradle.kts
+++ b/sentry-launchdarkly-server/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
   testImplementation(libs.launchdarkly.server)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-log4j2/build.gradle.kts
+++ b/sentry-log4j2/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
   testImplementation(libs.mockito.kotlin)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.log4j2")

--- a/sentry-logback/build.gradle.kts
+++ b/sentry-logback/build.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
   testImplementation(libs.mockito.kotlin)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.logback")

--- a/sentry-okhttp/build.gradle.kts
+++ b/sentry-okhttp/build.gradle.kts
@@ -43,8 +43,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 buildConfig {

--- a/sentry-openfeature/build.gradle.kts
+++ b/sentry-openfeature/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
   testImplementation(libs.openfeature)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-openfeign/build.gradle.kts
+++ b/sentry-openfeign/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
   testImplementation(libs.okhttp.mockwebserver)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-agentcustomization/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
   testImplementation(libs.mockito.kotlin)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-bootstrap/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
   testImplementation(libs.otel.semconv.incubating)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-core/build.gradle.kts
@@ -45,8 +45,6 @@ dependencies {
   testImplementation(libs.otel.semconv.incubating)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-opentelemetry/sentry-opentelemetry-otlp/build.gradle.kts
+++ b/sentry-opentelemetry/sentry-opentelemetry-otlp/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
   //  testImplementation(libs.otel.semconv.incubating)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-quartz/build.gradle.kts
+++ b/sentry-quartz/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
   testImplementation(libs.mockito.inline)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-reactor/build.gradle.kts
+++ b/sentry-reactor/build.gradle.kts
@@ -43,8 +43,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.reactor")

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
@@ -62,8 +62,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
@@ -65,8 +65,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-console/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console/build.gradle.kts
@@ -66,8 +66,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-jul/build.gradle.kts
+++ b/sentry-samples/sentry-samples-jul/build.gradle.kts
@@ -57,8 +57,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-log4j2/build.gradle.kts
+++ b/sentry-samples/sentry-samples-log4j2/build.gradle.kts
@@ -63,8 +63,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-logback/build.gradle.kts
+++ b/sentry-samples/sentry-samples-logback/build.gradle.kts
@@ -57,8 +57,6 @@ tasks.jar {
 // Fix the startScripts task dependency
 tasks.startScripts { dependsOn(tasks.shadowJar) }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-7/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-7/build.gradle.kts
@@ -68,8 +68,6 @@ tasks.withType<KotlinCompile>().configureEach {
   }
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
@@ -81,8 +81,6 @@ dependencies {
 
 dependencyManagement { imports { mavenBom(libs.otel.instrumentation.bom.get().toString()) } }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
@@ -84,8 +84,6 @@ dependencies {
   testImplementation("ch.qos.logback:logback-core:1.5.16")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<BootRun>("bootRunWithAgent").configure {
   group = "application"
 

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
@@ -82,8 +82,6 @@ dependencies {
 
 dependencyManagement { imports { mavenBom(libs.otel.instrumentation.bom.get().toString()) } }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
@@ -49,8 +49,6 @@ dependencies {
   testImplementation("ch.qos.logback:logback-core:1.5.16")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<KotlinCompile>().configureEach {
   kotlin {
     explicitApi()

--- a/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
@@ -83,8 +83,6 @@ dependencies {
   testImplementation("ch.qos.logback:logback-core:1.5.16")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.register<Test>("systemTest").configure {
   group = "verification"
   description = "Runs the System tests"

--- a/sentry-servlet-jakarta/build.gradle.kts
+++ b/sentry-servlet-jakarta/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
   testImplementation(libs.servlet.jakarta.api)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-servlet/build.gradle.kts
+++ b/sentry-servlet/build.gradle.kts
@@ -36,8 +36,6 @@ dependencies {
   testImplementation(libs.springboot.starter.web)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-spotlight/build.gradle.kts
+++ b/sentry-spotlight/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks { check { dependsOn(animalsnifferMain) } }
 
 buildConfig {

--- a/sentry-spring-7/build.gradle.kts
+++ b/sentry-spring-7/build.gradle.kts
@@ -82,8 +82,6 @@ dependencies {
   testImplementation(projects.sentryReactor)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.spring7")

--- a/sentry-spring-boot-4-starter/build.gradle.kts
+++ b/sentry-spring-boot-4-starter/build.gradle.kts
@@ -38,8 +38,6 @@ dependencies {
   errorprone(libs.nullaway)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-spring-boot-4/build.gradle.kts
+++ b/sentry-spring-boot-4/build.gradle.kts
@@ -108,8 +108,6 @@ dependencies {
   testImplementation(libs.springboot4.resttestclient)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.spring.boot4")

--- a/sentry-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-spring-boot-jakarta/build.gradle.kts
@@ -100,8 +100,6 @@ dependencies {
   testImplementation(projects.sentryAsyncProfiler)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.spring.boot.jakarta")

--- a/sentry-spring-boot-starter-jakarta/build.gradle.kts
+++ b/sentry-spring-boot-starter-jakarta/build.gradle.kts
@@ -38,8 +38,6 @@ dependencies {
   errorprone(libs.nullaway)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-spring-boot-starter/build.gradle.kts
+++ b/sentry-spring-boot-starter/build.gradle.kts
@@ -30,8 +30,6 @@ dependencies {
   errorprone(libs.nullaway)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     check("NullAway", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)

--- a/sentry-spring-jakarta/build.gradle.kts
+++ b/sentry-spring-jakarta/build.gradle.kts
@@ -77,8 +77,6 @@ dependencies {
   testImplementation(projects.sentryReactor)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 buildConfig {
   useJavaOutput()
   packageName("io.sentry.spring.jakarta")

--- a/sentry-system-test-support/build.gradle.kts
+++ b/sentry-system-test-support/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
   implementation(libs.mockito.kotlin)
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 apollo {
   service("service") {
     srcDir("src/main/graphql")

--- a/sentry-test-support/build.gradle.kts
+++ b/sentry-test-support/build.gradle.kts
@@ -31,5 +31,3 @@ dependencies {
   implementation(libs.kotlin.test.junit)
   implementation(libs.mockito.kotlin)
 }
-
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }

--- a/sentry/build.gradle.kts
+++ b/sentry/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
   signature("${gummyBearsModule}:${libs.versions.gummyBears.get()}@signature")
 }
 
-configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }
-
 animalsniffer {
   ignore =
     listOf(


### PR DESCRIPTION
## :scroll: Description
Removes redundant build-script declarations that restate values already provided centrally:

1. The line `configure<SourceSetContainer> { test { java.srcDir("src/test/java") } }` from all 51 build files that declared it.
2. The module-level `configure<JavaPluginExtension> { sourceCompatibility/targetCompatibility = VERSION_1_8 }` block in `sentry-apollo-4`.

## :bulb: Motivation and Context
1. `src/test/java` is already Gradle's default test source directory (added by the `java-library`/Java plugin), so re-adding it was a no-op. No convention plugin in `build-logic`/`buildSrc` resets the default source dirs — confirmed e.g. by `sentry-jdbc`, whose tests live in `src/test/kotlin` and which never had a `src/test/java` directory at all.
2. The root `build.gradle.kts` already sets `VERSION_1_8` source/target compatibility for every `java-library` subproject, so `sentry-apollo-4` declaring it again was a no-op.

Removing both reduces build-script noise.

## :green_heart: How did you test it?
`./gradlew spotlessApply apiDump` produced no changes, `spotlessKotlinGradleCheck` passes, and test sources still compile for both a `src/test/kotlin` module (`sentry-jdbc`) and a `src/test/java` module (`sentry-okhttp`). For `sentry-apollo-4`, confirmed the compiled bytecode is still Java 8 (major version 52) after removing the block, proving the root configuration still applies.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
