### PR TITLE
fix(android): Name the device-info caching thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
+
 ## 8.47.0
 
 ### Behavioral Changes

--- a/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/DefaultAndroidEventProcessor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -56,7 +57,8 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
     // noinspection Convert2MethodRef
     // some device info performs disk I/O, but it's result is cached, let's pre-cache it
     @Nullable Future<DeviceInfoUtil> deviceInfoUtil;
-    final @NotNull ExecutorService executorService = Executors.newSingleThreadExecutor();
+    final @NotNull ExecutorService executorService =
+        Executors.newSingleThreadExecutor(new DeviceInfoCacheThreadFactory());
     try {
       deviceInfoUtil =
           executorService.submit(() -> DeviceInfoUtil.getInstance(this.context, options));
@@ -424,5 +426,14 @@ final class DefaultAndroidEventProcessor implements EventProcessor {
   @Override
   public @Nullable Long getOrder() {
     return 8000L;
+  }
+
+  private static final class DeviceInfoCacheThreadFactory implements ThreadFactory {
+    @Override
+    public @NotNull Thread newThread(final @NotNull Runnable r) {
+      final Thread ret = new Thread(r, "SentryDeviceInfoCache");
+      ret.setDaemon(true);
+      return ret;
+    }
   }
 }


### PR DESCRIPTION
## :scroll: Description

`DefaultAndroidEventProcessor` pre-caches device info on a background thread using `Executors.newSingleThreadExecutor()` without a `ThreadFactory`. The JDK's default factory names such threads `pool-N-thread-M`, which is not identifiable as a Sentry thread.

This was the only thread-creation site in the SDK's production source that did not name its thread. This change supplies a `ThreadFactory` that names the (daemon) thread `SentryDeviceInfoCache`, matching the convention already used by `HostnameCache`, `SentryExecutorService`, and `AsyncHttpTransport`.

## :bulb: Motivation and Context

Named threads let customers identify which threads belong to the Sentry SDK when inspecting their apps (profilers, thread dumps, ANR traces). Every other thread the SDK spawns is already named; this closes the one remaining gap.

## :green_heart: How did you test it?

Existing `DefaultAndroidEventProcessor` unit tests continue to pass. The change only affects the name/daemon flag of the executor's thread, not its behavior.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
