### PR TITLE
perf(core): [Init Reflection 2] Cache class lookups and collapse double probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
+
 ## 8.45.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Performance
 
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
+- Cache reflective class lookups and avoid double-probing during SDK init ([#5636](https://github.com/getsentry/sentry-java/pull/5636))
 
 ## 8.45.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Internal
+### Performance
 
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
 

--- a/sentry/src/main/java/io/sentry/ScopesStorageFactory.java
+++ b/sentry/src/main/java/io/sentry/ScopesStorageFactory.java
@@ -23,24 +23,23 @@ public final class ScopesStorageFactory {
   private static @NotNull IScopesStorage createInternal(
       final @NotNull LoadClass loadClass, final @NotNull ILogger logger) {
     if (Platform.isJvm()) {
-      if (loadClass.isClassAvailable(OTEL_SCOPES_STORAGE, logger)) {
-        Class<?> otelScopesStorageClazz = loadClass.loadClass(OTEL_SCOPES_STORAGE, logger);
-        if (otelScopesStorageClazz != null) {
-          try {
-            final @Nullable Object otelScopesStorage =
-                otelScopesStorageClazz.getDeclaredConstructor().newInstance();
-            if (otelScopesStorage instanceof IScopesStorage) {
-              return (IScopesStorage) otelScopesStorage;
-            }
-          } catch (InstantiationException e) {
-            // TODO log
-          } catch (IllegalAccessException e) {
-            // TODO log
-          } catch (InvocationTargetException e) {
-            // TODO log
-          } catch (NoSuchMethodException e) {
-            // TODO log
+      final @Nullable Class<?> otelScopesStorageClazz =
+          loadClass.loadClass(OTEL_SCOPES_STORAGE, logger);
+      if (otelScopesStorageClazz != null) {
+        try {
+          final @Nullable Object otelScopesStorage =
+              otelScopesStorageClazz.getDeclaredConstructor().newInstance();
+          if (otelScopesStorage instanceof IScopesStorage) {
+            return (IScopesStorage) otelScopesStorage;
           }
+        } catch (InstantiationException e) {
+          // TODO log
+        } catch (IllegalAccessException e) {
+          // TODO log
+        } catch (InvocationTargetException e) {
+          // TODO log
+        } catch (NoSuchMethodException e) {
+          // TODO log
         }
       }
     }

--- a/sentry/src/main/java/io/sentry/SpanFactoryFactory.java
+++ b/sentry/src/main/java/io/sentry/SpanFactoryFactory.java
@@ -15,24 +15,23 @@ public final class SpanFactoryFactory {
   public static @NotNull ISpanFactory create(
       final @NotNull LoadClass loadClass, final @NotNull ILogger logger) {
     if (Platform.isJvm()) {
-      if (loadClass.isClassAvailable(OTEL_SPAN_FACTORY, logger)) {
-        Class<?> otelSpanFactoryClazz = loadClass.loadClass(OTEL_SPAN_FACTORY, logger);
-        if (otelSpanFactoryClazz != null) {
-          try {
-            final @Nullable Object otelSpanFactory =
-                otelSpanFactoryClazz.getDeclaredConstructor().newInstance();
-            if (otelSpanFactory instanceof ISpanFactory) {
-              return (ISpanFactory) otelSpanFactory;
-            }
-          } catch (InstantiationException e) {
-            // TODO log
-          } catch (IllegalAccessException e) {
-            // TODO log
-          } catch (InvocationTargetException e) {
-            // TODO log
-          } catch (NoSuchMethodException e) {
-            // TODO log
+      final @Nullable Class<?> otelSpanFactoryClazz =
+          loadClass.loadClass(OTEL_SPAN_FACTORY, logger);
+      if (otelSpanFactoryClazz != null) {
+        try {
+          final @Nullable Object otelSpanFactory =
+              otelSpanFactoryClazz.getDeclaredConstructor().newInstance();
+          if (otelSpanFactory instanceof ISpanFactory) {
+            return (ISpanFactory) otelSpanFactory;
           }
+        } catch (InstantiationException e) {
+          // TODO log
+        } catch (IllegalAccessException e) {
+          // TODO log
+        } catch (InvocationTargetException e) {
+          // TODO log
+        } catch (NoSuchMethodException e) {
+          // TODO log
         }
       }
     }

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -12,17 +12,23 @@ import org.jetbrains.annotations.Nullable;
 public class LoadClass {
 
   /**
-   * Try to load a class via reflection
+   * Loads and initializes a class via reflection. Use this when you intend to actually use the
+   * class (e.g. instantiate it or invoke its methods). The returned class is fully initialized, so
+   * its static initializers run. To merely check whether a class is on the classpath, use {@link
+   * #isClassAvailable} instead, which avoids running those initializers.
    *
    * @param clazz the full class name
    * @param logger an instance of ILogger
    * @return a Class&lt;?&gt; if it's available, or null
    */
   public @Nullable Class<?> loadClass(final @NotNull String clazz, final @Nullable ILogger logger) {
+    return loadClass(clazz, logger, true);
+  }
+
+  private @Nullable Class<?> loadClass(
+      final @NotNull String clazz, final @Nullable ILogger logger, final boolean initialize) {
     try {
-      // Don't initialize the class just to probe for availability; it gets initialized lazily on
-      // first use. This avoids running unrelated static initializers during SDK init.
-      return Class.forName(clazz, false, LoadClass.class.getClassLoader());
+      return Class.forName(clazz, initialize, LoadClass.class.getClassLoader());
     } catch (ClassNotFoundException e) {
       if (logger != null) {
         logger.log(SentryLevel.INFO, "Class not available: " + clazz);
@@ -39,8 +45,19 @@ public class LoadClass {
     return null;
   }
 
+  /**
+   * Probes whether a class is on the classpath without initializing it. Use this for availability
+   * checks (e.g. deciding whether to register an integration); the class is not initialized, so its
+   * static initializers do not run until something actually uses it. This keeps SDK init cheap by
+   * not triggering unrelated initializers. If you need to use the class, use {@link #loadClass}
+   * instead.
+   *
+   * @param clazz the full class name
+   * @param logger an instance of ILogger
+   * @return true if the class is on the classpath
+   */
   public boolean isClassAvailable(final @NotNull String clazz, final @Nullable ILogger logger) {
-    return loadClass(clazz, logger) != null;
+    return loadClass(clazz, logger, false) != null;
   }
 
   public boolean isClassAvailable(
@@ -48,6 +65,15 @@ public class LoadClass {
     return isClassAvailable(clazz, options != null ? options.getLogger() : null);
   }
 
+  /**
+   * Like {@link #isClassAvailable}, but defers the (non-initializing) availability check until the
+   * result is first read. Use this when the check itself should not run during SDK init but only
+   * later, on first access.
+   *
+   * @param clazz the full class name
+   * @param logger an instance of ILogger
+   * @return a lazily-evaluated availability check
+   */
   public LazyEvaluator<Boolean> isClassAvailableLazy(
       final @NotNull String clazz, final @Nullable ILogger logger) {
     return new LazyEvaluator<>(() -> isClassAvailable(clazz, logger));

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -20,7 +20,9 @@ public class LoadClass {
    */
   public @Nullable Class<?> loadClass(final @NotNull String clazz, final @Nullable ILogger logger) {
     try {
-      return Class.forName(clazz);
+      // Don't initialize the class just to probe for availability; it gets initialized lazily on
+      // first use. This avoids running unrelated static initializers during SDK init.
+      return Class.forName(clazz, false, LoadClass.class.getClassLoader());
     } catch (ClassNotFoundException e) {
       if (logger != null) {
         logger.log(SentryLevel.INFO, "Class not available: " + clazz);

--- a/sentry/src/main/java/io/sentry/util/LoadClass.java
+++ b/sentry/src/main/java/io/sentry/util/LoadClass.java
@@ -4,12 +4,24 @@ import com.jakewharton.nopen.annotation.Open;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** An Adapter for making Class.forName testable */
 @Open
 public class LoadClass {
+
+  /** Sentinel cached for class names that are known to be unavailable. */
+  private static final Object NOT_AVAILABLE = new Object();
+
+  /**
+   * Whether a class is on the classpath does not change during the lifetime of the process, so
+   * results are cached to avoid repeated {@link Class#forName} lookups (and the exceptions they
+   * throw for absent classes) when the same class is probed more than once.
+   */
+  private static final Map<String, Object> CLASSES = new ConcurrentHashMap<>();
 
   /**
    * Loads and initializes a class via reflection. Use this when you intend to actually use the
@@ -27,9 +39,17 @@ public class LoadClass {
 
   private @Nullable Class<?> loadClass(
       final @NotNull String clazz, final @Nullable ILogger logger, final boolean initialize) {
+    final @Nullable Object cached = CLASSES.get(clazz);
+    if (cached != null) {
+      return cached == NOT_AVAILABLE ? null : (Class<?>) cached;
+    }
     try {
-      return Class.forName(clazz, initialize, LoadClass.class.getClassLoader());
+      final Class<?> loadedClass =
+          Class.forName(clazz, initialize, LoadClass.class.getClassLoader());
+      CLASSES.put(clazz, loadedClass);
+      return loadedClass;
     } catch (ClassNotFoundException e) {
+      CLASSES.put(clazz, NOT_AVAILABLE);
       if (logger != null) {
         logger.log(SentryLevel.INFO, "Class not available: " + clazz);
       }

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -1,0 +1,49 @@
+package io.sentry.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class LoadClassTest {
+  @Test
+  fun `loadClass returns the class when it is available`() {
+    assertNotNull(LoadClass().loadClass("io.sentry.SentryEvent", null))
+  }
+
+  @Test
+  fun `loadClass returns null when the class is not available`() {
+    assertNull(LoadClass().loadClass("io.sentry.ThisClassDoesNotExist", null))
+  }
+
+  @Test
+  fun `isClassAvailable reflects whether the class is on the classpath`() {
+    val loadClass = LoadClass()
+    assertNotNull(loadClass.loadClass("io.sentry.SentryEvent", null))
+    assertFalse(
+      loadClass.isClassAvailable("io.sentry.ThisClassDoesNotExist", null as io.sentry.ILogger?)
+    )
+  }
+
+  @Test
+  fun `loadClass does not run the static initializer of the probed class`() {
+    // Reading the flag initializes the flag holder, not the probe.
+    assertFalse(LoadClassNoInitFlag.initialized)
+
+    // Obtaining the name via ::class.java does not initialize the probe either.
+    LoadClass().loadClass(LoadClassNoInitProbe::class.java.name, null)
+
+    // Availability probing must not trigger the probe's static initializer.
+    assertFalse(LoadClassNoInitFlag.initialized)
+  }
+}
+
+private object LoadClassNoInitFlag {
+  @JvmField var initialized = false
+}
+
+private object LoadClassNoInitProbe {
+  init {
+    LoadClassNoInitFlag.initialized = true
+  }
+}

--- a/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LoadClassTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LoadClassTest {
   @Test
@@ -26,24 +27,44 @@ class LoadClassTest {
   }
 
   @Test
-  fun `loadClass does not run the static initializer of the probed class`() {
+  fun `isClassAvailable does not run the static initializer of the probed class`() {
     // Reading the flag initializes the flag holder, not the probe.
-    assertFalse(LoadClassNoInitFlag.initialized)
+    assertFalse(IsClassAvailableNoInitFlag.initialized)
 
     // Obtaining the name via ::class.java does not initialize the probe either.
-    LoadClass().loadClass(LoadClassNoInitProbe::class.java.name, null)
+    LoadClass()
+      .isClassAvailable(IsClassAvailableNoInitProbe::class.java.name, null as io.sentry.ILogger?)
 
     // Availability probing must not trigger the probe's static initializer.
-    assertFalse(LoadClassNoInitFlag.initialized)
+    assertFalse(IsClassAvailableNoInitFlag.initialized)
+  }
+
+  @Test
+  fun `loadClass runs the static initializer of the loaded class`() {
+    assertFalse(LoadClassInitFlag.initialized)
+
+    LoadClass().loadClass(LoadClassInitProbe::class.java.name, null)
+
+    assertTrue(LoadClassInitFlag.initialized)
   }
 }
 
-private object LoadClassNoInitFlag {
+private object IsClassAvailableNoInitFlag {
   @JvmField var initialized = false
 }
 
-private object LoadClassNoInitProbe {
+private object IsClassAvailableNoInitProbe {
   init {
-    LoadClassNoInitFlag.initialized = true
+    IsClassAvailableNoInitFlag.initialized = true
+  }
+}
+
+private object LoadClassInitFlag {
+  @JvmField var initialized = false
+}
+
+private object LoadClassInitProbe {
+  init {
+    LoadClassInitFlag.initialized = true
   }
 }


### PR DESCRIPTION
## PR Stack (Init Reflection)

- #5634 — collection
- #5635 — [1] Probe class availability without initializing
- #5636 — [2] Cache class lookups and collapse double probes
- #5637 — [3] Gate Compose class probes behind their features

---

Part of [JAVA-587](https://linear.app/getsentry/issue/JAVA-587/reduce-reflection-cost-on-the-sdk-init-path)

## :scroll: Description

Two related reflection-cost reductions on top of [Init Reflection 1]:

- **Cache `LoadClass` results.** Whether a class is on the classpath doesn't change during the process lifetime, so results (including "not available") are cached in a static map. Repeated probes of the same class skip `Class.forName` entirely — and skip the `ClassNotFoundException` thrown for absent classes.
- **Collapse double-probes.** `SpanFactoryFactory` and `ScopesStorageFactory` called `isClassAvailable(X)` and then `loadClass(X)` — two `Class.forName` calls for the same class. They now call `loadClass(X)` once and null-check.

## :bulb: Motivation and Context

Second of three stacked PRs reducing reflection cost on the init path (customer-provided Perfetto trace, *Reduce SDK init time [Android]*).

## :green_heart: How did you test it?

Existing `LoadClassTest`, factory, and `Sentry` init tests pass; the cache returns identical availability results.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

PR 3 gates the Compose class probes behind the features that consume them.


## :stopwatch: Pixel 3 benchmark (untraced timing)

Repeatedly probing the same absent class (2000 calls × 6 rounds; cache hits after the first miss):

| | old (uncached `forName` each call) | new (cached) |
|---|---:|---:|
| per probe | 25,872 ns | **137 ns** |

~**188× faster** for repeat probes — once the first miss caches `NOT_AVAILABLE`, later probes skip both the `Class.forName` call and the `ClassNotFoundException`. (Traced counts are noisy here due to background class loading, so this is measured untraced.)

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
