### PR TITLE
ci(system-tests): Remove sed hacks for android module exclusion

### DIFF
--- a/.github/workflows/system-tests-backend.yml
+++ b/.github/workflows/system-tests-backend.yml
@@ -122,35 +122,6 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Exclude android modules from build
-        run: |
-          sed -i \
-            -e '/.*"sentry-android-ndk",/d' \
-            -e '/.*"sentry-android",/d' \
-            -e '/.*"sentry-compose",/d' \
-            -e '/.*"sentry-android-core",/d' \
-            -e '/.*"sentry-android-fragment",/d' \
-            -e '/.*"sentry-android-navigation",/d' \
-            -e '/.*"sentry-android-sqlite",/d' \
-            -e '/.*"sentry-android-timber",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android",/d' \
-            -e '/.*"sentry-android-integration-tests:sentry-uitest-android-critical",/d' \
-            -e '/.*"sentry-android-integration-tests:test-app-sentry",/d' \
-            -e '/.*"sentry-samples:sentry-samples-android",/d' \
-            -e '/.*"sentry-android-replay",/d' \
-            settings.gradle.kts
-
-      - name: Exclude android modules from ignore list
-        run: |
-          sed -i \
-            -e '/.*"sentry-uitest-android",/d' \
-            -e '/.*"sentry-uitest-android-benchmark",/d' \
-            -e '/.*"sentry-uitest-android-critical",/d' \
-            -e '/.*"test-app-sentry",/d' \
-            -e '/.*"sentry-samples-android",/d' \
-            build.gradle.kts
-
       - name: Build and run system tests
         run: |
           python3 test/system-test-runner.py test --module "${{ matrix.sample }}" --agent "${{ matrix.agent }}" --auto-init "${{ matrix.agent-auto-init }}" --build "true"


### PR DESCRIPTION
Removes the sed-based Android module exclusion (`Exclude android modules from build` / `Exclude android modules from ignore list`) from the backend system tests workflow.

These sed hacks slow down the build because they modify the buildscript classpath which forces everything (including all buildscripts) to recompile even though we should have cached versions of these for these workflows.

This mirrors #5397, which removed the identical sed hacks from the Spring Boot matrix workflows for the same reason.