### PR TITLE
feat(android): Add internal non-terminating envelope capture 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed`. The session is kept alive, marked pending-unhandled, and finalized as `unhandled` on session end (or `crashed` if a native crash follows). The existing `captureEnvelope(byte[], boolean)` behavior is unchanged. ([#XXXX](https://github.com/getsentry/sentry-java/pull/XXXX))
+
 ## 8.49.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed`. The session is kept alive, marked pending-unhandled, and finalized as `unhandled` on session end (or `crashed` if a native crash follows). The existing `captureEnvelope(byte[], boolean)` behavior is unchanged. ([#XXXX](https://github.com/getsentry/sentry-java/pull/XXXX))
+- Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid SDKs (e.g. Flutter) so unhandled exceptions that don't terminate the process no longer end the session as `crashed`. The session is kept alive, marked pending-unhandled, and finalized as `unhandled` on session end (or `crashed` if a native crash follows). The existing `captureEnvelope(byte[], boolean)` behavior is unchanged. ([#5795](https://github.com/getsentry/sentry-java/pull/5795))
 
 ## 8.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ### Fixes
 
 - Backfill release, environment, distribution, tags, and app version/build—and use the matching replay-on-error sample rate—for `ApplicationExitInfo` ANR and native crash events captured before SDK initialization, without reusing options cached by a later app update ([#5762](https://github.com/getsentry/sentry-java/pull/5762))

--- a/sentry-android-core/api/sentry-android-core.api
+++ b/sentry-android-core/api/sentry-android-core.api
@@ -315,6 +315,7 @@ public abstract interface class io/sentry/android/core/IDebugImagesLoader {
 public final class io/sentry/android/core/InternalSentrySdk {
 	public fun <init> ()V
 	public static fun captureEnvelope ([BZ)Lio/sentry/protocol/SentryId;
+	public static fun captureEnvelopeNonTerminating ([B)Lio/sentry/protocol/SentryId;
 	public static fun getAppStartMeasurement ()Ljava/util/Map;
 	public static fun getCurrentScope ()Lio/sentry/IScope;
 	public static fun serializeScope (Landroid/content/Context;Lio/sentry/android/core/SentryAndroidOptions;Lio/sentry/IScope;)Ljava/util/Map;

--- a/sentry-android-core/build.gradle.kts
+++ b/sentry-android-core/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
   testImplementation(libs.androidx.test.ext.junit)
   testImplementation(libs.androidx.test.runner)
   testImplementation(libs.awaitility.kotlin)
+  testImplementation(libs.google.truth)
   testImplementation(libs.mockito.kotlin)
   testImplementation(libs.mockito.inline)
   testImplementation(projects.sentryTestSupport)

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -40,7 +40,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,9 +54,6 @@ import org.jetbrains.annotations.Nullable;
 /** Sentry SDK internal API methods meant for being used by the Sentry Hybrid SDKs. */
 @ApiStatus.Internal
 public final class InternalSentrySdk {
-
-  @SuppressWarnings("CharsetObjectCanBeUsed")
-  private static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
 
   /**
    * @return a copy of the current scopes's topmost scope, or null in case the scopes is disabled
@@ -174,7 +171,58 @@ public final class InternalSentrySdk {
   @Nullable
   public static SentryId captureEnvelope(
       final @NotNull byte[] envelopeData, final boolean maybeStartNewSession) {
-    return captureEnvelope(envelopeData, maybeStartNewSession, true);
+    final @NotNull IScopes scopes = ScopesAdapter.getInstance();
+    final @NotNull SentryOptions options = scopes.getOptions();
+
+    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
+      final @NotNull ISerializer serializer = options.getSerializer();
+      final @Nullable SentryEnvelope envelope =
+          options.getEnvelopeReader().read(envelopeInputStream);
+      if (envelope == null) {
+        return null;
+      }
+
+      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
+
+      // determine session state based on events inside envelope
+      @Nullable Session.State status = null;
+      boolean crashedOrErrored = false;
+      for (SentryEnvelopeItem item : envelope.getItems()) {
+        envelopeItems.add(item);
+
+        final SentryEvent event = item.getEvent(serializer);
+        if (event != null) {
+          if (event.isCrashed()) {
+            status = Session.State.Crashed;
+          }
+          if (event.isCrashed() || event.isErrored()) {
+            crashedOrErrored = true;
+          }
+        }
+      }
+
+      // update session and add it to envelope if necessary
+      final @Nullable Session session =
+          updateSession(scopes, options, status, crashedOrErrored, false);
+      if (session != null) {
+        final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
+        envelopeItems.add(sessionItem);
+        deleteCurrentSessionFile(
+            options,
+            // should be sync if going to crash or already not a main thread
+            !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
+        if (maybeStartNewSession) {
+          scopes.startSession();
+        }
+      }
+
+      final SentryEnvelope repackagedEnvelope =
+          new SentryEnvelope(envelope.getHeader(), envelopeItems);
+      return scopes.captureEnvelope(repackagedEnvelope);
+    } catch (Throwable t) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    }
+    return null;
   }
 
   /**
@@ -203,14 +251,6 @@ public final class InternalSentrySdk {
    */
   @Nullable
   public static SentryId captureEnvelopeNonTerminating(final @NotNull byte[] envelopeData) {
-    return captureEnvelope(envelopeData, false, false);
-  }
-
-  @Nullable
-  private static SentryId captureEnvelope(
-      final @NotNull byte[] envelopeData,
-      final boolean maybeStartNewSession,
-      final boolean isTerminating) {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
 
@@ -222,56 +262,48 @@ public final class InternalSentrySdk {
         return null;
       }
 
-      final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
-
-      // determine session state based on events inside envelope
-      @Nullable Session.State status = null;
-      boolean crashedOrErrored = false;
       boolean markPendingUnhandled = false;
+      boolean addErrorsCount = false;
       for (SentryEnvelopeItem item : envelope.getItems()) {
-        envelopeItems.add(item);
-
         final SentryEvent event = item.getEvent(serializer);
         if (event != null) {
+          // isCrashed() means mechanism.handled=false (unhandled exception), not that the
+          // process terminated. For e.g Flutter that distinction is why we only mark pending here.
           if (event.isCrashed()) {
-            if (isTerminating) {
-              status = Session.State.Crashed;
-            } else {
-              // non-terminating: don't crash the session, only remember the unhandled exception.
-              markPendingUnhandled = true;
-            }
-          }
-          if (event.isCrashed() || event.isErrored()) {
-            crashedOrErrored = true;
+            markPendingUnhandled = true;
+            addErrorsCount = true;
+          } else if (event.isErrored()) {
+            addErrorsCount = true;
           }
         }
       }
 
-      // update session and add it to envelope if necessary
-      final @Nullable Session session =
-          updateSession(scopes, options, status, crashedOrErrored, markPendingUnhandled);
-      if (session != null) {
-        if (isTerminating) {
-          final SentryEnvelopeItem sessionItem =
-              SentryEnvelopeItem.fromSession(serializer, session);
-          envelopeItems.add(sessionItem);
-          deleteCurrentSessionFile(
-              options,
-              // should be sync if going to crash or already not a main thread
-              !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
-          if (maybeStartNewSession) {
-            scopes.startSession();
-          }
-        } else {
-          // non-terminating: keep the (still Ok) session on the scope, don't attach a session
-          // update, and persist it so the pending-unhandled flag survives process death.
+      if (markPendingUnhandled || addErrorsCount) {
+        final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
+        final boolean pending = markPendingUnhandled;
+        final boolean addErrors = addErrorsCount;
+        scopes.configureScope(
+            scope -> {
+              final @Nullable Session session = scope.getSession();
+              if (session != null) {
+                if (pending) {
+                  session.setPendingUnhandled(true);
+                }
+                if (session.update(null, null, addErrors, null) || pending) {
+                  sessionRef.set(session);
+                }
+              } else {
+                options.getLogger().log(INFO, "Session is null on captureEnvelopeNonTerminating");
+              }
+            });
+        final @Nullable Session session = sessionRef.get();
+        if (session != null) {
           persistCurrentSession(options, session);
         }
       }
 
-      final SentryEnvelope repackagedEnvelope =
-          new SentryEnvelope(envelope.getHeader(), envelopeItems);
-      return scopes.captureEnvelope(repackagedEnvelope);
+      // Capture the original envelope as-is (no session item attached).
+      return scopes.captureEnvelope(envelope);
     } catch (Throwable t) {
       options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
     }
@@ -372,7 +404,7 @@ public final class InternalSentrySdk {
     final File sessionFile = EnvelopeCache.getCurrentSessionFile(cacheDirPath);
     try (final OutputStream outputStream = new FileOutputStream(sessionFile);
         final Writer writer =
-            new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8_CHARSET))) {
+            new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
       options.getSerializer().serialize(session, writer);
     } catch (Throwable e) {
       options.getLogger().log(WARNING, "Failed to persist the current session.", e);

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -260,9 +260,7 @@ public final class InternalSentrySdk {
       for (SentryEnvelopeItem item : envelope.getItems()) {
         final SentryEvent event = item.getEvent(serializer);
         if (event != null) {
-          // isCrashed() means mechanism.handled=false (unhandled exception), not that the
-          // process terminated. For e.g Flutter that distinction is why we only mark pending here.
-          if (event.isCrashed()) {
+          if (event.getUnhandledException() != null) {
             markPendingUnhandled = true;
             addErrorsCount = true;
           } else if (event.isErrored()) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -32,9 +32,15 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.util.MapObjectWriter;
 import io.sentry.util.TracingUtils;
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +54,9 @@ import org.jetbrains.annotations.Nullable;
 /** Sentry SDK internal API methods meant for being used by the Sentry Hybrid SDKs. */
 @ApiStatus.Internal
 public final class InternalSentrySdk {
+
+  @SuppressWarnings("CharsetObjectCanBeUsed")
+  private static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
 
   /**
    * @return a copy of the current scopes's topmost scope, or null in case the scopes is disabled
@@ -153,13 +162,55 @@ public final class InternalSentrySdk {
    * - will not perform any sampling: it's up to the caller to take care of this<br>
    * - will enrich the envelope with a Session update if applicable<br>
    *
+   * <p>Unhandled events ({@code handled=false}) end the session as {@code crashed}. Prefer {@link
+   * #captureEnvelopeNonTerminating(byte[])} for hybrid runtimes where the process is expected to
+   * continue (e.g. Flutter).
+   *
    * @param envelopeData the serialized envelope data
+   * @param maybeStartNewSession if true, starts a new session after a crashed session is cleared
    * @return The Id (SentryId object) of the event, or null in case the envelope could not be
    *     captured
    */
   @Nullable
   public static SentryId captureEnvelope(
       final @NotNull byte[] envelopeData, final boolean maybeStartNewSession) {
+    return captureEnvelope(envelopeData, maybeStartNewSession, true);
+  }
+
+  /**
+   * Captures the provided envelope for a non-terminating hybrid exception (e.g. Flutter).
+   *
+   * <p>Compared to {@link #captureEnvelope(byte[], boolean)} this method does <strong>not</strong>
+   * treat {@code handled=false} as a crash that ends the session. Instead it:
+   *
+   * <ul>
+   *   <li>marks the current session as pending-unhandled and increments the error count
+   *   <li>keeps session status {@code Ok} and the same session id on the scope
+   *   <li>does not attach a session update item to this envelope
+   *   <li>does not start a new session
+   *   <li>persists the current session so pending-unhandled survives process death
+   * </ul>
+   *
+   * <p>The session is finalized later by normal lifecycle ({@code endSession} / background /
+   * previous-session recovery) as {@code unhandled}, unless a native crash escalates it to {@code
+   * crashed}.
+   *
+   * <p>Same as {@link #captureEnvelope(byte[], boolean)}, this method will not enrich events, run
+   * {@code beforeSend}, or sample — the caller is responsible for that.
+   *
+   * @param envelopeData the serialized envelope data
+   * @return the id of the captured envelope, or null if capture failed
+   */
+  @Nullable
+  public static SentryId captureEnvelopeNonTerminating(final @NotNull byte[] envelopeData) {
+    return captureEnvelope(envelopeData, false, false);
+  }
+
+  @Nullable
+  private static SentryId captureEnvelope(
+      final @NotNull byte[] envelopeData,
+      final boolean maybeStartNewSession,
+      final boolean isTerminating) {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
 
@@ -176,13 +227,19 @@ public final class InternalSentrySdk {
       // determine session state based on events inside envelope
       @Nullable Session.State status = null;
       boolean crashedOrErrored = false;
+      boolean markPendingUnhandled = false;
       for (SentryEnvelopeItem item : envelope.getItems()) {
         envelopeItems.add(item);
 
         final SentryEvent event = item.getEvent(serializer);
         if (event != null) {
           if (event.isCrashed()) {
-            status = Session.State.Crashed;
+            if (isTerminating) {
+              status = Session.State.Crashed;
+            } else {
+              // non-terminating: don't crash the session, only remember the unhandled exception.
+              markPendingUnhandled = true;
+            }
           }
           if (event.isCrashed() || event.isErrored()) {
             crashedOrErrored = true;
@@ -191,16 +248,24 @@ public final class InternalSentrySdk {
       }
 
       // update session and add it to envelope if necessary
-      final @Nullable Session session = updateSession(scopes, options, status, crashedOrErrored);
+      final @Nullable Session session =
+          updateSession(scopes, options, status, crashedOrErrored, markPendingUnhandled);
       if (session != null) {
-        final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
-        envelopeItems.add(sessionItem);
-        deleteCurrentSessionFile(
-            options,
-            // should be sync if going to crash or already not a main thread
-            !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
-        if (maybeStartNewSession) {
-          scopes.startSession();
+        if (isTerminating) {
+          final SentryEnvelopeItem sessionItem =
+              SentryEnvelopeItem.fromSession(serializer, session);
+          envelopeItems.add(sessionItem);
+          deleteCurrentSessionFile(
+              options,
+              // should be sync if going to crash or already not a main thread
+              !maybeStartNewSession || !scopes.getOptions().getThreadChecker().isMainThread());
+          if (maybeStartNewSession) {
+            scopes.startSession();
+          }
+        } else {
+          // non-terminating: keep the (still Ok) session on the scope, don't attach a session
+          // update, and persist it so the pending-unhandled flag survives process death.
+          persistCurrentSession(options, session);
         }
       }
 
@@ -296,17 +361,40 @@ public final class InternalSentrySdk {
     }
   }
 
+  private static void persistCurrentSession(
+      final @NotNull SentryOptions options, final @NotNull Session session) {
+    final String cacheDirPath = options.getCacheDirPath();
+    if (cacheDirPath == null) {
+      options.getLogger().log(INFO, "Cache dir is not set, not persisting the current session.");
+      return;
+    }
+
+    final File sessionFile = EnvelopeCache.getCurrentSessionFile(cacheDirPath);
+    try (final OutputStream outputStream = new FileOutputStream(sessionFile);
+        final Writer writer =
+            new BufferedWriter(new OutputStreamWriter(outputStream, UTF_8_CHARSET))) {
+      options.getSerializer().serialize(session, writer);
+    } catch (Throwable e) {
+      options.getLogger().log(WARNING, "Failed to persist the current session.", e);
+    }
+  }
+
   @Nullable
   private static Session updateSession(
       final @NotNull IScopes scopes,
       final @NotNull SentryOptions options,
       final @Nullable Session.State status,
-      final boolean crashedOrErrored) {
+      final boolean crashedOrErrored,
+      final boolean markPendingUnhandled) {
     final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
     scopes.configureScope(
         scope -> {
           final @Nullable Session session = scope.getSession();
           if (session != null) {
+            if (markPendingUnhandled) {
+              // remember the unhandled (but non-terminal) exception; finalized later as Unhandled.
+              session.setPendingUnhandled(true);
+            }
             final boolean updated = session.update(status, null, crashedOrErrored, null);
             // if we have an uncaughtExceptionHint we can end the session.
             if (updated) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -32,15 +32,9 @@ import io.sentry.protocol.SentryId;
 import io.sentry.protocol.User;
 import io.sentry.util.MapObjectWriter;
 import io.sentry.util.TracingUtils;
-import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,8 +196,7 @@ public final class InternalSentrySdk {
       }
 
       // update session and add it to envelope if necessary
-      final @Nullable Session session =
-          updateSession(scopes, options, status, crashedOrErrored, false);
+      final @Nullable Session session = updateSession(scopes, options, status, crashedOrErrored);
       if (session != null) {
         final SentryEnvelopeItem sessionItem = SentryEnvelopeItem.fromSession(serializer, session);
         envelopeItems.add(sessionItem);
@@ -279,27 +272,28 @@ public final class InternalSentrySdk {
       }
 
       if (markPendingUnhandled || addErrorsCount) {
-        final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
         final boolean pending = markPendingUnhandled;
         final boolean addErrors = addErrorsCount;
         scopes.configureScope(
             scope -> {
-              final @Nullable Session session = scope.getSession();
-              if (session != null) {
-                if (pending) {
-                  session.setPendingUnhandled(true);
-                }
-                if (session.update(null, null, addErrors, null) || pending) {
-                  sessionRef.set(session);
-                }
-              } else {
-                options.getLogger().log(INFO, "Session is null on captureEnvelopeNonTerminating");
-              }
+              scope.withSession(
+                  session -> {
+                    if (session != null) {
+                      final boolean updated =
+                          pending
+                              ? session.markPendingUnhandled()
+                              : session.update(null, null, addErrors, null);
+                      if (updated && options.getEnvelopeDiskCache() instanceof EnvelopeCache) {
+                        ((EnvelopeCache) options.getEnvelopeDiskCache())
+                            .persistCurrentSession(session);
+                      }
+                    } else {
+                      options
+                          .getLogger()
+                          .log(INFO, "Session is null on captureEnvelopeNonTerminating");
+                    }
+                  });
             });
-        final @Nullable Session session = sessionRef.get();
-        if (session != null) {
-          persistCurrentSession(options, session);
-        }
       }
 
       // Capture the original envelope as-is (no session item attached).
@@ -393,40 +387,17 @@ public final class InternalSentrySdk {
     }
   }
 
-  private static void persistCurrentSession(
-      final @NotNull SentryOptions options, final @NotNull Session session) {
-    final String cacheDirPath = options.getCacheDirPath();
-    if (cacheDirPath == null) {
-      options.getLogger().log(INFO, "Cache dir is not set, not persisting the current session.");
-      return;
-    }
-
-    final File sessionFile = EnvelopeCache.getCurrentSessionFile(cacheDirPath);
-    try (final OutputStream outputStream = new FileOutputStream(sessionFile);
-        final Writer writer =
-            new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
-      options.getSerializer().serialize(session, writer);
-    } catch (Throwable e) {
-      options.getLogger().log(WARNING, "Failed to persist the current session.", e);
-    }
-  }
-
   @Nullable
   private static Session updateSession(
       final @NotNull IScopes scopes,
       final @NotNull SentryOptions options,
       final @Nullable Session.State status,
-      final boolean crashedOrErrored,
-      final boolean markPendingUnhandled) {
+      final boolean crashedOrErrored) {
     final @NotNull AtomicReference<Session> sessionRef = new AtomicReference<>();
     scopes.configureScope(
         scope -> {
           final @Nullable Session session = scope.getSession();
           if (session != null) {
-            if (markPendingUnhandled) {
-              // remember the unhandled (but non-terminal) exception; finalized later as Unhandled.
-              session.setPendingUnhandled(true);
-            }
             final boolean updated = session.update(status, null, crashedOrErrored, null);
             // if we have an uncaughtExceptionHint we can end the session.
             if (updated) {

--- a/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
+++ b/sentry-android-core/src/main/java/io/sentry/android/core/InternalSentrySdk.java
@@ -34,6 +34,7 @@ import io.sentry.util.MapObjectWriter;
 import io.sentry.util.TracingUtils;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -168,14 +169,13 @@ public final class InternalSentrySdk {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
 
-    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
-      final @NotNull ISerializer serializer = options.getSerializer();
-      final @Nullable SentryEnvelope envelope =
-          options.getEnvelopeReader().read(envelopeInputStream);
-      if (envelope == null) {
-        return null;
-      }
+    final @Nullable SentryEnvelope envelope = readEnvelope(options, envelopeData);
+    if (envelope == null) {
+      return null;
+    }
 
+    try {
+      final @NotNull ISerializer serializer = options.getSerializer();
       final @NotNull List<SentryEnvelopeItem> envelopeItems = new ArrayList<>();
 
       // determine session state based on events inside envelope
@@ -212,8 +212,8 @@ public final class InternalSentrySdk {
       final SentryEnvelope repackagedEnvelope =
           new SentryEnvelope(envelope.getHeader(), envelopeItems);
       return scopes.captureEnvelope(repackagedEnvelope);
-    } catch (Throwable t) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
   }
@@ -247,14 +247,13 @@ public final class InternalSentrySdk {
     final @NotNull IScopes scopes = ScopesAdapter.getInstance();
     final @NotNull SentryOptions options = scopes.getOptions();
 
-    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
-      final @NotNull ISerializer serializer = options.getSerializer();
-      final @Nullable SentryEnvelope envelope =
-          options.getEnvelopeReader().read(envelopeInputStream);
-      if (envelope == null) {
-        return null;
-      }
+    final @Nullable SentryEnvelope envelope = readEnvelope(options, envelopeData);
+    if (envelope == null) {
+      return null;
+    }
 
+    try {
+      final @NotNull ISerializer serializer = options.getSerializer();
       boolean markPendingUnhandled = false;
       boolean addErrorsCount = false;
       for (SentryEnvelopeItem item : envelope.getItems()) {
@@ -296,10 +295,25 @@ public final class InternalSentrySdk {
 
       // Capture the original envelope as-is (no session item attached).
       return scopes.captureEnvelope(envelope);
-    } catch (Throwable t) {
-      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", t);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to capture envelope", e);
     }
     return null;
+  }
+
+  /**
+   * Reads an envelope from the given bytes. Besides the declared {@link IOException}, {@link
+   * io.sentry.IEnvelopeReader#read(InputStream)} also rejects malformed payloads with an unchecked
+   * {@link IllegalArgumentException}, hence the broader catch.
+   */
+  private static @Nullable SentryEnvelope readEnvelope(
+      final @NotNull SentryOptions options, final @NotNull byte[] envelopeData) {
+    try (final InputStream envelopeInputStream = new ByteArrayInputStream(envelopeData)) {
+      return options.getEnvelopeReader().read(envelopeInputStream);
+    } catch (Exception e) {
+      options.getLogger().log(SentryLevel.ERROR, "Failed to read envelope", e);
+      return null;
+    }
   }
 
   public static Map<String, Object> getAppStartMeasurement() {

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -22,6 +22,7 @@ import io.sentry.Session
 import io.sentry.SpanId
 import io.sentry.android.core.performance.ActivityLifecycleTimeSpan
 import io.sentry.android.core.performance.AppStartMetrics
+import io.sentry.cache.EnvelopeCache
 import io.sentry.exception.ExceptionMechanismException
 import io.sentry.protocol.App
 import io.sentry.protocol.Contexts
@@ -105,6 +106,21 @@ class InternalSentrySdkTest {
       val data = outputStream.toByteArray()
 
       InternalSentrySdk.captureEnvelope(data, maybeStartNewSession)
+    }
+
+    fun captureEnvelopeNonTerminatingWithEvent(event: SentryEvent = SentryEvent()) {
+      val options = Sentry.getCurrentScopes().options
+      val eventId = SentryId()
+      val header = SentryEnvelopeHeader(eventId)
+      val eventItem = SentryEnvelopeItem.fromEvent(options.serializer, event)
+
+      val envelope = SentryEnvelope(header, listOf(eventItem))
+
+      val outputStream = ByteArrayOutputStream()
+      options.serializer.serialize(envelope, outputStream)
+      val data = outputStream.toByteArray()
+
+      InternalSentrySdk.captureEnvelopeNonTerminating(data)
     }
 
     fun createSentryEventWithUnhandledException(): SentryEvent {
@@ -450,6 +466,99 @@ class InternalSentrySdkTest {
 
     // and the local session should be a new session
     assertNotEquals(capturedSession.sessionId, scopeRef.get().session!!.sessionId)
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating keeps the session Ok and marks it pending unhandled`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    val originalSid = AtomicReference<String>()
+    Sentry.configureScope { scope -> originalSid.set(scope.session!!.sessionId) }
+
+    // when capture envelope is called with an unhandled event through the non-terminating API
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+
+    // then only the original event envelope is captured, without a session item
+    assertEquals(1, fixture.capturedEnvelopes.size)
+    val capturedEnvelopeItems = fixture.capturedEnvelopes.first().items.toList()
+    assertEquals(1, capturedEnvelopeItems.size)
+    assertEquals(SentryItemType.Event, capturedEnvelopeItems[0].header.type)
+
+    // and the session stays alive on the scope, same id, marked pending unhandled
+    val scopeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> scopeSession.set(scope.session) }
+    assertEquals(Session.State.Ok, scopeSession.get().status)
+    assertTrue(scopeSession.get().isPendingUnhandled)
+    assertEquals(originalSid.get(), scopeSession.get().sessionId)
+
+    // and it is persisted so pending survives process death
+    val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
+    assertEquals(Session.State.Ok, persistedSession.status)
+    assertTrue(persistedSession.isPendingUnhandled)
+    assertEquals(originalSid.get(), persistedSession.sessionId)
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating then endSession finalizes the session as unhandled`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+    fixture.capturedEnvelopes.clear()
+
+    // when the session is ended by normal lifecycle
+    Sentry.endSession()
+
+    // then the ended session is captured as unhandled
+    val sessionItems =
+      fixture.capturedEnvelopes
+        .flatMap { it.items.toList() }
+        .filter {
+          it.header.type == SentryItemType.Session
+        }
+    assertEquals(1, sessionItems.size)
+    val endedSession =
+      fixture.options.serializer.deserialize(
+        InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
+        Session::class.java,
+      )!!
+    assertEquals(Session.State.Unhandled, endedSession.status)
+  }
+
+  @Test
+  fun `captureEnvelopeNonTerminating then a crash finalizes the session as crashed`() {
+    val fixture = Fixture()
+    fixture.init(context)
+
+    fixture.captureEnvelopeNonTerminatingWithEvent(
+      fixture.createSentryEventWithUnhandledException()
+    )
+    fixture.capturedEnvelopes.clear()
+
+    // when a subsequent hard crash is captured through the terminating API
+    fixture.captureEnvelopeWithEvent(fixture.createSentryEventWithUnhandledException())
+
+    // then the crash wins over the pending unhandled state
+    val sessionItems =
+      fixture.capturedEnvelopes
+        .flatMap { it.items.toList() }
+        .filter {
+          it.header.type == SentryItemType.Session
+        }
+    assertEquals(1, sessionItems.size)
+    val crashedSession =
+      fixture.options.serializer.deserialize(
+        InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
+        Session::class.java,
+      )!!
+    assertEquals(Session.State.Crashed, crashedSession.status)
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -5,6 +5,7 @@ import android.content.ContentProvider
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import io.sentry.Breadcrumb
 import io.sentry.Hint
 import io.sentry.IScope
@@ -39,7 +40,6 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -483,25 +483,25 @@ class InternalSentrySdkTest {
     )
 
     // then only the original event envelope is captured, without a session item
-    assertEquals(1, fixture.capturedEnvelopes.size)
+    assertThat(fixture.capturedEnvelopes).hasSize(1)
     val capturedEnvelopeItems = fixture.capturedEnvelopes.first().items.toList()
-    assertEquals(1, capturedEnvelopeItems.size)
-    assertEquals(SentryItemType.Event, capturedEnvelopeItems[0].header.type)
+    assertThat(capturedEnvelopeItems).hasSize(1)
+    assertThat(capturedEnvelopeItems[0].header.type).isEqualTo(SentryItemType.Event)
 
     // and the session stays alive on the scope, same id, marked pending unhandled
     val scopeSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> scopeSession.set(scope.session) }
-    assertEquals(Session.State.Ok, scopeSession.get().status)
-    assertTrue(scopeSession.get().isPendingUnhandled)
-    assertEquals(originalSid.get(), scopeSession.get().sessionId)
+    assertThat(scopeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(scopeSession.get().isPendingUnhandled).isTrue()
+    assertThat(scopeSession.get().sessionId).isEqualTo(originalSid.get())
 
     // and it is persisted so pending survives process death
     val sessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
     val persistedSession =
       fixture.options.serializer.deserialize(sessionFile.reader(), Session::class.java)!!
-    assertEquals(Session.State.Ok, persistedSession.status)
-    assertTrue(persistedSession.isPendingUnhandled)
-    assertEquals(originalSid.get(), persistedSession.sessionId)
+    assertThat(persistedSession.status).isEqualTo(Session.State.Ok)
+    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.sessionId).isEqualTo(originalSid.get())
   }
 
   @Test
@@ -524,13 +524,13 @@ class InternalSentrySdkTest {
         .filter {
           it.header.type == SentryItemType.Session
         }
-    assertEquals(1, sessionItems.size)
+    assertThat(sessionItems).hasSize(1)
     val endedSession =
       fixture.options.serializer.deserialize(
         InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
         Session::class.java,
       )!!
-    assertEquals(Session.State.Unhandled, endedSession.status)
+    assertThat(endedSession.status).isEqualTo(Session.State.Unhandled)
   }
 
   @Test
@@ -544,33 +544,33 @@ class InternalSentrySdkTest {
     val pendingSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> pendingSession.set(scope.session) }
     val oldSid = pendingSession.get().sessionId
-    assertTrue(pendingSession.get().isPendingUnhandled)
+    assertThat(pendingSession.get().isPendingUnhandled).isTrue()
     fixture.capturedEnvelopes.clear()
 
     // when a subsequent hard crash is captured through the existing terminating API
     fixture.captureEnvelopeWithEvent(fixture.createSentryEventWithUnhandledException(), true)
 
     // then the crash envelope contains the finalized old session
-    assertEquals(2, fixture.capturedEnvelopes.size)
+    assertThat(fixture.capturedEnvelopes).hasSize(2)
     val crashEnvelopeItems = fixture.capturedEnvelopes.last().items.toList()
-    assertEquals(2, crashEnvelopeItems.size)
-    assertEquals(SentryItemType.Event, crashEnvelopeItems[0].header.type)
-    assertEquals(SentryItemType.Session, crashEnvelopeItems[1].header.type)
+    assertThat(crashEnvelopeItems).hasSize(2)
+    assertThat(crashEnvelopeItems[0].header.type).isEqualTo(SentryItemType.Event)
+    assertThat(crashEnvelopeItems[1].header.type).isEqualTo(SentryItemType.Session)
     val crashedSession =
       fixture.options.serializer.deserialize(
         InputStreamReader(ByteArrayInputStream(crashEnvelopeItems[1].data)),
         Session::class.java,
       )!!
-    assertEquals(Session.State.Crashed, crashedSession.status)
-    assertFalse(crashedSession.isPendingUnhandled)
-    assertEquals(oldSid, crashedSession.sessionId)
+    assertThat(crashedSession.status).isEqualTo(Session.State.Crashed)
+    assertThat(crashedSession.isPendingUnhandled).isFalse()
+    assertThat(crashedSession.sessionId).isEqualTo(oldSid)
 
     // and a new Ok session with a different id is active
     val activeSession = AtomicReference<Session>()
     Sentry.configureScope { scope -> activeSession.set(scope.session) }
-    assertEquals(Session.State.Ok, activeSession.get().status)
-    assertFalse(activeSession.get().isPendingUnhandled)
-    assertNotEquals(oldSid, activeSession.get().sessionId)
+    assertThat(activeSession.get().status).isEqualTo(Session.State.Ok)
+    assertThat(activeSession.get().isPendingUnhandled).isFalse()
+    assertThat(activeSession.get().sessionId).isNotEqualTo(oldSid)
   }
 
   @Test

--- a/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
+++ b/sentry-android-core/src/test/java/io/sentry/android/core/InternalSentrySdkTest.kt
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -533,32 +534,43 @@ class InternalSentrySdkTest {
   }
 
   @Test
-  fun `captureEnvelopeNonTerminating then a crash finalizes the session as crashed`() {
+  fun `captureEnvelopeNonTerminating then a crash finalizes old session and starts a new one`() {
     val fixture = Fixture()
     fixture.init(context)
 
     fixture.captureEnvelopeNonTerminatingWithEvent(
       fixture.createSentryEventWithUnhandledException()
     )
+    val pendingSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> pendingSession.set(scope.session) }
+    val oldSid = pendingSession.get().sessionId
+    assertTrue(pendingSession.get().isPendingUnhandled)
     fixture.capturedEnvelopes.clear()
 
-    // when a subsequent hard crash is captured through the terminating API
-    fixture.captureEnvelopeWithEvent(fixture.createSentryEventWithUnhandledException())
+    // when a subsequent hard crash is captured through the existing terminating API
+    fixture.captureEnvelopeWithEvent(fixture.createSentryEventWithUnhandledException(), true)
 
-    // then the crash wins over the pending unhandled state
-    val sessionItems =
-      fixture.capturedEnvelopes
-        .flatMap { it.items.toList() }
-        .filter {
-          it.header.type == SentryItemType.Session
-        }
-    assertEquals(1, sessionItems.size)
+    // then the crash envelope contains the finalized old session
+    assertEquals(2, fixture.capturedEnvelopes.size)
+    val crashEnvelopeItems = fixture.capturedEnvelopes.last().items.toList()
+    assertEquals(2, crashEnvelopeItems.size)
+    assertEquals(SentryItemType.Event, crashEnvelopeItems[0].header.type)
+    assertEquals(SentryItemType.Session, crashEnvelopeItems[1].header.type)
     val crashedSession =
       fixture.options.serializer.deserialize(
-        InputStreamReader(ByteArrayInputStream(sessionItems[0].data)),
+        InputStreamReader(ByteArrayInputStream(crashEnvelopeItems[1].data)),
         Session::class.java,
       )!!
     assertEquals(Session.State.Crashed, crashedSession.status)
+    assertFalse(crashedSession.isPendingUnhandled)
+    assertEquals(oldSid, crashedSession.sessionId)
+
+    // and a new Ok session with a different id is active
+    val activeSession = AtomicReference<Session>()
+    Sentry.configureScope { scope -> activeSession.set(scope.session) }
+    assertEquals(Session.State.Ok, activeSession.get().status)
+    assertFalse(activeSession.get().isPendingUnhandled)
+    assertNotEquals(oldSid, activeSession.get().sessionId)
   }
 
   @Test

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -2492,6 +2492,10 @@ public abstract interface class io/sentry/Scope$IWithPropagationContext {
 	public abstract fun accept (Lio/sentry/PropagationContext;)V
 }
 
+public abstract interface class io/sentry/Scope$IWithSession {
+	public abstract fun accept (Lio/sentry/Session;)V
+}
+
 public abstract interface class io/sentry/Scope$IWithTransaction {
 	public abstract fun accept (Lio/sentry/ITransaction;)V
 }
@@ -4275,6 +4279,7 @@ public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/Jso
 	public fun getUserAgent ()Ljava/lang/String;
 	public fun isPendingUnhandled ()Z
 	public fun isTerminated ()Z
+	public fun markPendingUnhandled ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setInitAsTrue ()V
 	public fun setPendingUnhandled (Z)V
@@ -4843,6 +4848,7 @@ public class io/sentry/cache/EnvelopeCache : io/sentry/cache/IEnvelopeCache {
 	public static fun getPreviousSessionFile (Ljava/lang/String;)Ljava/io/File;
 	public fun iterator ()Ljava/util/Iterator;
 	public fun movePreviousSession (Ljava/io/File;Ljava/io/File;)V
+	public fun persistCurrentSession (Lio/sentry/Session;)V
 	public fun store (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)V
 	public fun storeEnvelope (Lio/sentry/SentryEnvelope;Lio/sentry/Hint;)Z
 	public fun waitPreviousSessionFlush ()Z

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -4273,9 +4273,11 @@ public final class io/sentry/Session : io/sentry/JsonSerializable, io/sentry/Jso
 	public fun getTimestamp ()Ljava/util/Date;
 	public fun getUnknown ()Ljava/util/Map;
 	public fun getUserAgent ()Ljava/lang/String;
+	public fun isPendingUnhandled ()Z
 	public fun isTerminated ()Z
 	public fun serialize (Lio/sentry/ObjectWriter;Lio/sentry/ILogger;)V
 	public fun setInitAsTrue ()V
+	public fun setPendingUnhandled (Z)V
 	public fun setUnknown (Ljava/util/Map;)V
 	public fun update (Lio/sentry/Session$State;Ljava/lang/String;Z)Z
 	public fun update (Lio/sentry/Session$State;Ljava/lang/String;ZLjava/lang/String;)Z
@@ -4296,6 +4298,7 @@ public final class io/sentry/Session$JsonKeys {
 	public static final field ERRORS Ljava/lang/String;
 	public static final field INIT Ljava/lang/String;
 	public static final field IP_ADDRESS Ljava/lang/String;
+	public static final field PENDING_UNHANDLED Ljava/lang/String;
 	public static final field RELEASE Ljava/lang/String;
 	public static final field SEQ Ljava/lang/String;
 	public static final field SID Ljava/lang/String;
@@ -4311,6 +4314,7 @@ public final class io/sentry/Session$State : java/lang/Enum {
 	public static final field Crashed Lio/sentry/Session$State;
 	public static final field Exited Lio/sentry/Session$State;
 	public static final field Ok Lio/sentry/Session$State;
+	public static final field Unhandled Lio/sentry/Session$State;
 	public static fun valueOf (Ljava/lang/String;)Lio/sentry/Session$State;
 	public static fun values ()[Lio/sentry/Session$State;
 }

--- a/sentry/src/main/java/io/sentry/Scope.java
+++ b/sentry/src/main/java/io/sentry/Scope.java
@@ -1008,7 +1008,8 @@ public final class Scope implements IScope {
   }
 
   /** The IWithSession callback */
-  interface IWithSession {
+  @ApiStatus.Internal
+  public interface IWithSession {
 
     /**
      * The accept method of the callback

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -21,7 +21,8 @@ public final class Session implements JsonUnknown, JsonSerializable {
     Ok,
     Exited,
     Crashed,
-    Abnormal
+    Abnormal,
+    Unhandled
   }
 
   /** started timestamp */
@@ -65,6 +66,14 @@ public final class Session implements JsonUnknown, JsonSerializable {
 
   /** the Abnormal mechanism, e.g. what was the reason for session to become abnormal (ANR) */
   private @Nullable String abnormalMechanism;
+
+  /**
+   * Whether the session experienced an unhandled (but non-terminal) exception. Kept locally and
+   * persisted with the session, but never sent as a status while the session is alive. On end() the
+   * session is finalized as {@link State#Unhandled} instead of {@link State#Exited} unless a crash
+   * escalated it to {@link State#Crashed}.
+   */
+  private boolean pendingUnhandled;
 
   /** The session lock, ops should be atomic */
   private final @NotNull AutoClosableReentrantLock sessionLock = new AutoClosableReentrantLock();
@@ -188,6 +197,24 @@ public final class Session implements JsonUnknown, JsonSerializable {
     return abnormalMechanism;
   }
 
+  /**
+   * Whether the session has a pending unhandled (non-terminal) exception that hasn't been finalized
+   * yet.
+   */
+  public boolean isPendingUnhandled() {
+    return pendingUnhandled;
+  }
+
+  /**
+   * Marks the session as having experienced an unhandled (non-terminal) exception without ending
+   * it. On {@link #end()} the session will be finalized as {@link State#Unhandled} unless a crash
+   * escalated it to {@link State#Crashed} first.
+   */
+  @ApiStatus.Internal
+  public void setPendingUnhandled(final boolean pendingUnhandled) {
+    this.pendingUnhandled = pendingUnhandled;
+  }
+
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})
   public @Nullable Date getTimestamp() {
     return timestamp;
@@ -209,7 +236,9 @@ public final class Session implements JsonUnknown, JsonSerializable {
 
       // at this state it might be Crashed already, so we don't check for it.
       if (status == State.Ok) {
-        status = State.Exited;
+        // a session that experienced an unhandled (but non-terminal) exception is finalized as
+        // Unhandled rather than Exited.
+        status = pendingUnhandled ? State.Unhandled : State.Exited;
       }
 
       if (timestamp != null) {
@@ -262,6 +291,10 @@ public final class Session implements JsonUnknown, JsonSerializable {
       boolean sessionHasBeenUpdated = false;
       if (status != null) {
         this.status = status;
+        // a real crash takes precedence over a pending unhandled (non-terminal) exception.
+        if (status == State.Crashed) {
+          pendingUnhandled = false;
+        }
         sessionHasBeenUpdated = true;
       }
 
@@ -318,21 +351,24 @@ public final class Session implements JsonUnknown, JsonSerializable {
    */
   @SuppressWarnings("MissingOverride")
   public @NotNull Session clone() {
-    return new Session(
-        status,
-        started,
-        timestamp,
-        errorCount.get(),
-        distinctId,
-        sessionId,
-        init,
-        sequence,
-        duration,
-        ipAddress,
-        userAgent,
-        environment,
-        release,
-        abnormalMechanism);
+    final Session session =
+        new Session(
+            status,
+            started,
+            timestamp,
+            errorCount.get(),
+            distinctId,
+            sessionId,
+            init,
+            sequence,
+            duration,
+            ipAddress,
+            userAgent,
+            environment,
+            release,
+            abnormalMechanism);
+    session.setPendingUnhandled(pendingUnhandled);
+    return session;
   }
 
   // JsonSerializable
@@ -354,6 +390,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
     public static final String IP_ADDRESS = "ip_address";
     public static final String USER_AGENT = "user_agent";
     public static final String ABNORMAL_MECHANISM = "abnormal_mechanism";
+    public static final String PENDING_UNHANDLED = "pending_unhandled";
   }
 
   @Override
@@ -383,6 +420,9 @@ public final class Session implements JsonUnknown, JsonSerializable {
     }
     if (abnormalMechanism != null) {
       writer.name(JsonKeys.ABNORMAL_MECHANISM).value(logger, abnormalMechanism);
+    }
+    if (pendingUnhandled) {
+      writer.name(JsonKeys.PENDING_UNHANDLED).value(pendingUnhandled);
     }
     writer.name(JsonKeys.ATTRS);
     writer.beginObject();
@@ -440,6 +480,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
       String environment = null;
       String release = null; // @NotNull
       String abnormalMechanism = null;
+      boolean pendingUnhandled = false;
 
       Map<String, Object> unknown = null;
       while (reader.peek() == JsonToken.NAME) {
@@ -482,6 +523,10 @@ public final class Session implements JsonUnknown, JsonSerializable {
             break;
           case JsonKeys.ABNORMAL_MECHANISM:
             abnormalMechanism = reader.nextStringOrNull();
+            break;
+          case JsonKeys.PENDING_UNHANDLED:
+            final Boolean pendingUnhandledValue = reader.nextBooleanOrNull();
+            pendingUnhandled = pendingUnhandledValue != null && pendingUnhandledValue;
             break;
           case JsonKeys.ATTRS:
             reader.beginObject();
@@ -542,6 +587,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
               environment,
               release,
               abnormalMechanism);
+      session.setPendingUnhandled(pendingUnhandled);
       session.setUnknown(unknown);
       reader.endObject();
       return session;

--- a/sentry/src/main/java/io/sentry/Session.java
+++ b/sentry/src/main/java/io/sentry/Session.java
@@ -201,6 +201,7 @@ public final class Session implements JsonUnknown, JsonSerializable {
    * Whether the session has a pending unhandled (non-terminal) exception that hasn't been finalized
    * yet.
    */
+  @ApiStatus.Internal
   public boolean isPendingUnhandled() {
     return pendingUnhandled;
   }
@@ -213,6 +214,22 @@ public final class Session implements JsonUnknown, JsonSerializable {
   @ApiStatus.Internal
   public void setPendingUnhandled(final boolean pendingUnhandled) {
     this.pendingUnhandled = pendingUnhandled;
+  }
+
+  /** Marks an active session as having experienced an unhandled non-terminal exception. */
+  @ApiStatus.Internal
+  public boolean markPendingUnhandled() {
+    try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+      if (status != State.Ok) {
+        return false;
+      }
+      pendingUnhandled = true;
+      errorCount.incrementAndGet();
+      init = null;
+      timestamp = DateUtils.getCurrentDateTime();
+      sequence = getSequenceTimestamp(timestamp);
+      return true;
+    }
   }
 
   @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -118,10 +118,14 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
         final @Nullable Session endingSession = readSessionFromEnvelope(envelope);
         final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
-        if (endingSession != null
-            && currentSession != null
-            && hasSameSessionId(endingSession, currentSession)
-            && !currentSessionFile.delete()) {
+        final boolean preservePendingSession =
+            endingSession != null
+                && currentSession != null
+                && currentSession.isPendingUnhandled()
+                && endingSession.getSessionId() != null
+                && currentSession.getSessionId() != null
+                && !Objects.equals(endingSession.getSessionId(), currentSession.getSessionId());
+        if (!preservePendingSession && !currentSessionFile.delete()) {
           options.getLogger().log(WARNING, "Current envelope doesn't exist.");
         }
       }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -115,8 +115,15 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     final File previousSessionFile = getPreviousSessionFile(directory.getAbsolutePath());
 
     if (HintUtils.hasType(hint, SessionEnd.class)) {
-      if (!currentSessionFile.delete()) {
-        options.getLogger().log(WARNING, "Current envelope doesn't exist.");
+      try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+        final @Nullable Session endingSession = readSessionFromEnvelope(envelope);
+        final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
+        if (endingSession != null
+            && currentSession != null
+            && hasSameSessionId(endingSession, currentSession)
+            && !currentSessionFile.delete()) {
+          options.getLogger().log(WARNING, "Current envelope doesn't exist.");
+        }
       }
     }
 
@@ -126,8 +133,22 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
 
     if (HintUtils.hasType(hint, SessionStart.class)) {
-      movePreviousSession(currentSessionFile, previousSessionFile);
-      updateCurrentSession(currentSessionFile, envelope);
+      try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+        final @Nullable Session startingSession = readSessionFromEnvelope(envelope);
+        if (startingSession != null) {
+          final @Nullable Session currentSession = readSessionFromDisk(currentSessionFile);
+          if (currentSession != null && hasSameSessionId(currentSession, startingSession)) {
+            if (!isNewerPendingOrErrorSnapshot(currentSession, startingSession)) {
+              writeSessionToDisk(currentSessionFile, startingSession);
+            }
+          } else {
+            movePreviousSession(currentSessionFile, previousSessionFile);
+            writeSessionToDisk(currentSessionFile, startingSession);
+          }
+        } else {
+          movePreviousSession(currentSessionFile, previousSessionFile);
+        }
+      }
 
       boolean crashedLastRun = false;
       final File crashMarkerFile = new File(options.getCacheDirPath(), NATIVE_CRASH_MARKER_FILE);
@@ -271,8 +292,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     }
   }
 
-  private void updateCurrentSession(
-      final @NotNull File currentSessionFile, final @NotNull SentryEnvelope envelope) {
+  private @Nullable Session readSessionFromEnvelope(final @NotNull SentryEnvelope envelope) {
     final Iterable<SentryEnvelopeItem> items = envelope.getItems();
 
     // we know that an envelope with a SessionStart hint has a single item inside
@@ -292,7 +312,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
                     "Item of type %s returned null by the parser.",
                     item.getHeader().getType());
           } else {
-            writeSessionToDisk(currentSessionFile, session);
+            return session;
           }
         } catch (Throwable e) {
           options.getLogger().log(ERROR, "Item failed to process.", e);
@@ -306,10 +326,35 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
                 item.getHeader().getType());
       }
     } else {
-      options
-          .getLogger()
-          .log(INFO, "Current envelope %s is empty", currentSessionFile.getAbsolutePath());
+      options.getLogger().log(INFO, "Current envelope is empty.");
     }
+    return null;
+  }
+
+  private @Nullable Session readSessionFromDisk(final @NotNull File sessionFile) {
+    if (!sessionFile.exists()) {
+      return null;
+    }
+    try (final Reader reader =
+        new BufferedReader(new InputStreamReader(new FileInputStream(sessionFile), UTF_8))) {
+      return serializer.getValue().deserialize(reader, Session.class);
+    } catch (Throwable e) {
+      options.getLogger().log(ERROR, "Failed to read session from disk.", e);
+      return null;
+    }
+  }
+
+  private boolean isNewerPendingOrErrorSnapshot(
+      final @NotNull Session currentSession, final @NotNull Session startingSession) {
+    return (currentSession.isPendingUnhandled() && !startingSession.isPendingUnhandled())
+        || currentSession.errorCount() > startingSession.errorCount();
+  }
+
+  private boolean hasSameSessionId(
+      final @NotNull Session firstSession, final @NotNull Session secondSession) {
+    return firstSession.getSessionId() != null
+        && secondSession.getSessionId() != null
+        && Objects.equals(firstSession.getSessionId(), secondSession.getSessionId());
   }
 
   private boolean writeEnvelopeToDisk(
@@ -346,6 +391,13 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
       options
           .getLogger()
           .log(ERROR, e, "Error writing Session to offline storage: %s", session.getSessionId());
+    }
+  }
+
+  @ApiStatus.Internal
+  public void persistCurrentSession(final @NotNull Session session) {
+    try (final @NotNull ISentryLifecycleToken ignored = sessionLock.acquire()) {
+      writeSessionToDisk(getCurrentSessionFile(directory.getAbsolutePath()), session);
     }
   }
 

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -346,7 +346,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     try (final Reader reader =
         new BufferedReader(new InputStreamReader(new FileInputStream(sessionFile), UTF_8))) {
       return serializer.getValue().deserialize(reader, Session.class);
-    } catch (Throwable e) {
+    } catch (Exception e) {
       options.getLogger().log(ERROR, "Failed to read session from disk.", e);
       return null;
     }

--- a/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
+++ b/sentry/src/main/java/io/sentry/cache/EnvelopeCache.java
@@ -106,6 +106,7 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
     return storeInternal(envelope, hint);
   }
 
+  @SuppressWarnings("JavaUtilDate")
   private boolean storeInternal(final @NotNull SentryEnvelope envelope, final @NotNull Hint hint) {
     Objects.requireNonNull(envelope, "Envelope is required.");
 
@@ -124,7 +125,10 @@ public class EnvelopeCache extends CacheStrategy implements IEnvelopeCache {
                 && currentSession.isPendingUnhandled()
                 && endingSession.getSessionId() != null
                 && currentSession.getSessionId() != null
-                && !Objects.equals(endingSession.getSessionId(), currentSession.getSessionId());
+                && !Objects.equals(endingSession.getSessionId(), currentSession.getSessionId())
+                && endingSession.getStarted() != null
+                && currentSession.getStarted() != null
+                && currentSession.getStarted().after(endingSession.getStarted());
         if (!preservePendingSession && !currentSessionFile.delete()) {
           options.getLogger().log(WARNING, "Current envelope doesn't exist.");
         }

--- a/sentry/src/test/java/io/sentry/PreviousSessionFinalizerTest.kt
+++ b/sentry/src/test/java/io/sentry/PreviousSessionFinalizerTest.kt
@@ -201,6 +201,47 @@ class PreviousSessionFinalizerTest {
   }
 
   @Test
+  fun `if previous session has pending unhandled and no crash marker, finalizes as unhandled`() {
+    val finalizer =
+      fixture.getSut(
+        tmpDir,
+        session =
+          Session(null, null, null, "io.sentry.sample@1.0").apply { setPendingUnhandled(true) },
+      )
+    finalizer.run()
+
+    verify(fixture.scopes)
+      .captureEnvelope(
+        argThat {
+          val session = fixture.sessionFromEnvelope(this)
+          session.release == "io.sentry.sample@1.0" &&
+            session.status == Session.State.Unhandled &&
+            session.isPendingUnhandled
+        }
+      )
+  }
+
+  @Test
+  fun `if previous session has pending unhandled but a native crash marker exists, finalizes as crashed`() {
+    val finalizer =
+      fixture.getSut(
+        tmpDir,
+        session =
+          Session(null, null, null, "io.sentry.sample@1.0").apply { setPendingUnhandled(true) },
+        nativeCrashTimestamp = Date(2023, 10, 1),
+      )
+    finalizer.run()
+
+    verify(fixture.scopes)
+      .captureEnvelope(
+        argThat {
+          val session = fixture.sessionFromEnvelope(this)
+          session.release == "io.sentry.sample@1.0" && session.status == Crashed
+        }
+      )
+  }
+
+  @Test
   fun `if previous session file exists, deletes previous session file`() {
     val finalizer = fixture.getSut(tmpDir, sessionFileExists = true)
     finalizer.run()

--- a/sentry/src/test/java/io/sentry/PreviousSessionFinalizerTest.kt
+++ b/sentry/src/test/java/io/sentry/PreviousSessionFinalizerTest.kt
@@ -228,7 +228,7 @@ class PreviousSessionFinalizerTest {
         tmpDir,
         session =
           Session(null, null, null, "io.sentry.sample@1.0").apply { setPendingUnhandled(true) },
-        nativeCrashTimestamp = Date(2023, 10, 1),
+        nativeCrashTimestamp = DateUtils.getDateTime("2023-10-01T00:00:00.000Z"),
       )
     finalizer.run()
 

--- a/sentry/src/test/java/io/sentry/SessionTest.kt
+++ b/sentry/src/test/java/io/sentry/SessionTest.kt
@@ -1,0 +1,84 @@
+package io.sentry
+
+import com.google.common.truth.Truth.assertThat
+import java.io.StringReader
+import java.io.StringWriter
+import kotlin.test.Test
+import org.mockito.kotlin.mock
+
+class SessionTest {
+
+  private fun okSession(): Session = Session(null, null, "environment", "release")
+
+  @Test
+  fun `end without pending unhandled finalizes as Exited`() {
+    val session = okSession()
+
+    session.end()
+
+    assertThat(session.status).isEqualTo(Session.State.Exited)
+  }
+
+  @Test
+  fun `end with pending unhandled finalizes as Unhandled`() {
+    val session = okSession()
+    assertThat(session.isPendingUnhandled).isFalse()
+
+    session.setPendingUnhandled(true)
+    session.end()
+
+    assertThat(session.status).isEqualTo(Session.State.Unhandled)
+    assertThat(session.isPendingUnhandled).isTrue()
+  }
+
+  @Test
+  fun `updating to Crashed clears pending unhandled and end stays Crashed`() {
+    val session = okSession()
+    session.setPendingUnhandled(true)
+
+    session.update(Session.State.Crashed, null, true)
+    session.end()
+
+    assertThat(session.status).isEqualTo(Session.State.Crashed)
+    assertThat(session.isPendingUnhandled).isFalse()
+  }
+
+  @Test
+  fun `clone preserves pending unhandled`() {
+    val session = okSession()
+    session.setPendingUnhandled(true)
+
+    val clone = session.clone()
+
+    assertThat(clone.isPendingUnhandled).isTrue()
+  }
+
+  @Test
+  fun `serialization round-trips pending unhandled and Unhandled status`() {
+    val logger = mock<ILogger>()
+    val session = okSession()
+    session.setPendingUnhandled(true)
+    session.end()
+    assertThat(session.status).isEqualTo(Session.State.Unhandled)
+
+    val writer = StringWriter()
+    session.serialize(JsonObjectWriter(writer, 100), logger)
+
+    val deserialized =
+      Session.Deserializer().deserialize(JsonObjectReader(StringReader(writer.toString())), logger)
+
+    assertThat(deserialized.status).isEqualTo(Session.State.Unhandled)
+    assertThat(deserialized.isPendingUnhandled).isTrue()
+  }
+
+  @Test
+  fun `pending unhandled defaults to false and is not serialized when unset`() {
+    val logger = mock<ILogger>()
+    val session = okSession()
+
+    val writer = StringWriter()
+    session.serialize(JsonObjectWriter(writer, 100), logger)
+
+    assertThat(writer.toString()).doesNotContain("pending_unhandled")
+  }
+}

--- a/sentry/src/test/java/io/sentry/SessionTest.kt
+++ b/sentry/src/test/java/io/sentry/SessionTest.kt
@@ -11,6 +11,42 @@ class SessionTest {
   private fun okSession(): Session = Session(null, null, "environment", "release")
 
   @Test
+  fun `markPendingUnhandled atomically updates an Ok session`() {
+    val session = okSession()
+    val initialTimestamp = session.timestamp
+
+    val updated = session.markPendingUnhandled()
+
+    assertThat(updated).isTrue()
+    assertThat(session.status).isEqualTo(Session.State.Ok)
+    assertThat(session.isPendingUnhandled).isTrue()
+    assertThat(session.errorCount()).isEqualTo(1)
+    assertThat(session.init).isNull()
+    assertThat(session.timestamp).isNotNull()
+    assertThat(session.timestamp!!.time).isAtLeast(initialTimestamp!!.time)
+    assertThat(session.sequence).isEqualTo(session.timestamp!!.time)
+  }
+
+  @Test
+  fun `markPendingUnhandled does not change terminal sessions`() {
+    for (state in Session.State.entries.filter { it != Session.State.Ok }) {
+      val session = okSession()
+      session.update(state, null, false)
+      val before = session.clone()
+
+      val updated = session.markPendingUnhandled()
+
+      assertThat(updated).isFalse()
+      assertThat(session.status).isEqualTo(before.status)
+      assertThat(session.isPendingUnhandled).isEqualTo(before.isPendingUnhandled)
+      assertThat(session.errorCount()).isEqualTo(before.errorCount())
+      assertThat(session.init).isEqualTo(before.init)
+      assertThat(session.timestamp).isEqualTo(before.timestamp)
+      assertThat(session.sequence).isEqualTo(before.sequence)
+    }
+  }
+
+  @Test
   fun `end without pending unhandled finalizes as Exited`() {
     val session = okSession()
 
@@ -29,6 +65,30 @@ class SessionTest {
 
     assertThat(session.status).isEqualTo(Session.State.Unhandled)
     assertThat(session.isPendingUnhandled).isTrue()
+  }
+
+  @Test
+  fun `end with pending unhandled keeps Abnormal as Abnormal`() {
+    val session = okSession()
+    session.setPendingUnhandled(true)
+    session.update(Session.State.Abnormal, null, false, "anr")
+
+    session.end()
+
+    assertThat(session.status).isEqualTo(Session.State.Abnormal)
+    assertThat(session.isPendingUnhandled).isTrue()
+  }
+
+  @Test
+  fun `end with pending unhandled keeps Crashed as Crashed`() {
+    val session = okSession()
+    session.setPendingUnhandled(true)
+    session.update(Session.State.Crashed, null, false)
+
+    session.end()
+
+    assertThat(session.status).isEqualTo(Session.State.Crashed)
+    assertThat(session.isPendingUnhandled).isFalse()
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -253,10 +253,10 @@ class EnvelopeCacheTest {
   @Test
   fun `mismatching SessionEnd preserves newer pending current session`() {
     val cache = fixture.getSUT()
-    val currentSession = createSession()
+    val endingSession = createSession(started = Date(1_000))
+    val currentSession = createSession(started = Date(2_000))
     currentSession.markPendingUnhandled()
     cache.persistCurrentSession(currentSession)
-    val endingSession = createSession()
 
     val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
     cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
@@ -268,6 +268,21 @@ class EnvelopeCacheTest {
         Session::class.java,
       )!!
     assertThat(persistedSession.sessionId).isEqualTo(currentSession.sessionId)
+  }
+
+  @Test
+  fun `mismatching newer SessionEnd deletes stale pending current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(started = Date(1_000))
+    currentSession.markPendingUnhandled()
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession(started = Date(2_000))
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -1,5 +1,6 @@
 package io.sentry.cache
 
+import com.google.common.truth.Truth.assertThat
 import io.sentry.DateUtils
 import io.sentry.Hint
 import io.sentry.ILogger
@@ -129,6 +130,157 @@ class EnvelopeCacheTest {
 
     file.deleteRecursively()
     assertTrue(didStore)
+  }
+
+  @Test
+  fun `delayed same SID SessionStart preserves newer pending snapshot`() {
+    val cache = fixture.getSUT()
+    val sid = SentryUUID.generateSentryId()
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val newerSession = createSession(sessionId = sid)
+    newerSession.markPendingUnhandled()
+    cache.persistCurrentSession(newerSession)
+
+    val delayedStart = createSession(sessionId = sid)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, delayedStart, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(sid)
+    assertThat(persistedSession.isPendingUnhandled).isTrue()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+    assertThat(previousSessionFile.exists()).isFalse()
+  }
+
+  @Test
+  fun `delayed same SID SessionStart preserves newer error count snapshot`() {
+    val cache = fixture.getSUT()
+    val sid = SentryUUID.generateSentryId()
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val newerSession = createSession(sessionId = sid)
+    newerSession.update(null, null, true)
+    cache.persistCurrentSession(newerSession)
+
+    val delayedStart = createSession(sessionId = sid)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, delayedStart, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(sid)
+    assertThat(persistedSession.isPendingUnhandled).isFalse()
+    assertThat(persistedSession.errorCount()).isEqualTo(1)
+    assertThat(previousSessionFile.exists()).isFalse()
+  }
+
+  @Test
+  fun `null SIDs on SessionStart rotate instead of preserving as same session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(sessionId = null)
+    currentSession.update(null, null, true)
+    cache.persistCurrentSession(currentSession)
+    val startingSession = createSession(sessionId = null)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, startingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val persistedCurrent =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    val persistedPrevious =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedCurrent.sessionId).isNull()
+    assertThat(persistedCurrent.errorCount()).isEqualTo(0)
+    assertThat(persistedPrevious.sessionId).isNull()
+    assertThat(persistedPrevious.errorCount()).isEqualTo(1)
+  }
+
+  @Test
+  fun `different SID SessionStart rotates current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+    val nextSession = createSession()
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, nextSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionStartHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val persistedCurrent =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    val persistedPrevious =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedCurrent.sessionId).isEqualTo(nextSession.sessionId)
+    assertThat(persistedPrevious.sessionId).isEqualTo(currentSession.sessionId)
+  }
+
+  @Test
+  fun `matching SessionEnd deletes current session`() {
+    val cache = fixture.getSUT()
+    val session = createSession()
+    cache.persistCurrentSession(session)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, session, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `mismatching SessionEnd preserves newer current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession()
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    val persistedSession =
+      fixture.options.serializer.deserialize(
+        currentSessionFile.bufferedReader(),
+        Session::class.java,
+      )!!
+    assertThat(persistedSession.sessionId).isEqualTo(currentSession.sessionId)
+  }
+
+  @Test
+  fun `null SIDs on SessionEnd preserve current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession(sessionId = null)
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession(sessionId = null)
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
+    assertThat(currentSessionFile.exists()).isTrue()
   }
 
   @Test
@@ -318,6 +470,36 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `AbnormalExit hint keeps persisted pending session as abnormal`() {
+    val cache = fixture.getSUT()
+
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val session = createSession().apply { setPendingUnhandled(true) }
+    fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null)
+    val abnormalHint =
+      object : AbnormalExit {
+        override fun mechanism(): String = "abnormal_mechanism"
+
+        override fun ignoreCurrentThread(): Boolean = false
+
+        override fun timestamp(): Long = session.started!!.time + TimeUnit.HOURS.toMillis(1)
+      }
+    val hints = HintUtils.createWithTypeCheckHint(abnormalHint)
+    cache.storeEnvelope(envelope, hints)
+
+    val updatedSession =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )
+    assertEquals(State.Abnormal, updatedSession!!.status)
+    assertEquals("abnormal_mechanism", updatedSession.abnormalMechanism)
+    assertTrue(updatedSession.isPendingUnhandled)
+  }
+
+  @Test
   fun `when AbnormalExit happened before previous session start, does not mark as abnormal`() {
     val cache = fixture.getSUT()
 
@@ -372,6 +554,29 @@ class EnvelopeCacheTest {
   }
 
   @Test
+  fun `NativeCrashExit hint keeps persisted pending session as crashed`() {
+    val cache = fixture.getSUT()
+
+    val previousSessionFile = EnvelopeCache.getPreviousSessionFile(fixture.options.cacheDirPath!!)
+    val session = createSession().apply { setPendingUnhandled(true) }
+    fixture.options.serializer.serialize(session, previousSessionFile.bufferedWriter())
+
+    val nativeCrashTimestamp = session.started!!.time + TimeUnit.HOURS.toMillis(1)
+    val envelope = SentryEnvelope.from(fixture.options.serializer, SentryEvent(), null)
+    val hints = HintUtils.createWithTypeCheckHint(NativeCrashExit { nativeCrashTimestamp })
+    cache.storeEnvelope(envelope, hints)
+
+    val updatedSession =
+      fixture.options.serializer.deserialize(
+        previousSessionFile.bufferedReader(),
+        Session::class.java,
+      )
+    assertEquals(State.Crashed, updatedSession!!.status)
+    assertEquals(nativeCrashTimestamp, updatedSession.timestamp!!.time)
+    assertFalse(updatedSession.isPendingUnhandled)
+  }
+
+  @Test
   fun `when NativeCrashExit happened before previous session start, does not mark as crashed`() {
     val cache = fixture.getSUT()
 
@@ -409,14 +614,17 @@ class EnvelopeCacheTest {
     assertFalse(didStore)
   }
 
-  private fun createSession(started: Date? = null): Session =
+  private fun createSession(
+    started: Date? = null,
+    sessionId: String? = SentryUUID.generateSentryId(),
+  ): Session =
     Session(
       Ok,
       started ?: DateUtils.getCurrentDateTime(),
       DateUtils.getCurrentDateTime(),
       0,
       "dis",
-      SentryUUID.generateSentryId(),
+      sessionId,
       true,
       null,
       null,

--- a/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
+++ b/sentry/src/test/java/io/sentry/cache/EnvelopeCacheTest.kt
@@ -251,9 +251,10 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `mismatching SessionEnd preserves newer current session`() {
+  fun `mismatching SessionEnd preserves newer pending current session`() {
     val cache = fixture.getSUT()
     val currentSession = createSession()
+    currentSession.markPendingUnhandled()
     cache.persistCurrentSession(currentSession)
     val endingSession = createSession()
 
@@ -270,7 +271,21 @@ class EnvelopeCacheTest {
   }
 
   @Test
-  fun `null SIDs on SessionEnd preserve current session`() {
+  fun `mismatching SessionEnd deletes non-pending current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+    val endingSession = createSession()
+
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `null SIDs on SessionEnd delete current session`() {
     val cache = fixture.getSUT()
     val currentSession = createSession(sessionId = null)
     cache.persistCurrentSession(currentSession)
@@ -279,8 +294,34 @@ class EnvelopeCacheTest {
     val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
     cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
 
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `malformed SessionEnd deletes current session`() {
+    val cache = fixture.getSUT()
+    val currentSession = createSession()
+    cache.persistCurrentSession(currentSession)
+
+    val envelope = SentryEnvelope(null, null, emptyList())
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!).exists())
+      .isFalse()
+  }
+
+  @Test
+  fun `unreadable current session on SessionEnd is deleted`() {
+    val cache = fixture.getSUT()
     val currentSessionFile = EnvelopeCache.getCurrentSessionFile(fixture.options.cacheDirPath!!)
-    assertThat(currentSessionFile.exists()).isTrue()
+    currentSessionFile.writeText("not-a-session")
+
+    val endingSession = createSession()
+    val envelope = SentryEnvelope.from(fixture.options.serializer, endingSession, null)
+    cache.storeEnvelope(envelope, HintUtils.createWithTypeCheckHint(SessionEndHint()))
+
+    assertThat(currentSessionFile.exists()).isFalse()
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/protocol/SessionSerializationTest.kt
+++ b/sentry/src/test/java/io/sentry/protocol/SessionSerializationTest.kt
@@ -53,6 +53,19 @@ class SessionSerializationTest {
     assertEquals(expectedJson, actualJson)
   }
 
+  @Test
+  fun `serialize and deserialize round-trips Unhandled status and pending unhandled flag`() {
+    val session = Session(null, null, "environment", "release")
+    session.setPendingUnhandled(true)
+    session.end()
+    assertEquals(Session.State.Unhandled, session.status)
+
+    val deserialized = deserialize(serialize(session))
+
+    assertEquals(Session.State.Unhandled, deserialized.status)
+    assertEquals(true, deserialized.isPendingUnhandled)
+  }
+
   // Helper
 
   private fun sanitizedFile(path: String): String =


### PR DESCRIPTION
## :scroll: Description

Add `InternalSentrySdk.captureEnvelopeNonTerminating` for hybrid runtimes such as Flutter where an unhandled exception does not terminate the process.

The new path keeps the current session alive with the same SID, increments its error count, persists a pending-unhandled marker in the existing session cache, and finalizes it as `unhandled` only when the session naturally ends. Existing `Abnormal` and `Crashed` terminal states remain authoritative, and the existing `captureEnvelope(byte[], boolean)` behavior used by other SDKs is unchanged.

## :bulb: Motivation and Context

Flutter currently forwards `handled=false` events through the terminating hybrid capture path. This marks the session as `crashed` and may start a replacement session even though the Flutter process continues running, which lowers crash-free session rates incorrectly.

This follows the session protocol's `unhandled` status for exceptions that are unhandled by the application but do not terminate the process.

## :green_heart: How did you test it?

- Added coverage for pending session mutation and serialization, natural/abnormal/crashed terminal precedence, previous-session recovery, SID-aware cache start/end handling, null SID handling, and terminating capture compatibility.

## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.

## :crystal_ball: Next steps

- Update the Flutter Android bridge to use `captureEnvelopeNonTerminating` for non-terminating unhandled events.

Made with [Cursor](https://cursor.com)