### PR TITLE
feat(samples): Enable Sentry Logs in the Android sample app

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
+++ b/sentry-samples/sentry-samples-android/src/main/AndroidManifest.xml
@@ -130,6 +130,11 @@
       android:name="io.sentry.debug"
       android:value="${sentryDebug}" />
 
+    <!--    how to enable Sentry Logs (Sentry.logger() calls are dropped unless this is on)-->
+    <meta-data
+      android:name="io.sentry.logs.enabled"
+      android:value="true" />
+
     <!--    how to disable verbose logging of the session replay feature-->
     <meta-data
       android:name="io.sentry.session-replay.debug"


### PR DESCRIPTION
The Android sample (`sentry-samples-android`) already emits structured logs via `Sentry.logger().log(...)` in `MainActivity.onCreate`, but they were silently dropped because Sentry Logs is disabled by default. This enables the feature via the manifest so the sample demonstrates logging out of the box.

```xml
<meta-data
  android:name="io.sentry.logs.enabled"
  android:value="true" />
```

Verified on a Pixel 10 (Android 17): the SDK reads `io.sentry.logs.enabled` as `true` at init and the `logger()` calls are no longer short-circuited as a no-op.

#skip-changelog (sample-only change, not user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)