### PR TITLE
fix(core): Record byte discards for event processor drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 
 ## 8.47.0

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -511,6 +511,7 @@ public final class SentryClient implements ISentryClient {
   private SentryLogEvent processLogEvent(
       @NotNull SentryLogEvent event, final @NotNull List<EventProcessor> eventProcessors) {
     for (final EventProcessor processor : eventProcessors) {
+      final @NotNull SentryLogEvent eventBeforeProcessor = event;
       try {
         event = processor.process(event);
       } catch (Throwable e) {
@@ -533,6 +534,13 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.LogItem);
+        final long logEventNumberOfBytes =
+            JsonSerializationUtils.byteSizeOf(
+                options.getSerializer(), options.getLogger(), eventBeforeProcessor);
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(
+                DiscardReason.EVENT_PROCESSOR, DataCategory.LogByte, logEventNumberOfBytes);
         break;
       }
     }
@@ -545,6 +553,7 @@ public final class SentryClient implements ISentryClient {
       final @NotNull List<EventProcessor> eventProcessors,
       final @NotNull Hint hint) {
     for (final EventProcessor processor : eventProcessors) {
+      final @NotNull SentryMetricsEvent eventBeforeProcessor = event;
       try {
         event = processor.process(event, hint);
       } catch (Throwable e) {
@@ -567,6 +576,15 @@ public final class SentryClient implements ISentryClient {
         options
             .getClientReportRecorder()
             .recordLostEvent(DiscardReason.EVENT_PROCESSOR, DataCategory.TraceMetric);
+        final long metricsEventNumberOfBytes =
+            JsonSerializationUtils.byteSizeOf(
+                options.getSerializer(), options.getLogger(), eventBeforeProcessor);
+        options
+            .getClientReportRecorder()
+            .recordLostEvent(
+                DiscardReason.EVENT_PROCESSOR,
+                DataCategory.TraceMetricByte,
+                metricsEventNumberOfBytes);
         break;
       }
     }

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -33,6 +33,7 @@ import io.sentry.test.injectForField
 import io.sentry.transport.ITransport
 import io.sentry.transport.ITransportGate
 import io.sentry.util.HintUtils
+import io.sentry.util.JsonSerializationUtils
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -342,6 +343,39 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when log is dropped by event processor, log byte discard is recorded`() {
+    val scope = createScope()
+    val logEvent = SentryLogEvent(SentryId(), SentryNanotimeDate(), "message", SentryLogLevel.WARN)
+    val logEventNumberOfBytes =
+      JsonSerializationUtils.byteSizeOf(
+        fixture.sentryOptions.serializer,
+        fixture.sentryOptions.logger,
+        logEvent,
+      )
+    scope.addEventProcessor(
+      object : EventProcessor {
+        override fun process(event: SentryLogEvent): SentryLogEvent? = null
+      }
+    )
+
+    val sut = fixture.getSut()
+    sut.captureLog(logEvent, scope)
+
+    verify(fixture.loggerBatchProcessor, never()).add(any())
+    assertClientReport(
+      fixture.sentryOptions.clientReportRecorder,
+      listOf(
+        DiscardedEvent(DiscardReason.EVENT_PROCESSOR.reason, DataCategory.LogItem.category, 1),
+        DiscardedEvent(
+          DiscardReason.EVENT_PROCESSOR.reason,
+          DataCategory.LogByte.category,
+          logEventNumberOfBytes,
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun `when beforeSendLog is returns new instance, new instance is sent`() {
     val scope = createScope()
     val expected =
@@ -414,6 +448,39 @@ class SentryClientTest {
       listOf(
         DiscardedEvent(DiscardReason.BEFORE_SEND.reason, DataCategory.TraceMetric.category, 1),
         DiscardedEvent(DiscardReason.BEFORE_SEND.reason, DataCategory.TraceMetricByte.category, 120),
+      ),
+    )
+  }
+
+  @Test
+  fun `when metric is dropped by event processor, metric byte discard is recorded`() {
+    val scope = createScope()
+    val metricsEvent = SentryMetricsEvent(SentryId(), SentryNanotimeDate(), "name", "gauge", 123.0)
+    val metricsEventNumberOfBytes =
+      JsonSerializationUtils.byteSizeOf(
+        fixture.sentryOptions.serializer,
+        fixture.sentryOptions.logger,
+        metricsEvent,
+      )
+    scope.addEventProcessor(
+      object : EventProcessor {
+        override fun process(event: SentryMetricsEvent, hint: Hint): SentryMetricsEvent? = null
+      }
+    )
+
+    val sut = fixture.getSut()
+    sut.captureMetric(metricsEvent, scope, null)
+
+    verify(fixture.metricsBatchProcessor, never()).add(any())
+    assertClientReport(
+      fixture.sentryOptions.clientReportRecorder,
+      listOf(
+        DiscardedEvent(DiscardReason.EVENT_PROCESSOR.reason, DataCategory.TraceMetric.category, 1),
+        DiscardedEvent(
+          DiscardReason.EVENT_PROCESSOR.reason,
+          DataCategory.TraceMetricByte.category,
+          metricsEventNumberOfBytes,
+        ),
       ),
     )
   }


### PR DESCRIPTION
## :scroll: Description
Record byte-count client report outcomes when event processors drop log or trace metric events.

This adds `LogByte` and `TraceMetricByte` discarded-event entries alongside the existing `LogItem` and `TraceMetric` count entries for EventProcessor drops.

## :bulb: Motivation and Context
Before this change, before-send and queue-overflow discard paths tracked both item count and byte count, but EventProcessor drops only tracked item count. This made byte-level client report accounting incomplete for logs and trace metrics.

## :green_heart: How did you test it?
- `./gradlew :sentry:test --tests "io.sentry.SentryClientTest"`
- `./gradlew spotlessApply apiDump`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps
