### PR TITLE
refactor: do not start redundant UI event transaction when one is already on Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- Don't start a redundant UI interaction transaction when a transaction is already bound to the Scope ([#5491](https://github.com/getsentry/sentry-java/issues/5491))
+  - Previously, `SentryGestureListener` always started a UI transaction and only afterwards skipped binding it to the Scope when a manually-bound transaction already existed, leaving the new transaction to be dropped as an idle transaction without children.
 - Fix potential NPE within `Scope.endSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
 
 ### Performance

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java
@@ -244,6 +244,21 @@ public final class SentryGestureListener implements GestureDetector.OnGestureLis
       }
     }
 
+    // if there's already a transaction bound to the Scope (e.g. started manually by the user), we
+    // skip starting a new UI transaction: it would never be bound to the Scope in applyScope, would
+    // gather no children, and would be dropped as an idle transaction without children
+    final @Nullable ITransaction[] boundTransaction = {null};
+    scopes.configureScope(scope -> boundTransaction[0] = scope.getTransaction());
+    if (boundTransaction[0] != null) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Transaction won't be created for view with id: %s since there's already a transaction bound to the Scope.",
+              viewIdentifier);
+      return;
+    }
+
     // we can only bind to the scope if there's no running transaction
     final String name = getActivityName(activity) + "." + viewIdentifier;
     final String op = UI_ACTION + "." + getGestureType(eventType);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/gestures/SentryGestureListenerTracingTest.kt
@@ -161,6 +161,18 @@ class SentryGestureListenerTracingTest {
   }
 
   @Test
+  fun `when a transaction is already bound to the Scope, does not start a new UI transaction`() {
+    val sut = fixture.getSut<View>()
+    val boundTransaction = SentryTracer(TransactionContext("bound", "op"), fixture.scopes)
+    whenever(fixture.scope.transaction).thenReturn(boundTransaction)
+
+    sut.onSingleTapUp(fixture.event)
+
+    verify(fixture.scopes, never()).startTransaction(any(), any<TransactionOptions>())
+    assertEquals(false, boundTransaction.isFinished)
+  }
+
+  @Test
   fun `stopTracing remove transaction from scope`() {
     val sut = fixture.getSut<View>()
     val expectedStatus = SpanStatus.CANCELLED


### PR DESCRIPTION
## :scroll: Description

`SentryGestureListener.startTracing` always called `scopes.startTransaction(...)` for a UI interaction and only afterwards, in `applyScope`, declined to bind the new transaction to the Scope when one was already bound there. The unbound UI transaction then gathered no children and was dropped as an idle transaction without children.

This change reads the Scope's currently bound transaction before building the `TransactionOptions`. If a transaction is already bound, it logs a debug message and returns early without starting a new UI transaction. The existing handling for the listener's own `activeTransaction` (reschedule-finish and stop-previous) is unchanged, so only the externally-bound case short-circuits.

## :bulb: Motivation and Context

When a user-bound transaction is active, the SDK created and immediately discarded a UI transaction on every interaction. Not starting it avoids that wasted work. See `sentry-android-core/src/main/java/io/sentry/android/core/internal/gestures/SentryGestureListener.java`.

Fixes #5491

* resolves: JAVA-541

## :green_heart: How did you test it?

Added a unit test in `SentryGestureListenerTracingTest` asserting that `scopes.startTransaction` is never invoked and the bound transaction is left untouched when a transaction is already on the Scope. Could not run `./gradlew :sentry-android-core:testDebugUnitTest` locally because no Java runtime is available in this environment.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

AI was used for assistance.
