### PR TITLE
feat(samples): Distinguish debug and release builds of the Android sample

### DIFF
--- a/sentry-samples/sentry-samples-android/build.gradle.kts
+++ b/sentry-samples/sentry-samples-android/build.gradle.kts
@@ -111,6 +111,8 @@ android {
 
   buildTypes {
     getByName("debug") {
+      // Suffix the id so debug and release builds can be installed side by side.
+      applicationIdSuffix = ".debug"
       addManifestPlaceholders(mapOf("sentryDebug" to true, "sentryEnvironment" to "debug"))
     }
     getByName("release") {

--- a/sentry-samples/sentry-samples-android/src/debug/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="app_name">Sentry Sample Debug</string>
+  <string name="build_type">DEBUG</string>
+</resources>

--- a/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.kt
+++ b/sentry-samples/sentry-samples-android/src/main/java/io/sentry/samples/android/MainActivity.kt
@@ -77,6 +77,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -245,6 +246,15 @@ fun CategoryNavigationRail(
           .clickable { scope.launch { rotation.animateTo(rotation.targetValue + 360.0f) } }
           .padding(12.dp)
           .rotate(rotation.value),
+    )
+    Spacer(Modifier.height(8.dp))
+    Text(
+      text = stringResource(R.string.build_type),
+      style = MaterialTheme.typography.labelSmall,
+      fontWeight = FontWeight.Bold,
+      color =
+        if (BuildConfig.DEBUG) MaterialTheme.colorScheme.error
+        else MaterialTheme.colorScheme.primary,
     )
     Spacer(Modifier.height(16.dp))
     Category.entries.forEach { category ->

--- a/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-  <string name="app_name">Sentry sample</string>
   <string name="crash_from_java">Crash from Java (UncaughtException)</string>
   <string name="out_of_memory">Out of Memory (Mulithreaded)</string>
   <string name="stack_overflow">Stack Overflow</string>

--- a/sentry-samples/sentry-samples-android/src/release/res/values/strings.xml
+++ b/sentry-samples/sentry-samples-android/src/release/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="app_name">Sentry Sample</string>
+  <string name="build_type">RELEASE</string>
+</resources>


### PR DESCRIPTION
## :scroll: Description

Makes the debug and release builds of the Android sample app distinguishable:

- **Different application id**: debug builds use the `.debug` application id suffix (`io.sentry.samples.android.debug`), so debug and release can be installed side by side.
- **Different launcher name**: `app_name` is defined per build type via source-set resources (`src/debug` / `src/release`) — `Sentry Sample Debug` for debug, `Sentry Sample` for release. The manifest keeps `android:label="@string/app_name"`.
- **In-app build type indicator**: a `DEBUG`/`RELEASE` badge is shown under the Sentry logo in the navigation rail. Its text comes from a per-build-type `build_type` string resource; the badge color is keyed on `BuildConfig.DEBUG` (red for debug, primary for release).

## :bulb: Motivation and Context

When testing SDK changes it's common to have both a debug and a release build of the sample on the same device. Previously they shared an application id and launcher name, so they couldn't coexist and were easy to confuse. This makes it clear at a glance which build you're looking at, both on the home screen and inside the app.

## :green_heart: How did you test it?

Built and installed the debug build on an emulator. Verified via `aapt2 dump badging` that it resolves to package `io.sentry.samples.android.debug` and label `Sentry Sample Debug`, coexisting with a release build (`io.sentry.samples.android` / `Sentry Sample`). Confirmed both variants process resources cleanly and the red `DEBUG` badge renders in-app.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

The Maestro flow in `sentry-samples/sentry-samples-android/maestro` uses `appId: io.sentry.samples.android`, which now matches the release build only. It is a manually-run dev tool (not in CI); run it against a release build, or point it at the `.debug` id when testing debug.

Ref: JAVA-631

#skip-changelog
