### PR TITLE
feat(spring): [Data Collection 6] Apply incoming request body policy

### DIFF
--- a/sentry-spring-7/src/main/java/io/sentry/spring7/SentrySpringFilter.java
+++ b/sentry-spring-7/src/main/java/io/sentry/spring7/SentrySpringFilter.java
@@ -110,7 +110,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
 
   private @NotNull HttpServletRequest resolveHttpServletRequest(
       final @NotNull IScopes scopes, final @NotNull HttpServletRequest request) {
-    if (scopes.getOptions().isSendDefaultPii()
+    if (scopes.getOptions().getDataCollectionResolver().isIncomingRequestBody()
         && qualifiesForCaching(request, scopes.getOptions().getMaxRequestBodySize())) {
       return new ContentCachingRequestWrapper(request, 0);
     }
@@ -155,7 +155,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
     @Override
     public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hint hint) {
       if (event.getRequest() != null
-          && options.isSendDefaultPii()
+          && options.getDataCollectionResolver().isIncomingRequestBody()
           && qualifiesForCaching(request, options.getMaxRequestBodySize())) {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }

--- a/sentry-spring-7/src/test/kotlin/io/sentry/spring7/SentrySpringFilterTest.kt
+++ b/sentry-spring-7/src/test/kotlin/io/sentry/spring7/SentrySpringFilterTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring7
 
 import io.sentry.Breadcrumb
+import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
@@ -316,6 +317,52 @@ class SentrySpringFilterTest {
         throw e
       }
     }
+  }
+
+  @Test
+  fun `data collection can enable request body when sendDefaultPii is false`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = false
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = setOf(HttpBodyType.INCOMING_REQUEST)
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertTrue(it is ContentCachingRequestWrapper) }, any())
+  }
+
+  @Test
+  fun `data collection can disable request body when sendDefaultPii is true`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = true
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = emptySet()
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertFalse(it is ContentCachingRequestWrapper) }, any())
   }
 
   private fun servletContextWithCustomCookieName(name: String): ServletContext =

--- a/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringFilter.java
+++ b/sentry-spring-jakarta/src/main/java/io/sentry/spring/jakarta/SentrySpringFilter.java
@@ -110,7 +110,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
 
   private @NotNull HttpServletRequest resolveHttpServletRequest(
       final @NotNull IScopes scopes, final @NotNull HttpServletRequest request) {
-    if (scopes.getOptions().isSendDefaultPii()
+    if (scopes.getOptions().getDataCollectionResolver().isIncomingRequestBody()
         && qualifiesForCaching(request, scopes.getOptions().getMaxRequestBodySize())) {
       return new ContentCachingRequestWrapper(request);
     }
@@ -155,7 +155,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
     @Override
     public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hint hint) {
       if (event.getRequest() != null
-          && options.isSendDefaultPii()
+          && options.getDataCollectionResolver().isIncomingRequestBody()
           && qualifiesForCaching(request, options.getMaxRequestBodySize())) {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }

--- a/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentrySpringFilterTest.kt
+++ b/sentry-spring-jakarta/src/test/kotlin/io/sentry/spring/jakarta/SentrySpringFilterTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring.jakarta
 
 import io.sentry.Breadcrumb
+import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
@@ -316,6 +317,52 @@ class SentrySpringFilterTest {
         throw e
       }
     }
+  }
+
+  @Test
+  fun `data collection can enable request body when sendDefaultPii is false`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = false
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = setOf(HttpBodyType.INCOMING_REQUEST)
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertTrue(it is ContentCachingRequestWrapper) }, any())
+  }
+
+  @Test
+  fun `data collection can disable request body when sendDefaultPii is true`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = true
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = emptySet()
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertFalse(it is ContentCachingRequestWrapper) }, any())
   }
 
   private fun servletContextWithCustomCookieName(name: String): ServletContext =

