### PR TITLE
perf(core): [Init Reflection 1] Probe class availability without initializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
+
 ## 8.45.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Internal
+### Performance
 
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
 

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -12,17 +12,23 @@ import org.jetbrains.annotations.Nullable;
 public class LoadClass {
 
   /**
-   * Try to load a class via reflection
+   * Loads and initializes a class via reflection. Use this when you intend to actually use the
+   * class (e.g. instantiate it or invoke its methods). The returned class is fully initialized, so
+   * its static initializers run. To merely check whether a class is on the classpath, use {@link
+   * #isClassAvailable} instead, which avoids running those initializers.
    *
    * @param clazz the full class name
    * @param logger an instance of ILogger
    * @return a Class&lt;?&gt; if it's available, or null
    */
   public @Nullable Class<?> loadClass(final @NotNull String clazz, final @Nullable ILogger logger) {
+    return loadClass(clazz, logger, true);
+  }
+
+  private @Nullable Class<?> loadClass(
+      final @NotNull String clazz, final @Nullable ILogger logger, final boolean initialize) {
     try {
-      // Don't initialize the class just to probe for availability; it gets initialized lazily on
-      // first use. This avoids running unrelated static initializers during SDK init.
-      return Class.forName(clazz, false, LoadClass.class.getClassLoader());
+      return Class.forName(clazz, initialize, LoadClass.class.getClassLoader());
     } catch (ClassNotFoundException e) {
       if (logger != null) {
         logger.log(SentryLevel.INFO, "Class not available: " + clazz);
@@ -39,8 +45,19 @@ public class LoadClass {
     return null;
   }
 
+  /**
+   * Probes whether a class is on the classpath without initializing it. Use this for availability
+   * checks (e.g. deciding whether to register an integration); the class is not initialized, so its
+   * static initializers do not run until something actually uses it. This keeps SDK init cheap by
+   * not triggering unrelated initializers. If you need to use the class, use {@link #loadClass}
+   * instead.
+   *
+   * @param clazz the full class name
+   * @param logger an instance of ILogger
+   * @return true if the class is on the classpath
+   */
   public boolean isClassAvailable(final @NotNull String clazz, final @Nullable ILogger logger) {
-    return loadClass(clazz, logger) != null;
+    return loadClass(clazz, logger, false) != null;
   }
 
   public boolean isClassAvailable(
@@ -48,6 +65,15 @@ public class LoadClass {
     return isClassAvailable(clazz, options != null ? options.getLogger() : null);
   }
 
+  /**
+   * Like {@link #isClassAvailable}, but defers the (non-initializing) availability check until the
+   * result is first read. Use this when the check itself should not run during SDK init but only
+   * later, on first access.
+   *
+   * @param clazz the full class name
+   * @param logger an instance of ILogger
+   * @return a lazily-evaluated availability check
+   */
   public LazyEvaluator<Boolean> isClassAvailableLazy(
       final @NotNull String clazz, final @Nullable ILogger logger) {
     return new LazyEvaluator<>(() -> isClassAvailable(clazz, logger));

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -20,7 +20,9 @@ public class LoadClass {
    */
   public @Nullable Class<?> loadClass(final @NotNull String clazz, final @Nullable ILogger logger) {
     try {
-      return Class.forName(clazz);
+      // Don't initialize the class just to probe for availability; it gets initialized lazily on
+      // first use. This avoids running unrelated static initializers during SDK init.
+      return Class.forName(clazz, false, LoadClass.class.getClassLoader());
     } catch (ClassNotFoundException e) {
       if (logger != null) {
         logger.log(SentryLevel.INFO, "Class not available: " + clazz);

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -1,0 +1,49 @@
+package io.sentry.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class LoadClassTest {
+  @Test
+  fun `loadClass returns the class when it is available`() {
+    assertNotNull(LoadClass().loadClass("io.sentry.SentryEvent", null))
+  }
+
+  @Test
+  fun `loadClass returns null when the class is not available`() {
+    assertNull(LoadClass().loadClass("io.sentry.ThisClassDoesNotExist", null))
+  }
+
+  @Test
+  fun `isClassAvailable reflects whether the class is on the classpath`() {
+    val loadClass = LoadClass()
+    assertNotNull(loadClass.loadClass("io.sentry.SentryEvent", null))
+    assertFalse(
+      loadClass.isClassAvailable("io.sentry.ThisClassDoesNotExist", null as io.sentry.ILogger?)
+    )
+  }
+
+  @Test
+  fun `loadClass does not run the static initializer of the probed class`() {
+    // Reading the flag initializes the flag holder, not the probe.
+    assertFalse(LoadClassNoInitFlag.initialized)
+
+    // Obtaining the name via ::class.java does not initialize the probe either.
+    LoadClass().loadClass(LoadClassNoInitProbe::class.java.name, null)
+
+    // Availability probing must not trigger the probe's static initializer.
+    assertFalse(LoadClassNoInitFlag.initialized)
+  }
+}
+
+private object LoadClassNoInitFlag {
+  @JvmField var initialized = false
+}
+
+private object LoadClassNoInitProbe {
+  init {
+    LoadClassNoInitFlag.initialized = true
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LoadClassTest {
   @Test
@@ -26,24 +27,44 @@ class LoadClassTest {
   }
 
   @Test
-  fun `loadClass does not run the static initializer of the probed class`() {
+  fun `isClassAvailable does not run the static initializer of the probed class`() {
     // Reading the flag initializes the flag holder, not the probe.
-    assertFalse(LoadClassNoInitFlag.initialized)
+    assertFalse(IsClassAvailableNoInitFlag.initialized)
 
     // Obtaining the name via ::class.java does not initialize the probe either.
-    LoadClass().loadClass(LoadClassNoInitProbe::class.java.name, null)
+    LoadClass()
+      .isClassAvailable(IsClassAvailableNoInitProbe::class.java.name, null as io.sentry.ILogger?)
 
     // Availability probing must not trigger the probe's static initializer.
-    assertFalse(LoadClassNoInitFlag.initialized)
+    assertFalse(IsClassAvailableNoInitFlag.initialized)
+  }
+
+  @Test
+  fun `loadClass runs the static initializer of the loaded class`() {
+    assertFalse(LoadClassInitFlag.initialized)
+
+    LoadClass().loadClass(LoadClassInitProbe::class.java.name, null)
+
+    assertTrue(LoadClassInitFlag.initialized)
   }
 }
 
-private object LoadClassNoInitFlag {
+private object IsClassAvailableNoInitFlag {
   @JvmField var initialized = false
 }
 
-private object LoadClassNoInitProbe {
+private object IsClassAvailableNoInitProbe {
   init {
-    LoadClassNoInitFlag.initialized = true
+    IsClassAvailableNoInitFlag.initialized = true
+  }
+}
+
+private object LoadClassInitFlag {
+  @JvmField var initialized = false
+}
+
+private object LoadClassInitProbe {
+  init {
+    LoadClassInitFlag.initialized = true
   }
 }


### PR DESCRIPTION
## PR Stack (Init Reflection)

- #5634 — collection
- #5635 — [1] Probe class availability without initializing
- #5636 — [2] Cache class lookups and collapse double probes
- #5637 — [3] Gate Compose class probes behind their features

---

Part of [JAVA-587](https://linear.app/getsentry/issue/JAVA-587/reduce-reflection-cost-on-the-sdk-init-path)

## :scroll: Description

`LoadClass.loadClass` used `Class.forName(name)`, which **initializes** the class. Since this method is used purely to probe whether an optional integration is on the classpath during `SentryAndroid.init`, that eagerly runs unrelated static initializers — the customer trace shows `androidx.compose.ui.node.Owner.<clinit>` and `FragmentLifecycleIntegration.<clinit>` executing under the availability check.

This switches to `Class.forName(name, false, classLoader)` so the class is loaded but only initialized lazily on first real use (e.g. when it's actually instantiated).

## :bulb: Motivation and Context

First of three stacked PRs reducing reflection cost on the init path, from the customer-provided Perfetto trace in the *Reduce SDK init time [Android]* project (JAVA-586 area).

## :green_heart: How did you test it?

New `LoadClassTest` including a guard asserting that probing a class does **not** run its static initializer; existing init/integration tests pass unchanged.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

PR 2 caches lookups and collapses double-probes; PR 3 gates the Compose probes behind their features.


## :stopwatch: Pixel 3 benchmark (ART method trace → Perfetto trace_processor)

Probing a class that has a (deliberately heavy) static initializer:

| | old `Class.forName(name)` | new `Class.forName(name, false, loader)` |
|---|---:|---:|
| target-class `<clinit>` invocations under the probe | 1 | **0** |

The static initializer runs under the old probe and is entirely skipped under the new one. In the production trace this was `androidx.compose.ui.node.Owner.<clinit>` and `FragmentLifecycleIntegration.<clinit>` running during init. (Method tracing inflates the absolute `<clinit>` time, so only the invocation count is reported.)

## :stopwatch: Cold-start macrobenchmark (Pixel 3, `sentry-samples-android`)

Jetpack Macrobenchmark, `StartupMode.COLD` + `CompilationMode.Full()`, 20 iterations. A new `android.os.Trace` marker (`SentryInitProbes`, a no-op unless tracing is active) lets a `TraceSectionMetric` measure just the 6 `isClassAvailable` probes instead of the ~560 ms whole start — so the sub-millisecond effect clears the noise floor.

| `SentryInitProbes` duration | median | min | max |
|---|---:|---:|---:|
| old (`forName` initializes) | 0.833 ms | 0.725 | 1.056 |
| **new (no-init)** | **0.434 ms** | 0.399 | 0.549 |

**Δ median ≈ −399 µs** per init on this app (timber + fragment + replay present), with non-overlapping ranges. The saving is the deferred static initializers — dominated by `ReplayIntegration.<clinit>` — which now run lazily on first use instead of under the probe. At whole-startup granularity (`timeToInitialDisplay` ≈ 563 ms ± 50 ms) the change is below run-to-run noise; it's a critical-path micro-optimization, not a measurable end-to-end startup win on its own.

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
