### PR TITLE
fix(anr): Detect main thread from tombstone via pid matching thread id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixes
 
+- Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
@@ -114,6 +114,14 @@ public class TombstoneParser implements Closeable {
         // the backend currently requires a stack-trace in exception
         exc.setStacktrace(stacktrace);
       }
+
+      // Android/Linux convention: the pid of the process is the same as the tid of the main thread.
+      // The main thread is special in that it is the only thread that can create a Looper and thus
+      // handle messages on the main thread
+      if (tombstone.pid == threadEntryValue.id) {
+        thread.setName("main");
+        thread.setMain(true);
+      }
       threads.add(thread);
     }
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
@@ -118,7 +118,7 @@ public class TombstoneParser implements Closeable {
       // thread id always equals the process id,
       // so we use it to reliably detect the main thread
       if (tombstone.pid == threadEntryValue.id) {
-        // the OS may provides a (truncated) process name; normalize it
+        // the OS may provide a (truncated) process name; normalize it
         // back to "main" so downstream consumers see a consistent name
         thread.setName("main");
         thread.setMain(true);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/tombstone/TombstoneParser.java
@@ -115,10 +115,11 @@ public class TombstoneParser implements Closeable {
         exc.setStacktrace(stacktrace);
       }
 
-      // Android/Linux convention: the pid of the process is the same as the tid of the main thread.
-      // The main thread is special in that it is the only thread that can create a Looper and thus
-      // handle messages on the main thread
+      // thread id always equals the process id,
+      // so we use it to reliably detect the main thread
       if (tombstone.pid == threadEntryValue.id) {
+        // the OS may provides a (truncated) process name; normalize it
+        // back to "main" so downstream consumers see a consistent name
         thread.setName("main");
         thread.setMain(true);
       }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/TombstoneIntegrationTest.kt
@@ -75,7 +75,8 @@ class TombstoneIntegrationTest : ApplicationExitIntegrationTestBase<TombstoneHin
     val crashedThreadId = 21891L
     assertEquals(crashedThreadId, event.exceptions!![0].threadId)
     val crashedThread = event.threads!!.find { thread -> thread.id == crashedThreadId }
-    assertEquals("samples.android", crashedThread!!.name)
+    assertEquals("main", crashedThread!!.name)
+    assertTrue(crashedThread.isMain!!)
     assertTrue(crashedThread.isCrashed!!)
 
     // Verify that frames from the app's native library are marked as in-app

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/tombstone/TombstoneParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/tombstone/TombstoneParserTest.kt
@@ -100,9 +100,6 @@ class TombstoneParserTest {
 
     // threads
     assertEquals(62, event.threads!!.size)
-
-    // exactly one thread is the main thread (its id equals the process id, 21891) and its name is
-    // normalized to "main"
     val mainThread = event.threads!!.single { it.isMain == true }
     assertEquals(21891, mainThread.id)
     assertEquals("main", mainThread.name)
@@ -407,10 +404,6 @@ class TombstoneParserTest {
 
   @Test
   fun `identifies the main thread via pid matching the thread id and normalizes its name`() {
-    // On Linux/Android the main thread's kernel thread id equals the process id (pid), so we use
-    // that to detect the main thread even when the OS renamed it to the (truncated) process name.
-    // The crashed thread (tid) is a different thread here to verify the two are handled
-    // independently.
     val tombstone =
       Tombstone.Builder()
         .pid(1000)
@@ -430,7 +423,6 @@ class TombstoneParserTest {
             0,
           )
         )
-        // crashed thread: id == tid
         .addThread(
           TombstoneThread(
             2000,
@@ -444,7 +436,6 @@ class TombstoneParserTest {
             0,
           )
         )
-        // background thread: neither main nor crashed
         .addThread(
           TombstoneThread(
             3000,
@@ -465,7 +456,6 @@ class TombstoneParserTest {
 
     val main = threads.single { it.isMain == true }
     assertEquals(1000, main.id)
-    // the OS-assigned process name is normalized back to "main"
     assertEquals("main", main.name)
 
     val crashed = threads.single { it.isCrashed == true }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/internal/tombstone/TombstoneParserTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/internal/tombstone/TombstoneParserTest.kt
@@ -12,6 +12,7 @@ import java.io.StringWriter
 import java.util.zip.GZIPInputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import org.mockito.kotlin.mock
 
@@ -99,6 +100,13 @@ class TombstoneParserTest {
 
     // threads
     assertEquals(62, event.threads!!.size)
+
+    // exactly one thread is the main thread (its id equals the process id, 21891) and its name is
+    // normalized to "main"
+    val mainThread = event.threads!!.single { it.isMain == true }
+    assertEquals(21891, mainThread.id)
+    assertEquals("main", mainThread.name)
+
     for (thread in event.threads!!) {
       assertNotNull(thread.id)
       if (thread.id == crashedThreadId) {
@@ -395,6 +403,80 @@ class TombstoneParserTest {
     val expectedJson = readGzippedResourceFile("/tombstone_debug_meta.json.gz")
 
     assertEquals(expectedJson, actualJson)
+  }
+
+  @Test
+  fun `identifies the main thread via pid matching the thread id and normalizes its name`() {
+    // On Linux/Android the main thread's kernel thread id equals the process id (pid), so we use
+    // that to detect the main thread even when the OS renamed it to the (truncated) process name.
+    // The crashed thread (tid) is a different thread here to verify the two are handled
+    // independently.
+    val tombstone =
+      Tombstone.Builder()
+        .pid(1000)
+        .tid(2000)
+        .signal(Signal(11, "SIGSEGV", 1, "SEGV_MAPERR", false, 0, 0, false, 0, null))
+        // main thread: id == pid, but the OS renamed it to the process name
+        .addThread(
+          TombstoneThread(
+            1000,
+            "io.sentry.samples.android",
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            listOf(BacktraceFrame(0, 0x100, 0, "main", 0, "/system/lib64/libc.so", 0, "")),
+            emptyList(),
+            0,
+            0,
+          )
+        )
+        // crashed thread: id == tid
+        .addThread(
+          TombstoneThread(
+            2000,
+            "crashed-worker",
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            listOf(BacktraceFrame(0, 0x200, 0, "crash", 0, "/system/lib64/libc.so", 0, "")),
+            emptyList(),
+            0,
+            0,
+          )
+        )
+        // background thread: neither main nor crashed
+        .addThread(
+          TombstoneThread(
+            3000,
+            "Thread-3",
+            emptyList(),
+            emptyList(),
+            emptyList(),
+            listOf(BacktraceFrame(0, 0x300, 0, "work", 0, "/system/lib64/libc.so", 0, "")),
+            emptyList(),
+            0,
+            0,
+          )
+        )
+        .build()
+
+    val event = parser.parse(tombstone)
+    val threads = event.threads!!
+
+    val main = threads.single { it.isMain == true }
+    assertEquals(1000, main.id)
+    // the OS-assigned process name is normalized back to "main"
+    assertEquals("main", main.name)
+
+    val crashed = threads.single { it.isCrashed == true }
+    assertEquals(2000, crashed.id)
+    assertNotEquals(true, crashed.isMain)
+    assertEquals("crashed-worker", crashed.name)
+
+    val background = threads.single { it.id == 3000L }
+    assertNotEquals(true, background.isMain)
+    assertNotEquals(true, background.isCrashed)
+    assertEquals("Thread-3", background.name)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

Analogous to the ANR thread-dump fix in #5733, applied it to the tombstone (`ApplicationExitInfo` native crash) path as well.

**Changes**

- Mark the tombstone thread whose id equals the process id as the main thread and set its name to `"main"`.

No public API change.

## :bulb: Motivation and Context

When the OS names the main thread after the process (or leaves it unnamed), native crashes were not attributed to the main thread. Matching on `id == pid` is robust and does not depend on the (truncatable) process name.

## :green_heart: How did you test it?

- Added a unit test to `TombstoneParserTest` covering main-thread detection and name normalization, with separate crashed/background threads to verify independence.
- Strengthened the existing snapshot test to assert the main thread is detected from real tombstone data.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
