### PR TITLE
perf(core): Skip redundant setBreadcrumbs call on the addBreadcrumb path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Performance
+
+- Notify scope observers once per breadcrumb by dropping the redundant `setBreadcrumbs` call on the `Scope.addBreadcrumb` path ([#5690](https://github.com/getsentry/sentry-java/pull/5690))
+
 ## 8.47.0
 
 ### Behavioral Changes

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -506,7 +506,6 @@ public final class Scope implements IScope {
 
       for (final IScopeObserver observer : options.getScopeObservers()) {
         observer.addBreadcrumb(breadcrumb);
-        observer.setBreadcrumbs(breadcrumbs);
       }
     } else {
       options.getLogger().log(SentryLevel.INFO, "Breadcrumb was dropped by beforeBreadcrumb");


### PR DESCRIPTION
Resolves [JAVA-606](https://linear.app/getsentry/issue/JAVA-606).

### Description

`Scope.addBreadcrumb` notified every scope observer twice per breadcrumb: `observer.addBreadcrumb(crumb)` followed by `observer.setBreadcrumbs(all)`. For `PersistingScopeObserver` the second call is a guaranteed no-op right after an add — it only does work when the collection is empty (the clear case) — yet it still acquires the `SynchronizedQueue` lock via `isEmpty()` and re-iterates the observer list on every breadcrumb.

This notifies observers once per add. `clearBreadcrumbs` still calls `setBreadcrumbs`.

### ⚠️ Reviewer note — public API contract

`IScopeObserver` is a **public** interface. In principle a third-party observer could implement only `setBreadcrumbs` and rely on it being called on every add, rather than the incremental `addBreadcrumb`. Removing the per-add `setBreadcrumbs` call changes the observer notification contract on the add path.

This PR treats that as an intentional contract clarification (observers must implement `addBreadcrumb` for incremental updates). **Flagging for a maintainer decision** — if we'd rather preserve the old contract, close this in favor of documentation only. Kept as draft for that reason.

### Source

Found via on-device Perfetto method-trace analysis of the Android SDK breadcrumb path. Part of [Reduce SDK init time [Android]](https://linear.app/getsentry/project/a59f90bd-5035-443a-a955-097a48547806).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Benchmark

Measured on-device with **androidx Microbenchmark 1.4.1** (`benchmark-junit4`) on a **Samsung Galaxy A55 (SM-A556B), Android API 36** (release build, non-minified).

The benchmark exercises the **caller-side** cost of a scope mutation with scope persistence enabled (`enableScopePersistence = true`, `cacheDirPath` set, **no** `beforeBreadcrumb`). The async serialize + disk write is dispatched to a no-op executor so it never runs on the measured thread — mirroring production, where it runs off-thread. Each branch is compared against its base commit (`aab952b82e`); the per-branch delta isolates this change. `allocationCount` is deterministic; `timeNs` has ~±10 ns run-to-run noise on a non-rooted device (unlocked clocks), so it is reported as a median and reproduced across 2 runs.

### How it was done

A **local, uncommitted** androidx microbenchmark module (`sentry-android-integration-tests/sentry-uitest-android-microbenchmark`) depending on `:sentry`, with a `BenchmarkRule` looping the scope mutation. Run with:

```
./gradlew :sentry-android-integration-tests:sentry-uitest-android-microbenchmark:connectedReleaseAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=UNLOCKED
```

### Result — `scope.addBreadcrumb()`

| Metric | main | This PR | Delta |
|---|---|---|---|
| allocationCount | 7 | 7 | none (expected) |
| timeNs (median) | ~242 ns | **229 ns** | ~-6% |

As expected, dropping the redundant per-observer `setBreadcrumbs` call is a small time/lock win with no allocation change. The `setTag` control path was unchanged.
