### PR TITLE
feat(core): [Data Collection 1] Add configuration types

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -383,6 +383,40 @@ public final class io/sentry/DataCategory : java/lang/Enum {
 	public static fun values ()[Lio/sentry/DataCategory;
 }
 
+public final class io/sentry/DataCollection {
+	public fun <init> ()V
+	public fun getCookies ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getDatabaseQueryData ()Ljava/lang/Boolean;
+	public fun getGraphql ()Lio/sentry/DataCollection$Graphql;
+	public fun getHttpBodies ()Ljava/util/Set;
+	public fun getHttpHeaders ()Lio/sentry/DataCollection$HttpHeaders;
+	public fun getQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getQueues ()Ljava/lang/Boolean;
+	public fun getUserInfo ()Ljava/lang/Boolean;
+	public fun setCookies (Lio/sentry/KeyValueCollectionBehavior;)V
+	public fun setDatabaseQueryData (Z)V
+	public fun setHttpBodies (Ljava/util/Set;)V
+	public fun setQueryParams (Lio/sentry/KeyValueCollectionBehavior;)V
+	public fun setQueues (Z)V
+	public fun setUserInfo (Z)V
+}
+
+public final class io/sentry/DataCollection$Graphql {
+	public fun <init> ()V
+	public fun getDocument ()Ljava/lang/Boolean;
+	public fun getVariables ()Ljava/lang/Boolean;
+	public fun setDocument (Z)V
+	public fun setVariables (Z)V
+}
+
+public final class io/sentry/DataCollection$HttpHeaders {
+	public fun <init> ()V
+	public fun getRequest ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getResponse ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun setRequest (Lio/sentry/KeyValueCollectionBehavior;)V
+	public fun setResponse (Lio/sentry/KeyValueCollectionBehavior;)V
+}
+
 public final class io/sentry/DateUtils {
 	public static fun dateToSeconds (Ljava/util/Date;)D
 	public static fun doubleToBigDecimal (D)Ljava/math/BigDecimal;
@@ -633,6 +667,15 @@ public final class io/sentry/Hint {
 public final class io/sentry/HostnameCache {
 	public fun getHostname ()Ljava/lang/String;
 	public static fun getInstance ()Lio/sentry/HostnameCache;
+}
+
+public final class io/sentry/HttpBodyType : java/lang/Enum {
+	public static final field INCOMING_REQUEST Lio/sentry/HttpBodyType;
+	public static final field INCOMING_RESPONSE Lio/sentry/HttpBodyType;
+	public static final field OUTGOING_REQUEST Lio/sentry/HttpBodyType;
+	public static final field OUTGOING_RESPONSE Lio/sentry/HttpBodyType;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/HttpBodyType;
+	public static fun values ()[Lio/sentry/HttpBodyType;
 }
 
 public final class io/sentry/HttpStatusCodeRange {
@@ -1379,6 +1422,24 @@ public final class io/sentry/JsonSerializer : io/sentry/ISerializer {
 public abstract interface class io/sentry/JsonUnknown {
 	public abstract fun getUnknown ()Ljava/util/Map;
 	public abstract fun setUnknown (Ljava/util/Map;)V
+}
+
+public final class io/sentry/KeyValueCollectionBehavior {
+	public static fun allowList ([Ljava/lang/String;)Lio/sentry/KeyValueCollectionBehavior;
+	public static fun denyList ([Ljava/lang/String;)Lio/sentry/KeyValueCollectionBehavior;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMode ()Lio/sentry/KeyValueCollectionBehavior$Mode;
+	public fun getTerms ()Ljava/util/List;
+	public fun hashCode ()I
+	public static fun off ()Lio/sentry/KeyValueCollectionBehavior;
+}
+
+public final class io/sentry/KeyValueCollectionBehavior$Mode : java/lang/Enum {
+	public static final field ALLOW_LIST Lio/sentry/KeyValueCollectionBehavior$Mode;
+	public static final field DENY_LIST Lio/sentry/KeyValueCollectionBehavior$Mode;
+	public static final field OFF Lio/sentry/KeyValueCollectionBehavior$Mode;
+	public static fun valueOf (Ljava/lang/String;)Lio/sentry/KeyValueCollectionBehavior$Mode;
+	public static fun values ()[Lio/sentry/KeyValueCollectionBehavior$Mode;
 }
 
 public final class io/sentry/MainEventProcessor : io/sentry/EventProcessor, java/io/Closeable {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -391,13 +391,11 @@ public final class io/sentry/DataCollection {
 	public fun getHttpBodies ()Ljava/util/Set;
 	public fun getHttpHeaders ()Lio/sentry/DataCollection$HttpHeaders;
 	public fun getQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
-	public fun getQueues ()Ljava/lang/Boolean;
 	public fun getUserInfo ()Ljava/lang/Boolean;
 	public fun setCookies (Lio/sentry/KeyValueCollectionBehavior;)V
 	public fun setDatabaseQueryData (Z)V
 	public fun setHttpBodies (Ljava/util/Set;)V
 	public fun setQueryParams (Lio/sentry/KeyValueCollectionBehavior;)V
-	public fun setQueues (Z)V
 	public fun setUserInfo (Z)V
 }
 

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -390,12 +390,12 @@ public final class io/sentry/DataCollection {
 	public fun getGraphql ()Lio/sentry/DataCollection$Graphql;
 	public fun getHttpBodies ()Ljava/util/Set;
 	public fun getHttpHeaders ()Lio/sentry/DataCollection$HttpHeaders;
-	public fun getQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getUrlQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun getUserInfo ()Ljava/lang/Boolean;
 	public fun setCookies (Lio/sentry/KeyValueCollectionBehavior;)V
 	public fun setDatabaseQueryData (Z)V
 	public fun setHttpBodies (Ljava/util/Set;)V
-	public fun setQueryParams (Lio/sentry/KeyValueCollectionBehavior;)V
+	public fun setUrlQueryParams (Lio/sentry/KeyValueCollectionBehavior;)V
 	public fun setUserInfo (Z)V
 }
 

--- a/sentry/src/main/java/io/sentry/DataCollection.java
+++ b/sentry/src/main/java/io/sentry/DataCollection.java
@@ -10,7 +10,8 @@ import org.jetbrains.annotations.Nullable;
 /** Configures data that the SDK collects automatically. */
 public final class DataCollection {
 
-  private boolean overridden;
+  // Forces Data Collection to be used even when no individual option has been configured.
+  private boolean forceDataCollection;
   private @Nullable Boolean userInfo;
   private @Nullable KeyValueCollectionBehavior cookies;
   private @Nullable KeyValueCollectionBehavior urlQueryParams;
@@ -23,8 +24,8 @@ public final class DataCollection {
     this(true);
   }
 
-  DataCollection(final boolean overridden) {
-    this.overridden = overridden;
+  DataCollection(final boolean forceDataCollection) {
+    this.forceDataCollection = forceDataCollection;
   }
 
   public @Nullable Boolean getUserInfo() {
@@ -82,7 +83,7 @@ public final class DataCollection {
 
   @ApiStatus.Internal
   boolean isExplicitlyConfigured() {
-    return overridden
+    return forceDataCollection
         || userInfo != null
         || cookies != null
         || urlQueryParams != null

--- a/sentry/src/main/java/io/sentry/DataCollection.java
+++ b/sentry/src/main/java/io/sentry/DataCollection.java
@@ -13,7 +13,7 @@ public final class DataCollection {
   private boolean overridden;
   private @Nullable Boolean userInfo;
   private @Nullable KeyValueCollectionBehavior cookies;
-  private @Nullable KeyValueCollectionBehavior queryParams;
+  private @Nullable KeyValueCollectionBehavior urlQueryParams;
   private @Nullable Set<HttpBodyType> httpBodies;
   private @Nullable Boolean databaseQueryData;
   private final @NotNull HttpHeaders httpHeaders = new HttpHeaders();
@@ -43,12 +43,12 @@ public final class DataCollection {
     this.cookies = cookies;
   }
 
-  public @Nullable KeyValueCollectionBehavior getQueryParams() {
-    return queryParams;
+  public @Nullable KeyValueCollectionBehavior getUrlQueryParams() {
+    return urlQueryParams;
   }
 
-  public void setQueryParams(final @Nullable KeyValueCollectionBehavior queryParams) {
-    this.queryParams = queryParams;
+  public void setUrlQueryParams(final @Nullable KeyValueCollectionBehavior urlQueryParams) {
+    this.urlQueryParams = urlQueryParams;
   }
 
   public @Nullable Set<HttpBodyType> getHttpBodies() {
@@ -85,7 +85,7 @@ public final class DataCollection {
     return overridden
         || userInfo != null
         || cookies != null
-        || queryParams != null
+        || urlQueryParams != null
         || httpBodies != null
         || databaseQueryData != null
         || httpHeaders.hasOverrides()

--- a/sentry/src/main/java/io/sentry/DataCollection.java
+++ b/sentry/src/main/java/io/sentry/DataCollection.java
@@ -16,7 +16,6 @@ public final class DataCollection {
   private @Nullable KeyValueCollectionBehavior queryParams;
   private @Nullable Set<HttpBodyType> httpBodies;
   private @Nullable Boolean databaseQueryData;
-  private @Nullable Boolean queues;
   private final @NotNull HttpHeaders httpHeaders = new HttpHeaders();
   private final @NotNull Graphql graphql = new Graphql();
 
@@ -73,14 +72,6 @@ public final class DataCollection {
     this.databaseQueryData = databaseQueryData;
   }
 
-  public @Nullable Boolean getQueues() {
-    return queues;
-  }
-
-  public void setQueues(final boolean queues) {
-    this.queues = queues;
-  }
-
   public @NotNull HttpHeaders getHttpHeaders() {
     return httpHeaders;
   }
@@ -97,7 +88,6 @@ public final class DataCollection {
         || queryParams != null
         || httpBodies != null
         || databaseQueryData != null
-        || queues != null
         || httpHeaders.hasOverrides()
         || graphql.hasOverrides();
   }

--- a/sentry/src/main/java/io/sentry/DataCollection.java
+++ b/sentry/src/main/java/io/sentry/DataCollection.java
@@ -1,0 +1,156 @@
+package io.sentry;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Configures data that the SDK collects automatically. */
+public final class DataCollection {
+
+  private boolean overridden;
+  private @Nullable Boolean userInfo;
+  private @Nullable KeyValueCollectionBehavior cookies;
+  private @Nullable KeyValueCollectionBehavior queryParams;
+  private @Nullable Set<HttpBodyType> httpBodies;
+  private @Nullable Boolean databaseQueryData;
+  private @Nullable Boolean queues;
+  private final @NotNull HttpHeaders httpHeaders = new HttpHeaders();
+  private final @NotNull Graphql graphql = new Graphql();
+
+  public DataCollection() {
+    this(true);
+  }
+
+  DataCollection(final boolean overridden) {
+    this.overridden = overridden;
+  }
+
+  public @Nullable Boolean getUserInfo() {
+    return userInfo;
+  }
+
+  public void setUserInfo(final boolean userInfo) {
+    this.userInfo = userInfo;
+  }
+
+  public @Nullable KeyValueCollectionBehavior getCookies() {
+    return cookies;
+  }
+
+  public void setCookies(final @Nullable KeyValueCollectionBehavior cookies) {
+    this.cookies = cookies;
+  }
+
+  public @Nullable KeyValueCollectionBehavior getQueryParams() {
+    return queryParams;
+  }
+
+  public void setQueryParams(final @Nullable KeyValueCollectionBehavior queryParams) {
+    this.queryParams = queryParams;
+  }
+
+  public @Nullable Set<HttpBodyType> getHttpBodies() {
+    return httpBodies;
+  }
+
+  public void setHttpBodies(final @Nullable Set<HttpBodyType> httpBodies) {
+    this.httpBodies =
+        httpBodies == null
+            ? null
+            : httpBodies.isEmpty()
+                ? Collections.<HttpBodyType>emptySet()
+                : Collections.unmodifiableSet(EnumSet.copyOf(httpBodies));
+  }
+
+  public @Nullable Boolean getDatabaseQueryData() {
+    return databaseQueryData;
+  }
+
+  public void setDatabaseQueryData(final boolean databaseQueryData) {
+    this.databaseQueryData = databaseQueryData;
+  }
+
+  public @Nullable Boolean getQueues() {
+    return queues;
+  }
+
+  public void setQueues(final boolean queues) {
+    this.queues = queues;
+  }
+
+  public @NotNull HttpHeaders getHttpHeaders() {
+    return httpHeaders;
+  }
+
+  public @NotNull Graphql getGraphql() {
+    return graphql;
+  }
+
+  @ApiStatus.Internal
+  boolean isExplicitlyConfigured() {
+    return overridden
+        || userInfo != null
+        || cookies != null
+        || queryParams != null
+        || httpBodies != null
+        || databaseQueryData != null
+        || queues != null
+        || httpHeaders.hasOverrides()
+        || graphql.hasOverrides();
+  }
+
+  /** Configures collection of request and response HTTP headers. */
+  public static final class HttpHeaders {
+    private @Nullable KeyValueCollectionBehavior request;
+    private @Nullable KeyValueCollectionBehavior response;
+
+    public @Nullable KeyValueCollectionBehavior getRequest() {
+      return request;
+    }
+
+    public void setRequest(final @Nullable KeyValueCollectionBehavior request) {
+      this.request = request;
+    }
+
+    public @Nullable KeyValueCollectionBehavior getResponse() {
+      return response;
+    }
+
+    public void setResponse(final @Nullable KeyValueCollectionBehavior response) {
+      this.response = response;
+    }
+
+    private boolean hasOverrides() {
+      return request != null || response != null;
+    }
+  }
+
+  /** Configures collection of GraphQL document and variable content. */
+  public static final class Graphql {
+    private @Nullable Boolean document;
+    private @Nullable Boolean variables;
+
+    public @Nullable Boolean getDocument() {
+      return document;
+    }
+
+    public void setDocument(final boolean document) {
+      this.document = document;
+    }
+
+    public @Nullable Boolean getVariables() {
+      return variables;
+    }
+
+    public void setVariables(final boolean variables) {
+      this.variables = variables;
+    }
+
+    private boolean hasOverrides() {
+      return document != null || variables != null;
+    }
+  }
+}

--- a/sentry/src/main/java/io/sentry/HttpBodyType.java
+++ b/sentry/src/main/java/io/sentry/HttpBodyType.java
@@ -1,0 +1,13 @@
+package io.sentry;
+
+/** A direction of automatically collected HTTP body content. */
+public enum HttpBodyType {
+  /** A request received by a server integration. */
+  INCOMING_REQUEST,
+  /** A request sent by a client integration. */
+  OUTGOING_REQUEST,
+  /** A response received by a client integration. */
+  INCOMING_RESPONSE,
+  /** A response sent by a server integration. */
+  OUTGOING_RESPONSE
+}

--- a/sentry/src/main/java/io/sentry/KeyValueCollectionBehavior.java
+++ b/sentry/src/main/java/io/sentry/KeyValueCollectionBehavior.java
@@ -1,0 +1,76 @@
+package io.sentry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NotNull;
+
+/** Controls how automatically collected key-value data is filtered. */
+public final class KeyValueCollectionBehavior {
+
+  /** The collection strategy applied to key-value data. */
+  public enum Mode {
+    /** Do not collect keys or values. */
+    OFF,
+    /** Collect keys and filter values whose keys match a deny-list term. */
+    DENY_LIST,
+    /** Collect keys and filter values unless their keys match an allow-list term. */
+    ALLOW_LIST
+  }
+
+  private final @NotNull Mode mode;
+  private final @NotNull List<String> terms;
+
+  private KeyValueCollectionBehavior(final @NotNull Mode mode, final @NotNull List<String> terms) {
+    this.mode = mode;
+    this.terms = Collections.unmodifiableList(new ArrayList<>(terms));
+  }
+
+  /** Disables collection of the category. */
+  public static @NotNull KeyValueCollectionBehavior off() {
+    return new KeyValueCollectionBehavior(Mode.OFF, Collections.<String>emptyList());
+  }
+
+  /**
+   * Collects the category and filters values whose keys match the built-in sensitive deny-list or
+   * one of {@code terms}.
+   */
+  public static @NotNull KeyValueCollectionBehavior denyList(final @NotNull String... terms) {
+    return new KeyValueCollectionBehavior(Mode.DENY_LIST, Arrays.asList(terms));
+  }
+
+  /**
+   * Collects the category and only includes plaintext values whose keys match one of {@code terms}.
+   * Values matching the built-in sensitive deny-list are still filtered.
+   */
+  public static @NotNull KeyValueCollectionBehavior allowList(final @NotNull String... terms) {
+    return new KeyValueCollectionBehavior(Mode.ALLOW_LIST, Arrays.asList(terms));
+  }
+
+  public @NotNull Mode getMode() {
+    return mode;
+  }
+
+  public @NotNull List<String> getTerms() {
+    return terms;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    final KeyValueCollectionBehavior that = (KeyValueCollectionBehavior) other;
+    return mode == that.mode && terms.equals(that.terms);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, terms);
+  }
+}

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -99,7 +99,6 @@ class DataCollectionTest {
 
     dataCollection.httpHeaders.setRequest(behavior)
 
-    assertThat(dataCollection.httpHeaders.request).isSameInstanceAs(behavior)
     assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
   }
 

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -1,0 +1,115 @@
+package io.sentry
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DataCollectionTest {
+  @Test
+  fun `public constructor creates explicit empty configuration`() {
+    val dataCollection = DataCollection()
+
+    assertThat(dataCollection.userInfo).isNull()
+    assertThat(dataCollection.cookies).isNull()
+    assertThat(dataCollection.queryParams).isNull()
+    assertThat(dataCollection.httpBodies).isNull()
+    assertThat(dataCollection.databaseQueryData).isNull()
+    assertThat(dataCollection.queues).isNull()
+    assertThat(dataCollection.httpHeaders.request).isNull()
+    assertThat(dataCollection.httpHeaders.response).isNull()
+    assertThat(dataCollection.graphql.document).isNull()
+    assertThat(dataCollection.graphql.variables).isNull()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `SDK-owned configuration starts unconfigured`() {
+    val dataCollection = DataCollection(false)
+
+    assertThat(dataCollection.isExplicitlyConfigured()).isFalse()
+  }
+
+  @Test
+  fun `nested override makes SDK-owned configuration explicit`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.graphql.setVariables(false)
+
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `explicit false is distinct from unset`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.setUserInfo(false)
+
+    assertThat(dataCollection.userInfo).isFalse()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `empty HTTP body set is distinct from unset`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.setHttpBodies(emptySet())
+
+    assertThat(dataCollection.httpBodies).isEmpty()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `HTTP body set is copied and immutable`() {
+    val bodies = mutableSetOf(HttpBodyType.INCOMING_REQUEST)
+    val dataCollection = DataCollection()
+
+    dataCollection.setHttpBodies(bodies)
+    bodies += HttpBodyType.OUTGOING_REQUEST
+
+    assertThat(dataCollection.httpBodies).containsExactly(HttpBodyType.INCOMING_REQUEST)
+    assertFailsWith<UnsupportedOperationException> {
+      dataCollection.httpBodies!!.add(HttpBodyType.OUTGOING_REQUEST)
+    }
+  }
+
+  @Test
+  fun `database query data false is distinct from unset`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.setDatabaseQueryData(false)
+
+    assertThat(dataCollection.databaseQueryData).isFalse()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `queues false is distinct from unset`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.setQueues(false)
+
+    assertThat(dataCollection.queues).isFalse()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `nested HTTP header override marks configuration explicit`() {
+    val dataCollection = DataCollection(false)
+    val behavior = KeyValueCollectionBehavior.denyList("authorization")
+
+    dataCollection.httpHeaders.setRequest(behavior)
+
+    assertThat(dataCollection.httpHeaders.request).isSameInstanceAs(behavior)
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `nested GraphQL false marks configuration explicit`() {
+    val dataCollection = DataCollection(false)
+
+    dataCollection.graphql.setVariables(false)
+
+    assertThat(dataCollection.graphql.variables).isFalse()
+    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+}

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertFailsWith
 
 class DataCollectionTest {
   @Test
-  fun `public constructor creates explicit empty configuration`() {
+  fun `public constructor forces Data Collection for empty configuration`() {
     val dataCollection = DataCollection()
 
     assertThat(dataCollection.userInfo).isNull()
@@ -22,7 +22,7 @@ class DataCollectionTest {
   }
 
   @Test
-  fun `SDK-owned configuration starts unconfigured`() {
+  fun `SDK-owned configuration does not force Data Collection`() {
     val dataCollection = DataCollection(false)
 
     assertThat(dataCollection.isExplicitlyConfigured()).isFalse()

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -11,7 +11,7 @@ class DataCollectionTest {
 
     assertThat(dataCollection.userInfo).isNull()
     assertThat(dataCollection.cookies).isNull()
-    assertThat(dataCollection.queryParams).isNull()
+    assertThat(dataCollection.urlQueryParams).isNull()
     assertThat(dataCollection.httpBodies).isNull()
     assertThat(dataCollection.databaseQueryData).isNull()
     assertThat(dataCollection.httpHeaders.request).isNull()

--- a/sentry/src/test/java/io/sentry/DataCollectionTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionTest.kt
@@ -14,7 +14,6 @@ class DataCollectionTest {
     assertThat(dataCollection.queryParams).isNull()
     assertThat(dataCollection.httpBodies).isNull()
     assertThat(dataCollection.databaseQueryData).isNull()
-    assertThat(dataCollection.queues).isNull()
     assertThat(dataCollection.httpHeaders.request).isNull()
     assertThat(dataCollection.httpHeaders.response).isNull()
     assertThat(dataCollection.graphql.document).isNull()
@@ -79,16 +78,6 @@ class DataCollectionTest {
     dataCollection.setDatabaseQueryData(false)
 
     assertThat(dataCollection.databaseQueryData).isFalse()
-    assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
-  }
-
-  @Test
-  fun `queues false is distinct from unset`() {
-    val dataCollection = DataCollection(false)
-
-    dataCollection.setQueues(false)
-
-    assertThat(dataCollection.queues).isFalse()
     assertThat(dataCollection.isExplicitlyConfigured()).isTrue()
   }
 

--- a/sentry/src/test/java/io/sentry/KeyValueCollectionBehaviorTest.kt
+++ b/sentry/src/test/java/io/sentry/KeyValueCollectionBehaviorTest.kt
@@ -1,0 +1,49 @@
+package io.sentry
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class KeyValueCollectionBehaviorTest {
+  @Test
+  fun `off has no terms`() {
+    val behavior = KeyValueCollectionBehavior.off()
+
+    assertThat(behavior.mode).isEqualTo(KeyValueCollectionBehavior.Mode.OFF)
+    assertThat(behavior.terms).isEmpty()
+  }
+
+  @Test
+  fun `deny list stores terms in order`() {
+    val behavior = KeyValueCollectionBehavior.denyList("token", "session")
+
+    assertThat(behavior.mode).isEqualTo(KeyValueCollectionBehavior.Mode.DENY_LIST)
+    assertThat(behavior.terms).containsExactly("token", "session").inOrder()
+  }
+
+  @Test
+  fun `allow list can be empty`() {
+    val behavior = KeyValueCollectionBehavior.allowList()
+
+    assertThat(behavior.mode).isEqualTo(KeyValueCollectionBehavior.Mode.ALLOW_LIST)
+    assertThat(behavior.terms).isEmpty()
+  }
+
+  @Test
+  fun `terms are copied and immutable`() {
+    val terms = arrayOf("token")
+    val behavior = KeyValueCollectionBehavior.denyList(*terms)
+
+    terms[0] = "password"
+
+    assertThat(behavior.terms).containsExactly("token")
+  }
+
+  @Test
+  fun `equal behaviors have equal hash codes`() {
+    val first = KeyValueCollectionBehavior.allowList("language", "theme")
+    val second = KeyValueCollectionBehavior.allowList("language", "theme")
+
+    assertThat(first).isEqualTo(second)
+    assertThat(first.hashCode()).isEqualTo(second.hashCode())
+  }
+}


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Add the foundational public types for configuring automatic data collection:

- `DataCollection`, with nullable raw overrides and nested HTTP-header and GraphQL settings
- `KeyValueCollectionBehavior`, with mutually exclusive off, deny-list, and allow-list modes
- `HttpBodyType`, covering the four specification-defined HTTP directions

The public `DataCollection()` constructor represents an explicit object, including an explicit empty configuration. A package-private constructor supports the unconfigured instance that `SentryOptions` will own in the next stack PR. Mutable collection inputs are copied and exposed as immutable values.

This PR intentionally does not expose the model through `SentryOptions` or change runtime collection behavior.

## :bulb: Motivation and Context

Establish the Java-shaped configuration model required by the Data Collection specification before adding resolution, configuration sources, and integration enforcement. Nullable raw values preserve the distinction between omitted values and explicit false or empty values.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:check`
- Unit tests cover explicit-empty state, SDK-owned unconfigured state, nullable overrides, nested overrides, immutable body sets, and key-value behavior construction.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add the always-present `DataCollection` instance and resolver to `SentryOptions`, then wire external configuration and integrations in subsequent stack PRs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
