### PR TITLE
build: Remove global per-test JVM heap cap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,10 +103,6 @@ allprojects {
                 TestLogEvent.PASSED,
                 TestLogEvent.FAILED
             )
-
-            // Cap JVM args per test
-            minHeapSize = "256m"
-            maxHeapSize = "2g"
         }
         withType<JavaCompile>().configureEach {
             options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Werror", "-Xlint:-classfile", "-Xlint:-processing", "-Xlint:-try"))

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -41,7 +41,7 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
       // Robolectric loads the android-all jar into each test JVM, which needs more heap
-      // than the default. This cap used to live in the root build.gradle.kts for all modules.
+      // than the default.
       all {
         it.minHeapSize = "256m"
         it.maxHeapSize = "2g"

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -40,6 +40,12 @@ android {
     unitTests.apply {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
+      // Robolectric loads the android-all jar into each test JVM, which needs more heap
+      // than the default. This cap used to live in the root build.gradle.kts for all modules.
+      all {
+        it.minHeapSize = "256m"
+        it.maxHeapSize = "2g"
+      }
     }
   }
 


### PR DESCRIPTION
Removes the global per-test JVM heap cap from the root `build.gradle.kts`:

```kotlin
// Cap JVM args per test
minHeapSize = "256m"
maxHeapSize = "2g"
```

This cap was applied to every module's test task via `allprojects`, but only one module actually needs it. CI confirmed that with the global cap removed, only `:sentry-android-core:testReleaseUnitTest` fails — with `OutOfMemoryError: Java heap space`, because Robolectric loads the `android-all` jar into each test JVM. Every other module passes on the JVM defaults.

The cap is therefore restored to just `sentry-android-core`'s `build.gradle.kts` (via `testOptions.unitTests.all { }`), where it is actually required.

Note: due to the fact that some tests didn't run on this PR because they were cached, we might need to add this to more tests later.