### PR TITLE
build: Bump target and compile SDK to 37 (JAVA-648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Dependencies
 
 - The SDK is now compiled with Android Gradle Plugin 9.2.1 ([#5779](https://github.com/getsentry/sentry-java/pull/5779))
+- The SDK is now compiled against Android API 37 ([#5796](https://github.com/getsentry/sentry-java/pull/5796))
 
 ## 8.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Dependencies
 
 - The SDK is now compiled with Android Gradle Plugin 9.2.1 ([#5779](https://github.com/getsentry/sentry-java/pull/5779))
-- The SDK is now compiled against Android API 37 ([#5796](https://github.com/getsentry/sentry-java/pull/5796))
+- The SDK has been fully tested for compatibility with Android 17 and platform 37; it is now compiled and tested against it ([#5796](https://github.com/getsentry/sentry-java/pull/5796))
 
 ## 8.49.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,20 +113,6 @@ allprojects {
 subprojects {
     apply { plugin("io.sentry.spotless") }
 
-    // AGP 9.2 bundles lint 9.2.1, which flags compileSdk 36 as outdated because 37 is available.
-    // We intentionally stay on compileSdk 36 until the API 37 bump (#5768), so silence that check
-    // for every Android module (library and application).
-    pluginManager.withPlugin("com.android.library") {
-        extensions.configure<com.android.build.gradle.BaseExtension> {
-            lintOptions { disable("GradleDependency") }
-        }
-    }
-    pluginManager.withPlugin("com.android.application") {
-        extensions.configure<com.android.build.gradle.BaseExtension> {
-            lintOptions { disable("GradleDependency") }
-        }
-    }
-
     plugins.withId(Config.QualityPlugins.detektPlugin) {
         configure<DetektExtension> {
             buildUponDefaultConfig = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ springboot4 = "4.1.0"
 sqldelight = "2.3.2"
 
 # Android
-targetSdk = "36"
-compileSdk = "36"
+targetSdk = "37"
+compileSdk = "37"
 minSdk = "21"
 
 [plugins]

--- a/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android-benchmark/build.gradle.kts
@@ -70,8 +70,6 @@ android {
   lint {
     warningsAsErrors = true
     checkDependencies = true
-    // Suppress OldTargetApi: lint 9.2.1 expects API 37 but we target 36
-    disable += "OldTargetApi"
 
     // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
     checkReleaseBuilds = false

--- a/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
+++ b/sentry-android-integration-tests/sentry-uitest-android/build.gradle.kts
@@ -69,8 +69,6 @@ android {
   lint {
     warningsAsErrors = true
     checkDependencies = true
-    // Suppress OldTargetApi: lint 9.2.1 expects API 37 but we target 36
-    disable += "OldTargetApi"
 
     // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
     checkReleaseBuilds = false

--- a/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
+++ b/sentry-android-replay/src/main/java/io/sentry/android/replay/video/SimpleVideoEncoder.kt
@@ -81,7 +81,7 @@ internal class SimpleVideoEncoder(
         val videoCapabilities =
           mediaCodec.codecInfo.getCapabilitiesForType(muxerConfig.mimeType).videoCapabilities
 
-        if (!videoCapabilities.bitrateRange.contains(bitRate)) {
+        if (videoCapabilities != null && !videoCapabilities.bitrateRange.contains(bitRate)) {
           options.logger.log(
             DEBUG,
             "Encoder doesn't support the provided bitRate: $bitRate, the value will be clamped to the closest one",


### PR DESCRIPTION
## :scroll: Description
Bumps `targetSdk` and `compileSdk` from 36 to 37 in `gradle/libs.versions.toml`.

Resolves JAVA-648
Closes #5778

## :green_heart: How did you test it?
Went though all the features of the sample app on a real android 17 device.

## :pencil: Checklist
- [x] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
