### PR TITLE
fix(anr): extend main thread detection from thread dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
+- Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- Detect the main thread in AnrV2 thread dumps when the OS renames it to the process name, by matching the thread whose `sysTid` equals the process id ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Detect the main thread in AnrV2 thread dumps when the OS renames it to the process name, by matching the thread whose `sysTid` equals the process id ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
+- Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -208,8 +208,7 @@ public class AnrV2Integration implements Integration, Closeable {
           new BufferedReader(new InputStreamReader(new ByteArrayInputStream(dump)))) {
         final Lines lines = Lines.readLines(reader);
 
-        final ThreadDumpParser threadDumpParser =
-            new ThreadDumpParser(options, isBackground, exitInfo.getProcessName());
+        final ThreadDumpParser threadDumpParser = new ThreadDumpParser(options, isBackground);
         threadDumpParser.parse(lines);
 
         final @NotNull List<SentryThread> threads = threadDumpParser.getThreads();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/AnrV2Integration.java
@@ -208,7 +208,8 @@ public class AnrV2Integration implements Integration, Closeable {
           new BufferedReader(new InputStreamReader(new ByteArrayInputStream(dump)))) {
         final Lines lines = Lines.readLines(reader);
 
-        final ThreadDumpParser threadDumpParser = new ThreadDumpParser(options, isBackground);
+        final ThreadDumpParser threadDumpParser =
+            new ThreadDumpParser(options, isBackground, exitInfo.getProcessName());
         threadDumpParser.parse(lines);
 
         final @NotNull List<SentryThread> threads = threadDumpParser.getThreads();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -174,6 +174,8 @@ public class ThreadDumpParser {
         artContextParser.parseLine(text);
       }
     }
+
+    markThreads();
   }
 
   private SentryThread parseThread(final @NotNull Lines lines) {
@@ -199,7 +201,11 @@ public class ThreadDumpParser {
         return null;
       }
       sentryThread.setId(tid);
-      sentryThread.setName(beginManagedThreadRe.group(1));
+      final String name = beginManagedThreadRe.group(1);
+      sentryThread.setName(name);
+      if ("main".equals(name)) {
+        sentryThread.setMain(true);
+      }
       final String state = beginManagedThreadRe.group(5);
       // sanitizing thread that have more details after their actual state, e.g.
       // "Native (still starting up)" <- we just need "Native" here
@@ -211,25 +217,20 @@ public class ThreadDumpParser {
         }
       }
     } else if (matches(beginUnmanagedNativeThreadRe, line.text)) {
-      final Long sysTid = getLong(beginUnmanagedNativeThreadRe, 3, null);
-      if (sysTid == null) {
+      final Long parsedSysTid = getLong(beginUnmanagedNativeThreadRe, 3, null);
+      if (parsedSysTid == null) {
         options.getLogger().log(SentryLevel.DEBUG, "No thread id in the dump, skipping thread.");
         // tid is required by our protocol
         return null;
       }
-      sentryThread.setId(sysTid);
+      sentryThread.setId(parsedSysTid);
       sentryThread.setName(beginUnmanagedNativeThreadRe.group(1));
+      if (parsedSysTid.equals(processId)) {
+        sentryThread.setMain(true);
+      }
     }
 
-    final String threadName = sentryThread.getName();
-    if (threadName != null) {
-      // the OS usually names the main thread "main", but it may also rename it to the process name
-      // (which can be truncated), so this is only a first guess - the sysTid==processId check in
-      // parseStacktrace is the authoritative signal and may still mark another thread as main
-      setMainThread(sentryThread, threadName.equals("main"));
-    }
-
-    // thread stacktrace
+    // thread stacktrace (also captures parsedSysTid for managed threads from the "| sysTid=" line)
     final SentryStackTrace stackTrace = parseStacktrace(lines, sentryThread);
     final List<SentryStackFrame> frames = stackTrace.getFrames();
     if (frames == null || frames.isEmpty()) {
@@ -266,10 +267,9 @@ public class ThreadDumpParser {
       }
       final String text = line.text;
       if (matches(sysTidRe, text)) {
-        // on Linux/Android the kernel thread id of the main thread always equals the process id
         final Long sysTid = getLong(sysTidRe, 1, null);
         if (sysTid != null && sysTid.equals(processId)) {
-          setMainThread(thread, true);
+          thread.setMain(true);
         }
       } else if (matches(javaRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
@@ -390,15 +390,21 @@ public class ThreadDumpParser {
     return stackTrace;
   }
 
-  private void setMainThread(final @NotNull SentryThread thread, final boolean isMain) {
-    thread.setMain(isMain);
-    // since it's an ANR, the crashed thread will always be main
-    thread.setCrashed(isMain);
-    thread.setCurrent(isMain && !isBackground);
-    if (isMain) {
-      // the OS may have renamed the main thread to the (truncated) process name; normalize it back
-      // to "main" so downstream consumers see a consistent name
-      thread.setName("main");
+  private void markThreads() {
+    for (final @NotNull SentryThread thread : threads) {
+      if (Boolean.TRUE.equals(thread.isMain())) {
+        // the OS may have renamed the main thread to the (truncated) process name; normalize it
+        // back to "main" so downstream consumers see a consistent name
+        thread.setName("main");
+
+        // since it's an ANR, the crashed thread will always be main
+        thread.setCrashed(true);
+        thread.setCurrent(!isBackground);
+      } else {
+        thread.setCrashed(false);
+        thread.setCurrent(false);
+        thread.setMain(false);
+      }
     }
   }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -217,20 +217,20 @@ public class ThreadDumpParser {
         }
       }
     } else if (matches(beginUnmanagedNativeThreadRe, line.text)) {
-      final Long parsedSysTid = getLong(beginUnmanagedNativeThreadRe, 3, null);
-      if (parsedSysTid == null) {
+      final Long sysTid = getLong(beginUnmanagedNativeThreadRe, 3, null);
+      if (sysTid == null) {
         options.getLogger().log(SentryLevel.DEBUG, "No thread id in the dump, skipping thread.");
         // tid is required by our protocol
         return null;
       }
-      sentryThread.setId(parsedSysTid);
+      sentryThread.setId(sysTid);
       sentryThread.setName(beginUnmanagedNativeThreadRe.group(1));
-      if (parsedSysTid.equals(processId)) {
+      if (sysTid.equals(processId)) {
         sentryThread.setMain(true);
       }
     }
 
-    // thread stacktrace (also captures parsedSysTid for managed threads from the "| sysTid=" line)
+    // thread stacktrace
     final SentryStackTrace stackTrace = parseStacktrace(lines, sentryThread);
     final List<SentryStackFrame> frames = stackTrace.getFrames();
     if (frames == null || frames.isEmpty()) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -104,6 +104,8 @@ public class ThreadDumpParser {
 
   private final boolean isBackground;
 
+  private final @Nullable String processName;
+
   private final @NotNull SentryStackTraceFactory stackTraceFactory;
 
   private final @NotNull Map<String, DebugImage> debugImages;
@@ -113,8 +115,16 @@ public class ThreadDumpParser {
   private final @NotNull ArtContextParser artContextParser = new ArtContextParser();
 
   public ThreadDumpParser(final @NotNull SentryOptions options, final boolean isBackground) {
+    this(options, isBackground, null);
+  }
+
+  public ThreadDumpParser(
+      final @NotNull SentryOptions options,
+      final boolean isBackground,
+      final @Nullable String processName) {
     this.options = options;
     this.isBackground = isBackground;
+    this.processName = processName;
     this.stackTraceFactory = new SentryStackTraceFactory(options);
     this.debugImages = new HashMap<>();
     this.threads = new ArrayList<>();
@@ -209,7 +219,9 @@ public class ThreadDumpParser {
 
     final String threadName = sentryThread.getName();
     if (threadName != null) {
-      final boolean isMain = threadName.equals("main");
+      final boolean isMain =
+          threadName.equals("main")
+              || (processName != null && threadName.equals(processName));
       sentryThread.setMain(isMain);
       // since it's an ANR, the crashed thread will always be main
       sentryThread.setCrashed(isMain);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -220,8 +220,7 @@ public class ThreadDumpParser {
     final String threadName = sentryThread.getName();
     if (threadName != null) {
       final boolean isMain =
-          threadName.equals("main")
-              || (processName != null && threadName.equals(processName));
+          threadName.equals("main") || (processName != null && threadName.equals(processName));
       sentryThread.setMain(isMain);
       // since it's an ANR, the crashed thread will always be main
       sentryThread.setCrashed(isMain);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -45,6 +45,12 @@ public class ThreadDumpParser {
   private static final Pattern BEGIN_UNMANAGED_NATIVE_THREAD_RE =
       Pattern.compile("\"(.*)\" (.*) ?sysTid=(\\d+)");
 
+  // e.g. "----- pid 12345 at 2024-01-01 10:00:00.000000000+0000 -----"
+  private static final Pattern PID_RE = Pattern.compile("----- pid (\\d+) at .*");
+
+  // e.g. "  | sysTid=12345 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8"
+  private static final Pattern SYS_TID_RE = Pattern.compile("\\s*\\|\\s*sysTid=(\\d+).*");
+
   // For reference, see native_stack_dump.cc and tombstone_proto_to_text.cpp in Android sources
   // Groups
   // 0:entire regex
@@ -104,7 +110,10 @@ public class ThreadDumpParser {
 
   private final boolean isBackground;
 
-  private final @Nullable String processName;
+  // the process id parsed from the thread dump header; on Linux/Android the main thread's kernel
+  // thread id (sysTid) always equals the process id, so we use it to reliably detect the main
+  // thread
+  private @Nullable Long processId;
 
   private final @NotNull SentryStackTraceFactory stackTraceFactory;
 
@@ -115,16 +124,8 @@ public class ThreadDumpParser {
   private final @NotNull ArtContextParser artContextParser = new ArtContextParser();
 
   public ThreadDumpParser(final @NotNull SentryOptions options, final boolean isBackground) {
-    this(options, isBackground, null);
-  }
-
-  public ThreadDumpParser(
-      final @NotNull SentryOptions options,
-      final boolean isBackground,
-      final @Nullable String processName) {
     this.options = options;
     this.isBackground = isBackground;
-    this.processName = processName;
     this.stackTraceFactory = new SentryStackTraceFactory(options);
     this.debugImages = new HashMap<>();
     this.threads = new ArrayList<>();
@@ -149,6 +150,7 @@ public class ThreadDumpParser {
 
     final Matcher beginManagedThreadRe = BEGIN_MANAGED_THREAD_RE.matcher("");
     final Matcher beginUnmanagedNativeThreadRe = BEGIN_UNMANAGED_NATIVE_THREAD_RE.matcher("");
+    final Matcher pidRe = PID_RE.matcher("");
 
     while (lines.hasNext()) {
       final Line line = lines.next();
@@ -166,6 +168,8 @@ public class ThreadDumpParser {
         if (thread != null) {
           threads.add(thread);
         }
+      } else if (matches(pidRe, text)) {
+        processId = getLong(pidRe, 1, null);
       } else {
         artContextParser.parseLine(text);
       }
@@ -219,12 +223,10 @@ public class ThreadDumpParser {
 
     final String threadName = sentryThread.getName();
     if (threadName != null) {
-      final boolean isMain =
-          threadName.equals("main") || (processName != null && threadName.equals(processName));
-      sentryThread.setMain(isMain);
-      // since it's an ANR, the crashed thread will always be main
-      sentryThread.setCrashed(isMain);
-      sentryThread.setCurrent(isMain && !isBackground);
+      // the OS usually names the main thread "main", but it may also rename it to the process name
+      // (which can be truncated), so this is only a first guess - the sysTid==processId check in
+      // parseStacktrace is the authoritative signal and may still mark another thread as main
+      setMainThread(sentryThread, threadName.equals("main"));
     }
 
     // thread stacktrace
@@ -249,6 +251,7 @@ public class ThreadDumpParser {
     final Matcher waitingToLockRe = WAITING_TO_LOCK_RE.matcher("");
     final Matcher waitingToLockUnknownRe = WAITING_TO_LOCK_UNKNOWN_RE.matcher("");
     final Matcher blankRe = BLANK_RE.matcher("");
+    final Matcher sysTidRe = SYS_TID_RE.matcher("");
 
     while (lines.hasNext()) {
       final Line line = lines.next();
@@ -257,7 +260,13 @@ public class ThreadDumpParser {
         break;
       }
       final String text = line.text;
-      if (matches(javaRe, text)) {
+      if (matches(sysTidRe, text)) {
+        // on Linux/Android the kernel thread id of the main thread always equals the process id
+        final Long sysTid = getLong(sysTidRe, 1, null);
+        if (sysTid != null && sysTid.equals(processId)) {
+          setMainThread(thread, true);
+        }
+      } else if (matches(javaRe, text)) {
         final SentryStackFrame frame = new SentryStackFrame();
         final String packageName = javaRe.group(1);
         final String className = javaRe.group(2);
@@ -374,6 +383,13 @@ public class ThreadDumpParser {
     // it's a thread dump
     stackTrace.setSnapshot(true);
     return stackTrace;
+  }
+
+  private void setMainThread(final @NotNull SentryThread thread, final boolean isMain) {
+    thread.setMain(isMain);
+    // since it's an ANR, the crashed thread will always be main
+    thread.setCrashed(isMain);
+    thread.setCurrent(isMain && !isBackground);
   }
 
   private boolean matches(final @NotNull Matcher matcher, final @NotNull String text) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/threaddump/ThreadDumpParser.java
@@ -231,6 +231,11 @@ public class ThreadDumpParser {
 
     // thread stacktrace
     final SentryStackTrace stackTrace = parseStacktrace(lines, sentryThread);
+    final List<SentryStackFrame> frames = stackTrace.getFrames();
+    if (frames == null || frames.isEmpty()) {
+      // skip threads without a stacktrace, they are not actionable
+      return null;
+    }
     sentryThread.setStacktrace(stackTrace);
     return sentryThread;
   }
@@ -390,6 +395,11 @@ public class ThreadDumpParser {
     // since it's an ANR, the crashed thread will always be main
     thread.setCrashed(isMain);
     thread.setCurrent(isMain && !isBackground);
+    if (isMain) {
+      // the OS may have renamed the main thread to the (truncated) process name; normalize it back
+      // to "main" so downstream consumers see a consistent name
+      thread.setName("main");
+    }
   }
 
   private boolean matches(final @NotNull Matcher matcher, final @NotNull String text) {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -184,8 +184,7 @@ class ThreadDumpParserTest {
 
   @Test
   fun `detects main thread when OS names it after the process`() {
-    val lines =
-      Lines.readLines(File("src/test/resources/thread_dump_process_name_main.txt"))
+    val lines = Lines.readLines(File("src/test/resources/thread_dump_process_name_main.txt"))
     val parser =
       ThreadDumpParser(
         SentryOptions().apply { addInAppInclude("io.sentry.samples") },

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -190,16 +190,28 @@ class ThreadDumpParserTest {
     parser.parse(lines)
     val threads = parser.threads
     // the main thread has been renamed to the (truncated) process name, but its sysTid equals the
-    // process id, which is how we detect it
-    val main = threads.find { it.name == "io.sentry.samples.android" }
+    // process id, which is how we detect it - its name is then normalized back to "main"
+    val main = threads.find { it.isMain == true }
     assertNotNull(main)
-    assertEquals(true, main!!.isMain)
+    assertEquals("main", main!!.name)
     assertEquals(true, main.isCrashed)
     assertEquals(true, main.isCurrent)
     val background = threads.find { it.name == "Thread-2" }
     assertNotNull(background)
     assertEquals(false, background!!.isMain)
     assertEquals(false, background.isCrashed)
+  }
+
+  @Test
+  fun `skips threads without a stacktrace`() {
+    val lines = Lines.readLines(File("src/test/resources/thread_dump_no_stacktrace.txt"))
+    val parser =
+      ThreadDumpParser(SentryOptions().apply { addInAppInclude("io.sentry.samples") }, false)
+    parser.parse(lines)
+    val threads = parser.threads
+    // the thread without any frames is skipped, only the one with a stacktrace remains
+    assertEquals(1, threads.size)
+    assertEquals("main", threads.first().name)
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -183,6 +183,29 @@ class ThreadDumpParserTest {
   }
 
   @Test
+  fun `detects main thread when OS names it after the process`() {
+    val lines =
+      Lines.readLines(File("src/test/resources/thread_dump_process_name_main.txt"))
+    val parser =
+      ThreadDumpParser(
+        SentryOptions().apply { addInAppInclude("io.sentry.samples") },
+        false,
+        "io.sentry.samples.android",
+      )
+    parser.parse(lines)
+    val threads = parser.threads
+    val main = threads.find { it.name == "io.sentry.samples.android" }
+    assertNotNull(main)
+    assertEquals(true, main!!.isMain)
+    assertEquals(true, main.isCrashed)
+    assertEquals(true, main.isCurrent)
+    val background = threads.find { it.name == "Thread-2" }
+    assertNotNull(background)
+    assertEquals(false, background!!.isMain)
+    assertEquals(false, background.isCrashed)
+  }
+
+  @Test
   fun `thread dump garbage`() {
     val lines = Lines.readLines(File("src/test/resources/thread_dump_bad_data.txt"))
     val parser =

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -183,16 +183,14 @@ class ThreadDumpParserTest {
   }
 
   @Test
-  fun `detects main thread when OS names it after the process`() {
+  fun `detects main thread via sysTid matching the process id when OS renames it`() {
     val lines = Lines.readLines(File("src/test/resources/thread_dump_process_name_main.txt"))
     val parser =
-      ThreadDumpParser(
-        SentryOptions().apply { addInAppInclude("io.sentry.samples") },
-        false,
-        "io.sentry.samples.android",
-      )
+      ThreadDumpParser(SentryOptions().apply { addInAppInclude("io.sentry.samples") }, false)
     parser.parse(lines)
     val threads = parser.threads
+    // the main thread has been renamed to the (truncated) process name, but its sysTid equals the
+    // process id, which is how we detect it
     val main = threads.find { it.name == "io.sentry.samples.android" }
     assertNotNull(main)
     assertEquals(true, main!!.isMain)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/threaddump/ThreadDumpParserTest.kt
@@ -100,12 +100,15 @@ class ThreadDumpParserTest {
     parser.parse(lines)
     val threads = parser.threads
     // just verifying a few important threads, as there are many
-    val thread = threads.find { it.name == "samples.android" }
+    // the OS named the main thread after the process; it is detected via sysTid==processId (9955)
+    // and its name is normalized back to "main"
+    val thread = threads.find { it.isMain == true }
     assertEquals(9955, thread!!.id)
+    assertEquals("main", thread.name)
     assertNull(thread.state)
-    assertEquals(false, thread.isCrashed)
-    assertEquals(false, thread.isMain)
-    assertEquals(false, thread.isCurrent)
+    assertEquals(true, thread.isCrashed)
+    assertEquals(true, thread.isMain)
+    assertEquals(true, thread.isCurrent)
 
     // Reverse frames so we can index them with the active frame at index 0
     val frames = thread.stacktrace!!.frames!!.reversed()

--- a/sentry-android-core/src/test/resources/thread_dump_no_stacktrace.txt
+++ b/sentry-android-core/src/test/resources/thread_dump_no_stacktrace.txt
@@ -1,0 +1,21 @@
+
+----- pid 12345 at 2024-01-01 10:00:00.000000000+0000 -----
+Cmd line: io.sentry.samples.android
+Build fingerprint: 'google/sdk_gphone64_arm64/emu64a:13/TE1A.220922.012/9302419:userdebug/dev-keys'
+ABI: 'arm64'
+
+DALVIK THREADS (2):
+"main" prio=5 tid=1 Runnable
+  | group="main" sCount=0 ucsCount=0 flags=0 obj=0x72a985e0 self=0xb400007cabc57380
+  | sysTid=12345 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8
+  | state=R schedstat=( 324804784 183300334 997 ) utm=23 stm=8 core=3 HZ=100
+  | stack=0x7ff93a9000-0x7ff93ab000 stackSize=8188KB
+  | held mutexes=
+  at io.sentry.samples.android.MainActivity.onCreate(MainActivity.java:42)
+
+"Thread-2" prio=5 tid=2 Sleeping
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0518 self=0xb400007cabc82ad0
+  | sysTid=12346 nice=0 cgrp=top-app sched=0/0 handle=0x7ace0a9cb0
+  | state=S schedstat=( 574039 4838087 11 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7acdfb2000-0x7acdfb4000 stackSize=991KB
+  | held mutexes=

--- a/sentry-android-core/src/test/resources/thread_dump_process_name_main.txt
+++ b/sentry-android-core/src/test/resources/thread_dump_process_name_main.txt
@@ -1,0 +1,24 @@
+
+----- pid 12345 at 2024-01-01 10:00:00.000000000+0000 -----
+Cmd line: io.sentry.samples.android
+Build fingerprint: 'google/sdk_gphone64_arm64/emu64a:13/TE1A.220922.012/9302419:userdebug/dev-keys'
+ABI: 'arm64'
+
+DALVIK THREADS (2):
+"io.sentry.samples.android" prio=5 tid=1 Runnable
+  | group="main" sCount=0 ucsCount=0 flags=0 obj=0x72a985e0 self=0xb400007cabc57380
+  | sysTid=12345 nice=-10 cgrp=top-app sched=0/0 handle=0x7deceb74f8
+  | state=R schedstat=( 324804784 183300334 997 ) utm=23 stm=8 core=3 HZ=100
+  | stack=0x7ff93a9000-0x7ff93ab000 stackSize=8188KB
+  | held mutexes=
+  at io.sentry.samples.android.MainActivity.onCreate(MainActivity.java:42)
+
+"Thread-2" prio=5 tid=2 Sleeping
+  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x136c0518 self=0xb400007cabc82ad0
+  | sysTid=12346 nice=0 cgrp=top-app sched=0/0 handle=0x7ace0a9cb0
+  | state=S schedstat=( 574039 4838087 11 ) utm=0 stm=0 core=1 HZ=100
+  | stack=0x7acdfb2000-0x7acdfb4000 stackSize=991KB
+  | held mutexes=
+  at java.lang.Thread.sleep(Native method)
+  at io.sentry.samples.android.BackgroundWorker.run(BackgroundWorker.java:20)
+


### PR DESCRIPTION
## :scroll: Description

Not every main thread has a `name="main"` set, so we ended up not correctly identifying it (on some Android versions/OEMs, native threads, etc...). 

To solve this we now rely on a common Linux/Android convention: The main thread kernel id (`sysTid`) is the same as the process id (`pid`). For managed Java threads, a fallback for the "main" thread name remains.

**Changes**

- Parses the process id from the thread dump header (`----- pid <pid> at ... -----`) and marks the thread whose `sysTid` equals it as the main thread.
- The main thread's name is normalized back to `"main"` so downstream consumers see a consistent name even when the OS renamed it.
- Threads without a stacktrace are skipped, as they are not actionable.

No public API change.

## :bulb: Motivation and Context

When the OS names the main thread after the process, ANRs were not attributed to the main thread and were reported without a stack trace. Matching on `sysTid == pid` is robust and does not depend on the (truncatable) process name.

Fixes JAVA-635
Fixes https://github.com/getsentry/sentry-java/issues/5731

## :green_heart: How did you test it?

- Added tests to `ThreadDumpParserTest`
- Updated existing tests

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC089VFRB8N9%3A1783415141.214909/?project=4510944073809921)

<!-- junior-session-footer:end -->
