### PR TITLE
perf(android): mini optimization: Guard manifest metadata debug logs behind isEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Skip building Android manifest metadata debug log messages when debug logging is disabled, reducing allocations during SDK init ([#5700](https://github.com/getsentry/sentry-java/pull/5700))
+- Skip building Android manifest metadata debug log messages when debug logging is disabled, reducing allocations during SDK init ([#5790](https://github.com/getsentry/sentry-java/pull/5790))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Skip building Android manifest metadata debug log messages when debug logging is disabled, reducing allocations during SDK init ([#5700](https://github.com/getsentry/sentry-java/pull/5700))
+
 ### Fixes
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))

--- a/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/ManifestMetadataReader.java
@@ -779,7 +779,9 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final boolean defaultValue) {
     final boolean value = metadata.getBoolean(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     return value;
   }
 
@@ -789,7 +791,9 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final @Nullable String defaultValue) {
     final String value = metadata.getString(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     return value;
   }
 
@@ -799,14 +803,18 @@ final class ManifestMetadataReader {
       final @NotNull String key,
       final @NotNull String defaultValue) {
     final String value = metadata.getString(key, defaultValue);
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     return value;
   }
 
   private static @Nullable List<String> readList(
       final @NotNull Bundle metadata, final @NotNull ILogger logger, final @NotNull String key) {
     final String value = metadata.getString(key);
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     if (value != null) {
       return Arrays.asList(value.split(",", -1));
     } else {
@@ -821,7 +829,9 @@ final class ManifestMetadataReader {
     if (value == -1) {
       value = ((Integer) metadata.getInt(key, -1)).doubleValue();
     }
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     return value;
   }
 
@@ -832,7 +842,9 @@ final class ManifestMetadataReader {
       final long defaultValue) {
     // manifest meta-data only reads int if the value is not big enough
     final long value = metadata.getInt(key, (int) defaultValue);
-    logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    if (logger.isEnabled(SentryLevel.DEBUG)) {
+      logger.log(SentryLevel.DEBUG, key + " read: " + value);
+    }
     return value;
   }
 


### PR DESCRIPTION
## 📜 Description

This is a mini optimization, this just reduces GC churn in the manifest reading which is a very expensive part of the startup.

This wraps each of the six helpers in a `logger.isEnabled(SentryLevel.DEBUG)` guard so the message is only built when debug logging is actually enabled. The guard is exactly the condition `DiagnosticLogger.log` already applies internally, so behavior is unchanged.

Closes getsentry/sentry-java#5700

## 💚 How did you test it?

Existing `ManifestMetadataReaderTest` coverage exercises these helpers. The change is behavior-preserving (only defers message construction), and `sentry-android-core` compiles with `apiDump` producing no `.api` changes.

## :pencil: Checklist

- [X] I added GH Issue ID *&* Linear ID
- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## 🔮 Next steps

None.