### PR TITLE
fix(core): Inject replayId into trace context for buffer mode errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 ### Fixes
 
 - Session Replay: Fix first recording segment missing for replays in `buffer` mode ([#5753](https://github.com/getsentry/sentry-java/pull/5753))
-- Fix error-to-replay linkage in buffer mode ([#5754](https://github.com/getsentry/sentry-java/pull/5754))
+- Session Replay: Fix error-to-replay linkage in `buffer` mode ([#5754](https://github.com/getsentry/sentry-java/pull/5754))
 - Prevent logs and metrics from remaining queued after a flush scheduling race ([#5756](https://github.com/getsentry/sentry-java/pull/5756))
 - Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Fixes
 
 - Session Replay: Fix first recording segment missing for replays in `buffer` mode ([#5753](https://github.com/getsentry/sentry-java/pull/5753))
+- Fix error-to-replay linkage in buffer mode ([#5754](https://github.com/getsentry/sentry-java/pull/5754))
 - Prevent logs and metrics from remaining queued after a flush scheduling race ([#5756](https://github.com/getsentry/sentry-java/pull/5756))
 - Fix main thread identification for tombstone (native crash) events ([#5742](https://github.com/getsentry/sentry-java/pull/5742))
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -37,6 +37,7 @@ public final class io/sentry/Baggage {
 	public fun <init> (Lio/sentry/Baggage;)V
 	public fun <init> (Lio/sentry/ILogger;)V
 	public fun <init> (Ljava/util/concurrent/ConcurrentHashMap;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;ZZLio/sentry/ILogger;)V
+	public fun forceSetReplayId (Lio/sentry/protocol/SentryId;)V
 	public fun forceSetSampleRate (Ljava/lang/Double;)V
 	public fun freeze ()V
 	public static fun fromEvent (Lio/sentry/SentryBaseEvent;Ljava/lang/String;Lio/sentry/SentryOptions;)Lio/sentry/Baggage;

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -451,6 +451,12 @@ public final class Baggage {
     set(DSCKeys.REPLAY_ID, replayId);
   }
 
+  /**
+   * Sets replay_id on the baggage bypassing the freeze check. In buffer mode the replay_id is
+   * unknown when the baggage is frozen, so it must be injected after {@link
+   * ReplayController#captureReplay} sets it on scope. This mirrors the JS SDK's <a
+   * href="https://github.com/getsentry/sentry-javascript/blob/develop/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts">setReplayIdOnDynamicSamplingContext</a>.
+   */
   @ApiStatus.Internal
   public void forceSetReplayId(final @NotNull SentryId replayId) {
     if (!SentryId.EMPTY_ID.equals(replayId)) {

--- a/sentry/src/main/java/io/sentry/Baggage.java
+++ b/sentry/src/main/java/io/sentry/Baggage.java
@@ -452,6 +452,13 @@ public final class Baggage {
   }
 
   @ApiStatus.Internal
+  public void forceSetReplayId(final @NotNull SentryId replayId) {
+    if (!SentryId.EMPTY_ID.equals(replayId)) {
+      keyValues.put(DSCKeys.REPLAY_ID, replayId.toString());
+    }
+  }
+
+  @ApiStatus.Internal
   public @Nullable String getOrgId() {
     return get(DSCKeys.ORG_ID);
   }

--- a/sentry/src/main/java/io/sentry/SentryClient.java
+++ b/sentry/src/main/java/io/sentry/SentryClient.java
@@ -250,6 +250,18 @@ public final class SentryClient implements ISentryClient {
       }
       if (shouldCaptureReplay) {
         options.getReplayController().captureReplay(event.isCrashed());
+        if (scope != null) {
+          final @Nullable SentryId replayId = scope.getReplayId();
+          if (replayId != null && !replayId.equals(SentryId.EMPTY_ID)) {
+            final @Nullable ITransaction transaction = scope.getTransaction();
+            if (transaction != null) {
+              final @Nullable Baggage baggage = transaction.getSpanContext().getBaggage();
+              if (baggage != null) {
+                baggage.forceSetReplayId(replayId);
+              }
+            }
+          }
+        }
       }
     }
 

--- a/sentry/src/test/java/io/sentry/SentryClientTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryClientTest.kt
@@ -3332,6 +3332,40 @@ class SentryClientTest {
   }
 
   @Test
+  fun `sets replayId on frozen transaction baggage after captureReplay for error events`() {
+    val replayId = SentryId()
+    fixture.sentryOptions.setReplayController(
+      object : ReplayController by NoOpReplayController.getInstance() {
+        override fun captureReplay(isTerminating: Boolean?) {}
+      }
+    )
+    val sut = fixture.getSut()
+
+    val baggage = Baggage(fixture.sentryOptions.logger)
+    baggage.traceId = SentryId().toString()
+    baggage.freeze()
+
+    val spanContext = SpanContext("op.load")
+    spanContext.baggage = baggage
+    val transaction = mock<ITransaction>()
+    whenever(transaction.spanContext).thenReturn(spanContext)
+    whenever(transaction.traceContext()).thenReturn(baggage.toTraceContext())
+
+    val scope = mock<IScope>()
+    whenever(scope.transaction).thenReturn(transaction)
+    whenever(scope.span).thenReturn(transaction)
+    whenever(scope.replayId).thenReturn(replayId)
+    whenever(scope.breadcrumbs).thenReturn(LinkedList<Breadcrumb>())
+    whenever(scope.extras).thenReturn(emptyMap())
+    whenever(scope.contexts).thenReturn(Contexts())
+    whenever(scope.propagationContext).thenReturn(PropagationContext())
+
+    sut.captureEvent(SentryEvent().apply { exceptions = listOf(SentryException()) }, scope)
+
+    assertEquals(replayId.toString(), baggage.getReplayId())
+  }
+
+  @Test
   fun `cleans up replay folder for Backfillable replay events`() {
     val dir = File(tmpDir.newFolder().absolutePath)
     val sut = fixture.getSut()


### PR DESCRIPTION
## :scroll: Description

In buffer mode, the scope's `replayId` is intentionally empty until `captureReplay()` is called (to avoid tagging events with a replay that may never be sent). However, the event's DSC is built from the active transaction's frozen baggage, which was frozen before `captureReplay()` set the `replayId`. This means error events that trigger a buffer replay flush have no `replay_id` in their DSC, breaking error-to-replay linkage.

After `captureReplay()` runs, we now force-set the `replayId` on the transaction's frozen baggage via `Baggage.forceSetReplayId()`, so the envelope header carries the correct `replay_id` in the DSC. This mirrors the JS SDK's [`setReplayIdOnDynamicSamplingContext`](https://github.com/getsentry/sentry-javascript/blob/develop/packages/replay-internal/src/util/resetReplayIdOnDynamicSamplingContext.ts).

## :bulb: Motivation and Context

Error events that trigger buffer-mode replay capture were not linked to the resulting replay, making it impossible to navigate from the error to its replay in the Sentry UI.

Example replay with a linked error event: https://sentry-sdks.sentry.io/explore/replays/49e737e2f6dc48f1a9c14692bd898bb7/?playlistEnd=2026-07-13T07:15:41&playlistStart=2026-07-06T07:15:41&project=5428559&query=&referrer=replayList&t_main=errors

## :green_heart: How did you test it?

- Existing `SentryClientTest` suite passes
- Manual verification with sample app in buffer mode: captured exception's DSC now contains the `replay_id`, and the error appears linked to the replay in Sentry

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
