### PR TITLE
test: Verify Java 8 API compatibility coverage

### DIFF
--- a/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransportFactory.java
+++ b/sentry-apache-http-client-5/src/main/java/io/sentry/transport/apache/ApacheHttpClientTransportFactory.java
@@ -28,7 +28,7 @@ public final class ApacheHttpClientTransportFactory implements ITransportFactory
 
   public ApacheHttpClientTransportFactory(final @NotNull TimeValue connectionTimeToLive) {
     this.connectionTimeToLive =
-        Objects.requireNonNull(connectionTimeToLive, "connectionTimeToLive is required");
+        java.util.Objects.requireNonNullElse(connectionTimeToLive, TimeValue.ofMinutes(1));
   }
 
   @Override

--- a/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
+++ b/sentry-jul/src/main/java/io/sentry/jul/SentryHandler.java
@@ -258,7 +258,7 @@ public class SentryHandler extends Handler {
   private @NotNull Breadcrumb createBreadcrumb(final @NotNull LogRecord record) {
     final Breadcrumb breadcrumb = new Breadcrumb();
     breadcrumb.setLevel(formatLevel(record.getLevel()));
-    breadcrumb.setCategory(record.getLoggerName());
+    breadcrumb.setCategory(java.util.Objects.requireNonNullElse(record.getLoggerName(), ""));
     if (record.getParameters() != null) {
       try {
         breadcrumb.setMessage(formatMessage(record.getMessage(), record.getParameters()));

--- a/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
+++ b/sentry-logback/src/main/java/io/sentry/logback/SentryAppender.java
@@ -230,7 +230,7 @@ public class SentryAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   protected @NotNull Breadcrumb createBreadcrumb(final @NotNull ILoggingEvent loggingEvent) {
     final Breadcrumb breadcrumb = new Breadcrumb();
     breadcrumb.setLevel(formatLevel(loggingEvent.getLevel()));
-    breadcrumb.setCategory(loggingEvent.getLoggerName());
+    breadcrumb.setCategory(Objects.requireNonNullElse(loggingEvent.getLoggerName(), ""));
     breadcrumb.setMessage(formatted(loggingEvent));
     return breadcrumb;
   }

--- a/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
+++ b/sentry-okhttp/src/main/java/io/sentry/okhttp/SentryOkHttpUtils.kt
@@ -76,7 +76,7 @@ internal object SentryOkHttpUtils {
     val headers = mutableMapOf<String, String>()
 
     for (i in 0 until requestHeaders.size) {
-      val name = requestHeaders.name(i)
+      val name = java.util.Objects.requireNonNullElse(requestHeaders.name(i), "")
 
       // header is only sent if isn't sensitive
       if (HttpUtils.containsSensitiveHeader(name)) {


### PR DESCRIPTION
## :scroll: Description
Intentionally introduce Java 8-incompatible JDK API references across several JVM integration modules.

This PR is a validation PR for #5745 and is expected to fail the Animal Sniffer checks wired into `check`.

Intentional violations:

- `:sentry-logback`: `Objects.requireNonNullElse(Object, Object)`
- `:sentry-jul`: `Objects.requireNonNullElse(Object, Object)`
- `:sentry-apache-http-client-5`: `Objects.requireNonNullElse(Object, Object)`
- `:sentry-okhttp`: `Objects.requireNonNullElse(Object, Object)`

This covers both modules that already had Animal Sniffer and modules that #5745 newly configures. The core `:sentry` violation was intentionally removed so the normal `check` lifecycle reaches non-core module failures in CI.

## :bulb: Motivation and Context
This verifies the Java 8 runtime API compatibility coverage added in #5745 catches newer JDK API references across multiple JVM SDK integration modules while leaving Android builds unaffected.

## :green_heart: How did you test it?

Normal `check` fails in a non-core module once the core violation is removed:

```text
./gradlew check --no-configuration-cache -Dorg.gradle.configureondemand=false

BUILD FAILED

[Undefined reference] io.sentry.transport.apache.(ApacheHttpClientTransportFactory.java:31)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
```

Focused `--continue` run confirms all intentional non-core violations are caught:

```text
./gradlew :sentry-logback:animalsnifferMain \
  :sentry-jul:animalsnifferMain \
  :sentry-apache-http-client-5:animalsnifferMain \
  :sentry-okhttp:animalsnifferMain \
  --continue --no-configuration-cache -Dorg.gradle.configureondemand=false

BUILD FAILED

[Undefined reference] io.sentry.jul.(SentryHandler.java:261)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
[Undefined reference] io.sentry.logback.(SentryAppender.java:233)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
[Undefined reference] io.sentry.transport.apache.(ApacheHttpClientTransportFactory.java:31)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
[Undefined reference | java18-1.0] io.sentry.okhttp.(SentryOkHttpUtils.kt:79)
  >> Object java.util.Objects.requireNonNullElse(Object, Object)
```

Android still assembles:

```text
./gradlew :sentry-android-core:assembleDebug :sentry-android-timber:assembleDebug \
  --no-configuration-cache -Dorg.gradle.configureondemand=false

BUILD SUCCESSFUL
```

Formatting/API generation still passes:

```text
./gradlew spotlessApply apiDump
BUILD SUCCESSFUL
```

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

Close this PR after confirming the workflow fails as expected.

#skip-changelog
