### PR TITLE
build: Remove redundant Java compatibility block from sentry-apollo-4

### DIFF
--- a/sentry-apollo-4/build.gradle.kts
+++ b/sentry-apollo-4/build.gradle.kts
@@ -11,11 +11,6 @@ plugins {
   alias(libs.plugins.animalsniffer)
 }
 
-configure<JavaPluginExtension> {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
   compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9


### PR DESCRIPTION
## :scroll: Description
Removes the module-level `configure<JavaPluginExtension> { sourceCompatibility/targetCompatibility = VERSION_1_8 }` block from `sentry-apollo-4`.

## :bulb: Motivation and Context
The root `build.gradle.kts` already sets `VERSION_1_8` source/target compatibility for every `java-library` subproject, so `sentry-apollo-4` declaring it again was a no-op. This is a follow-up to #5624 (redundant test source set declarations).

## :green_heart: How did you test it?
`spotlessKotlinGradleCheck` passes, `sentry-apollo-4` compiles, and the compiled bytecode is still Java 8 (major version 52) after removing the block — proving the root configuration still applies.

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
