### PR TITLE
feat(android): Compile against Android SDK 37

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -73,6 +73,11 @@ jobs:
           disk-size: 4096M
           script: echo "Generated AVD snapshot for caching."
 
+      # API 37 ships as a minor-versioned platform (android-37.0); install it
+      # explicitly so the build can resolve it.
+      - name: Install compileSdk platform
+        run: echo "y" | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "platforms;android-37.0"
+
       # Clean, build and release a test apk
       - name: Make assembleUiTests
         run: make assembleUiTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
   Sentry.finishExtendedAppStart()
   ```
+- Full support for Android 17 (API level 37) ([#5723](https://github.com/getsentry/sentry-java/pull/5723))
+  - The SDK is now compiled and targeted against `compileSdk`/`targetSdk` 37 and verified end-to-end on API 37: builds (incl. R8 full mode), Session Replay, crash & ANR reporting (JVM and native), and profiling
+  - Session Replay video encoding now handles the `@Nullable` `MediaCodecInfo.getVideoCapabilities()` introduced in the API 37 SDK
 - Add `trace_metric_byte` data category and record byte-level client reports when trace metrics are discarded ([#5626](https://github.com/getsentry/sentry-java/pull/5626))
 - Support the `io.sentry.tombstone.report-historical` manifest option to enable historical tombstone reporting via `AndroidManifest.xml` `<meta-data>` ([#5683](https://github.com/getsentry/sentry-java/pull/5683))
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,8 +45,8 @@ springboot4 = "4.0.0"
 sqldelight = "2.3.2"
 
 # Android
-targetSdk = "36"
-compileSdk = "36"
+targetSdk = "37"
+compileSdk = "37"
 minSdk = "21"
 
 [plugins]

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -81,7 +81,7 @@ internal class SimpleVideoEncoder(
         val videoCapabilities =
           mediaCodec.codecInfo.getCapabilitiesForType(muxerConfig.mimeType).videoCapabilities
 
-        if (!videoCapabilities.bitrateRange.contains(bitRate)) {
+        if (videoCapabilities != null && !videoCapabilities.bitrateRange.contains(bitRate)) {
           options.logger.log(
             DEBUG,
             "Encoder doesn't support the provided bitRate: $bitRate, the value will be clamped to the closest one",


### PR DESCRIPTION
Ref: [JAVA-631](https://linear.app/getsentry/issue/JAVA-631/android-17-smoke-test-checklist)

## :scroll: Description
Compile the Android SDK against **API 37 (Android 17)** by bumping `compileSdk` and `targetSdk` from 36 to 37 in `gradle/libs.versions.toml`.

This also fixes a compilation break the new SDK surfaces: in the API 37 `android.jar`, `MediaCodecInfo.CodecCapabilities.getVideoCapabilities()` is now annotated `@Nullable`. `SimpleVideoEncoder` dereferenced it without a null check, which fails Kotlin compilation. The access is already wrapped in a `try/catch`, so adding the null guard keeps behavior unchanged.

## :bulb: Motivation and Context
Verify the SDK builds and behaves correctly against the latest Android SDK so downstream apps can compile/target API 37 without issues.

Verified against API 37 on this branch: full SDK + sample assemble, clean lint (`AGP 8.13.1`), R8 full-mode release build (no missing rules, runs clean), external app consuming the published artifacts, and runtime coverage on an API 37 emulator (crashes, ANRs incl. native, Session Replay h264 encoding — the exact `SimpleVideoEncoder` path — messages, and profiling), all landing in Sentry.

## :green_heart: How did you test it?
- `./gradlew assemble` + sample `assembleRelease`/`assembleDebug` against compileSdk/targetSdk 37
- `lintRelease` on core Android modules — no issues
- R8 full-mode release APK installed and smoke-tested on an Android 17 (API 37) emulator
- Consumed the `publishToMavenLocal` artifacts from a standalone external app
- Exercised the sample app end-to-end on API 37 and confirmed events (incl. Session Replay video encoding) arrive in Sentry

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
- Add API 37 to the CI emulator matrix once tooling is broadly available.

