### PR TITLE
ci(android): Bump Maestro to 2.7.0 for UI critical tests

### DIFF
--- a/.github/workflows/integration-tests-ui-critical.yml
+++ b/.github/workflows/integration-tests-ui-critical.yml
@@ -15,7 +15,7 @@ env:
   BUILD_PATH: "build/outputs/apk/release"
   APK_NAME: "sentry-uitest-android-critical-release.apk"
   APK_ARTIFACT_NAME: "sentry-uitest-android-critical-release"
-  MAESTRO_VERSION: "2.1.0"
+  MAESTRO_VERSION: "2.7.0"
 
 jobs:
   build:


### PR DESCRIPTION
## :scroll: Description

Bumps the pinned Maestro CLI version from `2.1.0` to `2.7.0` (latest release, published 2026-07-20). 


## :pencil: Checklist

- [ ] I added GH Issue ID _&_ Linear ID
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


#skip-changelog
