### PR TITLE
chore(deps): Bump dependencies associated with SentrySQLiteDriver

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,10 @@ otelSemanticConventions = "1.40.0"
 otelSemanticConventionsAlpha = "1.40.0-alpha"
 retrofit = "2.9.0"
 room2 = "2.8.4"
-room3 = "3.0.0-alpha06"
-sagp = "6.10.0"
+room3 = "3.0.0-rc01"
+sagp = "6.13.0"
 sqlite = "2.6.2"
-sqliteAlpha = "2.7.0-alpha06" # Required by Room3 3.0.0-alpha*
+sqliteRc = "2.7.0-rc01" # Required by Room3 3.0.0-rc*
 slf4j = "1.7.30"
 spotless = "8.4.0"
 springboot2 = "2.7.18"
@@ -107,8 +107,8 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-room3-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room3" }
 androidx-room3-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room3" }
 androidx-sqlite = { module = "androidx.sqlite:sqlite", version.ref = "sqlite" }
-androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqliteAlpha" }
-androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqliteAlpha" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqliteRc" }
+androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqliteRc" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.2.1" }
 androidx-browser = { module = "androidx.browser:browser", version = "1.8.0" }
 async-profiler = { module = "tools.profiler:async-profiler", version.ref = "asyncProfiler" }


### PR DESCRIPTION
## :scroll: Description

Bumps SAGP to 6.13.0, Room 3 to 3.0.0-rc01, and androidx.sqlite to 2.7.0-rc01. 

## :bulb: Motivation and Context

Ensures the Android sample app runs against the latest Room build + picks up the SQLiteDriver auto-instrumentation introduced in SAGP 6.13.0. (Otherwise devs have to publish to mavenLocal to test that auto-instrumentation behavior.)

## :green_heart: How did you test it?

Manually. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
