### PR TITLE
perf(core): Detect Sentry executor thread without a name scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Performance
 
 - Skip `Hint` allocation in `Scope.addBreadcrumb` when no `beforeBreadcrumb` callback is set ([#5689](https://github.com/getsentry/sentry-java/pull/5689))
+- Speed up scope persistence by detecting the Sentry executor thread via a marker instead of a `Thread.getName()` name scan on every scope mutation ([#5691](https://github.com/getsentry/sentry-java/pull/5691))
 
 ## 8.47.0
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3182,6 +3182,7 @@ public final class io/sentry/SentryExecutorService : io/sentry/ISentryExecutorSe
 	public fun <init> (Lio/sentry/SentryOptions;)V
 	public fun close (J)V
 	public fun isClosed ()Z
+	public static fun isSentryExecutorThread ()Z
 	public fun prewarm ()V
 	public fun schedule (Ljava/lang/Runnable;J)Ljava/util/concurrent/Future;
 	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -149,14 +149,30 @@ public final class SentryExecutorService implements ISentryExecutorService {
     }
   }
 
+  /**
+   * Whether the calling thread is one of the Sentry executor threads. Cheap replacement for scanning
+   * {@code Thread.currentThread().getName()}, which is on hot paths (e.g. scope persistence on every
+   * scope mutation).
+   */
+  public static boolean isSentryExecutorThread() {
+    return Thread.currentThread() instanceof SentryExecutorServiceThread;
+  }
+
   private static final class SentryExecutorServiceThreadFactory implements ThreadFactory {
     private int cnt;
 
     @Override
     public @NotNull Thread newThread(final @NotNull Runnable r) {
-      final Thread ret = new Thread(r, "SentryExecutorServiceThreadFactory-" + cnt++);
+      final Thread ret =
+          new SentryExecutorServiceThread(r, "SentryExecutorServiceThreadFactory-" + cnt++);
       ret.setDaemon(true);
       return ret;
+    }
+  }
+
+  private static final class SentryExecutorServiceThread extends Thread {
+    SentryExecutorServiceThread(final @NotNull Runnable r, final @NotNull String name) {
+      super(r, name);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/SentryExecutorService.java
+++ b/sentry/src/main/java/io/sentry/SentryExecutorService.java
@@ -150,9 +150,9 @@ public final class SentryExecutorService implements ISentryExecutorService {
   }
 
   /**
-   * Whether the calling thread is one of the Sentry executor threads. Cheap replacement for scanning
-   * {@code Thread.currentThread().getName()}, which is on hot paths (e.g. scope persistence on every
-   * scope mutation).
+   * Whether the calling thread is one of the Sentry executor threads. Cheap replacement for
+   * scanning {@code Thread.currentThread().getName()}, which is on hot paths (e.g. scope
+   * persistence on every scope mutation).
    */
   public static boolean isSentryExecutorThread() {
     return Thread.currentThread() instanceof SentryExecutorServiceThread;

--- a/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
+++ b/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
@@ -7,6 +7,7 @@ import static io.sentry.cache.CacheUtils.ensureCacheDir;
 import io.sentry.Breadcrumb;
 import io.sentry.IScope;
 import io.sentry.ScopeObserverAdapter;
+import io.sentry.SentryExecutorService;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.SpanContext;
@@ -229,7 +230,7 @@ public final class PersistingScopeObserver extends ScopeObserverAdapter {
     if (!options.isEnableScopePersistence()) {
       return;
     }
-    if (Thread.currentThread().getName().contains("SentryExecutor")) {
+    if (SentryExecutorService.isSentryExecutorThread()) {
       // we're already on the sentry executor thread, so we can just execute it directly
       runSafely(task);
       return;


### PR DESCRIPTION
Resolves [JAVA-607](https://linear.app/getsentry/issue/JAVA-607).

### Description

`PersistingScopeObserver.serializeToDisk` decided whether it was already on the Sentry executor thread by scanning the thread name:

```java
if (Thread.currentThread().getName().contains("SentryExecutor")) { ... }
```

This runs on **every** scope mutation (breadcrumb, tag, trace, user, …), including on the main thread as the synchronous part of `addBreadcrumb`. The `Thread.getName()` + `String.contains` name scan is pure CPU overhead on that hot path.

This tags the executor threads with a package-private marker `Thread` subclass (thread name unchanged) and replaces the scan with a cheap `SentryExecutorService.isSentryExecutorThread()` identity check.

> **Note:** the original rationale claimed this removed a `String` allocation. On ART, `Thread.getName()` returns the cached name field **without allocating**, so the measured win is **CPU only** (avoiding the scan), not an allocation reduction — see the Benchmark section.

### API

Adds one method to the already `@ApiStatus.Internal` `SentryExecutorService`; `apiDump` regenerated (single-line `.api` addition).

### Source

Found via on-device Perfetto method-trace analysis of the Android SDK scope-persistence path (~3,130 scope stores go through this gate). Part of [Reduce SDK init time [Android]](https://linear.app/getsentry/project/a59f90bd-5035-443a-a955-097a48547806).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Benchmark

Measured on-device with **androidx Microbenchmark 1.4.1** (`benchmark-junit4`) on a **Samsung Galaxy A55 (SM-A556B), Android API 36** (release build, non-minified).

The benchmark exercises the **caller-side** cost of a scope mutation with scope persistence enabled (`enableScopePersistence = true`, `cacheDirPath` set, **no** `beforeBreadcrumb`). The async serialize + disk write is dispatched to a no-op executor so it never runs on the measured thread — mirroring production, where it runs off-thread. Each branch is compared against its base commit (`aab952b82e`); the per-branch delta isolates this change. `allocationCount` is deterministic; `timeNs` has ~±10 ns run-to-run noise on a non-rooted device (unlocked clocks), so it is reported as a median and reproduced across 2 runs.

### How it was done

A **local, uncommitted** androidx microbenchmark module (`sentry-android-integration-tests/sentry-uitest-android-microbenchmark`) depending on `:sentry`, with a `BenchmarkRule` looping the scope mutation. Run with:

```
./gradlew :sentry-android-integration-tests:sentry-uitest-android-microbenchmark:connectedReleaseAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=UNLOCKED
```

### Result

| Benchmark | Metric | main | This PR | Delta |
|---|---|---|---|---|
| `setTag` | timeNs (median) | ~127 ns | **~61 ns** | **~-52%** |
| `addBreadcrumb` | timeNs (median) | ~242 ns | **~192 ns** | ~-20% |
| both | allocationCount | 7 / 3 | 7 / 3 | none |

**Correction to the original rationale:** on ART, `Thread.getName()` returns the cached name field **without allocating a String**, so this change does **not** reduce `allocationCount`. The win is pure **CPU** — avoiding the `String.contains` scan of the thread name on every scope mutation — which is substantial for cheap mutations like `setTag` (roughly halved). Reproduced across 2 runs.

