### PR TITLE
Add @Throws on SentryOkHttpInterceptor::intercept.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Behavioral Changes
+
+- `SentryOkHttpInterceptor::intercept` now throws `IOException`. This is a source-only and Java-only breaking change ([#5654](https://github.com/getsentry/sentry-java/pull/5654))
+
 ### Fixes
 
 - Fix potential NPE within `Scope.endSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpInterceptor.kt
@@ -77,6 +77,7 @@ public open class SentryOkHttpInterceptor(
   }
 
   @Suppress("LongMethod")
+  @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     var request = chain.request()
 


### PR DESCRIPTION
## :scroll: Description
Add a `@Throws` on `SentryOkHttpInterceptor::intercept`.


## :bulb: Motivation and Context
Kotlin does not enforce checked exceptions, but Java does, so the @Throws annotation on Kotlin methods is necessary for Java interoperability.

resolves: #5653. 
resolves: [JAVA-594](https://linear.app/getsentry/issue/JAVA-594)

## :green_heart: How did you test it?
There are no logic code changes, so testing is not required.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps
For Kotlin developers, this is not a breaking change, because the `@Throws` annotation on Kotlin methods does not change the signature and therefore does not affect compilation. For Java developers, this is a breaking change, because the Java method signature is modified (Java treats thrown exceptions as part of the signature).