### PR TITLE
build: Remove redundant mavenCentral repository declarations

### DIFF
--- a/sentry-reactor/build.gradle.kts
+++ b/sentry-reactor/build.gradle.kts
@@ -62,8 +62,6 @@ tasks.withType<JavaCompile>().configureEach {
   }
 }
 
-repositories { mavenCentral() }
-
 tasks.jar {
   manifest {
     attributes(

--- a/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-opentelemetry-noagent/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console-otlp/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-console/build.gradle.kts
+++ b/sentry-samples/sentry-samples-console/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-jul/build.gradle.kts
+++ b/sentry-samples/sentry-samples-jul/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-log4j2/build.gradle.kts
+++ b/sentry-samples/sentry-samples-log4j2/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-logback/build.gradle.kts
+++ b/sentry-samples/sentry-samples-logback/build.gradle.kts
@@ -15,8 +15,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-netflix-dgs/build.gradle.kts
+++ b/sentry-samples/sentry-samples-netflix-dgs/build.gradle.kts
@@ -19,8 +19,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(platform(libs.springboot2.bom))
   implementation(libs.springboot.starter.web)

--- a/sentry-samples/sentry-samples-servlet/build.gradle.kts
+++ b/sentry-samples/sentry-samples-servlet/build.gradle.kts
@@ -8,8 +8,6 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(projects.sentryServlet)
   implementation("javax.servlet:javax.servlet-api:4.0.1")

--- a/sentry-samples/sentry-samples-spring-7/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-7/build.gradle.kts
@@ -26,8 +26,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencyManagement { imports { mavenBom(SpringBootPlugin.BOM_COORDINATES) } }
 
 dependencies {

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry-noagent/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-opentelemetry/build.gradle.kts
@@ -18,8 +18,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-otlp/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4-webflux/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencies {
   implementation(Config.Libs.kotlinReflect)
   implementation(kotlin(Config.kotlinStdLib, KotlinCompilerVersion.VERSION))

--- a/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-4/build.gradle.kts
@@ -17,8 +17,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 configure<JavaPluginExtension> {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry-noagent/build.gradle.kts
@@ -18,8 +18,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencyManagement {
   imports {
     mavenBom("org.springframework.boot:spring-boot-dependencies:${libs.versions.springboot3.get()}")

--- a/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta-opentelemetry/build.gradle.kts
@@ -19,8 +19,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencyManagement {
   imports {
     mavenBom("org.springframework.boot:spring-boot-dependencies:${libs.versions.springboot3.get()}")

--- a/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-jakarta/build.gradle.kts
@@ -18,8 +18,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencyManagement {
   imports {
     mavenBom("org.springframework.boot:spring-boot-dependencies:${libs.versions.springboot3.get()}")

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry-noagent/build.gradle.kts
@@ -21,8 +21,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories { mavenCentral() }
-
 fun springBoot2SupportsOptionalIntegrations(): Boolean {
   val version = libs.versions.springboot2.get().removeSuffix(".RELEASE")
   val parts = version.split(".").map { it.toIntOrNull() ?: 0 }

--- a/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-opentelemetry/build.gradle.kts
@@ -21,8 +21,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories { mavenCentral() }
-
 fun springBoot2SupportsOptionalIntegrations(): Boolean {
   val version = libs.versions.springboot2.get().removeSuffix(".RELEASE")
   val parts = version.split(".").map { it.toIntOrNull() ?: 0 }

--- a/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux-jakarta/build.gradle.kts
@@ -18,8 +18,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 dependencyManagement {
   imports {
     mavenBom("org.springframework.boot:spring-boot-dependencies:${libs.versions.springboot3.get()}")

--- a/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot-webflux/build.gradle.kts
@@ -21,8 +21,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories { mavenCentral() }
-
 fun springBoot2SupportsGraphql(): Boolean {
   val version = libs.versions.springboot2.get().removeSuffix(".RELEASE")
   val parts = version.split(".").map { it.toIntOrNull() ?: 0 }

--- a/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-boot/build.gradle.kts
@@ -21,8 +21,6 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 java.targetCompatibility = JavaVersion.VERSION_11
 
-repositories { mavenCentral() }
-
 fun springBoot2SupportsOptionalIntegrations(): Boolean {
   val version = libs.versions.springboot2.get().removeSuffix(".RELEASE")
   val parts = version.split(".").map { it.toIntOrNull() ?: 0 }

--- a/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring-jakarta/build.gradle.kts
@@ -24,8 +24,6 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 
 java.targetCompatibility = JavaVersion.VERSION_17
 
-repositories { mavenCentral() }
-
 // Apollo 4.x requires coroutines 1.9.0+, override Spring Boot's managed version
 extra["kotlin-coroutines.version"] = "1.9.0"
 

--- a/sentry-samples/sentry-samples-spring/build.gradle.kts
+++ b/sentry-samples/sentry-samples-spring/build.gradle.kts
@@ -25,8 +25,6 @@ java {
   targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-repositories { mavenCentral() }
-
 // Apollo 4.x requires coroutines 1.9.0+, override Spring Boot's managed version
 extra["kotlin-coroutines.version"] = "1.9.0"
 


### PR DESCRIPTION
## :scroll: Description
Removes the module-level `repositories { mavenCentral() }` block from all 25 build files that declared it — `sentry-reactor` and 24 sample modules.

## :bulb: Motivation and Context
`settings.gradle.kts` already declares `google()`, `mavenCentral()` and `mavenLocal()` centrally via `dependencyResolutionManagement` for every project, so these per-module blocks were redundant. With Gradle's default `PREFER_PROJECT` mode, declaring `mavenCentral()` in a module actually *narrowed* that module to only mavenCentral and ignored the central repositories; removing the block lets it fall back to the central superset, with no effect on resolution.

This is a follow-up to the earlier redundant build-script cleanups (#5624, #5633).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
