### PR TITLE
[Do Not Review] build: Raise minimum AGP to 9.1.1 for Android 17 toolchain prep

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agp: [ '8.7.0','8.8.0','8.9.0' ]
+        agp: [ '9.1.1', '9.2.0', '9.2.1' ]
         integrations: [ true, false ]
 
     name: AGP Matrix Release - AGP ${{ matrix.agp }} - Integrations ${{ matrix.integrations }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ The project uses **Gradle** with Kotlin DSL. Key build files:
 - `buildSrc/` and `build-logic/` - Custom build logic and plugins
 - `Makefile` - High-level build commands
 
+### Android toolchain (AGP 9)
+- **Minimum AGP:** 9.1.1 (fallback in `buildSrc/src/main/java/Config.kt`, currently 9.2.1)
+- **Minimum Gradle:** 9.4.1 (wrapper in `gradle/wrapper/gradle-wrapper.properties`)
+- SDK levels live in `gradle/libs.versions.toml` (`compileSdk`, `targetSdk`, `minSdk`)
+- **AGP 9 migration:** `gradle.properties` sets `android.builtInKotlin=false` and `android.newDsl=false` until we remove `kotlin-android` and adopt built-in Kotlin / new DSL (required before AGP 10)
+
 ## Essential Commands
 
 ### Development Workflow

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.LibraryExtension
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -116,6 +118,23 @@ allprojects {
 
 subprojects {
     apply { plugin("io.sentry.spotless") }
+
+    pluginManager.withPlugin("com.android.library") {
+        extensions.configure<LibraryExtension> {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_1_8
+                targetCompatibility = JavaVersion.VERSION_1_8
+            }
+        }
+    }
+    pluginManager.withPlugin("com.android.application") {
+        extensions.configure<AppExtension> {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_1_8
+                targetCompatibility = JavaVersion.VERSION_1_8
+            }
+        }
+    }
 
     plugins.withId(Config.QualityPlugins.detektPlugin) {
         configure<DetektExtension> {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,6 +1,6 @@
 
 object Config {
-    val AGP = System.getenv("VERSION_AGP") ?: "8.13.1"
+    val AGP = System.getenv("VERSION_AGP") ?: "9.2.1"
     val kotlinStdLib = "stdlib-jdk8"
     val kotlinStdLibVersionAndroid = "1.9.24"
     val kotlinTestJunit = "test-junit"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,10 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 # AndroidX required by AGP >= 3.6.x
 android.useAndroidX=true
-android.experimental.lint.version=8.13.1
+# AGP 9+ migration opt-outs until we remove kotlin-android plugin and adopt built-in Kotlin.
+android.builtInKotlin=false
+android.newDsl=false
+android.experimental.lint.version=9.2.1
 
 # Release information
 versionName=8.46.0

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -12,6 +12,11 @@ android {
   defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
   buildFeatures { buildConfig = false }
 
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
   testOptions {
     unitTests.apply {
       isReturnDefaultValues = true

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -25,10 +25,7 @@ android {
 
   buildFeatures { compose = true }
 
-  composeOptions {
-    kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    useLiveLiterals = false
-  }
+  composeOptions { kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get() }
 
   buildTypes {
     getByName("debug") { consumerProguardFiles("proguard-rules.pro") }

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -81,7 +81,7 @@ internal class SimpleVideoEncoder(
         val videoCapabilities =
           mediaCodec.codecInfo.getCapabilitiesForType(muxerConfig.mimeType).videoCapabilities
 
-        if (!videoCapabilities.bitrateRange.contains(bitRate)) {
+        if (videoCapabilities != null && !videoCapabilities.bitrateRange.contains(bitRate)) {
           options.logger.log(
             DEBUG,
             "Encoder doesn't support the provided bitRate: $bitRate, the value will be clamped to the closest one",

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -87,8 +87,6 @@ android {
     buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
   }
 
-  sourceSets["main"].apply { manifest.srcFile("src/androidMain/AndroidManifest.xml") }
-
   buildTypes {
     getByName("debug") { consumerProguardFiles("proguard-rules.pro") }
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }


### PR DESCRIPTION
## Summary
- Bump default AGP fallback to 9.2.1 (compileSdk 37 requires AGP 9.1.1+)
- Refresh agp-matrix to [9.1.1, 9.2.0, 9.2.1]
- Add AGP 9 migration opt-outs (builtInKotlin/newDsl) until kotlin-android removal
- AGP 9 compatibility fixes for replay, compose, and distribution modules

## Test plan
- [ ] ./gradlew check green locally
- [ ] agp-matrix workflow green (all AGP × integrations combinations)
- [ ] integration-tests-ui-critical green
- [ ] integration-tests-ui green
- [ ] integration-tests-benchmarks green
- [ ] system-tests-backend green


Made with [Cursor](https://cursor.com)