### PR TITLE
feat(core): [Data Collection 3] Add policy resolver

### DIFF
--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -417,6 +417,22 @@ public final class io/sentry/DataCollection$HttpHeaders {
 	public fun setResponse (Lio/sentry/KeyValueCollectionBehavior;)V
 }
 
+public final class io/sentry/DataCollectionResolver {
+	public fun getCookies ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getHttpRequestHeaders ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getHttpResponseHeaders ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun isDataCollectionConfigured ()Z
+	public fun isDatabaseQueryData ()Z
+	public fun isGraphqlDocument ()Z
+	public fun isGraphqlVariables ()Z
+	public fun isIncomingRequestBody ()Z
+	public fun isIncomingResponseBody ()Z
+	public fun isOutgoingRequestBody ()Z
+	public fun isOutgoingResponseBody ()Z
+	public fun isUserInfo ()Z
+}
+
 public final class io/sentry/DateUtils {
 	public static fun dateToSeconds (Ljava/util/Date;)D
 	public static fun doubleToBigDecimal (D)Ljava/math/BigDecimal;
@@ -3698,6 +3714,7 @@ public class io/sentry/SentryOptions {
 	public fun getContinuousProfiler ()Lio/sentry/IContinuousProfiler;
 	public fun getCron ()Lio/sentry/SentryOptions$Cron;
 	public fun getDataCollection ()Lio/sentry/DataCollection;
+	public fun getDataCollectionResolver ()Lio/sentry/DataCollectionResolver;
 	public fun getDateProvider ()Lio/sentry/SentryDateProvider;
 	public fun getDeadlineTimeout ()J
 	public fun getDebugMetaLoader ()Lio/sentry/internal/debugmeta/IDebugMetaLoader;

--- a/sentry/api/sentry.api
+++ b/sentry/api/sentry.api
@@ -419,7 +419,7 @@ public final class io/sentry/DataCollectionResolver {
 	public fun getCookies ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun getHttpRequestHeaders ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun getHttpResponseHeaders ()Lio/sentry/KeyValueCollectionBehavior;
-	public fun getQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
+	public fun getUrlQueryParams ()Lio/sentry/KeyValueCollectionBehavior;
 	public fun isDataCollectionConfigured ()Z
 	public fun isDatabaseQueryData ()Z
 	public fun isGraphqlDocument ()Z

--- a/sentry/src/main/java/io/sentry/DataCollectionResolver.java
+++ b/sentry/src/main/java/io/sentry/DataCollectionResolver.java
@@ -52,8 +52,8 @@ public final class DataCollectionResolver {
     return options.isSendDefaultPii() ? EMPTY_DENY_LIST : OFF;
   }
 
-  public @NotNull KeyValueCollectionBehavior getQueryParams() {
-    return explicitOrEmptyDenyList(options.getDataCollection().getQueryParams());
+  public @NotNull KeyValueCollectionBehavior getUrlQueryParams() {
+    return explicitOrEmptyDenyList(options.getDataCollection().getUrlQueryParams());
   }
 
   public @NotNull KeyValueCollectionBehavior getHttpRequestHeaders() {

--- a/sentry/src/main/java/io/sentry/DataCollectionResolver.java
+++ b/sentry/src/main/java/io/sentry/DataCollectionResolver.java
@@ -1,0 +1,105 @@
+package io.sentry;
+
+import java.util.Set;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Resolves effective Data Collection policies for SDK integrations. */
+@ApiStatus.Internal
+public final class DataCollectionResolver {
+
+  private static final @NotNull KeyValueCollectionBehavior OFF = KeyValueCollectionBehavior.off();
+  private static final @NotNull KeyValueCollectionBehavior EMPTY_DENY_LIST =
+      KeyValueCollectionBehavior.denyList();
+
+  private final @NotNull SentryOptions options;
+
+  DataCollectionResolver(final @NotNull SentryOptions options) {
+    this.options = options;
+  }
+
+  public boolean isDataCollectionConfigured() {
+    return options.getDataCollection().isExplicitlyConfigured();
+  }
+
+  public boolean isUserInfo() {
+    return explicitOrSendDefaultPii(options.getDataCollection().getUserInfo(), true);
+  }
+
+  public boolean isDatabaseQueryData() {
+    return explicitOrSendDefaultPii(options.getDataCollection().getDatabaseQueryData(), true);
+  }
+
+  public boolean isGraphqlDocument() {
+    return explicitOrSendDefaultPii(options.getDataCollection().getGraphql().getDocument(), true);
+  }
+
+  public boolean isGraphqlVariables() {
+    return explicitOrSendDefaultPii(options.getDataCollection().getGraphql().getVariables(), true);
+  }
+
+  public @NotNull KeyValueCollectionBehavior getCookies() {
+    final @NotNull DataCollection dataCollection = options.getDataCollection();
+    final @Nullable KeyValueCollectionBehavior cookies = dataCollection.getCookies();
+
+    if (cookies != null) {
+      return cookies;
+    }
+    if (isDataCollectionConfigured()) {
+      return EMPTY_DENY_LIST;
+    }
+    return options.isSendDefaultPii() ? EMPTY_DENY_LIST : OFF;
+  }
+
+  public @NotNull KeyValueCollectionBehavior getQueryParams() {
+    return explicitOrEmptyDenyList(options.getDataCollection().getQueryParams());
+  }
+
+  public @NotNull KeyValueCollectionBehavior getHttpRequestHeaders() {
+    return explicitOrEmptyDenyList(options.getDataCollection().getHttpHeaders().getRequest());
+  }
+
+  public @NotNull KeyValueCollectionBehavior getHttpResponseHeaders() {
+    return explicitOrEmptyDenyList(options.getDataCollection().getHttpHeaders().getResponse());
+  }
+
+  public boolean isIncomingRequestBody() {
+    return isHttpBodyEnabled(HttpBodyType.INCOMING_REQUEST, options.isSendDefaultPii());
+  }
+
+  public boolean isOutgoingRequestBody() {
+    return isHttpBodyEnabled(HttpBodyType.OUTGOING_REQUEST, true);
+  }
+
+  public boolean isIncomingResponseBody() {
+    return isHttpBodyEnabled(HttpBodyType.INCOMING_RESPONSE, true);
+  }
+
+  public boolean isOutgoingResponseBody() {
+    return isHttpBodyEnabled(HttpBodyType.OUTGOING_RESPONSE, options.isSendDefaultPii());
+  }
+
+  private boolean explicitOrSendDefaultPii(
+      final @Nullable Boolean explicit, final boolean defaultValue) {
+    if (explicit != null) {
+      return explicit;
+    }
+    return isDataCollectionConfigured() ? defaultValue : options.isSendDefaultPii();
+  }
+
+  private @NotNull KeyValueCollectionBehavior explicitOrEmptyDenyList(
+      final @Nullable KeyValueCollectionBehavior explicit) {
+    return explicit != null ? explicit : EMPTY_DENY_LIST;
+  }
+
+  private boolean isHttpBodyEnabled(
+      final @NotNull HttpBodyType bodyType, final boolean legacyFallback) {
+    final @NotNull DataCollection dataCollection = options.getDataCollection();
+    final @Nullable Set<HttpBodyType> httpBodies = dataCollection.getHttpBodies();
+    if (httpBodies != null) {
+      return httpBodies.contains(bodyType);
+    }
+    return isDataCollectionConfigured() || legacyFallback;
+  }
+}

--- a/sentry/src/main/java/io/sentry/SentryOptions.java
+++ b/sentry/src/main/java/io/sentry/SentryOptions.java
@@ -340,6 +340,9 @@ public class SentryOptions {
 
   private @NotNull DataCollection dataCollection = new DataCollection(false);
 
+  private final @NotNull DataCollectionResolver dataCollectionResolver =
+      new DataCollectionResolver(this);
+
   /** SSLSocketFactory for self-signed certificate trust * */
   private @Nullable SSLSocketFactory sslSocketFactory;
 
@@ -1716,6 +1719,12 @@ public class SentryOptions {
    */
   public void setDataCollection(final @NotNull DataCollection dataCollection) {
     this.dataCollection = dataCollection;
+  }
+
+  /** Returns the Data Collection policy resolver used by SDK integrations. */
+  @ApiStatus.Internal
+  public @NotNull DataCollectionResolver getDataCollectionResolver() {
+    return dataCollectionResolver;
   }
 
   /**

--- a/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
@@ -42,7 +42,7 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `user info override takes precedence over sendDefaultPii`() {
+  fun `user info uses configured Data Collection value`() {
     val options = SentryOptions().apply { isSendDefaultPii = true }
 
     options.dataCollection.setUserInfo(false)
@@ -68,25 +68,53 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `database query data falls back to sendDefaultPii and override takes precedence`() {
-    val options = SentryOptions().apply { isSendDefaultPii = true }
+  fun `database query data uses sendDefaultPii when Data Collection is absent`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isDatabaseQueryData).isFalse()
+
+    options.isSendDefaultPii = true
 
     assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
+  }
+
+  @Test
+  fun `database query data uses configured Data Collection value`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
 
     options.dataCollection.setDatabaseQueryData(false)
 
     assertThat(options.dataCollectionResolver.isDatabaseQueryData).isFalse()
+
+    options.isSendDefaultPii = false
+    options.dataCollection.setDatabaseQueryData(true)
+
+    assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
   }
 
   @Test
-  fun `GraphQL document falls back to sendDefaultPii and override takes precedence`() {
-    val options = SentryOptions().apply { isSendDefaultPii = true }
+  fun `GraphQL document uses sendDefaultPii when Data Collection is absent`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isGraphqlDocument).isFalse()
+
+    options.isSendDefaultPii = true
 
     assertThat(options.dataCollectionResolver.isGraphqlDocument).isTrue()
+  }
+
+  @Test
+  fun `GraphQL document uses configured Data Collection value`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
 
     options.dataCollection.graphql.setDocument(false)
 
     assertThat(options.dataCollectionResolver.isGraphqlDocument).isFalse()
+
+    options.isSendDefaultPii = false
+    options.dataCollection.graphql.setDocument(true)
+
+    assertThat(options.dataCollectionResolver.isGraphqlDocument).isTrue()
   }
 
   @Test
@@ -115,7 +143,7 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `cookies override takes precedence over sendDefaultPii`() {
+  fun `cookies use configured Data Collection behavior`() {
     val options = SentryOptions().apply { isSendDefaultPii = false }
     val behavior = KeyValueCollectionBehavior.allowList("language", "theme")
 
@@ -133,7 +161,7 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `URL query params override takes precedence`() {
+  fun `URL query params use configured Data Collection behavior`() {
     val options = SentryOptions()
     val behavior = KeyValueCollectionBehavior.allowList("language", "theme")
 
@@ -151,7 +179,7 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `HTTP request headers override takes precedence`() {
+  fun `HTTP request headers use configured Data Collection behavior`() {
     val options = SentryOptions()
     val behavior = KeyValueCollectionBehavior.allowList("content-type")
 
@@ -169,7 +197,7 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `HTTP response headers override takes precedence`() {
+  fun `HTTP response headers use configured Data Collection behavior`() {
     val options = SentryOptions()
     val behavior = KeyValueCollectionBehavior.off()
 
@@ -219,13 +247,27 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `GraphQL variables fall back to sendDefaultPii and override takes precedence`() {
-    val options = SentryOptions().apply { isSendDefaultPii = true }
+  fun `GraphQL variables use sendDefaultPii when Data Collection is absent`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isGraphqlVariables).isFalse()
+
+    options.isSendDefaultPii = true
 
     assertThat(options.dataCollectionResolver.isGraphqlVariables).isTrue()
+  }
+
+  @Test
+  fun `GraphQL variables use configured Data Collection value`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
 
     options.dataCollection.graphql.setVariables(false)
 
     assertThat(options.dataCollectionResolver.isGraphqlVariables).isFalse()
+
+    options.isSendDefaultPii = false
+    options.dataCollection.graphql.setVariables(true)
+
+    assertThat(options.dataCollectionResolver.isGraphqlVariables).isTrue()
   }
 }

--- a/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
@@ -25,7 +25,7 @@ class DataCollectionResolverTest {
 
     assertThat(options.dataCollectionResolver.isDataCollectionConfigured).isFalse()
 
-    options.dataCollection.queryParams = KeyValueCollectionBehavior.denyList()
+    options.dataCollection.urlQueryParams = KeyValueCollectionBehavior.denyList()
 
     assertThat(options.dataCollectionResolver.isDataCollectionConfigured).isTrue()
   }
@@ -125,21 +125,21 @@ class DataCollectionResolverTest {
   }
 
   @Test
-  fun `query params use default deny list when unset`() {
+  fun `URL query params use default deny list when unset`() {
     val options = SentryOptions()
 
-    assertThat(options.dataCollectionResolver.queryParams)
+    assertThat(options.dataCollectionResolver.urlQueryParams)
       .isEqualTo(KeyValueCollectionBehavior.denyList())
   }
 
   @Test
-  fun `query params override takes precedence`() {
+  fun `URL query params override takes precedence`() {
     val options = SentryOptions()
     val behavior = KeyValueCollectionBehavior.allowList("language", "theme")
 
-    options.dataCollection.queryParams = behavior
+    options.dataCollection.urlQueryParams = behavior
 
-    assertThat(options.dataCollectionResolver.queryParams).isEqualTo(behavior)
+    assertThat(options.dataCollectionResolver.urlQueryParams).isEqualTo(behavior)
   }
 
   @Test

--- a/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
+++ b/sentry/src/test/java/io/sentry/DataCollectionResolverTest.kt
@@ -1,0 +1,231 @@
+package io.sentry
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class DataCollectionResolverTest {
+  @Test
+  fun `one resolver is reused per options instance`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver).isSameInstanceAs(options.dataCollectionResolver)
+  }
+
+  @Test
+  fun `each options instance owns its resolver`() {
+    val first = SentryOptions()
+    val second = SentryOptions()
+
+    assertThat(first.dataCollectionResolver).isNotSameInstanceAs(second.dataCollectionResolver)
+  }
+
+  @Test
+  fun `data collection configured reflects namespace explicitness`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isDataCollectionConfigured).isFalse()
+
+    options.dataCollection.queryParams = KeyValueCollectionBehavior.denyList()
+
+    assertThat(options.dataCollectionResolver.isDataCollectionConfigured).isTrue()
+  }
+
+  @Test
+  fun `user info falls back to sendDefaultPii when unset`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isUserInfo).isFalse()
+
+    options.isSendDefaultPii = true
+
+    assertThat(options.dataCollectionResolver.isUserInfo).isTrue()
+  }
+
+  @Test
+  fun `user info override takes precedence over sendDefaultPii`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    options.dataCollection.setUserInfo(false)
+
+    assertThat(options.dataCollectionResolver.isUserInfo).isFalse()
+
+    options.isSendDefaultPii = false
+    options.dataCollection.setUserInfo(true)
+
+    assertThat(options.dataCollectionResolver.isUserInfo).isTrue()
+  }
+
+  @Test
+  fun `omitted booleans use data collection defaults once namespace is explicit`() {
+    val options = SentryOptions().apply { isSendDefaultPii = false }
+
+    options.dataCollection.cookies = KeyValueCollectionBehavior.off()
+
+    assertThat(options.dataCollectionResolver.isUserInfo).isTrue()
+    assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
+    assertThat(options.dataCollectionResolver.isGraphqlDocument).isTrue()
+    assertThat(options.dataCollectionResolver.isGraphqlVariables).isTrue()
+  }
+
+  @Test
+  fun `database query data falls back to sendDefaultPii and override takes precedence`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    assertThat(options.dataCollectionResolver.isDatabaseQueryData).isTrue()
+
+    options.dataCollection.setDatabaseQueryData(false)
+
+    assertThat(options.dataCollectionResolver.isDatabaseQueryData).isFalse()
+  }
+
+  @Test
+  fun `GraphQL document falls back to sendDefaultPii and override takes precedence`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    assertThat(options.dataCollectionResolver.isGraphqlDocument).isTrue()
+
+    options.dataCollection.graphql.setDocument(false)
+
+    assertThat(options.dataCollectionResolver.isGraphqlDocument).isFalse()
+  }
+
+  @Test
+  fun `cookies are off when unset and sendDefaultPii is false`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.cookies).isEqualTo(KeyValueCollectionBehavior.off())
+  }
+
+  @Test
+  fun `cookies use default deny list when unset and sendDefaultPii is true`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    assertThat(options.dataCollectionResolver.cookies)
+      .isEqualTo(KeyValueCollectionBehavior.denyList())
+  }
+
+  @Test
+  fun `cookies use default deny list when namespace is explicit`() {
+    val options = SentryOptions().apply { isSendDefaultPii = false }
+
+    options.dataCollection.setUserInfo(false)
+
+    assertThat(options.dataCollectionResolver.cookies)
+      .isEqualTo(KeyValueCollectionBehavior.denyList())
+  }
+
+  @Test
+  fun `cookies override takes precedence over sendDefaultPii`() {
+    val options = SentryOptions().apply { isSendDefaultPii = false }
+    val behavior = KeyValueCollectionBehavior.allowList("language", "theme")
+
+    options.dataCollection.cookies = behavior
+
+    assertThat(options.dataCollectionResolver.cookies).isEqualTo(behavior)
+  }
+
+  @Test
+  fun `query params use default deny list when unset`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.queryParams)
+      .isEqualTo(KeyValueCollectionBehavior.denyList())
+  }
+
+  @Test
+  fun `query params override takes precedence`() {
+    val options = SentryOptions()
+    val behavior = KeyValueCollectionBehavior.allowList("language", "theme")
+
+    options.dataCollection.queryParams = behavior
+
+    assertThat(options.dataCollectionResolver.queryParams).isEqualTo(behavior)
+  }
+
+  @Test
+  fun `HTTP request headers use default deny list when unset`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.httpRequestHeaders)
+      .isEqualTo(KeyValueCollectionBehavior.denyList())
+  }
+
+  @Test
+  fun `HTTP request headers override takes precedence`() {
+    val options = SentryOptions()
+    val behavior = KeyValueCollectionBehavior.allowList("content-type")
+
+    options.dataCollection.httpHeaders.request = behavior
+
+    assertThat(options.dataCollectionResolver.httpRequestHeaders).isEqualTo(behavior)
+  }
+
+  @Test
+  fun `HTTP response headers use default deny list when unset`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.httpResponseHeaders)
+      .isEqualTo(KeyValueCollectionBehavior.denyList())
+  }
+
+  @Test
+  fun `HTTP response headers override takes precedence`() {
+    val options = SentryOptions()
+    val behavior = KeyValueCollectionBehavior.off()
+
+    options.dataCollection.httpHeaders.response = behavior
+
+    assertThat(options.dataCollectionResolver.httpResponseHeaders).isEqualTo(behavior)
+  }
+
+  @Test
+  fun `HTTP bodies preserve direction-specific legacy fallbacks when data collection is absent`() {
+    val options = SentryOptions()
+
+    assertThat(options.dataCollectionResolver.isIncomingRequestBody).isFalse()
+    assertThat(options.dataCollectionResolver.isOutgoingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isIncomingResponseBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBody).isFalse()
+
+    options.isSendDefaultPii = true
+
+    assertThat(options.dataCollectionResolver.isIncomingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isIncomingResponseBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBody).isTrue()
+  }
+
+  @Test
+  fun `explicit empty data collection enables every HTTP body direction`() {
+    val options = SentryOptions().apply { dataCollection = DataCollection() }
+
+    assertThat(options.dataCollectionResolver.isIncomingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isIncomingResponseBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBody).isTrue()
+  }
+
+  @Test
+  fun `explicit HTTP body set controls every direction`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    options.dataCollection.httpBodies =
+      setOf(HttpBodyType.INCOMING_REQUEST, HttpBodyType.OUTGOING_RESPONSE)
+
+    assertThat(options.dataCollectionResolver.isIncomingRequestBody).isTrue()
+    assertThat(options.dataCollectionResolver.isOutgoingRequestBody).isFalse()
+    assertThat(options.dataCollectionResolver.isIncomingResponseBody).isFalse()
+    assertThat(options.dataCollectionResolver.isOutgoingResponseBody).isTrue()
+  }
+
+  @Test
+  fun `GraphQL variables fall back to sendDefaultPii and override takes precedence`() {
+    val options = SentryOptions().apply { isSendDefaultPii = true }
+
+    assertThat(options.dataCollectionResolver.isGraphqlVariables).isTrue()
+
+    options.dataCollection.graphql.setVariables(false)
+
+    assertThat(options.dataCollectionResolver.isGraphqlVariables).isFalse()
+  }
+}


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Add a centralized `DataCollectionResolver` owned by `SentryOptions`.

The resolver applies explicit Data Collection values first, specification defaults for omitted values once the namespace is configured, and integration-specific legacy fallbacks only while Data Collection is absent. It exposes behavior-named decisions for user information, database queries, GraphQL data, cookies, query parameters, HTTP headers, and directional HTTP bodies.

This PR establishes resolution only; production integration wiring follows in later stack PRs.

## :bulb: Motivation and Context

Centralizing resolution keeps `sendDefaultPii` and caller-selected fallback values out of integrations while preserving existing behavior for applications that have not opted into Data Collection.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- `./gradlew :sentry:test --tests="io.sentry.DataCollectionResolverTest"`
- `./gradlew apiCheck`

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Wire the resolved policies into automatic integration collection paths in subsequent stack PRs.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
