### PR TITLE
docs(agents): Prefer Google Truth for new unit test assertions

### DIFF
--- a/.cursor/rules/coding.mdc
+++ b/.cursor/rules/coding.mdc
@@ -31,7 +31,7 @@ sentry-java is the Java and Android SDK for Sentry. This repository contains the
 
 1. Follow existing code style and language
 2. Do not modify the API files (e.g. sentry.api) manually, instead run `./gradlew apiDump` to regenerate them
-3. Write comprehensive tests
+3. Write comprehensive tests. For assertions in new unit tests, prefer Google Truth (`com.google.common.truth.Truth.assertThat`) over `kotlin.test`/JUnit assertions; keep `kotlin.test` for test structure like `@Test` and `assertFailsWith`. Add `testImplementation(libs.google.truth)` to a module's `build.gradle.kts` if it isn't already present.
 4. New features should always be opt-in by default, extend `SentryOptions` or similar Option classes with getters and setters to enable/disable a new feature
 5. Consider backwards compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ The repository is organized into multiple modules:
 - Write comprehensive unit tests for new features
 - Android modules require both unit tests and instrumented tests where applicable
 - System tests validate end-to-end functionality with sample applications
+- **Assertions**: For new unit tests, prefer [Google Truth](https://truth.dev/) (`com.google.common.truth.Truth.assertThat`) over `kotlin.test`/JUnit assertions for its readable, fluent API. Keep using `kotlin.test` for test structure (`@Test`, `assertFailsWith`). See `sentry/src/test/java/io/sentry/DsnTest.kt` for the style. Don't rewrite existing `kotlin.test` assertions solely to switch libraries.
+- Truth is wired into the `sentry` module. When adding Truth-based tests to another module, add `testImplementation(libs.google.truth)` to that module's `build.gradle.kts`.
 
 ### Contributing Guidelines
 1. Follow existing code style and language


### PR DESCRIPTION
## :scroll: Description

Adds guidance for AI coding agents to prefer [Google Truth](https://truth.dev/) (`com.google.common.truth.Truth.assertThat`) over `kotlin.test`/JUnit assertions when writing assertions in **new** unit tests, while continuing to use `kotlin.test` for test structure (`@Test`, `assertFailsWith`).

Updated files:
- `AGENTS.md` — two bullets under *Testing Requirements* covering the preference, a pointer to `sentry/src/test/java/io/sentry/DsnTest.kt` as the reference style, and the per-module `testImplementation(libs.google.truth)` requirement.
- `.cursor/rules/coding.mdc` — a concise version of the same guidance (this rule is `alwaysApply: true`).

## :bulb: Motivation and Context

Truth (v1.4.5) is already a dependency in the `sentry` module and used in `DsnTest.kt`, but the rest of the repo uses `kotlin.test`. This documents Truth as the preferred choice going forward so new tests get its more readable, fluent assertions. The guidance explicitly avoids churn by not rewriting existing assertions solely to switch libraries.

## :green_heart: How did you test it?

Documentation-only change to agent instruction files. Ran `./gradlew spotlessApply apiDump` with no resulting code changes.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

As modules gain Truth-based tests, add `testImplementation(libs.google.truth)` to their `build.gradle.kts`.

#skip-changelog
