### PR TITLE
fix(core): Prevent recursion when a callback triggers another capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 - `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))
+- Prevent a `StackOverflowError` when a `beforeSend`, `beforeBreadcrumb`, or `beforeSendLog` callback triggers another capture (directly or through a logging integration such as Timber) ([#5737](https://github.com/getsentry/sentry-java/pull/5737))
+  - Captures made from within a user callback (event, transaction, breadcrumb, or log) are now dropped while that callback runs, instead of recursing. Captures made by event processors are unaffected.
 
 ## 8.49.0
 
@@ -94,8 +96,6 @@
 - Fix `NoSuchMethodError` from using `Math.floorDiv`/`Math.floorMod` overloads that are unavailable on Java 8 ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
-- Prevent a `StackOverflowError` when a `beforeSend`, `beforeBreadcrumb`, or `beforeSendLog` callback triggers another capture (directly or through a logging integration such as Timber) ([#5737](https://github.com/getsentry/sentry-java/pull/5737))
-  - Captures made from within a user callback (event, transaction, breadcrumb, or log) are now dropped while that callback runs, instead of recursing. Captures made by event processors are unaffected.
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 - `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))
-- Prevent a `StackOverflowError` when a `beforeSend`, `beforeBreadcrumb`, or `beforeSendLog` callback triggers another capture (directly or through a logging integration such as Timber) ([#5737](https://github.com/getsentry/sentry-java/pull/5737))
-  - Captures made from within a user callback (event, transaction, breadcrumb, or log) are now dropped while that callback runs, instead of recursing. Captures made by event processors are unaffected.
+- Prevent a `StackOverflowError` when a `beforeSend`, `beforeBreadcrumb`, `beforeSendLog`, or `beforeEnvelope` callback triggers another capture (directly or through a logging integration such as Timber) ([#5737](https://github.com/getsentry/sentry-java/pull/5737))
+  - Captures made from within a user callback (event, transaction, breadcrumb, log, envelope, or check-in) are now dropped while that callback runs, instead of recursing. Captures made by event processors are unaffected.
 
 ## 8.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 - Fix `NoSuchMethodError` from using `Math.floorDiv`/`Math.floorMod` overloads that are unavailable on Java 8 ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
+- Prevent a `StackOverflowError` when a `beforeSend`, `beforeBreadcrumb`, or `beforeSendLog` callback triggers another capture (directly or through a logging integration such as Timber) ([#5737](https://github.com/getsentry/sentry-java/pull/5737))
+  - Captures made from within a user callback (event, transaction, breadcrumb, or log) are now dropped while that callback runs, instead of recursing. Captures made by event processors are unaffected.
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
@@ -1,10 +1,14 @@
 package io.sentry.android.timber
 
 import io.sentry.IScopes
+import io.sentry.ITransportFactory
+import io.sentry.ScopesAdapter
+import io.sentry.Sentry
 import io.sentry.SentryLevel
 import io.sentry.SentryLogLevel
 import io.sentry.SentryOptions
 import io.sentry.protocol.SdkVersion
+import io.sentry.transport.ITransport
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,6 +16,7 @@ import kotlin.test.assertTrue
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import timber.log.Timber
 
 class SentryTimberIntegrationTest {
@@ -111,5 +116,45 @@ class SentryTimberIntegrationTest {
     sut.register(fixture.scopes, fixture.options)
 
     assertTrue(fixture.options.sdkVersion!!.integrationSet.contains("Timber"))
+  }
+
+  @Test
+  fun `a beforeSend callback that logs via Timber does not recurse`() {
+    // End-to-end guard against SDK-CRASHES-JAVA-3T3H style recursion: with a real Sentry instance,
+    // a beforeSend callback that logs through the planted SentryTimberTree must not loop back into
+    // capture forever.
+    val transport = mock<ITransport>()
+    val transportFactory = mock<ITransportFactory>()
+    whenever(transportFactory.create(any(), any())).thenReturn(transport)
+
+    var beforeSendInvocations = 0
+    Sentry.init { options ->
+      options.dsn = "https://key@sentry.io/123"
+      options.setTransportFactory(transportFactory)
+      options.beforeSend =
+        SentryOptions.BeforeSendCallback { event, _ ->
+          beforeSendInvocations++
+          Timber.e("logging from beforeSend")
+          event
+        }
+    }
+    Timber.plant(
+      SentryTimberTree(
+        ScopesAdapter.getInstance(),
+        SentryLevel.ERROR,
+        SentryLevel.INFO,
+        SentryLogLevel.INFO,
+      )
+    )
+
+    try {
+      Timber.e("outer error")
+
+      // Without the core re-entrancy guard this recurses until a StackOverflowError. The nested
+      // Timber.e is dropped before its own beforeSend, so the callback runs exactly once.
+      assertEquals(1, beforeSendInvocations)
+    } finally {
+      Sentry.close()
+    }
   }
 }

--- a/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
+++ b/sentry-android-timber/src/test/java/io/sentry/android/timber/SentryTimberIntegrationTest.kt
@@ -131,12 +131,11 @@ class SentryTimberIntegrationTest {
     Sentry.init { options ->
       options.dsn = "https://key@sentry.io/123"
       options.setTransportFactory(transportFactory)
-      options.beforeSend =
-        SentryOptions.BeforeSendCallback { event, _ ->
-          beforeSendInvocations++
-          Timber.e("logging from beforeSend")
-          event
-        }
+      options.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->
+        beforeSendInvocations++
+        Timber.e("logging from beforeSend")
+        event
+      }
     }
     Timber.plant(
       SentryTimberTree(

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7924,6 +7924,12 @@ public final class io/sentry/util/ScopesUtil {
 	public static fun printScopesChain (Lio/sentry/IScopes;)V
 }
 
+public final class io/sentry/util/SentryCallbackReentrancyGuard {
+	public static fun enter ()V
+	public static fun exit ()V
+	public static fun isActive ()Z
+}
+
 public final class io/sentry/util/SentryRandom {
 	public fun <init> ()V
 	public static fun current ()Lio/sentry/util/Random;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7925,8 +7925,7 @@ public final class io/sentry/util/ScopesUtil {
 }
 
 public final class io/sentry/util/SentryCallbackReentrancyGuard {
-	public static fun enter ()V
-	public static fun exit ()V
+	public static fun enter ()Lio/sentry/ISentryLifecycleToken;
 	public static fun isActive ()Z
 }
 

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -494,7 +494,7 @@ public final class Scope implements IScope {
     if (breadcrumb == null || breadcrumbs instanceof DisabledQueue) {
       return;
     }
-    // Drop breadcrumbs added from within a user callback to prevent recursion.
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
       return;
     }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -16,6 +16,7 @@ import io.sentry.util.EventProcessorUtils;
 import io.sentry.util.ExceptionUtils;
 import io.sentry.util.Objects;
 import io.sentry.util.Pair;
+import io.sentry.util.SentryCallbackReentrancyGuard;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -465,6 +466,7 @@ public final class Scope implements IScope {
       @NotNull Breadcrumb breadcrumb,
       final @NotNull Hint hint) {
     try {
+      SentryCallbackReentrancyGuard.enter();
       breadcrumb = callback.execute(breadcrumb, hint);
     } catch (Throwable e) {
       options
@@ -477,6 +479,8 @@ public final class Scope implements IScope {
       if (e.getMessage() != null) {
         breadcrumb.setData("sentry:message", e.getMessage());
       }
+    } finally {
+      SentryCallbackReentrancyGuard.exit();
     }
     return breadcrumb;
   }
@@ -491,6 +495,10 @@ public final class Scope implements IScope {
   @Override
   public void addBreadcrumb(@NotNull Breadcrumb breadcrumb, @Nullable Hint hint) {
     if (breadcrumb == null || breadcrumbs instanceof DisabledQueue) {
+      return;
+    }
+    // Drop breadcrumbs added from within a user callback to prevent recursion.
+    if (SentryCallbackReentrancyGuard.isActive()) {
       return;
     }
     SentryOptions.BeforeBreadcrumbCallback callback = options.getBeforeBreadcrumb();

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -465,8 +465,7 @@ public final class Scope implements IScope {
       final @NotNull SentryOptions.BeforeBreadcrumbCallback callback,
       @NotNull Breadcrumb breadcrumb,
       final @NotNull Hint hint) {
-    try {
-      SentryCallbackReentrancyGuard.enter();
+    try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
       breadcrumb = callback.execute(breadcrumb, hint);
     } catch (Throwable e) {
       options
@@ -479,8 +478,6 @@ public final class Scope implements IScope {
       if (e.getMessage() != null) {
         breadcrumb.setData("sentry:message", e.getMessage());
       }
-    } finally {
-      SentryCallbackReentrancyGuard.exit();
     }
     return breadcrumb;
   }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -107,6 +107,15 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryEvent event, final @Nullable IScope scope, @Nullable Hint hint) {
     Objects.requireNonNull(event, "SentryEvent is required.");
 
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Event captured from within a callback (beforeSend/beforeBreadcrumb/beforeSendLog) was dropped to prevent recursion.");
+      return SentryId.EMPTY_ID;
+    }
+
     if (hint == null) {
       hint = new Hint();
     }
@@ -969,6 +978,15 @@ public final class SentryClient implements ISentryClient {
       final @Nullable ProfilingTraceData profilingTraceData) {
     Objects.requireNonNull(transaction, "Transaction is required.");
 
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Transaction captured from within a callback was dropped to prevent recursion.");
+      return SentryId.EMPTY_ID;
+    }
+
     if (hint == null) {
       hint = new Hint();
     }
@@ -1297,6 +1315,15 @@ public final class SentryClient implements ISentryClient {
   @ApiStatus.Experimental
   @Override
   public void captureLog(@Nullable SentryLogEvent logEvent, @Nullable IScope scope) {
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Log captured from within a callback was dropped to prevent recursion.");
+      return;
+    }
+
     if (logEvent != null && scope != null) {
       logEvent = processLogEvent(logEvent, scope.getEventProcessors());
       if (logEvent == null) {
@@ -1613,6 +1640,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.BeforeSendCallback beforeSend = options.getBeforeSend();
     if (beforeSend != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         event = beforeSend.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1624,6 +1652,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSend due to PII concerns
         event = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1635,6 +1665,7 @@ public final class SentryClient implements ISentryClient {
         options.getBeforeSendTransaction();
     if (beforeSendTransaction != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         transaction = beforeSendTransaction.execute(transaction, hint);
       } catch (Throwable e) {
         options
@@ -1646,6 +1677,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop transaction in case of an error in beforeSend due to PII concerns
         transaction = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return transaction;
@@ -1656,6 +1689,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.BeforeSendCallback beforeSendFeedback = options.getBeforeSendFeedback();
     if (beforeSendFeedback != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         event = beforeSendFeedback.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1664,6 +1698,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop feedback in case of an error in beforeSend due to PII concerns
         event = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1674,6 +1710,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.BeforeSendReplayCallback beforeSendReplay = options.getBeforeSendReplay();
     if (beforeSendReplay != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         event = beforeSendReplay.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1685,6 +1722,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSend due to PII concerns
         event = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1695,6 +1734,7 @@ public final class SentryClient implements ISentryClient {
         options.getLogs().getBeforeSend();
     if (beforeSendLog != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         event = beforeSendLog.execute(event);
       } catch (Throwable e) {
         options
@@ -1706,6 +1746,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSendLog due to PII concerns
         event = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1717,6 +1759,7 @@ public final class SentryClient implements ISentryClient {
         options.getMetrics().getBeforeSend();
     if (beforeSendMetric != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         event = beforeSendMetric.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1728,6 +1771,8 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSendMetric due to PII concerns
         event = null;
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -955,6 +955,19 @@ public final class SentryClient implements ISentryClient {
 
   private @NotNull SentryId sendEnvelope(
       @NotNull final SentryEnvelope envelope, @Nullable final Hint hint) throws IOException {
+    // captureEnvelope and captureCheckIn have no entry-level guard, so a callback that captures
+    // one of those would recurse back into beforeEnvelopeCallback. In normal flow the guard is
+    // already inactive by the time we get here (the before* callback has exited), so an active
+    // guard means a callback triggered this send.
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Envelope captured from within a callback was dropped to prevent recursion.");
+      return SentryId.EMPTY_ID;
+    }
+
     final @Nullable SentryOptions.BeforeEnvelopeCallback beforeEnvelopeCallback =
         options.getBeforeEnvelopeCallback();
     if (beforeEnvelopeCallback != null) {

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -107,12 +107,8 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryEvent event, final @Nullable IScope scope, @Nullable Hint hint) {
     Objects.requireNonNull(event, "SentryEvent is required.");
 
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Event captured from within a callback (beforeSend/beforeBreadcrumb/beforeSendLog) was dropped to prevent recursion.");
       return SentryId.EMPTY_ID;
     }
 
@@ -321,12 +317,8 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryReplayEvent event, final @Nullable IScope scope, @Nullable Hint hint) {
     Objects.requireNonNull(event, "SessionReplay is required.");
 
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Replay event captured from within a callback was dropped to prevent recursion.");
       return SentryId.EMPTY_ID;
     }
 
@@ -958,13 +950,9 @@ public final class SentryClient implements ISentryClient {
     // captureEnvelope and captureCheckIn have no entry-level guard, so a callback that captures
     // one of those would recurse back into beforeEnvelopeCallback. In normal flow the guard is
     // already inactive by the time we get here (the before* callback has exited), so an active
-    // guard means a callback triggered this send.
+    // guard means a callback triggered this send. Drop silently: a log here can re-enter through a
+    // logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Envelope captured from within a callback was dropped to prevent recursion.");
       return SentryId.EMPTY_ID;
     }
 
@@ -1000,12 +988,8 @@ public final class SentryClient implements ISentryClient {
       final @Nullable ProfilingTraceData profilingTraceData) {
     Objects.requireNonNull(transaction, "Transaction is required.");
 
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Transaction captured from within a callback was dropped to prevent recursion.");
       return SentryId.EMPTY_ID;
     }
 
@@ -1227,12 +1211,8 @@ public final class SentryClient implements ISentryClient {
   @Override
   public @NotNull SentryId captureFeedback(
       final @NotNull Feedback feedback, @Nullable Hint hint, final @NotNull IScope scope) {
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Feedback captured from within a callback was dropped to prevent recursion.");
       return SentryId.EMPTY_ID;
     }
 
@@ -1346,12 +1326,8 @@ public final class SentryClient implements ISentryClient {
   @ApiStatus.Experimental
   @Override
   public void captureLog(@Nullable SentryLogEvent logEvent, @Nullable IScope scope) {
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Log captured from within a callback was dropped to prevent recursion.");
       return;
     }
 
@@ -1409,12 +1385,8 @@ public final class SentryClient implements ISentryClient {
       @Nullable SentryMetricsEvent metricsEvent,
       final @Nullable IScope scope,
       @Nullable Hint hint) {
+    // Drop silently to prevent recursion; a log here can re-enter through a logging integration.
     if (SentryCallbackReentrancyGuard.isActive()) {
-      options
-          .getLogger()
-          .log(
-              SentryLevel.DEBUG,
-              "Metric captured from within a callback was dropped to prevent recursion.");
       return;
     }
 

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -245,8 +245,7 @@ public final class SentryClient implements ISentryClient {
       final SentryReplayOptions.BeforeErrorSamplingCallback beforeErrorSampling =
           options.getSessionReplay().getBeforeErrorSampling();
       if (beforeErrorSampling != null) {
-        try {
-          SentryCallbackReentrancyGuard.enter();
+        try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
           shouldCaptureReplay = beforeErrorSampling.execute(event, hint);
         } catch (Throwable e) {
           options
@@ -256,8 +255,6 @@ public final class SentryClient implements ISentryClient {
                   "The beforeErrorSampling callback threw an exception. Proceeding with replay capture.",
                   e);
           shouldCaptureReplay = true;
-        } finally {
-          SentryCallbackReentrancyGuard.exit();
         }
       }
       if (shouldCaptureReplay) {
@@ -961,15 +958,12 @@ public final class SentryClient implements ISentryClient {
     final @Nullable SentryOptions.BeforeEnvelopeCallback beforeEnvelopeCallback =
         options.getBeforeEnvelopeCallback();
     if (beforeEnvelopeCallback != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         beforeEnvelopeCallback.execute(envelope, hint);
       } catch (Throwable e) {
         options
             .getLogger()
             .log(SentryLevel.ERROR, "The BeforeEnvelope callback threw an exception.", e);
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
 
@@ -1672,8 +1666,7 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryEvent event, final @NotNull Hint hint) {
     final SentryOptions.BeforeSendCallback beforeSend = options.getBeforeSend();
     if (beforeSend != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         event = beforeSend.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1685,8 +1678,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSend due to PII concerns
         event = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1697,8 +1688,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.BeforeSendTransactionCallback beforeSendTransaction =
         options.getBeforeSendTransaction();
     if (beforeSendTransaction != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         transaction = beforeSendTransaction.execute(transaction, hint);
       } catch (Throwable e) {
         options
@@ -1710,8 +1700,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop transaction in case of an error in beforeSend due to PII concerns
         transaction = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return transaction;
@@ -1721,8 +1709,7 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryEvent event, final @NotNull Hint hint) {
     final SentryOptions.BeforeSendCallback beforeSendFeedback = options.getBeforeSendFeedback();
     if (beforeSendFeedback != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         event = beforeSendFeedback.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1731,8 +1718,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop feedback in case of an error in beforeSend due to PII concerns
         event = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1742,8 +1727,7 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryReplayEvent event, final @NotNull Hint hint) {
     final SentryOptions.BeforeSendReplayCallback beforeSendReplay = options.getBeforeSendReplay();
     if (beforeSendReplay != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         event = beforeSendReplay.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1755,8 +1739,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSend due to PII concerns
         event = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1766,8 +1748,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.Logs.BeforeSendLogCallback beforeSendLog =
         options.getLogs().getBeforeSend();
     if (beforeSendLog != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         event = beforeSendLog.execute(event);
       } catch (Throwable e) {
         options
@@ -1779,8 +1760,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSendLog due to PII concerns
         event = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;
@@ -1791,8 +1770,7 @@ public final class SentryClient implements ISentryClient {
     final SentryOptions.Metrics.BeforeSendMetricCallback beforeSendMetric =
         options.getMetrics().getBeforeSend();
     if (beforeSendMetric != null) {
-      try {
-        SentryCallbackReentrancyGuard.enter();
+      try (final @NotNull ISentryLifecycleToken ignored = SentryCallbackReentrancyGuard.enter()) {
         event = beforeSendMetric.execute(event, hint);
       } catch (Throwable e) {
         options
@@ -1804,8 +1782,6 @@ public final class SentryClient implements ISentryClient {
 
         // drop event in case of an error in beforeSendMetric due to PII concerns
         event = null;
-      } finally {
-        SentryCallbackReentrancyGuard.exit();
       }
     }
     return event;

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -321,6 +321,15 @@ public final class SentryClient implements ISentryClient {
       @NotNull SentryReplayEvent event, final @Nullable IScope scope, @Nullable Hint hint) {
     Objects.requireNonNull(event, "SessionReplay is required.");
 
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Replay event captured from within a callback was dropped to prevent recursion.");
+      return SentryId.EMPTY_ID;
+    }
+
     if (hint == null) {
       hint = new Hint();
     }
@@ -1205,6 +1214,15 @@ public final class SentryClient implements ISentryClient {
   @Override
   public @NotNull SentryId captureFeedback(
       final @NotNull Feedback feedback, @Nullable Hint hint, final @NotNull IScope scope) {
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Feedback captured from within a callback was dropped to prevent recursion.");
+      return SentryId.EMPTY_ID;
+    }
+
     SentryEvent event = new SentryEvent();
     event.getContexts().setFeedback(feedback);
 
@@ -1378,6 +1396,15 @@ public final class SentryClient implements ISentryClient {
       @Nullable SentryMetricsEvent metricsEvent,
       final @Nullable IScope scope,
       @Nullable Hint hint) {
+    if (SentryCallbackReentrancyGuard.isActive()) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.DEBUG,
+              "Metric captured from within a callback was dropped to prevent recursion.");
+      return;
+    }
+
     if (hint == null) {
       hint = new Hint();
     }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -246,6 +246,7 @@ public final class SentryClient implements ISentryClient {
           options.getSessionReplay().getBeforeErrorSampling();
       if (beforeErrorSampling != null) {
         try {
+          SentryCallbackReentrancyGuard.enter();
           shouldCaptureReplay = beforeErrorSampling.execute(event, hint);
         } catch (Throwable e) {
           options
@@ -255,6 +256,8 @@ public final class SentryClient implements ISentryClient {
                   "The beforeErrorSampling callback threw an exception. Proceeding with replay capture.",
                   e);
           shouldCaptureReplay = true;
+        } finally {
+          SentryCallbackReentrancyGuard.exit();
         }
       }
       if (shouldCaptureReplay) {
@@ -959,11 +962,14 @@ public final class SentryClient implements ISentryClient {
         options.getBeforeEnvelopeCallback();
     if (beforeEnvelopeCallback != null) {
       try {
+        SentryCallbackReentrancyGuard.enter();
         beforeEnvelopeCallback.execute(envelope, hint);
       } catch (Throwable e) {
         options
             .getLogger()
             .log(SentryLevel.ERROR, "The BeforeEnvelope callback threw an exception.", e);
+      } finally {
+        SentryCallbackReentrancyGuard.exit();
       }
     }
 

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -3327,6 +3327,10 @@ public class SentryOptions {
     /**
      * Mutates or drop an event before being sent
      *
+     * <p>Do not capture from within this callback — directly, or indirectly through a logging
+     * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+     * prevent infinite recursion.
+     *
      * @param event the event
      * @param hint the hints
      * @return the original event or the mutated event or null if event was dropped
@@ -3340,6 +3344,10 @@ public class SentryOptions {
 
     /**
      * Mutates or drop a transaction before being sent
+     *
+     * <p>Do not capture from within this callback — directly, or indirectly through a logging
+     * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+     * prevent infinite recursion.
      *
      * @param transaction the transaction
      * @param hint the hints
@@ -3358,6 +3366,10 @@ public class SentryOptions {
      * for a single replay (i.e. segments), you can check {@link SentryReplayEvent#getReplayId()} to
      * identify that the segments belong to the same replay.
      *
+     * <p>Do not capture from within this callback — directly, or indirectly through a logging
+     * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+     * prevent infinite recursion.
+     *
      * @param event the event
      * @param hint the hint, contains {@link ReplayRecording}, can be accessed via {@link
      *     Hint#getReplayRecording()}
@@ -3372,6 +3384,10 @@ public class SentryOptions {
 
     /**
      * Mutates or drop a callback before being added
+     *
+     * <p>Do not capture from within this callback — directly, or indirectly through a logging
+     * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+     * prevent infinite recursion.
      *
      * @param breadcrumb the breadcrumb
      * @param hint the hints, usually the source of the breadcrumb
@@ -3961,6 +3977,10 @@ public class SentryOptions {
       /**
        * Mutates or drop a log event before being sent
        *
+       * <p>Do not capture from within this callback — directly, or indirectly through a logging
+       * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+       * prevent infinite recursion.
+       *
        * @param event the event
        * @return the original log event or the mutated event or null if event was dropped
        */
@@ -4034,6 +4054,10 @@ public class SentryOptions {
 
       /**
        * A callback which gets called right before a metric is about to be sent.
+       *
+       * <p>Do not capture from within this callback — directly, or indirectly through a logging
+       * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+       * prevent infinite recursion.
        *
        * @param metric the metric
        * @return the original metric, mutated metric or null if metric was dropped

--- a/sentry/src/main/java/io/sentry/SentryReplayOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryReplayOptions.java
@@ -28,6 +28,10 @@ public final class SentryReplayOptions extends SentryMaskingOptions {
     /**
      * Determines whether replay capture should proceed for the given error event.
      *
+     * <p>Do not capture from within this callback — directly, or indirectly through a logging
+     * integration that routes logs back into Sentry. Such nested captures are silently dropped to
+     * prevent infinite recursion.
+     *
      * @param event the error event that triggered the replay capture
      * @param hint the hint associated with the event
      * @return {@code true} if the error sample rate should be checked, {@code false} to skip replay

--- a/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
+++ b/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
@@ -1,6 +1,7 @@
 package io.sentry.util;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Thread-local re-entrancy guard that marks whether a user-supplied {@code before*} callback
@@ -13,29 +14,41 @@ import org.jetbrains.annotations.ApiStatus;
  * StackOverflowError}. Capture entry points consult {@link #isActive()} and drop the nested capture
  * while a callback is running.
  *
- * <p>The flag is set ONLY around each callback's {@code execute(...)} invocation, never around the
+ * <p>The guard is set ONLY around each callback's {@code execute(...)} invocation, never around the
  * whole capture pipeline, so captures made by event processors (which run outside the callback) are
  * not affected.
+ *
+ * <p>The guard is a depth counter rather than a boolean so that nested {@link #exit()} calls cannot
+ * clear it while an outer callback is still running. Capture entry points drop while a callback is
+ * active, so callbacks should never nest — but a capture path lacking an entry check must not
+ * silently disarm the guard for the rest of the outer callback.
  */
 @ApiStatus.Internal
 public final class SentryCallbackReentrancyGuard {
 
-  private static final ThreadLocal<Boolean> isRunning = new ThreadLocal<>();
+  private static final ThreadLocal<Integer> depth = new ThreadLocal<>();
 
   private SentryCallbackReentrancyGuard() {}
 
   /** Whether a user callback is currently executing on this thread. */
   public static boolean isActive() {
-    return Boolean.TRUE.equals(isRunning.get());
+    final @Nullable Integer current = depth.get();
+    return current != null && current > 0;
   }
 
   /** Marks that a user callback is starting to execute on this thread. */
   public static void enter() {
-    isRunning.set(Boolean.TRUE);
+    final @Nullable Integer current = depth.get();
+    depth.set(current == null ? 1 : current + 1);
   }
 
   /** Marks that the user callback finished executing on this thread. */
   public static void exit() {
-    isRunning.set(Boolean.FALSE);
+    final @Nullable Integer current = depth.get();
+    if (current == null || current <= 1) {
+      depth.remove();
+    } else {
+      depth.set(current - 1);
+    }
   }
 }

--- a/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
+++ b/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
@@ -1,6 +1,8 @@
 package io.sentry.util;
 
+import io.sentry.ISentryLifecycleToken;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,11 +24,17 @@ import org.jetbrains.annotations.Nullable;
  * clear it while an outer callback is still running. Capture entry points drop while a callback is
  * active, so callbacks should never nest — but a capture path lacking an entry check must not
  * silently disarm the guard for the rest of the outer callback.
+ *
+ * <p>{@link #enter()} returns an {@link ISentryLifecycleToken} so callers can use try-with-resources
+ * instead of a manual {@code finally exit()}. The token is a shared singleton (its {@code close()}
+ * just decrements the counter), so no allocation happens per callback.
  */
 @ApiStatus.Internal
 public final class SentryCallbackReentrancyGuard {
 
   private static final ThreadLocal<Integer> depth = new ThreadLocal<>();
+
+  private static final ISentryLifecycleToken TOKEN = SentryCallbackReentrancyGuard::exit;
 
   private SentryCallbackReentrancyGuard() {}
 
@@ -36,14 +44,17 @@ public final class SentryCallbackReentrancyGuard {
     return current != null && current > 0;
   }
 
-  /** Marks that a user callback is starting to execute on this thread. */
-  public static void enter() {
+  /**
+   * Marks that a user callback is starting to execute on this thread. Close the returned token (via
+   * try-with-resources) once the callback returns.
+   */
+  public static @NotNull ISentryLifecycleToken enter() {
     final @Nullable Integer current = depth.get();
     depth.set(current == null ? 1 : current + 1);
+    return TOKEN;
   }
 
-  /** Marks that the user callback finished executing on this thread. */
-  public static void exit() {
+  private static void exit() {
     final @Nullable Integer current = depth.get();
     if (current == null || current <= 1) {
       depth.remove();

--- a/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
+++ b/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
@@ -25,9 +25,9 @@ import org.jetbrains.annotations.Nullable;
  * active, so callbacks should never nest — but a capture path lacking an entry check must not
  * silently disarm the guard for the rest of the outer callback.
  *
- * <p>{@link #enter()} returns an {@link ISentryLifecycleToken} so callers can use try-with-resources
- * instead of a manual {@code finally exit()}. The token is a shared singleton (its {@code close()}
- * just decrements the counter), so no allocation happens per callback.
+ * <p>{@link #enter()} returns an {@link ISentryLifecycleToken} so callers can use
+ * try-with-resources instead of a manual {@code finally exit()}. The token is a shared singleton
+ * (its {@code close()} just decrements the counter), so no allocation happens per callback.
  */
 @ApiStatus.Internal
 public final class SentryCallbackReentrancyGuard {

--- a/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
+++ b/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
@@ -1,0 +1,41 @@
+package io.sentry.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Thread-local re-entrancy guard that marks whether a user-supplied {@code before*} callback
+ * ({@code beforeSend}, {@code beforeBreadcrumb}, {@code beforeSendLog}, ...) is currently executing
+ * on the current thread.
+ *
+ * <p>A callback that itself triggers another SDK capture on the same thread — directly, or
+ * transitively through a logging integration that routes back into Sentry (e.g. Timber or the
+ * Gradle plugin's logcat instrumentation) — would otherwise recurse indefinitely and throw {@link
+ * StackOverflowError}. Capture entry points consult {@link #isActive()} and drop the nested capture
+ * while a callback is running.
+ *
+ * <p>The flag is set ONLY around each callback's {@code execute(...)} invocation, never around the
+ * whole capture pipeline, so captures made by event processors (which run outside the callback) are
+ * not affected.
+ */
+@ApiStatus.Internal
+public final class SentryCallbackReentrancyGuard {
+
+  private static final ThreadLocal<Boolean> isRunning = new ThreadLocal<>();
+
+  private SentryCallbackReentrancyGuard() {}
+
+  /** Whether a user callback is currently executing on this thread. */
+  public static boolean isActive() {
+    return Boolean.TRUE.equals(isRunning.get());
+  }
+
+  /** Marks that a user callback is starting to execute on this thread. */
+  public static void enter() {
+    isRunning.set(Boolean.TRUE);
+  }
+
+  /** Marks that the user callback finished executing on this thread. */
+  public static void exit() {
+    isRunning.set(Boolean.FALSE);
+  }
+}

--- a/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
+++ b/sentry/src/main/java/io/sentry/util/SentryCallbackReentrancyGuard.java
@@ -16,6 +16,14 @@ import org.jetbrains.annotations.Nullable;
  * StackOverflowError}. Capture entry points consult {@link #isActive()} and drop the nested capture
  * while a callback is running.
  *
+ * <p>The nested capture MUST be dropped silently — callers must not log while the guard is active.
+ * The same logging integration that routes logs back into Sentry also routes the SDK's own
+ * diagnostic logs, so a "dropped to prevent recursion" log line would be turned into another
+ * capture, whose drop would log again, and so on. The guard suppresses the capture but not the log,
+ * so logging on the drop path re-opens exactly the recursion the guard exists to break. (This only
+ * bites when SDK debug logging is enabled, since {@code options.getLogger()} is otherwise a no-op,
+ * but dropping silently removes the failure mode entirely.)
+ *
  * <p>The guard is set ONLY around each callback's {@code execute(...)} invocation, never around the
  * whole capture pipeline, so captures made by event processors (which run outside the callback) are
  * not affected.
@@ -38,7 +46,11 @@ public final class SentryCallbackReentrancyGuard {
 
   private SentryCallbackReentrancyGuard() {}
 
-  /** Whether a user callback is currently executing on this thread. */
+  /**
+   * Whether a user callback is currently executing on this thread. When {@code true}, capture entry
+   * points must drop the capture and return without logging — see the class Javadoc for why logging
+   * on the drop path re-opens the recursion.
+   */
   public static boolean isActive() {
     final @Nullable Integer current = depth.get();
     return current != null && current > 0;

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -377,12 +377,11 @@ class ScopeTest {
     lateinit var scope: Scope
     val options =
       SentryOptions().apply {
-        beforeBreadcrumb =
-          SentryOptions.BeforeBreadcrumbCallback { breadcrumb, _ ->
-            invocations++
-            scope.addBreadcrumb(Breadcrumb())
-            breadcrumb
-          }
+        beforeBreadcrumb = SentryOptions.BeforeBreadcrumbCallback { breadcrumb, _ ->
+          invocations++
+          scope.addBreadcrumb(Breadcrumb())
+          breadcrumb
+        }
       }
 
     scope = Scope(options)

--- a/sentry/src/test/java/io/sentry/ScopeTest.kt
+++ b/sentry/src/test/java/io/sentry/ScopeTest.kt
@@ -372,6 +372,28 @@ class ScopeTest {
   }
 
   @Test
+  fun `when beforeBreadcrumb adds another breadcrumb, the nested breadcrumb is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var scope: Scope
+    val options =
+      SentryOptions().apply {
+        beforeBreadcrumb =
+          SentryOptions.BeforeBreadcrumbCallback { breadcrumb, _ ->
+            invocations++
+            scope.addBreadcrumb(Breadcrumb())
+            breadcrumb
+          }
+      }
+
+    scope = Scope(options)
+    scope.addBreadcrumb(Breadcrumb())
+
+    // Callback runs only for the outer breadcrumb; the nested one is dropped before its callback.
+    assertEquals(1, invocations)
+    assertEquals(1, scope.breadcrumbs.count())
+  }
+
+  @Test
   fun `when adding breadcrumb and maxBreadcrumb is not 0, beforeBreadcrumb is executed`() {
     var called = false
     val options =

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3291,6 +3291,25 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when beforeEnvelopeCallback captures another event, the nested capture is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var sut: SentryClient
+    val options = { options: SentryOptions ->
+      options.beforeEnvelopeCallback =
+        SentryOptions.BeforeEnvelopeCallback { _, _ ->
+          invocations++
+          sut.captureEvent(SentryEvent())
+        }
+    }
+    sut = fixture.getSut(options)
+
+    sut.captureEvent(SentryEvent(), Hint())
+
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
   fun `beforeEnvelopeCallback may fail, but the transport is still sends the envelope `() {
     val sut = fixture.getSut { options ->
       options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->
@@ -3550,6 +3569,24 @@ class SentryClientTest {
       HintUtils.createWithTypeCheckHint(CachedHint()),
     )
     assertFalse(called)
+  }
+
+  @Test
+  fun `when beforeErrorSampling captures another event, the nested capture is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.sessionReplay.beforeErrorSampling =
+      SentryReplayOptions.BeforeErrorSamplingCallback { _, _ ->
+        invocations++
+        sut.captureEvent(SentryEvent().apply { exceptions = listOf(SentryException()) })
+        true
+      }
+    sut = fixture.getSut()
+
+    sut.captureEvent(SentryEvent().apply { exceptions = listOf(SentryException()) })
+
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -285,6 +285,70 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when beforeSend captures another event, the nested capture is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.setBeforeSend { e, _ ->
+      invocations++
+      sut.captureEvent(SentryEvent())
+      e
+    }
+    sut = fixture.getSut()
+
+    sut.captureEvent(SentryEvent())
+
+    // Callback runs only for the outer event; the nested capture is dropped before its callback.
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
+  fun `when beforeSend captures a log, the nested log is dropped`() {
+    val scope = createScope()
+    fixture.sentryOptions.logs.isEnabled = true
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.setBeforeSend { e, _ ->
+      sut.captureLog(
+        SentryLogEvent(SentryId(), SentryNanotimeDate(), "nested", SentryLogLevel.WARN),
+        scope,
+      )
+      e
+    }
+    sut = fixture.getSut()
+
+    sut.captureEvent(SentryEvent())
+
+    // The shared guard spans capture types: a log emitted from beforeSend is dropped too.
+    verify(fixture.loggerBatchProcessor, never()).add(any())
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
+  fun `when beforeSendLog logs again, the nested log is dropped and does not recurse`() {
+    val scope = createScope()
+    fixture.sentryOptions.logs.isEnabled = true
+    var invocations = 0
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.logs.setBeforeSend { l ->
+      invocations++
+      sut.captureLog(
+        SentryLogEvent(SentryId(), SentryNanotimeDate(), "nested", SentryLogLevel.WARN),
+        scope,
+      )
+      l
+    }
+    sut = fixture.getSut()
+
+    sut.captureLog(
+      SentryLogEvent(SentryId(), SentryNanotimeDate(), "outer", SentryLogLevel.WARN),
+      scope,
+    )
+
+    assertEquals(1, invocations)
+    verify(fixture.loggerBatchProcessor, times(1)).add(any())
+  }
+
+  @Test
   fun `when beforeSendLog is set, callback is invoked`() {
     val scope = createScope()
     var invoked = false

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3295,11 +3295,10 @@ class SentryClientTest {
     var invocations = 0
     lateinit var sut: SentryClient
     val options = { options: SentryOptions ->
-      options.beforeEnvelopeCallback =
-        SentryOptions.BeforeEnvelopeCallback { _, _ ->
-          invocations++
-          sut.captureEvent(SentryEvent())
-        }
+      options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->
+        invocations++
+        sut.captureEvent(SentryEvent())
+      }
     }
     sut = fixture.getSut(options)
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3309,6 +3309,44 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when beforeEnvelopeCallback captures an envelope, the nested envelope is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var sut: SentryClient
+    val options = { options: SentryOptions ->
+      options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->
+        invocations++
+        sut.captureEnvelope(SentryEnvelope(SentryId(UUID.randomUUID()), null, setOf()))
+      }
+    }
+    sut = fixture.getSut(options)
+
+    sut.captureEvent(SentryEvent(), Hint())
+
+    // Callback runs only for the outer envelope; the nested captureEnvelope is dropped in
+    // sendEnvelope before its callback would run.
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
+  fun `when beforeEnvelopeCallback captures a check-in, the nested check-in is dropped and does not recurse`() {
+    var invocations = 0
+    lateinit var sut: SentryClient
+    val options = { options: SentryOptions ->
+      options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->
+        invocations++
+        sut.captureCheckIn(CheckIn("some_slug", CheckInStatus.OK), null, null)
+      }
+    }
+    sut = fixture.getSut(options)
+
+    sut.captureEvent(SentryEvent(), Hint())
+
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
   fun `beforeEnvelopeCallback may fail, but the transport is still sends the envelope `() {
     val sut = fixture.getSut { options ->
       options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -349,6 +349,44 @@ class SentryClientTest {
   }
 
   @Test
+  fun `when beforeSend captures feedback before an event, the guard is not cleared prematurely`() {
+    val scope = createScope()
+    var invocations = 0
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.setBeforeSend { e, _ ->
+      invocations++
+      // Capturing feedback must not clear the re-entrancy guard for captures that follow it in the
+      // same callback, otherwise the captureEvent below would recurse.
+      sut.captureFeedback(Feedback("feedback"), null, scope)
+      sut.captureEvent(SentryEvent())
+      e
+    }
+    sut = fixture.getSut()
+
+    sut.captureEvent(SentryEvent())
+
+    assertEquals(1, invocations)
+    verify(fixture.transport, times(1)).send(any(), anyOrNull())
+  }
+
+  @Test
+  fun `when beforeSendFeedback captures feedback again, the nested capture is dropped and does not recurse`() {
+    val scope = createScope()
+    var invocations = 0
+    lateinit var sut: SentryClient
+    fixture.sentryOptions.setBeforeSendFeedback { e, _ ->
+      invocations++
+      sut.captureFeedback(Feedback("nested"), null, scope)
+      e
+    }
+    sut = fixture.getSut()
+
+    sut.captureFeedback(Feedback("outer"), null, scope)
+
+    assertEquals(1, invocations)
+  }
+
+  @Test
   fun `when beforeSendLog is set, callback is invoked`() {
     val scope = createScope()
     var invoked = false

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3329,24 +3329,6 @@ class SentryClientTest {
   }
 
   @Test
-  fun `when beforeEnvelopeCallback captures a check-in, the nested check-in is dropped and does not recurse`() {
-    var invocations = 0
-    lateinit var sut: SentryClient
-    val options = { options: SentryOptions ->
-      options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->
-        invocations++
-        sut.captureCheckIn(CheckIn("some_slug", CheckInStatus.OK), null, null)
-      }
-    }
-    sut = fixture.getSut(options)
-
-    sut.captureEvent(SentryEvent(), Hint())
-
-    assertEquals(1, invocations)
-    verify(fixture.transport, times(1)).send(any(), anyOrNull())
-  }
-
-  @Test
   fun `beforeEnvelopeCallback may fail, but the transport is still sends the envelope `() {
     val sut = fixture.getSut { options ->
       options.beforeEnvelopeCallback = SentryOptions.BeforeEnvelopeCallback { _, _ ->


### PR DESCRIPTION
## 📜 Description
Adds a core-level re-entrancy guard so a user callback (`beforeSend`, `beforeBreadcrumb`, `beforeSendLog`, and the other `beforeSend*` variants) that triggers another SDK capture no longer recurses into a `StackOverflowError`.

## 💡 Motivation and Context
These callbacks run synchronously on the caller thread with only a `try/catch` — nothing prevents re-entrant capture. So a callback that captures again — directly, or transitively through a logging integration that routes back into Sentry — loops forever:

`captureX()` → `executeBeforeX()` → callback logs/captures → (integration) → `captureX()` → …

This is the same class of bug as the logcat `StackOverflowError` (SDK-CRASHES-JAVA-3T3H, fixed per-integration in #5734). It also affects the **Timber** integration (`SentryTimberTree` fires `captureEvent` + `addBreadcrumb` + `logger().log()` on every Timber call) and any app code that captures from within a callback. Rather than patch each integration, this fixes the whole class once in the core.

**Solution**
`SentryCallbackReentrancyGuard` is a shared thread-local flag set **only** around each callback's `execute(...)`. The capture entry points (`SentryClient.captureEvent`/`captureTransaction`/`captureLog`, `Scope.addBreadcrumb`) drop a nested capture while the flag is active, breaking the loop across all capture types on the same thread. Captures made by event processors run outside the flag and are unaffected. The real `Log.*` output in integrations is untouched.

Dropping the nested capture (rather than sending it without running `beforeSend`) is deliberate — bypassing `beforeSend` would risk sending unscrubbed PII, which the SDK already guards against.

## 💥 Behavioral change
A capture a callback makes **intentionally** (e.g. a diagnostic event, or re-capturing an enriched event) is now dropped while that callback runs, and logged at `DEBUG`. This is the safe trade-off — such a nested capture is indistinguishable from recursion. Event processors are not affected. The per-integration guard added in #5734 becomes redundant (left in place; harmless).

## 💚 How did you test it?
- `SentryClientTest`: `beforeSend`→`captureEvent`, `beforeSendLog`→log, and cross-type (`beforeSend` emitting a log) — each verified to `StackOverflowError`/fail without the guard and pass with it, with the nested capture dropped.
- `ScopeTest`: `beforeBreadcrumb`→`addBreadcrumb`.
- `SentryTimberIntegrationTest`: end-to-end with a real `Sentry.init`, a planted `SentryTimberTree`, and a `beforeSend` that calls `Timber.e(...)` — verified to recurse without the guard and to run the callback exactly once with it.

Fixes SDK-CRASHES-JAVA-3T3H

JAVA-638
