### PR TITLE
perf(android): Init the NDK integration off the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Reduce main-thread work during `Sentry.init` by initializing the NDK integration off the main thread (~1.48ms on a Pixel 10) ([#5785](https://github.com/getsentry/sentry-java/pull/5785))
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
 
 ## 8.49.0

--- a/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/NdkIntegration.java
@@ -49,25 +49,42 @@ public final class NdkIntegration implements Integration, Closeable {
         return;
       }
 
+      final @NotNull SentryAndroidOptions androidOptions = this.options;
+      // SentryNdk.init blocks the calling thread while it waits for the native library to load and
+      // installs the crash handler, so keep it off the main thread during init. The executor is
+      // single-threaded and preserves submission order, so this still runs before the outbox file
+      // observer and sender registered after it, which must not act until sentry-native has moved
+      // its files.
       try {
-        final Method method = sentryNdkClass.getMethod("init", SentryAndroidOptions.class);
-        final Object[] args = new Object[1];
-        args[0] = this.options;
-        method.invoke(null, args);
-
-        this.options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
-        addIntegrationToSdkVersion("Ndk");
-      } catch (NoSuchMethodException e) {
-        disableNdkIntegration(this.options);
-        this.options
-            .getLogger()
-            .log(SentryLevel.ERROR, "Failed to invoke the SentryNdk.init method.", e);
-      } catch (Throwable e) {
-        disableNdkIntegration(this.options);
-        this.options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
+        androidOptions.getExecutorService().submit(() -> initNdk(androidOptions));
+      } catch (Throwable t) {
+        disableNdkIntegration(androidOptions);
+        androidOptions.getLogger().log(SentryLevel.ERROR, "Failed to submit SentryNdk.init.", t);
       }
     } else {
       disableNdkIntegration(this.options);
+    }
+  }
+
+  private void initNdk(final @NotNull SentryAndroidOptions options) {
+    final @Nullable Class<?> ndkClass = sentryNdkClass;
+    if (ndkClass == null) {
+      return;
+    }
+    try {
+      final Method method = ndkClass.getMethod("init", SentryAndroidOptions.class);
+      final Object[] args = new Object[1];
+      args[0] = options;
+      method.invoke(null, args);
+
+      options.getLogger().log(SentryLevel.DEBUG, "NdkIntegration installed.");
+      addIntegrationToSdkVersion("Ndk");
+    } catch (NoSuchMethodException e) {
+      disableNdkIntegration(options);
+      options.getLogger().log(SentryLevel.ERROR, "Failed to invoke the SentryNdk.init method.", e);
+    } catch (Throwable e) {
+      disableNdkIntegration(options);
+      options.getLogger().log(SentryLevel.ERROR, "Failed to initialize SentryNdk.", e);
     }
   }
 

--- a/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/NdkIntegrationTest.kt
@@ -3,6 +3,8 @@ package io.sentry.android.core
 import io.sentry.ILogger
 import io.sentry.IScopes
 import io.sentry.SentryLevel
+import io.sentry.test.DeferredExecutorService
+import io.sentry.test.ImmediateExecutorService
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -155,6 +157,23 @@ class NdkIntegrationTest {
     assertFalse(options.isEnableScopeSync)
   }
 
+  @Test
+  fun `NdkIntegration inits off the calling thread`() {
+    SentryNdkRecording.initialized = false
+    val deferredExecutor = DeferredExecutorService()
+    val integration = fixture.getSut(SentryNdkRecording::class.java)
+    val options = getOptions().apply { executorService = deferredExecutor }
+
+    integration.register(fixture.scopes, options)
+
+    // register() only submits the work; init has not run yet
+    assertFalse(SentryNdkRecording.initialized)
+
+    deferredExecutor.runAll()
+
+    assertTrue(SentryNdkRecording.initialized)
+  }
+
   private fun getOptions(
     enableNdk: Boolean = true,
     cacheDir: String? = "abc",
@@ -164,9 +183,21 @@ class NdkIntegrationTest {
       isDebug = true
       isEnableNdk = enableNdk
       cacheDirPath = cacheDir
+      executorService = ImmediateExecutorService()
     }
 
   private class SentryNdkNoInit
+
+  private class SentryNdkRecording {
+    companion object {
+      var initialized = false
+
+      @JvmStatic
+      fun init(options: SentryAndroidOptions) {
+        initialized = true
+      }
+    }
+  }
 
   private class SentryNdkThrows {
     companion object {


### PR DESCRIPTION
## Summary

`NdkIntegration.register()` called `SentryNdk.init()` synchronously on the calling thread — the **main thread** under auto-init. That call blocks while it `await`s the native-library load latch and then installs the crash handler via JNI. On a Pixel 10 (Android 17, release build) it measured **~1.48 ms**, the second most expensive integration in the `Sentry.init` register loop.

This submits the reflective init to `options.getExecutorService()`. The executor is single-threaded and preserves submission order, so NDK init still runs **before** the outbox `EnvelopeFileObserverIntegration` and outbox `SendCachedEnvelopeIntegration` registered after it — which must not act until sentry-native has moved its files. Init failures still disable the integration (`enableNdk`/`enableScopeSync`), now on the executor thread.

### Trade-off

The native crash handler is now installed slightly later (when the executor reaches the task) rather than synchronously during `init()`. A native crash in the very first milliseconds of startup may therefore be missed. Flagging explicitly for review — this is the behavioral change [JAVA-618](https://linear.app/getsentry/issue/JAVA-618) anticipated for the NDK item.

## Measurement (Pixel 10, release, median of 10 cold starts)

| | before | after |
|---|--:|--:|
| `NdkIntegration.register()` | ~1476 µs | ~11 µs |

Follow-up to [JAVA-618](https://linear.app/getsentry/issue/JAVA-618). Companion PR (#5784) defers the shake-detector sensor init.
Fixes JAVA-610