### PR TITLE
refactor(core): Consolidate PersistingScopeObserver error handling

### DIFF
--- a/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
+++ b/sentry/src/main/java/io/sentry/cache/PersistingScopeObserver.java
@@ -231,27 +231,22 @@ public final class PersistingScopeObserver extends ScopeObserverAdapter {
     }
     if (Thread.currentThread().getName().contains("SentryExecutor")) {
       // we're already on the sentry executor thread, so we can just execute it directly
-      try {
-        task.run();
-      } catch (Throwable e) {
-        options.getLogger().log(ERROR, "Serialization task failed", e);
-      }
+      runSafely(task);
       return;
     }
 
     try {
-      options
-          .getExecutorService()
-          .submit(
-              () -> {
-                try {
-                  task.run();
-                } catch (Throwable e) {
-                  options.getLogger().log(ERROR, "Serialization task failed", e);
-                }
-              });
+      options.getExecutorService().submit(() -> runSafely(task));
     } catch (Throwable e) {
       options.getLogger().log(ERROR, "Serialization task could not be scheduled", e);
+    }
+  }
+
+  private void runSafely(final @NotNull Runnable task) {
+    try {
+      task.run();
+    } catch (Throwable e) {
+      options.getLogger().log(ERROR, "Serialization task failed", e);
     }
   }
 


### PR DESCRIPTION
Resolves [JAVA-608](https://linear.app/getsentry/issue/JAVA-608).

### Description

`PersistingScopeObserver.serializeToDisk` duplicated the same try/catch error-handling block in both the on-executor path and the `submit` wrapper. This extracts it into a single `runSafely(task)` helper used by both.



#skip-changelog
