### PR TITLE
feat(core): [Data Collection 2] Expose SentryOptions API

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -3697,6 +3697,7 @@ public class io/sentry/SentryOptions {
 	public fun getContextTags ()Ljava/util/List;
 	public fun getContinuousProfiler ()Lio/sentry/IContinuousProfiler;
 	public fun getCron ()Lio/sentry/SentryOptions$Cron;
+	public fun getDataCollection ()Lio/sentry/DataCollection;
 	public fun getDateProvider ()Lio/sentry/SentryDateProvider;
 	public fun getDeadlineTimeout ()J
 	public fun getDebugMetaLoader ()Lio/sentry/internal/debugmeta/IDebugMetaLoader;
@@ -3845,6 +3846,7 @@ public class io/sentry/SentryOptions {
 	public fun setConnectionTimeoutMillis (I)V
 	public fun setContinuousProfiler (Lio/sentry/IContinuousProfiler;)V
 	public fun setCron (Lio/sentry/SentryOptions$Cron;)V
+	public fun setDataCollection (Lio/sentry/DataCollection;)V
 	public fun setDateProvider (Lio/sentry/SentryDateProvider;)V
 	public fun setDeadlineTimeout (J)V
 	public fun setDebug (Z)V

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -338,6 +338,8 @@ public class SentryOptions {
   /** whether to send personal identifiable information along with events */
   private boolean sendDefaultPii = false;
 
+  private @NotNull DataCollection dataCollection = new DataCollection(false);
+
   /** SSLSocketFactory for self-signed certificate trust * */
   private @Nullable SSLSocketFactory sslSocketFactory;
 
@@ -1695,6 +1697,25 @@ public class SentryOptions {
 
   public void setSendDefaultPii(boolean sendDefaultPii) {
     this.sendDefaultPii = sendDefaultPii;
+  }
+
+  /**
+   * Returns the configuration for data that the SDK collects automatically.
+   *
+   * <p>The returned object is always present. Accessing it does not configure data collection, but
+   * setting one of its options does.
+   */
+  public @NotNull DataCollection getDataCollection() {
+    return dataCollection;
+  }
+
+  /**
+   * Replaces the configuration for data that the SDK collects automatically.
+   *
+   * <p>Passing an empty {@link DataCollection} opts into the documented data-collection defaults.
+   */
+  public void setDataCollection(final @NotNull DataCollection dataCollection) {
+    this.dataCollection = dataCollection;
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1715,7 +1715,9 @@ public class SentryOptions {
    * <p>Passing an empty {@link DataCollection} opts into the documented data-collection defaults.
    */
   public void setDataCollection(final @NotNull DataCollection dataCollection) {
-    this.dataCollection = dataCollection;
+    if (dataCollection != null) {
+      this.dataCollection = dataCollection;
+    }
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -1,5 +1,6 @@
 package io.sentry
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.SentryOptions.RequestSize
 import io.sentry.logger.ILoggerBatchProcessorFactory
 import io.sentry.util.StringUtils
@@ -20,6 +21,52 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
 class SentryOptionsTest {
+  @Test
+  fun `data collection is always present without being explicitly configured`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollection).isNotNull()
+    assertThat(options.dataCollection.isExplicitlyConfigured()).isFalse()
+  }
+
+  @Test
+  fun `data collection getter returns the same instance`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollection).isSameInstanceAs(options.dataCollection)
+    assertThat(options.dataCollection.isExplicitlyConfigured()).isFalse()
+  }
+
+  @Test
+  fun `setting a data collection override marks it explicitly configured`() {
+    val options = SentryOptions()
+
+    options.dataCollection.setUserInfo(false)
+
+    assertThat(options.dataCollection.userInfo).isFalse()
+    assertThat(options.dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `setting an empty data collection marks it explicitly configured`() {
+    val options = SentryOptions()
+
+    options.dataCollection = DataCollection()
+
+    assertThat(options.dataCollection.isExplicitlyConfigured()).isTrue()
+  }
+
+  @Test
+  fun `setting data collection replaces the default instance`() {
+    val options = SentryOptions()
+    val dataCollection = DataCollection().apply { setQueues(false) }
+
+    options.dataCollection = dataCollection
+
+    assertThat(options.dataCollection).isSameInstanceAs(dataCollection)
+    assertThat(options.dataCollection.queues).isFalse()
+  }
+
   @Test
   fun `when options is initialized, logger is not null`() {
     assertNotNull(SentryOptions().logger)

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -68,6 +68,21 @@ class SentryOptionsTest {
   }
 
   @Test
+  fun `setting null data collection preserves the current instance`() {
+    val options = SentryOptions()
+    val dataCollection = DataCollection().apply { setUserInfo(false) }
+    options.dataCollection = dataCollection
+
+    SentryOptions::class
+      .java
+      .getMethod("setDataCollection", DataCollection::class.java)
+      .invoke(options, null)
+
+    assertThat(options.dataCollection).isSameInstanceAs(dataCollection)
+    assertThat(options.dataCollection.userInfo).isFalse()
+  }
+
+  @Test
   fun `when options is initialized, logger is not null`() {
     assertNotNull(SentryOptions().logger)
   }

--- a/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryOptionsTest.kt
@@ -59,12 +59,12 @@ class SentryOptionsTest {
   @Test
   fun `setting data collection replaces the default instance`() {
     val options = SentryOptions()
-    val dataCollection = DataCollection().apply { setQueues(false) }
+    val dataCollection = DataCollection().apply { setUserInfo(false) }
 
     options.dataCollection = dataCollection
 
     assertThat(options.dataCollection).isSameInstanceAs(dataCollection)
-    assertThat(options.dataCollection.queues).isFalse()
+    assertThat(options.dataCollection.userInfo).isFalse()
   }
 
   @Test


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Expose the Data Collection configuration model through `SentryOptions`:

- Add an always-present `DataCollection` instance initialized in the unconfigured state
- Add public `getDataCollection()` and `setDataCollection(...)` accessors
- Preserve explicit-empty semantics for customer-created `DataCollection` objects
- Keep getter-only access unconfigured so the compatibility bridge can distinguish absence from opt-in

This PR only exposes and stores the configuration. It does not resolve effective policies or change runtime collection behavior.

## :bulb: Motivation and Context

Customers need a non-null, mutable configuration object so individual data-collection categories can be configured without first constructing the namespace. At the same time, the SDK must distinguish users who did not configure Data Collection from users who explicitly supplied an empty object and opted into the specification defaults.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:check`
- Added unit coverage for the unconfigured default, stable getter behavior, nested overrides, explicit-empty assignment, and replacing the default object.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Add centralized policy resolution and the legacy `sendDefaultPii` compatibility bridge, then wire configuration sources and integrations in subsequent stack PRs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
