### PR TITLE
ci: Use non-deprecated sentry-cli snapshots upload command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         # Skip on PRs from forks, which don't have access to the upload secret
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          sentry-cli build snapshots ./sentry-android-core/build/test-snapshots \
+          sentry-cli snapshots upload ./sentry-android-core/build/test-snapshots \
             --app-id sentry-android-core
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/integration-tests-ui.yml
+++ b/.github/workflows/integration-tests-ui.yml
@@ -86,7 +86,7 @@ jobs:
           if [ ${#pngs[@]} -gt 0 ]; then
             mkdir -p replay-snapshots
             cp "${pngs[@]}" replay-snapshots/
-            sentry-cli build snapshots ./replay-snapshots \
+            sentry-cli snapshots upload ./replay-snapshots \
               --app-id sentry-android-replay
           else
             echo "No replay snapshot files found, skipping upload"


### PR DESCRIPTION
## :scroll: Description

The `sentry-cli build snapshots` command is deprecated in favor of `sentry-cli snapshots upload`. This renames both usages in CI:

- `.github/workflows/build.yml` — the `sentry-android-core` test-snapshots upload step.
- `.github/workflows/integration-tests-ui.yml` — the `sentry-android-replay` replay-snapshots upload step.

The arguments (positional path + `--app-id`) are unchanged, since this is purely a command-group rename.

## :bulb: Motivation and Context

CI is emitting the following deprecation warning:

```
`sentry-cli build snapshots` is deprecated. Use `sentry-cli snapshots upload` instead.
```

Switching now silences the warning and keeps the upload steps working once the deprecated command is removed from `sentry-cli`.

## :green_heart: How did you test it?

CI-only change. The behavior is verified by the snapshot upload steps running green in CI. Note: the new subcommand could not be verified against a local `sentry-cli` source checkout (v3.1.0 still ships only `build snapshots`); the change follows the deprecation warning's explicit guidance, and CI installs the latest CLI via `curl -sL https://sentry.io/get-cli/`.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.

## :crystal_ball: Next steps
