### PR TITLE
perf(core): Drop per-instance lock from SentryId and SpanId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Probe class availability without initializing the class during SDK init ([#5635](https://github.com/getsentry/sentry-java/pull/5635))
 - Avoid constructing an exception per view when resolving view ids during view-hierarchy and gesture capture ([#5631](https://github.com/getsentry/sentry-java/pull/5631))
 - Start the frame metrics thread lazily on first collection instead of during SDK init ([#5641](https://github.com/getsentry/sentry-java/pull/5641))
+- Reduce `SentryId` and `SpanId` allocation overhead by replacing their per-instance `LazyEvaluator` (and its lock) with a lightweight lazily-generated `String`. ([#5645](https://github.com/getsentry/sentry-java/pull/5645))
 
 ## 8.46.0
 

--- a/sentry/src/main/java/io/sentry/SpanId.java
+++ b/sentry/src/main/java/io/sentry/SpanId.java
@@ -2,24 +2,35 @@ package io.sentry;
 
 import static io.sentry.util.StringUtils.PROPER_NIL_UUID;
 
-import io.sentry.util.LazyEvaluator;
 import java.io.IOException;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class SpanId implements JsonSerializable {
   public static final SpanId EMPTY_ID =
       new SpanId(PROPER_NIL_UUID.replace("-", "").substring(0, 16));
 
-  private final @NotNull LazyEvaluator<String> lazyValue;
+  private volatile @Nullable String value;
 
   public SpanId(final @NotNull String value) {
-    Objects.requireNonNull(value, "value is required");
-    this.lazyValue = new LazyEvaluator<>(() -> value);
+    this.value = Objects.requireNonNull(value, "value is required");
   }
 
-  public SpanId() {
-    this.lazyValue = new LazyEvaluator<>(SentryUUID::generateSpanId);
+  public SpanId() {}
+
+  private @NotNull String getValue() {
+    String result = value;
+    if (result == null) {
+      synchronized (this) {
+        result = value;
+        if (result == null) {
+          result = SentryUUID.generateSpanId();
+          value = result;
+        }
+      }
+    }
+    return result;
   }
 
   @Override
@@ -27,17 +38,17 @@ public final class SpanId implements JsonSerializable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SpanId spanId = (SpanId) o;
-    return lazyValue.getValue().equals(spanId.lazyValue.getValue());
+    return getValue().equals(spanId.getValue());
   }
 
   @Override
   public int hashCode() {
-    return lazyValue.getValue().hashCode();
+    return getValue().hashCode();
   }
 
   @Override
   public String toString() {
-    return lazyValue.getValue();
+    return getValue();
   }
 
   // JsonElementSerializer
@@ -45,7 +56,7 @@ public final class SpanId implements JsonSerializable {
   @Override
   public void serialize(final @NotNull ObjectWriter writer, final @NotNull ILogger logger)
       throws IOException {
-    writer.value(lazyValue.getValue());
+    writer.value(getValue());
   }
 
   // JsonElementDeserializer

--- a/sentry/src/main/java/io/sentry/protocol/SentryId.java
+++ b/sentry/src/main/java/io/sentry/protocol/SentryId.java
@@ -6,7 +6,6 @@ import io.sentry.JsonSerializable;
 import io.sentry.ObjectReader;
 import io.sentry.ObjectWriter;
 import io.sentry.SentryUUID;
-import io.sentry.util.LazyEvaluator;
 import io.sentry.util.StringUtils;
 import io.sentry.util.UUIDStringUtils;
 import java.io.IOException;
@@ -19,19 +18,15 @@ public final class SentryId implements JsonSerializable {
   public static final SentryId EMPTY_ID =
       new SentryId(StringUtils.PROPER_NIL_UUID.replace("-", ""));
 
-  private final @NotNull LazyEvaluator<String> lazyStringValue;
+  private volatile @Nullable String value;
+  private final @Nullable UUID uuid;
 
   public SentryId() {
     this((UUID) null);
   }
 
   public SentryId(@Nullable UUID uuid) {
-    if (uuid != null) {
-      this.lazyStringValue =
-          new LazyEvaluator<>(() -> normalize(UUIDStringUtils.toSentryIdString(uuid)));
-    } else {
-      this.lazyStringValue = new LazyEvaluator<>(SentryUUID::generateSentryId);
-    }
+    this.uuid = uuid;
   }
 
   public SentryId(final @NotNull String sentryIdString) {
@@ -42,16 +37,30 @@ public final class SentryId implements JsonSerializable {
               + "or 36 characters long (completed UUID). Received: "
               + sentryIdString);
     }
-    if (normalized.length() == 36) {
-      this.lazyStringValue = new LazyEvaluator<>(() -> normalize(normalized));
-    } else {
-      this.lazyStringValue = new LazyEvaluator<>(() -> normalized);
+    this.uuid = null;
+    this.value = normalized.length() == 36 ? normalized.replace("-", "") : normalized;
+  }
+
+  private @NotNull String getValue() {
+    String result = value;
+    if (result == null) {
+      synchronized (this) {
+        result = value;
+        if (result == null) {
+          result =
+              uuid != null
+                  ? normalize(UUIDStringUtils.toSentryIdString(uuid))
+                  : SentryUUID.generateSentryId();
+          value = result;
+        }
+      }
     }
+    return result;
   }
 
   @Override
   public String toString() {
-    return lazyStringValue.getValue();
+    return getValue();
   }
 
   @Override
@@ -59,12 +68,12 @@ public final class SentryId implements JsonSerializable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SentryId sentryId = (SentryId) o;
-    return lazyStringValue.getValue().equals(sentryId.lazyStringValue.getValue());
+    return getValue().equals(sentryId.getValue());
   }
 
   @Override
   public int hashCode() {
-    return lazyStringValue.getValue().hashCode();
+    return getValue().hashCode();
   }
 
   private @NotNull String normalize(@NotNull String uuidString) {


### PR DESCRIPTION
## :scroll: Description

`SentryId` and `SpanId` stored their string value behind a `LazyEvaluator<String>`. Each `LazyEvaluator` allocates an `AutoClosableReentrantLock` (a `ReentrantLock` subclass, including its internal `Sync` object) plus a capturing lambda — on **every** instance.

This change replaces the `LazyEvaluator<String>` in both classes with a plain `volatile String` guarded by a double-checked `synchronized (this)` block:

- Eager (string-arg) constructors now assign the value directly — no lazy wrapper, no lock.
- The no-arg / `UUID` constructors still defer UUID-string generation; `SentryId` keeps the `UUID` reference so `toSentryIdString` stays lazy.
- Synchronization is retained (not a lock-free race) because UUID generation is non-idempotent — two racing threads must not produce different ids for the same instance.

No public API change (`apiDump` produces no diff).

## :bulb: Motivation and Context

One `SentryId` is created per event/transaction and one `SpanId` per span, so these are among the most frequently allocated objects in the SDK. Paying for a per-instance `ReentrantLock` + lambda to guard a single `String` is pure overhead, and the eager string-arg constructors got no laziness benefit at all. Follow-up to the SDK Overhead Reduction work (#5499).

Resolves JAVA-589.

## :green_heart: How did you test it?

Existing `SpanIdTest` and `SentryIdTest` cover the lazy-generation and normalization behavior (UUID generated/normalized only once, not on init, etc.). The full `:sentry` unit test suite passes (3372/3373; the one failing `SentryIdTest` case is a pre-existing test-isolation artifact that fails identically on `main` and is unrelated to this change).

### Benchmark

Measured against `main` using the real compiled classes on the same JVM (Temurin 17.0.16). Allocation is measured via `ThreadMXBean.getThreadAllocatedBytes` (exact TLAB accounting), with objects stored into a live array so the JIT can't scalar-replace them. Throughput is single-threaded, best-of-10 measured rounds after 5 warmup rounds of 1M ops each.

| Scenario | Bytes/op (before → after) | Δ bytes | Throughput ops/ms (before → after) | Speedup |
|---|---|---|---|---|
| `SpanId(String)` eager | 104 → **16** | **−88 (−85%)** | 93,580 → **458,935** | **4.9×** |
| `SpanId()` lazy + `toString` | 232 → **144** | **−88 (−38%)** | 41,587 → **65,556** | **1.6×** |
| `SentryId(String)` eager | 104 → **24** | **−80 (−77%)** | 138,296 → **312,029** | **2.3×** |
| `SentryId()` lazy + `toString` | 320 → **208** | **−112 (−35%)** | 26,472 → **34,084** | **1.3×** |
| `SentryId(UUID)` lazy + `toString` | 408 → **304** | **−104 (−25%)** | 4,430 → **4,579** | **1.03×** |

The ~88-byte reduction on eager `SpanId` accounts exactly for the removed object graph: `LazyEvaluator` (24B) + `AutoClosableReentrantLock` (16B) + its internal `NonfairSync`/AQS (32B) + the capturing lambda (16B). Eager constructors (hot deserialization/propagation paths) win biggest. The lazy paths still shed the lock machinery; `SentryId(UUID)` throughput barely moves because that path is dominated by `UUID.randomUUID()` (a `SecureRandom` draw), not the lock.

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Other `LazyEvaluator`/`AutoClosableReentrantLock` usages that guard genuinely light objects can be reviewed similarly as part of the SDK overhead reduction effort.
