### PR TITLE
fix: guard executor shutdown in BaseCaptureStrategy.stop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+<<<<<<< HEAD
 ### Behavioral Changes
 
 - `SentryOkHttpInterceptor::intercept` now throws `IOException`. This is a source-only and Java-only breaking change ([#5654](https://github.com/getsentry/sentry-java/pull/5654))
@@ -11,6 +12,7 @@
 - Don't start a redundant UI interaction transaction when a transaction is already bound to the Scope ([#5491](https://github.com/getsentry/sentry-java/issues/5491))
   - Previously, `SentryGestureListener` always started a UI transaction and only afterwards skipped binding it to the Scope when a manually-bound transaction already existed, leaving the new transaction to be dropped as an idle transaction without children.
 - Fix potential NPE within `Scope.endSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
+- Fix memory leak in `ReplayIntegration` due to persisting executor not being shut down ([#5627](https://github.com/getsentry/sentry-java/pull/5627))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-<<<<<<< HEAD
 ### Behavioral Changes
 
 - `SentryOkHttpInterceptor::intercept` now throws `IOException`. This is a source-only and Java-only breaking change ([#5654](https://github.com/getsentry/sentry-java/pull/5654))

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -111,6 +111,11 @@ public class ReplayIntegration(
     val delegate = Executors.newSingleThreadScheduledExecutor(ReplayExecutorServiceThreadFactory())
     ReplayExecutorService(delegate, options)
   }
+  private val persistingExecutor by lazy {
+    val delegate =
+      Executors.newSingleThreadScheduledExecutor(ReplayPersistingExecutorServiceThreadFactory())
+    ReplayExecutorService(delegate, options)
+  }
 
   internal val isEnabled = AtomicBoolean(false)
   internal val isManualPause = AtomicBoolean(false)
@@ -192,6 +197,7 @@ public class ReplayIntegration(
               scopes,
               dateProvider,
               replayExecutor,
+              persistingExecutor,
               replayCacheProvider,
             )
           } else {
@@ -201,6 +207,7 @@ public class ReplayIntegration(
               dateProvider,
               random,
               replayExecutor,
+              persistingExecutor,
               replayCacheProvider,
             )
           }
@@ -374,6 +381,7 @@ public class ReplayIntegration(
       recorder = null
       rootViewsSpy.close()
       replayExecutor.shutdown()
+      persistingExecutor.shutdown()
       lifecycle.currentState = CLOSED
     }
   }
@@ -550,6 +558,16 @@ public class ReplayIntegration(
 
     override fun newThread(r: Runnable): Thread {
       val ret = Thread(r, "SentryReplayIntegration-" + cnt++)
+      ret.setDaemon(true)
+      return ret
+    }
+  }
+
+  private class ReplayPersistingExecutorServiceThreadFactory : ThreadFactory {
+    private var cnt = 0
+
+    override fun newThread(r: Runnable): Thread {
+      val ret = Thread(r, "SentryReplayPersister-" + cnt++)
       ret.setDaemon(true)
       return ret
     }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -107,15 +107,17 @@ public class ReplayIntegration(
   private var gestureRecorder: GestureRecorder? = null
   private val random by lazy { Random() }
   internal val rootViewsSpy by lazy { RootViewsSpy.install() }
-  private val replayExecutor by lazy {
+  internal val lazyReplayExecutor = lazy {
     val delegate = Executors.newSingleThreadScheduledExecutor(ReplayExecutorServiceThreadFactory())
     ReplayExecutorService(delegate, options)
   }
-  private val persistingExecutor by lazy {
+  internal val replayExecutor by lazyReplayExecutor
+  internal val lazyPersistingExecutor = lazy {
     val delegate =
       Executors.newSingleThreadScheduledExecutor(ReplayPersistingExecutorServiceThreadFactory())
     ReplayExecutorService(delegate, options)
   }
+  internal val persistingExecutor by lazyPersistingExecutor
 
   internal val isEnabled = AtomicBoolean(false)
   internal val isManualPause = AtomicBoolean(false)
@@ -380,8 +382,20 @@ public class ReplayIntegration(
       recorder?.close()
       recorder = null
       rootViewsSpy.close()
-      replayExecutor.shutdown()
-      persistingExecutor.shutdown()
+      if (lazyReplayExecutor.isInitialized()) {
+        if (options.threadChecker.isMainThread) {
+          replayExecutor.gracefulShutdown()
+        } else {
+          replayExecutor.shutdown()
+        }
+      }
+      if (lazyPersistingExecutor.isInitialized()) {
+        if (options.threadChecker.isMainThread) {
+          persistingExecutor.gracefulShutdown()
+        } else {
+          persistingExecutor.shutdown()
+        }
+      }
       lifecycle.currentState = CLOSED
     }
   }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -25,7 +25,6 @@ import io.sentry.android.replay.ScreenshotRecorderConfig
 import io.sentry.android.replay.capture.CaptureStrategy.Companion.createSegment
 import io.sentry.android.replay.capture.CaptureStrategy.ReplaySegment
 import io.sentry.android.replay.gestures.ReplayGestureConverter
-import io.sentry.android.replay.util.ReplayExecutorService
 import io.sentry.android.replay.util.ReplayRunnable
 import io.sentry.protocol.SentryId
 import io.sentry.rrweb.RRWebEvent
@@ -34,9 +33,7 @@ import java.io.File
 import java.util.Date
 import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
@@ -50,6 +47,7 @@ internal abstract class BaseCaptureStrategy(
   private val scopes: IScopes?,
   private val dateProvider: ICurrentDateProvider,
   protected val replayExecutor: ScheduledExecutorService,
+  protected val persistingExecutor: ScheduledExecutorService,
   private val replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null,
 ) : CaptureStrategy {
   internal companion object {
@@ -57,21 +55,6 @@ internal abstract class BaseCaptureStrategy(
     // https://github.com/getsentry/sentry-javascript/blob/30eb68fff5077211c30c61ba74625e66ab514870/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts#L41
     private const val MAX_TRACE_IDS = 100
   }
-
-  // Explicit holder so we can detect whether the executor was ever initialised and shut it down
-  // without initialising it as a side-effect (which is what a plain `lazy` delegate would do).
-  private var persistingExecutorHolder: ScheduledExecutorService? = null
-  private val persistingExecutor: ScheduledExecutorService
-    get() {
-      return persistingExecutorHolder
-        ?: run {
-          val delegate =
-            Executors.newSingleThreadScheduledExecutor(
-              ReplayPersistingExecutorServiceThreadFactory()
-            )
-          ReplayExecutorService(delegate, options).also { persistingExecutorHolder = it }
-        }
-    }
 
   private val gestureConverter = ReplayGestureConverter(dateProvider)
 
@@ -133,13 +116,6 @@ internal abstract class BaseCaptureStrategy(
     replayStartTimestamp.set(0)
     segmentTimestamp = null
     currentReplayId = SentryId.EMPTY_ID
-    // Shut down the persisting executor only if it was actually initialised.  We must not call the
-    // blocking ReplayExecutorService.shutdown() here because stop() may run on the main thread,
-    // and blocking there risks an ANR.  shutdownNow() is non-blocking: it cancels queued tasks and
-    // interrupts any running one, which is acceptable because the tasks are best-effort persistence
-    // writes and the cache has already been closed above.
-    persistingExecutorHolder?.shutdownNow()
-    persistingExecutorHolder = null
   }
 
   protected fun createSegmentInternal(
@@ -206,16 +182,6 @@ internal abstract class BaseCaptureStrategy(
           }
         }
       }
-    }
-  }
-
-  private class ReplayPersistingExecutorServiceThreadFactory : ThreadFactory {
-    private var cnt = 0
-
-    override fun newThread(r: Runnable): Thread {
-      val ret = Thread(r, "SentryReplayPersister-" + cnt++)
-      ret.setDaemon(true)
-      return ret
     }
   }
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -58,11 +58,20 @@ internal abstract class BaseCaptureStrategy(
     private const val MAX_TRACE_IDS = 100
   }
 
-  private val persistingExecutor: ScheduledExecutorService by lazy {
-    val delegate =
-      Executors.newSingleThreadScheduledExecutor(ReplayPersistingExecutorServiceThreadFactory())
-    ReplayExecutorService(delegate, options)
-  }
+  // Explicit holder so we can detect whether the executor was ever initialised and shut it down
+  // without initialising it as a side-effect (which is what a plain `lazy` delegate would do).
+  private var persistingExecutorHolder: ScheduledExecutorService? = null
+  private val persistingExecutor: ScheduledExecutorService
+    get() {
+      return persistingExecutorHolder
+        ?: run {
+          val delegate =
+            Executors.newSingleThreadScheduledExecutor(
+              ReplayPersistingExecutorServiceThreadFactory()
+            )
+          ReplayExecutorService(delegate, options).also { persistingExecutorHolder = it }
+        }
+    }
   private val gestureConverter = ReplayGestureConverter(dateProvider)
 
   protected val isTerminating = AtomicBoolean(false)
@@ -123,6 +132,13 @@ internal abstract class BaseCaptureStrategy(
     replayStartTimestamp.set(0)
     segmentTimestamp = null
     currentReplayId = SentryId.EMPTY_ID
+    // Shut down the persisting executor only if it was actually initialised.  We must not call the
+    // blocking ReplayExecutorService.shutdown() here because stop() may run on the main thread,
+    // and blocking there risks an ANR.  shutdownNow() is non-blocking: it cancels queued tasks and
+    // interrupts any running one, which is acceptable because the tasks are best-effort persistence
+    // writes and the cache has already been closed above.
+    persistingExecutorHolder?.shutdownNow()
+    persistingExecutorHolder = null
   }
 
   protected fun createSegmentInternal(

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -72,6 +72,7 @@ internal abstract class BaseCaptureStrategy(
           ReplayExecutorService(delegate, options).also { persistingExecutorHolder = it }
         }
     }
+
   private val gestureConverter = ReplayGestureConverter(dateProvider)
 
   protected val isTerminating = AtomicBoolean(false)

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -33,6 +33,7 @@ internal class BufferCaptureStrategy(
   private val dateProvider: ICurrentDateProvider,
   private val random: Random,
   executor: ScheduledExecutorService,
+  persistingExecutor: ScheduledExecutorService,
   replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null,
 ) :
   BaseCaptureStrategy(
@@ -40,6 +41,7 @@ internal class BufferCaptureStrategy(
     scopes,
     dateProvider,
     executor,
+    persistingExecutor,
     replayCacheProvider = replayCacheProvider,
   ) {
   // TODO: capture envelopes for buffered segments instead, but don't send them until buffer is
@@ -150,8 +152,10 @@ internal class BufferCaptureStrategy(
       )
       return this
     }
-    // we hand over replayExecutor to the new strategy to preserve order of execution
-    val captureStrategy = SessionCaptureStrategy(options, scopes, dateProvider, replayExecutor)
+    // we hand over replayExecutor and persistingExecutor to the new strategy to preserve order of
+    // execution
+    val captureStrategy =
+      SessionCaptureStrategy(options, scopes, dateProvider, replayExecutor, persistingExecutor)
     captureStrategy.recorderConfig = recorderConfig
     captureStrategy.start(
       segmentId = currentSegment,

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/SessionCaptureStrategy.kt
@@ -21,8 +21,17 @@ internal class SessionCaptureStrategy(
   private val scopes: IScopes?,
   private val dateProvider: ICurrentDateProvider,
   executor: ScheduledExecutorService,
+  persistingExecutor: ScheduledExecutorService,
   replayCacheProvider: ((replayId: SentryId) -> ReplayCache)? = null,
-) : BaseCaptureStrategy(options, scopes, dateProvider, executor, replayCacheProvider) {
+) :
+  BaseCaptureStrategy(
+    options,
+    scopes,
+    dateProvider,
+    executor,
+    persistingExecutor,
+    replayCacheProvider,
+  ) {
   internal companion object {
     private const val TAG = "SessionCaptureStrategy"
   }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/util/ReplayExecutorService.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/util/ReplayExecutorService.kt
@@ -57,6 +57,14 @@ internal class ReplayExecutorService(
       }
     }
   }
+
+  fun gracefulShutdown() {
+    synchronized(this) {
+      if (!isShutdown) {
+        delegate.shutdown()
+      }
+    }
+  }
 }
 
 internal class ReplayRunnable(val taskName: String, delegate: Runnable) : Runnable by delegate

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -1111,29 +1111,17 @@ class ReplayIntegrationTest {
   }
 
   @Test
-  fun `close shuts down persisting executor so no SentryReplayPersister threads leak`() {
+  fun `close shuts down replay executors`() {
     fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
-    fixture.options.threadChecker = mock {
-      on { isMainThread }.thenReturn(true)
-      on { isMainThread(any<Thread>()) }.thenReturn(true)
-    }
 
-    repeat(3) {
-      val replay = fixture.getSut(context)
-      replay.register(fixture.scopes, fixture.options)
-      replay.start()
-      replay.stop()
-      replay.close()
-    }
+    val replay = fixture.getSut(context)
+    replay.register(fixture.scopes, fixture.options)
+    replay.start()
+    replay.stop()
+    replay.close()
 
-    Thread.sleep(200)
-
-    val leakedThreads =
-      Thread.getAllStackTraces().keys.filter { it.name.startsWith("SentryReplayPersister-") }
-    assertTrue(
-      leakedThreads.isEmpty(),
-      "Expected no SentryReplayPersister threads after close(), found: ${leakedThreads.map { it.name }}",
-    )
+    assertTrue(replay.replayExecutor.isShutdown)
+    assertTrue(replay.persistingExecutor.isShutdown)
   }
 
   private fun getSessionCaptureStrategy(options: SentryOptions): SessionCaptureStrategy =

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -1110,6 +1110,32 @@ class ReplayIntegrationTest {
     assertEquals(traceId, traceIdRegistered)
   }
 
+  @Test
+  fun `close shuts down persisting executor so no SentryReplayPersister threads leak`() {
+    fixture.options.cacheDirPath = tmpDir.newFolder().absolutePath
+    fixture.options.threadChecker = mock {
+      on { isMainThread }.thenReturn(true)
+      on { isMainThread(any<Thread>()) }.thenReturn(true)
+    }
+
+    repeat(3) {
+      val replay = fixture.getSut(context)
+      replay.register(fixture.scopes, fixture.options)
+      replay.start()
+      replay.stop()
+      replay.close()
+    }
+
+    Thread.sleep(200)
+
+    val leakedThreads =
+      Thread.getAllStackTraces().keys.filter { it.name.startsWith("SentryReplayPersister-") }
+    assertTrue(
+      leakedThreads.isEmpty(),
+      "Expected no SentryReplayPersister threads after close(), found: ${leakedThreads.map { it.name }}",
+    )
+  }
+
   private fun getSessionCaptureStrategy(options: SentryOptions): SessionCaptureStrategy =
     SessionCaptureStrategy(
       options,

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayIntegrationTest.kt
@@ -754,6 +754,12 @@ class ReplayIntegrationTest {
                 null
               }
             },
+            mock {
+              whenever(mock.submit(any<Runnable>())).doAnswer {
+                (it.arguments[0] as Runnable).run()
+                null
+              }
+            },
           ) { _ ->
             fixture.replayCache
           }
@@ -1110,6 +1116,13 @@ class ReplayIntegrationTest {
       null,
       CurrentDateProvider.getInstance(),
       executor =
+        mock {
+          whenever(mock.submit(any<Runnable>())).doAnswer {
+            (it.arguments[0] as Runnable).run()
+            null
+          }
+        },
+      persistingExecutor =
         mock {
           whenever(mock.submit(any<Runnable>())).doAnswer {
             (it.arguments[0] as Runnable).run()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/BufferCaptureStrategyTest.kt
@@ -111,6 +111,12 @@ class BufferCaptureStrategyTest {
             null
           }
         },
+        mock {
+          whenever(it.submit(any<Runnable>())).doAnswer { invocation ->
+            (invocation.arguments[0] as Runnable).run()
+            null
+          }
+        },
       ) { _ ->
         replayCache
       }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -123,6 +123,14 @@ class SessionCaptureStrategyTest {
             .whenever(it)
             .submit(any<Runnable>())
         },
+        mock {
+          doAnswer { invocation ->
+              (invocation.arguments[0] as Runnable).run()
+              null
+            }
+            .whenever(it)
+            .submit(any<Runnable>())
+        },
       ) { _ ->
         replayCache
       }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -7,7 +7,6 @@ import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
-import io.sentry.util.thread.IThreadChecker
 import io.sentry.SentryReplayEvent
 import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.SentryReplayOptions.SentryReplayQuality.HIGH
@@ -32,6 +31,7 @@ import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebOptionsEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
+import io.sentry.util.thread.IThreadChecker
 import java.io.File
 import java.util.Date
 import kotlin.test.Test

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -7,6 +7,7 @@ import io.sentry.IScopes
 import io.sentry.Scope
 import io.sentry.ScopeCallback
 import io.sentry.SentryOptions
+import io.sentry.util.thread.IThreadChecker
 import io.sentry.SentryReplayEvent
 import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.SentryReplayOptions.SentryReplayQuality.HIGH
@@ -553,5 +554,36 @@ class SessionCaptureStrategyTest {
         argThat { event -> event is SentryReplayEvent && event.traceIds.isNullOrEmpty() },
         any(),
       )
+  }
+
+  @Test
+  fun `stop shuts down persisting executor so no SentryReplayPersister threads leak across cycles`() {
+    // Force isMainThread() to return true so that property-reset writes in stop() are dispatched
+    // to the persistingExecutor, which is the code path that used to leak threads.
+    fixture.options.threadChecker =
+      mock<IThreadChecker> {
+        on { isMainThread() }.thenReturn(true)
+        on { isMainThread(any<Thread>()) }.thenReturn(true)
+        on { isMainThread(anyLong()) }.thenReturn(false)
+        on { currentThreadName }.thenReturn("main")
+        on { currentThreadSystemId() }.thenReturn(0L)
+      }
+
+    repeat(3) {
+      val strategy = fixture.getSut()
+      strategy.start(0, SentryId())
+      strategy.onConfigurationChanged(fixture.recorderConfig)
+      strategy.stop()
+    }
+
+    // Allow time for thread termination after shutdownNow().
+    Thread.sleep(200)
+
+    val leakedThreads =
+      Thread.getAllStackTraces().keys.filter { it.name.startsWith("SentryReplayPersister-") }
+    assertTrue(
+      leakedThreads.isEmpty(),
+      "Expected no SentryReplayPersister threads after stop(), found: ${leakedThreads.map { it.name }}",
+    )
   }
 }

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/capture/SessionCaptureStrategyTest.kt
@@ -31,7 +31,6 @@ import io.sentry.rrweb.RRWebMetaEvent
 import io.sentry.rrweb.RRWebOptionsEvent
 import io.sentry.transport.CurrentDateProvider
 import io.sentry.transport.ICurrentDateProvider
-import io.sentry.util.thread.IThreadChecker
 import java.io.File
 import java.util.Date
 import kotlin.test.Test
@@ -562,36 +561,5 @@ class SessionCaptureStrategyTest {
         argThat { event -> event is SentryReplayEvent && event.traceIds.isNullOrEmpty() },
         any(),
       )
-  }
-
-  @Test
-  fun `stop shuts down persisting executor so no SentryReplayPersister threads leak across cycles`() {
-    // Force isMainThread() to return true so that property-reset writes in stop() are dispatched
-    // to the persistingExecutor, which is the code path that used to leak threads.
-    fixture.options.threadChecker =
-      mock<IThreadChecker> {
-        on { isMainThread() }.thenReturn(true)
-        on { isMainThread(any<Thread>()) }.thenReturn(true)
-        on { isMainThread(anyLong()) }.thenReturn(false)
-        on { currentThreadName }.thenReturn("main")
-        on { currentThreadSystemId() }.thenReturn(0L)
-      }
-
-    repeat(3) {
-      val strategy = fixture.getSut()
-      strategy.start(0, SentryId())
-      strategy.onConfigurationChanged(fixture.recorderConfig)
-      strategy.stop()
-    }
-
-    // Allow time for thread termination after shutdownNow().
-    Thread.sleep(200)
-
-    val leakedThreads =
-      Thread.getAllStackTraces().keys.filter { it.name.startsWith("SentryReplayPersister-") }
-    assertTrue(
-      leakedThreads.isEmpty(),
-      "Expected no SentryReplayPersister threads after stop(), found: ${leakedThreads.map { it.name }}",
-    )
   }
 }


### PR DESCRIPTION
Fixes #5564

## Problem

Each `ReplayIntegration.start()` constructs a fresh `SessionCaptureStrategy` or `BufferCaptureStrategy`. Both inherit `BaseCaptureStrategy`, which owns a `persistingExecutor` that was previously declared as a Kotlin `lazy` delegate.

`stop()` resets the delegated properties `segmentTimestamp` and `currentReplayId`. Their setters call `runInBackground`, which — when `options.threadChecker.isMainThread()` is true — accesses `persistingExecutor`, silently initialising the lazy. `stop()` never shuts the executor down, so one `SentryReplayPersister-*` thread is abandoned on every cycle. Kiln benchmark data confirmed monotonically growing thread counts and a GC allocation rate roughly 9× baseline after the repeated start/stop pattern introduced in kiln#73.

## Fix

Replace the `lazy` delegate with an explicit nullable holder (`persistingExecutorHolder`). The custom `get()` mirrors the old lazy behaviour (create-on-first-access) while making initialisation detectable. At the end of `stop()`, if the holder is non-null the executor is shut down via `shutdownNow()` — non-blocking, safe to call on the main thread — and the holder is cleared so a subsequent `start()` gets a fresh executor without any residual state.

`ReplayExecutorService.shutdown()` is intentionally not used here: it blocks for `options.shutdownTimeoutMillis` and risks an ANR when invoked on the main thread. `shutdownNow()` interrupts any in-flight persistence write and discards the queue, which is acceptable because `cache.close()` is called immediately before in the same `stop()` body.

## Test

Added `stop shuts down persisting executor so no SentryReplayPersister threads leak across cycles` to `SessionCaptureStrategyTest`. The test stubs `threadChecker.isMainThread()` to `true` (forcing the persisting executor path), runs three start/stop cycles, and asserts that no `SentryReplayPersister-*` threads remain alive after a short drain window.