### PR TITLE
perf(core): Remove executor prewarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Skip `Hint` allocation in `Scope.addBreadcrumb` when no `beforeBreadcrumb` callback is set ([#5689](https://github.com/getsentry/sentry-java/pull/5689))
 - Speed up scope persistence by detecting the Sentry executor thread via a marker instead of a `Thread.getName()` name scan on every scope mutation ([#5691](https://github.com/getsentry/sentry-java/pull/5691))
+- Remove executor prewarm during SDK init ([#5681](https://github.com/getsentry/sentry-java/pull/5681))
+  - The single-threaded `SentryExecutorService` queued the prewarm work ahead of the first useful task, so it could only delay init work, never speed it up; the thread and class loading it warmed are paid identically by the first real task submitted right after.
 
 ## 8.47.0
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidProfilerTest.kt
@@ -81,8 +81,6 @@ class AndroidProfilerTest {
         override fun close(timeoutMillis: Long) {}
 
         override fun isClosed() = false
-
-        override fun prewarm() = Unit
       }
 
     val options =

--- a/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/AndroidTransactionProfilerTest.kt
@@ -89,8 +89,6 @@ class AndroidTransactionProfilerTest {
         override fun close(timeoutMillis: Long) {}
 
         override fun isClosed() = false
-
-        override fun prewarm() = Unit
       }
 
     val options =

--- a/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
+++ b/sentry-test-support/src/main/kotlin/io/sentry/test/Mocks.kt
@@ -35,8 +35,6 @@ class ImmediateExecutorService : ISentryExecutorService {
   override fun close(timeoutMillis: Long) {}
 
   override fun isClosed(): Boolean = false
-
-  override fun prewarm() = Unit
 }
 
 class DeferredExecutorService : ISentryExecutorService {
@@ -74,8 +72,6 @@ class DeferredExecutorService : ISentryExecutorService {
 
   override fun isClosed(): Boolean = false
 
-  override fun prewarm() = Unit
-
   fun hasScheduledRunnables(): Boolean = scheduledRunnables.isNotEmpty()
 }
 
@@ -90,8 +86,6 @@ class NonOverridableNoOpSentryExecutorService : ISentryExecutorService {
   override fun close(timeoutMillis: Long) {}
 
   override fun isClosed(): Boolean = false
-
-  override fun prewarm() = Unit
 }
 
 fun createSentryClientMock(enabled: Boolean = true) =

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -1134,7 +1134,6 @@ public abstract interface class io/sentry/ISentryClient {
 public abstract interface class io/sentry/ISentryExecutorService {
 	public abstract fun close (J)V
 	public abstract fun isClosed ()Z
-	public abstract fun prewarm ()V
 	public abstract fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 	public abstract fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
@@ -1880,7 +1879,6 @@ public final class io/sentry/NoOpSentryExecutorService : io/sentry/ISentryExecut
 	public fun close (J)V
 	public static fun getInstance ()Lio/sentry/ISentryExecutorService;
 	public fun isClosed ()Z
-	public fun prewarm ()V
 	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 	public fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
@@ -3183,7 +3181,6 @@ public final class io/sentry/SentryExecutorService : io/sentry/ISentryExecutorSe
 	public fun close (J)V
 	public fun isClosed ()Z
 	public static fun isSentryExecutorThread ()Z
-	public fun prewarm ()V
 	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 	public fun submit (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;

--- a/sentry/src/main/java/io/sentry/ISentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/ISentryExecutorService.java
@@ -45,10 +45,4 @@ public interface ISentryExecutorService {
    * @return If the executorService was previously closed
    */
   boolean isClosed();
-
-  /**
-   * Pre-warms the executor service by increasing the initial queue capacity. SHOULD be called
-   * directly after instantiating this executor service.
-   */
-  void prewarm();
 }

--- a/sentry/src/main/java/io/sentry/NoOpSentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/NoOpSentryExecutorService.java
@@ -38,7 +38,4 @@ public final class NoOpSentryExecutorService implements ISentryExecutorService {
   public boolean isClosed() {
     return false;
   }
-
-  @Override
-  public void prewarm() {}
 }

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -351,7 +351,6 @@ public final class Sentry {
         // to set a new one
         if (options.getExecutorService().isClosed()) {
           options.setExecutorService(new SentryExecutorService(options));
-          options.getExecutorService().prewarm();
         }
 
         // load lazy fields of the options in a separate thread

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -17,13 +17,6 @@ import org.jetbrains.annotations.TestOnly;
 public final class SentryExecutorService implements ISentryExecutorService {
 
   /**
-   * ScheduledThreadPoolExecutor grows work queue by 50% each time. With the initial capacity of 16
-   * it will have to resize 4 times to reach 40, which is a decent middle-ground for prewarming.
-   * This will prevent from growing in unexpected areas of the SDK.
-   */
-  private static final int INITIAL_QUEUE_SIZE = 40;
-
-  /**
    * By default, the work queue is unbounded so it can grow as much as the memory allows. We want to
    * limit it by 271 which would be x8 times growth from the default initial capacity.
    */
@@ -31,9 +24,6 @@ public final class SentryExecutorService implements ISentryExecutorService {
 
   private final @NotNull ScheduledThreadPoolExecutor executorService;
   private final @NotNull AutoClosableReentrantLock lock = new AutoClosableReentrantLock();
-
-  @SuppressWarnings("UnnecessaryLambda")
-  private final @NotNull Runnable dummyRunnable = () -> {};
 
   private final @Nullable SentryOptions options;
 
@@ -117,35 +107,6 @@ public final class SentryExecutorService implements ISentryExecutorService {
   public boolean isClosed() {
     try (final @NotNull ISentryLifecycleToken ignored = lock.acquire()) {
       return executorService.isShutdown();
-    }
-  }
-
-  @SuppressWarnings({"FutureReturnValueIgnored"})
-  @Override
-  public void prewarm() {
-    try {
-      executorService.submit(
-          () -> {
-            try {
-              // schedule a bunch of dummy runnables in the future that will never execute to
-              // trigger
-              // queue growth and then purge the queue
-              for (int i = 0; i < INITIAL_QUEUE_SIZE; i++) {
-                final Future<?> future =
-                    executorService.schedule(dummyRunnable, 365L, TimeUnit.DAYS);
-                future.cancel(true);
-              }
-              executorService.purge();
-            } catch (RejectedExecutionException ignored) {
-              // ignore
-            }
-          });
-    } catch (RejectedExecutionException e) {
-      if (options != null) {
-        options
-            .getLogger()
-            .log(SentryLevel.WARNING, "Prewarm task rejected from " + executorService, e);
-      }
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -678,7 +678,6 @@ public class SentryOptions {
       // SentryExecutorService should be initialized before any
       // SendCachedEventFireAndForgetIntegration
       executorService = new SentryExecutorService(this);
-      executorService.prewarm();
     }
 
     // SpotlightIntegration is loaded via reflection to allow the sentry-spotlight module

--- a/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryExecutorServiceTest.kt
@@ -1,6 +1,5 @@
 package io.sentry
 
-import io.sentry.test.getProperty
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Callable
 import java.util.concurrent.CancellationException
@@ -189,21 +188,6 @@ class SentryExecutorServiceTest {
     sentryExecutor.schedule({}, 1000L)
 
     verify(executor).schedule(any<Runnable>(), any(), any())
-  }
-
-  @Test
-  fun `SentryExecutorService prewarm schedules dummy tasks and clears queue`() {
-    val executor = ScheduledThreadPoolExecutor(1)
-
-    val sentryExecutor = SentryExecutorService(executor, null)
-    sentryExecutor.prewarm()
-
-    Thread.sleep(1000)
-
-    // the internal queue/array should be resized 4 times to 54
-    assertEquals(54, (executor.queue.getProperty("queue") as Array<*>).size)
-    // the queue should be empty
-    assertEquals(0, executor.queue.size)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -778,7 +778,6 @@ class SentryTest {
       it.cacheDirPath = getTempPath()
       it.setLogger(logger)
       it.executorService = SentryExecutorService()
-      it.executorService.prewarm()
       it.executorService.close(0)
       it.isDebug = true
     }


### PR DESCRIPTION
## Summary

`prewarm()` scheduled 40 dummy tasks far in the future, cancelled them, and purged the queue, in order to pre-grow the single-threaded `ScheduledThreadPoolExecutor`'s work queue during `Sentry.init`. On-device measurement shows the cost it avoids is negligible-to-zero, so this removes it (and the now-unused constants) along with its two init call sites.

## Why it's safe to remove

prewarm's only job was to pre-grow the executor's work queue so a later resize wouldn't happen "in an unexpected area of the SDK". Measured on a Galaxy A55 (Android 16), growing the queue the full 16→54 (all three array resizes) costs **~8µs total** — and that is the ceiling: init only ever queues a handful of tasks, well under the default 16-slot capacity, so in practice **no resize happens and the saving is 0µs**.

`PrewarmBenchmarkTest`, n=1000 × 3 runs, median µs. Both paths schedule 40 tasks into an empty queue (identical per-insert work); they differ only in whether the backing array resizes:

| | Run 1 | Run 2 | Run 3 |
|---|---|---|---|
| grow 16→54 | 15 | 15 | 15 |
| preGrown 54 | 7 | 6 | 7 |
| **resize cost (delta)** | **~8** | **~9** | **~8** |

## It also can't help, and slightly regresses init

The executor is single-threaded and prewarm is submitted *ahead* of the first useful task (`loadLazyFields`, submitted right after in `Sentry.init`), so the 40-task loop can only delay that task, never speed it up. Thread creation and executor class-loading are paid by whichever task runs first, so `loadLazyFields` warms them identically with or without prewarm.

Measured end-to-end, the time until the first useful task finishes (from a fresh executor, n=400 × 3 runs) is **~100µs slower** with prewarm than without, at every percentile; a plain `submit(noop)` is indistinguishable from doing nothing:

| median µs | Run 1 | Run 2 | Run 3 |
|---|---|---|---|
| prewarm | 567 | 524 | 537 |
| no warming | 460 | 428 | 435 |

(`PrewarmBenchmarkTest` also records the per-op loop cost and the process-once class-loading cost, which is unavoidable regardless of prewarm; both confirm the above.)

## Changes

- Remove `prewarm()` from `ISentryExecutorService`, `SentryExecutorService` (and the now-unused `INITIAL_QUEUE_SIZE` / `dummyRunnable`), and `NoOpSentryExecutorService`.
- Remove the two init call sites (`Sentry.init` re-init branch and `SentryOptions.activate()`).
- Drop the prewarm unit test and mock overrides; add `PrewarmBenchmarkTest`.

Original prewarm PR: #4606 — its only stated reason was the queue-growth cost measured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)