### PR TITLE
fix(replay): Preserve segment ID after buffer-to-session conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Fixes
 
-- Fix replay segment ID normalization after buffer-to-session conversion ([#5753](https://github.com/getsentry/sentry-java/pull/5753))
+- Session Replay: Fix first recording segment missing for replays in `buffer` mode ([#5753](https://github.com/getsentry/sentry-java/pull/5753))
 - Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixes
 
+- Fix replay segment ID normalization after buffer-to-session conversion ([#5753](https://github.com/getsentry/sentry-java/pull/5753))
 - Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
 
 ### Dependencies

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -317,6 +317,7 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
     internal const val SEGMENT_KEY_REPLAY_SCREEN_AT_START = "replay.screen-at-start"
     internal const val SEGMENT_KEY_REPLAY_RECORDING = "replay.recording"
     internal const val SEGMENT_KEY_ID = "segment.id"
+    internal const val SEGMENT_KEY_FLUSHED = "replay.flushed"
 
     fun makeReplayCacheDir(options: SentryOptions, replayId: SentryId): File? =
       if (options.cacheDirPath.isNullOrEmpty()) {
@@ -415,8 +416,11 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
       }
 
       cache.frames.sortBy { it.timestamp }
-      // TODO: this should be removed when we start sending buffered segments on next launch
-      val normalizedSegmentId = if (replayType == SESSION) segmentId else 0
+      val wasFlushed = lastSegment[SEGMENT_KEY_FLUSHED]?.toBooleanStrictOrNull() == true
+      // In buffer mode, if the buffer was never flushed (no error triggered captureReplay),
+      // no segments were ever sent, so we normalize to 0. After a flush + conversion to
+      // session mode, the persisted segmentId is the real sequence number.
+      val normalizedSegmentId = if (replayType == SESSION || wasFlushed) segmentId else 0
       val normalizedTimestamp =
         if (replayType == SESSION) {
           segmentTimestamp

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -422,7 +422,7 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
       // session mode, the persisted segmentId is the real sequence number.
       val normalizedSegmentId = if (replayType == SESSION || wasFlushed) segmentId else 0
       val normalizedTimestamp =
-        if (replayType == SESSION || wasFlushed) {
+        if (replayType == SESSION) {
           segmentTimestamp
         } else {
           // in buffer mode we have to set the timestamp of the first frame as the actual start

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayCache.kt
@@ -422,7 +422,7 @@ public class ReplayCache(private val options: SentryOptions, private val replayI
       // session mode, the persisted segmentId is the real sequence number.
       val normalizedSegmentId = if (replayType == SESSION || wasFlushed) segmentId else 0
       val normalizedTimestamp =
-        if (replayType == SESSION) {
+        if (replayType == SESSION || wasFlushed) {
           segmentTimestamp
         } else {
           // in buffer mode we have to set the timestamp of the first frame as the actual start

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/ReplayIntegration.kt
@@ -261,6 +261,7 @@ public class ReplayIntegration(
       onSegmentSent = { newTimestamp ->
         captureStrategy?.currentSegment = captureStrategy?.currentSegment!! + 1
         captureStrategy?.segmentTimestamp = newTimestamp
+        captureStrategy?.isFlushed = true
       },
     )
     captureStrategy = captureStrategy?.convert()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -90,6 +90,9 @@ internal abstract class BaseCaptureStrategy(
     get() = cache?.replayCacheDir
 
   override var replayType by persistableAtomic<ReplayType>(propertyName = SEGMENT_KEY_REPLAY_TYPE)
+  // Tracks whether the buffer was flushed (segments sent to server). Used by fromDisk()
+  // to decide whether to normalize the segment ID to 0 on crash recovery: if never flushed,
+  // no segments reached the server, so the recovered segment must be 0.
   override var isFlushed: Boolean by
     persistableAtomic(initialValue = false, propertyName = SEGMENT_KEY_FLUSHED)
 

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BaseCaptureStrategy.kt
@@ -13,6 +13,7 @@ import io.sentry.SentryReplayEvent.ReplayType.BUFFER
 import io.sentry.SentryReplayEvent.ReplayType.SESSION
 import io.sentry.android.replay.ReplayCache
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_BIT_RATE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FLUSHED
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FRAME_RATE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_HEIGHT
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_ID
@@ -89,6 +90,8 @@ internal abstract class BaseCaptureStrategy(
     get() = cache?.replayCacheDir
 
   override var replayType by persistableAtomic<ReplayType>(propertyName = SEGMENT_KEY_REPLAY_TYPE)
+  override var isFlushed: Boolean by
+    persistableAtomic(initialValue = false, propertyName = SEGMENT_KEY_FLUSHED)
 
   protected val currentEvents: Deque<RRWebEvent> = ConcurrentLinkedDeque()
   private val traceIdsLock = Any()

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/BufferCaptureStrategy.kt
@@ -105,7 +105,6 @@ internal class BufferCaptureStrategy(
 
       if (segment is ReplaySegment.Created) {
         segment.capture(scopes)
-
         // we only want to increment segment_id in the case of success, but currentSegment
         // might be irrelevant since we changed strategies, so in the callback we increment
         // it on the new strategy already

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/capture/CaptureStrategy.kt
@@ -29,6 +29,7 @@ internal interface CaptureStrategy {
   val replayCacheDir: File?
   var replayType: ReplayType
   var segmentTimestamp: Date?
+  var isFlushed: Boolean
 
   fun start(segmentId: Int = 0, replayId: SentryId = SentryId(), replayType: ReplayType? = null)
 

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ReplayCacheTest.kt
@@ -9,6 +9,7 @@ import io.sentry.SentryOptions
 import io.sentry.SentryReplayEvent.ReplayType
 import io.sentry.android.replay.ReplayCache.Companion.ONGOING_SEGMENT
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_BIT_RATE
+import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FLUSHED
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_FRAME_RATE
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_HEIGHT
 import io.sentry.android.replay.ReplayCache.Companion.SEGMENT_KEY_ID
@@ -443,7 +444,7 @@ class ReplayCacheTest {
   }
 
   @Test
-  fun `sets segmentId to 0 for buffer mode`() {
+  fun `sets segmentId to 0 for buffer mode when not flushed`() {
     fixture.options.run { cacheDirPath = tmpDir.newFolder()?.absolutePath }
     val replayId = SentryId()
     val replayCacheFolder =
@@ -472,6 +473,39 @@ class ReplayCacheTest {
     val lastSegment = ReplayCache.fromDisk(fixture.options, replayId)!!
 
     assertEquals(0, lastSegment.id)
+  }
+
+  @Test
+  fun `preserves segmentId for buffer mode when already flushed`() {
+    fixture.options.run { cacheDirPath = tmpDir.newFolder()?.absolutePath }
+    val replayId = SentryId()
+    val replayCacheFolder =
+      File(fixture.options.cacheDirPath!!, "replay_$replayId").also { it.mkdirs() }
+    File(replayCacheFolder, ONGOING_SEGMENT).also {
+      it.writeText(
+        """
+                $SEGMENT_KEY_HEIGHT=912
+                $SEGMENT_KEY_WIDTH=416
+                $SEGMENT_KEY_FRAME_RATE=1
+                $SEGMENT_KEY_BIT_RATE=75000
+                $SEGMENT_KEY_ID=5
+                $SEGMENT_KEY_TIMESTAMP=2024-07-11T10:25:21.454Z
+                $SEGMENT_KEY_REPLAY_TYPE=BUFFER
+                $SEGMENT_KEY_FLUSHED=true
+                """
+          .trimIndent()
+      )
+    }
+
+    val screenshot = File(replayCacheFolder, "1720693523997.jpg").also { it.createNewFile() }
+    screenshot.outputStream().use {
+      Bitmap.createBitmap(1, 1, ARGB_8888).compress(JPEG, 80, it)
+      it.flush()
+    }
+
+    val lastSegment = ReplayCache.fromDisk(fixture.options, replayId)!!
+
+    assertEquals(5, lastSegment.id)
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

After a buffer-to-session conversion (`BufferCaptureStrategy.convert()`), the `replayType` stays `BUFFER` (intentionally — it tells the backend this replay was triggered by an error). However, if the app crashes after the conversion and `finalizePreviousReplay()` recovers the last segment on next launch, `ReplayCache.fromDisk()` was normalizing the segment ID to 0 for all `BUFFER`-type replays.

This created a **duplicate segment 0** with a late timestamp that overwrote the original segment 0 from the buffer flush, effectively losing the first segment of the replay.

The fix adds a persisted `isFlushed` flag that is set when the buffer is successfully flushed. `fromDisk()` now only normalizes the segment ID to 0 when the buffer was never flushed (i.e., no segments were ever sent to the server — the crash happened before any error triggered `captureReplay`).

## :bulb: Motivation and Context

Customers reported the first segment of error-triggered replays sometimes being missing or showing content from the wrong time range. This was caused by `finalizePreviousReplay` creating a duplicate segment 0 that replaced the original.

## :green_heart: How did you test it?

- Unit tests: updated existing test and added new test for the flushed case in `ReplayCacheTest`
- Manual test on emulator: configured sample app for buffer-only replay, triggered `captureException`, waited for session segments, force-killed, relaunched — verified the finalized segment has the correct sequential ID (not 0)
- Verified rrweb recording shows sequential segment IDs with proper timestamps

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- Investigate error-to-replay linkage issue (frozen transaction baggage doesn't pick up replayId set by `captureReplay` in buffer mode)