### PR TITLE
Replace deprecated ThrowableProxy with LogEvent#getThrown() in sentry-log4j2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 ### Fixes
 
 - Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
+- Replace deprecated `ThrowableProxy` with `LogEvent#getThrown()` in `sentry-log4j2` ([#5751](https://github.com/getsentry/sentry-java/pull/5751))
+
 
 ### Dependencies
 

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -273,7 +273,7 @@ public class SentryAppender extends AbstractAppender {
     event.setLogger(loggingEvent.getLoggerName());
     event.setLevel(formatLevel(loggingEvent.getLevel()));
 
-    final Throwable thrown = loggingEvent.getThrown();
+    final @Nullable Throwable thrown = loggingEvent.getThrown();
     if (thrown != null) {
       final Mechanism mechanism = new Mechanism();
       mechanism.setType(MECHANISM_TYPE);

--- a/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
+++ b/sentry-log4j2/src/main/java/io/sentry/log4j2/SentryAppender.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
-import org.apache.logging.log4j.core.impl.ThrowableProxy;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -274,13 +273,12 @@ public class SentryAppender extends AbstractAppender {
     event.setLogger(loggingEvent.getLoggerName());
     event.setLevel(formatLevel(loggingEvent.getLevel()));
 
-    final ThrowableProxy throwableInformation = loggingEvent.getThrownProxy();
-    if (throwableInformation != null) {
+    final Throwable thrown = loggingEvent.getThrown();
+    if (thrown != null) {
       final Mechanism mechanism = new Mechanism();
       mechanism.setType(MECHANISM_TYPE);
       final Throwable mechanismException =
-          new ExceptionMechanismException(
-              mechanism, throwableInformation.getThrowable(), Thread.currentThread());
+          new ExceptionMechanismException(mechanism, thrown, Thread.currentThread());
       event.setThrowable(mechanismException);
     }
 


### PR DESCRIPTION
…-log4j2

## :scroll: Description
Replaces the deprecated `ThrowableProxy` class with `LogEvent#getThrown()` in `SentryAppender`.

## :bulb: Motivation and Context
`ThrowableProxy` is deprecated in log4j2. The only usage in `SentryAppender` was calling
`.getThrowable()` on it to extract the underlying `Throwable`. `LogEvent` already exposes 
this directly via `getThrown()`, which is documented as a convenience method for exactly 
that purpose, so `ThrowableProxy` can be dropped entirely.

* resolves: #5439

## :green_heart: How did you test it?
Ran the existing `sentry-log4j2` test suite (`./gradlew :sentry-log4j2:test`) — all tests pass.

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps
N/A
