### PR TITLE
chore: Auto-request mobile team review on public API changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 *       @adinauer @romtsn @markushi @runningcode @0xadam-brown
+
+# Public API surface — auto-request a mobile SDK team review on API changes
+/sentry/api/sentry.api @getsentry/team-mobile
+/sentry-android-core/api/sentry-android-core.api @getsentry/team-mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *       @adinauer @romtsn @markushi @runningcode @0xadam-brown
 
-# Public API surface — auto-request a mobile SDK team review on API changes
-/sentry/api/sentry.api @getsentry/team-mobile
-/sentry-android-core/api/sentry-android-core.api @getsentry/team-mobile
+# Public API surface — also request a mobile SDK team review on API changes
+/sentry/api/sentry.api @adinauer @romtsn @markushi @runningcode @0xadam-brown @getsentry/team-mobile
+/sentry-android-core/api/sentry-android-core.api @adinauer @romtsn @markushi @runningcode @0xadam-brown @getsentry/team-mobile


### PR DESCRIPTION
## :scroll: Description

Adds CODEOWNERS rules for the committed binary-compatibility-validator baselines of the public SDK API surface

## :bulb: Motivation and Context

Public API changes in the mobile SDKs should be reviewed by another mobile SDK team member for cross-SDK consistency.

## :green_heart: How did you test it?

Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

