### PR TITLE
build: Suppress obsolete Java 8 option warning under JDK 21+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ allprojects {
             maxHeapSize = "2g"
         }
         withType<JavaCompile>().configureEach {
-            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing", "-Xlint:-try"))
+            options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing", "-Xlint:-try", "-Xlint:-options"))
         }
     }
 }


### PR DESCRIPTION
## :scroll: Description

TL;DR This suppresses an obsolete Java 8 warning. The Kotlin LSP bundles **JDK 25**, so its Gradle project import aborts and cross-module / external-library resolution silently stops working. Merging this PR allows us to use the Kotlin LSP in this repo: https://claude.com/plugins/kotlin-lsp


## :bulb: Motivation and Context

The `sentry` module targets Java 8 (`sourceCompatibility`/`targetCompatibility = 1.8`). On JDK 21+, `javac` flags `-source`/`-target 8` as obsolete:

```
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
error: warnings found and -Werror specified
```

Because the build uses `-Werror`, that warning becomes a hard error and `:sentry:compileJava` fails. CI pins Temurin JDK 17 (where the warning does not yet exist), so it never surfaces there — but it breaks any local build or tooling running on a newer JDK. In particular, the Kotlin LSP bundles JDK 25, so its Gradle project import aborts and cross-module / external-library resolution silently stops working.

`-Xlint:-options` is the exact suppression `javac` itself recommends when intentionally targeting an older release. It only silences the `[options]` lint category (obsolete source/target, unset bootstrap classpath) and leaves `-Werror` in force for everything else.

## :green_heart: How did you test it?

Reproduced the failure and confirmed the fix with JDK 25's `javac`:

- `javac -source 8 -target 8 -Xlint:all -Werror ...` → fails (exit 1)
- same command with `-Xlint:-options` added → passes (exit 0)

`./gradlew spotlessApply` is clean.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Longer term, the `[options]` warning points at the cleaner fix of switching from `-source`/`-target 8` to `--release 8` (which also sets the bootstrap classpath), but that is a broader change deferred to a follow-up.

#skip-changelog
