### PR TITLE
perf(core): Skip Hint allocation in addBreadcrumb without callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))
 
+### Performance
+
+- Skip `Hint` allocation in `Scope.addBreadcrumb` when no `beforeBreadcrumb` callback is set ([#5689](https://github.com/getsentry/sentry-java/pull/5689))
+
 ## 8.47.0
 
 ### Behavioral Changes

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -493,12 +493,11 @@ public final class Scope implements IScope {
     if (breadcrumb == null || breadcrumbs instanceof DisabledQueue) {
       return;
     }
-    if (hint == null) {
-      hint = new Hint();
-    }
-
     SentryOptions.BeforeBreadcrumbCallback callback = options.getBeforeBreadcrumb();
     if (callback != null) {
+      if (hint == null) {
+        hint = new Hint();
+      }
       breadcrumb = executeBeforeBreadcrumb(callback, breadcrumb, hint);
     }
     if (breadcrumb != null) {


### PR DESCRIPTION
Resolves [JAVA-605](https://linear.app/getsentry/issue/JAVA-605).

### Description

`Scope.addBreadcrumb(Breadcrumb, Hint)` allocated a `Hint` unconditionally when the caller passed `null`, even though the `Hint` is only ever used to pass to the `beforeBreadcrumb` callback. When no callback is configured (the common case) the `Hint` — a `HashMap` + `ArrayList` + `AutoClosableReentrantLock` — was created and immediately discarded on every breadcrumb.

This moves the allocation inside the `callback != null` branch, so no `Hint` is allocated on the common path.

Pure allocation elimination, no behavior change.

### Source

Found via on-device Perfetto method-trace analysis of the Android SDK (`Scope#addBreadcrumb` breadcrumb path). Part of [Reduce SDK init time [Android]](https://linear.app/getsentry/project/a59f90bd-5035-443a-a955-097a48547806).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Benchmark

Measured on-device with **androidx Microbenchmark 1.4.1** (`benchmark-junit4`) on a **Samsung Galaxy A55 (SM-A556B), Android API 36** (release build, non-minified).

The benchmark exercises the **caller-side** cost of a scope mutation with scope persistence enabled (`enableScopePersistence = true`, `cacheDirPath` set, **no** `beforeBreadcrumb`). The async serialize + disk write is dispatched to a no-op executor so it never runs on the measured thread — mirroring production, where it runs off-thread. Each branch is compared against its base commit (`aab952b82e`); the per-branch delta isolates this change. `allocationCount` is deterministic; `timeNs` has ~±10 ns run-to-run noise on a non-rooted device (unlocked clocks), so it is reported as a median and reproduced across 2 runs.

### How it was done

A **local, uncommitted** androidx microbenchmark module (`sentry-android-integration-tests/sentry-uitest-android-microbenchmark`) depending on `:sentry`, with a `BenchmarkRule` looping the scope mutation. Run with:

```
./gradlew :sentry-android-integration-tests:sentry-uitest-android-microbenchmark:connectedReleaseAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=UNLOCKED
```

### Result — `scope.addBreadcrumb()`

| Metric | main | This PR | Delta |
|---|---|---|---|
| allocationCount | 7 | **3** | **-4 per breadcrumb** |
| timeNs (median) | ~242 ns | **185 ns** | **~-24%** |

The 4 eliminated allocations are the `Hint` plus its `HashMap`, `ArrayList`, and `AutoClosableReentrantLock`. The `setTag` control path (unaffected by this change) was unchanged at ~127 ns / 3 allocs.
