### PR TITLE
fix(android): Preserve NDK stack on tombstone merge (JAVA-645) [on hold]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Preserve the native SDK crashing-thread stack when merging `ApplicationExitInfo` tombstones, so native crashes stay symbolicated and deobfuscated ([#5771](https://github.com/getsentry/sentry-java/pull/5771))
+
 ## 8.49.0
 
 ### Features

--- a/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/TombstoneIntegration.java
@@ -286,34 +286,54 @@ public class TombstoneIntegration implements Integration, Closeable {
 
     private void mergeNativeCrashes(
         final @NotNull SentryEvent nativeEvent, final @NotNull SentryEvent tombstoneEvent) {
-      // we take the event data verbatim from the Native SDK and only apply tombstone data where we
+      // We take the event data verbatim from the Native SDK and only apply tombstone data where we
       // are sure that it will improve the outcome:
       // * context from the Native SDK will be closer to what users want than any backfilling
-      // * the Native SDK only tracks the crashing thread  (vs. tombstone dumps all)
-      // * even for the crashing  we expect a much better stack-trace (+ symbolication)
-      // * tombstone adds additional exception meta-data to signal handler content
-      // * we add debug-meta for consistency since the Native SDK caches memory maps early
+      // * the Native SDK stack-trace + debug-meta are symbolicated against the uploaded debug
+      //   files; the tombstone's crashing-thread stack is the ART-unwound managed stack for
+      //   JNI-raised crashes, which cannot be symbolicated or ProGuard-deobfuscated
+      // * tombstone adds additional exception meta-data (signal info) to signal handler content
       @Nullable List<SentryException> tombstoneExceptions = tombstoneEvent.getExceptions();
       @Nullable DebugMeta tombstoneDebugMeta = tombstoneEvent.getDebugMeta();
       @Nullable List<SentryThread> tombstoneThreads = tombstoneEvent.getThreads();
-      if (tombstoneExceptions != null
-          && !tombstoneExceptions.isEmpty()
-          && tombstoneDebugMeta != null
-          && tombstoneThreads != null) {
-        // native crashes don't nest, we always expect one level.
-        SentryException exception = tombstoneExceptions.get(0);
-        @Nullable Mechanism mechanism = exception.getMechanism();
-        if (mechanism != null) {
-          mechanism.setType(NativeExceptionMechanism.TOMBSTONE_MERGED.getValue());
-        }
+      if (tombstoneExceptions == null
+          || tombstoneExceptions.isEmpty()
+          || tombstoneDebugMeta == null
+          || tombstoneThreads == null) {
+        return;
+      }
 
-        // Don't overwrite existing messages in the native event
-        if (nativeEvent.getMessage() == null
-            || nativeEvent.getMessage().getMessage() == null
-            || nativeEvent.getMessage().getMessage().isEmpty()) {
-          nativeEvent.setMessage(tombstoneEvent.getMessage());
-        }
+      // Don't overwrite existing messages in the native event
+      if (nativeEvent.getMessage() == null
+          || nativeEvent.getMessage().getMessage() == null
+          || nativeEvent.getMessage().getMessage().isEmpty()) {
+        nativeEvent.setMessage(tombstoneEvent.getMessage());
+      }
 
+      // native crashes don't nest, we always expect one level.
+      final SentryException tombstoneException = tombstoneExceptions.get(0);
+      @Nullable Mechanism tombstoneMechanism = tombstoneException.getMechanism();
+
+      final @Nullable List<SentryException> nativeExceptions = nativeEvent.getExceptions();
+      if (nativeExceptions != null && !nativeExceptions.isEmpty()) {
+        // Keep the Native SDK's crashing-thread stack-trace, threads and debug-meta, which are
+        // symbolicated against the uploaded debug files. Only enrich the Native SDK exception with
+        // the tombstone's signal meta-data and flag the merge via the mechanism type.
+        final SentryException nativeException = nativeExceptions.get(0);
+        @Nullable Mechanism nativeMechanism = nativeException.getMechanism();
+        if (nativeMechanism == null) {
+          nativeMechanism = new Mechanism();
+          nativeException.setMechanism(nativeMechanism);
+        }
+        nativeMechanism.setType(NativeExceptionMechanism.TOMBSTONE_MERGED.getValue());
+        if (tombstoneMechanism != null && tombstoneMechanism.getMeta() != null) {
+          nativeMechanism.setMeta(tombstoneMechanism.getMeta());
+        }
+      } else {
+        // Fallback: the Native SDK event carries no exception, so use the tombstone's data.
+        if (tombstoneMechanism != null) {
+          tombstoneMechanism.setType(NativeExceptionMechanism.TOMBSTONE_MERGED.getValue());
+        }
         nativeEvent.setExceptions(tombstoneExceptions);
         nativeEvent.setDebugMeta(tombstoneDebugMeta);
         nativeEvent.setThreads(tombstoneThreads);


### PR DESCRIPTION
> [!WARNING]
> **On hold — premise corrected by a control experiment.** A genuine native fault (null-deref inside `libnative-sample.so`) symbolicates to `native-sample.cpp:13` **on `main` without this change**, and also with it. Native symbolication / uploaded symbols were never broken — the original "unreadable native crash" was an artifact of the sample's `raise(SIGSEGV)`-from-JNI crash (a managed-origin crash whose tombstone stack is the ART/OAT managed chain).
>
> What this change actually does for a *real* native crash: `main` keeps the tombstone's **full mixed stack** (symbolicated native crash frame **+** the obfuscated managed call chain); this PR uses sentry-native's **native-only** crashing thread, which drops that call-chain context. So it is **neutral-to-worse** for genuine native crashes, not the win described below.
>
> The higher-value fix is to **deobfuscate the managed frames** in the merged native event (they stay obfuscated only because the event `platform == "native"`). See JAVA-645 for the reframed analysis. Holding this PR pending that decision.

---

## :scroll: Description

When `io.sentry.tombstone.enable=true`, a native crash that is also captured by sentry-native is reported through the `ApplicationExitInfo` tombstone path (`mechanism: TombstoneMerged`). `TombstoneIntegration.mergeNativeCrashes` kept the Native SDK event's contexts but **overwrote its `exceptions`, `threads`, and `debugMeta` with the tombstone's**. For JNI-raised crashes the tombstone's crashing-thread stack is the ART-unwound managed stack (OAT/VDEX frames), which cannot be symbolicated (native) or ProGuard-deobfuscated, so the merged event became unreadable.

This change keeps the Native SDK's crashing-thread stack-trace, threads and debug-meta — which are symbolicated against the uploaded debug files — and only enriches the Native SDK exception with the tombstone's signal metadata (and flags the merge via the mechanism type). It falls back to the tombstone's data when the Native SDK event carries no exception.

## :bulb: Motivation and Context

Native crashes on affected builds were effectively unreadable: obfuscated managed frames plus a couple of system frames, with no app source lines. Uploading native symbols and the ProGuard mapping did not help, because the frames that would consume them were discarded/replaced.

Evidence from a raw `TombstoneMerged` event JSON:
- Server symbolication works — `libsentry.so` shows `debug_status: "found"`, and sentry-native's own worker threads symbolicate to source (`sentry_backend_inproc.c:1238`, `sentry_batcher.c:339`).
- The crashing thread's frames were all `base.vdex`/`base.odex`/`boot.oat` with `symbolicator_status: "unknown_image"`, retaining obfuscated names; `libnative-sample.so` was `debug_status: "unused"`.
- The same event still contained fully-symbolicated sentry-native worker threads while the crashing thread carried the tombstone's managed stack — direct evidence the merge overwrote the good crashing-thread data.

Reproduced on Android 12, 16 and 17 (Pixel 3, Galaxy A55, Pixel 10) and SDK 8.48.0 / 8.49.0. The `sentry` monolith and `symbolicator` behave correctly — the fix is entirely client-side.

Fixes JAVA-645

## :green_heart: How did you test it?

Manually, with the `sentry-samples-android` release build (SAGP enabled, native symbols + ProGuard mapping uploaded):
- Before: `io.sentry.tombstone.enable=true` → `TombstoneMerged`, unsymbolicated / obfuscated crashing stack.
- With `io.sentry.tombstone.enable=false` → `mechanism: signalhandler`, and the pipeline symbolicates — confirming the merge was the cause.

Automated tests for `mergeNativeCrashes` still need to be added/updated (see Next steps) — this is a draft.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- Add/adjust `TombstoneIntegrationTest` coverage asserting the Native SDK crashing-thread stack/threads/debug-meta are preserved and only the mechanism/signal metadata is merged.
- Native-team review of the merge policy — in particular whether tombstone-only (no matching NDK event) crashes should retain managed frames tagged `platform: java` so ProGuard deobfuscation applies.

