### PR TITLE
fix(android): Avoid Math floor APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Fixes
 
-- Fix ISO 8601 timestamp handling on older Android versions by replacing unsupported `Math.floorDiv` and `Math.floorMod` calls ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
+- Fix `NoSuchMethodError` when using `Math.floorDiv`/`Math.floorMod` on Android < 24 ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Fixes
 
-- Avoid using `Math.floorDiv` and `Math.floorMod` on Android API levels where they are unavailable ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
+- Fix ISO 8601 timestamp handling on older Android versions by replacing unsupported `Math.floorDiv` and `Math.floorMod` calls ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
 - Fix main thread identification parsing for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Do not send threads without stacktraces for ApplicationExitInfo ANRs ([#5733](https://github.com/getsentry/sentry-java/pull/5733))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixes
 
+- Avoid using `Math.floorDiv` and `Math.floorMod` on Android API levels where they are unavailable ([#5743](https://github.com/getsentry/sentry-java/pull/5743))
 - Record byte-level client reports when event processors discard logs or trace metrics ([#5718](https://github.com/getsentry/sentry-java/pull/5718))
 - Name the device-info caching thread `SentryDeviceInfoCache` so all threads spawned by the SDK are identifiable ([#5684](https://github.com/getsentry/sentry-java/pull/5684))
 - Apply byte-category rate limits to log and trace metric envelope items ([#5716](https://github.com/getsentry/sentry-java/pull/5716))

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,6 +34,34 @@ limitations under the License.
 
 ---
 
+## Google Guava — LongMath (Apache 2.0)
+
+**Source:** https://github.com/google/guava/blob/v33.0.0/guava/src/com/google/common/math/LongMath.java<br>
+**License:** Apache License 2.0<br>
+**Copyright:** Copyright (C) 2011 The Guava Authors
+
+### Scope
+
+The Sentry Java SDK includes adapted floor division logic from Guava's `LongMath` class to support older Android API levels. The code resides in `io.sentry.vendor.SentryMath`.
+
+```
+Copyright (C) 2011 The Guava Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+---
+
 ## FasterXML Jackson — ISO8601Utils (Apache 2.0)
 
 **Source:** https://github.com/FasterXML/jackson-databind<br>

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -106,34 +106,6 @@ limitations under the License.
 
 ---
 
-## Android Open Source Project — Math (Apache 2.0)
-
-**Source:** https://cs.android.com/android/platform/superproject/+/android-latest-release:libcore/ojluni/src/main/java/java/lang/Math.java;l=1587-1630;drc=eea9c17e2bf4cce9b17d601cdc3b44ccb559271b<br>
-**License:** Apache License 2.0<br>
-**Copyright:** Copyright (C) 2010 The Android Open Source Project
-
-### Scope
-
-The Sentry Java SDK includes adapted `floorDiv` and `floorMod` helpers from the Android Open Source Project's `Math` implementation to support older Android API levels. The code resides in `io.sentry.vendor.SentryMath`.
-
-```
-Copyright (C) 2010 The Android Open Source Project
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
-
----
-
 ## Square — Tape (Apache 2.0)
 
 **Source:** https://github.com/square/tape (Commit: 445cd3fd0a7b3ec48c9ea3e0e86663fe6d3735d8)<br>

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -106,6 +106,34 @@ limitations under the License.
 
 ---
 
+## Android Open Source Project — Math (Apache 2.0)
+
+**Source:** https://cs.android.com/android/platform/superproject/+/android-latest-release:libcore/ojluni/src/main/java/java/lang/Math.java;l=1587-1630;drc=eea9c17e2bf4cce9b17d601cdc3b44ccb559271b<br>
+**License:** Apache License 2.0<br>
+**Copyright:** Copyright (C) 2010 The Android Open Source Project
+
+### Scope
+
+The Sentry Java SDK includes adapted `floorDiv` and `floorMod` helpers from the Android Open Source Project's `Math` implementation to support older Android API levels. The code resides in `io.sentry.vendor.SentryMath`.
+
+```
+Copyright (C) 2010 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+---
+
 ## Square — Tape (Apache 2.0)
 
 **Source:** https://github.com/square/tape (Commit: 445cd3fd0a7b3ec48c9ea3e0e86663fe6d3735d8)<br>

--- a/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
@@ -142,8 +142,8 @@ public final class SentryIso8601Utils {
       return formatTimestampWithCalendar(millis);
     }
 
-    final long epochDay = Math.floorDiv(millis, MILLIS_PER_DAY);
-    int millisOfDay = (int) Math.floorMod(millis, MILLIS_PER_DAY);
+    final long epochDay = floorDiv(millis, MILLIS_PER_DAY);
+    int millisOfDay = (int) floorMod(millis, MILLIS_PER_DAY);
 
     final int[] yearMonthDay = epochDayToYearMonthDay(epochDay);
     final int hour = millisOfDay / (int) MILLIS_PER_HOUR;
@@ -281,7 +281,7 @@ public final class SentryIso8601Utils {
 
   private static long daysFromYearMonthDay(int year, final int month, final int day) {
     year -= month <= 2 ? 1 : 0;
-    final long era = Math.floorDiv(year, 400);
+    final long era = floorDiv(year, 400L);
     final int yearOfEra = (int) (year - era * 400);
     final int dayOfYear = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1;
     final int dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear;
@@ -290,7 +290,7 @@ public final class SentryIso8601Utils {
 
   private static int[] epochDayToYearMonthDay(long epochDay) {
     epochDay += DAYS_0000_TO_1970;
-    final long era = Math.floorDiv(epochDay, 146097);
+    final long era = floorDiv(epochDay, 146097L);
     final int dayOfEra = (int) (epochDay - era * 146097);
     final int yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365;
     final int year = (int) (yearOfEra + era * 400);
@@ -299,6 +299,18 @@ public final class SentryIso8601Utils {
     final int day = dayOfYear - (153 * monthPrime + 2) / 5 + 1;
     final int month = monthPrime < 10 ? monthPrime + 3 : monthPrime - 9;
     return new int[] {year + (month <= 2 ? 1 : 0), month, day};
+  }
+
+  private static long floorDiv(final long x, final long y) {
+    long r = x / y;
+    if ((x ^ y) < 0 && r * y != x) {
+      r--;
+    }
+    return r;
+  }
+
+  private static long floorMod(final long x, final long y) {
+    return x - floorDiv(x, y) * y;
   }
 
   private static boolean isBeforeGregorianCutover(final int year, final int month, final int day) {

--- a/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
@@ -142,8 +142,8 @@ public final class SentryIso8601Utils {
       return formatTimestampWithCalendar(millis);
     }
 
-    final long epochDay = floorDiv(millis, MILLIS_PER_DAY);
-    int millisOfDay = (int) floorMod(millis, MILLIS_PER_DAY);
+    final long epochDay = SentryMath.floorDiv(millis, MILLIS_PER_DAY);
+    int millisOfDay = (int) SentryMath.floorMod(millis, MILLIS_PER_DAY);
 
     final int[] yearMonthDay = epochDayToYearMonthDay(epochDay);
     final int hour = millisOfDay / (int) MILLIS_PER_HOUR;
@@ -281,7 +281,7 @@ public final class SentryIso8601Utils {
 
   private static long daysFromYearMonthDay(int year, final int month, final int day) {
     year -= month <= 2 ? 1 : 0;
-    final long era = floorDiv(year, 400L);
+    final long era = SentryMath.floorDiv(year, 400L);
     final int yearOfEra = (int) (year - era * 400);
     final int dayOfYear = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1;
     final int dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear;
@@ -290,7 +290,7 @@ public final class SentryIso8601Utils {
 
   private static int[] epochDayToYearMonthDay(long epochDay) {
     epochDay += DAYS_0000_TO_1970;
-    final long era = floorDiv(epochDay, 146097L);
+    final long era = SentryMath.floorDiv(epochDay, 146097L);
     final int dayOfEra = (int) (epochDay - era * 146097);
     final int yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365;
     final int year = (int) (yearOfEra + era * 400);
@@ -299,18 +299,6 @@ public final class SentryIso8601Utils {
     final int day = dayOfYear - (153 * monthPrime + 2) / 5 + 1;
     final int month = monthPrime < 10 ? monthPrime + 3 : monthPrime - 9;
     return new int[] {year + (month <= 2 ? 1 : 0), month, day};
-  }
-
-  private static long floorDiv(final long x, final long y) {
-    long r = x / y;
-    if ((x ^ y) < 0 && r * y != x) {
-      r--;
-    }
-    return r;
-  }
-
-  private static long floorMod(final long x, final long y) {
-    return x - floorDiv(x, y) * y;
   }
 
   private static boolean isBeforeGregorianCutover(final int year, final int month, final int day) {

--- a/sentry/src/main/java/io/sentry/vendor/SentryMath.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryMath.java
@@ -1,21 +1,3 @@
-/*
- * Adapted from https://cs.android.com/android/platform/superproject/+/android-latest-release:libcore/ojluni/src/main/java/java/lang/Math.java;l=1587-1630;drc=eea9c17e2bf4cce9b17d601cdc3b44ccb559271b
- *
- * Copyright (C) 2010 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.sentry.vendor;
 
 final class SentryMath {
@@ -23,14 +5,17 @@ final class SentryMath {
   private SentryMath() {}
 
   static long floorDiv(final long x, final long y) {
-    long r = x / y;
-    if ((x ^ y) < 0 && r * y != x) {
-      r--;
-    }
-    return r;
+    final long quotient = x / y;
+    final long remainder = x % y;
+    return remainder != 0 && hasDifferentSigns(x, y) ? quotient - 1 : quotient;
   }
 
   static long floorMod(final long x, final long y) {
-    return x - floorDiv(x, y) * y;
+    final long remainder = x % y;
+    return remainder != 0 && hasDifferentSigns(x, y) ? remainder + y : remainder;
+  }
+
+  private static boolean hasDifferentSigns(final long x, final long y) {
+    return x < 0 != y < 0;
   }
 }

--- a/sentry/src/main/java/io/sentry/vendor/SentryMath.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryMath.java
@@ -1,3 +1,21 @@
+/*
+ * Adapted from https://github.com/google/guava/blob/v33.0.0/guava/src/com/google/common/math/LongMath.java
+ *
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.sentry.vendor;
 
 final class SentryMath {
@@ -6,16 +24,17 @@ final class SentryMath {
 
   static long floorDiv(final long x, final long y) {
     final long quotient = x / y;
-    final long remainder = x % y;
-    return remainder != 0 && hasDifferentSigns(x, y) ? quotient - 1 : quotient;
+    final long remainder = x - y * quotient;
+
+    if (remainder == 0) {
+      return quotient;
+    }
+
+    final int signum = 1 | (int) ((x ^ y) >> (Long.SIZE - 1));
+    return signum < 0 ? quotient + signum : quotient;
   }
 
   static long floorMod(final long x, final long y) {
-    final long remainder = x % y;
-    return remainder != 0 && hasDifferentSigns(x, y) ? remainder + y : remainder;
-  }
-
-  private static boolean hasDifferentSigns(final long x, final long y) {
-    return x < 0 != y < 0;
+    return x - floorDiv(x, y) * y;
   }
 }

--- a/sentry/src/main/java/io/sentry/vendor/SentryMath.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryMath.java
@@ -1,0 +1,36 @@
+/*
+ * Adapted from https://cs.android.com/android/platform/superproject/+/android-latest-release:libcore/ojluni/src/main/java/java/lang/Math.java;l=1587-1630;drc=eea9c17e2bf4cce9b17d601cdc3b44ccb559271b
+ *
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.sentry.vendor;
+
+final class SentryMath {
+
+  private SentryMath() {}
+
+  static long floorDiv(final long x, final long y) {
+    long r = x / y;
+    if ((x ^ y) < 0 && r * y != x) {
+      r--;
+    }
+    return r;
+  }
+
+  static long floorMod(final long x, final long y) {
+    return x - floorDiv(x, y) * y;
+  }
+}

--- a/sentry/src/test/java/io/sentry/vendor/SentryMathTest.kt
+++ b/sentry/src/test/java/io/sentry/vendor/SentryMathTest.kt
@@ -1,0 +1,58 @@
+package io.sentry.vendor
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class SentryMathTest {
+  @Test
+  fun `floorDiv matches Java Math floorDiv`() {
+    values.forEach { x ->
+      divisors.forEach { y -> assertThat(SentryMath.floorDiv(x, y)).isEqualTo(Math.floorDiv(x, y)) }
+    }
+  }
+
+  @Test
+  fun `floorMod matches Java Math floorMod`() {
+    values.forEach { x ->
+      divisors.forEach { y -> assertThat(SentryMath.floorMod(x, y)).isEqualTo(Math.floorMod(x, y)) }
+    }
+  }
+
+  @Test
+  fun `floorDiv throws when dividing by zero`() {
+    assertFailsWith<ArithmeticException> { SentryMath.floorDiv(1L, 0L) }
+  }
+
+  @Test
+  fun `floorMod throws when dividing by zero`() {
+    assertFailsWith<ArithmeticException> { SentryMath.floorMod(1L, 0L) }
+  }
+
+  private companion object {
+    val values =
+      listOf(
+        Long.MIN_VALUE,
+        -86_400_001L,
+        -86_400_000L,
+        -86_399_999L,
+        -401L,
+        -400L,
+        -399L,
+        -2L,
+        -1L,
+        0L,
+        1L,
+        2L,
+        399L,
+        400L,
+        401L,
+        86_399_999L,
+        86_400_000L,
+        86_400_001L,
+        Long.MAX_VALUE,
+      )
+
+    val divisors = listOf(Long.MIN_VALUE, -146_097L, -400L, -1L, 1L, 400L, 146_097L, Long.MAX_VALUE)
+  }
+}


### PR DESCRIPTION
## :scroll: Description
Replace `Math.floorDiv` and `Math.floorMod` usage in `SentryIso8601Utils` with a package-private `SentryMath` helper.

## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-java/issues/5741

`SentryIso8601Utils` lives in the shared `sentry` module and is reachable from Android. Android supports minSdk 21 in this repo, but `java.lang.Math.floorDiv`/`floorMod` are only available on newer Android API levels. Calling them from shared code can crash Android apps on supported older devices with `NoSuchMethodError`.

The replacement helper adapts Apache-licensed Guava `LongMath` floor division logic and adds matching attribution in `THIRD_PARTY_NOTICES.md`. `floorMod` is implemented through `floorDiv` so it matches Java `Math.floorMod` for both positive and negative divisors.

## :green_heart: How did you test it?
- `./gradlew :sentry:test --tests "io.sentry.vendor.SentryMathTest" --tests "io.sentry.DateUtilsTest"`
- `./gradlew :sentry:animalsnifferMain`
- `./gradlew spotlessApply apiDump`
- `rg -n "\\bMath\\.(floorDiv|floorMod)" sentry/src/main/java sentry-android-core/src/main/java -g '*.java' -g '*.kt'`

## :pencil: Checklist
- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
None.
