### PR TITLE
test: Verify Java 8 API check in logback

### DIFF
--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -230,7 +230,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   protected @NotNull Breadcrumb createBreadcrumb(final @NotNull ILoggingEvent loggingEvent) {
     final Breadcrumb breadcrumb = new Breadcrumb();
     breadcrumb.setLevel(formatLevel(loggingEvent.getLevel()));
-    breadcrumb.setCategory(loggingEvent.getLoggerName());
+    breadcrumb.setCategory(Objects.requireNonNullElse(loggingEvent.getLoggerName(), ""));
     breadcrumb.setMessage(formatted(loggingEvent));
     return breadcrumb;
   }

--- a/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
@@ -290,7 +290,7 @@ public final class SentryIso8601Utils {
 
   private static int[] epochDayToYearMonthDay(long epochDay) {
     epochDay += DAYS_0000_TO_1970;
-    final long era = SentryMath.floorDiv(epochDay, 146097L);
+    final long era = Math.floorDiv(epochDay, 146097);
     final int dayOfEra = (int) (epochDay - era * 146097);
     final int yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365;
     final int year = (int) (yearOfEra + era * 400);

--- a/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
+++ b/sentry/src/main/java/io/sentry/vendor/SentryIso8601Utils.java
@@ -290,7 +290,7 @@ public final class SentryIso8601Utils {
 
   private static int[] epochDayToYearMonthDay(long epochDay) {
     epochDay += DAYS_0000_TO_1970;
-    final long era = Math.floorDiv(epochDay, 146097);
+    final long era = SentryMath.floorDiv(epochDay, 146097L);
     final int dayOfEra = (int) (epochDay - era * 146097);
     final int yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36524 - dayOfEra / 146096) / 365;
     final int year = (int) (yearOfEra + era * 400);


### PR DESCRIPTION
## :scroll: Description
Intentionally introduce the Java 9-only `Objects.requireNonNullElse(Object, Object)` API in the `sentry-logback` module.

This PR is a validation PR for #5745 and is expected to fail the new Java 8 API compatibility workflow.

## :bulb: Motivation and Context
This verifies that the Codehaus Java 8 Animal Sniffer signature check catches Java 8 runtime incompatibilities outside the core `:sentry` module too.

## :green_heart: How did you test it?

Expected failure:

```text
./gradlew java8ApiCompatibility --init-script .github/gradle/java8-api-compatibility.init.gradle.kts --no-configuration-cache -Dorg.gradle.configureondemand=false

[Undefined reference] io.sentry.logback.(SentryAppender.java:233)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
```

Formatting/API generation still passes:

```text
./gradlew spotlessApply apiDump
BUILD SUCCESSFUL
```

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Close this PR after confirming the workflow fails as expected.

#skip-changelog
