### PR TITLE
fix(samples): Add Retrofit R8 full-mode keep rules to Android sample

### DIFF
--- a/sentry-samples/sentry-samples-android/proguard-rules.pro
+++ b/sentry-samples/sentry-samples-android/proguard-rules.pro
@@ -32,3 +32,15 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLParameters
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
+
+# Retrofit relies on generic signatures for its service methods. Under R8 full mode these are
+# stripped for classes that aren't kept, which breaks call-adapter creation (SecondActivity's
+# GithubAPI request). Keep the signature attributes and Retrofit's generic types.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+# Keep the response model so Gson can deserialize it.
+-keep class io.sentry.samples.android.Repo { *; }


### PR DESCRIPTION
Ref: [JAVA-631](https://linear.app/getsentry/issue/JAVA-631/android-17-smoke-test-checklist)

## :scroll: Description
The Android sample crashes when opening `SecondActivity` in a **release** build:

```
java.lang.IllegalArgumentException: Unable to create call adapter for interface retrofit2.Call
    ... at SecondActivity.onResume → updateRepos → GithubAPI.service.listRepos(...)
```

The sample's release build uses **R8 full mode** (AGP 8+ default), which strips generic signatures from classes that aren't explicitly kept. Retrofit needs those signatures to build a call adapter for `GithubAPI.listRepos(): Call<List<Repo>>`, so it fails and the activity crashes on resume.

This adds the standard Retrofit R8-full-mode keep rules to `sentry-samples-android/proguard-rules.pro`:
- keep `Signature`, `InnerClasses`, `EnclosingMethod` attributes
- keep `retrofit2.Call` / `retrofit2.Response` / `kotlin.coroutines.Continuation` (allow obfuscation/shrinking)
- keep annotated Retrofit service interfaces
- keep the `Repo` response model for Gson

## :bulb: Motivation and Context
The sample is unusable in release mode on the Tracing screen (Open Second Activity → crash). It's a missing-ProGuard-rule bug, independent of API level or SDK version.

## :green_heart: How did you test it?
Built the sample release APK with `-Pandroid.enableR8.fullMode=true`, installed on an emulator, and opened Second Activity. Before: crash on resume. After: `SecondActivity` loads and the GitHub request succeeds (`items: 30`).

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
None.

#skip-changelog

