### PR TITLE
fix(compose): Update isImportantForBounds to return true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))
+- `SentryTagModifierNode.isImportantForBounds` now matches the default behavior and returns `true` ([#5789](https://github.com/getsentry/sentry-java/pull/5789))
 
 ## 8.49.0
 

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -57,8 +57,8 @@ public object SentryModifier {
     // SemanticsModifierNode.isImportantForBounds() was added as an abstract method in
     // compose-ui 1.11. Classes compiled against earlier versions lack this method in
     // their bytecode, which causes AbstractMethodError when the accessibility tree is
-    // traversed on 1.11+ runtimes. 
-    // Returning true to match the default behavior 
+    // traversed on 1.11+ runtimes.
+    // Returning true to match the default behavior
     // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/SemanticsModifierNode.kt;l=69-83;drc=bd7809b4bc9205721c2f1bc681694dd348885849
     @Suppress("unused") fun isImportantForBounds(): Boolean = true
   }

--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -55,13 +55,11 @@ public object SentryModifier {
     }
 
     // SemanticsModifierNode.isImportantForBounds() was added as an abstract method in
-    // compose-ui 1.11.  Classes compiled against earlier versions lack this method in
+    // compose-ui 1.11. Classes compiled against earlier versions lack this method in
     // their bytecode, which causes AbstractMethodError when the accessibility tree is
-    // traversed on 1.11+ runtimes.  We can't use the `override` keyword here because
-    // the method doesn't exist in the compile-time dependency (compose-ui 1.6.x), but
-    // the JVM satisfies the abstract-method requirement at runtime via signature
-    // matching.  SentryTagModifierNode only stores a semantic tag and has no visual
-    // effect on layout, so it is not important for bounds.
-    @Suppress("unused") fun isImportantForBounds(): Boolean = false
+    // traversed on 1.11+ runtimes. 
+    // Returning true to match the default behavior 
+    // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/SemanticsModifierNode.kt;l=69-83;drc=bd7809b4bc9205721c2f1bc681694dd348885849
+    @Suppress("unused") fun isImportantForBounds(): Boolean = true
   }
 }


### PR DESCRIPTION
As any inner node could be important for semantics. This also matches the default behavior 
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/SemanticsModifierNode.kt;l=69-83;drc=bd7809b4bc9205721c2f1bc681694dd348885849

## :scroll: Description

Fixes [isImportantForBounds](https://github.com/getsentry/sentry-java/issues/5786)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.


## :crystal_ball: Next steps
