### PR TITLE
perf(android): Init shake detector off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Reduce main-thread work during `Sentry.init` by resolving the shake-detector accelerometer off the main thread (~1.75ms on a Pixel 10) ([#5784](https://github.com/getsentry/sentry-java/pull/5784))
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 
 ## 8.49.0

--- a/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
@@ -44,11 +44,24 @@ public final class FeedbackShakeIntegration
                 : null,
             "SentryAndroidOptions is required");
 
-    if (!this.options.getFeedbackOptions().isUseShakeGesture()) {
+    final @NotNull SentryAndroidOptions options = this.options;
+
+    if (!options.getFeedbackOptions().isUseShakeGesture()) {
       return;
     }
 
-    shakeDetector.init(application, options.getLogger());
+    // Resolving the accelerometer is the most expensive part of init (the first SensorManager
+    // access), so warm it up off the main thread. start() re-runs init() on demand, so shake
+    // detection still works if an activity resumes before this completes.
+    try {
+      options
+          .getExecutorService()
+          .submit(() -> shakeDetector.init(application, options.getLogger()));
+    } catch (Throwable t) {
+      options
+          .getLogger()
+          .log(SentryLevel.WARNING, "Failed to submit shake detector initialization.", t);
+    }
 
     addIntegrationToSdkVersion("FeedbackShake");
     application.registerActivityLifecycleCallbacks(this);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/FeedbackShakeIntegration.java
@@ -50,6 +50,11 @@ public final class FeedbackShakeIntegration
       return;
     }
 
+    // Re-arm the detector in case this integration is being re-registered after a previous close()
+    // (e.g. a second Sentry.init reusing the same options), otherwise the closed latch would keep
+    // shake detection off permanently.
+    shakeDetector.reopen();
+
     // Resolving the accelerometer is the most expensive part of init (the first SensorManager
     // access), so warm it up off the main thread. start() re-runs init() on demand, so shake
     // detection still works if an activity resumes before this completes.

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -55,12 +55,12 @@ public final class SentryShakeDetector implements SensorEventListener {
    * Initializes the sensor manager and accelerometer sensor. This is separated from start() so the
    * values can be resolved once and reused across activity transitions.
    */
-  void init(final @NotNull Context context, final @NotNull ILogger logger) {
+  synchronized void init(final @NotNull Context context, final @NotNull ILogger logger) {
     this.logger = logger;
     init(context);
   }
 
-  private void init(final @NotNull Context context) {
+  private synchronized void init(final @NotNull Context context) {
     if (sensorManager == null) {
       sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
     }
@@ -74,7 +74,8 @@ public final class SentryShakeDetector implements SensorEventListener {
     }
   }
 
-  public void start(final @NotNull Context context, final @NotNull Listener shakeListener) {
+  public synchronized void start(
+      final @NotNull Context context, final @NotNull Listener shakeListener) {
     this.listener = shakeListener;
     init(context);
     if (sensorManager == null) {
@@ -89,7 +90,7 @@ public final class SentryShakeDetector implements SensorEventListener {
     sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_NORMAL, handler);
   }
 
-  public void stop() {
+  public synchronized void stop() {
     listener = null;
     if (sensorManager != null) {
       sensorManager.unregisterListener(this);
@@ -105,7 +106,7 @@ public final class SentryShakeDetector implements SensorEventListener {
   }
 
   /** Stops detection and releases the background thread. */
-  public void close() {
+  public synchronized void close() {
     stop();
     if (handlerThread != null) {
       // quitSafely drains pending messages (including the clear posted by stop) before exiting

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -53,6 +53,14 @@ public final class SentryShakeDetector implements SensorEventListener {
   }
 
   /**
+   * Re-arms the detector after a previous {@link #close()} so it can be reused when the owning
+   * integration is registered again (e.g. a second {@code Sentry.init}).
+   */
+  synchronized void reopen() {
+    closed = false;
+  }
+
+  /**
    * Initializes the sensor manager and accelerometer sensor. This is separated from start() so the
    * values can be resolved once and reused across activity transitions.
    */

--- a/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/SentryShakeDetector.java
@@ -40,6 +40,7 @@ public final class SentryShakeDetector implements SensorEventListener {
   private @Nullable Handler handler;
   private volatile @Nullable Listener listener;
   private @NotNull ILogger logger;
+  private boolean closed;
 
   private final @NotNull SampleQueue queue = new SampleQueue();
 
@@ -61,6 +62,11 @@ public final class SentryShakeDetector implements SensorEventListener {
   }
 
   private synchronized void init(final @NotNull Context context) {
+    // A warm-up submitted to the executor can be drained after close() (integrations are closed
+    // before the executor shuts down), so bail out instead of spinning up a new HandlerThread.
+    if (closed) {
+      return;
+    }
     if (sensorManager == null) {
       sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
     }
@@ -76,6 +82,9 @@ public final class SentryShakeDetector implements SensorEventListener {
 
   public synchronized void start(
       final @NotNull Context context, final @NotNull Listener shakeListener) {
+    if (closed) {
+      return;
+    }
     this.listener = shakeListener;
     init(context);
     if (sensorManager == null) {
@@ -107,6 +116,7 @@ public final class SentryShakeDetector implements SensorEventListener {
 
   /** Stops detection and releases the background thread. */
   public synchronized void close() {
+    closed = true;
     stop();
     if (handlerThread != null) {
       // quitSafely drains pending messages (including the clear posted by stop) before exiting

--- a/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -90,6 +91,24 @@ class FeedbackShakeIntegrationTest {
     deferredExecutor.runAll()
 
     verify(fixture.application, never()).getSystemService(eq(Context.SENSOR_SERVICE))
+  }
+
+  @Test
+  fun `re-registering after close re-arms shake detection`() {
+    // A second Sentry.init reusing the same integration must revive shake detection rather than
+    // stay off because of the closed latch.
+    val deferredExecutor = DeferredExecutorService()
+    fixture.options.executorService = deferredExecutor
+    whenever(fixture.application.getSystemService(any())).thenReturn(null)
+
+    val sut = fixture.getSut(useShakeGesture = true)
+    sut.register(fixture.scopes, fixture.options)
+    sut.close()
+    sut.register(fixture.scopes, fixture.options)
+
+    deferredExecutor.runAll()
+
+    verify(fixture.application, atLeastOnce()).getSystemService(eq(Context.SENSOR_SERVICE))
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
@@ -76,6 +76,23 @@ class FeedbackShakeIntegrationTest {
   }
 
   @Test
+  fun `warm-up drained after close does not resolve the sensor`() {
+    // Integrations are closed before the executor drains, so a queued warm-up can run after
+    // close(). It must be a no-op rather than resolving the sensor and spinning up a HandlerThread.
+    val deferredExecutor = DeferredExecutorService()
+    fixture.options.executorService = deferredExecutor
+    whenever(fixture.application.getSystemService(any())).thenReturn(null)
+
+    val sut = fixture.getSut(useShakeGesture = true)
+    sut.register(fixture.scopes, fixture.options)
+    sut.close()
+
+    deferredExecutor.runAll()
+
+    verify(fixture.application, never()).getSystemService(eq(Context.SENSOR_SERVICE))
+  }
+
+  @Test
   fun `when useShakeGesture is disabled does not register activity lifecycle callbacks`() {
     val sut = fixture.getSut(useShakeGesture = false)
     sut.register(fixture.scopes, fixture.options)

--- a/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/FeedbackShakeIntegrationTest.kt
@@ -2,13 +2,17 @@ package io.sentry.android.core
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.sentry.Scopes
 import io.sentry.SentryFeedbackOptions
+import io.sentry.test.DeferredExecutorService
+import io.sentry.test.ImmediateExecutorService
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -20,7 +24,11 @@ class FeedbackShakeIntegrationTest {
   private class Fixture {
     val application = mock<Application>()
     val scopes = mock<Scopes>()
-    val options = SentryAndroidOptions().apply { dsn = "https://key@sentry.io/proj" }
+    val options =
+      SentryAndroidOptions().apply {
+        dsn = "https://key@sentry.io/proj"
+        executorService = ImmediateExecutorService()
+      }
     val activity = mock<Activity>()
     val formHandler = mock<SentryFeedbackOptions.IFormHandler>()
 
@@ -47,6 +55,24 @@ class FeedbackShakeIntegrationTest {
     sut.register(fixture.scopes, fixture.options)
 
     verify(fixture.application).registerActivityLifecycleCallbacks(any())
+  }
+
+  @Test
+  fun `resolves the accelerometer sensor off the main thread`() {
+    val deferredExecutor = DeferredExecutorService()
+    fixture.options.executorService = deferredExecutor
+    whenever(fixture.application.getSystemService(any())).thenReturn(null)
+
+    val sut = fixture.getSut(useShakeGesture = true)
+    sut.register(fixture.scopes, fixture.options)
+
+    // Callback registration stays synchronous, but the expensive SensorManager lookup is deferred.
+    verify(fixture.application).registerActivityLifecycleCallbacks(any())
+    verify(fixture.application, never()).getSystemService(eq(Context.SENSOR_SERVICE))
+
+    deferredExecutor.runAll()
+
+    verify(fixture.application).getSystemService(eq(Context.SENSOR_SERVICE))
   }
 
   @Test


### PR DESCRIPTION
## Summary

`FeedbackShakeIntegration.register()` resolved the accelerometer via `SensorManager` synchronously on the calling thread — the **main thread** under auto-init. On a Pixel 10 (Android 17, release build) this first `SensorManager` access measured **~1.75 ms**, making it the single most expensive integration in the `Sentry.init` register loop (the loop total was ~5.1 ms).

This moves the pre-warm `shakeDetector.init(...)` onto `options.getExecutorService()`. `SentryShakeDetector.start()` already re-runs the idempotent `init()` on demand, so shake detection still works if an activity resumes before the warm-up finishes. `SentryShakeDetector`'s lifecycle methods (`init`/`start`/`stop`/`close`) are now `synchronized` so the executor warm-up and a main-thread `start()` cannot race on the sensor fields.

## Measurement (Pixel 10, release, median of 10 cold starts)

| | before | after |
|---|--:|--:|
| `FeedbackShakeIntegration.register()` | ~1754 µs | ~40 µs |
| register loop total | ~5.1 ms | ~3.3 ms |

Follow-up to [JAVA-618](https://linear.app/getsentry/issue/JAVA-618). Companion PR defers the other big synchronous item (NDK init).