### PR TITLE
fix(samples): Use float literal for session-replay sample rate

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
       android:value="canvas" />
     <meta-data
       android:name="io.sentry.session-replay.session-sample-rate"
-      android:value="1" />
+      android:value="1.0" />
     <meta-data
       android:name="io.sentry.session-replay.mask-all-text"
       android:value="true" />


### PR DESCRIPTION
## :scroll: Description

The Android sample app set the session replay sample rate as an integer literal:

```xml
<meta-data
    android:name="io.sentry.session-replay.session-sample-rate"
    android:value="1" />
```

aapt stores `"1"` as an integer. `ManifestMetadataReader.readDouble` reads the value via `Bundle.getFloat(key, -1)`, which does not coerce an int-typed value — it returns the default and the Android framework logs a warning like:

```
W/Bundle: Key io.sentry.session-replay.session-sample-rate expected Float but value was a java.lang.Integer.  The default value -1 was returned.
```

The reader then falls back to `getInt`, so the resulting value is still correct (`1.0`), but a framework warning is logged on every startup. Using the float literal `"1.0"` stores the value as a float, so `getFloat` succeeds on the first read and no warning is logged. This also matches the other sample-rate entries in the same manifest, which already use `1.0`.


## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
