### PR TITLE
fix(compose): add isImportantForBounds() to SentryTagModifierNode for compose-ui 1.11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Don't start a redundant UI interaction transaction when a transaction is already bound to the Scope ([#5491](https://github.com/getsentry/sentry-java/issues/5491))
   - Previously, `SentryGestureListener` always started a UI transaction and only afterwards skipped binding it to the Scope when a manually-bound transaction already existed, leaving the new transaction to be dropped as an idle transaction without children.
 - Fix potential NPE within `Scope.endSession()` ([#5657](https://github.com/getsentry/sentry-java/pull/5657))
+- Fix AbstractMethodError when compose-ui 1.11+ is used in combination with `Modifier.sentryTag()` or the Sentry Kotlin compiler plugin ([#5672](https://github.com/getsentry/sentry-java/pull/5672))
 
 ### Performance
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -53,5 +53,16 @@ public object SentryModifier {
     override fun SemanticsPropertyReceiver.applySemantics() {
       this[SentryTag] = tag
     }
+
+    // SemanticsModifierNode.isImportantForBounds() was added as an abstract method in
+    // compose-ui 1.11.  Classes compiled against earlier versions lack this method in
+    // their bytecode, which causes AbstractMethodError when the accessibility tree is
+    // traversed on 1.11+ runtimes.  We can't use the `override` keyword here because
+    // the method doesn't exist in the compile-time dependency (compose-ui 1.6.x), but
+    // the JVM satisfies the abstract-method requirement at runtime via signature
+    // matching.  SentryTagModifierNode only stores a semantic tag and has no visual
+    // effect on layout, so it is not important for bounds.
+    @Suppress("unused")
+    fun isImportantForBounds(): Boolean = false
   }
 }

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -62,7 +62,6 @@ public object SentryModifier {
     // the JVM satisfies the abstract-method requirement at runtime via signature
     // matching.  SentryTagModifierNode only stores a semantic tag and has no visual
     // effect on layout, so it is not important for bounds.
-    @Suppress("unused")
-    fun isImportantForBounds(): Boolean = false
+    @Suppress("unused") fun isImportantForBounds(): Boolean = false
   }
 }


### PR DESCRIPTION
Fixes #5662

## Problem

`compose-ui 1.11` added `SemanticsModifierNode.isImportantForBounds()` as an **abstract** method. `SentryTagModifierNode` was compiled against `compose-ui 1.6.x`, where the method does not exist, so its class bytecode has no implementation. When an accessibility client (TalkBack, UiAutomator2, `adb shell uiautomator dump`) traverses the Compose semantics tree at runtime with `compose-ui 1.11+`, the JVM cannot find the method and throws:

```
AbstractMethodError: abstract method "boolean androidx.compose.ui.node.SemanticsModifierNode.isImportantForBounds()"
    at SentryTagModifierNode (SentryModifier.kt)
```

## Fix

Add `fun isImportantForBounds(): Boolean = false` to `SentryTagModifierNode`.

The `override` keyword is intentionally omitted because the method is absent from the `compose-ui 1.6.x` compile-time dependency — using `override` would fail to compile. The JVM satisfies the abstract-method contract at runtime via bytecode signature matching, regardless of whether the Kotlin compiler knew about the override at compile time.

`SentryTagModifierNode` stores only a semantic tag with no layout or visual effect, so `false` is the correct return value (it does not affect touch-bounds computation).

## Testing

Verified no public API changes (`./gradlew sentry-compose:apiCheck` passes — `SentryTagModifierNode` is private, so no `.api` file update required). The fix applies cleanly to the existing `compose-ui 1.6.x` compile target without version bumps.