### PR TITLE
build: Extract shared Android lint config into a build-logic plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,12 +3,14 @@ plugins {
 }
 
 repositories {
+  google()
   gradlePluginPortal()
 }
 
 dependencies {
   implementation(libs.animalsniffer.gradle.plugin)
   implementation(libs.spotlessLib)
+  compileOnly(libs.android.gradle.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/src/main/kotlin/io.sentry.android.lint.gradle.kts
+++ b/build-logic/src/main/kotlin/io.sentry.android.lint.gradle.kts
@@ -1,0 +1,25 @@
+import com.android.build.api.dsl.CommonExtension
+
+// Shared Android lint configuration for the SDK's library and application modules.
+// See Tor Norbye's rationale for checkGeneratedSources/checkDependencies:
+// https://groups.google.com/forum/#!msg/lint-dev/JqTI4eQ8GpI/nBfS7xLKBwAJ
+pluginManager.withPlugin("com.android.base") {
+  extensions.configure(CommonExtension::class.java) {
+    lint {
+      warningsAsErrors = true
+      // Avoids false "unused" reports for code used only by generated classes (e.g. ViewBinding).
+      checkGeneratedSources = true
+      // Lets `:module:lint` also analyze dependency modules.
+      checkDependencies = true
+      // Test sources dominate lint time; skipping them is the main speed-up.
+      ignoreTestSources = true
+
+      // Suppress OldTargetApi: lint 8.13.1 expects API 37 but we target 36. Only the
+      // application modules set targetSdk, so this is a no-op for the library modules.
+      disable += "OldTargetApi"
+
+      // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+      checkReleaseBuilds = false
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ otelSemanticConventionsAlpha = "1.42.0-alpha"
 retrofit = "2.9.0"
 room2 = "2.8.4"
 room3 = "3.0.0-rc01"
+# Keep in sync with Config.AGP in buildSrc (the version modules actually build with).
+# Used compile-only by build-logic to configure the Android lint DSL.
+agp = "8.13.1"
 sagp = "6.13.0"
 sqlite = "2.6.2"
 sqliteRc = "2.7.0-rc01" # Required by Room3 3.0.0-rc*
@@ -77,6 +80,7 @@ sentry = { id = "io.sentry.android.gradle", version.ref = "sagp"}
 shadow = { id = "com.gradleup.shadow", version = "9.4.1" }
 
 [libraries]
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 animalsniffer-gradle-plugin = { module = "ru.vyarus:gradle-animalsniffer-plugin", version.ref = "animalsniffer" }
 apache-httpclient = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.0.4" }
 apollo2-coroutines = { module = "com.apollographql.apollo:apollo-coroutines-support", version.ref = "apollo" }

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.errorprone)
   alias(libs.plugins.gradle.versions)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -47,14 +48,6 @@ android {
         it.maxHeapSize = "2g"
       }
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 plugins {
   id("com.android.library")
   alias(libs.plugins.kotlin.android)
+  id("io.sentry.android.lint")
 }
 
 android {

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -35,14 +36,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.errorprone)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -65,16 +66,6 @@ android {
   }
 
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-    // Suppress OldTargetApi: lint 8.13.1 expects API 37 but we target 36
-    disable += "OldTargetApi"
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
-  }
 
   androidComponents.beforeVariants {
     if (it.buildType == "debug") {

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
@@ -4,11 +4,15 @@ plugins {
   id("com.android.application")
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.compose)
+  id("io.sentry.android.lint")
 }
 
 android {
   compileSdk = libs.versions.compileSdk.get().toInt()
   namespace = "io.sentry.uitest.android.critical"
+
+  // Baseline the pre-existing lint issues in this test app; only new issues fail the build.
+  lint { baseline = file("lint-baseline.xml") }
 
   signingConfigs {
     getByName("debug") {

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/lint-baseline.xml
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.13.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.13.1)" variant="all" version="8.13.1">
+
+    <issue
+        id="SuspiciousImport"
+        message="Don&apos;t include `android.R` here; use a fully qualified name for each usage instead"
+        errorLine1="import android.R"
+        errorLine2="~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/io/sentry/uitest/android/critical/NotificationHelper.kt"
+            line="3"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MissingApplicationIcon"
+        message="Should explicitly set `android:icon`, there is no default"
+        errorLine1="  &lt;application"
+        errorLine2="   ~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="7"
+            column="4"/>
+    </issue>
+
+</issues>

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.errorprone)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -63,16 +64,6 @@ android {
   }
 
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-    // Suppress OldTargetApi: lint 8.13.1 expects API 37 but we target 36
-    disable += "OldTargetApi"
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
-  }
 
   androidComponents.beforeVariants {
     if (it.buildType == "debug") {

--- a/sentry-android-integration-tests/test-app-plain/build.gradle.kts
+++ b/sentry-android-integration-tests/test-app-plain/build.gradle.kts
@@ -1,8 +1,14 @@
-plugins { id("com.android.application") }
+plugins {
+  id("com.android.application")
+  id("io.sentry.android.lint")
+}
 
 android {
   compileSdk = libs.versions.compileSdk.get().toInt()
   namespace = "io.sentry.java.tests.perf.appplain"
+
+  // Baseline the pre-existing lint issues in this test app; only new issues fail the build.
+  lint { baseline = file("lint-baseline.xml") }
 
   defaultConfig {
     applicationId = "io.sentry.java.tests.perf.appplain"

--- a/sentry-android-integration-tests/test-app-plain/lint-baseline.xml
+++ b/sentry-android-integration-tests/test-app-plain/lint-baseline.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.13.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.13.1)" variant="all" version="8.13.1">
+
+    <issue
+        id="FragmentTagUsage"
+        message="Replace the &lt;fragment> tag with FragmentContainerView."
+        errorLine1="    &lt;fragment"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/content_main.xml"
+            line="8"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="RedundantLabel"
+        message="Redundant label can be removed"
+        errorLine1="            android:label=&quot;@string/app_name&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.3.0 is available: 1.7.1"
+        errorLine1="  implementation(&quot;androidx.appcompat:appcompat:1.3.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="52"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.material:material than 1.4.0 is available: 1.14.0"
+        errorLine1="  implementation(&quot;com.google.android.material:material:1.4.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="53"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-fragment than 2.3.5 is available: 2.9.8"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-fragment:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="55"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-ui than 2.3.5 is available: 2.9.8"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-ui:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="56"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 21"
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-night/themes.xml"
+            line="13"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 21"
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/themes.xml"
+            line="13"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.hello_second_fragment` appears to be unused"
+        errorLine1="    &lt;string name=&quot;hello_second_fragment&quot;>Hello second fragment. Arg: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive roundIcon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use the existing version catalog reference (`libs.androidx.appcompat`) instead"
+        errorLine1="  implementation(&quot;androidx.appcompat:appcompat:1.3.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="52"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;com.google.android.material:material:1.4.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="53"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use the existing version catalog reference (`libs.androidx.constraintlayout`) instead"
+        errorLine1="  implementation(&quot;androidx.constraintlayout:constraintlayout:2.2.1&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="54"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-fragment:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="55"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-ui:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="56"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;com.google.android.material.floatingactionbutton.FloatingActionButton"
+        errorLine2="     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_main.xml"
+            line="25"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 36"
+        errorLine1="        android:layout_marginRight=&quot;@dimen/fab_margin&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_main.xml"
+            line="31"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/sentry-android-integration-tests/test-app-sentry/build.gradle.kts
+++ b/sentry-android-integration-tests/test-app-sentry/build.gradle.kts
@@ -1,8 +1,14 @@
-plugins { id("com.android.application") }
+plugins {
+  id("com.android.application")
+  id("io.sentry.android.lint")
+}
 
 android {
   compileSdk = libs.versions.compileSdk.get().toInt()
   namespace = "io.sentry.java.tests.perf.appsentry"
+
+  // Baseline the pre-existing lint issues in this test app; only new issues fail the build.
+  lint { baseline = file("lint-baseline.xml") }
 
   defaultConfig {
     applicationId = "io.sentry.java.tests.perf.appsentry"

--- a/sentry-android-integration-tests/test-app-sentry/lint-baseline.xml
+++ b/sentry-android-integration-tests/test-app-sentry/lint-baseline.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.13.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.13.1)" variant="all" version="8.13.1">
+
+    <issue
+        id="FragmentTagUsage"
+        message="Replace the &lt;fragment> tag with FragmentContainerView."
+        errorLine1="    &lt;fragment"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="src/main/res/layout/content_main.xml"
+            line="8"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="RedundantLabel"
+        message="Redundant label can be removed"
+        errorLine1="            android:label=&quot;@string/app_name&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="18"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.appcompat:appcompat than 1.3.0 is available: 1.7.1"
+        errorLine1="  implementation(&quot;androidx.appcompat:appcompat:1.3.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="52"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.android.material:material than 1.4.0 is available: 1.14.0"
+        errorLine1="  implementation(&quot;com.google.android.material:material:1.4.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="53"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-fragment than 2.3.5 is available: 2.9.8"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-fragment:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="55"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.navigation:navigation-ui than 2.3.5 is available: 2.9.8"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-ui:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="56"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 21"
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values-night/themes.xml"
+            line="13"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 21"
+        errorLine1="        &lt;item name=&quot;android:statusBarColor&quot; tools:targetApi=&quot;l&quot;>?attr/colorPrimaryVariant&lt;/item>"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/themes.xml"
+            line="13"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.hello_second_fragment` appears to be unused"
+        errorLine1="    &lt;string name=&quot;hello_second_fragment&quot;>Hello second fragment. Arg: %1$s&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive icon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="MonochromeLauncherIcon"
+        message="The application adaptive roundIcon is missing a monochrome tag"
+        errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
+        errorLine2="^">
+        <location
+            file="src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use the existing version catalog reference (`libs.androidx.appcompat`) instead"
+        errorLine1="  implementation(&quot;androidx.appcompat:appcompat:1.3.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="52"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;com.google.android.material:material:1.4.0&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="53"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use the existing version catalog reference (`libs.androidx.constraintlayout`) instead"
+        errorLine1="  implementation(&quot;androidx.constraintlayout:constraintlayout:2.2.1&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="54"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-fragment:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="55"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  implementation(&quot;androidx.navigation:navigation-ui:2.3.5&quot;)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="56"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image"
+        errorLine1="    &lt;com.google.android.material.floatingactionbutton.FloatingActionButton"
+        errorLine2="     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_main.xml"
+            line="25"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="RtlHardcoded"
+        message="Redundant attribute `layout_marginRight`; already defining `layout_marginEnd` with `targetSdkVersion` 36"
+        errorLine1="        android:layout_marginRight=&quot;@dimen/fab_margin&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/layout/activity_main.xml"
+            line="31"
+            column="9"/>
+    </issue>
+
+</issues>

--- a/sentry-android-integration-tests/test-app-size/build.gradle.kts
+++ b/sentry-android-integration-tests/test-app-size/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("com.android.application")
   id("io.sentry.android.gradle")
+  id("io.sentry.android.lint")
 }
 
 android {

--- a/sentry-android-navigation/build.gradle.kts
+++ b/sentry-android-navigation/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -35,14 +36,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   id("com.android.library")
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -34,14 +35,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   // needed because of Kotlin 1.4.x

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.gradle.versions)
+  id("io.sentry.android.lint")
   // TODO: enable it later
   //    alias(libs.plugins.detekt)
 }
@@ -47,14 +48,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -35,14 +36,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -42,14 +43,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-android/build.gradle.kts
+++ b/sentry-android/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("com.android.library")
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
+  id("io.sentry.android.lint")
 }
 
 android {

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("com.android.library")
   alias(libs.plugins.gradle.versions)
   alias(libs.plugins.detekt)
+  id("io.sentry.android.lint")
   alias(libs.plugins.dokka)
   alias(libs.plugins.dokka.javadoc)
   `maven-publish` // necessary for publishMavenLocal task to publish correct artifacts
@@ -100,14 +101,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }

--- a/sentry-launchdarkly-android/build.gradle.kts
+++ b/sentry-launchdarkly-android/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("com.android.library")
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.gradle.versions)
+  id("io.sentry.android.lint")
 }
 
 android {
@@ -35,14 +36,6 @@ android {
       isReturnDefaultValues = true
       isIncludeAndroidResources = true
     }
-  }
-
-  lint {
-    warningsAsErrors = true
-    checkDependencies = true
-
-    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
-    checkReleaseBuilds = false
   }
 
   buildFeatures { buildConfig = true }


### PR DESCRIPTION
## :scroll: Description

Extracts the Android lint configuration that was copy-pasted across the Android modules into a single `io.sentry.android.lint` convention plugin in `build-logic`, and applies it to every Android module except the sample.

The shared config is:

```kotlin
lint {
  warningsAsErrors = true
  checkGeneratedSources = true   // new
  checkDependencies = true
  ignoreTestSources = true       // new
  disable += "OldTargetApi"      // centralized from the uitest modules
  checkReleaseBuilds = false
}
```

Two settings are new relative to the previous per-module blocks:
- **`ignoreTestSources = true`** — makes AGP skip creating the test-source lint analysis tasks (`lintAnalyzeDebugUnitTest` / `lintAnalyzeDebugAndroidTest`). This is the main speed-up: on `sentry-android-core`, warm lint dropped from ~4.8s to ~1.8s (~60% faster), since unit-test analysis was the dominant cost.
- **`checkGeneratedSources = true`** — avoids false "unused" reports for code used only by generated classes (e.g. ViewBinding), per [Tor Norbye's rationale](https://groups.google.com/forum/#!msg/lint-dev/JqTI4eQ8GpI/nBfS7xLKBwAJ).

Implementation notes:
- AGP is a `compileOnly` dependency of `build-logic`, so each module supplies its own AGP at runtime. This keeps the **AGP compatibility matrix** (8.7–8.9) unaffected — no second AGP copy is bundled.
- The `OldTargetApi` suppression that previously lived in the two uitest modules is now centralized in the plugin (it's a no-op for library modules, which don't set `targetSdk`).
- The test/benchmark apps (`test-app-plain`, `test-app-sentry`, `sentry-uitest-android-critical`) carry pre-existing lint issues, so they get `lint-baseline.xml` files rather than blocking the new strict config. `test-app-size` lints clean once `OldTargetApi` is centralized, so it needs no baseline.
- `sentry-samples-android` keeps its own sample-specific lint config and is intentionally left out.

## :bulb: Motivation and Context

Speed up `./gradlew check` lint runs and remove the duplicated `lint {}` block that was maintained by hand in ~11 module build files.

## :green_heart: How did you test it?

Ran `lint` on every changed module and confirmed all pass, including that the newly-enabled `checkGeneratedSources` surfaces no new errors and that the baselines filter the pre-existing issues in the test apps. Verified the `build-logic` plugin configures AGP's lint DSL at runtime with `compileOnly` AGP and that `ignoreTestSources` removes the test-analysis tasks across library, KMP (`sentry-compose`), and application module types.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None.

#skip-changelog
