### PR TITLE
feat(samples): Make Native Crash button fault inside app native code

### DIFF
--- a/sentry-samples/sentry-samples-android/src/main/cpp/native-sample.cpp
+++ b/sentry-samples/sentry-samples-android/src/main/cpp/native-sample.cpp
@@ -1,15 +1,23 @@
 #include <jni.h>
 #include <android/log.h>
 #include <sentry.h>
-#include <signal.h>
 
 #define TAG "sentry-sample"
 
 extern "C" {
 
+// Faults inside this named function so the crashing frame resolves to a real
+// symbol + source line. A bare raise(SIGSEGV) would instead fault in libc and,
+// for a JNI-originated crash, not exercise app-native symbolication.
+[[gnu::noinline]]
+static void trigger_null_deref() {
+    volatile int *ptr = nullptr;
+    *ptr = 42;
+}
+
 JNIEXPORT void JNICALL Java_io_sentry_samples_android_NativeSample_crash(JNIEnv *env, jclass cls) {
     __android_log_print(ANDROID_LOG_WARN, TAG, "About to crash.");
-    raise(SIGSEGV);
+    trigger_null_deref();
 }
 
 JNIEXPORT void JNICALL Java_io_sentry_samples_android_NativeSample_message(JNIEnv *env, jclass cls) {


### PR DESCRIPTION
## :scroll: Description

Changes the Android sample's **Native Crash** button so it faults *inside app native code* — a null-pointer dereference in a named function (`trigger_null_deref` in `native-sample.cpp`) — instead of `raise(SIGSEGV)`.

## :bulb: Motivation and Context

`raise(SIGSEGV)` faults inside `libc`, and for a crash originated from a JNI call the unwind is either the managed ART/OAT stack or a degenerate native stack — so it does **not** exercise symbolication of the app's own native code. A genuine null-deref inside a named function faults with a valid PC inside `libnative-sample.so`, so the crashing frame resolves to a real symbol + source line. This makes it easy to verify native symbol upload / symbolication end-to-end from the sample.

Came out of the JAVA-645 investigation, where `raise(SIGSEGV)` turned out to be a poor vehicle for testing native symbolication.

## :green_heart: How did you test it?

During the JAVA-645 investigation, an equivalent null-deref (`crash()` → `trigger_null_deref()`) was run on a Pixel 10 (Android 17), release build with SAGP (`uploadNativeSymbols=true`), and the crashing frame symbolicated to `trigger_null_deref` in `native-sample.cpp` with the source line shown.

This exact change compiles (`assembleRelease`); I did not re-flash it, so the reported line reflects the committed layout — `*ptr = 42;` is `native-sample.cpp:15`.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

None — sample-only change.

#skip-changelog
