### PR TITLE
perf(android): [Init Reflection 3] Gate Compose class probes behind their features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
 - Cache reflective class lookups and avoid double-probing during SDK init ([#5636](https://github.com/getsentry/sentry-java/pull/5636))
+- Only probe for Compose classes during init when user interaction tracking or view hierarchy capture is enabled ([#5637](https://github.com/getsentry/sentry-java/pull/5637))
 
 ## 8.45.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AndroidOptionsInitializer.java
@@ -211,15 +211,18 @@ final class AndroidOptionsInitializer {
 
     final @NotNull LazyEvaluator<Boolean> isAndroidXScrollViewAvailable =
         loadClass.isClassAvailableLazy("androidx.core.view.ScrollingView", options);
-    final boolean isComposeUpstreamAvailable =
-        loadClass.isClassAvailable(COMPOSE_CLASS_NAME, options);
 
-    if (options.getGestureTargetLocators().isEmpty()) {
+    // Gated behind the features that actually consume these so the Compose class lookups only run
+    // when user interaction tracking or view hierarchy capture is enabled. Repeated COMPOSE_CLASS
+    // probes across both blocks are deduplicated by LoadClass's cache.
+    final boolean isUserInteractionEnabled =
+        options.isEnableUserInteractionBreadcrumbs() || options.isEnableUserInteractionTracing();
+    if (isUserInteractionEnabled && options.getGestureTargetLocators().isEmpty()) {
       final List<GestureTargetLocator> gestureTargetLocators = new ArrayList<>(2);
       gestureTargetLocators.add(new AndroidViewGestureTargetLocator(isAndroidXScrollViewAvailable));
 
       final boolean isComposeAvailable =
-          (isComposeUpstreamAvailable
+          (loadClass.isClassAvailable(COMPOSE_CLASS_NAME, options)
               && loadClass.isClassAvailable(
                   SENTRY_COMPOSE_GESTURE_INTEGRATION_CLASS_NAME, options));
 
@@ -229,8 +232,9 @@ final class AndroidOptionsInitializer {
       options.setGestureTargetLocators(gestureTargetLocators);
     }
 
-    if (options.getViewHierarchyExporters().isEmpty()
-        && isComposeUpstreamAvailable
+    if (options.isAttachViewHierarchy()
+        && options.getViewHierarchyExporters().isEmpty()
+        && loadClass.isClassAvailable(COMPOSE_CLASS_NAME, options)
         && loadClass.isClassAvailable(
             SENTRY_COMPOSE_VIEW_HIERARCHY_INTEGRATION_CLASS_NAME, options)) {
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidOptionsInitializerTest.kt
@@ -807,6 +807,51 @@ class AndroidOptionsInitializerTest {
   }
 
   @Test
+  fun `does not set gesture target locators when user interaction tracking is disabled`() {
+    fixture.sentryOptions.isEnableUserInteractionBreadcrumbs = false
+    fixture.sentryOptions.isEnableUserInteractionTracing = false
+
+    fixture.initSutWithClassLoader(
+      classesToLoad =
+        listOf(
+          AndroidOptionsInitializer.COMPOSE_CLASS_NAME,
+          AndroidOptionsInitializer.SENTRY_COMPOSE_GESTURE_INTEGRATION_CLASS_NAME,
+        )
+    )
+
+    assertTrue { fixture.sentryOptions.gestureTargetLocators.isEmpty() }
+  }
+
+  @Test
+  fun `does not set compose view hierarchy exporter when attachViewHierarchy is disabled`() {
+    // attachViewHierarchy defaults to false
+    fixture.initSutWithClassLoader(
+      classesToLoad =
+        listOf(
+          AndroidOptionsInitializer.COMPOSE_CLASS_NAME,
+          AndroidOptionsInitializer.SENTRY_COMPOSE_VIEW_HIERARCHY_INTEGRATION_CLASS_NAME,
+        )
+    )
+
+    assertTrue { fixture.sentryOptions.viewHierarchyExporters.isEmpty() }
+  }
+
+  @Test
+  fun `sets compose view hierarchy exporter when attachViewHierarchy is enabled and compose is available`() {
+    fixture.sentryOptions.isAttachViewHierarchy = true
+
+    fixture.initSutWithClassLoader(
+      classesToLoad =
+        listOf(
+          AndroidOptionsInitializer.COMPOSE_CLASS_NAME,
+          AndroidOptionsInitializer.SENTRY_COMPOSE_VIEW_HIERARCHY_INTEGRATION_CLASS_NAME,
+        )
+    )
+
+    assertTrue { fixture.sentryOptions.viewHierarchyExporters.size == 1 }
+  }
+
+  @Test
   fun `AndroidMemoryCollector is set to options`() {
     fixture.initSut()
 


### PR DESCRIPTION
## PR Stack (Init Reflection)

- #5634 — collection
- #5635 — [1] Probe class availability without initializing
- #5636 — [2] Cache class lookups and collapse double probes
- #5637 — [3] Gate Compose class probes behind their features

---

Part of [JAVA-587](https://linear.app/getsentry/issue/JAVA-587/reduce-reflection-cost-on-the-sdk-init-path)

## :scroll: Description

The Compose gesture and view-hierarchy class lookups ran during `init` regardless of configuration. Probing `androidx.compose.ui.node.Owner` is the most expensive lookup in the trace (it triggers `Owner.<clinit>` before [Init Reflection 1]).

This gates them behind the features that actually consume them:
- gesture locators (and their Compose probes) → `enableUserInteractionBreadcrumbs || enableUserInteractionTracing`
- Compose view-hierarchy exporter probe → `attachViewHierarchy` (default `false`)

Repeated `COMPOSE_CLASS_NAME` probes across the two blocks are deduplicated by the `LoadClass` cache from [Init Reflection 2].

## :bulb: Motivation and Context

Third of three stacked PRs reducing reflection cost on the init path (customer-provided Perfetto trace, *Reduce SDK init time [Android]*).

## :green_heart: How did you test it?

New `AndroidOptionsInitializerTest` cases: no gesture locators when user interaction tracking is disabled; no Compose view-hierarchy exporter when `attachViewHierarchy` is off; exporter present when enabled and Compose is available. Full `sentry-android-core` unit tests pass.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps

Top of the Init Reflection stack.


## :stopwatch: Pixel 3 benchmark (ART method trace → Perfetto trace_processor)

With user interaction tracking and view hierarchy capture disabled, the Compose class probes init used to run unconditionally:

| | old (ungated) | new (gated) |
|---|---:|---:|
| Compose class probes | 3 | **0** |
| resulting `ClassNotFoundException` constructions | 9 | **0** |

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
