### PR TITLE
feat: added `report historic tombstones` option to the manifest reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Support the `io.sentry.tombstone.report-historical` manifest option to enable historical tombstone reporting via `AndroidManifest.xml` `<meta-data>` ([#5683](https://github.com/getsentry/sentry-java/pull/5683))
+
 ## 8.47.0
 
 ### Behavioral Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -37,6 +37,7 @@ final class ManifestMetadataReader {
 
   static final String TOMBSTONE_ENABLE = "io.sentry.tombstone.enable";
   static final String TOMBSTONE_ATTACH_RAW = "io.sentry.tombstone.attach-raw";
+  static final String TOMBSTONE_REPORT_HISTORICAL = "io.sentry.tombstone.report-historical";
 
   static final String AUTO_INIT = "io.sentry.auto-init";
   static final String NDK_ENABLE = "io.sentry.ndk.enable";
@@ -232,6 +233,12 @@ final class ManifestMetadataReader {
             readBool(metadata, logger, TOMBSTONE_ENABLE, options.isTombstoneEnabled()));
         options.setAttachRawTombstone(
             readBool(metadata, logger, TOMBSTONE_ATTACH_RAW, options.isAttachRawTombstone()));
+        options.setReportHistoricalTombstones(
+            readBool(
+                metadata,
+                logger,
+                TOMBSTONE_REPORT_HISTORICAL,
+                options.isReportHistoricalTombstones()));
 
         // use enableAutoSessionTracking as fallback
         options.setEnableAutoSessionTracking(

--- a/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/ManifestMetadataReaderTest.kt
@@ -314,6 +314,56 @@ class ManifestMetadataReaderTest {
   }
 
   @Test
+  fun `applyMetadata reads tombstone enable to options`() {
+    // Arrange
+    val bundle = bundleOf(ManifestMetadataReader.TOMBSTONE_ENABLE to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(true, fixture.options.isTombstoneEnabled)
+  }
+
+  @Test
+  fun `applyMetadata reads tombstone enable to options and keeps default`() {
+    // Arrange
+    val context = fixture.getContext()
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(false, fixture.options.isTombstoneEnabled)
+  }
+
+  @Test
+  fun `applyMetadata reads tombstone report historical to options`() {
+    // Arrange
+    val bundle = bundleOf(ManifestMetadataReader.TOMBSTONE_REPORT_HISTORICAL to true)
+    val context = fixture.getContext(metaData = bundle)
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(true, fixture.options.isReportHistoricalTombstones)
+  }
+
+  @Test
+  fun `applyMetadata reads tombstone report historical to options and keeps default`() {
+    // Arrange
+    val context = fixture.getContext()
+
+    // Act
+    ManifestMetadataReader.applyMetadata(context, fixture.options, fixture.buildInfoProvider)
+
+    // Assert
+    assertEquals(false, fixture.options.isReportHistoricalTombstones)
+  }
+
+  @Test
   fun `applyMetadata reads anr report historical to options`() {
     // Arrange
     val bundle = bundleOf(ManifestMetadataReader.ANR_REPORT_HISTORICAL to true)


### PR DESCRIPTION
## :scroll: Description
Added the missing option.


## :bulb: Motivation and Context
It was missing. Now it's there.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
