### PR TITLE
perf(android): Defer SentryFrameMetricsCollector thread startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Speed up touch gesture target detection on deeply nested view hierarchies by hit-testing in local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
 - Avoid constructing an exception per view when resolving view ids during view-hierarchy and gesture capture ([#5631](https://github.com/getsentry/sentry-java/pull/5631))
+- Start the frame metrics thread lazily on first collection instead of during SDK init ([#5641](https://github.com/getsentry/sentry-java/pull/5641))
 
 ## 8.46.0
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -14,12 +14,14 @@ import android.view.FrameMetrics;
 import android.view.Window;
 import androidx.annotation.RequiresApi;
 import io.sentry.ILogger;
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SentryUUID;
 import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.android.core.ContextUtils;
 import io.sentry.android.core.SentryFramesDelayResult;
+import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -45,7 +47,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
   private final @NotNull Set<Window> trackedWindows = new CopyOnWriteArraySet<>();
 
   private final @NotNull ILogger logger;
-  private @Nullable Handler handler;
+  private volatile @Nullable Handler handler;
+  private final @NotNull AutoClosableReentrantLock handlerLock = new AutoClosableReentrantLock();
   private @Nullable WeakReference<Window> currentWindow;
   private final @NotNull Map<String, FrameMetricsCollectorListener> listenerMap =
       new ConcurrentHashMap<>();
@@ -113,12 +116,8 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
     }
     isAvailable = true;
 
-    HandlerThread handlerThread =
-        new HandlerThread("io.sentry.android.core.internal.util.SentryFrameMetricsCollector");
-    handlerThread.setUncaughtExceptionHandler(
-        (thread, e) -> logger.log(SentryLevel.ERROR, "Error during frames measurements.", e));
-    handlerThread.start();
-    handler = new Handler(handlerThread.getLooper());
+    // The frame metrics HandlerThread is started lazily on the first startCollection() call.
+    // Starting it here would block the main thread on HandlerThread.getLooper() during SDK init.
 
     // We have to register the lifecycle callback, even if no profile is started, otherwise when we
     // start a profile, we wouldn't have the current activity and couldn't get the frameMetrics.
@@ -281,10 +280,32 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
     if (!isAvailable) {
       return null;
     }
+    ensureHandlerThreadStarted();
     final String uid = SentryUUID.generateSentryId();
     listenerMap.put(uid, listener);
     trackCurrentWindow();
     return uid;
+  }
+
+  /**
+   * Lazily starts the background HandlerThread used to receive frame metrics. Deferred out of the
+   * constructor because {@link HandlerThread#getLooper()} blocks the caller (the main thread during
+   * SDK init) until the thread is ready, and the handler is only needed once collection starts.
+   */
+  private void ensureHandlerThreadStarted() {
+    if (handler != null) {
+      return;
+    }
+    try (final @NotNull ISentryLifecycleToken ignored = handlerLock.acquire()) {
+      if (handler == null) {
+        final HandlerThread handlerThread =
+            new HandlerThread("io.sentry.android.core.internal.util.SentryFrameMetricsCollector");
+        handlerThread.setUncaughtExceptionHandler(
+            (thread, e) -> logger.log(SentryLevel.ERROR, "Error during frames measurements.", e));
+        handlerThread.start();
+        handler = new Handler(handlerThread.getLooper());
+      }
+    }
   }
 
   public void stopCollection(final @Nullable String listenerId) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollectorTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollectorTest.kt
@@ -142,6 +142,16 @@ class SentryFrameMetricsCollectorTest {
   }
 
   @Test
+  fun `handler thread is started lazily on first startCollection`() {
+    val collector = fixture.getSut(context)
+    // not started during construction (would block the main thread on getLooper at SDK init)
+    assertNull(collector.getProperty<Handler?>("handler"))
+
+    collector.startCollection(mock())
+    assertNotNull(collector.getProperty<Handler?>("handler"))
+  }
+
+  @Test
   fun `collector calls addOnFrameMetricsAvailableListener when an activity starts`() {
     val collector = fixture.getSut(context)
 


### PR DESCRIPTION
Resolves [JAVA-535](https://linear.app/getsentry/issue/JAVA-535/defer-sentryframemetricscollector-thread-startup)

## :scroll: Description

`SentryFrameMetricsCollector` created and started its `HandlerThread` in the constructor and then called `new Handler(handlerThread.getLooper())`. `getLooper()` **blocks** the caller until the new thread's looper is ready — and the collector is constructed on the **main thread** during `SentryAndroid.init` (`loadDefaultAndMetadataOptions`).

The `handler` is only ever used by `trackCurrentWindow()`, which no-ops until a listener is registered via `startCollection()`. So this starts the `HandlerThread` lazily on the first `startCollection()` (profiling / `SpanFrameMetricsCollector`). The constructor still registers the activity-lifecycle callback (current-window tracking is unchanged) but no longer blocks. Apps that never collect frame metrics never start the thread at all.

Reusing the SDK's shared executor isn't viable here: `addOnFrameMetricsAvailableListener` requires a dedicated non-main-thread `Handler` (Looper), which the shared `ScheduledExecutorService` doesn't provide — so the right move is to defer the dedicated thread, not share one.

## :bulb: Motivation and Context

From the customer-provided Perfetto trace (`sentryinvest`): the main thread blocked ~5.75 ms on `HandlerThread.getLooper()` during init via `SentryFrameMetricsCollector.<init>`.

## :green_heart: How did you test it?

`SentryFrameMetricsCollectorTest` (incl. a new test asserting `handler` is null after construction and non-null after `startCollection`); full `sentry-android-core` suite passes.

**Pixel 3 (Android 12) benchmark — ART method trace → Perfetto trace_processor:**

| construction | `HandlerThread.getLooper()` | blocking `Object.wait()` |
|---|---:|---:|
| old (pre-change) | 1 | 1 |
| new (deferred) | **0** | **0** |

The synchronous main-thread wait for the frame-metrics looper is entirely removed from construction.

**Cold-start A/B — `sentry-samples-android` (release, Pixel 3, 15 cold starts each via `am start -W -S`, `TotalTime` ms, first cold-disk run dropped):**

| | median | mean | min | stdev |
|---|---:|---:|---:|---:|
| with change | 434 | 434 | 416 | 9 |
| without change | 441 | 459 | 421 | 49 |

Directionally faster on every statistic, but **within end-to-end cold-start noise**. Note this sample auto-inits Sentry *and* calls `Sentry.startProfiler()` in `onCreate`, so frame collection (the lazy-thread trigger) fires during startup either way — the change just moves *when* within startup. So this isn't a strong end-to-end showcase; the deterministic proof is the ART trace above. The real win is for apps that don't start frame collection at startup (the thread is then never created at init).

> ⚠️ **Caveat:** these runs were captured in a very warm room (~34 °C), so thermal throttling may have affected the absolute timings and likely contributed to the elevated variance / spikes in the "without change" run (stdev 49 vs 9).

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
