### PR TITLE
build: Bump AGP to 9.2.1 and migrate Android modules

### DIFF
--- a/.github/workflows/agp-matrix.yml
+++ b/.github/workflows/agp-matrix.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agp: [ '8.7.0','8.8.0','8.9.0' ]
+        agp: [ '9.0.0', '9.1.1', '9.2.1' ]
         integrations: [ true, false ]
 
     name: AGP Matrix Release - AGP ${{ matrix.agp }} - Integrations ${{ matrix.integrations }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 
+### Dependencies
+
+- The SDK is now compiled with Android Gradle Plugin 9.2.1 ([#5779](https://github.com/getsentry/sentry-java/pull/5779))
+
 ## 8.49.0
 
 ### Features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,20 @@ allprojects {
 subprojects {
     apply { plugin("io.sentry.spotless") }
 
+    // AGP 9.2 bundles lint 9.2.1, which flags compileSdk 36 as outdated because 37 is available.
+    // We intentionally stay on compileSdk 36 until the API 37 bump (#5768), so silence that check
+    // for every Android module (library and application).
+    pluginManager.withPlugin("com.android.library") {
+        extensions.configure<com.android.build.gradle.BaseExtension> {
+            lintOptions { disable("GradleDependency") }
+        }
+    }
+    pluginManager.withPlugin("com.android.application") {
+        extensions.configure<com.android.build.gradle.BaseExtension> {
+            lintOptions { disable("GradleDependency") }
+        }
+    }
+
     plugins.withId(Config.QualityPlugins.detektPlugin) {
         configure<DetektExtension> {
             buildUponDefaultConfig = true
@@ -165,6 +179,18 @@ subprojects {
 
                 sourceCompatibility = JavaVersion.VERSION_1_8
                 targetCompatibility = JavaVersion.VERSION_1_8
+            }
+        }
+
+        // AGP 9 defaults Android modules to Java 11. Pin the published library modules back
+        // to Java 8 so their bytecode stays consumable by Java 8 projects, mirroring the
+        // java-library pin above.
+        plugins.withId("com.android.library") {
+            configure<com.android.build.gradle.BaseExtension> {
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_1_8
+                    targetCompatibility = JavaVersion.VERSION_1_8
+                }
             }
         }
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,6 +1,6 @@
 
 object Config {
-    val AGP = System.getenv("VERSION_AGP") ?: "8.13.1"
+    val AGP = System.getenv("VERSION_AGP") ?: "9.2.1"
     val kotlinStdLib = "stdlib-jdk8"
     val kotlinStdLibVersionAndroid = "1.9.24"
     val kotlinTestJunit = "test-junit"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,10 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 # AndroidX required by AGP >= 3.6.x
 android.useAndroidX=true
-android.experimental.lint.version=8.13.1
+# AGP 9+ migration opt-outs until we remove kotlin-android plugin and adopt built-in Kotlin.
+android.builtInKotlin=false
+android.newDsl=false
+android.experimental.lint.version=9.2.1
 
 # Release information
 versionName=8.49.0

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -1,5 +1,6 @@
 import net.ltgt.gradle.errorprone.errorprone
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
 
 plugins {
   id("com.android.library")
@@ -33,7 +34,11 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
-  kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
+  kotlin { compilerOptions.jvmTarget = JVM_1_8 }
 
   testOptions {
     animationsDisabled = true

--- a/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/internal/util/SentryFrameMetricsCollector.java
@@ -91,7 +91,7 @@ public final class SentryFrameMetricsCollector implements Application.ActivityLi
   }
 
   @SuppressWarnings("deprecation")
-  @SuppressLint({"NewApi", "PrivateApi"})
+  @SuppressLint({"NewApi", "PrivateApi", "DiscouragedPrivateApi"})
   public SentryFrameMetricsCollector(
       final @NotNull Context context,
       final @NotNull ILogger logger,

--- a/sentry-android-core/src/main/res/layout/sentry_dialog_user_feedback.xml
+++ b/sentry-android-core/src/main/res/layout/sentry_dialog_user_feedback.xml
@@ -47,6 +47,7 @@
         android:layout_height="wrap_content"
         android:hint="Your Name"
         android:inputType="textPersonName"
+        android:autofillHints="name"
         android:background="@drawable/sentry_edit_text_border"
         android:paddingHorizontal="8dp"
         android:layout_below="@id/sentry_dialog_user_feedback_txt_name" />
@@ -66,6 +67,7 @@
         android:layout_height="wrap_content"
         android:hint="your.email@example.org"
         android:inputType="textEmailAddress"
+        android:autofillHints="emailAddress"
         android:background="@drawable/sentry_edit_text_border"
         android:paddingHorizontal="8dp"
         android:layout_below="@id/sentry_dialog_user_feedback_txt_email" />
@@ -85,6 +87,7 @@
         android:layout_height="wrap_content"
         android:lines="6"
         android:inputType="textMultiLine"
+        android:importantForAutofill="no"
         android:gravity="top|left"
         android:hint="What's the bug? What did you expect?"
         android:background="@drawable/sentry_edit_text_border"

--- a/sentry-android-distribution/build.gradle.kts
+++ b/sentry-android-distribution/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -12,6 +13,10 @@ android {
   defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
   buildFeatures { buildConfig = false }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   testOptions {
     unitTests.apply {
       isReturnDefaultValues = true
@@ -21,7 +26,7 @@ android {
 }
 
 kotlin {
-  jvmToolchain(17)
+  compilerOptions.jvmTarget = JVM_1_8
   compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
   explicitApi()
 }

--- a/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
+++ b/sentry-android-distribution/src/test/java/io/sentry/android/distribution/UpdateResponseParserTest.kt
@@ -8,8 +8,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
 class UpdateResponseParserTest {
 
   private lateinit var options: SentryOptions

--- a/sentry-android-fragment/build.gradle.kts
+++ b/sentry-android-fragment/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id("com.android.library")
@@ -23,10 +25,14 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-    compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-    compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
   }
 
   testOptions {

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import net.ltgt.gradle.errorprone.errorprone
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.application")
@@ -64,12 +65,12 @@ android {
     }
   }
 
-  kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
+  kotlin { compilerOptions.jvmTarget = JvmTarget.JVM_11 }
 
   lint {
     warningsAsErrors = true
     checkDependencies = true
-    // Suppress OldTargetApi: lint 8.13.1 expects API 37 but we target 36
+    // Suppress OldTargetApi: lint 9.2.1 expects API 37 but we target 36
     disable += "OldTargetApi"
 
     // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/build.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.application")
@@ -31,7 +32,7 @@ android {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
-  kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
+  kotlin { compilerOptions.jvmTarget = JvmTarget.JVM_11 }
   buildFeatures { compose = true }
   composeOptions { kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get() }
   androidComponents.beforeVariants {

--- a/sentry-android-integration-tests/sentry-uitest-android-macrobenchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-macrobenchmark/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+
 plugins {
   id("com.android.test")
   alias(libs.plugins.kotlin.android)
@@ -30,7 +32,7 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
-  kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11 }
+  kotlin { compilerOptions.jvmTarget = JVM_11 }
 
   targetProjectPath = ":sentry-samples:sentry-samples-android"
   // Run the test in its own process so it measures the target app cold, not itself.

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import net.ltgt.gradle.errorprone.errorprone
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("com.android.application")
@@ -56,18 +57,19 @@ android {
   buildTypes {
     getByName("release") {
       isMinifyEnabled = true
+      isShrinkResources = true
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
       signingConfig = signingConfigs.getByName("debug") // to be able to run release mode
       testProguardFiles("proguard-rules.pro")
     }
   }
 
-  kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
+  kotlin { compilerOptions.jvmTarget = JvmTarget.JVM_11 }
 
   lint {
     warningsAsErrors = true
     checkDependencies = true
-    // Suppress OldTargetApi: lint 8.13.1 expects API 37 but we target 36
+    // Suppress OldTargetApi: lint 9.2.1 expects API 37 but we target 36
     disable += "OldTargetApi"
 
     // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.

--- a/sentry-android-navigation/build.gradle.kts
+++ b/sentry-android-navigation/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id("com.android.library")
@@ -23,10 +25,14 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-    compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-    compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+    compilerOptions.jvmTarget = JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
   }
 
   testOptions {

--- a/sentry-android-ndk/build.gradle.kts
+++ b/sentry-android-ndk/build.gradle.kts
@@ -26,6 +26,10 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
 
   testOptions {

--- a/sentry-android-replay/build.gradle.kts
+++ b/sentry-android-replay/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
@@ -25,20 +27,21 @@ android {
 
   buildFeatures { compose = true }
 
-  composeOptions {
-    kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    useLiveLiterals = false
-  }
+  composeOptions { kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get() }
 
   buildTypes {
     getByName("debug") { consumerProguardFiles("proguard-rules.pro") }
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-    compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-    compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
   }
 
   testOptions {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/ScreenshotRecorderTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/ScreenshotRecorderTest.kt
@@ -14,8 +14,10 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
 class ScreenshotRecorderTest {
 
   internal class Fixture() {

--- a/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
+++ b/sentry-android-replay/src/test/java/io/sentry/android/replay/util/ViewsTest.kt
@@ -20,8 +20,10 @@ import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
 class ViewsTest {
 
   @BeforeTest

--- a/sentry-android-sqlite/build.gradle.kts
+++ b/sentry-android-sqlite/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id("com.android.library")
@@ -23,10 +25,14 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-    compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-    compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
   }
 
   testOptions {

--- a/sentry-android-timber/build.gradle.kts
+++ b/sentry-android-timber/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   id("com.android.library")
@@ -30,10 +32,14 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin {
-    compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-    compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-    compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+    compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+    compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
   }
 
   testOptions {

--- a/sentry-apache-http-client-5/build.gradle.kts
+++ b/sentry-apache-http-client-5/build.gradle.kts
@@ -1,5 +1,6 @@
 import net.ltgt.gradle.errorprone.errorprone
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
   `java-library`
@@ -10,10 +11,10 @@ plugins {
   alias(libs.plugins.gradle.versions)
 }
 
-tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
-  compilerOptions.languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
-  compilerOptions.apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9
+kotlin {
+  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+  compilerOptions.languageVersion = KotlinVersion.KOTLIN_1_9
+  compilerOptions.apiVersion = KotlinVersion.KOTLIN_1_9
 }
 
 dependencies {

--- a/sentry-compose/build.gradle.kts
+++ b/sentry-compose/build.gradle.kts
@@ -87,12 +87,14 @@ android {
     buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
   }
 
-  sourceSets["main"].apply { manifest.srcFile("src/androidMain/AndroidManifest.xml") }
-
   buildTypes {
     getByName("debug") { consumerProguardFiles("proguard-rules.pro") }
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
+
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
 
   testOptions {
     animationsDisabled = true

--- a/sentry-launchdarkly-android/build.gradle.kts
+++ b/sentry-launchdarkly-android/build.gradle.kts
@@ -27,6 +27,10 @@ android {
     getByName("release") { consumerProguardFiles("proguard-rules.pro") }
   }
 
+  // AGP 9 only generates unit tests for the testBuildType. CI disables the debug
+  // variant, so unit tests must target release to run at all.
+  testBuildType = "release"
+
   kotlin { compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8 }
 
   testOptions {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ pluginManagement {
     }
     mavenCentral()
     gradlePluginPortal()
+    google()
   }
 }
 


### PR DESCRIPTION
We need to bump AGP to 9.2 because compile SDK introduced a breaking change (`37.0` vs `37`) which makes it very difficult to compile using AGP 8.X.

AGP 9.X introduced several breaking changes that we try to mitigate in this PR.

* AGP 9.X sets the java target compile level to 11 from 8, so we override this to keep the same level.
* AGP 9.X includes a bundles kotlin plugin, we disable this with `android.builtInKotlin=false`
* AGP 9.X has a new DSL which we disable with `android.builtInKotlin=false`
* AGP 9.X disables unit tests for debug variants. we therefore set the test variant to release in modules where debug is disabled.
* Fix and ignore some AGP 9.X lint warnings

Fixes getsentry/sentry-java#5777<br>Linear: getsentry/sentry-java#5777 (getsentry/sentry-java#5777)

#skip-changelog

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

[https://claude.ai/code/session_01EmE8hdaj9H9K61opK2PZ6U](<https://claude.ai/code/session_01EmE8hdaj9H9K61opK2PZ6U>)