### PR TITLE
perf(core): Lazily allocate AutoClosableReentrantLock (JAVA-588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Avoid constructing an exception per view when resolving view ids during view-hierarchy and gesture capture ([#5631](https://github.com/getsentry/sentry-java/pull/5631))
 - Start the frame metrics thread lazily on first collection instead of during SDK init ([#5641](https://github.com/getsentry/sentry-java/pull/5641))
 - Reduce `SentryId` and `SpanId` allocation overhead by replacing their per-instance `LazyEvaluator` (and its lock) with a lightweight lazily-generated `String`. ([#5645](https://github.com/getsentry/sentry-java/pull/5645))
+- Lazily allocate the `ReentrantLock` backing `AutoClosableReentrantLock` to avoid eager lock allocations for SDK objects that never contend during `SentryAndroid.init` ([#5643](https://github.com/getsentry/sentry-java/pull/5643))
 
 ## 8.46.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7589,7 +7589,7 @@ public abstract class io/sentry/transport/TransportResult {
 	public static fun success ()Lio/sentry/transport/TransportResult;
 }
 
-public final class io/sentry/util/AutoClosableReentrantLock : java/util/concurrent/locks/ReentrantLock {
+public final class io/sentry/util/AutoClosableReentrantLock {
 	public fun <init> ()V
 	public fun acquire ()Lio/sentry/ISentryLifecycleToken;
 }

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7589,9 +7589,10 @@ public abstract class io/sentry/transport/TransportResult {
 	public static fun success ()Lio/sentry/transport/TransportResult;
 }
 
-public final class io/sentry/util/AutoClosableReentrantLock {
+public final class io/sentry/util/AutoClosableReentrantLock : io/sentry/ISentryLifecycleToken {
 	public fun <init> ()V
 	public fun acquire ()Lio/sentry/ISentryLifecycleToken;
+	public fun close ()V
 }
 
 public final class io/sentry/util/CheckInUtils {

--- a/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
+++ b/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
@@ -1,16 +1,57 @@
 package io.sentry.util;
 
 import io.sentry.ISentryLifecycleToken;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantLock;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
-public final class AutoClosableReentrantLock extends ReentrantLock {
+/**
+ * Hands out an {@link ISentryLifecycleToken} from {@link #acquire()} for use with
+ * try-with-resources (replacing {@code synchronized} blocks).
+ *
+ * <p>The underlying {@link ReentrantLock} is created lazily on the first {@link #acquire()}. Many
+ * SDK objects hold a lock but never contend on it (especially during {@code SentryAndroid.init}),
+ * so the eager allocation of a {@link ReentrantLock} (and its {@code AbstractQueuedSynchronizer})
+ * was pure GC and main-thread overhead. We keep a {@link ReentrantLock} rather than reverting to
+ * {@code synchronized} to stay friendly to virtual threads (Loom), see #3715.
+ */
+public final class AutoClosableReentrantLock {
 
-  private static final long serialVersionUID = -3283069816958445549L;
+  private static final @NotNull AtomicReferenceFieldUpdater<
+          AutoClosableReentrantLock, ReentrantLock>
+      LOCK_UPDATER =
+          AtomicReferenceFieldUpdater.newUpdater(
+              AutoClosableReentrantLock.class, ReentrantLock.class, "lock");
 
-  public ISentryLifecycleToken acquire() {
-    lock();
-    return new AutoClosableReentrantLockLifecycleToken(this);
+  private volatile @Nullable ReentrantLock lock;
+
+  public @NotNull ISentryLifecycleToken acquire() {
+    final @NotNull ReentrantLock theLock = getOrCreateLock();
+    theLock.lock();
+    return new AutoClosableReentrantLockLifecycleToken(theLock);
+  }
+
+  private @NotNull ReentrantLock getOrCreateLock() {
+    final @Nullable ReentrantLock existing = lock;
+    if (existing != null) {
+      return existing;
+    }
+    // The loser of the race discards its candidate and uses the winner's lock, so all callers
+    // contend on the same instance.
+    final @NotNull ReentrantLock candidate = new ReentrantLock();
+    if (LOCK_UPDATER.compareAndSet(this, null, candidate)) {
+      return candidate;
+    }
+    final @Nullable ReentrantLock winner = lock;
+    return winner != null ? winner : candidate;
+  }
+
+  @TestOnly
+  boolean isLocked() {
+    final @Nullable ReentrantLock current = lock;
+    return current != null && current.isLocked();
   }
 
   static final class AutoClosableReentrantLockLifecycleToken implements ISentryLifecycleToken {

--- a/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
+++ b/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
@@ -3,6 +3,7 @@ package io.sentry.util;
 import io.sentry.ISentryLifecycleToken;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantLock;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -17,6 +18,7 @@ import org.jetbrains.annotations.TestOnly;
  * was pure GC and main-thread overhead. We keep a {@link ReentrantLock} rather than reverting to
  * {@code synchronized} to stay friendly to virtual threads (Loom), see #3715.
  */
+@ApiStatus.Internal
 public final class AutoClosableReentrantLock {
 
   private static final @NotNull AtomicReferenceFieldUpdater<
@@ -38,20 +40,24 @@ public final class AutoClosableReentrantLock {
     if (existing != null) {
       return existing;
     }
-    // The loser of the race discards its candidate and uses the winner's lock, so all callers
-    // contend on the same instance.
     final @NotNull ReentrantLock candidate = new ReentrantLock();
     if (LOCK_UPDATER.compareAndSet(this, null, candidate)) {
       return candidate;
     }
-    final @Nullable ReentrantLock winner = lock;
-    return winner != null ? winner : candidate;
+    // The CAS can only fail because another thread installed its lock first, and the field is
+    // never reset, so all callers end up contending on that same instance.
+    return Objects.requireNonNull(lock, "lock must have been set by the winning thread");
   }
 
   @TestOnly
   boolean isLocked() {
     final @Nullable ReentrantLock current = lock;
     return current != null && current.isLocked();
+  }
+
+  @TestOnly
+  boolean isLockAllocated() {
+    return lock != null;
   }
 
   static final class AutoClosableReentrantLockLifecycleToken implements ISentryLifecycleToken {

--- a/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
+++ b/sentry/src/main/java/io/sentry/util/AutoClosableReentrantLock.java
@@ -17,9 +17,13 @@ import org.jetbrains.annotations.TestOnly;
  * so the eager allocation of a {@link ReentrantLock} (and its {@code AbstractQueuedSynchronizer})
  * was pure GC and main-thread overhead. We keep a {@link ReentrantLock} rather than reverting to
  * {@code synchronized} to stay friendly to virtual threads (Loom), see #3715.
+ *
+ * <p>{@link #acquire()} returns this instance as the token, so the steady-state acquire/close path
+ * allocates nothing. Reentrant acquires stay balanced because try-with-resources calls {@link
+ * #close()} exactly once per acquire.
  */
 @ApiStatus.Internal
-public final class AutoClosableReentrantLock {
+public final class AutoClosableReentrantLock implements ISentryLifecycleToken {
 
   private static final @NotNull AtomicReferenceFieldUpdater<
           AutoClosableReentrantLock, ReentrantLock>
@@ -30,9 +34,13 @@ public final class AutoClosableReentrantLock {
   private volatile @Nullable ReentrantLock lock;
 
   public @NotNull ISentryLifecycleToken acquire() {
-    final @NotNull ReentrantLock theLock = getOrCreateLock();
-    theLock.lock();
-    return new AutoClosableReentrantLockLifecycleToken(theLock);
+    getOrCreateLock().lock();
+    return this;
+  }
+
+  @Override
+  public void close() {
+    Objects.requireNonNull(lock, "close() called before acquire()").unlock();
   }
 
   private @NotNull ReentrantLock getOrCreateLock() {
@@ -58,19 +66,5 @@ public final class AutoClosableReentrantLock {
   @TestOnly
   boolean isLockAllocated() {
     return lock != null;
-  }
-
-  static final class AutoClosableReentrantLockLifecycleToken implements ISentryLifecycleToken {
-
-    private final @NotNull ReentrantLock lock;
-
-    AutoClosableReentrantLockLifecycleToken(final @NotNull ReentrantLock lock) {
-      this.lock = lock;
-    }
-
-    @Override
-    public void close() {
-      lock.unlock();
-    }
   }
 }

--- a/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
+++ b/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
@@ -19,7 +19,9 @@ class AutoClosableReentrantLockTest {
   @Test
   fun `does not allocate the underlying lock until first acquire`() {
     val lock = AutoClosableReentrantLock()
-    assertFalse(lock.isLocked)
+    assertFalse(lock.isLockAllocated)
+    lock.acquire().use {}
+    assertTrue(lock.isLockAllocated)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
+++ b/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class AutoClosableReentrantLockTest {
@@ -14,6 +15,12 @@ class AutoClosableReentrantLockTest {
     val lock = AutoClosableReentrantLock()
     lock.acquire().use { assertTrue(lock.isLocked) }
     assertFalse(lock.isLocked)
+  }
+
+  @Test
+  fun `acquire returns the lock itself as the token, allocating nothing`() {
+    val lock = AutoClosableReentrantLock()
+    lock.acquire().use { token -> assertSame(lock, token) }
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
+++ b/sentry/src/test/java/io/sentry/util/AutoClosableReentrantLockTest.kt
@@ -1,6 +1,10 @@
 package io.sentry.util
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -9,6 +13,51 @@ class AutoClosableReentrantLockTest {
   fun `calls lock in acquire and unlock on close`() {
     val lock = AutoClosableReentrantLock()
     lock.acquire().use { assertTrue(lock.isLocked) }
+    assertFalse(lock.isLocked)
+  }
+
+  @Test
+  fun `does not allocate the underlying lock until first acquire`() {
+    val lock = AutoClosableReentrantLock()
+    assertFalse(lock.isLocked)
+  }
+
+  @Test
+  fun `supports reentrant acquire from the same thread`() {
+    val lock = AutoClosableReentrantLock()
+    lock.acquire().use {
+      lock.acquire().use { assertTrue(lock.isLocked) }
+      assertTrue(lock.isLocked)
+    }
+    assertFalse(lock.isLocked)
+  }
+
+  @Test
+  fun `mutually excludes concurrent threads`() {
+    val lock = AutoClosableReentrantLock()
+    val inCriticalSection = AtomicInteger(0)
+    val maxObserved = AtomicInteger(0)
+    val start = CountDownLatch(1)
+    val threadCount = 8
+    val iterations = 1000
+    val threads =
+      (0 until threadCount).map {
+        Thread {
+          start.await()
+          repeat(iterations) {
+            lock.acquire().use {
+              val current = inCriticalSection.incrementAndGet()
+              maxObserved.accumulateAndGet(current, ::maxOf)
+              inCriticalSection.decrementAndGet()
+            }
+          }
+        }
+      }
+    threads.forEach(Thread::start)
+    start.countDown()
+    threads.forEach { it.join(TimeUnit.SECONDS.toMillis(10)) }
+
+    assertEquals(1, maxObserved.get())
     assertFalse(lock.isLocked)
   }
 }


### PR DESCRIPTION
## :scroll: Description

`io.sentry.util.AutoClosableReentrantLock` extended `java.util.concurrent.locks.ReentrantLock`, and ~57 SDK classes create one eagerly in a field initializer. Constructing the SDK object graph therefore allocated a `ReentrantLock` (plus its `AbstractQueuedSynchronizer` `Sync`) per object — even for objects whose lock is never acquired.

This change holds the `ReentrantLock` internally and creates it **lazily on the first `acquire()`**, using an `AtomicReferenceFieldUpdater` CAS so the lazy creation is atomic and stays Loom-friendly (no `synchronized`, preserving the intent of #3715). If the CAS loses the first-acquire race, the caller uses the winner's lock; that invariant is enforced with an explicit non-null check so a broken invariant fails loudly instead of silently handing two threads different locks.

On top of the lazy lock, `AutoClosableReentrantLock` now implements `ISentryLifecycleToken` itself and `acquire()` returns `this`, eliminating the per-acquire lifecycle-token allocation entirely. That allocation happened on **every** lock use forever, not just at init, so the steady-state acquire/close path is now allocation-free. Semantics are unchanged: try-with-resources closes once per acquire (reentrant acquires stay balanced) and unlocking without holding the lock still throws `IllegalMonitorStateException`.

## :bulb: Motivation and Context

Part of the *Reduce SDK init time [Android]* effort (JAVA-588). A customer-provided Perfetto trace showed ~81 `ReentrantLock` allocations on the **main thread** under `SentryAndroid.init`, contributing GC pressure and main-thread CPU. With lazy allocation, only locks actually acquired during init allocate; the many never-contended locks no longer allocate at construction.

**Compatibility note:** this is technically a binary-compatibility change — `AutoClosableReentrantLock` no longer extends `ReentrantLock`, so the inherited `ReentrantLock` public methods leave its API surface (reflected in `sentry.api`). A usage audit confirmed every call site uses only `acquire()` (try-with-resources); nothing calls `lock()`/`unlock()`/`tryLock()`/`isHeldByCurrentThread()` directly or types a field/param as `ReentrantLock`, so no caller is affected. The class is now also marked `@ApiStatus.Internal` to make explicit that it carries no compatibility guarantees for external consumers.

An on-device A/B benchmark on a Pixel 3 (run locally, not included in this PR) quantified the allocation reduction and confirmed `acquire()` hot-path throughput is unchanged — see results below.

## :chart_with_upwards_trend: Benchmark results (Pixel 3, Android 12)

Measured on a **release** build using ART instrumented method tracing, with slices counted in Perfetto `trace_processor` (btrace app-tracing is broken on this device). The A/B was done by swapping only `AutoClosableReentrantLock` between the old (`extends ReentrantLock`) and new (lazy) implementations and rebuilding; everything else is identical.

**Real `SentryAndroid.init` (cold) — lock allocations**

| | `ReentrantLock` (+ `AbstractQueuedSynchronizer`) allocated | `acquire()` calls |
|---|---|---|
| Old (eager) | 107 | 40 |
| New (lazy)  | 37  | 40 |

**70 fewer `ReentrantLock` allocations per init (140 fewer heap objects: 70 locks + 70 `Sync`), a ~65% reduction.** Counts were identical across 3 runs of each build. Both builds make the same 40 `acquire()` calls, so the init code path is unchanged — only never-contended locks stop allocating (37 distinct locks are acquired during init vs 107 created). (This benchmark app allocates 107; the customer trace above showed ~81.)

**Construction cost (per lock):** old ~73–78 ns/alloc, new ~60–66 ns/alloc → ~11.5 ns saved per allocation. Across the 70 avoided allocations that is ≈0.8 µs of direct allocation work per init — below the cold-start noise floor. The benefit is therefore reduced allocation/GC pressure, not a measurable init-latency win.

**`acquire()` hot path:** ~161 ns/op for `acquire()` + `close()` when the lock already exists — unchanged; the lazy path adds only a volatile read + null check after the first acquire.

## :green_heart: How did you test it?

Unit tests in `AutoClosableReentrantLockTest` (lazy creation asserted directly against the underlying lock field via a `@TestOnly` accessor, token identity — `acquire()` returns the lock itself, reentrancy, and an 8-thread × 1000-iteration mutual-exclusion stress test); full `:sentry:test` suite green.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Biggest remaining main-thread init cost in the same trace is Manifest parsing (~147ms) — tracked separately (SDK-1322 / JAVA-531, compile-time injection).

Fixes JAVA-588