--- a/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
+++ b/sentry-spring/src/main/java/io/sentry/spring/SentrySpringFilter.java
@@ -110,7 +110,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
 
   private @NotNull HttpServletRequest resolveHttpServletRequest(
       final @NotNull IScopes scopes, final @NotNull HttpServletRequest request) {
-    if (scopes.getOptions().isSendDefaultPii()
+    if (scopes.getOptions().getDataCollectionResolver().isIncomingRequestBody()
         && qualifiesForCaching(request, scopes.getOptions().getMaxRequestBodySize())) {
       return new ContentCachingRequestWrapper(request);
     }
@@ -155,7 +155,7 @@ public class SentrySpringFilter extends OncePerRequestFilter {
     @Override
     public @NotNull SentryEvent process(@NotNull SentryEvent event, @NotNull Hint hint) {
       if (event.getRequest() != null
-          && options.isSendDefaultPii()
+          && options.getDataCollectionResolver().isIncomingRequestBody()
           && qualifiesForCaching(request, options.getMaxRequestBodySize())) {
         event.getRequest().setData(requestPayloadExtractor.extract(request, options));
       }

--- a/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
+++ b/sentry-spring/src/test/kotlin/io/sentry/spring/SentrySpringFilterTest.kt
@@ -1,6 +1,7 @@
 package io.sentry.spring
 
 import io.sentry.Breadcrumb
+import io.sentry.HttpBodyType
 import io.sentry.IScope
 import io.sentry.IScopes
 import io.sentry.ISentryLifecycleToken
@@ -316,6 +317,52 @@ class SentrySpringFilterTest {
         throw e
       }
     }
+  }
+
+  @Test
+  fun `data collection can enable request body when sendDefaultPii is false`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = false
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = setOf(HttpBodyType.INCOMING_REQUEST)
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertTrue(it is ContentCachingRequestWrapper) }, any())
+  }
+
+  @Test
+  fun `data collection can disable request body when sendDefaultPii is true`() {
+    val options =
+      SentryOptions().apply {
+        isSendDefaultPii = true
+        maxRequestBodySize = SMALL
+        dataCollection.httpBodies = emptySet()
+      }
+    val listener =
+      fixture.getSut(
+        request =
+          MockMvcRequestBuilders.post(URI.create("http://example.com"))
+            .content("xxx")
+            .contentType("application/json")
+            .buildRequest(MockServletContext()),
+        options = options,
+      )
+
+    listener.doFilter(fixture.request, fixture.response, fixture.chain)
+
+    verify(fixture.chain).doFilter(check { assertFalse(it is ContentCachingRequestWrapper) }, any())
   }
 
   private fun servletContextWithCustomCookieName(name: String): ServletContext =


### PR DESCRIPTION
## PR Stack (Data Collection)

- #5759
- #5760
- #5761
- #5799
- #5800
- #5801
- #5802
- #5803
- #5804
- #5805
- #5806
- #5807
- #5810
- #5811
- #5812
- #5831
- #5832
- #5834
- #5937
- #5983
- #6036
- #6038
- #6064
- #6065
- #6075
- #6076
- #6122

---

## :scroll: Description

Apply the incoming request body policy to Spring MVC request caching and extraction in the Spring, Spring Jakarta, and Spring 7 integrations.

The policy controls body content only. Existing MIME type, length, and `maxRequestBodySize` checks remain additive, and legacy `sendDefaultPii` behavior is preserved when Data Collection is absent.

## :bulb: Motivation and Context

Incoming server request bodies can contain customer data and need a direction-specific collection decision without changing technical request metadata.

Refs #5666

## :green_heart: How did you test it?

- `./gradlew spotlessApply apiDump`
- Spring, Spring Jakarta, and Spring 7 filter tests

## :pencil: Checklist

- [x] I added GH Issue ID _&_ Linear ID
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Apply the remaining client and server HTTP body directions.

#skip-changelog

> ⚠️ **Merge this PR using a merge commit** (not squash). Only the collection branch is squash-merged into main.
