### PR TITLE
fix(core): Guard clearSession with session lock to prevent NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Prevent a potential `NullPointerException` by guarding `Scope.clearSession()` with the session lock ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
+- Fix potential NPE within `Scope.clearSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix potential NPE within `Scope.clearSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
+- Fix potential NPE within `Scope.endSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Prevent a potential `NullPointerException` by guarding `Scope.clearSession()` with the session lock ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
+
 ### Performance
 
 - Speed up touch gesture target detection on deeply nested view hierarchies by hit-testing in local coordinates instead of calling `getLocationOnScreen` per view ([#5595](https://github.com/getsentry/sentry-java/pull/5595))

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1147,7 +1147,9 @@ public final class Scope implements IScope {
   @ApiStatus.Internal
   @Override
   public void clearSession() {
-    session = null;
+    try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+      session = null;
+    }
   }
 
   @ApiStatus.Internal


### PR DESCRIPTION
## :scroll: Description

`Scope.clearSession()` didn't acquire a `sessionLock`, causing a NPE within `Scope.endSession()`.

Fixes [SENTRY-JAVA issue](https://sentry.sentry.io/issues/6761199649/?project=4506812075540480).

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
