### PR TITLE
ci: Add Android 37 emulator to critical UI test matrix (JAVA-647)

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -75,6 +75,10 @@ jobs:
             target: google_apis
             channel: canary # Necessary for ATDs
             arch: x86_64
+          - api-level: "37.0" # Android 17; API 37 ships only as a minor-versioned image
+            target: google_apis_ps16k # API 37 has no plain google_apis image
+            channel: canary # Necessary for ATDs
+            arch: x86_64
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -85,6 +89,22 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # The runner ships an outdated avdmanager that writes target=android-0 into the
+      # AVD config for minor-versioned packages (android-37.x), so the emulator clamps
+      # to API 3 and boots misconfigured. Update cmdline-tools so avdmanager parses it.
+      # See https://github.com/ReactiveCircus/android-emulator-runner/issues/482
+      - name: Update SDK cmdline-tools
+        id: cmdline-tools
+        run: |
+          SDK="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/usr/local/lib/android/sdk}}"
+          yes | "$SDK/cmdline-tools/latest/bin/sdkmanager" --install "cmdline-tools;latest" > /dev/null
+          # sdkmanager won't overwrite the preinstalled dir, so it installs to latest-2.
+          if [ -d "$SDK/cmdline-tools/latest-2" ]; then
+            rm -rf "$SDK/cmdline-tools/latest"
+            mv "$SDK/cmdline-tools/latest-2" "$SDK/cmdline-tools/latest"
+          fi
+          echo "version=$("$SDK/cmdline-tools/latest/bin/sdkmanager" --version 2>/dev/null | grep -Eo '^[0-9][0-9.]*' | head -1)" >> "$GITHUB_OUTPUT"
+
       - name: AVD cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: avd-cache
@@ -92,7 +112,9 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}
+          # Keyed on the cmdline-tools version so AVDs created by the old, broken
+          # avdmanager are invalidated automatically.
+          key: avd-api-${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.target }}-tools${{ steps.cmdline-tools.outputs.version }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## :scroll: Description

Add an API level 37 (Android 17) emulator to the critical UI integration test matrix.

This is possible with the workaround from [ReactiveCircus/android-emulator-runner#482](https://github.com/ReactiveCircus/android-emulator-runner/issues/482) (originally identified by jpcottin in [yschimke/okhttp](https://github.com/yschimke/okhttp/compare/master...jpcottin:okhttp:master)).

## :bulb: Motivation and Context

Resolves [JAVA-647](https://linear.app/getsentry/issue/JAVA-647/add-android-sdk-37-emulator-to-the-matrix). Keep CI emulator coverage current with the latest Android platform so the critical UI tests catch regressions on Android 17 alongside the existing API 31/33/35/36 runs.

## :green_heart: How did you test it?

CI — all matrix rows including API 37.0 pass on this PR.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#skip-changelog
