### PR TITLE
perf(core): Create outbox and cache dirs lazily instead of during init (JAVA-613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Behavioral Changes
+
+- The outbox and cache directories are no longer created by `Sentry.init` ([#5792](https://github.com/getsentry/sentry-java/pull/5792))
+  - They are now created lazily by whichever component first writes into them, off the init thread. As a result, the directories at `SentryOptions.getOutboxPath()` and `SentryOptions.getCacheDirPath()` are not guaranteed to exist once `Sentry.init` returns.
+  - If you write envelopes into the outbox path yourself instead of going through the SDK — as hybrid SDKs do for `captureEnvelope` — create the directory first, e.g. `new File(outboxPath).mkdirs()`.
+
 ### Improvements
 
 - Skip building Android manifest metadata debug log messages when debug logging is disabled, reducing allocations during SDK init ([#5790](https://github.com/getsentry/sentry-java/pull/5790))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Performance
 
+- Create the outbox and cache directories lazily in their consumers instead of during SDK init, moving the `mkdirs()` calls off the init (main) thread ([#5792](https://github.com/getsentry/sentry-java/pull/5792))
 - Reduce the number of SDK threads: `LifecycleWatcher` now schedules the session-end task on the shared timer executor instead of creating a dedicated `java.util.Timer` thread ([#5819](https://github.com/getsentry/sentry-java/pull/5819))
 - Speed up deserialization of arbitrary JSON objects by typing numbers without throwing exceptions ([#5783](https://github.com/getsentry/sentry-java/pull/5783))
 

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -10,9 +10,9 @@ import io.sentry.OutboxSender;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.util.AutoClosableReentrantLock;
+import io.sentry.util.LazyDirectory;
 import io.sentry.util.Objects;
 import java.io.Closeable;
-import java.io.File;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -68,12 +68,9 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
       final @NotNull IScopes scopes,
       final @NotNull SentryOptions options,
       final @NotNull String path) {
-    // Create the outbox dir lazily here (on the executor) so the observer can watch it for
-    // envelopes written by hybrid SDKs, instead of blocking Sentry.init on the mkdirs.
-    final File outboxDir = new File(path);
-    if (!outboxDir.isDirectory()) {
-      outboxDir.mkdirs();
-    }
+    // Materialize the outbox dir here (on the executor) so the observer can watch it for envelopes
+    // written by hybrid SDKs, instead of blocking Sentry.init on the mkdirs.
+    new LazyDirectory(path).getOrCreate();
 
     final OutboxSender outboxSender =
         new OutboxSender(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -12,6 +12,7 @@ import io.sentry.SentryOptions;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.Objects;
 import java.io.Closeable;
+import java.io.File;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -67,6 +68,13 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
       final @NotNull IScopes scopes,
       final @NotNull SentryOptions options,
       final @NotNull String path) {
+    // Create the outbox dir lazily here (on the executor) so the observer can watch it for
+    // envelopes written by hybrid SDKs, instead of blocking Sentry.init on the mkdirs.
+    final File outboxDir = new File(path);
+    if (!outboxDir.isDirectory()) {
+      outboxDir.mkdirs();
+    }
+
     final OutboxSender outboxSender =
         new OutboxSender(
             scopes,

--- a/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/EnvelopeFileObserverIntegration.java
@@ -10,9 +10,10 @@ import io.sentry.OutboxSender;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.util.AutoClosableReentrantLock;
-import io.sentry.util.LazyDirectory;
+import io.sentry.util.FileUtils;
 import io.sentry.util.Objects;
 import java.io.Closeable;
+import java.io.File;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -68,9 +69,11 @@ public abstract class EnvelopeFileObserverIntegration implements Integration, Cl
       final @NotNull IScopes scopes,
       final @NotNull SentryOptions options,
       final @NotNull String path) {
-    // Materialize the outbox dir here (on the executor) so the observer can watch it for envelopes
+    // Create the outbox dir here (on the executor) so the observer can watch it for envelopes
     // written by hybrid SDKs, instead of blocking Sentry.init on the mkdirs.
-    new LazyDirectory(path).getOrCreate();
+    if (!FileUtils.createDirectory(new File(path))) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to create outbox dir %s", path);
+    }
 
     final OutboxSender outboxSender =
         new OutboxSender(

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -48,7 +48,8 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
       final @NotNull ICurrentDateProvider currentDateProvider) {
     super(
         options,
-        Objects.requireNonNull(options.getCacheDirPath(), "cacheDirPath must not be null"),
+        new LazyDirectory(
+            Objects.requireNonNull(options.getCacheDirPath(), "cacheDirPath must not be null")),
         options.getMaxCacheItems());
     this.currentDateProvider = currentDateProvider;
   }

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -18,7 +18,6 @@ import io.sentry.cache.EnvelopeCache;
 import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.FileUtils;
 import io.sentry.util.HintUtils;
-import io.sentry.util.LazyDirectory;
 import io.sentry.util.Objects;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -48,8 +47,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
       final @NotNull ICurrentDateProvider currentDateProvider) {
     super(
         options,
-        new LazyDirectory(
-            Objects.requireNonNull(options.getCacheDirPath(), "cacheDirPath must not be null")),
+        Objects.requireNonNull(options.getCacheDirPath(), "cacheDirPath must not be null"),
         options.getMaxCacheItems());
     this.currentDateProvider = currentDateProvider;
   }
@@ -108,9 +106,13 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
           .log(DEBUG, "Outbox path is null, the startup crash marker file will not be written");
       return;
     }
-    // The outbox dir is no longer created during Sentry.init, so materialize it here in case the
-    // native SDK (which normally creates it) is disabled.
-    final File outboxDir = new LazyDirectory(outboxPath).getOrCreate();
+    // The outbox dir is no longer created during Sentry.init, so create it here in case the native
+    // SDK (which normally creates it) is disabled.
+    final File outboxDir = new File(outboxPath);
+    if (!FileUtils.createDirectory(outboxDir)) {
+      options.getLogger().log(ERROR, "Failed to create outbox dir %s", outboxPath);
+      return;
+    }
     final File crashMarkerFile = new File(outboxDir, STARTUP_CRASH_MARKER_FILE);
     try {
       crashMarkerFile.createNewFile();

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -18,6 +18,7 @@ import io.sentry.cache.EnvelopeCache;
 import io.sentry.transport.ICurrentDateProvider;
 import io.sentry.util.FileUtils;
 import io.sentry.util.HintUtils;
+import io.sentry.util.LazyDirectory;
 import io.sentry.util.Objects;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -93,7 +94,7 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
 
   @TestOnly
   public @NotNull File getDirectory() {
-    return directory;
+    return directory.getFile();
   }
 
   private void writeStartupCrashMarkerFile() {
@@ -106,14 +107,11 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
           .log(DEBUG, "Outbox path is null, the startup crash marker file will not be written");
       return;
     }
-    final File crashMarkerFile = new File(outboxPath, STARTUP_CRASH_MARKER_FILE);
+    // The outbox dir is no longer created during Sentry.init, so materialize it here in case the
+    // native SDK (which normally creates it) is disabled.
+    final File outboxDir = new LazyDirectory(outboxPath).getOrCreate();
+    final File crashMarkerFile = new File(outboxDir, STARTUP_CRASH_MARKER_FILE);
     try {
-      // The outbox dir is no longer created during Sentry.init, so ensure it exists here in case
-      // the native SDK (which normally creates it) is disabled.
-      final File outboxDir = crashMarkerFile.getParentFile();
-      if (outboxDir != null && !outboxDir.isDirectory()) {
-        outboxDir.mkdirs();
-      }
       crashMarkerFile.createNewFile();
     } catch (Throwable e) {
       options.getLogger().log(ERROR, "Error writing the startup crash marker file to the disk", e);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/cache/AndroidEnvelopeCache.java
@@ -108,6 +108,12 @@ public final class AndroidEnvelopeCache extends EnvelopeCache {
     }
     final File crashMarkerFile = new File(outboxPath, STARTUP_CRASH_MARKER_FILE);
     try {
+      // The outbox dir is no longer created during Sentry.init, so ensure it exists here in case
+      // the native SDK (which normally creates it) is disabled.
+      final File outboxDir = crashMarkerFile.getParentFile();
+      if (outboxDir != null && !outboxDir.isDirectory()) {
+        outboxDir.mkdirs();
+      }
       crashMarkerFile.createNewFile();
     } catch (Throwable e) {
       options.getLogger().log(ERROR, "Error writing the startup crash marker file to the disk", e);

--- a/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/EnvelopeFileObserverIntegrationTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -121,5 +123,20 @@ class EnvelopeFileObserverIntegrationTest {
       )
     verify(fixture.logger)
       .log(eq(SentryLevel.DEBUG), eq("EnvelopeFileObserverIntegration installed."))
+  }
+
+  @Test
+  fun `register creates the outbox dir when it does not exist yet`() {
+    val outboxDir = File(file, "outbox")
+    assertFalse(outboxDir.exists())
+
+    fixture.getSut { it.executorService = ImmediateExecutorService() }
+    val integration =
+      object : EnvelopeFileObserverIntegration() {
+        override fun getPath(options: SentryOptions): String = outboxDir.absolutePath
+      }
+    integration.register(fixture.scopes, fixture.scopes.options)
+
+    assertTrue(outboxDir.isDirectory)
   }
 }

--- a/sentry-android-core/src/test/java/io/sentry/android/core/cache/AndroidEnvelopeCacheTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/cache/AndroidEnvelopeCacheTest.kt
@@ -126,6 +126,20 @@ class AndroidEnvelopeCacheTest {
   }
 
   @Test
+  fun `creates outbox dir when writing startup crash file and dir does not exist yet`() {
+    val cache = fixture.getSut(dir = tmpDir, appStartMillis = 1000L, currentTimeMillis = 2000L)
+
+    val outboxDir = File(fixture.options.outboxPath!!)
+    assertTrue(outboxDir.deleteRecursively())
+    assertFalse(outboxDir.exists())
+
+    val hints = HintUtils.createWithTypeCheckHint(UncaughtHint())
+    cache.storeEnvelope(fixture.envelope, hints)
+
+    assertTrue(fixture.startupCrashMarkerFile.exists())
+  }
+
+  @Test
   fun `when no AnrV2 hint exists, does not write last anr report file`() {
     val cache = fixture.getSut(tmpDir)
 

--- a/sentry-android-integration-tests/sentry-uitest-android-critical/src/main/java/io/sentry/uitest/android/critical/MainActivity.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android-critical/src/main/java/io/sentry/uitest/android/critical/MainActivity.kt
@@ -66,6 +66,9 @@ class MainActivity : ComponentActivity() {
             Button(onClick = { Sentry.close() }) { Text("Close SDK") }
             Button(
               onClick = {
+                // The SDK creates the outbox dir lazily on its executor, so an external
+                // writer has to create it itself.
+                File(outboxPath).mkdirs()
                 val file = File(outboxPath, "corrupted.envelope")
                 val corruptedEnvelopeContent =
                   """

--- a/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
+++ b/sentry-android-integration-tests/sentry-uitest-android/src/androidTest/java/io/sentry/uitest/android/EnvelopeTests.kt
@@ -262,9 +262,14 @@ class EnvelopeTests : BaseUiTest() {
       optionsRef = options
     }
 
+    // The SDK creates the outbox dir lazily on its executor, so an external writer racing
+    // Sentry.init has to create it itself.
+    val outboxDir = File(optionsRef!!.outboxPath!!)
+    outboxDir.mkdirs()
+
     // based on
     // https://github.com/getsentry/sentry-native/blob/20d5d5f75f1f48228f2f47e2bb99b17f9996ebbf/ndk/lib/src/androidTest/java/io/sentry/ndk/SentryNdkTest.java#L131
-    File(optionsRef!!.outboxPath, "14779dbf-b2f0-4c00-f4e5-4a287abc4267")
+    File(outboxDir, "14779dbf-b2f0-4c00-f4e5-4a287abc4267")
       .writeText(
         """
         {"dsn":"https://key@sentry.io/proj","event_id":"729ff878-5539-458d-f657-a1acf423a127","sent_at":"2025-04-02T10:02:04.732577Z"}

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4836,7 +4836,6 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	protected static final field UTF_8 Ljava/nio/charset/Charset;
 	protected final field cacheLock Lio/sentry/util/AutoClosableReentrantLock;
 	protected final field sessionLock Lio/sentry/util/AutoClosableReentrantLock;
-	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/util/LazyDirectory;I)V
 	public fun <init> (Lio/sentry/SentryOptions;Ljava/lang/String;I)V
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/cache/IEnvelopeCache;
 	public fun discard (Lio/sentry/SentryEnvelope;)V
@@ -7693,6 +7692,7 @@ public final class io/sentry/util/ExceptionUtils {
 
 public final class io/sentry/util/FileUtils {
 	public fun <init> ()V
+	public static fun createDirectory (Ljava/io/File;)Z
 	public static fun deleteRecursively (Ljava/io/File;)Z
 	public static fun readBytesFromFile (Ljava/lang/String;J)[B
 	public static fun readText (Ljava/io/File;)Ljava/lang/String;
@@ -7762,6 +7762,7 @@ public final class io/sentry/util/LazyDirectory {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getFile ()Ljava/io/File;
 	public fun getOrCreate ()Ljava/io/File;
+	public fun resolve (Ljava/lang/String;)Ljava/io/File;
 }
 
 public final class io/sentry/util/LazyEvaluator {

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7757,6 +7757,12 @@ public final class io/sentry/util/JsonSerializationUtils {
 	public static fun calendarToMap (Ljava/util/Calendar;)Ljava/util/Map;
 }
 
+public final class io/sentry/util/LazyDirectory {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getFile ()Ljava/io/File;
+	public fun getOrCreate ()Ljava/io/File;
+}
+
 public final class io/sentry/util/LazyEvaluator {
 	public fun <init> (Lio/sentry/util/LazyEvaluator$Evaluator;)V
 	public fun getValue ()Ljava/lang/Object;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4836,6 +4836,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	protected static final field UTF_8 Ljava/nio/charset/Charset;
 	protected final field cacheLock Lio/sentry/util/AutoClosableReentrantLock;
 	protected final field sessionLock Lio/sentry/util/AutoClosableReentrantLock;
+	public fun <init> (Lio/sentry/SentryOptions;Lio/sentry/util/LazyDirectory;I)V
 	public fun <init> (Lio/sentry/SentryOptions;Ljava/lang/String;I)V
 	public static fun create (Lio/sentry/SentryOptions;)Lio/sentry/cache/IEnvelopeCache;
 	public fun discard (Lio/sentry/SentryEnvelope;)V

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -7762,7 +7762,6 @@ public final class io/sentry/util/LazyDirectory {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getFile ()Ljava/io/File;
 	public fun getOrCreate ()Ljava/io/File;
-	public fun resolve (Ljava/lang/String;)Ljava/io/File;
 }
 
 public final class io/sentry/util/LazyEvaluator {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -616,19 +616,14 @@ public final class Sentry {
     // TODO: read values from conf file, Build conf or system envs
     // eg release, distinctId, sentryClientName
 
-    // this should be after setting serializers
-    final String outboxPath = options.getOutboxPath();
-    if (outboxPath != null) {
-      final File outboxDir = new File(outboxPath);
-      outboxDir.mkdirs();
-    } else {
+    // The outbox and cache dirs are created lazily by their consumers (envelope cache, outbox file
+    // observer, native SDK) off the init thread, so we don't stat/mkdir them here.
+    if (options.getOutboxPath() == null) {
       logger.log(SentryLevel.INFO, "No outbox dir path is defined in options.");
     }
 
     final String cacheDirPath = options.getCacheDirPath();
     if (cacheDirPath != null) {
-      final File cacheDir = new File(cacheDirPath);
-      cacheDir.mkdirs();
       final IEnvelopeCache envelopeCache = options.getEnvelopeDiskCache();
       // only overwrite the cache impl if it's not already set
       if (envelopeCache instanceof NoOpEnvelopeCache) {

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -24,6 +24,7 @@ import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.DebugMetaPropertiesApplier;
 import io.sentry.util.FileUtils;
 import io.sentry.util.InitUtil;
+import io.sentry.util.LazyDirectory;
 import io.sentry.util.LoadClass;
 import io.sentry.util.Platform;
 import io.sentry.util.SentryRandom;
@@ -463,8 +464,9 @@ public final class Sentry {
           () -> {
             final String cacheDirPath = options.getCacheDirPathWithoutDsn();
             if (cacheDirPath != null) {
+              final @NotNull LazyDirectory cacheDir = new LazyDirectory(cacheDirPath);
               final @NotNull File appStartProfilingConfigFile =
-                  new File(cacheDirPath, APP_START_PROFILING_CONFIG_FILE_NAME);
+                  new File(cacheDir.getFile(), APP_START_PROFILING_CONFIG_FILE_NAME);
               try {
                 // We always delete the config file for app start profiling
                 FileUtils.deleteRecursively(appStartProfilingConfigFile);
@@ -481,6 +483,9 @@ public final class Sentry {
                           "Tracing is disabled and app start profiling will not start.");
                   return;
                 }
+                // The cache dir is no longer created during init, so materialize it here before
+                // writing: createNewFile() fails if the parent is missing.
+                cacheDir.getOrCreate();
                 if (appStartProfilingConfigFile.createNewFile()) {
                   // If old app start profiling is false, it means the transaction will not be
                   // sampled, but we create the file anyway to allow continuous profiling on app

--- a/sentry/src/main/java/io/sentry/Sentry.java
+++ b/sentry/src/main/java/io/sentry/Sentry.java
@@ -24,7 +24,6 @@ import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.DebugMetaPropertiesApplier;
 import io.sentry.util.FileUtils;
 import io.sentry.util.InitUtil;
-import io.sentry.util.LazyDirectory;
 import io.sentry.util.LoadClass;
 import io.sentry.util.Platform;
 import io.sentry.util.SentryRandom;
@@ -464,9 +463,9 @@ public final class Sentry {
           () -> {
             final String cacheDirPath = options.getCacheDirPathWithoutDsn();
             if (cacheDirPath != null) {
-              final @NotNull LazyDirectory cacheDir = new LazyDirectory(cacheDirPath);
+              final @NotNull File cacheDir = new File(cacheDirPath);
               final @NotNull File appStartProfilingConfigFile =
-                  new File(cacheDir.getFile(), APP_START_PROFILING_CONFIG_FILE_NAME);
+                  new File(cacheDir, APP_START_PROFILING_CONFIG_FILE_NAME);
               try {
                 // We always delete the config file for app start profiling
                 FileUtils.deleteRecursively(appStartProfilingConfigFile);
@@ -483,9 +482,14 @@ public final class Sentry {
                           "Tracing is disabled and app start profiling will not start.");
                   return;
                 }
-                // The cache dir is no longer created during init, so materialize it here before
-                // writing: createNewFile() fails if the parent is missing.
-                cacheDir.getOrCreate();
+                // The cache dir is no longer created during init, so create it here before writing:
+                // createNewFile() fails if the parent is missing.
+                if (!FileUtils.createDirectory(cacheDir)) {
+                  options
+                      .getLogger()
+                      .log(SentryLevel.ERROR, "Failed to create cache dir %s", cacheDirPath);
+                  return;
+                }
                 if (appStartProfilingConfigFile.createNewFile()) {
                   // If old app start profiling is false, it means the transaction will not be
                   // sampled, but we create the file anyway to allow continuous profiling on app

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -1104,7 +1104,11 @@ public class SentryOptions {
   }
 
   /**
-   * Returns the outbox path if cacheDirPath is set
+   * Returns the outbox path if cacheDirPath is set.
+   *
+   * <p>The directory is created lazily by the SDK on a background thread, so it is not guaranteed
+   * to exist when {@code Sentry.init} returns. Callers writing envelopes here directly (for example
+   * hybrid SDKs) must create it themselves, e.g. {@code new File(outboxPath).mkdirs()}.
    *
    * @return the outbox path or null if not set
    */

--- a/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
@@ -10,6 +10,7 @@ import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
 import io.sentry.Session;
 import io.sentry.clientreport.DiscardReason;
+import io.sentry.util.LazyDirectory;
 import io.sentry.util.LazyEvaluator;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
@@ -39,7 +40,7 @@ abstract class CacheStrategy {
   protected @NotNull SentryOptions options;
   protected final @NotNull LazyEvaluator<ISerializer> serializer =
       new LazyEvaluator<>(() -> options.getSerializer());
-  protected final @NotNull File directory;
+  protected final @NotNull LazyDirectory directory;
   private final int maxSize;
 
   CacheStrategy(
@@ -49,7 +50,7 @@ abstract class CacheStrategy {
     Objects.requireNonNull(directoryPath, "Directory is required.");
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
 
-    this.directory = new File(directoryPath);
+    this.directory = new LazyDirectory(directoryPath);
 
     this.maxSize = maxSize;
   }
@@ -60,13 +61,12 @@ abstract class CacheStrategy {
    * @return true if valid and has permissions or false otherwise
    */
   protected boolean isDirectoryValid() {
-    if (!directory.isDirectory() || !directory.canWrite() || !directory.canRead()) {
+    final File dir = directory.getFile();
+    if (!dir.isDirectory() || !dir.canWrite() || !dir.canRead()) {
       options
           .getLogger()
           .log(
-              ERROR,
-              "The directory for caching files is inaccessible.: %s",
-              directory.getAbsolutePath());
+              ERROR, "The directory for caching files is inaccessible.: %s", dir.getAbsolutePath());
       return false;
     }
     return true;

--- a/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
@@ -45,10 +45,11 @@ abstract class CacheStrategy {
 
   CacheStrategy(
       final @NotNull SentryOptions options,
-      final @NotNull LazyDirectory directory,
+      final @NotNull String directoryPath,
       final int maxSize) {
+    Objects.requireNonNull(directoryPath, "Directory is required.");
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
-    this.directory = Objects.requireNonNull(directory, "Directory is required.");
+    this.directory = new LazyDirectory(directoryPath);
     this.maxSize = maxSize;
   }
 

--- a/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
+++ b/sentry/src/main/java/io/sentry/cache/CacheStrategy.java
@@ -45,13 +45,10 @@ abstract class CacheStrategy {
 
   CacheStrategy(
       final @NotNull SentryOptions options,
-      final @NotNull String directoryPath,
+      final @NotNull LazyDirectory directory,
       final int maxSize) {
-    Objects.requireNonNull(directoryPath, "Directory is required.");
     this.options = Objects.requireNonNull(options, "SentryOptions is required.");
-
-    this.directory = new LazyDirectory(directoryPath);
-
+    this.directory = Objects.requireNonNull(directory, "Directory is required.");
     this.maxSize = maxSize;
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -26,7 +26,6 @@ import io.sentry.hints.SessionStart;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HintUtils;
-import io.sentry.util.LazyDirectory;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -84,7 +83,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       options.getLogger().log(WARNING, "cacheDirPath is null, returning NoOpEnvelopeCache");
       return NoOpEnvelopeCache.getInstance();
     } else {
-      return new EnvelopeCache(options, new LazyDirectory(cacheDirPath), maxCacheItems);
+      return new EnvelopeCache(options, cacheDirPath, maxCacheItems);
     }
   }
 
@@ -92,14 +91,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       final @NotNull SentryOptions options,
       final @NotNull String cacheDirPath,
       final int maxCacheItems) {
-    this(options, new LazyDirectory(cacheDirPath), maxCacheItems);
-  }
-
-  public EnvelopeCache(
-      final @NotNull SentryOptions options,
-      final @NotNull LazyDirectory directory,
-      final int maxCacheItems) {
-    super(options, directory, maxCacheItems);
+    super(options, cacheDirPath, maxCacheItems);
     previousSessionLatch = new CountDownLatch(1);
   }
 
@@ -396,7 +388,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         fileNameMap.put(envelope, fileName);
       }
 
-      return new File(directory.getFile().getAbsolutePath(), fileName);
+      return directory.resolve(fileName);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -109,6 +109,11 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
   private boolean storeInternal(final @NotNull SentryEnvelope envelope, final @NotNull Hint hint) {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
+    // Create the cache dir lazily on the first write so Sentry.init doesn't block on the mkdirs.
+    if (!directory.isDirectory()) {
+      directory.mkdirs();
+    }
+
     rotateCacheIfNeeded(allEnvelopeFiles());
 
     final File currentSessionFile = getCurrentSessionFile(directory.getAbsolutePath());

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -110,14 +110,12 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
     // Create the cache dir lazily on the first write so Sentry.init doesn't block on the mkdirs.
-    if (!directory.isDirectory()) {
-      directory.mkdirs();
-    }
+    final String directoryPath = directory.getOrCreate().getAbsolutePath();
 
     rotateCacheIfNeeded(allEnvelopeFiles());
 
-    final File currentSessionFile = getCurrentSessionFile(directory.getAbsolutePath());
-    final File previousSessionFile = getPreviousSessionFile(directory.getAbsolutePath());
+    final File currentSessionFile = getCurrentSessionFile(directoryPath);
+    final File previousSessionFile = getPreviousSessionFile(directoryPath);
 
     if (HintUtils.hasType(hint, SessionEnd.class)) {
       if (!currentSessionFile.delete()) {
@@ -204,7 +202,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
   @SuppressWarnings("JavaUtilDate")
   private void tryEndPreviousSession(final @NotNull Hint hint) {
     final Object sdkHint = HintUtils.getSentrySdkHint(hint);
-    final File previousSessionFile = getPreviousSessionFile(directory.getAbsolutePath());
+    final File previousSessionFile = getPreviousSessionFile(directory.getFile().getAbsolutePath());
 
     if (previousSessionFile.exists()) {
       options.getLogger().log(WARNING, "Previous session is not ended, we'd need to end it.");
@@ -390,7 +388,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         fileNameMap.put(envelope, fileName);
       }
 
-      return new File(directory.getAbsolutePath(), fileName);
+      return new File(directory.getFile().getAbsolutePath(), fileName);
     }
   }
 
@@ -436,7 +434,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     if (isDirectoryValid()) {
       // lets filter the session.json here
       final File[] files =
-          directory.listFiles((__, fileName) -> fileName.endsWith(SUFFIX_ENVELOPE_FILE));
+          directory.getFile().listFiles((__, fileName) -> fileName.endsWith(SUFFIX_ENVELOPE_FILE));
       if (files != null) {
         return files;
       }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -26,6 +26,7 @@ import io.sentry.hints.SessionStart;
 import io.sentry.transport.NoOpEnvelopeCache;
 import io.sentry.util.AutoClosableReentrantLock;
 import io.sentry.util.HintUtils;
+import io.sentry.util.LazyDirectory;
 import io.sentry.util.Objects;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -83,7 +84,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       options.getLogger().log(WARNING, "cacheDirPath is null, returning NoOpEnvelopeCache");
       return NoOpEnvelopeCache.getInstance();
     } else {
-      return new EnvelopeCache(options, cacheDirPath, maxCacheItems);
+      return new EnvelopeCache(options, new LazyDirectory(cacheDirPath), maxCacheItems);
     }
   }
 
@@ -91,7 +92,14 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       final @NotNull SentryOptions options,
       final @NotNull String cacheDirPath,
       final int maxCacheItems) {
-    super(options, cacheDirPath, maxCacheItems);
+    this(options, new LazyDirectory(cacheDirPath), maxCacheItems);
+  }
+
+  public EnvelopeCache(
+      final @NotNull SentryOptions options,
+      final @NotNull LazyDirectory directory,
+      final int maxCacheItems) {
+    super(options, directory, maxCacheItems);
     previousSessionLatch = new CountDownLatch(1);
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -375,6 +375,10 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
    * Returns the envelope's file path. If the envelope wasn't added to the cache beforehand, a
    * random file name is assigned.
    *
+   * <p>This only computes a path and never creates the directory, so that {@link
+   * #discard(SentryEnvelope)} doesn't resurrect a cache dir it is only deleting from. Writers go
+   * through {@link #storeInternal}, which creates the directory up front.
+   *
    * @param envelope the SentryEnvelope object
    * @return the file
    */
@@ -388,7 +392,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
         fileNameMap.put(envelope, fileName);
       }
 
-      return directory.resolve(fileName);
+      return new File(directory.getFile(), fileName);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/util/FileUtils.java
+++ b/sentry/src/main/java/io/sentry/util/FileUtils.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
@@ -34,6 +35,19 @@ public final class FileUtils {
       if (!deleteRecursively(f)) return false;
     }
     return file.delete();
+  }
+
+  /**
+   * Creates the directory and any missing parents, if it does not exist yet.
+   *
+   * <p>Callers are expected to log a failure: a missing directory otherwise surfaces later as an
+   * unrelated-looking write error.
+   *
+   * @param directory the directory to create
+   * @return true if the directory exists once this returns, false if it could not be created
+   */
+  public static boolean createDirectory(final @NotNull File directory) {
+    return directory.isDirectory() || directory.mkdirs();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/util/FileUtils.java
+++ b/sentry/src/main/java/io/sentry/util/FileUtils.java
@@ -47,7 +47,9 @@ public final class FileUtils {
    * @return true if the directory exists once this returns, false if it could not be created
    */
   public static boolean createDirectory(final @NotNull File directory) {
-    return directory.isDirectory() || directory.mkdirs();
+    // mkdirs() also returns false when another thread created the directory first, so re-check
+    // instead of reporting a failure the caller would act on by skipping its write.
+    return directory.isDirectory() || directory.mkdirs() || directory.isDirectory();
   }
 
   /**

--- a/sentry/src/main/java/io/sentry/util/LazyDirectory.java
+++ b/sentry/src/main/java/io/sentry/util/LazyDirectory.java
@@ -10,9 +10,9 @@ import org.jetbrains.annotations.NotNull;
  * init thread.
  *
  * <p>Read paths should use {@link #getFile()}, which never touches the filesystem. Write paths
- * should use {@link #resolve(String)} so the directory is guaranteed to exist before the file is
- * written to. Creation is not cached: on Android the cache dir lives under {@code
- * Context.getCacheDir()}, which the system may wipe at any time, so each write re-checks.
+ * should call {@link #getOrCreate()} once before writing. Creation is not cached: on Android the
+ * cache dir lives under {@code Context.getCacheDir()}, which the system may wipe at any time, so
+ * each write re-checks.
  */
 @ApiStatus.Internal
 public final class LazyDirectory {
@@ -32,13 +32,5 @@ public final class LazyDirectory {
   public @NotNull File getOrCreate() {
     FileUtils.createDirectory(file);
     return file;
-  }
-
-  /**
-   * Returns a file inside this directory, creating the directory first so the returned file can be
-   * written to.
-   */
-  public @NotNull File resolve(final @NotNull String child) {
-    return new File(getOrCreate(), child);
   }
 }

--- a/sentry/src/main/java/io/sentry/util/LazyDirectory.java
+++ b/sentry/src/main/java/io/sentry/util/LazyDirectory.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
  * A filesystem directory that is created on demand rather than up front, so the (potentially
  * blocking) {@code mkdirs()} runs on the thread that first writes into it instead of on the SDK
  * init thread.
+ *
+ * <p>Read paths should use {@link #getFile()}, which never touches the filesystem. Write paths
+ * should use {@link #resolve(String)} so the directory is guaranteed to exist before the file is
+ * written to. Creation is not cached: on Android the cache dir lives under {@code
+ * Context.getCacheDir()}, which the system may wipe at any time, so each write re-checks.
  */
 @ApiStatus.Internal
 public final class LazyDirectory {
@@ -25,9 +30,15 @@ public final class LazyDirectory {
 
   /** Returns the directory, creating it and any missing parents if it does not exist yet. */
   public @NotNull File getOrCreate() {
-    if (!file.isDirectory()) {
-      file.mkdirs();
-    }
+    FileUtils.createDirectory(file);
     return file;
+  }
+
+  /**
+   * Returns a file inside this directory, creating the directory first so the returned file can be
+   * written to.
+   */
+  public @NotNull File resolve(final @NotNull String child) {
+    return new File(getOrCreate(), child);
   }
 }

--- a/sentry/src/main/java/io/sentry/util/LazyDirectory.java
+++ b/sentry/src/main/java/io/sentry/util/LazyDirectory.java
@@ -30,6 +30,8 @@ public final class LazyDirectory {
 
   /** Returns the directory, creating it and any missing parents if it does not exist yet. */
   public @NotNull File getOrCreate() {
+    // A failed mkdirs is not reported here: callers are write paths, so the failure surfaces as the
+    // write error they already log and report.
     FileUtils.createDirectory(file);
     return file;
   }

--- a/sentry/src/main/java/io/sentry/util/LazyDirectory.java
+++ b/sentry/src/main/java/io/sentry/util/LazyDirectory.java
@@ -1,0 +1,33 @@
+package io.sentry.util;
+
+import java.io.File;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A filesystem directory that is created on demand rather than up front, so the (potentially
+ * blocking) {@code mkdirs()} runs on the thread that first writes into it instead of on the SDK
+ * init thread.
+ */
+@ApiStatus.Internal
+public final class LazyDirectory {
+
+  private final @NotNull File file;
+
+  public LazyDirectory(final @NotNull String path) {
+    this.file = new File(path);
+  }
+
+  /** Returns the directory without touching the filesystem. */
+  public @NotNull File getFile() {
+    return file;
+  }
+
+  /** Returns the directory, creating it and any missing parents if it does not exist yet. */
+  public @NotNull File getOrCreate() {
+    if (!file.isDirectory()) {
+      file.mkdirs();
+    }
+    return file;
+  }
+}

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -183,7 +183,7 @@ class SentryTest {
   }
 
   @Test
-  fun `outboxPath should be created at initialization`() {
+  fun `outboxPath is not created during initialization`() {
     var sentryOptions: SentryOptions? = null
     initForTest {
       it.dsn = dsn
@@ -191,13 +191,13 @@ class SentryTest {
       sentryOptions = it
     }
 
+    // The outbox dir is created lazily by its consumers (file observer, native SDK), not at init.
     val file = File(sentryOptions!!.outboxPath!!)
-    assertTrue(file.exists())
-    file.deleteOnExit()
+    assertFalse(file.exists())
   }
 
   @Test
-  fun `cacheDirPath should be created at initialization`() {
+  fun `cacheDirPath is not created during initialization`() {
     var sentryOptions: SentryOptions? = null
     initForTest {
       it.dsn = dsn
@@ -205,13 +205,13 @@ class SentryTest {
       sentryOptions = it
     }
 
+    // The cache dir is created lazily on the first envelope store, not at init.
     val file = File(sentryOptions!!.cacheDirPath!!)
-    assertTrue(file.exists())
-    file.deleteOnExit()
+    assertFalse(file.exists())
   }
 
   @Test
-  fun `getCacheDirPathWithoutDsn should be created at initialization`() {
+  fun `cacheDirPathWithoutDsn is not created during initialization`() {
     var sentryOptions: SentryOptions? = null
     initForTest {
       it.dsn = dsn
@@ -221,8 +221,7 @@ class SentryTest {
 
     val cacheDirPathWithoutDsn = sentryOptions!!.cacheDirPathWithoutDsn!!
     val file = File(cacheDirPathWithoutDsn)
-    assertTrue(file.exists())
-    file.deleteOnExit()
+    assertFalse(file.exists())
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/SentryTest.kt
+++ b/sentry/src/test/java/io/sentry/SentryTest.kt
@@ -1317,6 +1317,23 @@ class SentryTest {
   }
 
   @Test
+  fun `init creates app start profiling config when the cache dir does not exist yet`() {
+    val path = getTempPath()
+    // Profiling is left disabled on purpose: it is the only other init-time consumer that creates
+    // the cache dir, so with it off nothing materializes the dir before the config is written.
+    initForTest {
+      it.dsn = dsn
+      it.cacheDirPath = path
+      it.isEnableAppStartProfiling = false
+      it.isStartProfilerOnAppStart = true
+      it.tracesSampleRate = 0.0
+      it.profilesSampleRate = null
+      it.executorService = ImmediateExecutorService()
+    }
+    assertTrue(File(path, "app_start_profiling_config").exists())
+  }
+
+  @Test
   fun `init saves SentryAppStartProfilingOptions to disk`() {
     var options = SentryOptions()
     val path = getTempPath()

--- a/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
@@ -9,6 +9,7 @@ import io.sentry.Session
 import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
+import io.sentry.util.LazyDirectory
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStreamReader
@@ -130,7 +131,7 @@ class CacheStrategyTest {
   }
 
   private class CustomCache(options: SentryOptions, path: String, maxSize: Int) :
-    CacheStrategy(options, path, maxSize)
+    CacheStrategy(options, LazyDirectory(path), maxSize)
 
   private fun createTempFilesSortByOldestToNewest(): Array<File> {
     val f1 = Files.createTempFile(fixture.dir.toPath(), "f1", ".json").toFile()

--- a/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/CacheStrategyTest.kt
@@ -9,7 +9,6 @@ import io.sentry.Session
 import io.sentry.clientreport.ClientReportTestHelper.Companion.assertClientReport
 import io.sentry.clientreport.DiscardReason
 import io.sentry.clientreport.DiscardedEvent
-import io.sentry.util.LazyDirectory
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStreamReader
@@ -131,7 +130,7 @@ class CacheStrategyTest {
   }
 
   private class CustomCache(options: SentryOptions, path: String, maxSize: Int) :
-    CacheStrategy(options, LazyDirectory(path), maxSize)
+    CacheStrategy(options, path, maxSize)
 
   private fun createTempFilesSortByOldestToNewest(): Array<File> {
     val f1 = Files.createTempFile(fixture.dir.toPath(), "f1", ".json").toFile()

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -466,7 +466,7 @@ class EnvelopeCacheTest {
     cache.store(envelopeA, Hint())
     cache.store(envelopeB, Hint())
 
-    assertEquals(2, cache.directory.list()?.size)
+    assertEquals(2, cache.directory.file.list()?.size)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -105,6 +105,19 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `does not create cache dir on discard`() {
+    val cache = fixture.getSUT()
+
+    val file = File(fixture.options.cacheDirPath!!)
+    assertTrue(file.deleteRecursively())
+    assertFalse(file.exists())
+
+    cache.discard(SentryEnvelope.from(fixture.options.serializer, createSession(), null))
+
+    assertFalse(file.exists())
+  }
+
+  @Test
   fun `creates current file on session start`() {
     val cache = fixture.getSUT()
 

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -80,6 +80,22 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `creates cache dir on store when it does not exist yet`() {
+    val cache = fixture.getSUT()
+
+    val file = File(fixture.options.cacheDirPath!!)
+    assertTrue(file.deleteRecursively())
+    assertFalse(file.exists())
+
+    cache.store(SentryEnvelope.from(fixture.options.serializer, createSession(), null))
+
+    assertTrue(file.exists())
+    assertEquals(1, file.list()?.size)
+
+    file.deleteRecursively()
+  }
+
+  @Test
   fun `tolerates discarding unknown envelope`() {
     val cache = fixture.getSUT()
 

--- a/sentry/src/test/java/io/sentry/util/FileUtilsTest.kt
+++ b/sentry/src/test/java/io/sentry/util/FileUtilsTest.kt
@@ -1,7 +1,10 @@
 package io.sentry.util
 
+import com.google.common.truth.Truth.assertThat
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -72,5 +75,52 @@ class FileUtilsTest {
     val text = "Lorem ipsum dolor sit amet\nLorem ipsum dolor sit amet"
     f.writeText(text)
     assertEquals(text, FileUtils.readText(f))
+  }
+
+  @Test
+  fun `createDirectory creates the directory and any missing parents`() {
+    val dir = File(Files.createTempDirectory("create-dir-test").toFile(), "nested/outbox")
+
+    assertThat(FileUtils.createDirectory(dir)).isTrue()
+    assertThat(dir.isDirectory).isTrue()
+  }
+
+  @Test
+  fun `createDirectory returns true when the directory already exists`() {
+    val dir = Files.createTempDirectory("create-dir-test").toFile()
+
+    assertThat(FileUtils.createDirectory(dir)).isTrue()
+  }
+
+  @Test
+  fun `createDirectory returns false when the directory cannot be created`() {
+    val file = Files.createTempFile("create-dir-test", "test").toFile()
+
+    // a regular file already occupies the path, so it can never become a directory
+    assertThat(FileUtils.createDirectory(file)).isFalse()
+  }
+
+  @Test
+  fun `createDirectory returns true for every caller when threads race to create it`() {
+    val threadCount = 8
+    // mkdirs() returns false for the losers of the race, so every caller must still see success
+    repeat(50) { iteration ->
+      val dir = File(Files.createTempDirectory("create-dir-race").toFile(), "run$iteration/outbox")
+      val barrier = CyclicBarrier(threadCount)
+      val results = ConcurrentLinkedQueue<Boolean>()
+
+      val threads =
+        (1..threadCount).map {
+          Thread {
+            barrier.await()
+            results.add(FileUtils.createDirectory(dir))
+          }
+        }
+      threads.forEach { it.start() }
+      threads.forEach { it.join() }
+
+      assertThat(results).hasSize(threadCount)
+      assertThat(results).doesNotContain(false)
+    }
   }
 }

--- a/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
@@ -32,4 +32,25 @@ class LazyDirectoryTest {
     assertThat(lazyDirectory.getOrCreate().isDirectory).isTrue()
     assertThat(lazyDirectory.getOrCreate().isDirectory).isTrue()
   }
+
+  @Test
+  fun `resolve creates the directory so the child can be written to`() {
+    val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
+    val lazyDirectory = LazyDirectory(path.toString())
+
+    val child = lazyDirectory.resolve("envelope.envelope")
+
+    assertThat(child.parentFile.isDirectory).isTrue()
+    assertThat(child.createNewFile()).isTrue()
+  }
+
+  @Test
+  fun `getOrCreate recreates the directory after it is deleted`() {
+    val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
+    val lazyDirectory = LazyDirectory(path.toString())
+
+    assertThat(lazyDirectory.getOrCreate().delete()).isTrue()
+
+    assertThat(lazyDirectory.getOrCreate().isDirectory).isTrue()
+  }
 }

--- a/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
@@ -34,17 +34,6 @@ class LazyDirectoryTest {
   }
 
   @Test
-  fun `resolve creates the directory so the child can be written to`() {
-    val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
-    val lazyDirectory = LazyDirectory(path.toString())
-
-    val child = lazyDirectory.resolve("envelope.envelope")
-
-    assertThat(child.parentFile.isDirectory).isTrue()
-    assertThat(child.createNewFile()).isTrue()
-  }
-
-  @Test
   fun `getOrCreate recreates the directory after it is deleted`() {
     val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
     val lazyDirectory = LazyDirectory(path.toString())

--- a/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
+++ b/sentry/src/test/java/io/sentry/util/LazyDirectoryTest.kt
@@ -1,0 +1,35 @@
+package io.sentry.util
+
+import com.google.common.truth.Truth.assertThat
+import java.nio.file.Files
+import kotlin.test.Test
+
+class LazyDirectoryTest {
+  @Test
+  fun `getFile does not create the directory`() {
+    val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
+    val lazyDirectory = LazyDirectory(path.toString())
+
+    assertThat(lazyDirectory.file.exists()).isFalse()
+  }
+
+  @Test
+  fun `getOrCreate creates the directory and any missing parents`() {
+    val path = Files.createTempDirectory("lazy-dir-test").resolve("nested").resolve("outbox")
+    val lazyDirectory = LazyDirectory(path.toString())
+
+    val created = lazyDirectory.getOrCreate()
+
+    assertThat(created.isDirectory).isTrue()
+    assertThat(created.absolutePath).isEqualTo(path.toFile().absolutePath)
+  }
+
+  @Test
+  fun `getOrCreate is idempotent when the directory already exists`() {
+    val path = Files.createTempDirectory("lazy-dir-test").resolve("outbox")
+    val lazyDirectory = LazyDirectory(path.toString())
+
+    assertThat(lazyDirectory.getOrCreate().isDirectory).isTrue()
+    assertThat(lazyDirectory.getOrCreate().isDirectory).isTrue()
+  }
+}


### PR DESCRIPTION
## :scroll: Description

`Sentry.initConfigurations` created the outbox and cache directories synchronously via `mkdirs()` on the init thread — which on Android is the main thread. This moves both off the synchronous init path by creating each directory lazily in its consumer:

- **Cache dir** — created at the start of `EnvelopeCache.storeInternal`, so the first envelope write (on the transport thread) creates it. Covers envelopes, sessions, crash markers, and the Android ANR/tombstone markers, which all live under `cacheDirPath`.
- **Outbox dir** — created in `EnvelopeFileObserverIntegration.startOutboxSender` (runs on the executor) before `startWatching()`, and before writing the startup-crash marker in `AndroidEnvelopeCache`. The native SDK already creates the outbox dir itself during `sentry_init`, so NDK crash writes are unaffected.

### :warning: Behavior change for outbox writers

Previously `Sentry.init` created the outbox dir synchronously, so it was guaranteed to exist once `init` returned. It is now created on the SDK executor, so anything writing envelopes into the outbox itself must create the dir first (`new File(outboxPath).mkdirs()`). I checked RN, Flutter, Unity and none of them should be affected by this. Native was fixed in 0.16.0 and that is already merged.

## :bulb: Motivation and Context

This can cause ANRs as we are blocking the main thread with disk I/O during startup.

## :green_heart: How did you test it?

Relying on integration tests for this. Some of them failed with this integration. I also asked JR which other SDKs might be affected by this.

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Verify the init-time improvement as a batch via Perfetto/macrobenchmark (individually below noise).




