### PR TITLE
perf(json): Avoid exceptions when typing JSON numbers (JAVA-536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Performance
 
 - Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))
+- Speed up deserialization of arbitrary JSON objects by typing numbers without throwing exceptions ([#5783](https://github.com/getsentry/sentry-java/pull/5783))
 
 ## 8.50.1
 

--- a/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
+++ b/sentry/src/main/java/io/sentry/JsonObjectDeserializer.java
@@ -172,17 +172,16 @@ public final class JsonObjectDeserializer {
   }
 
   private Object nextNumber(JsonObjectReader reader) throws IOException {
-    try {
-      return reader.nextInt();
-    } catch (Exception exception) {
-      // Need to try/fail as there are no int/double/long tokens.
+    // JSON has no int/double token distinction. Probing with reader.nextInt() and catching the
+    // NumberFormatException it throws for every non-integer (e.g. timestamps) dominated the cost of
+    // deserializing arbitrary objects. Read once as a double and narrow to an int only when the
+    // value is integral and fits, which reproduces the previous return types without any throws.
+    final double value = reader.nextDouble();
+    final int intValue = (int) value;
+    if (intValue == value) {
+      return intValue;
     }
-    try {
-      return reader.nextDouble();
-    } catch (Exception exception) {
-      // Need to try/fail as there are no int/double/long tokens.
-    }
-    return reader.nextLong();
+    return value;
   }
 
   private @Nullable Token getCurrentToken() {

--- a/sentry/src/test/java/io/sentry/JsonObjectDeserializerTest.kt
+++ b/sentry/src/test/java/io/sentry/JsonObjectDeserializerTest.kt
@@ -1,8 +1,10 @@
 package io.sentry
 
+import java.io.IOException
 import java.io.StringReader
 import java.lang.Exception
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.fail
 import org.junit.Test
@@ -40,6 +42,54 @@ class JsonObjectDeserializerTest {
     val json = "1.1"
     val actual = deserialize(json)
     assertEquals(1.1, actual)
+  }
+
+  // A value that is integral and fits an int is typed as Integer (regardless of how it was
+  // written); anything else is a Double. This matches the behavior prior to removing the
+  // exception-based number typing.
+
+  @Test
+  fun `deserialize negative int`() {
+    assertEquals(-5, deserialize("-5"))
+  }
+
+  @Test
+  fun `deserialize negative double`() {
+    assertEquals(-3.14, deserialize("-3.14"))
+  }
+
+  @Test
+  fun `deserialize integral exponent notation as int`() {
+    assertEquals(100, deserialize("1e2"))
+    assertEquals(100, deserialize("1E2"))
+  }
+
+  @Test
+  fun `deserialize fractional exponent notation as double`() {
+    assertEquals(0.0025, deserialize("2.5e-3"))
+  }
+
+  @Test
+  fun `deserialize whole-valued decimal as int`() {
+    assertEquals(1, deserialize("1.0"))
+  }
+
+  @Test
+  fun `deserialize integer larger than int range as double`() {
+    assertEquals(1.0e10, deserialize("10000000000"))
+    assertEquals(2147483648.0, deserialize("2147483648"))
+  }
+
+  @Test
+  fun `deserialize max int as int`() {
+    assertEquals(Int.MAX_VALUE, deserialize("2147483647"))
+  }
+
+  @Test
+  fun `deserialize rejects literal overflowing to infinity`() {
+    // Strict JSON forbids non-finite numbers, so an out-of-range literal must fail rather than be
+    // stored as Infinity.
+    assertFailsWith<IOException> { deserialize("1e400") }
   }
 
   @Test


### PR DESCRIPTION
## :scroll: Description

`JsonObjectDeserializer.nextNumber()` (used when deserializing arbitrary/unknown JSON into a generic `Map`/`List` tree) decided whether a JSON number was an `int` or a `double` by calling `reader.nextInt()` and catching the `NumberFormatException` it throws for every non-integer value, then falling back to `reader.nextDouble()`. Because `NumberFormatException` fills in a stack trace, every floating-point value (timestamps, measurements, …) paid the cost of a thrown exception.

This replaces the exception-driven typing by reading the literal as a `double` once and narrowing it back to an `int` only when the value is integral and fits:

```java
final double value = reader.nextDouble();
final int intValue = (int) value;
if (intValue == value) {
  return intValue;
}
return value;
```

**Return types are intentionally unchanged** — `Integer` for values that are integral and fit an `int`, `Double` otherwise (fractional or out of int range). This matters: callers read integers back out of the generic tree and cast them (e.g. `ReplayRecording` casts rrweb `source`/`type` values to `Integer`/`int`), and defined fields such as `MeasurementValue.value` and context values like `thread.id` would otherwise change on the wire (`4` → `4.0`). Only the internal path to those same results changes; no exceptions are thrown.

Note that `reader.nextDouble()` is used rather than `Double.parseDouble(reader.nextString())`: it reuses the reader's already-buffered numeric token instead of materializing a `String` and re-parsing it, and it keeps the reader's non-finite guard, so a literal that overflows to infinity (`1e400`) is still rejected as malformed JSON instead of being stored as `Infinity`. (`NaN`/`Infinity` *literals* never reach this method — the reader tokenizes them as `STRING`, not `NUMBER`, even in lenient mode.)

For context: Gson and Moshi both return `Double` for *all* numbers when deserializing arbitrary JSON. We deliberately do **not** match that here, because the generic tree feeds code that depends on the int/double distinction.

One deliberate narrowing versus the old code: the previous `reader.nextLong()` fallback is gone, so `nextNumber()` no longer returns `Long`. Integers beyond int range were already returned as `Double` by the old path (`nextInt()` failed, `nextDouble()` then succeeded), so this only removes a branch that was unreachable for well-formed numbers; values above 2^53 still lose precision exactly as before.

## :bulb: Motivation and Context

Part of [JAVA-536](https://linear.app/getsentry/issue/JAVA-536) (optimize vendored libraries for startup performance). While benchmarking whether the vendored gson JSON streaming code should be replaced with moshi, this exception-based number typing showed up as a self-inflicted cost. The moshi comparison itself concluded a swap is **not** worthwhile (the vendored gson engine is as fast or faster, and moshi would add Okio + churn ~80 files); full data is in JAVA-536.

## :chart_with_upwards_trend: Benchmark

Parsing one `sentry_event.json` into a generic object tree, median ms per 1000 iterations (desktop JVM, 5 warmup rounds, median of 10):

| Scenario | Before | After |
|---|---:|---:|
| Isolated number typing (recursive read, number handling only differs) | ~33 ms | ~16 ms |
| End-to-end via `JsonObjectDeserializer.nextObjectOrNull()` | ~37 ms | ~34 ms |

Removing the exceptions roughly halves the number-typing work in isolation. End-to-end the win is more modest (~5%), because `JsonObjectDeserializer`'s token-stack allocations dominate that path; payloads with many floating-point values (e.g. profiling measurements) benefit more.

Numbers were measured with a local micro-benchmark (not committed, to keep this PR to the fix + tests); the before/after was obtained by stashing the change and re-running. Methodology: preload the payload into memory, parse it `nextObjectOrNull` ×1000 per timed run, 2–5 warmup rounds discarded, report the median. The benchmark measured the `Double.parseDouble(nextString())` variant; the committed `nextDouble()` version avoids an additional `String` allocation and re-parse per number, so it should be at least as fast. Full moshi-vs-gson comparison data is in JAVA-536.

## :green_heart: How did you test it?

- Full `sentry` unit test suite passes (3434 tests, 0 failures).
- Added edge-case tests to `JsonObjectDeserializerTest` covering negative ints/doubles, integral vs. fractional exponent notation (`1e2` → `Integer`, `2.5e-3` → `Double`), whole-valued decimals (`1.0` → `Integer`), integers beyond int range (→ `Double`, never `Long`), the `Int.MAX_VALUE` boundary, and a literal that overflows to infinity (`1e400` → rejected) — locking in the return types that must not change.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
