### PR TITLE
test(replay): ignore flaky ComposeMaskingOptionsTest unmask test

### DIFF
--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
@@ -220,7 +220,9 @@ class ComposeMaskingOptionsTest {
   }
 
   @Test
-  @Ignore("Flaky: Robolectric intermittently reports zero bounds for nodes, causing isVisible=false and making the assertion non-deterministic")
+  @Ignore(
+    "Flaky: Robolectric intermittently reports zero bounds for nodes, causing isVisible=false and making the assertion non-deterministic"
+  )
   fun `when sentry-unmask modifier is set unmasks the node`() {
     ComposeMaskingOptionsActivity.textModifierApplier = { Modifier.sentryReplayUnmask() }
     val activity = buildActivity(ComposeMaskingOptionsActivity::class.java).setup()

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/viewhierarchy/ComposeMaskingOptionsTest.kt
@@ -44,6 +44,7 @@ import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.GenericViewHiera
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.ImageViewHierarchyNode
 import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode.TextViewHierarchyNode
 import java.io.File
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -219,6 +220,7 @@ class ComposeMaskingOptionsTest {
   }
 
   @Test
+  @Ignore("Flaky: Robolectric intermittently reports zero bounds for nodes, causing isVisible=false and making the assertion non-deterministic")
   fun `when sentry-unmask modifier is set unmasks the node`() {
     ComposeMaskingOptionsActivity.textModifierApplier = { Modifier.sentryReplayUnmask() }
     val activity = buildActivity(ComposeMaskingOptionsActivity::class.java).setup()


### PR DESCRIPTION
## Summary

Marks `when sentry-unmask modifier is set unmasks the node` in `ComposeMaskingOptionsTest` as `@Ignore` while the underlying flakiness is investigated.

The test intermittently fails because Robolectric reports zero bounds for some Compose nodes when running the full test class, causing `isVisible = false` and making the `shouldMask` assertion non-deterministic. The comment already in the test body documents this behaviour.

## What changed

- Added `@Ignore` annotation with a descriptive message to the flaky test method
- Added `import kotlin.test.Ignore`

## What's not verified

- `spotlessApply` could not be run in this environment — CI will verify formatting.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC089VFRB8N9%3A1782291920.898669%22)